### PR TITLE
[FLINK-4925] [metrics] Integrate meters into IOMetricGroups

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorIOMetricGroup.java
@@ -18,6 +18,8 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MeterView;
 
 /**
  * Metric group that contains shareable pre-defined IO-related metrics. The metrics registration is
@@ -28,10 +30,15 @@ public class OperatorIOMetricGroup extends ProxyMetricGroup<OperatorMetricGroup>
 	private final Counter numRecordsIn;
 	private final Counter numRecordsOut;
 
+	private final Meter numRecordsInRate;
+	private final Meter numRecordsOutRate;
+
 	public OperatorIOMetricGroup(OperatorMetricGroup parentMetricGroup) {
 		super(parentMetricGroup);
 		numRecordsIn = parentMetricGroup.counter("numRecordsIn");
 		numRecordsOut = parentMetricGroup.counter("numRecordsOut");
+		numRecordsInRate = parentMetricGroup.meter("numRecordsInPerSecond", new MeterView(numRecordsIn, 60));
+		numRecordsOutRate = parentMetricGroup.meter("numRecordsOutPerSecond", new MeterView(numRecordsOut, 60));
 	}
 
 	public Counter getNumRecordsInCounter() {
@@ -40,5 +47,13 @@ public class OperatorIOMetricGroup extends ProxyMetricGroup<OperatorMetricGroup>
 
 	public Counter getNumRecordsOutCounter() {
 		return numRecordsOut;
+	}
+
+	public Meter getNumRecordsInRateMeter() {
+		return numRecordsInRate;
+	}
+
+	public Meter getNumRecordsOutRate() {
+		return numRecordsOutRate;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MeterView;
 
 /**
  * Metric group that contains shareable pre-defined IO-related metrics. The metrics registration is
@@ -30,12 +32,19 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 	private final Counter numBytesInLocal;
 	private final Counter numBytesInRemote;
 
+	private final Meter numBytesInRateLocal;
+	private final Meter numBytesInRateRemote;
+	private final Meter numBytesOutRate;
+
 	public TaskIOMetricGroup(TaskMetricGroup parent) {
 		super(parent);
 
 		this.numBytesOut = counter("numBytesOut");
 		this.numBytesInLocal = counter("numBytesInLocal");
 		this.numBytesInRemote = counter("numBytesInRemote");
+		this.numBytesOutRate = meter("numBytesOutPerSecond", new MeterView(numBytesOut, 60));
+		this.numBytesInRateLocal = meter("numBytesInLocalPerSecond", new MeterView(numBytesInLocal, 60));
+		this.numBytesInRateRemote = meter("numBytesInRemotePerSecond", new MeterView(numBytesInRemote, 60));
 	}
 
 	public Counter getNumBytesOutCounter() {
@@ -48,5 +57,17 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 
 	public Counter getNumBytesInRemoteCounter() {
 		return numBytesInRemote;
+	}
+
+	public Meter getNumBytesInRateLocalMeter() {
+		return numBytesInRateLocal;
+	}
+
+	public Meter getNumBytesInRateRemoteMeter() {
+		return numBytesInRateRemote;
+	}
+
+	public Meter getNumBytesOutRateMeter() {
+		return numBytesOutRate;
 	}
 }


### PR DESCRIPTION
This PR introduces Meters into the existing *IOMetricGroups, providing rates for the number of incoming/outgoing records/bytes.