### PR TITLE
[FLINK-4516] update leadership information in ResourceManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -61,14 +61,14 @@ public interface ResourceManagerGateway extends RpcGateway {
 	/**
 	 * Requests a slot from the resource manager.
 	 *
-	 * @param jobMasterLeaderID leader id of the JobMaster
 	 * @param resourceManagerLeaderID leader if of the ResourceMaster
+	 * @param jobMasterLeaderID leader if of the JobMaster
 	 * @param slotRequest The slot to request
 	 * @return The confirmation that the slot gets allocated
 	 */
 	Future<RMSlotRequestReply> requestSlot(
-		UUID jobMasterLeaderID,
 		UUID resourceManagerLeaderID,
+		UUID jobMasterLeaderID,
 		SlotRequest slotRequest,
 		@RpcTimeout Time timeout);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServices.java
@@ -19,12 +19,18 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 
+import java.util.UUID;
 import java.util.concurrent.Executor;
 
 /**
  * Interface which provides access to services of the ResourceManager.
  */
 public interface ResourceManagerServices {
+
+	/**
+	 * Gets the current leader id assigned at the ResourceManager.
+	 */
+	UUID getLeaderID();
 
 	/**
 	 * Allocates a resource according to the resource profile.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/JobMasterRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/JobMasterRegistration.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.registration;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+
+import java.util.UUID;
+
+/**
+ * This class is responsible for grouping the JobMasterGateway and the JobMaster's
+ * leader id
+ */
+public class JobMasterRegistration {
+
+	private static final long serialVersionUID = -2062957799469434614L;
+
+	private final JobID jobID;
+
+	private final UUID leaderID;
+
+	private final JobMasterGateway jobMasterGateway;
+
+	public JobMasterRegistration(
+			JobID jobID,
+			UUID leaderID,
+			JobMasterGateway jobMasterGateway) {
+		this.jobID = jobID;
+		this.leaderID = leaderID;
+		this.jobMasterGateway = jobMasterGateway;
+	}
+
+	public JobID getJobID() {
+		return jobID;
+	}
+
+
+	public UUID getLeaderID() {
+		return leaderID;
+	}
+
+	public JobMasterGateway getJobMasterGateway() {
+		return jobMasterGateway;
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingSlotManager.java
@@ -26,6 +26,7 @@ import org.mockito.Mockito;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Executor;
 
 public class TestingSlotManager extends SlotManager {
@@ -59,6 +60,13 @@ public class TestingSlotManager extends SlotManager {
 	}
 
 	private static class TestingResourceManagerServices implements ResourceManagerServices {
+
+		private final UUID leaderID = UUID.randomUUID();
+
+		@Override
+		public UUID getLeaderID() {
+			return leaderID;
+		}
 
 		@Override
 		public void allocateResource(ResourceProfile resourceProfile) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
@@ -498,10 +498,18 @@ public class SlotManagerTest {
 
 		private static class TestingRmServices implements ResourceManagerServices {
 
-			private List<ResourceProfile> allocatedContainers;
+			private final UUID leaderID;
+
+			private final List<ResourceProfile> allocatedContainers;
 
 			public TestingRmServices() {
+				this.leaderID = UUID.randomUUID();
 				this.allocatedContainers = new LinkedList<>();
+			}
+
+			@Override
+			public UUID getLeaderID() {
+				return leaderID;
 			}
 
 			@Override


### PR DESCRIPTION
The leadership information remained static for connectedJobMasters. This updates it to remove stale JobMasters when they lose leadership status.