### PR TITLE
[FLINK-4829] snapshot accumulators on a best-effort basis

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/accumulators/AccumulatorRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/accumulators/AccumulatorRegistry.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 
 /**
@@ -44,7 +45,8 @@ public class AccumulatorRegistry {
 			new HashMap<Metric, Accumulator<?, ?>>();
 
 	/* User-defined Accumulator values stored for the executing task. */
-	private final Map<String, Accumulator<?, ?>> userAccumulators = new HashMap<>();
+	private final Map<String, Accumulator<?, ?>> userAccumulators =
+			new ConcurrentHashMap<>(4);
 
 	/* The reporter reference that is handed to the reporting tasks. */
 	private final ReadWriteReporter reporter;


### PR DESCRIPTION
Heartbeats should not fail when accumulators could not be snapshotted. Instead, we should simply skip the reporting of the failed accumulator. Eventually, the accumulator will be reported; at the latest, when the job finishes.