### PR TITLE
[FLINK-4800] Refactor the ContinuousFileMonitoringFunction code and the related tests.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -82,10 +82,6 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * An ExecutionEnvironment for streaming jobs. An instance of it is
- * necessary to construct streaming topologies.
- */
-/**
  * The StreamExecutionEnvironment is the context in which a streaming program is executed. A
  * {@link LocalStreamEnvironment} will cause execution in the current JVM, a
  * {@link RemoteStreamEnvironment} will cause execution on a remote setup.
@@ -1350,18 +1346,20 @@ public abstract class StreamExecutionEnvironment {
 		Preconditions.checkNotNull(monitoringMode, "Unspecified monitoring mode.");
 
 		Preconditions.checkArgument(monitoringMode.equals(FileProcessingMode.PROCESS_ONCE) ||
-						interval >= ContinuousFileMonitoringFunction.MIN_MONITORING_INTERVAL,
-				"The path monitoring interval cannot be less than " +
-						ContinuousFileMonitoringFunction.MIN_MONITORING_INTERVAL + " ms.");
+				interval >= ContinuousFileMonitoringFunction.MIN_MONITORING_INTERVAL,
+			"The path monitoring interval cannot be less than " +
+					ContinuousFileMonitoringFunction.MIN_MONITORING_INTERVAL + " ms.");
 
-		ContinuousFileMonitoringFunction<OUT> monitoringFunction = new ContinuousFileMonitoringFunction<>(
+		ContinuousFileMonitoringFunction<OUT> monitoringFunction =
+			new ContinuousFileMonitoringFunction<>(
 				inputFormat, inputFormat.getFilePath().toString(),
 				monitoringMode, getParallelism(), interval);
 
-		ContinuousFileReaderOperator<OUT, ?> reader = new ContinuousFileReaderOperator<>(inputFormat);
+		ContinuousFileReaderOperator<OUT> reader =
+			new ContinuousFileReaderOperator<>(inputFormat);
 
 		SingleOutputStreamOperator<OUT> source = addSource(monitoringFunction, sourceName)
-				.transform("FileSplitReader_" + sourceName, typeInfo, reader);
+				.transform("Split Reader: " + sourceName, typeInfo, reader);
 
 		return new DataStreamSource<>(source);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
@@ -19,13 +19,11 @@ package org.apache.flink.streaming.api.functions.source;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.io.FileInputFormat;
 import org.apache.flink.api.common.io.FilePathFilter;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.JobException;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
 import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
@@ -35,52 +33,59 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
- * This is the single (non-parallel) task which takes a {@link FileInputFormat} and is responsible for
- * i) monitoring a user-provided path, ii) deciding which files should be further read and processed,
- * iii) creating the {@link FileInputSplit FileInputSplits} corresponding to those files, and iv) assigning
- * them to downstream tasks for further reading and processing. Which splits will be further processed
- * depends on the user-provided {@link FileProcessingMode} and the {@link FilePathFilter}.
- * The splits of the files to be read are then forwarded to the downstream
- * {@link ContinuousFileReaderOperator} which can have parallelism greater than one.
+ * This is the single (non-parallel) monitoring task which takes a {@link FileInputFormat}
+ * and, depending on the {@link FileProcessingMode} and the {@link FilePathFilter}, it is responsible for:
+ *
+ * <ol>
+ *     <li>Monitoring a user-provided path.</li>
+ *     <li>Deciding which files should be further read and processed.</li>
+ *     <li>Creating the {@link FileInputSplit splits} corresponding to those files.</li>
+ *     <li>Assigning them to downstream tasks for further processing.</li>
+ * </ol>
+ *
+ * The splits to be read are forwarded to the downstream {@link ContinuousFileReaderOperator}
+ * which can have parallelism greater than one.
+ *
+ * <b>IMPORTANT NOTE: </b> Splits are forwarded downstream for reading in ascending modification time order,
+ * based on the modification time of the files they belong to.
  */
 @Internal
 public class ContinuousFileMonitoringFunction<OUT>
