### PR TITLE
[FLINK-4866] [streaming] Make Trigger.clear() Abstract to Enforce Implementation

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
@@ -116,7 +116,7 @@ public abstract class Trigger<T, W extends Window> implements Serializable {
 	 * 
 	 * <p>By default, this method does nothing.
 	 */
-	public void clear(W window, TriggerContext ctx) throws Exception {}
+	public abstract void clear(W window, TriggerContext ctx) throws Exception;
 
 	// ------------------------------------------------------------------------
 	

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/AllWindowTranslationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/AllWindowTranslationTest.java
@@ -308,6 +308,9 @@ public class AllWindowTranslationTest {
 				public boolean canMerge() {
 					return false;
 				}
+
+				@Override
+				public void clear(TimeWindow window, TriggerContext ctx) throws Exception {}
 			});
 		} catch (UnsupportedOperationException e) {
 			// expected

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowTranslationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowTranslationTest.java
@@ -318,6 +318,9 @@ public class WindowTranslationTest {
 				public boolean canMerge() {
 					return false;
 				}
+
+				@Override
+				public void clear(TimeWindow window, TriggerContext ctx) throws Exception {}
 			});
 		} catch (UnsupportedOperationException e) {
 			// expected


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

This PR makes Trigger.clear() method to be abstract, so that implementors of custom triggers will not forget to clean up their state/timers properly.