### PR TITLE
[hotfix] Treat taskManager's rpc address and location separately

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -680,13 +680,14 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 
 	@RpcMethod
 	public Future<RegistrationResponse> registerTaskManager(
+			final String taskManagerRpcAddress,
 			final TaskManagerLocation taskManagerLocation,
 			final UUID leaderId) throws Exception
 	{
 		if (!JobMaster.this.leaderSessionID.equals(leaderId)) {
 			log.warn("Discard registration from TaskExecutor {} at ({}) because the expected " +
 							"leader session ID {} did not equal the received leader session ID {}.",
-					taskManagerLocation.getResourceID(), taskManagerLocation.addressString(),
+					taskManagerLocation.getResourceID(), taskManagerRpcAddress,
 					JobMaster.this.leaderSessionID, leaderId);
 			throw new Exception("Leader id not match, expected: " + JobMaster.this.leaderSessionID
 					+ ", actual: " + leaderId);
@@ -702,7 +703,7 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 			return getRpcService().execute(new Callable<TaskExecutorGateway>() {
 				@Override
 				public TaskExecutorGateway call() throws Exception {
-					return getRpcService().connect(taskManagerLocation.addressString(), TaskExecutorGateway.class)
+					return getRpcService().connect(taskManagerRpcAddress, TaskExecutorGateway.class)
 							.get(rpcTimeout.getSize(), rpcTimeout.getUnit());
 				}
 			}).handleAsync(new BiFunction<TaskExecutorGateway, Throwable, RegistrationResponse>() {
@@ -715,7 +716,7 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 					if (!JobMaster.this.leaderSessionID.equals(leaderId)) {
 						log.warn("Discard registration from TaskExecutor {} at ({}) because the expected " +
 										"leader session ID {} did not equal the received leader session ID {}.",
-								taskManagerLocation.getResourceID(), taskManagerLocation.addressString(),
+								taskManagerId, taskManagerRpcAddress,
 								JobMaster.this.leaderSessionID, leaderId);
 						return new RegistrationResponse.Decline("Invalid leader session id");
 					}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -196,12 +196,14 @@ public interface JobMasterGateway extends CheckpointCoordinatorGateway {
 	/**
 	 * Register the task manager at the job manager.
 	 *
-	 * @param taskManagerLocation location of the task manager
-	 * @param leaderId            identifying the job leader
-	 * @param timeout             for the rpc call
+	 * @param taskManagerRpcAddress the rpc address of the task manager
+	 * @param taskManagerLocation   location of the task manager
+	 * @param leaderId              identifying the job leader
+	 * @param timeout               for the rpc call
 	 * @return Future registration response indicating whether the registration was successful or not
 	 */
 	Future<RegistrationResponse> registerTaskManager(
+			final String taskManagerRpcAddress,
 			final TaskManagerLocation taskManagerLocation,
 			final UUID leaderId,
 			@RpcTimeout final Time timeout);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -206,7 +206,7 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 		taskSlotTable.start(new SlotActionsImpl());
 
 		// start the job leader service
-		jobLeaderService.start(getRpcService(), haServices, new JobLeaderListenerImpl());
+		jobLeaderService.start(getAddress(), getRpcService(), haServices, new JobLeaderListenerImpl());
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -379,9 +379,10 @@ public class TaskExecutorTest extends TestLogger {
 		final JobMasterGateway jobMasterGateway = mock(JobMasterGateway.class);
 
 		when(jobMasterGateway.registerTaskManager(
-			eq(taskManagerLocation),
-			eq(jobManagerLeaderId),
-			any(Time.class)
+				any(String.class),
+				eq(taskManagerLocation),
+				eq(jobManagerLeaderId),
+				any(Time.class)
 		)).thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(new JMTMRegistrationSuccess(jmResourceId, blobPort)));
 		when(jobMasterGateway.getAddress()).thenReturn(jobManagerAddress);
 
@@ -483,9 +484,10 @@ public class TaskExecutorTest extends TestLogger {
 		final JobMasterGateway jobMasterGateway = mock(JobMasterGateway.class);
 
 		when(jobMasterGateway.registerTaskManager(
-			eq(taskManagerLocation),
-			eq(jobManagerLeaderId),
-			any(Time.class)
+				any(String.class),
+				eq(taskManagerLocation),
+				eq(jobManagerLeaderId),
+				any(Time.class)
 		)).thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(new JMTMRegistrationSuccess(jmResourceId, blobPort)));
 		when(jobMasterGateway.getAddress()).thenReturn(jobManagerAddress);
 


### PR DESCRIPTION
I forgot that rpc address and the address from TaskManagerLocation are not the same thing, we should use rpc address to communicate. 
I revert some codes to Till's original version, sorry about this. 