### PR TITLE
[FLINK-4733] Port WebInterface to metric system

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -287,8 +287,8 @@ public class WebRuntimeMonitor implements WebMonitor {
 			.GET("/jobs/:jobid/checkpoints", handler(new JobCheckpointsHandler(currentGraphs)))
 			.GET("/jobs/:jobid/metrics", handler(new JobMetricsHandler(metricFetcher)))
 
-			.GET("/taskmanagers", handler(new TaskManagersHandler(DEFAULT_REQUEST_TIMEOUT)))
-			.GET("/taskmanagers/:" + TaskManagersHandler.TASK_MANAGER_ID_KEY + "/metrics", handler(new TaskManagersHandler(DEFAULT_REQUEST_TIMEOUT)))
+			.GET("/taskmanagers", handler(new TaskManagersHandler(DEFAULT_REQUEST_TIMEOUT, metricFetcher)))
+			.GET("/taskmanagers/:" + TaskManagersHandler.TASK_MANAGER_ID_KEY + "/metrics", handler(new TaskManagersHandler(DEFAULT_REQUEST_TIMEOUT, metricFetcher)))
 			.GET("/taskmanagers/:" + TaskManagersHandler.TASK_MANAGER_ID_KEY + "/log", 
 				new TaskManagerLogHandler(retriever, context, jobManagerAddressPromise.future(), timeout,
 					TaskManagerLogHandler.FileMode.LOG, config, enableSSL))

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -262,12 +262,12 @@ public class WebRuntimeMonitor implements WebMonitor {
 
 			.GET("/jobs", handler(new CurrentJobIdsHandler(DEFAULT_REQUEST_TIMEOUT)))
 
-			.GET("/jobs/:jobid", handler(new JobDetailsHandler(currentGraphs)))
-			.GET("/jobs/:jobid/vertices", handler(new JobDetailsHandler(currentGraphs)))
+			.GET("/jobs/:jobid", handler(new JobDetailsHandler(currentGraphs, metricFetcher)))
+			.GET("/jobs/:jobid/vertices", handler(new JobDetailsHandler(currentGraphs, metricFetcher)))
 
-			.GET("/jobs/:jobid/vertices/:vertexid", handler(new JobVertexDetailsHandler(currentGraphs)))
+			.GET("/jobs/:jobid/vertices/:vertexid", handler(new JobVertexDetailsHandler(currentGraphs, metricFetcher)))
 			.GET("/jobs/:jobid/vertices/:vertexid/subtasktimes", handler(new SubtasksTimesHandler(currentGraphs)))
-			.GET("/jobs/:jobid/vertices/:vertexid/taskmanagers", handler(new JobVertexTaskManagersHandler(currentGraphs)))
+			.GET("/jobs/:jobid/vertices/:vertexid/taskmanagers", handler(new JobVertexTaskManagersHandler(currentGraphs, metricFetcher)))
 			.GET("/jobs/:jobid/vertices/:vertexid/accumulators", handler(new JobVertexAccumulatorsHandler(currentGraphs)))
 			.GET("/jobs/:jobid/vertices/:vertexid/checkpoints", handler(new JobVertexCheckpointsHandler(currentGraphs)))
 			.GET("/jobs/:jobid/vertices/:vertexid/backpressure", handler(new JobVertexBackPressureHandler(
@@ -276,8 +276,8 @@ public class WebRuntimeMonitor implements WebMonitor {
 							refreshInterval)))
 			.GET("/jobs/:jobid/vertices/:vertexid/metrics", handler(new JobVertexMetricsHandler(metricFetcher)))
 			.GET("/jobs/:jobid/vertices/:vertexid/subtasks/accumulators", handler(new SubtasksAllAccumulatorsHandler(currentGraphs)))
-			.GET("/jobs/:jobid/vertices/:vertexid/subtasks/:subtasknum", handler(new SubtaskCurrentAttemptDetailsHandler(currentGraphs)))
-			.GET("/jobs/:jobid/vertices/:vertexid/subtasks/:subtasknum/attempts/:attempt", handler(new SubtaskExecutionAttemptDetailsHandler(currentGraphs)))
+			.GET("/jobs/:jobid/vertices/:vertexid/subtasks/:subtasknum", handler(new SubtaskCurrentAttemptDetailsHandler(currentGraphs, metricFetcher)))
+			.GET("/jobs/:jobid/vertices/:vertexid/subtasks/:subtasknum/attempts/:attempt", handler(new SubtaskExecutionAttemptDetailsHandler(currentGraphs, metricFetcher)))
 			.GET("/jobs/:jobid/vertices/:vertexid/subtasks/:subtasknum/attempts/:attempt/accumulators", handler(new SubtaskExecutionAttemptAccumulatorsHandler(currentGraphs)))
 
 			.GET("/jobs/:jobid/plan", handler(new JobPlanHandler(currentGraphs)))

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandler.java
@@ -20,16 +20,16 @@ package org.apache.flink.runtime.webmonitor.handlers;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 
-import org.apache.flink.api.common.accumulators.Accumulator;
-import org.apache.flink.api.common.accumulators.LongCounter;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
+import org.apache.flink.runtime.webmonitor.metrics.MetricStore;
 
 import java.io.StringWriter;
 import java.util.Map;
@@ -45,9 +45,12 @@ import java.util.Map;
  * </ul>
  */
 public class JobDetailsHandler extends AbstractExecutionGraphRequestHandler {
-	
-	public JobDetailsHandler(ExecutionGraphHolder executionGraphHolder) {
+
+	private final MetricFetcher fetcher;
+
+	public JobDetailsHandler(ExecutionGraphHolder executionGraphHolder, MetricFetcher fetcher) {
 		super(executionGraphHolder);
+		this.fetcher = fetcher;
 	}
 
 	@Override
@@ -124,13 +127,6 @@ public class JobDetailsHandler extends AbstractExecutionGraphRequestHandler {
 			ExecutionState jobVertexState = 
 					ExecutionJobVertex.getAggregateJobVertexState(tasksPerState, ejv.getParallelism());
 			jobVerticesPerState[jobVertexState.ordinal()]++;
-			
-			Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> metrics = ejv.getAggregatedMetricAccumulators();
-
-			LongCounter readBytes = (LongCounter) metrics.get(AccumulatorRegistry.Metric.NUM_BYTES_IN);
-			LongCounter writeBytes = (LongCounter) metrics.get(AccumulatorRegistry.Metric.NUM_BYTES_OUT);
-			LongCounter readRecords = (LongCounter) metrics.get(AccumulatorRegistry.Metric.NUM_RECORDS_IN);
-			LongCounter writeRecords = (LongCounter) metrics.get(AccumulatorRegistry.Metric.NUM_RECORDS_OUT);
 
 			gen.writeStartObject();
 			gen.writeStringField("id", ejv.getJobVertexId().toString());
@@ -148,11 +144,36 @@ public class JobDetailsHandler extends AbstractExecutionGraphRequestHandler {
 			}
 			gen.writeEndObject();
 			
+			long numBytesIn = 0;
+			long numBytesOut = 0;
+			long numRecordsIn = 0;
+			long numRecordsOut = 0;
+
+			for (AccessExecutionVertex vertex : ejv.getTaskVertices()) {
+				IOMetrics ioMetrics = vertex.getCurrentExecutionAttempt().getIOMetrics();
+
+				if (ioMetrics != null) { // execAttempt is already finished, use final metrics stored in ExecutionGraph
+					numBytesIn += ioMetrics.getNumBytesInLocal() + ioMetrics.getNumBytesInRemote();
+					numBytesOut += ioMetrics.getNumBytesOut();
+					numRecordsIn += ioMetrics.getNumRecordsIn();
+					numRecordsOut += ioMetrics.getNumRecordsOut();
+				} else { // execAttempt is still running, use MetricQueryService instead
+					fetcher.update();
+					MetricStore.SubtaskMetricStore metrics = fetcher.getMetricStore().getSubtaskMetricStore(graph.getJobID().toString(), ejv.getJobVertexId().toString(), vertex.getParallelSubtaskIndex());
+					if (metrics != null) {
+						numBytesIn += Long.valueOf(metrics.getMetric("numBytesInLocal", "0")) + Long.valueOf(metrics.getMetric("numBytesInRemote", "0"));
+						numBytesOut += Long.valueOf(metrics.getMetric("numBytesOut", "0"));
+						numRecordsIn += Long.valueOf(metrics.getMetric("numRecordsIn", "0"));
+						numRecordsOut += Long.valueOf(metrics.getMetric("numRecordsOut", "0"));
+					}
+				}
+			}
+
 			gen.writeObjectFieldStart("metrics");
-			gen.writeNumberField("read-bytes", readBytes != null ? readBytes.getLocalValuePrimitive() : -1L);
-			gen.writeNumberField("write-bytes", writeBytes != null ? writeBytes.getLocalValuePrimitive() : -1L);
-			gen.writeNumberField("read-records", readRecords != null ? readRecords.getLocalValuePrimitive() : -1L);
-			gen.writeNumberField("write-records",writeRecords != null ? writeRecords.getLocalValuePrimitive() : -1L);
+			gen.writeNumberField("read-bytes", numBytesIn);
+			gen.writeNumberField("write-bytes", numBytesOut);
+			gen.writeNumberField("read-records", numRecordsIn);
+			gen.writeNumberField("write-records", numRecordsOut);
 			gen.writeEndObject();
 			
 			gen.writeEndObject();

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandler.java
@@ -20,14 +20,14 @@ package org.apache.flink.runtime.webmonitor.handlers;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 
-import org.apache.flink.api.common.accumulators.Accumulator;
-import org.apache.flink.api.common.accumulators.LongCounter;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
+import org.apache.flink.runtime.webmonitor.metrics.MetricStore;
 
 import java.io.StringWriter;
 import java.util.Map;
@@ -37,9 +37,12 @@ import java.util.Map;
  * and the runtime and metrics of all its subtasks.
  */
 public class JobVertexDetailsHandler extends AbstractJobVertexRequestHandler {
-	
-	public JobVertexDetailsHandler(ExecutionGraphHolder executionGraphHolder) {
+
+	private final MetricFetcher fetcher;
+
+	public JobVertexDetailsHandler(ExecutionGraphHolder executionGraphHolder, MetricFetcher fetcher) {
 		super(executionGraphHolder);
+		this.fetcher = fetcher;
 	}
 
 	@Override
@@ -71,25 +74,6 @@ public class JobVertexDetailsHandler extends AbstractJobVertexRequestHandler {
 			long endTime = status.isTerminal() ? vertex.getStateTimestamp(status) : -1;
 			long duration = startTime > 0 ? ((endTime > 0 ? endTime : now) - startTime) : -1;
 			
-			Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> metrics = vertex.getCurrentExecutionAttempt().getFlinkAccumulators();
-			LongCounter readBytes;
-			LongCounter writeBytes;
-			LongCounter readRecords;
-			LongCounter writeRecords;
-			
-			if (metrics != null) {
-				readBytes = (LongCounter) metrics.get(AccumulatorRegistry.Metric.NUM_BYTES_IN);
-				writeBytes = (LongCounter) metrics.get(AccumulatorRegistry.Metric.NUM_BYTES_OUT);
-				readRecords = (LongCounter) metrics.get(AccumulatorRegistry.Metric.NUM_RECORDS_IN);
-				writeRecords = (LongCounter) metrics.get(AccumulatorRegistry.Metric.NUM_RECORDS_OUT);
-			}
-			else {
-				readBytes = null;
-				writeBytes = null;
-				readRecords = null;
-				writeRecords = null;
-			}
-			
 			gen.writeStartObject();
 			gen.writeNumberField("subtask", num);
 			gen.writeStringField("status", status.name());
@@ -99,11 +83,34 @@ public class JobVertexDetailsHandler extends AbstractJobVertexRequestHandler {
 			gen.writeNumberField("end-time", endTime);
 			gen.writeNumberField("duration", duration);
 
+			IOMetrics ioMetrics = vertex.getCurrentExecutionAttempt().getIOMetrics();
+
+			long numBytesIn = 0;
+			long numBytesOut = 0;
+			long numRecordsIn = 0;
+			long numRecordsOut = 0;
+
+			if (ioMetrics != null) { // execAttempt is already finished, use final metrics stored in ExecutionGraph
+				numBytesIn = ioMetrics.getNumBytesInLocal() + ioMetrics.getNumBytesInRemote();
+				numBytesOut = ioMetrics.getNumBytesOut();
+				numRecordsIn = ioMetrics.getNumRecordsIn();
+				numRecordsOut = ioMetrics.getNumRecordsOut();
+			} else { // execAttempt is still running, use MetricQueryService instead
+				fetcher.update();
+				MetricStore.SubtaskMetricStore metrics = fetcher.getMetricStore().getSubtaskMetricStore(params.get("jobid"), jobVertex.getJobVertexId().toString(), vertex.getParallelSubtaskIndex());
+				if (metrics != null) {
+					numBytesIn += Long.valueOf(metrics.getMetric("numBytesInLocal", "0")) + Long.valueOf(metrics.getMetric("numBytesInRemote", "0"));
+					numBytesOut += Long.valueOf(metrics.getMetric("numBytesOut", "0"));
+					numRecordsIn += Long.valueOf(metrics.getMetric("numRecordsIn", "0"));
+					numRecordsOut += Long.valueOf(metrics.getMetric("numRecordsOut", "0"));
+				}
+			}
+
 			gen.writeObjectFieldStart("metrics");
-			gen.writeNumberField("read-bytes", readBytes != null ? readBytes.getLocalValuePrimitive() : -1L);
-			gen.writeNumberField("write-bytes", writeBytes != null ? writeBytes.getLocalValuePrimitive() : -1L);
-			gen.writeNumberField("read-records", readRecords != null ? readRecords.getLocalValuePrimitive() : -1L);
-			gen.writeNumberField("write-records",writeRecords != null ? writeRecords.getLocalValuePrimitive() : -1L);
+			gen.writeNumberField("read-bytes", numBytesIn);
+			gen.writeNumberField("write-bytes", numBytesOut);
+			gen.writeNumberField("read-records", numRecordsIn);
+			gen.writeNumberField("write-records", numRecordsOut);
 			gen.writeEndObject();
 			
 			gen.writeEndObject();

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskCurrentAttemptDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskCurrentAttemptDetailsHandler.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.webmonitor.handlers;
 
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
 
 import java.util.Map;
 
@@ -28,8 +29,8 @@ import java.util.Map;
  */
 public class SubtaskCurrentAttemptDetailsHandler extends SubtaskExecutionAttemptDetailsHandler {
 	
-	public SubtaskCurrentAttemptDetailsHandler(ExecutionGraphHolder executionGraphHolder) {
-		super(executionGraphHolder);
+	public SubtaskCurrentAttemptDetailsHandler(ExecutionGraphHolder executionGraphHolder, MetricFetcher fetcher) {
+		super(executionGraphHolder, fetcher);
 	}
 
 	@Override

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricStore.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricStore.java
@@ -23,7 +23,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static org.apache.flink.runtime.metrics.dump.MetricDump.METRIC_CATEGORY_COUNTER;
 import static org.apache.flink.runtime.metrics.dump.MetricDump.METRIC_CATEGORY_GAUGE;
@@ -76,6 +78,10 @@ public class MetricStore {
 					if (tm == null) {
 						tm = new TaskManagerMetricStore();
 						taskManagers.put(tmID, tm);
+					}
+					if (name.contains("GarbageCollector")) {
+						String gcName = name.substring("Status.JVM.GarbageCollector.".length(), name.lastIndexOf('.'));
+						tm.addGarbageCollectorName(gcName);
 					}
 					addMetric(tm.metrics, name, metric);
 					break;
@@ -260,6 +266,11 @@ public class MetricStore {
 	 * Sub-structure containing metrics of a single TaskManager.
 	 */
 	public static class TaskManagerMetricStore extends ComponentMetricStore {
+		public final Set<String> garbageCollectorNames = new HashSet<>();
+		
+		public void addGarbageCollectorName(String name) {
+			garbageCollectorNames.add(name);
+		}
 	}
 
 	/**

--- a/flink-runtime-web/web-dashboard/app/partials/taskmanager/taskmanager.metrics.jade
+++ b/flink-runtime-web/web-dashboard/app/partials/taskmanager/taskmanager.metrics.jade
@@ -50,19 +50,19 @@ div(ng-if="metrics.id")
     tbody
       tr
         td Heap
-        td {{metrics.metrics.gauges['memory.heap.committed'].value | humanizeBytes}}
-        td {{metrics.metrics.gauges['memory.heap.init'].value | humanizeBytes}}
-        td {{metrics.metrics.gauges['memory.heap.max'].value | humanizeBytes}}
+        td {{ metrics.metrics.heapCommitted | humanizeBytes  }}
+        td {{ metrics.metrics.heapUsed | humanizeBytes  }}
+        td {{ metrics.metrics.heapMax | humanizeBytes  }}
       tr
         td Non-Heap
-        td {{metrics.metrics.gauges['memory.non-heap.committed'].value | humanizeBytes}}
-        td {{metrics.metrics.gauges['memory.non-heap.init'].value | humanizeBytes}}
-        td {{metrics.metrics.gauges['memory.non-heap.max'].value | humanizeBytes}}
+        td {{ metrics.metrics.nonHeapCommitted | humanizeBytes  }}
+        td {{ metrics.metrics.nonHeapUsed | humanizeBytes  }}
+        td {{ metrics.metrics.nonHeapMax | humanizeBytes  }}
       tr
         td Total
-        td {{metrics.metrics.gauges['memory.total.committed'].value | humanizeBytes}}
-        td {{metrics.metrics.gauges['memory.total.init'].value | humanizeBytes}}
-        td {{metrics.metrics.gauges['memory.total.max'].value | humanizeBytes}}
+        td {{ metrics.metrics.totalCommitted | humanizeBytes  }}
+        td {{ metrics.metrics.totalUsed | humanizeBytes  }}
+        td {{ metrics.metrics.totalMax | humanizeBytes  }}
 
   h2 Outside JVM
   table.table.table-properties
@@ -75,14 +75,31 @@ div(ng-if="metrics.id")
     tbody
       tr
         td Direct
-        td {{ metrics.metrics.gauges['direct-memory.direct.count'].value }}
-        td {{ metrics.metrics.gauges['direct-memory.direct.used'].value | humanizeBytes }}
-        td {{ metrics.metrics.gauges['direct-memory.direct.capacity'].value | humanizeBytes }}
+        td {{ metrics.metrics.directCount }}
+        td {{ metrics.metrics.directUsed }}
+        td {{ metrics.metrics.directTotal }}
       tr
         td Mapped
-        td {{ metrics.metrics.gauges['direct-memory.mapped.count'].value }}
-        td {{ metrics.metrics.gauges['direct-memory.mapped.used'].value | humanizeBytes }}
-        td {{ metrics.metrics.gauges['direct-memory.mapped.capacity'].value | humanizeBytes }}
+        td {{ metrics.metrics.mappedCount }}
+        td {{ metrics.metrics.mappedUsed }}
+        td {{ metrics.metrics.mappedMax }}
+
+  h1 Network
+
+  h2 MemorySegments
+  table.table.table-properties
+    thead
+      tr
+        th Type
+        th Count
+    tbody
+      tr
+        td Available
+        td {{ metrics.metrics.memorySegmentsAvailable }}
+      tr
+        td Total
+        td {{ metrics.metrics.memorySegmentsTotal }}
+
 
   h1 Garbage Collection
   table.table.table-properties
@@ -91,38 +108,8 @@ div(ng-if="metrics.id")
         th Collector
         th Count
         th Time
-    tbody
-      tr
-        td PS-MarkSweep
-        td(table-property value="metrics.metrics.gauges['gc.PS-MarkSweep.count'].value")
-        td(table-property value="metrics.metrics.gauges['gc.PS-MarkSweep.time'].value | humanizeDuration")
-      tr
-        td PS-Scavenge
-        td(table-property value="metrics.metrics.gauges['gc.PS-Scavenge.count'].value")
-        td(table-property value="metrics.metrics.gauges['gc.PS-Scavenge.time'].value | humanizeDuration")
-
-  h1 Other Memory Pools
-  table.table.table-properties
-    thead
-      tr
-        th Pool
-        td Relative Usage
-    tbody
-      tr
-        td Code Cache
-        td(table-property value="metrics.metrics.gauges['memory.pools.Code-Cache.usage'].value | number:2")
-      tr
-        td Compressed Class Space
-        td(table-property value="metrics.metrics.gauges['memory.pools.Compressed-Class-Space.usage'].value | number:2")
-      tr
-        td Metaspace
-        td(table-property value="metrics.metrics.gauges['memory.pools.Metaspace.usage'].value | number:2")
-      tr
-        td PS Eden Space
-        td(table-property value="metrics.metrics.gauges['memory.pools.PS-Eden-Space.usage'].value | number:2")
-      tr
-        td PS Old Gen
-        td(table-property value="metrics.metrics.gauges['memory.pools.PS-Old-Gen.usage'].value | number:2")
-      tr
-        td PS Survivor Space
-        td(table-property value="metrics.metrics.gauges['memory.pools.PS-Survivor-Space.usage'].value | number:2")
+    tbody(ng-repeat="g in metrics.metrics.garbageCollectors")
+      tr  
+        td {{ g.name }}
+        td {{ g.count }}
+        td {{ g.time }}

--- a/flink-runtime-web/web-dashboard/web/partials/taskmanager/taskmanager.metrics.html
+++ b/flink-runtime-web/web-dashboard/web/partials/taskmanager/taskmanager.metrics.html
@@ -57,21 +57,21 @@ limitations under the License.
     <tbody>
       <tr>
         <td>Heap</td>
-        <td>{{metrics.metrics.gauges['memory.heap.committed'].value | humanizeBytes}}</td>
-        <td>{{metrics.metrics.gauges['memory.heap.init'].value | humanizeBytes}}</td>
-        <td>{{metrics.metrics.gauges['memory.heap.max'].value | humanizeBytes}}</td>
+        <td>{{ metrics.metrics.heapCommitted | humanizeBytes  }}</td>
+        <td>{{ metrics.metrics.heapUsed | humanizeBytes  }}</td>
+        <td>{{ metrics.metrics.heapMax | humanizeBytes  }}</td>
       </tr>
       <tr>
         <td>Non-Heap</td>
-        <td>{{metrics.metrics.gauges['memory.non-heap.committed'].value | humanizeBytes}}</td>
-        <td>{{metrics.metrics.gauges['memory.non-heap.init'].value | humanizeBytes}}</td>
-        <td>{{metrics.metrics.gauges['memory.non-heap.max'].value | humanizeBytes}}</td>
+        <td>{{ metrics.metrics.nonHeapCommitted | humanizeBytes  }}</td>
+        <td>{{ metrics.metrics.nonHeapUsed | humanizeBytes  }}</td>
+        <td>{{ metrics.metrics.nonHeapMax | humanizeBytes  }}</td>
       </tr>
       <tr>
         <td>Total</td>
-        <td>{{metrics.metrics.gauges['memory.total.committed'].value | humanizeBytes}}</td>
-        <td>{{metrics.metrics.gauges['memory.total.init'].value | humanizeBytes}}</td>
-        <td>{{metrics.metrics.gauges['memory.total.max'].value | humanizeBytes}}</td>
+        <td>{{ metrics.metrics.totalCommitted | humanizeBytes  }}</td>
+        <td>{{ metrics.metrics.totalUsed | humanizeBytes  }}</td>
+        <td>{{ metrics.metrics.totalMax | humanizeBytes  }}</td>
       </tr>
     </tbody>
   </table>
@@ -88,15 +88,35 @@ limitations under the License.
     <tbody>
       <tr>
         <td>Direct</td>
-        <td>{{ metrics.metrics.gauges['direct-memory.direct.count'].value }}</td>
-        <td>{{ metrics.metrics.gauges['direct-memory.direct.used'].value | humanizeBytes }}</td>
-        <td>{{ metrics.metrics.gauges['direct-memory.direct.capacity'].value | humanizeBytes }}</td>
+        <td>{{ metrics.metrics.directCount }}</td>
+        <td>{{ metrics.metrics.directUsed }}</td>
+        <td>{{ metrics.metrics.directTotal }}</td>
       </tr>
       <tr>
         <td>Mapped</td>
-        <td>{{ metrics.metrics.gauges['direct-memory.mapped.count'].value }}</td>
-        <td>{{ metrics.metrics.gauges['direct-memory.mapped.used'].value | humanizeBytes }}</td>
-        <td>{{ metrics.metrics.gauges['direct-memory.mapped.capacity'].value | humanizeBytes }}</td>
+        <td>{{ metrics.metrics.mappedCount }}</td>
+        <td>{{ metrics.metrics.mappedUsed }}</td>
+        <td>{{ metrics.metrics.mappedMax }}</td>
+      </tr>
+    </tbody>
+  </table>
+  <h1>Network</h1>
+  <h2>MemorySegments</h2>
+  <table class="table table-properties">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Count</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Available</td>
+        <td>{{ metrics.metrics.memorySegmentsAvailable }}</td>
+      </tr>
+      <tr>
+        <td>Total</td>
+        <td>{{ metrics.metrics.memorySegmentsTotal }}</td>
       </tr>
     </tbody>
   </table>
@@ -109,51 +129,11 @@ limitations under the License.
         <th>Time</th>
       </tr>
     </thead>
-    <tbody>
-      <tr>
-        <td>PS-MarkSweep</td>
-        <td table-property="table-property" value="metrics.metrics.gauges['gc.PS-MarkSweep.count'].value"></td>
-        <td table-property="table-property" value="metrics.metrics.gauges['gc.PS-MarkSweep.time'].value | humanizeDuration"></td>
-      </tr>
-      <tr>
-        <td>PS-Scavenge</td>
-        <td table-property="table-property" value="metrics.metrics.gauges['gc.PS-Scavenge.count'].value"></td>
-        <td table-property="table-property" value="metrics.metrics.gauges['gc.PS-Scavenge.time'].value | humanizeDuration"></td>
-      </tr>
-    </tbody>
-  </table>
-  <h1>Other Memory Pools</h1>
-  <table class="table table-properties">
-    <thead>
-      <tr>
-        <th>Pool</th>
-        <td>Relative Usage</td>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Code Cache</td>
-        <td table-property="table-property" value="metrics.metrics.gauges['memory.pools.Code-Cache.usage'].value | number:2"></td>
-      </tr>
-      <tr>
-        <td>Compressed Class Space</td>
-        <td table-property="table-property" value="metrics.metrics.gauges['memory.pools.Compressed-Class-Space.usage'].value | number:2"></td>
-      </tr>
-      <tr>
-        <td>Metaspace</td>
-        <td table-property="table-property" value="metrics.metrics.gauges['memory.pools.Metaspace.usage'].value | number:2"></td>
-      </tr>
-      <tr>
-        <td>PS Eden Space</td>
-        <td table-property="table-property" value="metrics.metrics.gauges['memory.pools.PS-Eden-Space.usage'].value | number:2"></td>
-      </tr>
-      <tr>
-        <td>PS Old Gen</td>
-        <td table-property="table-property" value="metrics.metrics.gauges['memory.pools.PS-Old-Gen.usage'].value | number:2"></td>
-      </tr>
-      <tr>
-        <td>PS Survivor Space</td>
-        <td table-property="table-property" value="metrics.metrics.gauges['memory.pools.PS-Survivor-Space.usage'].value | number:2"></td>
+    <tbody ng-repeat="g in metrics.metrics.garbageCollectors">
+      <tr> 
+        <td>{{ g.name }}</td>
+        <td>{{ g.count }}</td>
+        <td>{{ g.time }}</td>
       </tr>
     </tbody>
   </table>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -123,20 +123,15 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>io.dropwizard.metrics</groupId>
-			<artifactId>metrics-core</artifactId>
-			<version>${metrics.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.dropwizard.metrics</groupId>
-			<artifactId>metrics-jvm</artifactId>
-			<version>${metrics.version}</version>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>${jackson.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>io.dropwizard.metrics</groupId>
-			<artifactId>metrics-json</artifactId>
-			<version>${metrics.version}</version>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>${jackson.version}</version>
 		</dependency>
 
 		<dependency>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/accumulators/AccumulatorRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/accumulators/AccumulatorRegistry.java
@@ -20,18 +20,16 @@ package org.apache.flink.runtime.accumulators;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.accumulators.Accumulator;
-import org.apache.flink.api.common.accumulators.LongCounter;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 
 /**
- * Main accumulator registry which encapsulates internal and user-defined accumulators.
+ * Main accumulator registry which encapsulates user-defined accumulators.
  */
 public class AccumulatorRegistry {
 
@@ -40,32 +38,13 @@ public class AccumulatorRegistry {
 	protected final JobID jobID;
 	protected final ExecutionAttemptID taskID;
 
-	/* Flink's internal Accumulator values stored for the executing task. */
-	private final Map<Metric, Accumulator<?, ?>> flinkAccumulators =
-			new HashMap<Metric, Accumulator<?, ?>>();
-
 	/* User-defined Accumulator values stored for the executing task. */
 	private final Map<String, Accumulator<?, ?>> userAccumulators =
 			new ConcurrentHashMap<>(4);
 
-	/* The reporter reference that is handed to the reporting tasks. */
-	private final ReadWriteReporter reporter;
-
-	/**
-	 * Flink metrics supported
-	 */
-	public enum Metric {
-		NUM_RECORDS_IN,
-		NUM_RECORDS_OUT,
-		NUM_BYTES_IN,
-		NUM_BYTES_OUT
-	}
-
-
 	public AccumulatorRegistry(JobID jobID, ExecutionAttemptID taskID) {
 		this.jobID = jobID;
 		this.taskID = taskID;
-		this.reporter = new ReadWriteReporter(flinkAccumulators);
 	}
 
 	/**
@@ -74,7 +53,7 @@ public class AccumulatorRegistry {
 	 */
 	public AccumulatorSnapshot getSnapshot() {
 		try {
-			return new AccumulatorSnapshot(jobID, taskID, flinkAccumulators, userAccumulators);
+			return new AccumulatorSnapshot(jobID, taskID, userAccumulators);
 		} catch (Throwable e) {
 			LOG.warn("Failed to serialize accumulators for task.", e);
 			return null;
@@ -86,61 +65,6 @@ public class AccumulatorRegistry {
 	 */
 	public Map<String, Accumulator<?, ?>> getUserMap() {
 		return userAccumulators;
-	}
-
-	/**
-	 * Gets the reporter for flink internal metrics.
-	 */
-	public Reporter getReadWriteReporter() {
-		return reporter;
-	}
-
-	/**
-	 * Interface for Flink's internal accumulators.
-	 */
-	public interface Reporter {
-		void reportNumRecordsIn(long value);
-		void reportNumRecordsOut(long value);
-		void reportNumBytesIn(long value);
-		void reportNumBytesOut(long value);
-	}
-
-	/**
-	 * Accumulator based reporter for keeping track of internal metrics (e.g. bytes and records in/out)
-	 */
-	private static class ReadWriteReporter implements Reporter {
-
-		private LongCounter numRecordsIn = new LongCounter();
-		private LongCounter numRecordsOut = new LongCounter();
-		private LongCounter numBytesIn = new LongCounter();
-		private LongCounter numBytesOut = new LongCounter();
-
-		private ReadWriteReporter(Map<Metric, Accumulator<?,?>> accumulatorMap) {
-			accumulatorMap.put(Metric.NUM_RECORDS_IN, numRecordsIn);
-			accumulatorMap.put(Metric.NUM_RECORDS_OUT, numRecordsOut);
-			accumulatorMap.put(Metric.NUM_BYTES_IN, numBytesIn);
-			accumulatorMap.put(Metric.NUM_BYTES_OUT, numBytesOut);
-		}
-
-		@Override
-		public void reportNumRecordsIn(long value) {
-			numRecordsIn.add(value);
-		}
-
-		@Override
-		public void reportNumRecordsOut(long value) {
-			numRecordsOut.add(value);
-		}
-
-		@Override
-		public void reportNumBytesIn(long value) {
-			numBytesIn.add(value);
-		}
-
-		@Override
-		public void reportNumBytesOut(long value) {
-			numBytesOut.add(value);
-		}
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/accumulators/AccumulatorSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/accumulators/AccumulatorSnapshot.java
@@ -40,21 +40,14 @@ public class AccumulatorSnapshot implements Serializable {
 	private final ExecutionAttemptID executionAttemptID;
 
 	/**
-	 * Flink internal accumulators which can be deserialized using the system class loader.
-	 */
-	private final SerializedValue<Map<AccumulatorRegistry.Metric, Accumulator<?, ?>>> flinkAccumulators;
-
-	/**
 	 * Serialized user accumulators which may require the custom user class loader.
 	 */
 	private final SerializedValue<Map<String, Accumulator<?, ?>>> userAccumulators;
 
 	public AccumulatorSnapshot(JobID jobID, ExecutionAttemptID executionAttemptID,
-							Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> flinkAccumulators,
 							Map<String, Accumulator<?, ?>> userAccumulators) throws IOException {
 		this.jobID = jobID;
 		this.executionAttemptID = executionAttemptID;
-		this.flinkAccumulators = new SerializedValue<Map<AccumulatorRegistry.Metric, Accumulator<?, ?>>>(flinkAccumulators);
 		this.userAccumulators = new SerializedValue<Map<String, Accumulator<?, ?>>>(userAccumulators);
 	}
 
@@ -64,14 +57,6 @@ public class AccumulatorSnapshot implements Serializable {
 
 	public ExecutionAttemptID getExecutionAttemptID() {
 		return executionAttemptID;
-	}
-
-	/**
-	 * Gets the Flink (internal) accumulators values.
-	 * @return the serialized map
-	 */
-	public Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> deserializeFlinkAccumulators() throws IOException, ClassNotFoundException {
-		return flinkAccumulators.deserializeValue(getClass().getClassLoader());
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecution.java
@@ -17,13 +17,9 @@
  */
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.api.common.accumulators.Accumulator;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
-
-import java.util.Map;
 
 /**
  * Common interface for the runtime {@link Execution and {@link ArchivedExecution}.
@@ -88,18 +84,11 @@ public interface AccessExecution {
 	StringifiedAccumulatorResult[] getUserAccumulatorsStringified();
 
 	/**
-	 * Returns the system-defined accumulators.
-	 *
-	 * @return system-defined accumulators.
-	 * @deprecated Will be removed in FLINK-4527
-	 */
-	@Deprecated
-	Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> getFlinkAccumulators();
-
-	/**
 	 * Returns the subtask index of this execution.
 	 *
 	 * @return subtask index of this execution.
 	 */
 	int getParallelSubtaskIndex();
+
+	IOMetrics getIOMetrics();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
@@ -18,8 +18,6 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.accumulators.Accumulator;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.checkpoint.stats.CheckpointStatsTracker;
@@ -151,15 +149,6 @@ public interface AccessExecutionGraph {
 	 * @throws IOException indicates that the serialization has failed
 	 */
 	Map<String, SerializedValue<Object>> getAccumulatorsSerialized() throws IOException;
-
-	/**
-	 * Returns the aggregated system-defined accumulators.
-	 *
-	 * @return aggregated system-defined accumulators.
-	 * @deprecated Will be removed in FLINK-4527
-	 */
-	@Deprecated
-	Map<ExecutionAttemptID, Map<AccumulatorRegistry.Metric, Accumulator<?, ?>>> getFlinkAccumulators();
 
 	/**
 	 * Returns whether this execution graph was archived.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionJobVertex.java
@@ -17,15 +17,11 @@
  */
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.api.common.accumulators.Accumulator;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.checkpoint.stats.OperatorCheckpointStats;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import scala.Option;
-
-import java.util.Map;
 
 /**
  * Common interface for the runtime {@link ExecutionJobVertex} and {@link ArchivedExecutionJobVertex}.
@@ -79,15 +75,6 @@ public interface AccessExecutionJobVertex {
 	 * @return checkpoint stats for this job vertex.
 	 */
 	Option<OperatorCheckpointStats> getCheckpointStats();
-
-	/**
-	 * Returns the aggregated system-defined accumulators.
-	 *
-	 * @return aggregated system-defined accumulators.
-	 * @deprecated Will be removed in FLINK-4527
-	 */
-	@Deprecated
-	Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> getAggregatedMetricAccumulators();
 
 	/**
 	 * Returns the aggregated user-defined accumulators as strings.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecution.java
@@ -17,15 +17,12 @@
  */
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.api.common.accumulators.Accumulator;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.ExceptionUtils;
 
 import java.io.Serializable;
-import java.util.Map;
 
 public class ArchivedExecution implements AccessExecution, Serializable {
 	private static final long serialVersionUID = 4817108757483345173L;
@@ -46,13 +43,12 @@ public class ArchivedExecution implements AccessExecution, Serializable {
 	/* Continuously updated map of user-defined accumulators */
 	private final StringifiedAccumulatorResult[] userAccumulators;
 
-	/* Continuously updated map of internal accumulators */
-	private final Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> flinkAccumulators;
 	private final int parallelSubtaskIndex;
+
+	private final IOMetrics ioMetrics;
 
 	public ArchivedExecution(Execution execution) {
 		this.userAccumulators = execution.getUserAccumulatorsStringified();
-		this.flinkAccumulators = execution.getFlinkAccumulators();
 		this.attemptId = execution.getAttemptId();
 		this.attemptNumber = execution.getAttemptNumber();
 		this.stateTimestamps = execution.getStateTimestamps();
@@ -60,6 +56,7 @@ public class ArchivedExecution implements AccessExecution, Serializable {
 		this.state = execution.getState();
 		this.failureCause = ExceptionUtils.stringifyException(execution.getFailureCause());
 		this.assignedResourceLocation = execution.getAssignedResourceLocation();
+		this.ioMetrics = execution.getIOMetrics();
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -106,13 +103,14 @@ public class ArchivedExecution implements AccessExecution, Serializable {
 		return userAccumulators;
 	}
 
-	@Override
-	public Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> getFlinkAccumulators() {
-		return flinkAccumulators;
-	}
 
 	@Override
 	public int getParallelSubtaskIndex() {
 		return parallelSubtaskIndex;
+	}
+
+	@Override
+	public IOMetrics getIOMetrics() {
+		return ioMetrics;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
@@ -19,8 +19,6 @@ package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.ArchivedExecutionConfig;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.accumulators.Accumulator;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.checkpoint.ArchivedCheckpointStatsTracker;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
@@ -31,7 +29,6 @@ import org.apache.flink.util.SerializedValue;
 
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -206,24 +203,6 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
 	@Override
 	public CheckpointStatsTracker getCheckpointStatsTracker() {
 		return tracker;
-	}
-
-	/**
-	 * Gets the internal flink accumulator map of maps which contains some metrics.
-	 *
-	 * @return A map of accumulators for every executed task.
-	 */
-	@Override
-	public Map<ExecutionAttemptID, Map<AccumulatorRegistry.Metric, Accumulator<?, ?>>> getFlinkAccumulators() {
-		Map<ExecutionAttemptID, Map<AccumulatorRegistry.Metric, Accumulator<?, ?>>> flinkAccumulators =
-			new HashMap<>();
-
-		for (AccessExecutionVertex vertex : getAllExecutionVertices()) {
-			Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> taskAccs = vertex.getCurrentExecutionAttempt().getFlinkAccumulators();
-			flinkAccumulators.put(vertex.getCurrentExecutionAttempt().getAttemptId(), taskAccs);
-		}
-
-		return flinkAccumulators;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionJobVertex.java
@@ -19,7 +19,6 @@ package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.AccumulatorHelper;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.checkpoint.stats.CheckpointStatsTracker;
 import org.apache.flink.runtime.checkpoint.stats.OperatorCheckpointStats;
@@ -46,7 +45,6 @@ public class ArchivedExecutionJobVertex implements AccessExecutionJobVertex, Ser
 
 	private final int maxParallelism;
 
-	private final Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> aggregatedMetricAccumulators;
 	private final Option<OperatorCheckpointStats> checkpointStats;
 	private final StringifiedAccumulatorResult[] archivedUserAccumulators;
 
@@ -55,8 +53,6 @@ public class ArchivedExecutionJobVertex implements AccessExecutionJobVertex, Ser
 		for (int x = 0; x < taskVertices.length; x++) {
 			taskVertices[x] = jobVertex.getTaskVertices()[x].archive();
 		}
-
-		aggregatedMetricAccumulators = jobVertex.getAggregatedMetricAccumulators();
 
 		Map<String, Accumulator<?, ?>> tmpArchivedUserAccumulators = new HashMap<>();
 		for (ExecutionVertex vertex : jobVertex.getTaskVertices()) {
@@ -114,10 +110,6 @@ public class ArchivedExecutionJobVertex implements AccessExecutionJobVertex, Ser
 		}
 
 		return getAggregateJobVertexState(num, parallelism);
-	}
-
-	public Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> getAggregatedMetricAccumulators() {
-		return this.aggregatedMetricAccumulators;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -20,13 +20,11 @@ package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.AccumulatorHelper;
-import org.apache.flink.api.common.accumulators.LongCounter;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.core.io.InputSplitSource;
 import org.apache.flink.core.io.LocatableInputSplit;
 import org.apache.flink.runtime.JobException;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.checkpoint.stats.CheckpointStatsTracker;
 import org.apache.flink.runtime.checkpoint.stats.OperatorCheckpointStats;
@@ -443,37 +441,6 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 	// --------------------------------------------------------------------------------------------
 	//  Accumulators / Metrics
 	// --------------------------------------------------------------------------------------------
-	
-	public Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> getAggregatedMetricAccumulators() {
-		// some specialized code to speed things up
-		long bytesRead = 0;
-		long bytesWritten = 0;
-		long recordsRead = 0;
-		long recordsWritten = 0;
-		
-		for (ExecutionVertex v : getTaskVertices()) {
-			Map<AccumulatorRegistry.Metric, Accumulator<?, ?>> metrics = v.getCurrentExecutionAttempt().getFlinkAccumulators();
-			
-			if (metrics != null) {
-				LongCounter br = (LongCounter) metrics.get(AccumulatorRegistry.Metric.NUM_BYTES_IN);
-				LongCounter bw = (LongCounter) metrics.get(AccumulatorRegistry.Metric.NUM_BYTES_OUT);
-				LongCounter rr = (LongCounter) metrics.get(AccumulatorRegistry.Metric.NUM_RECORDS_IN);
-				LongCounter rw = (LongCounter) metrics.get(AccumulatorRegistry.Metric.NUM_RECORDS_OUT);
-				
-				bytesRead += br != null ? br.getLocalValuePrimitive() : 0;
-				bytesWritten += bw != null ? bw.getLocalValuePrimitive() : 0;
-				recordsRead += rr != null ? rr.getLocalValuePrimitive() : 0;
-				recordsWritten += rw != null ? rw.getLocalValuePrimitive() : 0;
-			}
-		}
-
-		HashMap<AccumulatorRegistry.Metric, Accumulator<?, ?>> agg = new HashMap<>();
-		agg.put(AccumulatorRegistry.Metric.NUM_BYTES_IN, new LongCounter(bytesRead));
-		agg.put(AccumulatorRegistry.Metric.NUM_BYTES_OUT, new LongCounter(bytesWritten));
-		agg.put(AccumulatorRegistry.Metric.NUM_RECORDS_IN, new LongCounter(recordsRead));
-		agg.put(AccumulatorRegistry.Metric.NUM_RECORDS_OUT, new LongCounter(recordsWritten));
-		return agg;
-	}
 
 	public StringifiedAccumulatorResult[] getAggregatedUserAccumulatorsStringified() {
 		Map<String, Accumulator<?, ?>> userAccumulators = new HashMap<String, Accumulator<?, ?>>();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IOMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IOMetrics.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.metrics.Meter;
+
+import java.io.Serializable;
+
+/**
+ * An instance of this class represents a snapshot of the io-related metrics of a single task.
+ */
+public class IOMetrics implements Serializable {
+	private static final long serialVersionUID = -7208093607556457183L;
+	private final long numRecordsIn;
+	private final long numRecordsOut;
+
+	private final double numRecordsInPerSecond;
+	private final double numRecordsOutPerSecond;
+
+	private final long numBytesInLocal;
+	private final long numBytesInRemote;
+	private final long numBytesOut;
+
+	private final double numBytesInLocalPerSecond;
+	private final double numBytesInRemotePerSecond;
+	private final double numBytesOutPerSecond;
+
+	public IOMetrics(Meter recordsIn, Meter recordsOut, Meter bytesLocalIn, Meter bytesRemoteIn, Meter bytesOut) {
+		this.numRecordsIn = recordsIn.getCount();
+		this.numRecordsInPerSecond = recordsIn.getRate();
+		this.numRecordsOut = recordsOut.getCount();
+		this.numRecordsOutPerSecond = recordsOut.getRate();
+		this.numBytesInLocal = bytesLocalIn.getCount();
+		this.numBytesInLocalPerSecond = bytesLocalIn.getRate();
+		this.numBytesInRemote = bytesRemoteIn.getCount();
+		this.numBytesInRemotePerSecond = bytesRemoteIn.getRate();
+		this.numBytesOut = bytesOut.getCount();
+		this.numBytesOutPerSecond = bytesOut.getRate();
+	}
+
+	public long getNumRecordsIn() {
+		return numRecordsIn;
+	}
+
+	public long getNumRecordsOut() {
+		return numRecordsOut;
+	}
+
+	public long getNumBytesInLocal() {
+		return numBytesInLocal;
+	}
+
+	public long getNumBytesInRemote() {
+		return numBytesInRemote;
+	}
+
+	public long getNumBytesInTotal() {
+		return numBytesInLocal + numBytesInRemote;
+	}
+
+	public long getNumBytesOut() {
+		return numBytesOut;
+	}
+
+	public double getNumRecordsInPerSecond() {
+		return numRecordsInPerSecond;
+	}
+
+	public double getNumRecordsOutPerSecond() {
+		return numRecordsOutPerSecond;
+	}
+
+	public double getNumBytesInLocalPerSecond() {
+		return numBytesInLocalPerSecond;
+	}
+
+	public double getNumBytesInRemotePerSecond() {
+		return numBytesInRemotePerSecond;
+	}
+
+	public double getNumBytesOutPerSecond() {
+		return numBytesOutPerSecond;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Instance.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Instance.java
@@ -75,8 +75,6 @@ public class Instance implements SlotOwner {
 	/** Time when last heat beat has been received from the task manager running on this taskManager. */
 	private volatile long lastReceivedHeartBeat = System.currentTimeMillis();
 
-	private byte[] lastMetricsReport;
-
 	/** Flag marking the instance as alive or as dead. */
 	private volatile boolean isDead;
 
@@ -187,14 +185,6 @@ public class Instance implements SlotOwner {
 	 */
 	public void reportHeartBeat() {
 		this.lastReceivedHeartBeat = System.currentTimeMillis();
-	}
-
-	public void setMetricsReport(byte[] lastMetricsReport) {
-		this.lastMetricsReport = lastMetricsReport;
-	}
-
-	public byte[] getLastMetricsReport() {
-		return lastMetricsReport;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceManager.java
@@ -96,7 +96,7 @@ public class InstanceManager {
 		}
 	}
 
-	public boolean reportHeartBeat(InstanceID instanceId, byte[] lastMetricsReport) {
+	public boolean reportHeartBeat(InstanceID instanceId) {
 		if (instanceId == null) {
 			throw new IllegalArgumentException("InstanceID may not be null.");
 		}
@@ -118,7 +118,6 @@ public class InstanceManager {
 			}
 
 			host.reportHeartBeat();
-			host.setMetricsReport(lastMetricsReport);
 
 			if (LOG.isDebugEnabled()) {
 				LOG.debug("Received heartbeat from TaskManager " + host);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractRecordReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractRecordReader.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.io.network.api.reader;
 
 import org.apache.flink.core.io.IOReadableWritable;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer;
 import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer.DeserializationResult;
 import org.apache.flink.runtime.io.network.api.serialization.SpillingAdaptiveSpanningRecordDeserializer;
@@ -121,13 +120,6 @@ abstract class AbstractRecordReader<T extends IOReadableWritable> extends Abstra
 			if (buffer != null && !buffer.isRecycled()) {
 				buffer.recycle();
 			}
-		}
-	}
-
-	@Override
-	public void setReporter(AccumulatorRegistry.Reporter reporter) {
-		for (RecordDeserializer<?> deserializer : recordDeserializers) {
-			deserializer.setReporter(reporter);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/BufferReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/BufferReader.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.io.network.api.reader;
 
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
@@ -47,10 +46,5 @@ public final class BufferReader extends AbstractReader {
 				}
 			}
 		}
-	}
-
-	@Override
-	public void setReporter(AccumulatorRegistry.Reporter reporter) {
-
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/ReaderBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/ReaderBase.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.io.network.api.reader;
 
 import java.io.IOException;
 
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.util.event.EventListener;
 
@@ -51,10 +50,5 @@ public interface ReaderBase {
 	void startNextSuperstep();
 
 	boolean hasReachedEndOfSuperstep();
-
-	/**
-	 * Setter for the reporter, e.g. for the number of records emitted and the number of bytes read.
-	 */
-	void setReporter(AccumulatorRegistry.Reporter reporter);
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/AdaptiveSpanningRecordDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/AdaptiveSpanningRecordDeserializer.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.io.network.api.serialization;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.util.DataInputDeserializer;
 import org.apache.flink.runtime.util.DataOutputSerializer;
@@ -45,8 +44,6 @@ public class AdaptiveSpanningRecordDeserializer<T extends IOReadableWritable> im
 	private final SpanningWrapper spanningWrapper;
 
 	private Buffer currentBuffer;
-
-	private AccumulatorRegistry.Reporter reporter;
 
 	public AdaptiveSpanningRecordDeserializer() {
 		this.nonSpanningWrapper = new NonSpanningWrapper();
@@ -93,17 +90,9 @@ public class AdaptiveSpanningRecordDeserializer<T extends IOReadableWritable> im
 		if (nonSpanningRemaining >= 4) {
 			int len = this.nonSpanningWrapper.readInt();
 
-			if (reporter != null) {
-				reporter.reportNumBytesIn(len);
-			}
-
 			if (len <= nonSpanningRemaining - 4) {
 				// we can get a full record from here
 				target.read(this.nonSpanningWrapper);
-
-				if (reporter != null) {
-					reporter.reportNumRecordsIn(1);
-				}
 
 				return (this.nonSpanningWrapper.remaining() == 0) ?
 						DeserializationResult.LAST_RECORD_FROM_BUFFER :
@@ -127,10 +116,6 @@ public class AdaptiveSpanningRecordDeserializer<T extends IOReadableWritable> im
 		if (this.spanningWrapper.hasFullRecord()) {
 			// get the full record
 			target.read(this.spanningWrapper);
-
-			if (reporter != null) {
-				reporter.reportNumRecordsIn(1);
-			}
 
 			// move the remainder to the non-spanning wrapper
 			// this does not copy it, only sets the memory segment
@@ -157,12 +142,6 @@ public class AdaptiveSpanningRecordDeserializer<T extends IOReadableWritable> im
 	@Override
 	public boolean hasUnfinishedData() {
 		return this.nonSpanningWrapper.remaining() > 0 || this.spanningWrapper.getNumGatheredBytes() > 0;
-	}
-
-	@Override
-	public void setReporter(AccumulatorRegistry.Reporter reporter) {
-		this.reporter = reporter;
-		this.spanningWrapper.setReporter(reporter);
 	}
 
 	// -----------------------------------------------------------------------------------------------------------------
@@ -447,8 +426,6 @@ public class AdaptiveSpanningRecordDeserializer<T extends IOReadableWritable> im
 
 		private int recordLimit;
 
-		private AccumulatorRegistry.Reporter reporter;
-
 		public SpanningWrapper() {
 			this.lengthBuffer = ByteBuffer.allocate(4);
 			this.lengthBuffer.order(ByteOrder.BIG_ENDIAN);
@@ -485,10 +462,6 @@ public class AdaptiveSpanningRecordDeserializer<T extends IOReadableWritable> im
 					return;
 				} else {
 					this.recordLength = this.lengthBuffer.getInt(0);
-
-					if (reporter != null) {
-						reporter.reportNumBytesIn(this.recordLength);
-					}
 
 					this.lengthBuffer.clear();
 					segmentPosition = toPut;
@@ -633,10 +606,6 @@ public class AdaptiveSpanningRecordDeserializer<T extends IOReadableWritable> im
 		@Override
 		public int read(byte[] b) throws IOException {
 			return this.serializationReadBuffer.read(b);
-		}
-
-		public void setReporter(AccumulatorRegistry.Reporter reporter) {
-			this.reporter = reporter;
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/RecordDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/RecordDeserializer.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 
 /**
@@ -65,9 +64,4 @@ public interface RecordDeserializer<T extends IOReadableWritable> {
 	void clear();
 	
 	boolean hasUnfinishedData();
-
-	/**
-	 * Setter for the reporter, e.g. for the number of records emitted and the number of bytes read.
-	 */
-	void setReporter(AccumulatorRegistry.Reporter reporter);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/RecordSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/RecordSerializer.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 
 /**
@@ -65,11 +64,6 @@ public interface RecordSerializer<T extends IOReadableWritable> {
 	void clear();
 	
 	boolean hasData();
-
-	/**
-	 * Setter for the reporter, e.g. for the number of records emitted and the number of bytes read.
-	 */
-	void setReporter(AccumulatorRegistry.Reporter reporter);
 
 	/**
 	 * Insantiates all metrics.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
@@ -26,7 +26,6 @@ import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.util.DataOutputSerializer;
 
@@ -52,8 +51,6 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 
 	/** Limit of current {@link MemorySegment} of target buffer */
 	private int limit;
-
-	private AccumulatorRegistry.Reporter reporter;
 
 	private transient Counter numBytesOut;
 
@@ -84,11 +81,6 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 
 		int len = this.serializationBuffer.length();
 		this.lengthBuffer.putInt(0, len);
-
-		if (reporter != null) {
-			reporter.reportNumBytesOut(len);
-			reporter.reportNumRecordsOut(1);
-		}
 		
 		if (numBytesOut != null) {
 			numBytesOut.inc(len);
@@ -189,11 +181,6 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 	public boolean hasData() {
 		// either data in current target buffer or intermediate buffers
 		return this.position > 0 || (this.lengthBuffer.hasRemaining() || this.dataBuffer.hasRemaining());
-	}
-
-	@Override
-	public void setReporter(AccumulatorRegistry.Reporter reporter) {
-		this.reporter = reporter;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.io.network.api.writer;
 
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.serialization.RecordSerializer;
 import org.apache.flink.runtime.io.network.api.serialization.SpanningRecordSerializer;
@@ -197,15 +196,6 @@ public class RecordWriter<T extends IOReadableWritable> {
 					serializer.clear();
 				}
 			}
-		}
-	}
-
-	/**
-	 * Counter for the number of records emitted and the records processed.
-	 */
-	public void setReporter(AccumulatorRegistry.Reporter reporter) {
-		for(RecordSerializer<?> serializer : serializers) {
-			serializer.setReporter(reporter);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationHeadTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationHeadTask.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.operators.Driver;
@@ -114,9 +113,8 @@ public class IterationHeadTask<X, Y, S extends Function, OT> extends AbstractIte
 		List<RecordWriter<?>> finalOutputWriters = new ArrayList<RecordWriter<?>>();
 		final TaskConfig finalOutConfig = this.config.getIterationHeadFinalOutputConfig();
 		final ClassLoader userCodeClassLoader = getUserCodeClassLoader();
-		AccumulatorRegistry.Reporter reporter = getEnvironment().getAccumulatorRegistry().getReadWriteReporter();
 		this.finalOutputCollector = BatchTask.getOutputCollector(this, finalOutConfig,
-				userCodeClassLoader, finalOutputWriters, config.getNumOutputs(), finalOutConfig.getNumOutputs(), reporter);
+				userCodeClassLoader, finalOutputWriters, config.getNumOutputs(), finalOutConfig.getNumOutputs());
 
 		// sanity check the setup
 		final int writersIntoStepFunction = this.eventualOutputs.size();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorIOMetricGroup.java
@@ -56,4 +56,21 @@ public class OperatorIOMetricGroup extends ProxyMetricGroup<OperatorMetricGroup>
 	public Meter getNumRecordsOutRate() {
 		return numRecordsOutRate;
 	}
+
+	/**
+	 * Causes the containing task to use this operators input record counter.
+	 */
+	public void reuseInputMetricsForTask() {
+		TaskIOMetricGroup taskIO = parentMetricGroup.parent().getIOMetricGroup();
+		taskIO.reuseRecordsInputCounter(this.numRecordsIn);
+		
+	}
+
+	/**
+	 * Causes the containing task to use this operators output record counter.
+	 */
+	public void reuseOutputMetricsForTask() {
+		TaskIOMetricGroup taskIO = parentMetricGroup.parent().getIOMetricGroup();
+		taskIO.reuseRecordsOutputCounter(this.numRecordsOut);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -23,9 +23,14 @@ import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MeterView;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.taskmanager.Task;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Metric group that contains shareable pre-defined IO-related metrics. The metrics registration is
@@ -36,10 +41,14 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 	private final Counter numBytesOut;
 	private final Counter numBytesInLocal;
 	private final Counter numBytesInRemote;
+	private final SumCounter numRecordsIn;
+	private final SumCounter numRecordsOut;
 
 	private final Meter numBytesInRateLocal;
 	private final Meter numBytesInRateRemote;
 	private final Meter numBytesOutRate;
+	private final Meter numRecordsInRate;
+	private final Meter numRecordsOutRate;
 
 	private final MetricGroup buffers;
 
@@ -52,10 +61,21 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 		this.numBytesOutRate = meter("numBytesOutPerSecond", new MeterView(numBytesOut, 60));
 		this.numBytesInRateLocal = meter("numBytesInLocalPerSecond", new MeterView(numBytesInLocal, 60));
 		this.numBytesInRateRemote = meter("numBytesInRemotePerSecond", new MeterView(numBytesInRemote, 60));
+		this.numRecordsIn = counter("numRecordsIn", new SumCounter());
+		this.numRecordsOut = counter("numRecordsOut", new SumCounter());
+		this.numRecordsInRate = meter("numRecordsInPerSecond", new MeterView(numRecordsIn, 60));
+		this.numRecordsOutRate = meter("numRecordsOutPerSecond", new MeterView(numRecordsOut, 60));
 
 		this.buffers = addGroup("buffers");
 	}
 
+	public IOMetrics createSnapshot() {
+		return new IOMetrics(numRecordsInRate, numRecordsOutRate, numBytesInRateLocal, numBytesInRateRemote, numBytesOutRate);
+	}
+
+	// ============================================================================================
+	// Getters
+	// ============================================================================================
 	public Counter getNumBytesOutCounter() {
 		return numBytesOut;
 	}
@@ -68,11 +88,19 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 		return numBytesInRemote;
 	}
 
-	public Meter getNumBytesInRateLocalMeter() {
+	public Counter getNumRecordsInCounter() {
+		return numRecordsIn;
+	}
+
+	public Counter getNumRecordsOutCounter() {
+		return numRecordsOut;
+	}
+
+	public Meter getNumBytesInLocalRateMeter() {
 		return numBytesInRateLocal;
 	}
 
-	public Meter getNumBytesInRateRemoteMeter() {
+	public Meter getNumBytesInRemoteRateMeter() {
 		return numBytesInRateRemote;
 	}
 
@@ -131,6 +159,41 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 			}
 
 			return totalBuffers;
+		}
+	}
+
+	// ============================================================================================
+	// Metric Reuse
+	// ============================================================================================
+	public void reuseRecordsInputCounter(Counter numRecordsInCounter) {
+		this.numRecordsIn.addCounter(numRecordsInCounter);
+	}
+
+	public void reuseRecordsOutputCounter(Counter numRecordsOutCounter) {
+		this.numRecordsOut.addCounter(numRecordsOutCounter);
+	}
+
+	/**
+	 * A {@link SimpleCounter} that can contain other {@link Counter}s. A call to {@link SumCounter#getCount()} returns
+	 * the sum of this counters and all contained counters.
+	 */
+	private static class SumCounter extends SimpleCounter {
+		private final List<Counter> internalCounters = new ArrayList<>();
+
+		SumCounter() {
+		}
+
+		public void addCounter(Counter toAdd) {
+			internalCounters.add(toAdd);
+		}
+
+		@Override
+		public long getCount() {
+			long sum = super.getCount();
+			for (Counter counter : internalCounters) {
+				sum += counter.getCount();
+			}
+			return sum;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
@@ -243,6 +243,10 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 		String headName =  getEnvironment().getTaskInfo().getTaskName().split("->")[0].trim();
 		this.metrics = getEnvironment().getMetricGroup()
 			.addOperator(headName.startsWith("CHAIN") ? headName.substring(6) : headName);
+		this.metrics.getIOMetricGroup().reuseInputMetricsForTask();
+		if (config.getNumberOfChainedStubs() == 0) {
+			this.metrics.getIOMetricGroup().reuseOutputMetricsForTask();
+		}
 
 		// initialize the readers.
 		// this does not yet trigger any stream consuming or processing.
@@ -1305,6 +1309,10 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 
 				ct.setup(chainedStubConf, taskName, previous, containingTask, cl, executionConfig, accumulatorMap);
 				chainedTasksTarget.add(0, ct);
+
+				if (i == numChained - 1) {
+					ct.getIOMetrics().reuseOutputMetricsForTask();
+				}
 
 				previous = ct;
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
@@ -29,7 +29,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.reader.MutableReader;
@@ -354,11 +353,6 @@ public class DataSinkTask<IT> extends AbstractInvokable {
 		} else {
 			throw new Exception("Illegal input group size in task configuration: " + groupSize);
 		}
-
-		final AccumulatorRegistry accumulatorRegistry = getEnvironment().getAccumulatorRegistry();
-		final AccumulatorRegistry.Reporter reporter = accumulatorRegistry.getReadWriteReporter();
-
-		inputReader.setReporter(reporter);
 		
 		this.inputTypeSerializerFactory = this.config.getInputSerializer(0, getUserCodeClassLoader());
 		@SuppressWarnings({ "rawtypes" })

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
@@ -109,6 +109,8 @@ public class DataSinkTask<IT> extends AbstractInvokable {
 
 		RuntimeContext ctx = createRuntimeContext();
 		final Counter numRecordsIn = ((OperatorMetricGroup) ctx.getMetricGroup()).getIOMetricGroup().getNumRecordsInCounter();
+		((OperatorMetricGroup) ctx.getMetricGroup()).getIOMetricGroup().reuseInputMetricsForTask();
+		((OperatorMetricGroup) ctx.getMetricGroup()).getIOMetricGroup().reuseOutputMetricsForTask();
 		
 		if(RichOutputFormat.class.isAssignableFrom(this.format.getClass())){
 			((RichOutputFormat) this.format).setRuntimeContext(ctx);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
@@ -27,7 +27,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
@@ -284,11 +283,8 @@ public class DataSourceTask<OT> extends AbstractInvokable {
 		this.chainedTasks = new ArrayList<ChainedDriver<?, ?>>();
 		this.eventualOutputs = new ArrayList<RecordWriter<?>>();
 
-		final AccumulatorRegistry accumulatorRegistry = getEnvironment().getAccumulatorRegistry();
-		final AccumulatorRegistry.Reporter reporter = accumulatorRegistry.getReadWriteReporter();
-
 		this.output = BatchTask.initOutputs(this, cl, this.config, this.chainedTasks, this.eventualOutputs,
-				getExecutionConfig(), reporter, getEnvironment().getAccumulatorRegistry().getUserMap());
+				getExecutionConfig(), getEnvironment().getAccumulatorRegistry().getUserMap());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
@@ -103,7 +103,11 @@ public class DataSourceTask<OT> extends AbstractInvokable {
 
 		RuntimeContext ctx = createRuntimeContext();
 		Counter completedSplitsCounter = ctx.getMetricGroup().counter("numSplitsProcessed");
+		((OperatorMetricGroup) ctx.getMetricGroup()).getIOMetricGroup().reuseInputMetricsForTask();
 		Counter numRecordsOut = ((OperatorMetricGroup) ctx.getMetricGroup()).getIOMetricGroup().getNumRecordsOutCounter();
+		if (this.config.getNumberOfChainedStubs() == 0) {
+			((OperatorMetricGroup) ctx.getMetricGroup()).getIOMetricGroup().reuseOutputMetricsForTask();
+		}
 
 		if (RichInputFormat.class.isAssignableFrom(this.format.getClass())) {
 			((RichInputFormat) this.format).setRuntimeContext(ctx);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedDriver.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.operators.BatchTask;
 import org.apache.flink.runtime.operators.util.DistributedRuntimeUDFContext;
@@ -104,6 +105,9 @@ public abstract class ChainedDriver<IT, OT> implements Collector<IT> {
 	@Override
 	public abstract void collect(IT record);
 
+	public OperatorIOMetricGroup getIOMetrics() {
+		return this.metrics.getIOMetricGroup();
+	}
 	
 	protected RuntimeContext getUdfRuntimeContext() {
 		return this.udfContext;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -414,6 +414,10 @@ public class Task implements Runnable, TaskActions {
 		return accumulatorRegistry;
 	}
 
+	public TaskMetricGroup getMetricGroup() {
+		return metrics;
+	}
+
 	public Thread getExecutingThread() {
 		return executingThread;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskExecutionState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskExecutionState.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
 import org.apache.flink.runtime.util.SerializedThrowable;
 
 /**
@@ -48,6 +49,7 @@ public class TaskExecutionState implements java.io.Serializable {
 
 	/** Serialized flink and user-defined accumulators */
 	private final AccumulatorSnapshot accumulators;
+	private final IOMetrics ioMetrics;
 
 	/**
 	 * Creates a new task execution state update, with no attached exception and no accumulators.
@@ -60,7 +62,7 @@ public class TaskExecutionState implements java.io.Serializable {
 	 *        the execution state to be reported
 	 */
 	public TaskExecutionState(JobID jobID, ExecutionAttemptID executionId, ExecutionState executionState) {
-		this(jobID, executionId, executionState, null, null);
+		this(jobID, executionId, executionState, null, null, null);
 	}
 
 	/**
@@ -75,7 +77,7 @@ public class TaskExecutionState implements java.io.Serializable {
 	 */
 	public TaskExecutionState(JobID jobID, ExecutionAttemptID executionId,
 							ExecutionState executionState, Throwable error) {
-		this(jobID, executionId, executionState, error, null);
+		this(jobID, executionId, executionState, error, null, null);
 	}
 
 	/**
@@ -95,7 +97,7 @@ public class TaskExecutionState implements java.io.Serializable {
 	 */
 	public TaskExecutionState(JobID jobID, ExecutionAttemptID executionId,
 			ExecutionState executionState, Throwable error,
-			AccumulatorSnapshot accumulators) {
+			AccumulatorSnapshot accumulators, IOMetrics ioMetrics) {
 
 		if (jobID == null || executionId == null || executionState == null) {
 			throw new NullPointerException();
@@ -110,6 +112,7 @@ public class TaskExecutionState implements java.io.Serializable {
 			this.throwable = null;
 		}
 		this.accumulators = accumulators;
+		this.ioMetrics = ioMetrics;
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -162,6 +165,10 @@ public class TaskExecutionState implements java.io.Serializable {
 	 */
 	public AccumulatorSnapshot getAccumulators() {
 		return accumulators;
+	}
+
+	public IOMetrics getIOMetrics() {
+		return ioMetrics;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1028,12 +1028,12 @@ class JobManager(
         TaskManagerInstance(Option(instanceManager.getRegisteredInstanceById(instanceID)))
       )
 
-    case Heartbeat(instanceID, metricsReport, accumulators) =>
+    case Heartbeat(instanceID, accumulators) =>
       log.debug(s"Received heartbeat message from $instanceID.")
 
       updateAccumulators(accumulators)
 
-      instanceManager.reportHeartBeat(instanceID, metricsReport)
+      instanceManager.reportHeartBeat(instanceID)
 
     case message: AccumulatorMessage => handleAccumulatorMessage(message)
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/TaskManagerMessages.scala
@@ -52,15 +52,12 @@ object TaskManagerMessages {
 
   /**
    * Reports liveliness of the TaskManager instance with the given instance ID to the
-   * This message is sent to the job. This message reports the TaskManagers
-   * metrics, as a byte array.
+   * This message is sent to the job.
    *
    * @param instanceID The instance ID of the reporting TaskManager.
-   * @param metricsReport utf-8 encoded JSON metrics report from the metricRegistry.
    * @param accumulators Accumulators of tasks serialized as Tuple2[internal, user-defined]
    */
-  case class Heartbeat(instanceID: InstanceID, metricsReport: Array[Byte],
-     accumulators: Seq[AccumulatorSnapshot])
+  case class Heartbeat(instanceID: InstanceID, accumulators: Seq[AccumulatorSnapshot])
 
 
   // --------------------------------------------------------------------------

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -23,7 +23,6 @@ import java.lang.management.ManagementFactory
 import java.net.{InetAddress, InetSocketAddress}
 import java.util
 import java.util.UUID
-import java.util.concurrent.TimeUnit
 
 import _root_.akka.actor._
 import _root_.akka.pattern.ask
@@ -1296,7 +1295,8 @@ class TaskManager(
             task.getExecutionId,
             task.getExecutionState,
             task.getFailureCause,
-            accumulators)
+            accumulators,
+            task.getMetricGroup.getIOMetricGroup.createSnapshot())
         )
       )
     }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.taskmanager
 
 import java.io.{File, FileInputStream, IOException}
-import java.lang.management.{ManagementFactory, OperatingSystemMXBean}
+import java.lang.management.ManagementFactory
 import java.net.{InetAddress, InetSocketAddress}
 import java.util
 import java.util.UUID
@@ -28,10 +28,6 @@ import java.util.concurrent.TimeUnit
 import _root_.akka.actor._
 import _root_.akka.pattern.ask
 import _root_.akka.util.Timeout
-import com.codahale.metrics.json.MetricsModule
-import com.codahale.metrics.jvm.{BufferPoolMetricSet, GarbageCollectorMetricSet, MemoryUsageGaugeSet}
-import com.codahale.metrics.{Gauge, MetricFilter, MetricRegistry}
-import com.fasterxml.jackson.databind.ObjectMapper
 import grizzled.slf4j.Logger
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.flink.configuration._
@@ -155,19 +151,7 @@ class TaskManager(
   /** Handler for distributed files cached by this TaskManager */
   protected val fileCache = new FileCache(config.configuration)
 
-  /** Registry of metrics periodically transmitted to the JobManager */
-  private val metricRegistry = TaskManager.createMetricsRegistry()
-
   private var taskManagerMetricGroup : TaskManagerMetricGroup = _
-
-  /** Metric serialization */
-  private val metricRegistryMapper: ObjectMapper = new ObjectMapper()
-    .registerModule(
-      new MetricsModule(
-        TimeUnit.SECONDS,
-        TimeUnit.MILLISECONDS,
-        false,
-        MetricFilter.ALL))
 
   /** Actors which want to be notified once this task manager has been
     * registered at the job manager */
@@ -1332,7 +1316,6 @@ class TaskManager(
   protected def sendHeartbeatToJobManager(): Unit = {
     try {
       log.debug("Sending heartbeat to JobManager")
-      val metricsReport: Array[Byte] = metricRegistryMapper.writeValueAsBytes(metricRegistry)
 
       val accumulatorEvents =
         scala.collection.mutable.Buffer[AccumulatorSnapshot]()
@@ -1351,7 +1334,7 @@ class TaskManager(
       }
 
        currentJobManager foreach {
-        jm => jm ! decorateMessage(Heartbeat(instanceID, metricsReport, accumulatorEvents))
+        jm => jm ! decorateMessage(Heartbeat(instanceID, accumulatorEvents))
       }
     }
     catch {
@@ -2480,50 +2463,5 @@ object TaskManager {
         }
       case (_, id) => throw new IllegalArgumentException(s"Temporary file directory #$id is null.")
     }
-  }
-
-  /**
-   * Creates the registry of default metrics, including stats about garbage collection, memory
-   * usage, and system CPU load.
-   *
-   * @return The registry with the default metrics.
-   */
-  private def createMetricsRegistry() : MetricRegistry = {
-    val metricRegistry = new MetricRegistry()
-
-    // register default metrics
-    metricRegistry.register("gc", new GarbageCollectorMetricSet)
-    metricRegistry.register("memory", new MemoryUsageGaugeSet)
-    metricRegistry.register("direct-memory", new BufferPoolMetricSet(
-      ManagementFactory.getPlatformMBeanServer))
-    metricRegistry.register("load", new Gauge[Double] {
-      override def getValue: Double =
-        ManagementFactory.getOperatingSystemMXBean().getSystemLoadAverage()
-    })
-
-    val osBean: OperatingSystemMXBean = ManagementFactory.getOperatingSystemMXBean()
-
-    try {
-      val fetchCPULoadMethod = Class.forName("com.sun.management.OperatingSystemMXBean")
-        .getMethods()
-        .find( _.getName() == "getProcessCpuLoad" )
-
-      // verify that we can invoke the method
-      fetchCPULoadMethod.map(_.invoke(osBean).asInstanceOf[Double]).getOrElse(-1.0)
-
-      metricRegistry.register("cpuLoad", new Gauge[Double] {
-        override def getValue: Double = fetchCPULoadMethod
-          .map(_.invoke(osBean).asInstanceOf[Double]).getOrElse(-1.0)
-      })
-    }
-    catch {
-      case t: Throwable =>
-        LOG.warn("Cannot access com.sun.management.OperatingSystemMXBean.getProcessCpuLoad()" +
-          " - CPU load metrics will not be available.")
-        metricRegistry.register("cpuLoad", new Gauge[Double] {
-          override def getValue: Double = -1.0
-        })
-    }
-    metricRegistry
   }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CoordinatorShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CoordinatorShutdownTest.java
@@ -28,7 +28,7 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.ExternalizedCheckpointSettings;
 import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
-import org.apache.flink.runtime.jobmanager.Tasks;
+import org.apache.flink.runtime.jobmanager.JobManagerHARecoveryTest;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
@@ -51,14 +51,15 @@ public class CoordinatorShutdownTest {
 	public void testCoordinatorShutsDownOnFailure() {
 		LocalFlinkMiniCluster cluster = null;
 		try {
-			Configuration noTaskManagerConfig = new Configuration();
-			noTaskManagerConfig.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 0);
-			cluster = new LocalFlinkMiniCluster(noTaskManagerConfig, true);
+			Configuration config = new Configuration();
+			config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
+			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 1);
+			cluster = new LocalFlinkMiniCluster(config, true);
 			cluster.start();
 			
 			// build a test graph with snapshotting enabled
 			JobVertex vertex = new JobVertex("Test Vertex");
-			vertex.setInvokableClass(Tasks.NoOpInvokable.class);
+			vertex.setInvokableClass(JobManagerHARecoveryTest.BlockingInvokable.class);
 			List<JobVertexID> vertexIdList = Collections.singletonList(vertex.getID());
 			
 			JobGraph testGraph = new JobGraph("test job", vertex);
@@ -72,11 +73,11 @@ public class CoordinatorShutdownTest {
 					testGraph,
 					ListeningBehaviour.EXECUTION_RESULT);
 			
-			// submit is successful, but then the job dies because no TaskManager / slot is available
+			// submit is successful, but then the job blocks due to the invokable
 			Future<Object> submitFuture = jmGateway.ask(submitMessage, timeout);
 			Await.result(submitFuture, timeout);
 
-			// get the execution graph and make sure the coordinator is properly shut down
+			// get the execution graph and store the ExecutionGraph reference
 			Future<Object> jobRequestFuture = jmGateway.ask(
 					new JobManagerMessages.RequestJob(testGraph.getJobID()),
 					timeout);
@@ -84,8 +85,12 @@ public class CoordinatorShutdownTest {
 			ExecutionGraph graph = (ExecutionGraph)((JobManagerMessages.JobFound) Await.result(jobRequestFuture, timeout)).executionGraph();
 			
 			assertNotNull(graph);
+
+			JobManagerHARecoveryTest.BlockingInvokable.unblock();
+
 			graph.waitUntilFinished();
 			
+			// verify that the coordinator was shut down
 			CheckpointCoordinator coord = graph.getCheckpointCoordinator();
 			assertTrue(coord == null || coord.isShutdown());
 		}
@@ -105,12 +110,15 @@ public class CoordinatorShutdownTest {
 	public void testCoordinatorShutsDownOnSuccess() {
 		LocalFlinkMiniCluster cluster = null;
 		try {
-			cluster = new LocalFlinkMiniCluster(new Configuration(), true);
+			Configuration config = new Configuration();
+			config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
+			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 1);
+			cluster = new LocalFlinkMiniCluster(config, true);
 			cluster.start();
 			
 			// build a test graph with snapshotting enabled
 			JobVertex vertex = new JobVertex("Test Vertex");
-			vertex.setInvokableClass(Tasks.NoOpInvokable.class);
+			vertex.setInvokableClass(JobManagerHARecoveryTest.BlockingInvokable.class);
 			List<JobVertexID> vertexIdList = Collections.singletonList(vertex.getID());
 
 			JobGraph testGraph = new JobGraph("test job", vertex);
@@ -124,11 +132,11 @@ public class CoordinatorShutdownTest {
 					testGraph,
 					ListeningBehaviour.EXECUTION_RESULT);
 
-			// submit is successful, but then the job dies because no TaskManager / slot is available
+			// submit is successful, but then the job blocks due to the invokable
 			Future<Object> submitFuture = jmGateway.ask(submitMessage, timeout);
 			Await.result(submitFuture, timeout);
 
-			// get the execution graph and make sure the coordinator is properly shut down
+			// get the execution graph and store the ExecutionGraph reference
 			Future<Object> jobRequestFuture = jmGateway.ask(
 					new JobManagerMessages.RequestJob(testGraph.getJobID()),
 					timeout);
@@ -136,8 +144,12 @@ public class CoordinatorShutdownTest {
 			ExecutionGraph graph = (ExecutionGraph)((JobManagerMessages.JobFound) Await.result(jobRequestFuture, timeout)).executionGraph();
 
 			assertNotNull(graph);
+
+			JobManagerHARecoveryTest.BlockingInvokable.unblock();
+			
 			graph.waitUntilFinished();
 
+			// verify that the coordinator was shut down
 			CheckpointCoordinator coord = graph.getCheckpointCoordinator();
 			assertTrue(coord == null || coord.isShutdown());
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -27,15 +27,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
-import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
@@ -50,7 +46,6 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
 import org.apache.flink.runtime.operators.BatchTask;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
@@ -335,7 +330,7 @@ public class ExecutionGraphDeploymentTest {
 
 		ExecutionAttemptID attemptID = eg.getJobVertex(v1.getID()).getTaskVertices()[0].getCurrentExecutionAttempt().getAttemptId();
 		eg.updateState(new TaskExecutionState(jobId, attemptID, ExecutionState.RUNNING));
-		eg.updateState(new TaskExecutionState(jobId, attemptID, ExecutionState.FINISHED, null, new AccumulatorSnapshot(jobId, attemptID, new HashMap<AccumulatorRegistry.Metric, Accumulator<?, ?>>(), new HashMap<String, Accumulator<?, ?>>())));
+		eg.updateState(new TaskExecutionState(jobId, attemptID, ExecutionState.FINISHED, null));
 
 		assertEquals(JobStatus.FAILED, eg.getState());
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceManagerTest.java
@@ -186,12 +186,12 @@ public class InstanceManagerTest{
 					probe3.getRef(), ici3, hardwareDescription, 1, leaderSessionID);
 
 			// report some immediate heart beats
-			assertTrue(cm.reportHeartBeat(instanceID1, new byte[] {}));
-			assertTrue(cm.reportHeartBeat(instanceID2, new byte[] {}));
-			assertTrue(cm.reportHeartBeat(instanceID3, new byte[] {}));
+			assertTrue(cm.reportHeartBeat(instanceID1));
+			assertTrue(cm.reportHeartBeat(instanceID2));
+			assertTrue(cm.reportHeartBeat(instanceID3));
 
 			// report heart beat for non-existing instance
-			assertFalse(cm.reportHeartBeat(new InstanceID(), new byte[] {}));
+			assertFalse(cm.reportHeartBeat(new InstanceID()));
 
 			final long WAIT = 200;
 			CommonTestUtils.sleepUninterruptibly(WAIT);
@@ -205,7 +205,7 @@ public class InstanceManagerTest{
 			long h3 = it.next().getLastHeartBeat();
 
 			// send one heart beat again and verify that the
-			assertTrue(cm.reportHeartBeat(instance1.getId(), new byte[] {}));
+			assertTrue(cm.reportHeartBeat(instance1.getId()));
 			long newH1 = instance1.getLastHeartBeat();
 
 			long now = System.currentTimeMillis();
@@ -244,7 +244,7 @@ public class InstanceManagerTest{
 				// expected
 			}
 			
-			assertFalse(cm.reportHeartBeat(new InstanceID(), new byte[] {}));
+			assertFalse(cm.reportHeartBeat(new InstanceID()));
 		}
 		catch (Exception e) {
 			System.err.println(e.getMessage());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/reader/AbstractReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/reader/AbstractReaderTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.io.network.api.reader;
 
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.EndOfSuperstepEvent;
@@ -183,11 +182,6 @@ public class AbstractReaderTest {
 
 		protected MockReader(InputGate inputGate) {
 			super(inputGate);
-		}
-
-		@Override
-		public void setReporter(AccumulatorRegistry.Reporter reporter) {
-
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroupTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
+import org.apache.flink.runtime.operators.testutils.UnregisteredTaskMetricsGroup;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class TaskIOMetricGroupTest {
+	@Test
+	public void testTaskIOMetricGroup() {
+		TaskMetricGroup task = new UnregisteredTaskMetricsGroup();
+		TaskIOMetricGroup taskIO = task.getIOMetricGroup();
+
+		// test counter forwarding
+		assertNotNull(taskIO.getNumRecordsInCounter());
+		assertNotNull(taskIO.getNumRecordsOutCounter());
+
+		Counter c1 = new SimpleCounter();
+		c1.inc(32L);
+		Counter c2 = new SimpleCounter();
+		c2.inc(64L);
+
+		taskIO.reuseRecordsInputCounter(c1);
+		taskIO.reuseRecordsOutputCounter(c2);
+		assertEquals(32L, taskIO.getNumRecordsInCounter().getCount());
+		assertEquals(64L, taskIO.getNumRecordsOutCounter().getCount());
+
+		// test IOMetrics instantiation
+		taskIO.getNumBytesInLocalCounter().inc(100L);
+		taskIO.getNumBytesInRemoteCounter().inc(150L);
+		taskIO.getNumBytesOutCounter().inc(250L);
+		
+		IOMetrics io = taskIO.createSnapshot();
+		assertEquals(32L, io.getNumRecordsIn());
+		assertEquals(64L, io.getNumRecordsOut());
+		assertEquals(100L, io.getNumBytesInLocal());
+		assertEquals(150L, io.getNumBytesInRemote());
+		assertEquals(250L, io.getNumBytesOut());
+	}
+}

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerLike.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerLike.scala
@@ -226,10 +226,9 @@ trait TestingJobManagerLike extends FlinkActor {
         case (jobID, (updated, actors)) if updated =>
           currentJobs.get(jobID) match {
             case Some((graph, jobInfo)) =>
-              val flinkAccumulators = graph.getFlinkAccumulators
               val userAccumulators = graph.aggregateUserAccumulators
               actors foreach {
-                 actor => actor ! UpdatedAccumulators(jobID, flinkAccumulators, userAccumulators)
+                 actor => actor ! UpdatedAccumulators(jobID, userAccumulators)
               }
             case None =>
           }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
@@ -23,7 +23,6 @@ import java.util.Map
 import akka.actor.ActorRef
 import org.apache.flink.api.common.JobID
 import org.apache.flink.api.common.accumulators.Accumulator
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry
 import org.apache.flink.runtime.checkpoint.savepoint.Savepoint
 import org.apache.flink.runtime.executiongraph.{AccessExecutionGraph, ExecutionAttemptID, ExecutionGraph}
 import org.apache.flink.runtime.instance.ActorGateway
@@ -73,7 +72,6 @@ object TestingJobManagerMessages {
    * Reports updated accumulators back to the listener.
    */
   case class UpdatedAccumulators(jobID: JobID,
-    flinkAccumulators: Map[ExecutionAttemptID, Map[AccumulatorRegistry.Metric, Accumulator[_,_]]],
     userAccumulators: Map[String, Accumulator[_,_]])
 
   /** Notifies the sender when the [[TestingJobManager]] has been elected as the leader

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -69,6 +69,7 @@ public class StreamConfig implements Serializable {
 	private static final String OUT_STREAM_EDGES = "outStreamEdges";
 	private static final String IN_STREAM_EDGES = "inStreamEdges";
 	private static final String OPERATOR_NAME = "operatorName";
+	private static final String CHAIN_END = "chainEnd";
 
 	private static final String CHECKPOINTING_ENABLED = "checkpointing";
 	private static final String CHECKPOINT_MODE = "checkpointMode";
@@ -476,6 +477,14 @@ public class StreamConfig implements Serializable {
 
 	public boolean isChainStart() {
 		return config.getBoolean(IS_CHAINED_VERTEX, false);
+	}
+
+	public void setChainEnd() {
+		config.setBoolean(CHAIN_END, true);
+	}
+
+	public boolean isChainEnd() {
+		return config.getBoolean(CHAIN_END, false);
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -231,6 +231,9 @@ public class StreamingJobGraphGenerator {
 				config.setChainIndex(chainIndex);
 				config.setOperatorName(streamGraph.getStreamNode(currentNodeId).getOperatorName());
 				chainedConfigs.get(startNodeId).put(currentNodeId, config);
+				if (chainableOutputs.isEmpty()) {
+					config.setChainEnd();
+				}
 			}
 
 			return transitiveOutEdges;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -163,6 +163,12 @@ public abstract class AbstractStreamOperator<OUT>
 		
 		this.metrics = container.getEnvironment().getMetricGroup().addOperator(config.getOperatorName());
 		this.output = new CountingOutput(output, ((OperatorMetricGroup) this.metrics).getIOMetricGroup().getNumRecordsOutCounter());
+		if (config.isChainStart()) {
+			((OperatorMetricGroup) this.metrics).getIOMetricGroup().reuseInputMetricsForTask();
+		}
+		if (config.isChainEnd()) {
+			((OperatorMetricGroup) this.metrics).getIOMetricGroup().reuseOutputMetricsForTask();
+		}
 		Configuration taskManagerConfig = container.getEnvironment().getTaskManagerInfo().getConfiguration();
 		int historySize = taskManagerConfig.getInteger(ConfigConstants.METRICS_LATENCY_HISTORY_SIZE, ConfigConstants.DEFAULT_METRICS_LATENCY_HISTORY_SIZE);
 		if (historySize <= 0) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -27,7 +27,6 @@ import org.apache.flink.metrics.Gauge;
 import org.apache.flink.runtime.jobgraph.tasks.StatefulTask;
 import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
@@ -202,12 +201,6 @@ public class StreamInputProcessor<IN> {
 				}
 				return false;
 			}
-		}
-	}
-	
-	public void setReporter(AccumulatorRegistry.Reporter reporter) {
-		for (RecordDeserializer<?> deserializer : recordDeserializers) {
-			deserializer.setReporter(reporter);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.runtime.jobgraph.tasks.StatefulTask;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
@@ -267,12 +266,6 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 					}
 				}
 			}
-		}
-	}
-	
-	public void setReporter(AccumulatorRegistry.Reporter reporter) {
-		for (RecordDeserializer<?> deserializer : recordDeserializers) {
-			deserializer.setReporter(reporter);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -48,9 +47,6 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 					getEnvironment().getIOManager());
 
 			// make sure that stream tasks report their I/O statistics
-			AccumulatorRegistry registry = getEnvironment().getAccumulatorRegistry();
-			AccumulatorRegistry.Reporter reporter = registry.getReadWriteReporter();
-			inputProcessor.setReporter(reporter);
 			inputProcessor.setMetricGroup(getEnvironment().getMetricGroup().getIOMetricGroup());
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -227,7 +227,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 				timerService = new SystemProcessingTimeService(this, getCheckpointLock(), timerThreadFactory);
 			}
 
-			operatorChain = new OperatorChain<>(this, getEnvironment().getAccumulatorRegistry().getReadWriteReporter());
+			operatorChain = new OperatorChain<>(this);
 			headOperator = operatorChain.getHeadOperator();
 
 			getEnvironment().getMetricGroup().gauge("lastCheckpointSize", new Gauge<Long>() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
@@ -73,9 +72,6 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends StreamTask<OUT, TwoInputS
 				getEnvironment().getIOManager());
 
 		// make sure that stream tasks report their I/O statistics
-		AccumulatorRegistry registry = getEnvironment().getAccumulatorRegistry();
-		AccumulatorRegistry.Reporter reporter = registry.getReadWriteReporter();
-		this.inputProcessor.setReporter(reporter);
 		inputProcessor.setMetricGroup(getEnvironment().getMetricGroup().getIOMetricGroup());
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.runtime.operators;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -149,9 +148,7 @@ public class StreamOperatorChainingTest {
 		StreamTask<Integer, StreamMap<Integer, Integer>> mockTask =
 				createMockTask(streamConfig, chainedVertex.getName());
 
-		OperatorChain<Integer, StreamMap<Integer, Integer>> operatorChain = new OperatorChain<>(
-				mockTask,
-				mock(AccumulatorRegistry.Reporter.class));
+		OperatorChain<Integer, StreamMap<Integer, Integer>> operatorChain = new OperatorChain<>(mockTask);
 
 		headOperator.setup(mockTask, streamConfig, operatorChain.getChainEntryPoint());
 
@@ -291,9 +288,7 @@ public class StreamOperatorChainingTest {
 		StreamTask<Integer, StreamMap<Integer, Integer>> mockTask =
 				createMockTask(streamConfig, chainedVertex.getName());
 
-		OperatorChain<Integer, StreamMap<Integer, Integer>> operatorChain = new OperatorChain<>(
-				mockTask,
-				mock(AccumulatorRegistry.Reporter.class));
+		OperatorChain<Integer, StreamMap<Integer, Integer>> operatorChain = new OperatorChain<>(mockTask);
 
 		headOperator.setup(mockTask, streamConfig, operatorChain.getChainEntryPoint());
 


### PR DESCRIPTION
# This PR relies on #2613, #2614 and #2615. Thus, the first 5 commits should not be reviewed here.

This PR ports the remaining parts of the WebInterface to rely on the metric system.
# TaskManager metrics

In a7011e8305d7c828fabc4245358c2d21568fd561 the TaskManagersHandler is modified to use the metric system. In addition, the garbage collector section in the WebInterface was enhanced to no longer rely on hard-coded GC names, but instead be dynamic. The recently introduced network metrics have been added as well.

cbff6d6aab80bc423a09aa6b62c80a2f409d796a then removes the remnants of the old metrics that are now unused. This affects the TaskManager(no longer gathers these metrics) and Heartbeat messages (no longer includes a metrics report). As a result the DropWizard dependency was removed. The transitive jackson dependency is now explicitly set for both flink-runtime and flink-runtime-web.
# Task metrics

The Webinterface shows how many records/bytes each task has received or sent. Until now these were gathered with system specific accumulators.

cab25496ff5991de60e757f68c5d5139c86f34ba these accumulators were removed.

Under the new system, bytes In/Out is measured per task (since it doesn't make sense within chained operators), while records In/Out is measured per operator. In order to display the records metrics for each task it was thus necessary to "reuse" some operator counters for the task.

This is implemented in 16983485198a61bec0418adb833508dcaf276170 by re-registering the numRecordsIn counter of the first operator in the chain and the the numRecordsOut counter of the last operator on the task level 

This re-use could (sadly) not be done automatically within the metric system. Instead 2 helper methods were added to the OperatorIOMetricGroup, which are called for example within BatchTask#invoke(), which forward the counters to the TaskIOMetricGroup where they are stored and re-registered.

With these metrics being re-registered they can be accessed easily via the MetricQueryService from the WebInterface handlers. The downside is that this service provides no guarantee that the most up-to-date metrics for a finished task will be transferred. It was thus necessary to store a snapshot of these IOMetrics within the ExecutionGraph, similar to the system accumulators, which the handlers could access as well.

The handlers were finally adjusted in 8be5145a9406dc8d6d661299c9ee98aa09233df4. For running tasks they access metrics via the MetricQueryService, whereas for finished tasks they rely on the metrics stored in the ExecutionGraph.
