### PR TITLE
[FLINK-4563] [metrics] scope caching not adjusted for multiple reporters

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
@@ -102,12 +102,13 @@ public class AbstractMetricGroupTest {
 		@Override
 		public void notifyOfAddedMetric(Metric metric, String metricName, MetricGroup group) {
 			assertEquals("A-B-C-D-1", group.getMetricIdentifier(metricName));
-			assertEquals("A-B-RR-D-1", group.getMetricIdentifier(metricName, staticCharacterFilter));
-			assertEquals("RR-B-C-D-1", group.getMetricIdentifier(metricName, this));
-			assertEquals("A-RR-C-D-1", group.getMetricIdentifier(metricName, new CharacterFilter() {
+			// ignore all next filters for scope -  because scopeString cached with only first filter
+			assertEquals("A-B-C-D-1", group.getMetricIdentifier(metricName, staticCharacterFilter));
+			assertEquals("A-B-C-D-1", group.getMetricIdentifier(metricName, this));
+			assertEquals("A-B-C-D-4", group.getMetricIdentifier(metricName, new CharacterFilter() {
 				@Override
 				public String filterCharacters(String input) {
-					return input.replace("B", "RR");
+					return input.replace("B", "RR").replace("1", "4");
 				}
 			}));
 			countSuccessChecks++;
@@ -120,13 +121,14 @@ public class AbstractMetricGroupTest {
 		}
 		@Override
 		public void notifyOfAddedMetric(Metric metric, String metricName, MetricGroup group) {
-			assertEquals("A!B!C!D!1", group.getMetricIdentifier(metricName));
 			assertEquals("A!RR!C!D!1", group.getMetricIdentifier(metricName, this));
-			assertEquals("A!B!RR!D!1", group.getMetricIdentifier(metricName, staticCharacterFilter));
-			assertEquals("RR!B!C!D!1", group.getMetricIdentifier(metricName, new CharacterFilter() {
+			// ignore all next filters -  because scopeString cached with only first filter
+			assertEquals("A!RR!C!D!1", group.getMetricIdentifier(metricName));
+			assertEquals("A!RR!C!D!1", group.getMetricIdentifier(metricName, staticCharacterFilter));
+			assertEquals("A!RR!C!D!3", group.getMetricIdentifier(metricName, new CharacterFilter() {
 				@Override
 				public String filterCharacters(String input) {
-					return input.replace("A", "RR");
+					return input.replace("A", "RR").replace("1", "3");
 				}
 			}));
 			countSuccessChecks++;
@@ -140,6 +142,7 @@ public class AbstractMetricGroupTest {
 
 		void checkMethod(Metric metric, String metricName, AbstractMetricGroup group) {
 			try {
+				// this filters will be use always because use incorrect of reporterIndex
 				assertEquals("A.B.RR.D.1", group.getMetricIdentifier(metricName, staticCharacterFilter));
 				assertEquals("A.B.RR.D.1", group.getMetricIdentifier(metricName, staticCharacterFilter, getReporters().size() + 2));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
@@ -17,12 +17,18 @@
  */
 package org.apache.flink.runtime.metrics.groups;
 
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.metrics.util.TestReporter;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class AbstractMetricGroupTest {
@@ -43,5 +49,71 @@ public class AbstractMetricGroupTest {
 		assertTrue(group.getAllVariables().isEmpty());
 		
 		registry.shutdown();
+	}
+
+	@Test
+	public void filteringForMultipleReporters() {
+		Configuration config = new Configuration();
+		config.setString(ConfigConstants.METRICS_SCOPE_NAMING_TM, "A.B.C.D");
+		config.setString(ConfigConstants.METRICS_REPORTERS_LIST, "test1,test2");
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter1.class.getName());
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter2.class.getName());
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "!");
+
+		TestReporter1.filter = new CharacterFilter() {
+			@Override
+			public String filterCharacters(String input) {
+				return input.replace("C", "RR");
+			}
+		};
+
+		MetricRegistry registry = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(config));
+		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "host", "id");
+		tmGroup.counter(1);
+		registry.shutdown();
+		assert TestReporter1.countSuccess == 2;
+	}
+
+	public static class TestReporter1 extends TestReporter {
+		protected static CharacterFilter filter; // for test case: one filter for different reporters with different of scope delimiter
+		protected static int countSuccess = 0;
+
+		@Override
+		public String filterCharacters(String input) {
+			return input.replace("A", "RR");
+		}
+		@Override
+		public void notifyOfAddedMetric(Metric metric, String metricName, MetricGroup group) {
+			assertEquals("A.B.C.D.1", group.getMetricIdentifier(metricName));
+			assertEquals("A.B.RR.D.1", group.getMetricIdentifier(metricName, TestReporter1.filter));
+			assertEquals("RR.B.C.D.1", group.getMetricIdentifier(metricName, this));
+			assertEquals("A.RR.C.D.1", group.getMetricIdentifier(metricName, new CharacterFilter() {
+				@Override
+				public String filterCharacters(String input) {
+					return input.replace("B", "RR");
+				}
+			}));
+			countSuccess++;
+		}
+	}
+
+	public static class TestReporter2 extends TestReporter1 {
+		@Override
+		public String filterCharacters(String input) {
+			return input.replace("B", "RR");
+		}
+		@Override
+		public void notifyOfAddedMetric(Metric metric, String metricName, MetricGroup group) {
+			assertEquals("A!B!C!D!1", group.getMetricIdentifier(metricName));
+			assertEquals("A!RR!C!D!1", group.getMetricIdentifier(metricName, this));
+			assertEquals("A!B!RR!D!1", group.getMetricIdentifier(metricName, TestReporter1.filter));
+			assertEquals("RR!B!C!D!1", group.getMetricIdentifier(metricName, new CharacterFilter() {
+				@Override
+				public String filterCharacters(String input) {
+					return input.replace("A", "RR");
+				}
+			}));
+			countSuccess++;
+		}
 	}
 }


### PR DESCRIPTION
Hello. 
It is implementation FLINK-4563.
In `AbstractMetricGroup.java` added characterFilter and firstReporterIndex for cached scopeString
