### PR TITLE
[FLINK-4923] [Metrics] Expose input/output buffers and bufferPool usa…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -220,4 +220,10 @@ class PipelinedSubpartition extends ResultSubpartition {
 			throw new IllegalStateException("Already registered listener.");
 		}
 	}
+
+	public int getNumberOfQueuedBuffers() {
+		synchronized (buffers) {
+			return buffers.size();
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -221,9 +221,8 @@ class PipelinedSubpartition extends ResultSubpartition {
 		}
 	}
 
+	@Override
 	public int getNumberOfQueuedBuffers() {
-		synchronized (buffers) {
 			return buffers.size();
-		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -220,12 +220,33 @@ public class ResultPartition implements BufferPoolOwner {
 		return bufferPool;
 	}
 
+	public BufferPool getBufferPool() {
+		return bufferPool;
+	}
+
 	public int getTotalNumberOfBuffers() {
 		return totalNumberOfBuffers;
 	}
 
 	public long getTotalNumberOfBytes() {
 		return totalNumberOfBytes;
+	}
+
+	public int getNumberOfQueuedBuffers() {
+		int totalBuffers = 0;
+
+		for (ResultSubpartition subpartition : subpartitions) {
+
+			if (subpartition instanceof PipelinedSubpartition) {
+				totalBuffers += ((PipelinedSubpartition) subpartition).getNumberOfQueuedBuffers();
+			}
+
+			if (subpartition instanceof SpillableSubpartition) {
+				totalBuffers += ((SpillableSubpartition) subpartition).getNumberOfQueuedBuffers();
+			}
+		}
+
+		return totalBuffers;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -236,14 +236,7 @@ public class ResultPartition implements BufferPoolOwner {
 		int totalBuffers = 0;
 
 		for (ResultSubpartition subpartition : subpartitions) {
-
-			if (subpartition instanceof PipelinedSubpartition) {
-				totalBuffers += ((PipelinedSubpartition) subpartition).getNumberOfQueuedBuffers();
-			}
-
-			if (subpartition instanceof SpillableSubpartition) {
-				totalBuffers += ((SpillableSubpartition) subpartition).getNumberOfQueuedBuffers();
-			}
+			totalBuffers += subpartition.getNumberOfQueuedBuffers();
 		}
 
 		return totalBuffers;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -83,4 +83,6 @@ public abstract class ResultSubpartition {
 
 	abstract public boolean isReleased();
 
+	abstract public int getNumberOfQueuedBuffers();
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -227,4 +227,10 @@ class SpillableSubpartition extends ResultSubpartition {
 				getTotalNumberOfBuffers(), getTotalNumberOfBytes(), isFinished, readView != null,
 				spillWriter != null);
 	}
+
+	public int getNumberOfQueuedBuffers() {
+		synchronized (buffers) {
+			return buffers.size();
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -228,9 +228,8 @@ class SpillableSubpartition extends ResultSubpartition {
 				spillWriter != null);
 	}
 
+	@Override
 	public int getNumberOfQueuedBuffers() {
-		synchronized (buffers) {
 			return buffers.size();
-		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -227,17 +227,28 @@ public class SingleInputGate implements InputGate {
 	}
 
 	public int getNumberOfQueuedBuffers() {
-		int totalBuffers = 0;
+		int retry = 0;
 
-		for (Map.Entry<IntermediateResultPartitionID, InputChannel> entry: inputChannels.entrySet()) {
-			InputChannel channel = entry.getValue();
+		// re-try 3 times, if fails, return 0 for "unknown"
+		while(retry < 3) {
+			try {
+				int totalBuffers = 0;
 
-			if (channel instanceof RemoteInputChannel) {
-				totalBuffers += ((RemoteInputChannel) channel).getNumberOfQueuedBuffers();
+				for (Map.Entry<IntermediateResultPartitionID, InputChannel> entry : inputChannels.entrySet()) {
+					InputChannel channel = entry.getValue();
+
+					if (channel instanceof RemoteInputChannel) {
+						totalBuffers += ((RemoteInputChannel) channel).getNumberOfQueuedBuffers();
+					}
+				}
+
+				return  totalBuffers;
+			} catch (Exception e) {
+				retry++;
 			}
 		}
 
-		return  totalBuffers;
+		return 0;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -212,6 +212,10 @@ public class SingleInputGate implements InputGate {
 		return bufferPool;
 	}
 
+	public BufferPool getBufferPool() {
+		return bufferPool;
+	}
+
 	@Override
 	public int getPageSize() {
 		if (bufferPool != null) {
@@ -220,6 +224,20 @@ public class SingleInputGate implements InputGate {
 		else {
 			throw new IllegalStateException("Input gate has not been initialized with buffers.");
 		}
+	}
+
+	public int getNumberOfQueuedBuffers() {
+		int totalBuffers = 0;
+
+		for (Map.Entry<IntermediateResultPartitionID, InputChannel> entry: inputChannels.entrySet()) {
+			InputChannel channel = entry.getValue();
+
+			if (channel instanceof RemoteInputChannel) {
+				totalBuffers += ((RemoteInputChannel) channel).getNumberOfQueuedBuffers();
+			}
+		}
+
+		return  totalBuffers;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricGroup;
 
 /**
  * Metric group that contains shareable pre-defined IO-related metrics. The metrics registration is
@@ -30,12 +31,16 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 	private final Counter numBytesInLocal;
 	private final Counter numBytesInRemote;
 
+	private final MetricGroup buffers;
+
 	public TaskIOMetricGroup(TaskMetricGroup parent) {
 		super(parent);
 
 		this.numBytesOut = counter("numBytesOut");
 		this.numBytesInLocal = counter("numBytesInLocal");
 		this.numBytesInRemote = counter("numBytesInRemote");
+
+		this.buffers = addGroup("Buffers");
 	}
 
 	public Counter getNumBytesOutCounter() {
@@ -48,5 +53,9 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 
 	public Counter getNumBytesInRemoteCounter() {
 		return numBytesInRemote;
+	}
+
+	public MetricGroup getBuffersGroup() {
+		return buffers;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -19,7 +19,11 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.taskmanager.Task;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 
 /**
  * Metric group that contains shareable pre-defined IO-related metrics. The metrics registration is
@@ -57,5 +61,112 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 
 	public MetricGroup getBuffersGroup() {
 		return buffers;
+	}
+
+	// ------------------------------------------------------------------------
+	//  metrics of Buffers group
+	// ------------------------------------------------------------------------
+	/**
+	 * Input received buffers gauge of a task
+	 */
+	public static class InputBuffersGauge implements Gauge<Integer> {
+
+		private final Task task;
+
+		public InputBuffersGauge(Task task) {
+			this.task = task;
+		}
+
+		@Override
+		public Integer getValue() {
+			int totalBuffers = 0;
+
+			for(SingleInputGate inputGate: task.getAllInputGates()) {
+				totalBuffers += inputGate.getNumberOfQueuedBuffers();
+			}
+
+			return totalBuffers;
+		}
+	}
+
+	/**
+	 * Output produced buffers gauge of a task
+	 */
+	public static class OutputBuffersGauge implements Gauge<Integer> {
+
+		private final Task task;
+
+		public OutputBuffersGauge(Task task) {
+			this.task = task;
+		}
+
+		@Override
+		public Integer getValue() {
+			int totalBuffers = 0;
+
+			for(ResultPartition producedPartition: task.getProducedPartitions()) {
+				totalBuffers += producedPartition.getNumberOfQueuedBuffers();
+			}
+
+			return totalBuffers;
+		}
+	}
+
+	/**
+	 * Input buffer pool usage gauge of a task
+	 */
+	public static class InputBufferPoolUsageGauge implements Gauge<Float> {
+
+		private final Task task;
+
+		public InputBufferPoolUsageGauge(Task task) {
+			this.task = task;
+		}
+
+		@Override
+		public Float getValue() {
+			int availableBuffers = 0;
+			int bufferPoolSize = 0;
+
+			for(SingleInputGate inputGate: task.getAllInputGates()) {
+				availableBuffers += inputGate.getBufferPool().getNumberOfAvailableMemorySegments();
+				bufferPoolSize += inputGate.getBufferPool().getNumBuffers();
+			}
+
+			if (bufferPoolSize != 0) {
+				return ((float)(bufferPoolSize - availableBuffers)) / bufferPoolSize;
+			} else {
+				return 0.0f;
+			}
+		}
+	}
+
+	/**
+	 * Output buffer pool usage gauge of a task
+	 */
+	public static class OutputBufferPoolUsageGauge implements Gauge<Float> {
+
+		private final Task task;
+
+		public OutputBufferPoolUsageGauge(Task task) {
+			this.task = task;
+		}
+
+		@Override
+		public Float getValue() {
+			int availableBuffers = 0;
+			int bufferPoolSize = 0;
+
+			for(ResultPartition resultPartition: task.getProducedPartitions()) {
+				availableBuffers += resultPartition.getBufferPool().getNumberOfAvailableMemorySegments();
+				bufferPoolSize += resultPartition.getBufferPool().getNumBuffers();
+			}
+
+			if (bufferPoolSize != 0) {
+				return ((float)(bufferPoolSize - availableBuffers)) / bufferPoolSize;
+			} else {
+				return 0.0f;
+			}
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.metrics.Gauge;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
@@ -347,6 +348,12 @@ public class Task implements Runnable, TaskActions {
 
 		// finally, create the executing thread, but do not start it
 		executingThread = new Thread(TASK_THREADS_GROUP, this, taskNameWithSubtask);
+
+		// add metric for buffers
+		this.metrics.getIOMetricGroup().getBuffersGroup().gauge("numIn", new InputBuffersGauge());
+		this.metrics.getIOMetricGroup().getBuffersGroup().gauge("numOut", new OutputBuffersGauge());
+		this.metrics.getIOMetricGroup().getBuffersGroup().gauge("InPoolUsage", new InputBufferPoolUsageGauge());
+		this.metrics.getIOMetricGroup().getBuffersGroup().gauge("OutPoolUsage", new OutputBufferPoolUsageGauge());
 	}
 
 	// ------------------------------------------------------------------------
@@ -1261,6 +1268,78 @@ public class Task implements Runnable, TaskActions {
 			}
 			catch (Throwable t) {
 				logger.error("Error in the task canceler", t);
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  metrics
+	// ------------------------------------------------------------------------
+
+	private class InputBuffersGauge implements Gauge<Integer> {
+
+		@Override
+		public Integer getValue() {
+			int totalBuffers = 0;
+
+			for(SingleInputGate inputGate: inputGates) {
+				totalBuffers += inputGate.getNumberOfQueuedBuffers();
+			}
+
+			return totalBuffers;
+		}
+	}
+
+	private class OutputBuffersGauge implements Gauge<Integer> {
+
+		@Override
+		public Integer getValue() {
+			int totalBuffers = 0;
+
+			for(ResultPartition producedPartition: producedPartitions) {
+				totalBuffers += producedPartition.getNumberOfQueuedBuffers();
+			}
+
+			return totalBuffers;
+		}
+	}
+
+	private class InputBufferPoolUsageGauge implements Gauge<Float> {
+
+		@Override
+		public Float getValue() {
+			int availableBuffers = 0;
+			int bufferPoolSize = 0;
+
+			for(SingleInputGate inputGate: inputGates) {
+				availableBuffers += inputGate.getBufferPool().getNumberOfAvailableMemorySegments();
+				bufferPoolSize += inputGate.getBufferPool().getNumBuffers();
+			}
+
+			if (bufferPoolSize != 0) {
+				return ((float)(bufferPoolSize - availableBuffers)) / bufferPoolSize;
+			} else {
+				return 0.0f;
+			}
+		}
+	}
+
+	private class OutputBufferPoolUsageGauge implements Gauge<Float> {
+
+		@Override
+		public Float getValue() {
+			int availableBuffers = 0;
+			int bufferPoolSize = 0;
+
+			for(ResultPartition resultPartition: producedPartitions){
+				availableBuffers += resultPartition.getBufferPool().getNumberOfAvailableMemorySegments();
+				bufferPoolSize += resultPartition.getBufferPool().getNumBuffers();
+			}
+
+			if (bufferPoolSize != 0) {
+				return ((float)(bufferPoolSize - availableBuffers)) / bufferPoolSize;
+			} else {
+				return 0.0f;
 			}
 		}
 	}


### PR DESCRIPTION
The buffers and buffer usage of Input/output bufferPool for a task reflect wether a task congestion.
So we expose the following Metrics as a Buffers MetricGroup on the TaskIOMetricGroup, all these metrics is a gauge.
1. numIn of Buffers: received buffers of all InputGates of a task
2. numOut of Buffers: buffers of all produced ResultPartitions of a task
3. InPoolUsage of Buffers: bufferPool usage of all InputGates of a task
4. OutPoolUsage of Buffers: bufferPool usage of all produced ResultPartitions of a task