### PR TITLE
[FLINK-4857] Remove throws clause from ZooKeeperUtils functions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounter.java
@@ -71,9 +71,8 @@ public class ZooKeeperCheckpointIDCounter implements CheckpointIDCounter {
 	 *
 	 * @param client      Curator ZooKeeper client
 	 * @param counterPath ZooKeeper path for the counter. It's sufficient to have a path per-job.
-	 * @throws Exception
 	 */
-	public ZooKeeperCheckpointIDCounter(CuratorFramework client, String counterPath) throws Exception {
+	public ZooKeeperCheckpointIDCounter(CuratorFramework client, String counterPath) {
 		this.client = checkNotNull(client, "Curator client");
 		this.counterPath = checkNotNull(counterPath, "Counter path");
 		this.sharedCount = new SharedCount(client, counterPath, 1);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/StandaloneUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/StandaloneUtils.java
@@ -57,7 +57,7 @@ public final class StandaloneUtils {
 	 * @param configuration Configuration instance containing hte host and port information
 	 * @param jobManagerName Name of the JobManager actor
 	 * @return StandaloneLeaderRetrievalService
-	 * @throws UnknownHostException
+	 * @throws UnknownHostException if the host name cannot be resolved into an {@link InetAddress}
 	 */
 	public static StandaloneLeaderRetrievalService createLeaderRetrievalService(
 			Configuration configuration,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -158,10 +158,9 @@ public class ZooKeeperUtils {
 	 *
 	 * @param configuration {@link Configuration} object containing the configuration values
 	 * @return {@link ZooKeeperLeaderRetrievalService} instance.
-	 * @throws Exception
 	 */
 	public static ZooKeeperLeaderRetrievalService createLeaderRetrievalService(
-			Configuration configuration) throws Exception {
+			Configuration configuration) {
 		CuratorFramework client = startCuratorFramework(configuration);
 		String leaderPath = ConfigurationUtil.getStringWithDeprecatedKeys(
 				configuration,
@@ -178,10 +177,9 @@ public class ZooKeeperUtils {
 	 *
 	 * @param configuration {@link Configuration} object containing the configuration values
 	 * @return {@link ZooKeeperLeaderElectionService} instance.
-	 * @throws Exception
 	 */
 	public static ZooKeeperLeaderElectionService createLeaderElectionService(
-			Configuration configuration) throws Exception {
+			Configuration configuration) {
 
 		CuratorFramework client = startCuratorFramework(configuration);
 
@@ -194,11 +192,10 @@ public class ZooKeeperUtils {
 	 * @param client        The {@link CuratorFramework} ZooKeeper client to use
 	 * @param configuration {@link Configuration} object containing the configuration values
 	 * @return {@link ZooKeeperLeaderElectionService} instance.
-	 * @throws Exception
 	 */
 	public static ZooKeeperLeaderElectionService createLeaderElectionService(
 			CuratorFramework client,
-			Configuration configuration) throws Exception {
+			Configuration configuration) {
 
 		String latchPath = ConfigurationUtil.getStringWithDeprecatedKeys(
 				configuration,
@@ -220,6 +217,7 @@ public class ZooKeeperUtils {
 	 * @param client        The {@link CuratorFramework} ZooKeeper client to use
 	 * @param configuration {@link Configuration} object
 	 * @return {@link ZooKeeperSubmittedJobGraphStore} instance
+	 * @throws Exception if the submitted job graph store cannot be created
 	 */
 	public static ZooKeeperSubmittedJobGraphStore createSubmittedJobGraphs(
 			CuratorFramework client,
@@ -248,6 +246,7 @@ public class ZooKeeperUtils {
 	 * @param jobId                          ID of job to create the instance for
 	 * @param maxNumberOfCheckpointsToRetain The maximum number of checkpoints to retain
 	 * @return {@link ZooKeeperCompletedCheckpointStore} instance
+	 * @throws Exception if the completed checkpoint store cannot be created
 	 */
 	public static CompletedCheckpointStore createCompletedCheckpoints(
 			CuratorFramework client,
@@ -287,7 +286,7 @@ public class ZooKeeperUtils {
 	public static ZooKeeperCheckpointIDCounter createCheckpointIDCounter(
 			CuratorFramework client,
 			Configuration configuration,
-			JobID jobId) throws Exception {
+			JobID jobId) {
 
 		String checkpointIdCounterPath = ConfigurationUtil.getStringWithDeprecatedKeys(
 				configuration,
@@ -307,7 +306,7 @@ public class ZooKeeperUtils {
 	 * @param prefix Prefix for the created files
 	 * @param <T> Type of the state objects
 	 * @return {@link FileSystemStateStorageHelper} instance
-	 * @throws IOException
+	 * @throws IOException if file system state storage cannot be created
 	 */
 	public static <T extends Serializable> FileSystemStateStorageHelper<T> createFileSystemStateStorage(
 			Configuration configuration,


### PR DESCRIPTION
Remove the unnecessary throws clauses from all ZooKeeperUtils' functions which don't
throw an actual exception.

Removing the exceptions will allow to properly implement the `HighAvailabilityServices` in the Flip-6 branch. We could apply this PR also directly to the feature branch if we don't want to rebase it.