### PR TITLE
[hotfix] [kafka] Fix RackAwareMode instantiation in Kafka 0.10 test

### DIFF
--- a/flink-streaming-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -279,7 +279,7 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 
 		ZkUtils zkUtils = getZkUtils();
 		try {
-			AdminUtils.createTopic(zkUtils, topic, numberOfPartitions, replicationFactor, topicConfig, new kafka.admin.RackAwareMode.Enforced$());
+			AdminUtils.createTopic(zkUtils, topic, numberOfPartitions, replicationFactor, topicConfig, kafka.admin.RackAwareMode.Enforced$.MODULE$);
 		} finally {
 			zkUtils.close();
 		}


### PR DESCRIPTION
The IDE is complaining that `new kafka.admin.RackAwareMode.Enforced$()` has private access.
Looking at Kafka's own tests [[1](https://github.com/apache/kafka/blob/41e676d29587042994a72baa5000a8861a075c8c/streams/src/test/java/org/apache/kafka/streams/integration/utils/KafkaEmbedded.java)], `kafka.admin.RackAwareMode.Enforced$.MODULE$` seems to be the correct way to instantiate a `RackAwareMode`.