### PR TITLE
[FLINK-4444][runtime]Add a InputChannel and ResultSubPartition for DFS

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionLocation.java
@@ -56,6 +56,7 @@ public class ResultPartitionLocation implements Serializable {
 	private enum LocationType {
 		LOCAL,
 		REMOTE,
+		DFS,
 		UNKNOWN
 	}
 
@@ -72,6 +73,10 @@ public class ResultPartitionLocation implements Serializable {
 		return new ResultPartitionLocation(LocationType.LOCAL, null);
 	}
 
+	public static ResultPartitionLocation createDFS() {
+		return new ResultPartitionLocation(LocationType.DFS, null);
+	}
+
 	public static ResultPartitionLocation createUnknown() {
 		return new ResultPartitionLocation(LocationType.UNKNOWN, null);
 	}
@@ -84,6 +89,10 @@ public class ResultPartitionLocation implements Serializable {
 
 	public boolean isRemote() {
 		return locationType == LocationType.REMOTE;
+	}
+
+	public boolean isDFS() {
+		return locationType == LocationType.DFS;
 	}
 
 	public boolean isUnknown() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DFSFileWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DFSFileWriter.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.FileSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Writer for writing buffer to DFS file.
+ */
+public class DFSFileWriter {
+	private static final long defaultFlushLength = HadoopFileSystem.getHadoopConfiguration().getLong("dfs.flush.size", 64 *  1024 * 1024);
+
+	private static final int replica = HadoopFileSystem.getHadoopConfiguration().getInt("dfs.file.replica", 2);
+
+	private static final Logger LOG = LoggerFactory.getLogger(DFSFileWriter.class);
+
+	/** DFS output stream. */
+	private FSDataOutputStream outputStream;
+
+	/** length for deciding when to call flush. */
+	private long unFlushedLen;
+
+	public DFSFileWriter(String filename) {
+		try {
+			FileSystem fs = FileSystem.get(new URI("hdfs:/tmp"), HadoopFileSystem.getHadoopConfiguration());
+			if (fs == null) {
+				LOG.warn("Fail to get HadoopFileSystem");
+			}
+			outputStream = fs.create(new Path(filename), (short)replica);
+			LOG.info("Create file(" + filename + ") as result file.");
+		}
+		catch (Exception e) {
+			LOG.warn("Fail to create file due to " + e.getMessage());
+			outputStream = null;
+		}
+		unFlushedLen = 0;
+	}
+
+
+	// ------------------------------------------------------------------------
+	// Consume
+	// ------------------------------------------------------------------------
+
+	/**
+	 * writer buffer to dfs file
+	 */
+	void write(Buffer buffer) throws IOException {
+		if (outputStream == null) {
+			throw new IOException("OutputStream is not successfully created.");
+		}
+
+		// first write a header and then data
+		outputStream.writeInt(buffer.isBuffer() ? 1 : 0);
+		outputStream.writeInt(buffer.getSize());
+		outputStream.write(buffer.getNioBuffer().array(), 0, buffer.getSize());
+		unFlushedLen += buffer.getSize();
+
+		// automatically call flush per 64M
+		if (unFlushedLen  > defaultFlushLength) {
+			outputStream.flush();
+			unFlushedLen = 0;
+		}
+	}
+
+	void close() throws IOException {
+		outputStream.close();
+	}
+
+	void flush() throws IOException {
+		outputStream.flush();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DFSSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DFSSubpartition.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
+import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A HDFS subpartition, which is able to spill to hdfs.
+ *
+ * <p> Buffers are all write to HDFS.
+ */
+class DFSSubpartition extends ResultSubpartition {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DFSSubpartition.class);
+
+	/** The writer used for write buffer to dfs file. */
+	DFSFileWriter dfsWriter;
+
+	/** Flag indicating whether the subpartition has been finished. */
+	private boolean isFinished;
+
+	/** Flag indicating whether the subpartition has been released. */
+	private volatile boolean isReleased;
+
+	DFSSubpartition(int index, ResultPartition parent, String filename) {
+		super(index, parent);
+		dfsWriter = new DFSFileWriter(filename);
+	}
+
+	@Override
+	public boolean add(Buffer buffer) throws IOException {
+		checkNotNull(buffer);
+
+		if (isFinished || isReleased) {
+			return false;
+		}
+
+		dfsWriter.write(buffer);
+
+		return true;
+	}
+
+	@Override
+	public void finish() throws IOException {
+		if (add(EventSerializer.toBuffer(EndOfPartitionEvent.INSTANCE))) {
+			isFinished = true;
+		}
+
+		// close the hdfsWriter to commit the file
+		if (dfsWriter != null) {
+			dfsWriter.close();
+		}
+	}
+
+	@Override
+	public void release() throws IOException {
+		if (isReleased) {
+			return;
+		}
+
+		dfsWriter.close();
+		isReleased = true;
+	}
+
+	@Override
+	public int releaseMemory() throws IOException {
+		dfsWriter.flush();
+		return 0;
+	}
+
+	@Override
+	public boolean isReleased() {
+		return isReleased;
+	}
+
+	@Override
+	public ResultSubpartitionView createReadView(BufferProvider bufferProvider) throws IOException {
+		throw new UnsupportedOperationException("Not support createReadView on HDFSSubPartition");
+	}
+
+	@Override
+	public String toString() {
+		return String.format("DFSSubpartition," +
+						"finished? %s, read view? %s, writer? %s]",
+				isFinished, null,	dfsWriter != null);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DFSSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DFSSubpartition.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -108,5 +109,10 @@ class DFSSubpartition extends ResultSubpartition {
 		return String.format("DFSSubpartition," +
 						"finished? %s, read view? %s, writer? %s]",
 				isFinished, null,	dfsWriter != null);
+	}
+
+	@VisibleForTesting
+	void setDFSWriter(DFSFileWriter writer) {
+		this.dfsWriter = writer;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -166,6 +166,13 @@ public class ResultPartition implements BufferPoolOwner {
 
 				break;
 
+			case DFS:
+				for (int i = 0; i < subpartitions.length; i++) {
+					subpartitions[i] = new DFSSubpartition(i, this, jobId.toString() + "mid/" + partitionId.getPartitionId().toString() + "/" + i);
+				}
+
+				break;
+
 			default:
 				throw new IllegalArgumentException("Unsupported result partition type.");
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -18,16 +18,25 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+
 public enum ResultPartitionType {
 
-	BLOCKING(true, false, false),
+	BLOCKING(PersistentType.LOCAL, false, false),
 
-	PIPELINED(false, true, true),
+	PIPELINED(PersistentType.NON, true, true),
 
-	PIPELINED_PERSISTENT(true, true, true);
+	PIPELINED_PERSISTENT(PersistentType.LOCAL, true, true),
+
+	DFS(PersistentType.DFS, false, false);
+
+	public enum PersistentType {
+		NON,
+		LOCAL,
+		DFS
+	}
 
 	/** Does the partition live longer than the consuming task? */
-	private final boolean isPersistent;
+	private final PersistentType persistentType;
 
 	/** Can the partition be consumed while being produced? */
 	private final boolean isPipelined;
@@ -38,8 +47,8 @@ public enum ResultPartitionType {
 	/**
 	 * Specifies the behaviour of an intermediate result partition at runtime.
 	 */
-	ResultPartitionType(boolean isPersistent, boolean isPipelined, boolean hasBackPressure) {
-		this.isPersistent = isPersistent;
+	ResultPartitionType(PersistentType persistentType, boolean isPipelined, boolean hasBackPressure) {
+		this.persistentType = persistentType;
 		this.isPipelined = isPipelined;
 		this.hasBackPressure = hasBackPressure;
 	}
@@ -56,7 +65,7 @@ public enum ResultPartitionType {
 		return isPipelined;
 	}
 
-	public boolean isPersistent() {
-		return isPersistent;
+	public PersistentType getPersistentType() {
+		return persistentType;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/DFSFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/DFSFileReader.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.hadoop.fs.FileSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.EOFException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+
+/**
+ * A DFS file reader, which read data from a dfs file.
+ */
+public class DFSFileReader {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DFSFileReader.class);
+
+	/** DFS input stream. */
+	private FSDataInputStream input;
+
+	/**
+	 * Flag indicating whether the dfs file is opened for read.
+	 */
+	private boolean isOpen;
+
+	private DFSInputChannel channel;
+
+	/**
+	 * read thread which read data from dfs file and put data into DFSInputChannel's buffer.
+	 */
+	private DFSReadThread readThread;
+
+	/**
+	 * the path of the dfs file
+	 */
+	private String path;
+
+	public DFSFileReader(DFSInputChannel channel, String path) {
+		this.channel = channel;
+		this.path = path;
+	}
+
+
+	// ------------------------------------------------------------------------
+	// Consume
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Requests a subpartition, begin to read the dfs file.
+	 */
+	void requestSubpartition(int subpartitionIndex) throws IOException, InterruptedException {
+		if (!isOpen) {
+			// Create a input stream and start the read thread
+			FileSystem fs = null;
+			try {
+				fs = FileSystem.get(new URI("hdfs:/tmp"), HadoopFileSystem.getHadoopConfiguration());
+			}
+			catch (Exception e) {
+				throw new InterruptedException("Open dfs file read fail " + e.getMessage());
+			}
+			String filename = path + "/" + subpartitionIndex;
+			input = fs.open(new Path(filename));
+			isOpen = true;
+			readThread = new DFSReadThread(input, channel);
+			readThread.setDaemon(true);
+			readThread.start();
+			LOG.info("Begin to read from dfs file(" + filename + ").");
+		}
+	}
+
+	/**
+	 * Retriggers a remote subpartition request.
+	 */
+	void requestSubpartition(final int subpartitionIndex,
+									final DFSInputChannel inputChannel,
+									int delayMs) throws IOException, InterruptedException {
+		//do nothing
+	}
+
+	public void close() {
+		try {
+			readThread.shutdown();
+			readThread.join();
+		}
+		catch (InterruptedException e) {
+			LOG.warn("Read thread interrupt exception: " + e.getMessage());
+		}
+	}
+
+	public boolean isOpen() {
+		return isOpen;
+	}
+
+	/**
+	 * read thread, for reading data from dfs file
+	 */
+	public static class DFSReadThread extends Thread {
+
+		private final FSDataInputStream inputStream;
+
+		private final DFSInputChannel inputChannel;
+
+		private volatile boolean alive;
+
+		public DFSReadThread(FSDataInputStream inputStream, DFSInputChannel inputChannel) {
+			this.inputStream = inputStream;
+			this.inputChannel = inputChannel;
+			this.alive = true;
+		}
+
+		public void shutdown() {
+            this.alive = false;
+		}
+
+		@Override
+		public void run() {
+			ByteBuffer header = ByteBuffer.allocateDirect(8);
+			BufferProvider bufferProvider = inputChannel.getBufferProvider();
+			if (bufferProvider == null) {
+				return;
+			}
+			LOG.debug("dfs read thread start.");
+			while(this.alive) {
+				try {
+					//first read the header, and then data
+					boolean isBuffer = inputStream.readInt() == 1 ? true : false;
+					int size = inputStream.readInt();
+					if (size > 0)
+					{
+						Buffer buffer;
+						if (!isBuffer) {
+							byte[] byteArray = new byte[size];
+							inputStream.readFully(byteArray, 0, size);
+
+							MemorySegment memSeg = MemorySegmentFactory.wrap(byteArray);
+							buffer = new Buffer(memSeg, FreeingBufferRecycler.INSTANCE, false);
+						}
+						else {
+							buffer = bufferProvider.requestBuffer();
+							if (buffer != null) {
+								buffer.setSize(size);
+							}
+							inputStream.readFully(buffer.getNioBuffer().array(), 0, size);
+						}
+
+						inputChannel.onBuffer(buffer);
+					}
+					else {
+						continue;
+					}
+				}
+				catch (EOFException e) {
+					LOG.debug("dfs read reach end.");
+					break;
+				}
+				catch (IOException e) {
+					LOG.warn("dfs read thread fail " + e.getMessage());
+					inputChannel.onError(e);
+					break;
+				}
+				catch (Exception e) {
+					LOG.warn("dfs read thread fail with " + e.getClass().getName());
+					inputChannel.onError(e);
+					break;
+				}
+			}
+			LOG.debug("dfs read thread stopped.");
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/DFSFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/DFSFileReader.java
@@ -136,7 +136,7 @@ public class DFSFileReader {
 		}
 
 		public void shutdown() {
-            this.alive = false;
+			this.alive = false;
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/DFSInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/DFSInputChannel.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.event.TaskEvent;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.metrics.groups.IOMetricGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Tuple2;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * An input channel, which requests data from dfs file.
+ */
+public class DFSInputChannel extends InputChannel {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DFSInputChannel.class);
+
+	/** ID to distinguish this channel from other channels. */
+	private final InputChannelID id = new InputChannelID();
+
+	/** The reader used for read dfs file. */
+	private final DFSFileReader dfsReader;
+
+	/**
+	 * The received buffers. Received buffers are enqueued by the read thread in DFSFileReader and the queue
+	 * is consumed by the receiving task thread.
+	 */
+	private final Queue<Buffer> receivedBuffers = new ArrayDeque<Buffer>();
+
+	/**
+	 * Flag indicating whether this channel has been released. Either called by the receiving task
+	 * thread or the task manager actor.
+	 */
+	private final AtomicBoolean isReleased = new AtomicBoolean();
+
+	/**
+	 * the jobId, for generate HDFS file name
+	 */
+	private JobID jobID;
+
+	public DFSInputChannel(
+			SingleInputGate inputGate,
+			int channelIndex,
+			ResultPartitionID partitionId,
+			JobID jobID,
+			IOMetricGroup metrics) {
+
+		this(inputGate, channelIndex, partitionId, jobID,
+				new Tuple2<Integer, Integer>(0, 0), metrics);
+	}
+
+	public DFSInputChannel(
+			SingleInputGate inputGate,
+			int channelIndex,
+			ResultPartitionID partitionId,
+			JobID jobID,
+			Tuple2<Integer, Integer> initialAndMaxBackoff,
+			IOMetricGroup metrics) {
+
+		super(inputGate, channelIndex, partitionId, initialAndMaxBackoff, metrics.getNumBytesInRemoteCounter());
+		this.jobID = jobID;
+		dfsReader = new DFSFileReader(this, jobID.toString() + "_" + partitionId.getPartitionId().toString());
+	}
+
+	// ------------------------------------------------------------------------
+	// Consume
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Requests a dfs subpartition.
+	 */
+	@Override
+	void requestSubpartition(int subpartitionIndex) throws IOException, InterruptedException {
+		if (!dfsReader.isOpen()) {
+			// dfsReader begin to read the partition file
+			dfsReader.requestSubpartition(subpartitionIndex);
+		}
+	}
+
+	/**
+	 * Retriggers a dfs subpartition request.
+	 */
+	void retriggerSubpartitionRequest(int subpartitionIndex) throws IOException, InterruptedException {
+		//do nothing
+	}
+
+	@Override
+	Buffer getNextBuffer() throws IOException {
+		checkState(!isReleased.get(), "Queried for a buffer after channel has been closed.");
+		checkState(dfsReader.isOpen(), "Queried for a buffer before requesting a queue.");
+
+		checkError();
+
+		synchronized (receivedBuffers) {
+			Buffer buffer = receivedBuffers.poll();
+
+			// Sanity check that channel is only queried after a notification
+			if (buffer == null) {
+				throw new IOException("Queried input channel for data although non is available.");
+			}
+
+			numBytesIn.inc(buffer.getSize());
+			return buffer;
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	// Task events
+	// ------------------------------------------------------------------------
+
+	@Override
+	void sendTaskEvent(TaskEvent event) throws IOException {
+		// Nothing to do
+	}
+
+	// ------------------------------------------------------------------------
+	// Life cycle
+	// ------------------------------------------------------------------------
+
+	@Override
+	boolean isReleased() {
+		return isReleased.get();
+	}
+
+	@Override
+	void notifySubpartitionConsumed() {
+		// Nothing to do
+	}
+
+	/**
+	 * Releases all received buffers and closes the dfsReader
+	 */
+	@Override
+	void releaseAllResources() throws IOException {
+		if (isReleased.compareAndSet(false, true)) {
+			synchronized (receivedBuffers) {
+				Buffer buffer;
+				while ((buffer = receivedBuffers.poll()) != null) {
+					buffer.recycle();
+				}
+			}
+
+			// The released flag has to be set before closing the connection to ensure that
+			// buffers received concurrently with closing are properly recycled.
+			if (dfsReader != null) {
+				dfsReader.close();
+			}
+		}
+	}
+
+	public void failPartitionRequest() {
+		setError(new PartitionNotFoundException(partitionId));
+	}
+
+	@Override
+	public String toString() {
+		return "DFSInputChannel [" + partitionId + ", numberOfQueuedBuffers " + getNumberOfQueuedBuffers() + "]";
+	}
+
+	// ------------------------------------------------------------------------
+	// Network I/O notifications (called by network I/O thread)
+	// ------------------------------------------------------------------------
+
+	public int getNumberOfQueuedBuffers() {
+		synchronized (receivedBuffers) {
+			return receivedBuffers.size();
+		}
+	}
+
+	public InputChannelID getInputChannelId() {
+		return id;
+	}
+
+	public BufferProvider getBufferProvider() {
+		if (isReleased.get()) {
+			return null;
+		}
+
+		return inputGate.getBufferProvider();
+	}
+
+	public void onBuffer(Buffer buffer) {
+		boolean success = false;
+
+		try {
+			synchronized (receivedBuffers) {
+				if (!isReleased.get()) {
+					receivedBuffers.add(buffer);
+
+					notifyAvailableBuffer();
+
+					success = true;
+				}
+			}
+		}
+		finally {
+			if (!success) {
+				buffer.recycle();
+			}
+		}
+	}
+
+	public void onError(Throwable cause) {
+		setError(cause);
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/DFSInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/DFSInputChannel.java
@@ -115,7 +115,6 @@ public class DFSInputChannel extends InputChannel {
 	@Override
 	Buffer getNextBuffer() throws IOException {
 		checkState(!isReleased.get(), "Queried for a buffer after channel has been closed.");
-		checkState(dfsReader.isOpen(), "Queried for a buffer before requesting a queue.");
 
 		checkError();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -542,12 +542,12 @@ public class SingleInputGate implements InputGate {
 						metrics
 				);
 			}
-            else if (partitionLocation.isDFS()) {
-                inputChannels[i] = new DFSInputChannel(inputGate, i, partitionId, jobId,
-                        networkEnvironment.getPartitionRequestInitialAndMaxBackoff(),
-                        metrics
-                );
-            }
+			else if (partitionLocation.isDFS()) {
+				inputChannels[i] = new DFSInputChannel(inputGate, i, partitionId, jobId,
+						networkEnvironment.getPartitionRequestInitialAndMaxBackoff(),
+						metrics
+				);
+			}
 			else if (partitionLocation.isUnknown()) {
 				inputChannels[i] = new UnknownInputChannel(inputGate, i, partitionId,
 						networkEnvironment.getPartitionManager(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -542,6 +542,12 @@ public class SingleInputGate implements InputGate {
 						metrics
 				);
 			}
+            else if (partitionLocation.isDFS()) {
+                inputChannels[i] = new DFSInputChannel(inputGate, i, partitionId, jobId,
+                        networkEnvironment.getPartitionRequestInitialAndMaxBackoff(),
+                        metrics
+                );
+            }
 			else if (partitionLocation.isUnknown()) {
 				inputChannels[i] = new UnknownInputChannel(inputGate, i, partitionId,
 						networkEnvironment.getPartitionManager(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/DFSSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/DFSSubpartitionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+public class DFSSubpartitionTest extends SubpartitionTestBase {
+
+	@Override
+	DFSSubpartition createSubpartition() {
+		final ResultPartition parent = mock(ResultPartition.class);
+
+		DFSSubpartition sp = new DFSSubpartition(0, parent, "abc");
+		sp.setDFSWriter(mock(DFSFileWriter.class));
+		return sp;
+	}
+
+	@Test
+	public void testReleaseParent() throws Exception {
+	}
+
+	@Test
+	public void testReleaseParentAfterSpilled() throws Exception {
+	}
+
+	@Test
+	public void testCreateReadView() throws Exception {
+		final DFSSubpartition subpartition = createSubpartition();
+
+		try {
+			subpartition.createReadView(null);
+
+			fail("Did not throw expected exception when create read view.");
+		}
+		catch (UnsupportedOperationException expected) {
+		}
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/DFSInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/DFSInputChannelTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.util.TestBufferFactory;
+import org.apache.flink.runtime.operators.testutils.UnregisteredTaskMetricsGroup;
+import org.junit.Test;
+import scala.Tuple2;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class DFSInputChannelTest {
+
+	@Test
+	public void testOnBufferAndGet() throws Exception {
+		// Setup
+		final SingleInputGate inputGate = mock(SingleInputGate.class);
+		final DFSInputChannel inputChannel = createDFSInputChannel(inputGate);
+
+		// The test
+		inputChannel.onBuffer(TestBufferFactory.getMockBuffer());
+
+		assertTrue(inputChannel.getNextBuffer() != null);
+	}
+
+	// ---------------------------------------------------------------------------------------------
+
+	private DFSInputChannel createDFSInputChannel(SingleInputGate inputGate)
+			throws IOException, InterruptedException {
+		return new DFSInputChannel(
+			inputGate,
+			0,
+			new ResultPartitionID(),
+			new JobID(),
+			new Tuple2<Integer, Integer>(0, 0),
+			new UnregisteredTaskMetricsGroup.DummyIOMetricGroup());
+	}
+}


### PR DESCRIPTION
This pr add a DFSInputChannel and DFSSubpartition, which enable user ouput the results of an operator to DFS and then downstream operators can read data from DFS.

This is mainly used for batch jobs. This is party of the issue #[4419](https://issues.apache.org/jira/browse/FLINK-4419).
