### PR TITLE
[FLINK-4504][dataset api]Support user to decide whether the result of an operator is presistent

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionMode.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionMode.java
@@ -82,5 +82,13 @@ public enum ExecutionMode {
 	 * is typically more expensive to execute than the {@link #BATCH} mode. It does
 	 * guarantee that no successive operations are ever executed concurrently.
 	 */
-	BATCH_FORCED
+	BATCH_FORCED,
+
+	/**
+	 * This mode executes the program in batch way, while data is
+	 * forwarded from producer to distribute file system and then to consumer. This mode
+	 * is typically more expensive to execute than the {@link #BATCH} mode. It does
+	 * guarantee that the result will never be lost and producer can exist after finish.
+	 */
+	BATCH_PERSISTENT
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -86,6 +86,12 @@ public final class ConfigConstants {
 	public static final String RESTART_STRATEGY_FAILURE_RATE_DELAY = "restart-strategy.failure-rate.delay";
 
 	/**
+	 * Config parameter for the persistent type of the result of an operator
+	 */
+	@PublicEvolving
+	public static final String OPERATOR_RESULT_PERSISTENT_TYPE = "operator.result.persistent-type";
+
+	/**
 	 * Config parameter for the number of re-tries for failed tasks. Setting this
 	 * value to 0 effectively disables fault tolerance.
 	 *

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -439,7 +439,13 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 			}
 		}
 	}
-	
+
+	public void addAll(Map<String, String> other) {
+		synchronized (this.confData) {
+			this.confData.putAll(other);
+		}
+	}
+
 	/**
 	 * Adds all entries from the given configuration into this configuration. The keys
 	 * are prepended with the given prefix.

--- a/flink-core/src/main/java/org/apache/flink/configuration/UnmodifiableConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/UnmodifiableConfiguration.java
@@ -21,6 +21,7 @@ package org.apache.flink.configuration;
 import org.apache.flink.annotation.Public;
 
 import java.util.Properties;
+import java.util.Map;
 
 /**
  * Unmodifiable version of the Configuration class.
@@ -58,6 +59,11 @@ public class UnmodifiableConfiguration extends Configuration {
 
 	@Override
 	public final void addAll(Configuration other, String prefix) {
+		error();
+	}
+
+	@Override
+	public final void addAll(Map<String, String> other) {
 		error();
 	}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/Operator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/Operator.java
@@ -25,6 +25,9 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.util.Preconditions;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Base class of all operators in the Java API.
  * 
@@ -37,6 +40,8 @@ public abstract class Operator<OUT, O extends Operator<OUT, O>> extends DataSet<
 	protected String name;
 	
 	protected int parallelism = ExecutionConfig.PARALLELISM_DEFAULT;
+
+	protected Map<String, String> options = new HashMap<>();
 
 	protected Operator(ExecutionEnvironment context, TypeInformation<OUT> resultType) {
 		super(context, resultType);
@@ -102,5 +107,27 @@ public abstract class Operator<OUT, O extends Operator<OUT, O>> extends DataSet<
 		@SuppressWarnings("unchecked")
 		O returnType = (O) this;
 		return returnType;
+	}
+
+	/**
+	 * Sets options for this operator.
+	 *
+	 * @param key The name of option to set, now only 'operator.result.persistent' can be set.
+	 * @param value The option's value
+	 * @return The operator with set parallelism.
+	 */
+	public O setOptions(String key, String value) {
+		this.options.put(key, value);
+
+		@SuppressWarnings("unchecked")
+		O returnType = (O) this;
+		return returnType;
+	}
+
+	/**
+	 * Gets all options of this operator.
+	 */
+	public Map<String, String> getOptions() {
+		return this.options;
 	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/OperatorTranslation.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/OperatorTranslation.java
@@ -124,6 +124,7 @@ public class OperatorTranslation {
 		Operator<I> input = translate(typedInput);
 		
 		org.apache.flink.api.common.operators.Operator<O> dataFlowOp = typedOp.translateToDataFlow(input);
+		dataFlowOp.getParameters().addAll(op.getOptions());
 		
 		if (op instanceof UdfOperator<?>) {
 			@SuppressWarnings("unchecked")
@@ -160,6 +161,7 @@ public class OperatorTranslation {
 		Operator<I2> input2 = translate(typedInput2);
 		
 		org.apache.flink.api.common.operators.Operator<O> dataFlowOp = typedOp.translateToDataFlow(input1, input2);
+		dataFlowOp.getParameters().addAll(op.getOptions());
 		
 		if (op instanceof UdfOperator<?> ) {
 			@SuppressWarnings("unchecked")

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/DagConnection.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/DagConnection.java
@@ -19,6 +19,7 @@
 package org.apache.flink.optimizer.dag;
 
 import org.apache.flink.api.common.ExecutionMode;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.optimizer.dataproperties.InterestingProperties;
 import org.apache.flink.optimizer.plandump.DumpableConnection;
 import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
@@ -87,7 +88,12 @@ public class DagConnection implements EstimateProvider, DumpableConnection<Optim
 		this.source = source;
 		this.target = target;
 		this.shipStrategy = shipStrategy;
-		this.dataExchangeMode = exchangeMode;
+		if (source.getOperator().getParameters().containsKey(ConfigConstants.OPERATOR_RESULT_PERSISTENT_TYPE)) {
+			this.dataExchangeMode = ExecutionMode.BATCH_PERSISTENT;
+		}
+		else {
+			this.dataExchangeMode = exchangeMode;
+		}
 	}
 	
 	/**
@@ -104,7 +110,12 @@ public class DagConnection implements EstimateProvider, DumpableConnection<Optim
 		this.source = source;
 		this.target = null;
 		this.shipStrategy = ShipStrategyType.NONE;
-		this.dataExchangeMode = exchangeMode;
+		if (source.getOperator().getParameters().containsKey(ConfigConstants.OPERATOR_RESULT_PERSISTENT_TYPE)) {
+			this.dataExchangeMode = ExecutionMode.BATCH_PERSISTENT;
+		}
+		else {
+			this.dataExchangeMode = exchangeMode;
+		}
 	}
 
 	/**

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -791,6 +791,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 					!(pred instanceof IterationPlanNode) && // cannot chain with iteration heads currently
 					inConn.getShipStrategy() == ShipStrategyType.FORWARD &&
 					inConn.getLocalStrategy() == LocalStrategy.NONE &&
+					inConn.getDataExchangeMode() != DataExchangeMode.BATCH_PERSISTENT &&
 					pred.getOutgoingChannels().size() == 1 &&
 					node.getParallelism() == pred.getParallelism() &&
 					node.getBroadcastInputs().isEmpty();
@@ -1112,6 +1113,11 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 				resultType = channel.getSource().isOnDynamicPath()
 						? ResultPartitionType.PIPELINED
 						: ResultPartitionType.BLOCKING;
+				break;
+
+			case BATCH_PERSISTENT:
+				// results should be persistent, put it to distribute file system
+				resultType = ResultPartitionType.DFS;
 				break;
 
 			case PIPELINE_WITH_BATCH_FALLBACK:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/InputChannelDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/InputChannelDeploymentDescriptor.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.slf4j.Logger;
@@ -99,8 +100,12 @@ public class InputChannelDeploymentDescriptor implements Serializable {
 
 			final ResultPartitionLocation partitionLocation;
 
+			// if its producer's result type is DFS, the partitionLocation should also be DFS
+			if (consumedPartition.getIntermediateResult().getResultType() == ResultPartitionType.DFS) {
+				partitionLocation = ResultPartitionLocation.createDFS();
+			}
 			// The producing task needs to be RUNNING or already FINISHED
-			if (consumedPartition.isConsumable() && producerSlot != null &&
+			else if (consumedPartition.isConsumable() && producerSlot != null &&
 					(producerState == ExecutionState.RUNNING
 							|| producerState == ExecutionState.FINISHED)) {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/DataExchangeMode.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/DataExchangeMode.java
@@ -39,6 +39,13 @@ public enum DataExchangeMode {
 	BATCH,
 
 	/**
+	 * The data exchange is decoupled. The sender first produces its entire result to distribute file system(dfs) and finishes.
+	 * After that, the receiver is started and may consume the data from dfs.
+	 * The producer
+	 */
+	BATCH_PERSISTENT,
+
+	/**
 	 * The data exchange starts like in {@link #PIPELINED} and falls back to {@link #BATCH}
 	 * for recovery runs.
 	 */
@@ -124,5 +131,9 @@ public enum DataExchangeMode {
 		FORWARD[ExecutionMode.BATCH_FORCED.ordinal()] = BATCH;
 		SHUFFLE[ExecutionMode.BATCH_FORCED.ordinal()] = BATCH;
 		BREAKING[ExecutionMode.BATCH_FORCED.ordinal()] = BATCH;
+
+		FORWARD[ExecutionMode.BATCH_PERSISTENT.ordinal()] = BATCH_PERSISTENT;
+		SHUFFLE[ExecutionMode.BATCH_PERSISTENT.ordinal()] = BATCH_PERSISTENT;
+		BREAKING[ExecutionMode.BATCH_PERSISTENT.ordinal()] = BATCH_PERSISTENT;
 	}
 }


### PR DESCRIPTION
This pr is based on #2674 , it add an setOptions() interface to the class Operator, so user can calltext.flatMap().setOptions(ConfigConstants.OPERATOR_RESULT_PERSISTENT_TYPE , "DFS") to specify that the result of flaMap() should be put to DFS.
