### PR TITLE
[FLINK-4780] Make GraphiteReporter protocol configurable

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -348,6 +348,7 @@ Parameters:
 
 - `host` - the Graphite server host
 - `port` - the Graphite server port
+- `protocol` - protocol to use (TCP/UDP)
 
 ### StatsD (org.apache.flink.metrics.statsd.StatsDReporter)
 Dependency:


### PR DESCRIPTION
This PR allows the GraphiteReporter to use UDP for the data transmission. This is configured by setting metrics.reporter.<name>.protocol to either TCP or UDP.