### PR TITLE
[FLINK-3706] Fix YARN test instability

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -309,12 +309,13 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	}
 
 	/**
-	 * Test deployment to non-existing queue. (user-reported error)
-	 * Deployment to the queue is possible because there are no queues, so we don't check.
+	 * Test deployment to non-existing queue & ensure that the system logs a WARN message
+	 * for the user. (Users had unexpected behavior of Flink on YARN because they mistyped the
+	 * target queue. With an error message, we can help users identifying the issue)
 	 */
 	@Test
-	public void testNonexistingQueue() {
-		LOG.info("Starting testNonexistingQueue()");
+	public void testNonexistingQueueWARNmessage() {
+		LOG.info("Starting testNonexistingQueueWARNmessage()");
 		addTestAppender(YarnClusterDescriptor.class, Level.WARN);
 		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
 				"-t", flinkLibFolder.getAbsolutePath(),
@@ -322,8 +323,8 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 				"-jm", "768",
 				"-tm", "1024",
 				"-qu", "doesntExist"}, "to unknown queue: doesntExist", null, RunTypes.YARN_SESSION, 1);
-		checkForLogString("The specified queue 'doesntExist' does not exist. Available queues: default, qa-team");
-		LOG.info("Finished testNonexistingQueue()");
+		checkForLogString("The specified queue 'doesntExist' does not exist. Available queues");
+		LOG.info("Finished testNonexistingQueueWARNmessage()");
 	}
 
 	/**

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -84,7 +84,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 	public void testDetachedMode() {
 		LOG.info("Starting testDetachedMode()");
 		addTestAppender(FlinkYarnSessionCli.class, Level.INFO);
-		Runner runner = startWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
+		startWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
 						"-t", flinkLibFolder.getAbsolutePath(),
 						"-n", "1",
 						"-jm", "768",
@@ -162,21 +162,6 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		LOG.info("Finished testQueryCluster()");
 	}
 
-	/**
-	 * Test deployment to non-existing queue. (user-reported error)
-	 * Deployment to the queue is possible because there are no queues, so we don't check.
-	 */
-	@Test
-	public void testNonexistingQueue() {
-		LOG.info("Starting testNonexistingQueue()");
-		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
-				"-t", flinkLibFolder.getAbsolutePath(),
-				"-n", "1",
-				"-jm", "768",
-				"-tm", "1024",
-				"-qu", "doesntExist"}, "Number of connected TaskManagers changed to 1. Slots available: 1", null, RunTypes.YARN_SESSION, 0);
-		LOG.info("Finished testNonexistingQueue()");
-	}
 
 	/**
 	 * The test cluster has the following resources:

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
@@ -90,9 +90,6 @@ public class YARNSessionFIFOSecuredITCase extends YARNSessionFIFOITCase {
 	public void testQueryCluster() {}
 
 	@Override
-	public void testNonexistingQueue() {}
-
-	@Override
 	public void testResourceComputation() {}
 
 	@Override


### PR DESCRIPTION
The most important change in this commit is that the `YarnTestBase.Runner` doesn't do `try {} catch (Throwable t) { fail(t); }` anymore, which doesn't lead to a test failure, because its called outside the main thread.
With the change, all throwables are reported back to the main thread and fail the test there properly (many YARN tests benefit from this change).

I ran the changes multiple times and they were not failing with YARN tests.

@mxm could you quickly review the changes? The change is rather small, I was considering to push a hotfix, but decided to do a quick PR review round.