-	extends RichSourceFunction<FileInputSplit> implements Checkpointed<Long> {
+	extends RichSourceFunction<TimestampedFileInputSplit> implements Checkpointed<Long> {
 
 	private static final long serialVersionUID = 1L;
 
 	private static final Logger LOG = LoggerFactory.getLogger(ContinuousFileMonitoringFunction.class);
 
 	/**
-	 * The minimum interval allowed between consecutive path scans. This is applicable if the
-	 * {@code watchType} is set to {@code PROCESS_CONTINUOUSLY}.
+	 * The minimum interval allowed between consecutive path scans.
+	 * <p><b>NOTE:</b> Only applicable to the {@code PROCESS_CONTINUOUSLY} mode.
 	 */
-	public static final long MIN_MONITORING_INTERVAL = 100l;
+	public static final long MIN_MONITORING_INTERVAL = 1L;
 
 	/** The path to monitor. */
 	private final String path;
 
-	/** The default parallelism for the job, as this is going to be the parallelism of the downstream readers. */
+	/** The parallelism of the downstream readers. */
 	private final int readerParallelism;
 
 	/** The {@link FileInputFormat} to be read. */
 	private FileInputFormat<OUT> format;
 
-	/** How often to monitor the state of the directory for new data. */
+	/** The interval between consecutive path scans. */
 	private final long interval;
 
 	/** Which new data to process (see {@link FileProcessingMode}. */
 	private final FileProcessingMode watchType;
 
-	private Long globalModificationTime;
+	/** The maximum file modification time seen so far. */
+	private volatile long globalModificationTime;
 
 	private transient Object checkpointLock;
 
@@ -91,10 +96,12 @@ public class ContinuousFileMonitoringFunction<OUT>
 		FileProcessingMode watchType,
 		int readerParallelism, long interval) {
 
-		if (watchType != FileProcessingMode.PROCESS_ONCE && interval < MIN_MONITORING_INTERVAL) {
-			throw new IllegalArgumentException("The specified monitoring interval (" + interval + " ms) is " +
-				"smaller than the minimum allowed one (100 ms).");
-		}
+		Preconditions.checkArgument(
+			watchType == FileProcessingMode.PROCESS_ONCE || interval >= MIN_MONITORING_INTERVAL,
+			"The specified monitoring interval (" + interval + " ms) is smaller than the minimum " +
+				"allowed one (" + MIN_MONITORING_INTERVAL + " ms)."
+		);
+
 		this.format = Preconditions.checkNotNull(format, "Unspecified File Input Format.");
 		this.path = Preconditions.checkNotNull(path, "Unspecified Path.");
 
@@ -105,16 +112,17 @@ public class ContinuousFileMonitoringFunction<OUT>
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public void open(Configuration parameters) throws Exception {
-		LOG.info("Opening File Monitoring Source.");
-
 		super.open(parameters);
 		format.configure(parameters);
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Opened File Monitoring Source for path: " + path + ".");
+		}
 	}
 
 	@Override
-	public void run(SourceFunction.SourceContext<FileInputSplit> context) throws Exception {
+	public void run(SourceFunction.SourceContext<TimestampedFileInputSplit> context) throws Exception {
 		FileSystem fileSystem = FileSystem.get(new URI(path));
 
 		checkpointLock = context.getCheckpointLock();
@@ -146,104 +154,61 @@ public class ContinuousFileMonitoringFunction<OUT>
 		}
 	}
 
-	private void monitorDirAndForwardSplits(FileSystem fs, SourceContext<FileInputSplit> context) throws IOException, JobException {
+	private void monitorDirAndForwardSplits(FileSystem fs,
+											SourceContext<TimestampedFileInputSplit> context) throws IOException {
 		assert (Thread.holdsLock(checkpointLock));
 
-		List<Tuple2<Long, List<FileInputSplit>>> splitsByModTime = getInputSplitSortedOnModTime(fs);
+		Map<Path, FileStatus> eligibleFiles = listEligibleFiles(fs);
+		Map<Long, List<TimestampedFileInputSplit>> splitsSortedByModTime = getInputSplitsSortedByModTime(eligibleFiles);
 
-		Iterator<Tuple2<Long, List<FileInputSplit>>> it = splitsByModTime.iterator();
-		while (it.hasNext()) {
-			forwardSplits(it.next(), context);
-			it.remove();
-		}
-	}
-
-	private void forwardSplits(Tuple2<Long, List<FileInputSplit>> splitsToFwd, SourceContext<FileInputSplit> context) {
-		assert (Thread.holdsLock(checkpointLock));
-
-		Long modTime = splitsToFwd.f0;
-		List<FileInputSplit> splits = splitsToFwd.f1;
-
-		Iterator<FileInputSplit> it = splits.iterator();
-		while (it.hasNext()) {
-			FileInputSplit split = it.next();
-			processSplit(split, context);
-			it.remove();
-		}
-
-		// update the global modification time
-		if (modTime >= globalModificationTime) {
-			globalModificationTime = modTime;
-		}
-	}
-
-	private void processSplit(FileInputSplit split, SourceContext<FileInputSplit> context) {
-		LOG.info("Forwarding split: " + split);
-		context.collect(split);
-	}
-
-	private List<Tuple2<Long, List<FileInputSplit>>> getInputSplitSortedOnModTime(FileSystem fileSystem) throws IOException {
-		List<FileStatus> eligibleFiles = listEligibleFiles(fileSystem);
-		if (eligibleFiles.isEmpty()) {
-			return new ArrayList<>();
-		}
-
-		Map<Long, List<FileInputSplit>> splitsToForward = getInputSplits(eligibleFiles);
-		List<Tuple2<Long, List<FileInputSplit>>> sortedSplitsToForward = new ArrayList<>();
-
-		for (Map.Entry<Long, List<FileInputSplit>> entry : splitsToForward.entrySet()) {
-			sortedSplitsToForward.add(new Tuple2<>(entry.getKey(), entry.getValue()));
-		}
-
-		Collections.sort(sortedSplitsToForward, new Comparator<Tuple2<Long, List<FileInputSplit>>>() {
-			@Override
-			public int compare(Tuple2<Long, List<FileInputSplit>> o1, Tuple2<Long, List<FileInputSplit>> o2) {
-				return (int) (o1.f0 - o2.f0);
+		for (Map.Entry<Long, List<TimestampedFileInputSplit>> splits: splitsSortedByModTime.entrySet()) {
+			long modificationTime = splits.getKey();
+			for (TimestampedFileInputSplit split: splits.getValue()) {
+				LOG.info("Forwarding split: " + split);
+				context.collect(split);
 			}
-		});
-
-		return sortedSplitsToForward;
+			// update the global modification time
+			globalModificationTime = Math.max(globalModificationTime, modificationTime);
+		}
 	}
 
 	/**
-	 * Creates the input splits for the path to be forwarded to the downstream tasks of the
-	 * {@link ContinuousFileReaderOperator}. Those tasks are going to read their contents for further
-	 * processing. Splits belonging to files in the {@code eligibleFiles} list are the ones
-	 * that are shipped for further processing.
+	 * Creates the input splits to be forwarded to the downstream tasks of the
+	 * {@link ContinuousFileReaderOperator}. Splits are sorted <b>by modification time</b> before
+	 * being forwarded and only splits belonging to files in the {@code eligibleFiles}
+	 * list will be processed.
 	 * @param eligibleFiles The files to process.
 	 */
-	private Map<Long, List<FileInputSplit>> getInputSplits(List<FileStatus> eligibleFiles) throws IOException {
+	private Map<Long, List<TimestampedFileInputSplit>> getInputSplitsSortedByModTime(
+				Map<Path, FileStatus> eligibleFiles) throws IOException {
+
+		Map<Long, List<TimestampedFileInputSplit>> splitsByModTime = new TreeMap<>();
 		if (eligibleFiles.isEmpty()) {
-			return new HashMap<>();
+			return splitsByModTime;
 		}
 
-		FileInputSplit[] inputSplits = format.createInputSplits(readerParallelism);
-
-		Map<Long, List<FileInputSplit>> splitsPerFile = new HashMap<>();
-		for (FileInputSplit split: inputSplits) {
-			for (FileStatus file: eligibleFiles) {
-				if (file.getPath().equals(split.getPath())) {
-					Long modTime = file.getModificationTime();
-
-					List<FileInputSplit> splitsToForward = splitsPerFile.get(modTime);
-					if (splitsToForward == null) {
-						splitsToForward = new LinkedList<>();
-						splitsPerFile.put(modTime, splitsToForward);
-					}
-					splitsToForward.add(split);
-					break;
+		for (FileInputSplit split: format.createInputSplits(readerParallelism)) {
+			FileStatus fileStatus = eligibleFiles.get(split.getPath());
+			if (fileStatus != null) {
+				Long modTime = fileStatus.getModificationTime();
+				List<TimestampedFileInputSplit> splitsToForward = splitsByModTime.get(modTime);
+				if (splitsToForward == null) {
+					splitsToForward = new ArrayList<>();
+					splitsByModTime.put(modTime, splitsToForward);
 				}
+				splitsToForward.add(new TimestampedFileInputSplit(
+					modTime, split.getSplitNumber(), split.getPath(),
+					split.getStart(), split.getLength(), split.getHostnames()));
 			}
 		}
-		return splitsPerFile;
+		return splitsByModTime;
 	}
 
 	/**
-	 * Returns the files that have data to be processed. This method returns the
-	 * Paths to the aforementioned files. It is up to the {@link #processSplit(FileInputSplit, SourceContext)}
-	 * method to decide which parts of the file to be processed, and forward them downstream.
+	 * Returns the paths of the files not yet processed.
+	 * @param fileSystem The filesystem where the monitored directory resides.
 	 */
-	private List<FileStatus> listEligibleFiles(FileSystem fileSystem) throws IOException {
+	private Map<Path, FileStatus> listEligibleFiles(FileSystem fileSystem) throws IOException {
 
 		final FileStatus[] statuses;
 		try {
@@ -251,20 +216,20 @@ public class ContinuousFileMonitoringFunction<OUT>
 		} catch (IOException e) {
 			// we may run into an IOException if files are moved while listing their status
 			// delay the check for eligible files in this case
-			return Collections.emptyList();
+			return Collections.emptyMap();
 		}
 
 		if (statuses == null) {
 			LOG.warn("Path does not exist: {}", path);
-			return Collections.emptyList();
+			return Collections.emptyMap();
 		} else {
-			List<FileStatus> files = new ArrayList<>();
+			Map<Path, FileStatus> files = new HashMap<>();
 			// handle the new files
 			for (FileStatus status : statuses) {
 				Path filePath = status.getPath();
 				long modificationTime = status.getModificationTime();
 				if (!shouldIgnore(filePath, modificationTime)) {
-					files.add(status);
+					files.put(filePath, status);
 				}
 			}
 			return files;
@@ -273,19 +238,19 @@ public class ContinuousFileMonitoringFunction<OUT>
 
 	/**
 	 * Returns {@code true} if the file is NOT to be processed further.
-	 * This happens in the following cases:
-	 *
-	 * If the user-specified path filtering method returns {@code true} for the file,
-	 * or if the modification time of the file is smaller than the {@link #globalModificationTime}, which
-	 * is the time of the most recent modification found in any of the already processed files.
+	 * This happens if the modification time of the file is smaller than
+	 * the {@link #globalModificationTime}.
+	 * @param filePath the path of the file to check.
+	 * @param modificationTime the modification time of the file.
 	 */
 	private boolean shouldIgnore(Path filePath, long modificationTime) {
 		assert (Thread.holdsLock(checkpointLock));
 		boolean shouldIgnore = modificationTime <= globalModificationTime;
-		if (shouldIgnore) {
-			LOG.debug("Ignoring " + filePath + ", with mod time= " + modificationTime + " and global mod time= " + globalModificationTime);
+		if (shouldIgnore && LOG.isDebugEnabled()) {
+			LOG.debug("Ignoring " + filePath + ", with mod time= " + modificationTime +
+				" and global mod time= " + globalModificationTime);
 		}
-		return  shouldIgnore;
+		return shouldIgnore;
 	}
 
 	@Override
@@ -295,7 +260,10 @@ public class ContinuousFileMonitoringFunction<OUT>
 			globalModificationTime = Long.MAX_VALUE;
 			isRunning = false;
 		}
-		LOG.info("Closed File Monitoring Source.");
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Closed File Monitoring Source for path: " + path + ".");
+		}
 	}
 
 	@Override
@@ -316,7 +284,7 @@ public class ContinuousFileMonitoringFunction<OUT>
 
 	@Override
 	public Long snapshotState(long checkpointId, long checkpointTimestamp) throws Exception {
-		return globalModificationTime;
+		return this.globalModificationTime;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -22,11 +22,9 @@ import org.apache.flink.api.common.io.CheckpointableInputFormat;
 import org.apache.flink.api.common.io.FileInputFormat;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FSDataOutputStream;
-import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.streaming.api.operators.StreamCheckpointedOperator;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -43,44 +41,42 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.PriorityQueue;
 import java.util.Queue;
 
+import static org.apache.flink.streaming.api.functions.source.TimestampedFileInputSplit.EOS;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * This is the operator that reads the {@link FileInputSplit FileInputSplits} received from
- * the preceding {@link ContinuousFileMonitoringFunction}. This operator can have parallelism
- * greater than 1, contrary to the {@link ContinuousFileMonitoringFunction} which has
- * a parallelism of 1.
+ * The operator that reads the {@link TimestampedFileInputSplit splits} received from the preceding
+ * {@link ContinuousFileMonitoringFunction}. Contrary to the {@link ContinuousFileMonitoringFunction}
+ * which has a parallelism of 1, this operator can have DOP > 1.
  * <p/>
- * This operator will receive the split descriptors, put them in a queue, and have another
- * thread read the actual data from the split. This architecture allows the separation of the
- * reading thread, from the one emitting the checkpoint barriers, thus removing any potential
+ * As soon as a split descriptor is received, it is put in a queue, and have another
+ * thread read the actual data of the split. This architecture allows the separation of the
+ * reading thread from the one emitting the checkpoint barriers, thus removing any potential
  * back-pressure.
  */
 @Internal
-public class ContinuousFileReaderOperator<OUT, S extends Serializable> extends AbstractStreamOperator<OUT>
-	implements OneInputStreamOperator<FileInputSplit, OUT>, OutputTypeConfigurable<OUT>, StreamCheckpointedOperator {
+public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OUT>
+	implements OneInputStreamOperator<TimestampedFileInputSplit, OUT>, OutputTypeConfigurable<OUT>, StreamCheckpointedOperator {
 
 	private static final long serialVersionUID = 1L;
 
 	private static final Logger LOG = LoggerFactory.getLogger(ContinuousFileReaderOperator.class);
-
-	/** A value that serves as a kill-pill to stop the reading thread when no more splits remain. */
-	private static final FileInputSplit EOS = new FileInputSplit(-1, null, -1, -1, null);
 
 	private FileInputFormat<OUT> format;
 	private TypeSerializer<OUT> serializer;
 
 	private transient Object checkpointLock;
 
-	private transient SplitReader<S, OUT> reader;
+	private transient SplitReader<OUT> reader;
 	private transient SourceFunction.SourceContext<OUT> readerContext;
-	private Tuple3<List<FileInputSplit>, FileInputSplit, S> readerState;
+	private List<TimestampedFileInputSplit> restoredReaderState;
 
 	public ContinuousFileReaderOperator(FileInputFormat<OUT> format) {
 		this.format = checkNotNull(format);
@@ -110,13 +106,13 @@ public class ContinuousFileReaderOperator<OUT, S extends Serializable> extends A
 			timeCharacteristic, getProcessingTimeService(), checkpointLock, output, watermarkInterval);
 
 		// and initialize the split reading thread
-		this.reader = new SplitReader<>(format, serializer, readerContext, checkpointLock, readerState);
-		this.readerState = null;
+		this.reader = new SplitReader<>(format, serializer, readerContext, checkpointLock, restoredReaderState);
+		this.restoredReaderState = null;
 		this.reader.start();
 	}
 
 	@Override
-	public void processElement(StreamRecord<FileInputSplit> element) throws Exception {
+	public void processElement(StreamRecord<TimestampedFileInputSplit> element) throws Exception {
 		reader.addSplit(element.getValue());
 	}
 
@@ -157,7 +153,7 @@ public class ContinuousFileReaderOperator<OUT, S extends Serializable> extends A
 		}
 		reader = null;
 		readerContext = null;
-		readerState = null;
+		restoredReaderState = null;
 		format = null;
 		serializer = null;
 	}
@@ -190,7 +186,7 @@ public class ContinuousFileReaderOperator<OUT, S extends Serializable> extends A
 		output.close();
 	}
 
-	private class SplitReader<S extends Serializable, OT> extends Thread {
+	private class SplitReader<OT> extends Thread {
 
 		private volatile boolean isRunning;
 
@@ -200,44 +196,39 @@ public class ContinuousFileReaderOperator<OUT, S extends Serializable> extends A
 		private final Object checkpointLock;
 		private final SourceFunction.SourceContext<OT> readerContext;
 
-		private final Queue<FileInputSplit> pendingSplits;
+		private final Queue<TimestampedFileInputSplit> pendingSplits;
 
-		private FileInputSplit currentSplit = null;
+		private TimestampedFileInputSplit currentSplit;
 
-		private S restoredFormatState = null;
-
-		private volatile boolean isSplitOpen = false;
+		private volatile boolean isSplitOpen;
 
 		private SplitReader(FileInputFormat<OT> format,
 					TypeSerializer<OT> serializer,
 					SourceFunction.SourceContext<OT> readerContext,
 					Object checkpointLock,
-					Tuple3<List<FileInputSplit>, FileInputSplit, S> restoredState) {
+					List<TimestampedFileInputSplit> restoredState) {
 
 			this.format = checkNotNull(format, "Unspecified FileInputFormat.");
 			this.serializer = checkNotNull(serializer, "Unspecified Serializer.");
 			this.readerContext = checkNotNull(readerContext, "Unspecified Reader Context.");
 			this.checkpointLock = checkNotNull(checkpointLock, "Unspecified checkpoint lock.");
 
-			this.pendingSplits = new ArrayDeque<>();
 			this.isRunning = true;
+
+			this.pendingSplits = new PriorityQueue<>(10, new Comparator<TimestampedFileInputSplit>() {
+				@Override
+				public int compare(TimestampedFileInputSplit o1, TimestampedFileInputSplit o2) {
+					return o1.compareTo(o2);
+				}
+			});
 
 			// this is the case where a task recovers from a previous failed attempt
 			if (restoredState != null) {
-				List<FileInputSplit> pending = restoredState.f0;
-				FileInputSplit current = restoredState.f1;
-				S formatState = restoredState.f2;
-
-				for (FileInputSplit split : pending) {
-					pendingSplits.add(split);
-				}
-
-				this.currentSplit = current;
-				this.restoredFormatState = formatState;
+				this.pendingSplits.addAll(restoredState);
 			}
 		}
 
-		private void addSplit(FileInputSplit split) {
+		private void addSplit(TimestampedFileInputSplit split) {
 			checkNotNull(split, "Cannot insert a null value in the pending splits queue.");
 			synchronized (checkpointLock) {
 				this.pendingSplits.add(split);
@@ -259,43 +250,32 @@ public class ContinuousFileReaderOperator<OUT, S extends Serializable> extends A
 
 					synchronized (checkpointLock) {
 
-						if (this.currentSplit != null) {
-
-							if (currentSplit.equals(EOS)) {
-								isRunning = false;
-								break;
-							}
-
-							if (this.format instanceof CheckpointableInputFormat && restoredFormatState != null) {
-
-								@SuppressWarnings("unchecked")
-								CheckpointableInputFormat<FileInputSplit, S> checkpointableFormat =
-										(CheckpointableInputFormat<FileInputSplit, S>) this.format;
-
-								checkpointableFormat.reopen(currentSplit, restoredFormatState);
-							} else {
-								// this is the case of a non-checkpointable input format that will reprocess the last split.
-								LOG.info("Format " + this.format.getClass().getName() + " does not support checkpointing.");
-								format.open(currentSplit);
-							}
-							// reset the restored state to null for the next iteration
-							this.restoredFormatState = null;
-						} else {
-
-							// get the next split to read.
+						if (currentSplit == null) {
 							currentSplit = this.pendingSplits.poll();
-
 							if (currentSplit == null) {
 								checkpointLock.wait(50);
 								continue;
 							}
+						}
 
-							if (currentSplit.equals(EOS)) {
-								isRunning = false;
-								break;
-							}
+						if (currentSplit.equals(EOS)) {
+							isRunning = false;
+							break;
+						}
+
+						if (this.format instanceof CheckpointableInputFormat && currentSplit.getSplitState() != null) {
+							// recovering after a node failure with an input
+							// format that supports resetting the offset
+							((CheckpointableInputFormat<TimestampedFileInputSplit, Serializable>) this.format).
+								reopen(currentSplit, currentSplit.getSplitState());
+						} else {
+							// we either have a new split, or we recovered from a node
+							// failure but the input format does not support resetting the offset.
 							this.format.open(currentSplit);
 						}
+
+						// reset the restored state to null for the next iteration
+						this.currentSplit.resetSplitState();
 						this.isSplitOpen = true;
 					}
 
@@ -348,34 +328,17 @@ public class ContinuousFileReaderOperator<OUT, S extends Serializable> extends A
 			}
 		}
 
-		private Tuple3<List<FileInputSplit>, FileInputSplit, S> getReaderState() throws IOException {
-			List<FileInputSplit> snapshot = new ArrayList<>(this.pendingSplits.size());
-			for (FileInputSplit split: this.pendingSplits) {
-				snapshot.add(split);
-			}
-
-			// remove the current split from the list if inside.
-			if (this.currentSplit != null && this.currentSplit.equals(pendingSplits.peek())) {
-				this.pendingSplits.remove();
-			}
-
-			if (this.currentSplit != null) {
-				if (this.format instanceof CheckpointableInputFormat) {
-					@SuppressWarnings("unchecked")
-					CheckpointableInputFormat<FileInputSplit, S> checkpointableFormat =
-							(CheckpointableInputFormat<FileInputSplit, S>) this.format;
-
-					S formatState = this.isSplitOpen ?
-							checkpointableFormat.getCurrentState() :
-							restoredFormatState;
-					return new Tuple3<>(snapshot, currentSplit, formatState);
-				} else {
-					LOG.info("The format does not support checkpointing. The current input split will be re-read from start upon recovery.");
-					return new Tuple3<>(snapshot, currentSplit, null);
+		private List<TimestampedFileInputSplit> getReaderState() throws IOException {
+			List<TimestampedFileInputSplit> snapshot = new ArrayList<>(this.pendingSplits.size());
+			if (currentSplit != null ) {
+				if (this.format instanceof CheckpointableInputFormat && this.isSplitOpen) {
+					Serializable formatState = ((CheckpointableInputFormat<TimestampedFileInputSplit, Serializable>) this.format).getCurrentState();
+					this.currentSplit.setSplitState(formatState);
 				}
-			} else {
-				return new Tuple3<>(snapshot, null, null);
+				snapshot.add(this.currentSplit);
 			}
+			snapshot.addAll(this.pendingSplits);
+			return snapshot;
 		}
 
 		public void cancel() {
@@ -389,45 +352,27 @@ public class ContinuousFileReaderOperator<OUT, S extends Serializable> extends A
 	public void snapshotState(FSDataOutputStream os, long checkpointId, long timestamp) throws Exception {
 		final ObjectOutputStream oos = new ObjectOutputStream(os);
 
-		Tuple3<List<FileInputSplit>, FileInputSplit, S> readerState = this.reader.getReaderState();
-		List<FileInputSplit> pendingSplits = readerState.f0;
-		FileInputSplit currSplit = readerState.f1;
-		S formatState = readerState.f2;
-
-		// write the current split
-		oos.writeObject(currSplit);
-		oos.writeInt(pendingSplits.size());
-		for (FileInputSplit split : pendingSplits) {
+		List<TimestampedFileInputSplit> readerState = this.reader.getReaderState();
+		oos.writeInt(readerState.size());
+		for (TimestampedFileInputSplit split : readerState) {
 			oos.writeObject(split);
 		}
-
-		// write the state of the reading channel
-		oos.writeObject(formatState);
 		oos.flush();
 	}
 
 	@Override
 	public void restoreState(FSDataInputStream is) throws Exception {
+
+		checkState(this.restoredReaderState == null,
+			"The reader state has already been initialized.");
+
 		final ObjectInputStream ois = new ObjectInputStream(is);
 
-		// read the split that was being read
-		FileInputSplit currSplit = (FileInputSplit) ois.readObject();
-
-		// read the pending splits list
-		List<FileInputSplit> pendingSplits = new ArrayList<>();
 		int noOfSplits = ois.readInt();
+		List<TimestampedFileInputSplit> pendingSplits = new ArrayList<>(noOfSplits);
 		for (int i = 0; i < noOfSplits; i++) {
-			FileInputSplit split = (FileInputSplit) ois.readObject();
-			pendingSplits.add(split);
+			pendingSplits.add((TimestampedFileInputSplit) ois.readObject());
 		}
-
-		// read the state of the format
-		@SuppressWarnings("unchecked")
-		S formatState = (S) ois.readObject();
-
-		// set the whole reader state for the open() to find.
-		checkState(this.readerState == null, "The reader state has already been initialized.");
-
-		this.readerState = new Tuple3<>(pendingSplits, currSplit, formatState);
+		this.restoredReaderState = pendingSplits;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FileProcessingMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FileProcessingMode.java
@@ -20,12 +20,15 @@ package org.apache.flink.streaming.api.functions.source;
 import org.apache.flink.annotation.PublicEvolving;
 
 /**
- * Specifies when the computation of the {@link ContinuousFileMonitoringFunction}
- * will be triggered.
+ * The mode in which the {@link ContinuousFileMonitoringFunction} operates.
+ * This can be either {@link #PROCESS_ONCE} or {@link #PROCESS_CONTINUOUSLY}.
  */
 @PublicEvolving
 public enum FileProcessingMode {
 
-	PROCESS_ONCE,				// Processes the current content of a file/path only ONCE, and stops monitoring.
-	PROCESS_CONTINUOUSLY		// Reprocesses the whole file when new data is appended.
+	/** Processes the current contents of the path and exits. */
+	PROCESS_ONCE,
+
+	/** Periodically scans the path for new data. */
+	PROCESS_CONTINUOUSLY
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/TimestampedFileInputSplit.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/TimestampedFileInputSplit.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.source;
+
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+
+/**
+ * An extended {@link FileInputSplit} that also includes information about:
+ * <ul>
+ *     <li>The modification time of the file this split belongs to.</li>
+ *     <li>When checkpointing, the state of the split at the moment of the checkpoint.</li>
+ * </ul>
+ * This class is used by the {@link ContinuousFileMonitoringFunction} and the
+ * {@link ContinuousFileReaderOperator} to perform continuous file processing.
+ * */
+public class TimestampedFileInputSplit extends FileInputSplit implements Comparable<TimestampedFileInputSplit>{
+
+	/** The modification time of the file this split belongs to. */
+	private final long modificationTime;
+
+	/**
+	 * The state of the split. This information is used when
+	 * restoring from a checkpoint and allows to resume reading the
+	 * underlying file from the point we left off.
+	 * */
+	private Serializable splitState;
+
+	/** A special {@link TimestampedFileInputSplit} signaling the end of the stream of splits.*/
+	public static final TimestampedFileInputSplit EOS =
+		new TimestampedFileInputSplit(Long.MIN_VALUE, -1, null, -1, -1, null);
+
+	/**
+	 * Creates a {@link TimestampedFileInputSplit} based on the file modification time and
+	 * the rest of the information of the {@link FileInputSplit}, as returned by the
+	 * underlying filesystem.
+	 *
+	 * @param modificationTime the modification file of the file this split belongs to
+	 * @param num    the number of this input split
+	 * @param file   the file name
+	 * @param start  the position of the first byte in the file to process
+	 * @param length the number of bytes in the file to process (-1 is flag for "read whole file")
+	 * @param hosts  the list of hosts containing the block, possibly {@code null}
+	 */
+	public TimestampedFileInputSplit(long modificationTime, int num, Path file, long start, long length, String[] hosts) {
+		super(num, file, start, length, hosts);
+
+		Preconditions.checkArgument(modificationTime >= 0 || modificationTime == Long.MIN_VALUE,
+			"Invalid File Split Modification Time: "+ modificationTime +".");
+
+		this.modificationTime = modificationTime;
+	}
+
+	/**
+	 * Sets the state of the split. This information is used when
+	 * restoring from a checkpoint and allows to resume reading the
+	 * underlying file from the point we left off.
+	 * <p>
+	 * This is applicable to {@link org.apache.flink.api.common.io.FileInputFormat FileInputFormats}
+	 * that implement the {@link org.apache.flink.api.common.io.CheckpointableInputFormat
+	 * CheckpointableInputFormat} interface.
+	 * */
+	public void setSplitState(Serializable state) {
+		this.splitState = state;
+	}
+
+	/**
+	 * Sets the state of the split to {@code null}.
+	 */
+	public void resetSplitState() {
+		this.setSplitState(null);
+	}
+
+	/** @return the state of the split. */
+	public Serializable getSplitState() {
+		return this.splitState;
+	}
+
+	/** @return The modification time of the file this split belongs to. */
+	public long getModificationTime() {
+		return this.modificationTime;
+	}
+
+	@Override
+	public int compareTo(TimestampedFileInputSplit o) {
+		long modTimeComp = this.modificationTime - o.modificationTime;
+		if (modTimeComp != 0L) {
+			// we cannot just cast the modTimeComp to int
+			// because it may overflow
+			return modTimeComp > 0 ? 1 : -1;
+		}
+
+		int pathComp = this.getPath().compareTo(o.getPath());
+		return pathComp != 0 ? pathComp : this.getSplitNumber() - o.getSplitNumber();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		} else if (o != null && o instanceof TimestampedFileInputSplit && super.equals(o)) {
+			TimestampedFileInputSplit that = (TimestampedFileInputSplit) o;
+			return this.modificationTime == that.modificationTime;
+		}
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		int res = 37 * (int)(this.modificationTime ^ (this.modificationTime >>> 32));
+		return 37 * res + super.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return "[" + getSplitNumber() + "] " + getPath() +" mod@ "+
+			modificationTime + " : " + getStart() + " + " + getLength();
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/TimestampedFileInputSplitTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/TimestampedFileInputSplitTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.functions.source.TimestampedFileInputSplit;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TimestampedFileInputSplitTest {
+
+	@Test
+	public void testSplitEquality() {
+
+		TimestampedFileInputSplit eos1 = TimestampedFileInputSplit.EOS;
+		TimestampedFileInputSplit eos2 = TimestampedFileInputSplit.EOS;
+
+		Assert.assertEquals(eos1, eos2);
+
+		TimestampedFileInputSplit richFirstSplit =
+			new TimestampedFileInputSplit(10, 2, new Path("test"), 0, 100, null);
+		Assert.assertNotEquals(eos1, richFirstSplit);
+
+		TimestampedFileInputSplit richSecondSplit =
+			new TimestampedFileInputSplit(10, 2, new Path("test"), 0, 100, null);
+		Assert.assertEquals(richFirstSplit, richSecondSplit);
+
+		TimestampedFileInputSplit richModSecondSplit =
+			new TimestampedFileInputSplit(11, 2, new Path("test"), 0, 100, null);
+		Assert.assertNotEquals(richSecondSplit, richModSecondSplit);
+
+		TimestampedFileInputSplit richThirdSplit =
+			new TimestampedFileInputSplit(10, 2, new Path("test/test1"), 0, 100, null);
+		Assert.assertEquals(richThirdSplit.getModificationTime(), 10);
+		Assert.assertNotEquals(richFirstSplit, richThirdSplit);
+
+		TimestampedFileInputSplit richThirdSplitCopy =
+			new TimestampedFileInputSplit(10, 2, new Path("test/test1"), 0, 100, null);
+		Assert.assertEquals(richThirdSplitCopy, richThirdSplit);
+	}
+
+	@Test
+	public void testSplitComparison() {
+		TimestampedFileInputSplit richFirstSplit =
+			new TimestampedFileInputSplit(10, 3, new Path("test/test1"), 0, 100, null);
+
+		TimestampedFileInputSplit richSecondSplit =
+			new TimestampedFileInputSplit(10, 2, new Path("test/test2"), 0, 100, null);
+
+		TimestampedFileInputSplit richThirdSplit =
+			new TimestampedFileInputSplit(10, 1, new Path("test/test2"), 0, 100, null);
+
+		TimestampedFileInputSplit richForthSplit =
+			new TimestampedFileInputSplit(11, 0, new Path("test/test3"), 0, 100, null);
+
+		// lexicographically on the path order
+		Assert.assertTrue(richFirstSplit.compareTo(richSecondSplit) < 0);
+		Assert.assertTrue(richFirstSplit.compareTo(richThirdSplit) < 0);
+
+		// same mod time, same file so smaller split number first
+		Assert.assertTrue(richThirdSplit.compareTo(richSecondSplit) < 0);
+
+		// smaller modification time first
+		Assert.assertTrue(richThirdSplit.compareTo(richForthSplit) < 0);
+	}
+
+	@Test
+	public void testIllegalArgument() {
+		try {
+			new TimestampedFileInputSplit(-10, 2, new Path("test"), 0, 100, null); // invalid modification time
+		} catch (Exception e) {
+			if (!(e instanceof IllegalArgumentException)) {
+				Assert.fail(e.getMessage());
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces the `TimestampedFileInputSplit` which extends the class `FileInputSplit`
and also contains:
i) the modification time of the file the split belongs to and also, and
ii) when checkpointing, the point the reader is currently reading from.

The latter will be useful for rescaling. With this addition, the `ContinuousFileMonitoringFunction` sends `TimestampedFileInputSplits` to the Readers, and the Readers' state now contain only `TimestampedFileInputSplit`s. 

In addition, this PR also refactors the code of the `ContinuousFileMonitoringFunction`, the `ContinuousFileReaderOperator`, and the related tests. The `ContinuousFileMonitoringFunction` 
still checks for files that have not been  processed based on their modification time, sorts 
these files by modification time, splits them in `TimestampedFileInputSplits`, and forwards 
these splits downstream to the `ContinuousFileReaderOperator`.