### PR TITLE
[FLINK-4833] properly log exceptions in CountMinHeavyHitter

### DIFF
--- a/flink-contrib/flink-operator-stats/src/main/java/org/apache/flink/contrib/operatorstatistics/heavyhitters/CountMinHeavyHitter.java
+++ b/flink-contrib/flink-operator-stats/src/main/java/org/apache/flink/contrib/operatorstatistics/heavyhitters/CountMinHeavyHitter.java
@@ -123,9 +123,9 @@ public class CountMinHeavyHitter implements HeavyHitter, Serializable {
 			cardinality+=cmToMerge.cardinality;
 
 		}catch (ClassCastException ex){
-			throw new CMHeavyHitterMergeException("Both heavy hitter objects must belong to the same class");
+			throw new CMHeavyHitterMergeException("Both heavy hitter objects must belong to the same class", ex);
 		}catch (Exception ex){
-			throw new CMHeavyHitterMergeException("Cannot merge count min sketches: "+ex.getMessage());
+			throw new CMHeavyHitterMergeException("Cannot merge count min sketches: ", ex);
 		}
 	}
 
@@ -138,8 +138,13 @@ public class CountMinHeavyHitter implements HeavyHitter, Serializable {
 	}
 
 	protected static class CMHeavyHitterMergeException extends HeavyHitterMergeException {
+
 		public CMHeavyHitterMergeException(String message) {
 			super(message);
+		}
+
+		public CMHeavyHitterMergeException(String message, Throwable cause) {
+			super(message, cause);
 		}
 	}
 

--- a/flink-contrib/flink-operator-stats/src/main/java/org/apache/flink/contrib/operatorstatistics/heavyhitters/HeavyHitterMergeException.java
+++ b/flink-contrib/flink-operator-stats/src/main/java/org/apache/flink/contrib/operatorstatistics/heavyhitters/HeavyHitterMergeException.java
@@ -25,4 +25,8 @@ public class HeavyHitterMergeException extends Exception {
 	public HeavyHitterMergeException(String message) {
 		super(message);
 	}
+
+	public HeavyHitterMergeException(String message, Throwable cause) {
+		super(message, cause);
+	}
 }


### PR DESCRIPTION
This logs the underlying exception properly which could help us to find the exact cause of the reported problems.