### PR TITLE
[FLINK-4801] [types] Input type inference is faulty with custom Tuples and RichFunctions

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractionUtils.java
@@ -20,7 +20,9 @@ package org.apache.flink.api.java.typeutils;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -81,6 +83,12 @@ public class TypeExtractionUtils {
 		}
 	}
 
+	/**
+	 * Checks if the given function has been implemented using a Java 8 lambda. If yes, a LambdaExecutable
+	 * is returned describing the method/constructor. Otherwise null.
+	 *
+	 * @throws TypeExtractionException lambda extraction is pretty hacky, it might fail for unknown JVM issues.
+	 */
 	public static LambdaExecutable checkAndExtractLambda(Function function) throws TypeExtractionException {
 		try {
 			// get serialized lambda
@@ -163,5 +171,35 @@ public class TypeExtractionUtils {
 			clazz = clazz.getSuperclass();
 		}
 		return result;
+	}
+
+	/**
+	 * Convert ParameterizedType or Class to a Class.
+	 */
+	public static Class<?> typeToClass(Type t) {
+		if (t instanceof Class) {
+			return (Class<?>)t;
+		}
+		else if (t instanceof ParameterizedType) {
+			return ((Class<?>)((ParameterizedType) t).getRawType());
+		}
+		throw new IllegalArgumentException("Cannot convert type to class");
+	}
+
+	/**
+	 * Checks if a type can be converted to a Class. This is true for ParameterizedType and Class.
+	 */
+	public static boolean isClassType(Type t) {
+		return t instanceof Class<?> || t instanceof ParameterizedType;
+	}
+
+	/**
+	 * Checks whether two types are type variables describing the same.
+	 */
+	public static boolean sameTypeVars(Type t1, Type t2) {
+		return t1 instanceof TypeVariable &&
+			t2 instanceof TypeVariable &&
+			((TypeVariable<?>) t1).getName().equals(((TypeVariable<?>) t2).getName()) &&
+			((TypeVariable<?>) t1).getGenericDeclaration().equals(((TypeVariable<?>) t2).getGenericDeclaration());
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/Serializers.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/Serializers.java
@@ -34,7 +34,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.java.typeutils.GenericTypeInfo;
 import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
-import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.api.java.typeutils.TypeExtractionUtils;
 
 import java.io.Serializable;
 import java.lang.reflect.Field;
@@ -113,8 +113,8 @@ public class Serializers {
 			ParameterizedType parameterizedFieldType = (ParameterizedType) fieldType;
 			
 			for (Type t: parameterizedFieldType.getActualTypeArguments()) {
-				if (TypeExtractor.isClassType(t) ) {
-					recursivelyRegisterType(TypeExtractor.typeToClass(t), config, alreadySeen);
+				if (TypeExtractionUtils.isClassType(t) ) {
+					recursivelyRegisterType(TypeExtractionUtils.typeToClass(t), config, alreadySeen);
 				}
 			}
 


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.
- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)
- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added
- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

This PR solves an issue with `TypeExtractor` logic separated into two methods `createTypeInfoFromInput` and `findCorrespodingInfo`. I merged the two methods into one and added a test for it.
