### PR TITLE
[FLINK-3999]: Rename the `running` flag in the drivers to `canceled`

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,7 +26,7 @@
 # to reference a specific Flink version, because this is the only place where
 # we change the version for the complete docs when forking of a release branch
 # etc.
-version: "1.2"
+version: "1.2-SNAPSHOT"
 version_hadoop1: "1.2-hadoop1-SNAPSHOT"
 version_short: "1.2" # Used for the top navbar w/o snapshot suffix
 is_snapshot_version: true

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,7 +26,7 @@
 # to reference a specific Flink version, because this is the only place where
 # we change the version for the complete docs when forking of a release branch
 # etc.
-version: "1.2-SNAPSHOT"
+version: "1.2"
 version_hadoop1: "1.2-hadoop1-SNAPSHOT"
 version_short: "1.2" # Used for the top navbar w/o snapshot suffix
 is_snapshot_version: true

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationHeadTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationHeadTask.java
@@ -299,7 +299,7 @@ public class IterationHeadTask<X, Y, S extends Function, OT> extends AbstractIte
 
 			DataInputView superstepResult = null;
 
-			while (this.running && !terminationRequested()) {
+			while (!this.cancelled && !terminationRequested()) {
 
 				if (log.isInfoEnabled()) {
 					log.info(formatLogString("starting iteration [" + currentIteration() + "]"));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationIntermediateTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationIntermediateTask.java
@@ -83,7 +83,7 @@ public class IterationIntermediateTask<S extends Function, OT> extends AbstractI
 		
 		SuperstepKickoffLatch nextSuperstepLatch = SuperstepKickoffLatchBroker.instance().get(brokerKey());
 
-		while (this.running && !terminationRequested()) {
+		while (!this.cancelled && !terminationRequested()) {
 
 			if (log.isInfoEnabled()) {
 				log.info(formatLogString("starting iteration [" + currentIteration() + "]"));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationTailTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationTailTask.java
@@ -98,7 +98,7 @@ public class IterationTailTask<S extends Function, OT> extends AbstractIterative
 		
 		SuperstepKickoffLatch nextSuperStepLatch = SuperstepKickoffLatchBroker.instance().get(brokerKey());
 		
-		while (this.running && !terminationRequested()) {
+		while (!this.cancelled && !terminationRequested()) {
 
 			if (log.isInfoEnabled()) {
 				log.info(formatLogString("starting iteration [" + currentIteration() + "]"));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AbstractCachedBuildSideJoinDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AbstractCachedBuildSideJoinDriver.java
@@ -173,7 +173,7 @@ public abstract class AbstractCachedBuildSideJoinDriver<IT1, IT2, OT> extends Jo
 		final FlatJoinFunction<IT1, IT2, OT> matchStub = this.taskContext.getStub();
 		final Collector<OT> collector = new CountingCollector<>(this.taskContext.getOutputCollector(), numRecordsOut);
 		
-		while (this.running && matchIterator != null && matchIterator.callWithNextKey(matchStub, collector));
+		while (!this.cancelled && matchIterator != null && matchIterator.callWithNextKey(matchStub, collector));
 	}
 
 	@Override
@@ -208,7 +208,7 @@ public abstract class AbstractCachedBuildSideJoinDriver<IT1, IT2, OT> extends Jo
 
 	@Override
 	public void teardown() {
-		this.running = false;
+		this.cancelled= true;
 		if (this.matchIterator != null) {
 			this.matchIterator.close();
 		}
@@ -216,7 +216,7 @@ public abstract class AbstractCachedBuildSideJoinDriver<IT1, IT2, OT> extends Jo
 
 	@Override
 	public void cancel() {
-		this.running = false;
+		this.cancelled = true;
 		if (this.matchIterator != null) {
 			this.matchIterator.abort();
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AbstractOuterJoinDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AbstractOuterJoinDriver.java
@@ -157,7 +157,7 @@ public abstract class AbstractOuterJoinDriver<IT1, IT2, OT> implements Driver<Fl
 		final Collector<OT> collector = new CountingCollector<>(this.taskContext.getOutputCollector(), numRecordsOut);
 		final JoinTaskIterator<IT1, IT2, OT> outerJoinIterator = this.outerJoinIterator;
 		
-		while (this.cancelled && outerJoinIterator.callWithNextKey(joinStub, collector)) ;
+		while (!this.cancelled && outerJoinIterator.callWithNextKey(joinStub, collector)) ;
 	}
 	
 	

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AbstractOuterJoinDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AbstractOuterJoinDriver.java
@@ -48,14 +48,14 @@ public abstract class AbstractOuterJoinDriver<IT1, IT2, OT> implements Driver<Fl
 	protected TaskContext<FlatJoinFunction<IT1, IT2, OT>, OT> taskContext;
 	
 	protected volatile JoinTaskIterator<IT1, IT2, OT> outerJoinIterator; // the iterator that does the actual outer join
-	protected volatile boolean running;
+	protected volatile boolean cancelled;
 	
 	// ------------------------------------------------------------------------
 	
 	@Override
 	public void setup(TaskContext<FlatJoinFunction<IT1, IT2, OT>, OT> context) {
 		this.taskContext = context;
-		this.running = true;
+		this.cancelled = false;
 	}
 	
 	@Override
@@ -157,7 +157,7 @@ public abstract class AbstractOuterJoinDriver<IT1, IT2, OT> implements Driver<Fl
 		final Collector<OT> collector = new CountingCollector<>(this.taskContext.getOutputCollector(), numRecordsOut);
 		final JoinTaskIterator<IT1, IT2, OT> outerJoinIterator = this.outerJoinIterator;
 		
-		while (this.running && outerJoinIterator.callWithNextKey(joinStub, collector)) ;
+		while (this.cancelled && outerJoinIterator.callWithNextKey(joinStub, collector)) ;
 	}
 	
 	
@@ -171,7 +171,7 @@ public abstract class AbstractOuterJoinDriver<IT1, IT2, OT> implements Driver<Fl
 	
 	@Override
 	public void cancel() {
-		this.running = false;
+		this.cancelled = true;
 		if (this.outerJoinIterator != null) {
 			this.outerJoinIterator.abort();
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AllReduceDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AllReduceDriver.java
@@ -51,7 +51,7 @@ public class AllReduceDriver<T> implements Driver<ReduceFunction<T>, T> {
 
 	private TypeSerializer<T> serializer;
 	
-	private boolean running;
+	private boolean cancelled;
 
 	private boolean objectReuseEnabled = false;
 
@@ -60,7 +60,7 @@ public class AllReduceDriver<T> implements Driver<ReduceFunction<T>, T> {
 	@Override
 	public void setup(TaskContext<ReduceFunction<T>, T> context) {
 		this.taskContext = context;
-		this.running = true;
+		this.cancelled = false;
 	}
 	
 	@Override
@@ -128,7 +128,7 @@ public class AllReduceDriver<T> implements Driver<ReduceFunction<T>, T> {
 
 			T value = val1;
 
-			while (running && (val2 = input.next(val2)) != null) {
+			while (!cancelled && (val2 = input.next(val2)) != null) {
 				numRecordsIn.inc();
 				value = stub.reduce(value, val2);
 
@@ -144,7 +144,7 @@ public class AllReduceDriver<T> implements Driver<ReduceFunction<T>, T> {
 			collector.collect(value);
 		} else {
 			T val2;
-			while (running && (val2 = input.next()) != null) {
+			while (!cancelled && (val2 = input.next()) != null) {
 				numRecordsIn.inc();
 				val1 = stub.reduce(val1, val2);
 			}
@@ -158,6 +158,6 @@ public class AllReduceDriver<T> implements Driver<ReduceFunction<T>, T> {
 
 	@Override
 	public void cancel() {
-		this.running = false;
+		this.cancelled = true;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupDriver.java
@@ -55,7 +55,7 @@ public class CoGroupDriver<IT1, IT2, OT> implements Driver<CoGroupFunction<IT1, 
 	
 	private CoGroupTaskIterator<IT1, IT2> coGroupIterator;				// the iterator that does the actual cogroup
 	
-	private volatile boolean running;
+	private volatile boolean cancelled;
 
 	private boolean objectReuseEnabled = false;
 
@@ -65,7 +65,7 @@ public class CoGroupDriver<IT1, IT2, OT> implements Driver<CoGroupFunction<IT1, 
 	@Override
 	public void setup(TaskContext<CoGroupFunction<IT1, IT2, OT>, OT> context) {
 		this.taskContext = context;
-		this.running = true;
+		this.cancelled = false;
 	}
 	
 
@@ -155,7 +155,7 @@ public class CoGroupDriver<IT1, IT2, OT> implements Driver<CoGroupFunction<IT1, 
 		final Collector<OT> collector = new CountingCollector<>(this.taskContext.getOutputCollector(), numRecordsOut);
 		final CoGroupTaskIterator<IT1, IT2> coGroupIterator = this.coGroupIterator;
 		
-		while (this.running && coGroupIterator.next()) {
+		while (!this.cancelled && coGroupIterator.next()) {
 			coGroupStub.coGroup(coGroupIterator.getValues1(), coGroupIterator.getValues2(), collector);
 		}
 	}
@@ -172,7 +172,7 @@ public class CoGroupDriver<IT1, IT2, OT> implements Driver<CoGroupFunction<IT1, 
 
 	@Override
 	public void cancel() throws Exception {
-		this.running = false;
+		this.cancelled = true;
 		cleanup();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupWithSolutionSetFirstDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupWithSolutionSetFirstDriver.java
@@ -56,7 +56,7 @@ public class CoGroupWithSolutionSetFirstDriver<IT1, IT2, OT> implements Resettab
 	
 	private IT1 solutionSideRecord;
 	
-	protected volatile boolean running;
+	protected volatile boolean cancelled;
 
 	private boolean objectReuseEnabled = false;
 
@@ -65,7 +65,7 @@ public class CoGroupWithSolutionSetFirstDriver<IT1, IT2, OT> implements Resettab
 	@Override
 	public void setup(TaskContext<CoGroupFunction<IT1, IT2, OT>, OT> context) {
 		this.taskContext = context;
-		this.running = true;
+		this.cancelled = false;
 	}
 	
 	@Override
@@ -172,7 +172,7 @@ public class CoGroupWithSolutionSetFirstDriver<IT1, IT2, OT> implements Resettab
 
 				IT1 buildSideRecord = solutionSideRecord;
 
-				while (this.running && probeSideInput.nextKey()) {
+				while (!this.cancelled && probeSideInput.nextKey()) {
 					IT2 current = probeSideInput.getCurrent();
 
 					IT1 matchedRecord = prober.getMatchFor(current, buildSideRecord);
@@ -188,7 +188,7 @@ public class CoGroupWithSolutionSetFirstDriver<IT1, IT2, OT> implements Resettab
 				final JoinHashMap<IT1>.Prober<IT2> prober = join.createProber(this.probeSideComparator, this.pairComparator);
 				final TypeSerializer<IT1> serializer = join.getBuildSerializer();
 
-				while (this.running && probeSideInput.nextKey()) {
+				while (!this.cancelled && probeSideInput.nextKey()) {
 					IT2 current = probeSideInput.getCurrent();
 
 					IT1 buildSideRecord = prober.lookupMatch(current);
@@ -209,7 +209,7 @@ public class CoGroupWithSolutionSetFirstDriver<IT1, IT2, OT> implements Resettab
 
 				IT1 buildSideRecord;
 
-				while (this.running && probeSideInput.nextKey()) {
+				while (!this.cancelled && probeSideInput.nextKey()) {
 					IT2 current = probeSideInput.getCurrent();
 
 					buildSideRecord = prober.getMatchFor(current);
@@ -225,7 +225,7 @@ public class CoGroupWithSolutionSetFirstDriver<IT1, IT2, OT> implements Resettab
 				final JoinHashMap<IT1>.Prober<IT2> prober = join.createProber(this.probeSideComparator, this.pairComparator);
 				final TypeSerializer<IT1> serializer = join.getBuildSerializer();
 
-				while (this.running && probeSideInput.nextKey()) {
+				while (!this.cancelled && probeSideInput.nextKey()) {
 					IT2 current = probeSideInput.getCurrent();
 
 					IT1 buildSideRecord = prober.lookupMatch(current);
@@ -254,6 +254,6 @@ public class CoGroupWithSolutionSetFirstDriver<IT1, IT2, OT> implements Resettab
 
 	@Override
 	public void cancel() {
-		this.running = false;
+		this.cancelled = true;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupWithSolutionSetSecondDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupWithSolutionSetSecondDriver.java
@@ -54,7 +54,7 @@ public class CoGroupWithSolutionSetSecondDriver<IT1, IT2, OT> implements Resetta
 	
 	private IT2 solutionSideRecord;
 	
-	protected volatile boolean running;
+	protected volatile boolean cancelled;
 
 	private boolean objectReuseEnabled = false;
 
@@ -63,7 +63,7 @@ public class CoGroupWithSolutionSetSecondDriver<IT1, IT2, OT> implements Resetta
 	@Override
 	public void setup(TaskContext<CoGroupFunction<IT1, IT2, OT>, OT> context) {
 		this.taskContext = context;
-		this.running = true;
+		this.cancelled = false;
 	}
 	
 	@Override
@@ -171,7 +171,7 @@ public class CoGroupWithSolutionSetSecondDriver<IT1, IT2, OT> implements Resetta
 
 				IT2 buildSideRecord = solutionSideRecord;
 
-				while (this.running && probeSideInput.nextKey()) {
+				while (!this.cancelled && probeSideInput.nextKey()) {
 					IT1 current = probeSideInput.getCurrent();
 
 					IT2 matchedRecord = prober.getMatchFor(current, buildSideRecord);
@@ -187,7 +187,7 @@ public class CoGroupWithSolutionSetSecondDriver<IT1, IT2, OT> implements Resetta
 				final JoinHashMap<IT2>.Prober<IT1> prober = join.createProber(this.probeSideComparator, this.pairComparator);
 				final TypeSerializer<IT2> serializer = join.getBuildSerializer();
 
-				while (this.running && probeSideInput.nextKey()) {
+				while (!this.cancelled && probeSideInput.nextKey()) {
 					IT1 current = probeSideInput.getCurrent();
 
 					IT2 buildSideRecord = prober.lookupMatch(current);
@@ -209,7 +209,7 @@ public class CoGroupWithSolutionSetSecondDriver<IT1, IT2, OT> implements Resetta
 
 				IT2 buildSideRecord;
 
-				while (this.running && probeSideInput.nextKey()) {
+				while (!this.cancelled && probeSideInput.nextKey()) {
 					IT1 current = probeSideInput.getCurrent();
 
 					buildSideRecord = prober.getMatchFor(current);
@@ -225,7 +225,7 @@ public class CoGroupWithSolutionSetSecondDriver<IT1, IT2, OT> implements Resetta
 				final JoinHashMap<IT2>.Prober<IT1> prober = join.createProber(this.probeSideComparator, this.pairComparator);
 				final TypeSerializer<IT2> serializer = join.getBuildSerializer();
 
-				while (this.running && probeSideInput.nextKey()) {
+				while (!this.cancelled && probeSideInput.nextKey()) {
 					IT1 current = probeSideInput.getCurrent();
 
 					IT2 buildSideRecord = prober.lookupMatch(current);
@@ -254,6 +254,6 @@ public class CoGroupWithSolutionSetSecondDriver<IT1, IT2, OT> implements Resetta
 
 	@Override
 	public void cancel() {
-		this.running = false;
+		this.cancelled = true;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/FlatMapDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/FlatMapDriver.java
@@ -47,14 +47,14 @@ public class FlatMapDriver<IT, OT> implements Driver<FlatMapFunction<IT, OT>, OT
 
 	private TaskContext<FlatMapFunction<IT, OT>, OT> taskContext;
 	
-	private volatile boolean running;
+	private volatile boolean cancelled;
 
 	private boolean objectReuseEnabled = false;
 
 	@Override
 	public void setup(TaskContext<FlatMapFunction<IT, OT>, OT> context) {
 		this.taskContext = context;
-		this.running = true;
+		this.cancelled = false;
 	}
 
 	@Override
@@ -96,14 +96,14 @@ public class FlatMapDriver<IT, OT> implements Driver<FlatMapFunction<IT, OT>, OT
 			IT record = this.taskContext.<IT>getInputSerializer(0).getSerializer().createInstance();
 
 
-			while (this.running && ((record = input.next(record)) != null)) {
+			while (!this.cancelled && ((record = input.next(record)) != null)) {
 				numRecordsIn.inc();
 				function.flatMap(record, output);
 			}
 		} else {
 			IT record;
 
-			while (this.running && ((record = input.next()) != null)) {
+			while (!this.cancelled && ((record = input.next()) != null)) {
 				numRecordsIn.inc();
 				function.flatMap(record, output);
 			}
@@ -117,6 +117,6 @@ public class FlatMapDriver<IT, OT> implements Driver<FlatMapFunction<IT, OT>, OT
 
 	@Override
 	public void cancel() {
-		this.running = false;
+		this.cancelled = true;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/GroupReduceDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/GroupReduceDriver.java
@@ -55,7 +55,7 @@ public class GroupReduceDriver<IT, OT> implements Driver<GroupReduceFunction<IT,
 
 	private TypeComparator<IT> comparator;
 
-	private volatile boolean running;
+	private volatile boolean cancelled;
 
 	private boolean objectReuseEnabled = false;
 
@@ -64,7 +64,7 @@ public class GroupReduceDriver<IT, OT> implements Driver<GroupReduceFunction<IT,
 	@Override
 	public void setup(TaskContext<GroupReduceFunction<IT, OT>, OT> context) {
 		this.taskContext = context;
-		this.running = true;
+		this.cancelled = false;
 	}
 	
 	@Override
@@ -120,14 +120,14 @@ public class GroupReduceDriver<IT, OT> implements Driver<GroupReduceFunction<IT,
 		if (objectReuseEnabled) {
 			final ReusingKeyGroupedIterator<IT> iter = new ReusingKeyGroupedIterator<IT>(this.input, this.serializer, this.comparator);
 			// run stub implementation
-			while (this.running && iter.nextKey()) {
+			while (!this.cancelled && iter.nextKey()) {
 				stub.reduce(iter.getValues(), output);
 			}
 		}
 		else {
 			final NonReusingKeyGroupedIterator<IT> iter = new NonReusingKeyGroupedIterator<IT>(this.input, this.comparator);
 			// run stub implementation
-			while (this.running && iter.nextKey()) {
+			while (!this.cancelled && iter.nextKey()) {
 				stub.reduce(iter.getValues(), output);
 			}
 		}
@@ -138,6 +138,6 @@ public class GroupReduceDriver<IT, OT> implements Driver<GroupReduceFunction<IT,
 
 	@Override
 	public void cancel() {
-		this.running = false;
+		this.cancelled = true;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/NoOpDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/NoOpDriver.java
@@ -39,14 +39,14 @@ public class NoOpDriver<T> implements Driver<AbstractRichFunction, T> {
 
 	private TaskContext<AbstractRichFunction, T> taskContext;
 	
-	private volatile boolean running;
+	private volatile boolean cancelled;
 
 	private boolean objectReuseEnabled = false;
 
 	@Override
 	public void setup(TaskContext<AbstractRichFunction, T> context) {
 		this.taskContext = context;
-		this.running = true;
+		this.cancelled = false;
 	}
 
 	@Override
@@ -85,13 +85,13 @@ public class NoOpDriver<T> implements Driver<AbstractRichFunction, T> {
 		if (objectReuseEnabled) {
 			T record = this.taskContext.<T>getInputSerializer(0).getSerializer().createInstance();
 
-			while (this.running && ((record = input.next(record)) != null)) {
+			while (!this.cancelled && ((record = input.next(record)) != null)) {
 				numRecordsIn.inc();
 				output.collect(record);
 			}
 		} else {
 			T record;
-			while (this.running && ((record = input.next()) != null)) {
+			while (!this.cancelled && ((record = input.next()) != null)) {
 				numRecordsIn.inc();
 				output.collect(record);
 			}
@@ -104,6 +104,6 @@ public class NoOpDriver<T> implements Driver<AbstractRichFunction, T> {
 
 	@Override
 	public void cancel() {
-		this.running = false;
+		this.cancelled = true;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceDriver.java
@@ -62,7 +62,7 @@ public class ReduceDriver<T> implements Driver<ReduceFunction<T>, T> {
 	@Override
 	public void setup(TaskContext<ReduceFunction<T>, T> context) {
 		this.taskContext = context;
-		this.cancelled = true;
+		this.cancelled = false;
 	}
 	
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/ReduceDriver.java
@@ -53,7 +53,7 @@ public class ReduceDriver<T> implements Driver<ReduceFunction<T>, T> {
 
 	private TypeComparator<T> comparator;
 	
-	private volatile boolean running;
+	private volatile boolean cancelled;
 
 	private boolean objectReuseEnabled = false;
 
@@ -62,7 +62,7 @@ public class ReduceDriver<T> implements Driver<ReduceFunction<T>, T> {
 	@Override
 	public void setup(TaskContext<ReduceFunction<T>, T> context) {
 		this.taskContext = context;
-		this.running = true;
+		this.cancelled = true;
 	}
 	
 	@Override
@@ -132,7 +132,7 @@ public class ReduceDriver<T> implements Driver<ReduceFunction<T>, T> {
 			T value = reuse1;
 
 			// iterate over key groups
-			while (this.running && value != null) {
+			while (!this.cancelled && value != null) {
 				numRecordsIn.inc();
 				comparator.setReference(value);
 
@@ -169,7 +169,7 @@ public class ReduceDriver<T> implements Driver<ReduceFunction<T>, T> {
 			T value = input.next();
 
 			// iterate over key groups
-			while (this.running && value != null) {
+			while (!this.cancelled && value != null) {
 				numRecordsIn.inc();
 				comparator.setReference(value);
 				T res = value;
@@ -196,6 +196,6 @@ public class ReduceDriver<T> implements Driver<ReduceFunction<T>, T> {
 
 	@Override
 	public void cancel() {
-		this.running = false;
+		this.cancelled = true;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/TempBarrier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/TempBarrier.java
@@ -155,7 +155,7 @@ public class TempBarrier<T> implements CloseableInputProvider<T> {
 		
 		private final SpillingBuffer buffer;
 		
-		private volatile boolean running = true;
+		private volatile boolean cancelled = false;
 		
 		private TempWritingThread(MutableObjectIterator<T> input, TypeSerializer<T> serializer, SpillingBuffer buffer) {
 			super("Temp writer");
@@ -175,7 +175,7 @@ public class TempBarrier<T> implements CloseableInputProvider<T> {
 			try {
 				T record = serializer.createInstance();
 				
-				while (this.running && ((record = input.next(record)) != null)) {
+				while (!this.cancelled && ((record = input.next(record)) != null)) {
 					serializer.serialize(record, buffer);
 				}
 				
@@ -187,7 +187,7 @@ public class TempBarrier<T> implements CloseableInputProvider<T> {
 		}
 		
 		public void shutdown() {
-			this.running = false;
+			this.cancelled = true;
 			this.interrupt();
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/UnionWithTempOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/UnionWithTempOperator.java
@@ -31,13 +31,13 @@ public class UnionWithTempOperator<T> implements Driver<Function, T> {
 	
 	private TaskContext<Function, T> taskContext;
 	
-	private volatile boolean running;
+	private volatile boolean cancelled;
 	
 	
 	@Override
 	public void setup(TaskContext<Function, T> context) {
 		this.taskContext = context;
-		this.running = true;
+		this.cancelled = false;
 	}
 
 	@Override
@@ -68,13 +68,13 @@ public class UnionWithTempOperator<T> implements Driver<Function, T> {
 		T record;
 		
 		final MutableObjectIterator<T> input = this.taskContext.getInput(STREAMED_INPUT);
-		while (this.running && ((record = input.next(reuse)) != null)) {
+		while (!this.cancelled && ((record = input.next(reuse)) != null)) {
 			numRecordsIn.inc();
 			output.collect(record);
 		}
 		
 		final MutableObjectIterator<T> cache = this.taskContext.getInput(CACHED_INPUT);
-		while (this.running && ((record = cache.next(reuse)) != null)) {
+		while (!this.cancelled && ((record = cache.next(reuse)) != null)) {
 			numRecordsIn.inc();
 			output.collect(record);
 		}
@@ -85,6 +85,6 @@ public class UnionWithTempOperator<T> implements Driver<Function, T> {
 
 	@Override
 	public void cancel() {
-		this.running = false;
+		this.cancelled = true;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedReduceCombineDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedReduceCombineDriver.java
@@ -75,7 +75,7 @@ public class ChainedReduceCombineDriver<T> extends ChainedDriver<T, T> {
 
 	private List<MemorySegment> memory;
 
-	private volatile boolean running;
+	private volatile boolean cancelled;
 
 	// ------------------------------------------------------------------------
 
@@ -92,7 +92,7 @@ public class ChainedReduceCombineDriver<T> extends ChainedDriver<T, T> {
 	@Override
 	public void setup(AbstractInvokable parent) {
 		this.parent = parent;
-		running = true;
+		cancelled = true;
 
 		strategy = config.getDriverStrategy();
 
@@ -201,7 +201,7 @@ public class ChainedReduceCombineDriver<T> extends ChainedDriver<T, T> {
 				T value = reuse1;
 
 				// iterate over key groups
-				while (running && value != null) {
+				while (!cancelled && value != null) {
 					comparator.setReference(value);
 
 					// iterate within a key group
@@ -236,7 +236,7 @@ public class ChainedReduceCombineDriver<T> extends ChainedDriver<T, T> {
 				T value = input.next();
 
 				// iterate over key groups
-				while (running && value != null) {
+				while (!cancelled && value != null) {
 					comparator.setReference(value);
 					T res = value;
 
@@ -290,7 +290,7 @@ public class ChainedReduceCombineDriver<T> extends ChainedDriver<T, T> {
 
 	@Override
 	public void cancelTask() {
-		running = false;
+		cancelled = true;
 
 		try {
 			if (sorter != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedReduceCombineDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedReduceCombineDriver.java
@@ -92,7 +92,7 @@ public class ChainedReduceCombineDriver<T> extends ChainedDriver<T, T> {
 	@Override
 	public void setup(AbstractInvokable parent) {
 		this.parent = parent;
-		cancelled = true;
+		cancelled = false;
 
 		strategy = config.getDriverStrategy();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/SynchronousChainedCombineDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/SynchronousChainedCombineDriver.java
@@ -77,7 +77,7 @@ public class SynchronousChainedCombineDriver<IN, OUT> extends ChainedDriver<IN, 
 
 	private List<MemorySegment> memory;
 	
-	private volatile boolean running = true;
+	private volatile boolean cancelled = false;
 
 	// --------------------------------------------------------------------------------------------
 
@@ -133,14 +133,14 @@ public class SynchronousChainedCombineDriver<IN, OUT> extends ChainedDriver<IN, 
 		this.sorter.dispose();
 		this.parent.getEnvironment().getMemoryManager().release(this.memory);
 
-		if (this.running) {
+		if (!this.cancelled) {
 			BatchTask.closeUserCode(this.combiner);
 		}
 	}
 
 	@Override
 	public void cancelTask() {
-		this.running = false;
+		this.cancelled = true;
 		try {
 			this.sorter.dispose();
 		}
@@ -218,7 +218,7 @@ public class SynchronousChainedCombineDriver<IN, OUT> extends ChainedDriver<IN, 
 				final Collector<OUT> output = this.outputCollector;
 
 				// run stub implementation
-				while (this.running && keyIter.nextKey()) {
+				while (!this.cancelled && keyIter.nextKey()) {
 					stub.combine(keyIter.getValues(), output);
 				}
 			}
@@ -234,7 +234,7 @@ public class SynchronousChainedCombineDriver<IN, OUT> extends ChainedDriver<IN, 
 				final Collector<OUT> output = this.outputCollector;
 
 				// run stub implementation
-				while (this.running && keyIter.nextKey()) {
+				while (!this.cancelled && keyIter.nextKey()) {
 					stub.combine(keyIter.getValues(), output);
 				}
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/CompactingHashTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/CompactingHashTable.java
@@ -175,7 +175,7 @@ public class CompactingHashTable<T> extends AbstractMutableHashTable<T> {
 	private int numBuckets;
 	
 	/** Flag to interrupt closed loops */
-	private boolean running = true;
+	private boolean cancelled = false;
 	
 	/** Flag necessary so a resize is never triggered during a resize since the code paths are interleaved */
 	private boolean isResizing;
@@ -291,7 +291,7 @@ public class CompactingHashTable<T> extends AbstractMutableHashTable<T> {
 
 	@Override
 	public void abort() {
-		this.running = false;
+		this.cancelled = true;
 		LOG.debug("Cancelling hash table operations.");
 	}
 
@@ -312,7 +312,7 @@ public class CompactingHashTable<T> extends AbstractMutableHashTable<T> {
 		// go over the complete input and insert every element into the hash table
 		
 		T value;
-		while (this.running && (value = input.next()) != null) {
+		while (this.cancelled && (value = input.next()) != null) {
 			insertOrReplaceRecord(value);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/CompactingHashTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/CompactingHashTable.java
@@ -312,7 +312,7 @@ public class CompactingHashTable<T> extends AbstractMutableHashTable<T> {
 		// go over the complete input and insert every element into the hash table
 		
 		T value;
-		while (this.cancelled && (value = input.next()) != null) {
+		while (!this.cancelled && (value = input.next()) != null) {
 			insertOrReplaceRecord(value);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildFirstHashJoinIterator.java
@@ -57,7 +57,7 @@ public class NonReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIte
 
 	private final boolean buildSideOuterJoin;
 
-	private volatile boolean running = true;
+	private volatile boolean cancelled = false;
 
 	// --------------------------------------------------------------------------------------------
 
@@ -137,7 +137,7 @@ public class NonReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIte
 					probeCopy = this.probeSideSerializer.copy(probeRecord);
 					matchFunction.join(tmpRec, probeCopy, collector);
 					
-					while (this.running && ((nextBuildSideRecord = buildSideIterator.next()) != null)) {
+					while (!this.cancelled && ((nextBuildSideRecord = buildSideIterator.next()) != null)) {
 						// call match on the next pair
 						// make sure we restore the value of the probe side record
 						probeCopy = this.probeSideSerializer.copy(probeRecord);
@@ -159,7 +159,7 @@ public class NonReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIte
 				if (buildSideOuterJoin && probeRecord == null && nextBuildSideRecord != null) {
 					matchFunction.join(nextBuildSideRecord, null, collector);
 
-					while (this.running && ((nextBuildSideRecord = buildSideIterator.next()) != null)) {
+					while (!this.cancelled && ((nextBuildSideRecord = buildSideIterator.next()) != null)) {
 						matchFunction.join(nextBuildSideRecord, null, collector);
 					}
 				}
@@ -174,7 +174,7 @@ public class NonReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIte
 
 	@Override
 	public void abort() {
-		this.running = false;
+		this.cancelled = true;
 		this.hashJoin.abort();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildSecondHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/NonReusingBuildSecondHashJoinIterator.java
@@ -56,7 +56,7 @@ public class NonReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinIt
 
 	private final boolean probeSideOuterJoin;
 
-	private volatile boolean running = true;
+	private volatile boolean cancelled = false;
 
 	// --------------------------------------------------------------------------------------------
 
@@ -135,7 +135,7 @@ public class NonReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinIt
 					probeCopy = this.probeSideSerializer.copy(probeRecord);
 					matchFunction.join(probeCopy, tmpRec, collector);
 					
-					while (this.running && ((nextBuildSideRecord = buildSideIterator.next()) != null)) {
+					while (!this.cancelled && ((nextBuildSideRecord = buildSideIterator.next()) != null)) {
 						// call match on the next pair
 						// make sure we restore the value of the probe side record
 						probeCopy = this.probeSideSerializer.copy(probeRecord);
@@ -156,7 +156,7 @@ public class NonReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinIt
 				// and join with null.
 				if (buildSideOuterJoin && probeRecord == null && nextBuildSideRecord != null) {
 					matchFunction.join(null, nextBuildSideRecord, collector);
-					while (this.running && ((nextBuildSideRecord = buildSideIterator.next()) != null)) {
+					while (!this.cancelled && ((nextBuildSideRecord = buildSideIterator.next()) != null)) {
 						matchFunction.join(null, nextBuildSideRecord, collector);
 					}
 				}
@@ -171,7 +171,7 @@ public class NonReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinIt
 	
 	@Override
 	public void abort() {
-		this.running = false;
+		this.cancelled = true;
 		this.hashJoin.abort();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildFirstHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildFirstHashJoinIterator.java
@@ -60,7 +60,7 @@ public class ReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIterat
 
 	private final boolean buildSideOuterJoin;
 	
-	private volatile boolean running = true;
+	private volatile boolean cancelled = false;
 	
 	// --------------------------------------------------------------------------------------------
 	
@@ -131,7 +131,7 @@ public class ReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIterat
 			if (probeRecord != null && nextBuildSideRecord != null) {
 				matchFunction.join(nextBuildSideRecord, probeRecord, collector);
 
-				while (this.running && ((nextBuildSideRecord = buildSideIterator.next(nextBuildSideRecord)) != null)) {
+				while (!this.cancelled && ((nextBuildSideRecord = buildSideIterator.next(nextBuildSideRecord)) != null)) {
 					matchFunction.join(nextBuildSideRecord, probeRecord, collector);
 				}
 			} else {
@@ -143,7 +143,7 @@ public class ReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIterat
 					// call match on the first pair
 					matchFunction.join(nextBuildSideRecord, null, collector);
 
-					while (this.running && ((nextBuildSideRecord = buildSideIterator.next(nextBuildSideRecord)) != null)) {
+					while (!this.cancelled && ((nextBuildSideRecord = buildSideIterator.next(nextBuildSideRecord)) != null)) {
 						// call match on the next pair
 						// make sure we restore the value of the probe side record
 						matchFunction.join(nextBuildSideRecord, null, collector);
@@ -160,7 +160,7 @@ public class ReusingBuildFirstHashJoinIterator<V1, V2, O> extends HashJoinIterat
 
 	@Override
 	public void abort() {
-		this.running = false;
+		this.cancelled = true;
 		this.hashJoin.abort();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildSecondHashJoinIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/ReusingBuildSecondHashJoinIterator.java
@@ -60,7 +60,7 @@ public class ReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinItera
 
 	private final boolean buildSideOuterJoin;
 	
-	private volatile boolean running = true;
+	private volatile boolean cancelled = false;
 	
 	// --------------------------------------------------------------------------------------------
 	
@@ -129,7 +129,7 @@ public class ReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinItera
 			if (probeRecord != null && nextBuildSideRecord != null) {
 				matchFunction.join(probeRecord, nextBuildSideRecord, collector);
 
-				while (this.running && ((nextBuildSideRecord = buildSideIterator.next(nextBuildSideRecord)) != null)) {
+				while (!this.cancelled && ((nextBuildSideRecord = buildSideIterator.next(nextBuildSideRecord)) != null)) {
 					matchFunction.join(probeRecord, nextBuildSideRecord, collector);
 				}
 			} else {
@@ -139,7 +139,7 @@ public class ReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinItera
 
 				if (buildSideOuterJoin && probeRecord == null && nextBuildSideRecord != null) {
 					matchFunction.join(null, nextBuildSideRecord, collector);
-					while (this.running && ((nextBuildSideRecord = buildSideIterator.next(nextBuildSideRecord)) != null)) {
+					while (!this.cancelled && ((nextBuildSideRecord = buildSideIterator.next(nextBuildSideRecord)) != null)) {
 						matchFunction.join(null, nextBuildSideRecord, collector);
 					}
 				}
@@ -154,7 +154,7 @@ public class ReusingBuildSecondHashJoinIterator<V1, V2, O> extends HashJoinItera
 	
 	@Override
 	public void abort() {
-		this.running = false;
+		this.cancelled = true;
 		this.hashJoin.abort();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/MemoryLogger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/MemoryLogger.java
@@ -55,7 +55,7 @@ public class MemoryLogger extends Thread {
 	
 	private final ActorSystem monitored;
 	
-	private volatile boolean cancelled = true;
+	private volatile boolean cancelled = false;
 	
 	/**
 	 * Creates a new memory logger that logs in the given interval and lives as long as the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/MemoryLogger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/MemoryLogger.java
@@ -55,7 +55,7 @@ public class MemoryLogger extends Thread {
 	
 	private final ActorSystem monitored;
 	
-	private volatile boolean running = true;
+	private volatile boolean cancelled = true;
 	
 	/**
 	 * Creates a new memory logger that logs in the given interval and lives as long as the
@@ -97,7 +97,7 @@ public class MemoryLogger extends Thread {
 	}
 	
 	public void shutdown() {
-		this.running = false;
+		this.cancelled = true;
 		interrupt();
 	}
 	
@@ -106,7 +106,7 @@ public class MemoryLogger extends Thread {
 	@Override
 	public void run() {
 		try {
-			while (running && (monitored == null || !monitored.isTerminated())) {
+			while (!cancelled && (monitored == null || !monitored.isTerminated())) {
 				logger.info(getMemoryUsageStatsAsString(memoryBean));
 				logger.info(getDirectMemoryStatsAsString(directBufferBean));
 				logger.info(getMemoryPoolStatsAsString(poolBeans));
@@ -116,7 +116,7 @@ public class MemoryLogger extends Thread {
 					Thread.sleep(interval);
 				}
 				catch (InterruptedException e) {
-					if (running) {
+					if (!cancelled) {
 						throw e;
 					}
 				}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerConcurrentModReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerConcurrentModReleaseTest.java
@@ -88,7 +88,7 @@ public class MemoryManagerConcurrentModReleaseTest {
 		
 		private final ArrayList<MemorySegment> toModify;
 		
-		private volatile boolean running = true;
+		private volatile boolean cancelled = false;
 
 		
 		private Modifier(ArrayList<MemorySegment> toModify) {
@@ -96,12 +96,12 @@ public class MemoryManagerConcurrentModReleaseTest {
 		}
 
 		public void cancel() {
-			running = false;
+			cancelled = true;
 		}
 
 		@Override
 		public void run() {
-			while (running) {
+			while (!cancelled) {
 				try {
 					MemorySegment seg = toModify.remove(0);
 					toModify.add(seg);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
@@ -88,7 +88,7 @@ public class DriverTestBase<S extends Function> extends TestLogger implements Ta
 	
 	private Driver<S, Record> driver;
 	
-	private volatile boolean running = true;
+	private volatile boolean cancelled = false;
 
 	private ExecutionConfig executionConfig;
 	
@@ -205,7 +205,7 @@ public class DriverTestBase<S extends Function> extends TestLogger implements Ta
 				throw new Exception("The user defined 'open()' method caused an exception: " + t.getMessage(), t);
 			}
 
-			if (!running) {
+			if (cancelled) {
 				return;
 			}
 			
@@ -213,7 +213,7 @@ public class DriverTestBase<S extends Function> extends TestLogger implements Ta
 			driver.run();
 
 			// close. We close here such that a regular close throwing an exception marks a task as failed.
-			if (this.running) {
+			if (!this.cancelled) {
 				FunctionUtils.closeFunction (this.stub);
 				stubOpen = false;
 			}
@@ -240,7 +240,7 @@ public class DriverTestBase<S extends Function> extends TestLogger implements Ta
 			}
 
 			// drop exception, if the task was canceled
-			if (this.running) {
+			if (!this.cancelled) {
 				throw ex;
 			}
 
@@ -272,7 +272,7 @@ public class DriverTestBase<S extends Function> extends TestLogger implements Ta
 	}
 	
 	public void cancel() throws Exception {
-		this.running = false;
+		this.cancelled = true;
 		
 		// compensate for races, where cancel is called before the driver is set
 		// not that this is an artifact of a bad design of this test base, where the setup

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnaryOperatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnaryOperatorTestBase.java
@@ -88,7 +88,7 @@ public class UnaryOperatorTestBase<S extends Function, IN, OUT> extends TestLogg
 	
 	private Driver<S, OUT> driver;
 	
-	private volatile boolean running;
+	private volatile boolean cancelled;
 
 	private ExecutionConfig executionConfig;
 	
@@ -187,7 +187,7 @@ public class UnaryOperatorTestBase<S extends Function, IN, OUT> extends TestLogg
 		this.stub = (S)stubClass.newInstance();
 
 		// regular running logic
-		this.running = true;
+		this.cancelled = false;
 		boolean stubOpen = false;
 
 		try {
@@ -212,7 +212,7 @@ public class UnaryOperatorTestBase<S extends Function, IN, OUT> extends TestLogg
 			driver.run();
 
 			// close. We close here such that a regular close throwing an exception marks a task as failed.
-			if (this.running) {
+			if (!this.cancelled) {
 				FunctionUtils.closeFunction (this.stub);
 				stubOpen = false;
 			}
@@ -241,7 +241,7 @@ public class UnaryOperatorTestBase<S extends Function, IN, OUT> extends TestLogg
 			}
 
 			// drop exception, if the task was canceled
-			if (this.running) {
+			if (!this.cancelled) {
 				throw ex;
 			}
 
@@ -269,7 +269,7 @@ public class UnaryOperatorTestBase<S extends Function, IN, OUT> extends TestLogg
 	}
 	
 	public void cancel() throws Exception {
-		this.running = false;
+		this.cancelled = true;
 		this.driver.cancel();
 	}
 


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-3999] Rename the `running` flag in the drivers to `canceled`")
  - Added the cancelled flag instead of the running flag to replace the functionality since it was not truly "running".
 - Modified the operators to have the cancelled instead of running even in tests

- [ ] Documentation
  - Modified the Example for the Loading Data where the import statement needed to be changed.

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
  - Ran a Travis build and local mvn tests as well.

@ggevay  if you could help review. Thank you.
