### PR TITLE
[FLINK-4652] [streaming connectors] Automatically refresh AWS credentials

### DIFF
--- a/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
+++ b/flink-streaming-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
@@ -51,8 +51,9 @@ public class AWSUtil {
 		awsClientConfig.setUserAgent("Apache Flink " + EnvironmentInformation.getVersion() +
 			" (" + EnvironmentInformation.getRevisionInformation().commitId + ") Kinesis Connector");
 
+		// utilize automatic refreshment of credentials by directly passing the AWSCredentialsProvider
 		AmazonKinesisClient client = new AmazonKinesisClient(
-			AWSUtil.getCredentialsProvider(configProps).getCredentials(), awsClientConfig);
+			AWSUtil.getCredentialsProvider(configProps), awsClientConfig);
 
 		client.setRegion(Region.getRegion(Regions.fromName(configProps.getProperty(AWSConfigConstants.AWS_REGION))));
 		if (configProps.containsKey(AWSConfigConstants.AWS_ENDPOINT)) {


### PR DESCRIPTION
By using the credentials explicitly we are responsible for checking and refreshing credentials before they expire. If no refreshment is done we will encounter AmazonServiceException: 'The security token included in the request is expired'. Utilize automatic refreshment of credentials by passing the AWSCredentialsProvider directly to AmazonClient by removing the getCredentials() call.