### PR TITLE
[FLINK-4876] Allow web interface to be bound to a specific ip/interface/inetHost

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -131,7 +131,7 @@ For Kafka and ZK, process-wide JAAS config will be created using the provided se
 
 - `taskmanager.log.path`: The config parameter defining the taskmanager log file location
 
-- `jobmanager.web.address`: Address of the JobManager's web interface (DEFAULT: 0.0.0.0).
+- `jobmanager.web.address`: Address of the JobManager's web interface (DEFAULT: anyLocalAddress()).
 
 - `jobmanager.web.port`: Port of the JobManager's web interface (DEFAULT: 8081).
 

--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -131,6 +131,8 @@ For Kafka and ZK, process-wide JAAS config will be created using the provided se
 
 - `taskmanager.log.path`: The config parameter defining the taskmanager log file location
 
+- `jobmanager.web.address`: Address of the JobManager's web interface (DEFAULT: 0.0.0.0).
+
 - `jobmanager.web.port`: Port of the JobManager's web interface (DEFAULT: 8081).
 
 - `jobmanager.web.tmpdir`: This configuration parameter allows defining the Flink web directory to be used by the web interface. The web interface

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -1200,7 +1200,7 @@ public final class ConfigConstants {
 	/** The config key for the address of the JobManager web frontend. */
 	public static final ConfigOption<String> DEFAULT_JOB_MANAGER_WEB_FRONTEND_ADDRESS =
 		key("jobmanager.web.address")
-			.defaultValue("0.0.0.0");
+			.noDefaultValue();
 
 	/** The config key for the port of the JobManager web frontend.
 	 * Setting this value to {@code -1} disables the web frontend. */

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -546,7 +546,12 @@ public final class ConfigConstants {
 	
 	
 	// ------------------------- JobManager Web Frontend ----------------------
-	
+
+	/**
+	 * The port for the runtime monitor web-frontend server.
+	 */
+	public static final String JOB_MANAGER_WEB_ADDRESS_KEY = "jobmanager.web.address";
+
 	/**
 	 * The port for the runtime monitor web-frontend server.
 	 */
@@ -1194,7 +1199,10 @@ public final class ConfigConstants {
 	
 	
 	// ------------------------- JobManager Web Frontend ----------------------
-	
+
+	/** The config key for the address of the JobManager web frontend. */
+	public static final String DEFAULT_JOB_MANAGER_WEB_FRONTEND_ADDRESS = "0.0.0.0";
+
 	/** The config key for the port of the JobManager web frontend.
 	 * Setting this value to {@code -1} disables the web frontend. */
 	public static final int DEFAULT_JOB_MANAGER_WEB_FRONTEND_PORT = 8081;

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -21,6 +21,8 @@ package org.apache.flink.configuration;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 
+import static org.apache.flink.configuration.ConfigOptions.key;
+
 /**
  * This class contains all constants for the configuration. That includes the configuration keys and
  * the default values.
@@ -546,11 +548,6 @@ public final class ConfigConstants {
 	
 	
 	// ------------------------- JobManager Web Frontend ----------------------
-
-	/**
-	 * The port for the runtime monitor web-frontend server.
-	 */
-	public static final String JOB_MANAGER_WEB_ADDRESS_KEY = "jobmanager.web.address";
 
 	/**
 	 * The port for the runtime monitor web-frontend server.
@@ -1201,7 +1198,9 @@ public final class ConfigConstants {
 	// ------------------------- JobManager Web Frontend ----------------------
 
 	/** The config key for the address of the JobManager web frontend. */
-	public static final String DEFAULT_JOB_MANAGER_WEB_FRONTEND_ADDRESS = "0.0.0.0";
+	public static final ConfigOption<String> DEFAULT_JOB_MANAGER_WEB_FRONTEND_ADDRESS =
+		key("jobmanager.web.address")
+			.defaultValue("0.0.0.0");
 
 	/** The config key for the port of the JobManager web frontend.
 	 * Setting this value to {@code -1} disables the web frontend. */

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -63,7 +63,7 @@ parallelism.default: 1
  
 # The address under which the web-based runtime monitor listens.
 
-+jobmanager.web.address: 0.0.0.0
+jobmanager.web.address: 0.0.0.0
 
 # The port under which the web-based runtime monitor listens.
 # A value of -1 deactivates the web server.

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -60,6 +60,10 @@ parallelism.default: 1
 #==============================================================================
 # Web Frontend
 #==============================================================================
+ 
+# The address under which the web-based runtime monitor listens.
+
++jobmanager.web.address: 0.0.0.0
 
 # The port under which the web-based runtime monitor listens.
 # A value of -1 deactivates the web server.

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -63,7 +63,7 @@ parallelism.default: 1
  
 # The address under which the web-based runtime monitor listens.
 
-jobmanager.web.address: 0.0.0.0
+#jobmanager.web.address: 0.0.0.0
 
 # The port under which the web-based runtime monitor listens.
 # A value of -1 deactivates the web server.

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorConfig.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorConfig.java
@@ -28,6 +28,9 @@ public class WebMonitorConfig {
 	//  Config Keys
 	// ------------------------------------------------------------------------
 
+	/** The address for the runtime monitor web-frontend server. */
+	public static final String JOB_MANAGER_WEB_ADDRESS_KEY = ConfigConstants.JOB_MANAGER_WEB_ADDRESS_KEY;
+
 	/** The port for the runtime monitor web-frontend server. */
 	public static final String JOB_MANAGER_WEB_PORT_KEY = ConfigConstants.JOB_MANAGER_WEB_PORT_KEY;
 
@@ -38,6 +41,9 @@ public class WebMonitorConfig {
 	// ------------------------------------------------------------------------
 	//  Default values
 	// ------------------------------------------------------------------------
+
+	/** Default address for the web dashboard (= 0.0.0.0) */
+	public static final String DEFAULT_JOB_MANAGER_WEB_FRONTEND_ADDRESS = ConfigConstants.DEFAULT_JOB_MANAGER_WEB_FRONTEND_ADDRESS;
 
 	/** Default port for the web dashboard (= 8081) */
 	public static final int DEFAULT_JOB_MANAGER_WEB_FRONTEND_PORT = ConfigConstants.DEFAULT_JOB_MANAGER_WEB_FRONTEND_PORT;
@@ -61,6 +67,9 @@ public class WebMonitorConfig {
 		this.config = config;
 	}
 
+	public String getWebFrontendAddress() {
+		return config.getString(JOB_MANAGER_WEB_ADDRESS_KEY, DEFAULT_JOB_MANAGER_WEB_FRONTEND_ADDRESS);
+	}
 
 	public int getWebFrontendPort() {
 		return config.getInteger(JOB_MANAGER_WEB_PORT_KEY, DEFAULT_JOB_MANAGER_WEB_FRONTEND_PORT);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorConfig.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorConfig.java
@@ -28,9 +28,6 @@ public class WebMonitorConfig {
 	//  Config Keys
 	// ------------------------------------------------------------------------
 
-	/** The address for the runtime monitor web-frontend server. */
-	public static final String JOB_MANAGER_WEB_ADDRESS_KEY = ConfigConstants.JOB_MANAGER_WEB_ADDRESS_KEY;
-
 	/** The port for the runtime monitor web-frontend server. */
 	public static final String JOB_MANAGER_WEB_PORT_KEY = ConfigConstants.JOB_MANAGER_WEB_PORT_KEY;
 
@@ -41,9 +38,6 @@ public class WebMonitorConfig {
 	// ------------------------------------------------------------------------
 	//  Default values
 	// ------------------------------------------------------------------------
-
-	/** Default address for the web dashboard (= 0.0.0.0) */
-	public static final String DEFAULT_JOB_MANAGER_WEB_FRONTEND_ADDRESS = ConfigConstants.DEFAULT_JOB_MANAGER_WEB_FRONTEND_ADDRESS;
 
 	/** Default port for the web dashboard (= 8081) */
 	public static final int DEFAULT_JOB_MANAGER_WEB_FRONTEND_PORT = ConfigConstants.DEFAULT_JOB_MANAGER_WEB_FRONTEND_PORT;
@@ -68,7 +62,7 @@ public class WebMonitorConfig {
 	}
 
 	public String getWebFrontendAddress() {
-		return config.getString(JOB_MANAGER_WEB_ADDRESS_KEY, DEFAULT_JOB_MANAGER_WEB_FRONTEND_ADDRESS);
+		return config.getValue(ConfigConstants.DEFAULT_JOB_MANAGER_WEB_FRONTEND_ADDRESS);
 	}
 
 	public int getWebFrontendPort() {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -402,7 +402,12 @@ public class WebRuntimeMonitor implements WebMonitor {
 				.channel(NioServerSocketChannel.class)
 				.childHandler(initializer);
 
-		Channel ch = this.bootstrap.bind(configuredAddress, configuredPort).sync().channel();
+		Channel ch;
+		if (configuredAddress == null) {
+			ch = this.bootstrap.bind(configuredPort).sync().channel();
+		} else {
+			ch = this.bootstrap.bind(configuredAddress, configuredPort).sync().channel();
+		}
 		this.serverChannel = ch;
 
 		InetSocketAddress bindAddress = (InetSocketAddress) ch.localAddress();

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -159,7 +159,9 @@ public class WebRuntimeMonitor implements WebMonitor {
 		this.retriever = new JobManagerRetriever(this, actorSystem, AkkaUtils.getTimeout(config), timeout);
 		
 		final WebMonitorConfig cfg = new WebMonitorConfig(config);
-		
+
+		final String configuredAddress = cfg.getWebFrontendAddress();
+
 		final int configuredPort = cfg.getWebFrontendPort();
 		if (configuredPort < 0) {
 			throw new IllegalArgumentException("Web frontend port is invalid: " + configuredPort);
@@ -400,7 +402,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 				.channel(NioServerSocketChannel.class)
 				.childHandler(initializer);
 
-		Channel ch = this.bootstrap.bind(configuredPort).sync().channel();
+		Channel ch = this.bootstrap.bind(configuredAddress, configuredPort).sync().channel();
 		this.serverChannel = ch;
 
 		InetSocketAddress bindAddress = (InetSocketAddress) ch.localAddress();


### PR DESCRIPTION
Currently the web interface automatically binds to all interfaces on 0.0.0.0. IMHO there are some use cases to only bind to a specific ipadress, (e.g. access through an authenticated proxy, not binding on the management or backup interface)
- [x ] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)
- [x ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added
- [x ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
