### PR TITLE
[FLINK-4373] [cluster management] Introduce AllocationID, ResourceProfile, and AllocatedSlot

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/AllocationID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/AllocationID.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework.types;
+
+import org.apache.flink.util.AbstractID;
+
+/**
+ * Unique identifier for a slot allocated by a JobManager from a TaskManager.
+ * Also identifies a pending allocation request, and is constant across retries.
+ * 
+ * <p>This ID is used for all synchronization of the status of Slots from TaskManagers
+ * that are not free (i.e., have been allocated by a job).
+ */
+public class AllocationID extends AbstractID {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Constructs a new random AllocationID.
+	 */
+	public AllocationID() {
+		super();
+	}
+
+	/**
+	 * Constructs a new AllocationID with the given parts.
+	 *
+	 * @param lowerPart the lower bytes of the ID
+	 * @param upperPart the higher bytes of the ID
+	 */
+	public AllocationID(long lowerPart, long upperPart) {
+		super(lowerPart, upperPart);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework.types;
+
+import java.io.Serializable;
+
+/**
+ * Describe the resource profile of the slot, either when requiring or offering it. The profile can be
+ * checked whether it can match another profile's requirement, and furthermore we may calculate a matching
+ * score to decide which profile we should choose when we have lots of candidate slots.
+ */
+public class ResourceProfile implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	public static final ResourceProfile UNKNOWN = new ResourceProfile(-1.0, -1L);
+
+	// ------------------------------------------------------------------------
+
+	/** How many cpu cores are needed, use double so we can specify cpu like 0.1 */
+	private final double cpuCores;
+
+	/** How many memory in mb are needed */
+	private final long memoryInMB;
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Creates a new ResourceProfile.
+	 * 
+	 * @param cpuCores   The number of CPU cores (possibly fractional, i.e., 0.2 cores)
+	 * @param memoryInMB The size of the memory, in megabytes.
+	 */
+	public ResourceProfile(double cpuCores, long memoryInMB) {
+		this.cpuCores = cpuCores;
+		this.memoryInMB = memoryInMB;
+	}
+
+	/**
+	 * Creates a copy of the given ResourceProfile.
+	 * 
+	 * @param other The ResourceProfile to copy. 
+	 */
+	public ResourceProfile(ResourceProfile other) {
+		this.cpuCores = other.cpuCores;
+		this.memoryInMB = other.memoryInMB;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Get the cpu cores needed
+	 * @return The cpu cores, 1.0 means a full cpu thread
+	 */
+	public double getCpuCores() {
+		return cpuCores;
+	}
+
+	/**
+	 * Get the memory needed in MB
+	 * @return The memory in MB
+	 */
+	public long getMemoryInMB() {
+		return memoryInMB;
+	}
+
+	/**
+	 * Check whether required resource profile can be matched
+	 *
+	 * @param required the required resource profile
+	 * @return true if the requirement is matched, otherwise false
+	 */
+	public boolean isMatching(ResourceProfile required) {
+		return cpuCores >= required.getCpuCores() && memoryInMB >= required.getMemoryInMB();
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public int hashCode() {
+		long cpuBits = Double.doubleToLongBits(cpuCores);
+		return (int) (cpuBits ^ (cpuBits >>> 32) ^ memoryInMB ^ (memoryInMB >> 32));
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == this) {
+			return true;
+		}
+		else if (obj != null && obj.getClass() == ResourceProfile.class) {
+			ResourceProfile that = (ResourceProfile) obj;
+			return this.cpuCores == that.cpuCores && this.memoryInMB == that.memoryInMB; 
+		}
+		else {
+			return false;
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "ResourceProfile{" +
+			"cpuCores=" + cpuCores +
+			", memoryInMB=" + memoryInMB +
+			'}';
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/AllocatedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/AllocatedSlot.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager.slots;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The {@code AllocatedSlot} represents a slot that the JobManager allocated from a TaskManager.
+ * It represents a slice of allocated resources from the TaskManager.
+ * 
+ * <p>To allocate an {@code AllocatedSlot}, the requests a slot from the ResourceManager. The
+ * ResourceManager picks (or starts) a TaskManager that will then allocate the slot to the
+ * JobManager and notify the JobManager.
+ * 
+ * <p>Note: Prior to the resource management changes introduced in (Flink Improvement Proposal 6),
+ * an AllocatedSlot was allocated to the JobManager as soon as the TaskManager registered at the
+ * JobManager. All slots had a default unknown resource profile. 
+ */
+public class AllocatedSlot {
+
+	/** The ID under which the slot is allocated. Uniquely identifies the slot. */
+	private final AllocationID slotAllocationId;
+
+	/** The ID of the job this slot is allocated for */
+	private final JobID jobID;
+
+	/** The location information of the TaskManager to which this slot belongs */
+	private final TaskManagerLocation taskManagerLocation;
+
+	/** The resource profile of the slot provides */
+	private final ResourceProfile resourceProfile;
+
+	/** TEMP until the new RPC is in place: The actor gateway to communicate with the TaskManager */
+	private final ActorGateway taskManagerActorGateway;
+
+	/** The number of the slot on the TaskManager to which slot belongs. Purely informational. */
+	private final int slotNumber;
+
+	// ------------------------------------------------------------------------
+
+	public AllocatedSlot(
+			AllocationID slotAllocationId,
+			JobID jobID,
+			TaskManagerLocation location,
+			int slotNumber,
+			ResourceProfile resourceProfile,
+			ActorGateway actorGateway)
+	{
+		this.slotAllocationId = checkNotNull(slotAllocationId);
+		this.jobID = checkNotNull(jobID);
+		this.taskManagerLocation = checkNotNull(location);
+		this.slotNumber = slotNumber;
+		this.resourceProfile = checkNotNull(resourceProfile);
+		this.taskManagerActorGateway = checkNotNull(actorGateway);
+	}
+
+	public AllocatedSlot(AllocatedSlot other) {
+		this.slotAllocationId = other.slotAllocationId;
+		this.jobID = other.jobID;
+		this.taskManagerLocation = other.taskManagerLocation;
+		this.slotNumber = other.slotNumber;
+		this.resourceProfile = other.resourceProfile;
+		this.taskManagerActorGateway = other.taskManagerActorGateway;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Gets the ID under which the slot is allocated, which uniquely identifies the slot.
+	 * 
+	 * @return The ID under which the slot is allocated
+	 */
+	public AllocationID getSlotAllocationId() {
+		return slotAllocationId;
+	}
+
+	/**
+	 * Returns the ID of the job this allocated slot belongs to.
+	 *
+	 * @return the ID of the job this allocated slot belongs to
+	 */
+	public JobID getJobID() {
+		return jobID;
+	}
+
+	/**
+	 * Gets the number of the slot.
+	 *
+	 * @return The number of the slot on the TaskManager.
+	 */
+	public int getSlotNumber() {
+		return slotNumber;
+	}
+
+	/**
+	 * Gets the resource profile of the slot.
+	 *
+	 * @return The resource profile of the slot.
+	 */
+	public ResourceProfile getResourceProfile() {
+		return resourceProfile;
+	}
+
+	/**
+	 * Gets the location info of the TaskManager that offers this slot.
+	 *
+	 * @return The location info of the TaskManager that offers this slot
+	 */
+	public TaskManagerLocation getTaskManagerLocation() {
+		return taskManagerLocation;
+	}
+
+	/**
+	 * Gets the actor gateway that can be used to send messages to the TaskManager.
+	 * <p>
+	 * This method should be removed once the new interface-based RPC abstraction is in place
+	 *
+	 * @return The actor gateway that can be used to send messages to the TaskManager.
+	 */
+	public ActorGateway getTaskManagerActorGateway() {
+		return taskManagerActorGateway;
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public String toString() {
+		return "AllocatedSlot " + slotAllocationId + " @ " + taskManagerLocation + " - " + slotNumber;
+	}
+}


### PR DESCRIPTION
These classes are introduced as part of the cluster management rework (FLIP-6)

The `AllocatedSlot` represents a slot on the TaskManager, reserved by a JobManager. Prior to FLIP-6, all slots are always implicitly reserved by the JobManager at which the TaskManagers register. With FLIP-6, slots are dynamically allocated - hence the AllocatedSlot.

A `Slot` is then an `AllocatedSlot` used by the Scheduler/ExecutionGraph for a task deployment, possibly sub-dividing the slot for slot sharing. It references the executed tasks, subslots, and has fields determining whether the slot is in use or freed.

After this pull request, `Slot`, `SimpleSlot`, and `SharedSlot` have a dual functionality to support FLIP-6 and the current style.