### PR TITLE
[FLINK-3722] [runtime] Don't / and % when sorting

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/IndexedSortable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/IndexedSortable.java
@@ -30,9 +30,33 @@ public interface IndexedSortable {
 	int compare(int i, int j);
 
 	/**
+	 * Compare records at the given addresses consistent with the semantics of
+	 * {@link java.util.Comparator#compare(Object, Object)}.
+
+	 * @param segmentNumberI index of memory segment containing first record
+	 * @param segmentOffsetI offset into memory segment containing first record
+	 * @param segmentNumberJ index of memory segment containing second record
+	 * @param segmentOffsetJ offset into memory segment containing second record
+	 * @return a negative integer, zero, or a positive integer as the
+	 *         first argument is less than, equal to, or greater than the
+	 *         second.
+	 */
+	int compare(int segmentNumberI, int segmentOffsetI, int segmentNumberJ, int segmentOffsetJ);
+
+	/**
 	 * Swap items at the given addresses.
 	 */
 	void swap(int i, int j);
+
+	/**
+	 * Swap records at the given addresses.
+	 *
+	 * @param segmentNumberI index of memory segment containing first record
+	 * @param segmentOffsetI offset into memory segment containing first record
+	 * @param segmentNumberJ index of memory segment containing second record
+	 * @param segmentOffsetJ offset into memory segment containing second record
+	 */
+	void swap(int segmentNumberI, int segmentOffsetI, int segmentNumberJ, int segmentOffsetJ);
 
 	/**
 	 * Gets the number of elements in the sortable.
@@ -41,4 +65,18 @@ public interface IndexedSortable {
 	 */
 	int size();
 
+	/**
+	 * Gets the size of each record, the number of bytes separating the head
+	 * of successive records.
+	 *
+	 * @return The record size
+	 */
+	int recordSize();
+
+	/**
+	 * Gets the number of elements in each memory segment.
+	 *
+	 * @return The number of records per segment
+	 */
+	int recordsPerSegment();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/QuickSort.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/QuickSort.java
@@ -26,9 +26,19 @@ public final class QuickSort implements IndexedSorter {
 	public QuickSort() {
 	}
 
-	private static void fix(IndexedSortable s, int p, int r) {
-		if (s.compare(p, r) > 0) {
-			s.swap(p, r);
+	/**
+	 * Fix the records into sorted order, swapping when the first record is
+	 * greater than the second record.
+	 *
+	 * @param s paged sortable
+	 * @param pN page number of first record
+	 * @param pO page offset of first record
+	 * @param rN page number of second record
+	 * @param rO page offset of second record
+	 */
+	private static void fix(IndexedSortable s, int pN, int pO, int rN, int rO) {
+		if (s.compare(pN, pO, rN, rO) > 0) {
+			s.swap(pN, pO, rN, rO);
 		}
 	}
 
@@ -45,85 +55,154 @@ public final class QuickSort implements IndexedSorter {
 
 	/**
 	 * Sort the given range of items using quick sort. {@inheritDoc} If the recursion depth falls below
-	 * {@link #getMaxDepth},
-	 * then switch to {@link HeapSort}.
+	 * {@link #getMaxDepth}, then switch to {@link HeapSort}.
 	 */
 	public void sort(final IndexedSortable s, int p, int r) {
-		sortInternal(s, p, r, getMaxDepth(r - p));
+		int recordsPerSegment = s.recordsPerSegment();
+		int recordSize = s.recordSize();
+		int maxOffset = recordSize * (recordsPerSegment - 1);
+
+		int pN = p / recordsPerSegment;
+		int pO = (p % recordsPerSegment) * recordSize;
+
+		int rN = r / recordsPerSegment;
+		int rO = (r % recordsPerSegment) * recordSize;
+
+		sortInternal(s, recordsPerSegment, recordSize, maxOffset, p, pN, pO, r, rN, rO, getMaxDepth(r - p));
 	}
 
 	public void sort(IndexedSortable s) {
 		sort(s, 0, s.size());
 	}
 
-	private static void sortInternal(final IndexedSortable s, int p, int r, int depth) {
+	/**
+	 * Sort the given range of items using quick sort. If the recursion depth falls below
+	 * {@link #getMaxDepth}, then switch to {@link HeapSort}.
+	 *
+	 * @param s paged sortable
+	 * @param recordsPerSegment number of records per memory segment
+	 * @param recordSize number of bytes per record
+	 * @param maxOffset offset of a last record in a memory segment
+	 * @param p index of first record in range
+	 * @param pN page number of first record in range
+	 * @param pO page offset of first record in range
+	 * @param r index of last-plus-one'th record in range
+	 * @param rN page number of last-plus-one'th record in range
+	 * @param rO page offset of last-plus-one'th record in range
+	 * @param depth recursion depth
+	 *
+	 * @see #sort(IndexedSortable, int, int)
+	 */
+	private static void sortInternal(final IndexedSortable s, int recordsPerSegment, int recordSize, int maxOffset,
+			int p, int pN, int pO, int r, int rN, int rO, int depth) {
 		while (true) {
 			if (r - p < 13) {
-				for (int i = p; i < r; ++i) {
-					for (int j = i; j > p && s.compare(j - 1, j) > 0; --j) {
-						s.swap(j, j - 1);
+				// switch to insertion sort
+				int i = p+1, iN, iO; if (pO == maxOffset) { iN = pN+1; iO = 0; } else { iN = pN; iO = pO+recordSize; }
+
+				while (i < r) {
+					int j = i, jN = iN, jO = iO;
+					int jd = j-1, jdN, jdO; if (jO == 0) { jdN = jN-1; jdO = maxOffset; } else { jdN = jN; jdO = jO-recordSize; }
+
+					while (j > p && s.compare(jdN, jdO, jN, jO) > 0) {
+						s.swap(jN, jO, jdN, jdO);
+
+						j = jd; jN = jdN; jO = jdO;
+						jd--; if (jdO == 0) { jdN--; jdO = maxOffset; } else { jdO -= recordSize; }
 					}
+
+					i++; if (iO == maxOffset) { iN++; iO = 0; } else { iO += recordSize; }
 				}
 				return;
 			}
+
 			if (--depth < 0) {
-				// give up
+				// switch to heap sort
 				alt.sort(s, p, r);
 				return;
 			}
 
+			int rdN, rdO; if (rO == 0) { rdN = rN-1; rdO = maxOffset; } else { rdN = rN; rdO = rO-recordSize; }
+			int m = (p+r)>>>1, mN = m / recordsPerSegment, mO = (m % recordsPerSegment) * recordSize;
+
 			// select, move pivot into first position
-			fix(s, (p + r) >>> 1, p);
-			fix(s, (p + r) >>> 1, r - 1);
-			fix(s, p, r - 1);
+			fix(s, mN, mO, pN, pO);
+			fix(s, mN, mO, rdN, rdO);
+			fix(s, pN, pO, rdN, rdO);
 
 			// Divide
-			int i = p;
-			int j = r;
-			int ll = p;
-			int rr = r;
+			int i = p, iN = pN, iO = pO;
+			int j = r, jN = rN, jO = rO;
+			int ll = p, llN = pN, llO = pO;
+			int rr = r, rrN = rN, rrO = rO;
 			int cr;
 			while (true) {
-				while (++i < j) {
-					if ((cr = s.compare(i, p)) > 0) {
+				i++; if (iO == maxOffset) { iN++; iO = 0; } else { iO += recordSize; }
+
+				while (i < j) {
+					if ((cr = s.compare(iN, iO, pN, pO)) > 0) {
 						break;
 					}
-					if (0 == cr && ++ll != i) {
-						s.swap(ll, i);
+
+					if (0 == cr) {
+						ll++; if (llO == maxOffset) { llN++; llO = 0; } else { llO += recordSize; }
+
+						if (ll != i) {
+							s.swap(llN, llO, iN, iO);
+						}
 					}
+
+					i++; if (iO == maxOffset) { iN++; iO = 0; } else { iO += recordSize; }
 				}
-				while (--j > i) {
-					if ((cr = s.compare(p, j)) > 0) {
+
+				j--; if (jO == 0) { jN--; jO = maxOffset; } else { jO -= recordSize; }
+
+				while (j > i) {
+					if ((cr = s.compare(pN, pO, jN, jO)) > 0) {
 						break;
 					}
-					if (0 == cr && --rr != j) {
-						s.swap(rr, j);
+
+					if (0 == cr) {
+						rr--; if (rrO == 0) { rrN--; rrO = maxOffset; } else { rrO -= recordSize; }
+
+						if (rr != j) {
+							s.swap(rrN, rrO, jN, jO);
+						}
 					}
+
+					j--; if (jO == 0) { jN--; jO = maxOffset; } else { jO -= recordSize; }
 				}
 				if (i < j) {
-					s.swap(i, j);
+					s.swap(iN, iO, jN, jO);
 				} else {
 					break;
 				}
 			}
-			j = i;
+			j = i; jN = iN; jO = iO;
 			// swap pivot- and all eq values- into position
 			while (ll >= p) {
-				s.swap(ll--, --i);
+				i--; if (iO == 0) { iN--; iO = maxOffset; } else { iO -= recordSize; }
+
+				s.swap(llN, llO, iN, iO);
+
+				ll--; if (llO == 0) { llN--; llO = maxOffset; } else { llO -= recordSize; }
 			}
 			while (rr < r) {
-				s.swap(rr++, j++);
+				s.swap(rrN, rrO, jN, jO);
+
+				rr++; if (rrO == maxOffset) { rrN++; rrO = 0; } else { rrO += recordSize; }
+				j++; if (jO == maxOffset) { jN++; jO = 0; } else { jO += recordSize; }
 			}
 
 			// Conquer
 			// Recurse on smaller interval first to keep stack shallow
 			assert i != j;
 			if (i - p < r - j) {
-				sortInternal(s, p, i, depth);
-				p = j;
+				sortInternal(s, recordsPerSegment, recordSize, maxOffset, p, pN, pO, i, iN, iO, depth);
+				p = j; pN = jN; pO = jO;
 			} else {
-				sortInternal(s, j, r, depth);
-				r = i;
+				sortInternal(s, recordsPerSegment, recordSize, maxOffset, j, jN, jO, r, rN, rO, depth);
+				r = i; rN = iN; rO = iO;
 			}
 		}
 	}


### PR DESCRIPTION
Replace division and modulus with addition and subtraction.

The timing chart below has three columns for two Gelly algorithms with increasing scale. The first is timings for the master branch. The second column replaces division and modulus with shift-and-bitmask by storing each element in a power-of-2 chunk of memory. The third column is for this PR which modifies the sort algorithm to track the buffer number and offset for each index. This code has the advantage that there is no wasted memory.

In this comparison, for both int and long, we look to be already operating on power-of-2 size elements. I would expect this PR to perform relatively better with the FixedLengthRecordSorter instrumented from FLINK-4705 where shift-and-bitmask would be padding elements.

This initial PR does not modify `HeapSort`. I wanted to first get acceptance for the current set of modifications. There are further optimizations which can be benchmarked in follow-on tickets.

```
HITS, scale=16, INT   : runtime=   1.618 (8)      1.524 (8) ( -5.82%)   1.546 (8) ( -4.47%)
HITS, scale=16, LONG  : runtime=   1.579 (8)      1.552 (8) ( -1.76%)   1.541 (8) ( -2.43%)
HITS, scale=16, STRING: runtime=   1.774 (8)      1.739 (8) ( -1.99%)   1.701 (8) ( -4.11%)

HITS, scale=17, INT   : runtime=   2.032 (8)      1.950 (8) ( -4.06%)   1.937 (8) ( -4.71%)
HITS, scale=17, LONG  : runtime=   1.986 (8)      1.923 (8) ( -3.15%)   1.926 (8) ( -3.01%)
HITS, scale=17, STRING: runtime=   2.377 (8)      2.275 (8) ( -4.30%)   2.289 (8) ( -3.68%)

HITS, scale=18, INT   : runtime=   2.894 (8)      2.761 (8) ( -4.59%)   2.762 (8) ( -4.54%)
HITS, scale=18, LONG  : runtime=   2.863 (8)      2.754 (8) ( -3.81%)   2.735 (8) ( -4.48%)
HITS, scale=18, STRING: runtime=   3.683 (8)      3.455 (8) ( -6.18%)   3.461 (8) ( -6.02%)

HITS, scale=19, INT   : runtime=   4.914 (8)      4.631 (8) ( -5.76%)   4.595 (8) ( -6.49%)
HITS, scale=19, LONG  : runtime=   4.792 (8)      4.578 (8) ( -4.45%)   4.538 (8) ( -5.28%)
HITS, scale=19, STRING: runtime=   6.484 (8)      6.149 (8) ( -5.18%)   6.118 (8) ( -5.64%)

HITS, scale=20, INT   : runtime=   8.662 (8)      8.086 (8) ( -6.64%)   8.091 (8) ( -6.59%)
HITS, scale=20, LONG  : runtime=   8.407 (8)      7.993 (8) ( -4.93%)   7.918 (8) ( -5.82%)
HITS, scale=20, STRING: runtime=  11.946 (8)     11.327 (8) ( -5.18%)  11.272 (8) ( -5.64%)

HITS, scale=21, INT   : runtime=  16.248 (8)     15.137 (8) ( -6.84%)  15.207 (8) ( -6.41%)
HITS, scale=21, LONG  : runtime=  15.907 (8)     14.750 (8) ( -7.28%)  14.724 (8) ( -7.44%)
HITS, scale=21, STRING: runtime=  23.634 (8)     22.596 (8) ( -4.39%)  22.546 (8) ( -4.61%)

HITS, scale=22, INT   : runtime=  31.964 (8)     29.954 (8) ( -6.29%)  29.808 (8) ( -6.74%)
HITS, scale=22, LONG  : runtime=  31.244 (8)     29.241 (8) ( -6.41%)  28.829 (8) ( -7.73%)
HITS, scale=22, STRING: runtime=  47.870 (6)     45.942 (6) ( -4.03%)  45.987 (8) ( -3.93%)

HITS, scale=23, INT   : runtime=  65.146 (4)     60.245 (4) ( -7.52%)  60.008 (4) ( -7.89%)
HITS, scale=23, LONG  : runtime=  64.770 (4)     59.828 (4) ( -7.63%)  59.334 (4) ( -8.39%)
HITS, scale=23, STRING: runtime= 103.690 (2)     99.335 (2) ( -4.20%)  98.919 (3) ( -4.60%)

HITS, scale=24, INT   : runtime= 156.567 (2)    138.923 (2) (-11.27%) 141.185 (2) ( -9.82%)
HITS, scale=24, LONG  : runtime= 141.904 (2)    132.292 (2) ( -6.77%) 129.677 (2) ( -8.62%)
HITS, scale=24, STRING: runtime= 221.081 (1)    217.128 (1) ( -1.79%) 213.822 (1) ( -3.28%)

HITS, scale=25, INT   : runtime=                                      280.720 (1)          
HITS, scale=25, LONG  : runtime= 321.418 (1)    297.764 (1) ( -7.36%) 293.982 (1) ( -8.54%)


JaccardIndex, scale=12, INT   : runtime=   0.413 (8)      0.424 (8) (  2.57%)   0.408 (8) ( -1.30%)
JaccardIndex, scale=12, LONG  : runtime=   0.440 (8)      0.414 (8) ( -5.85%)   0.424 (8) ( -3.64%)
JaccardIndex, scale=12, STRING: runtime=   0.667 (8)      0.647 (8) ( -2.91%)   0.644 (8) ( -3.38%)

JaccardIndex, scale=13, INT   : runtime=   0.811 (8)      0.743 (8) ( -8.45%)   0.764 (8) ( -5.75%)
JaccardIndex, scale=13, LONG  : runtime=   0.885 (8)      0.822 (8) ( -7.12%)   0.805 (8) ( -9.01%)
JaccardIndex, scale=13, STRING: runtime=   1.599 (8)      1.489 (8) ( -6.86%)   1.486 (8) ( -7.04%)

JaccardIndex, scale=14, INT   : runtime=   1.809 (8)      1.621 (8) (-10.43%)   1.649 (8) ( -8.87%)
JaccardIndex, scale=14, LONG  : runtime=   2.003 (8)      1.834 (8) ( -8.43%)   1.800 (8) (-10.13%)
JaccardIndex, scale=14, STRING: runtime=   3.855 (8)      3.666 (8) ( -4.91%)   3.667 (8) ( -4.86%)

JaccardIndex, scale=15, INT   : runtime=   4.693 (8)      4.158 (8) (-11.40%)   4.148 (8) (-11.62%)
JaccardIndex, scale=15, LONG  : runtime=   5.205 (8)      4.936 (8) ( -5.17%)   4.712 (8) ( -9.48%)
JaccardIndex, scale=15, STRING: runtime=  10.882 (8)     10.429 (8) ( -4.16%)  10.529 (8) ( -3.24%)

JaccardIndex, scale=16, INT   : runtime=  13.504 (8)     11.852 (8) (-12.24%)  12.124 (8) (-10.22%)
JaccardIndex, scale=16, LONG  : runtime=  14.933 (8)     13.482 (8) ( -9.72%)  13.279 (8) (-11.08%)
JaccardIndex, scale=16, STRING: runtime=  31.802 (8)     30.549 (8) ( -3.94%)  30.910 (8) ( -2.80%)

JaccardIndex, scale=17, INT   : runtime=  36.742 (8)     32.542 (8) (-11.43%)  33.193 (8) ( -9.66%)
JaccardIndex, scale=17, LONG  : runtime=  40.648 (6)     37.355 (6) ( -8.10%)  36.786 (8) ( -9.50%)
JaccardIndex, scale=17, STRING: runtime=  89.418 (4)     84.632 (4) ( -5.35%)  86.596 (4) ( -3.16%)

JaccardIndex, scale=18, INT   : runtime= 102.126 (4)     91.521 (4) (-10.38%)  90.900 (4) (-10.99%)
JaccardIndex, scale=18, LONG  : runtime= 121.389 (3)    113.324 (3) ( -6.64%) 112.323 (4) ( -7.47%)
JaccardIndex, scale=18, STRING: runtime= 251.373 (2)    240.014 (2) ( -4.52%) 243.849 (2) ( -2.99%)

JaccardIndex, scale=19, INT   : runtime= 286.927 (1)    254.767 (1) (-11.21%) 260.911 (2) ( -9.07%)
JaccardIndex, scale=19, LONG  : runtime= 331.742 (1)    303.246 (1) ( -8.59%) 301.764 (2) ( -9.04%)
```
