### PR TITLE
[FLINK-4889] [InstanceManager] Remove ActorRef dependency from InstanceManager

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/Messages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/Messages.scala
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.messages
 
+import org.apache.flink.runtime.instance.InstanceID
+
 /**
  * Generic messages between JobManager, TaskManager, JobClient.
  */
@@ -39,7 +41,7 @@ object Messages {
    *
    * @param reason The reason for disconnecting, to be displayed in log and error messages.
    */
-  case class Disconnect(reason: String) extends RequiresLeaderSessionID
+  case class Disconnect(instanceId: InstanceID, reason: String) extends RequiresLeaderSessionID
 
   /**
    * Accessor for the case object instance, to simplify Java interoperability.


### PR DESCRIPTION
The `InstanceManager` should not know about the underlying RPC abstraction, namely Akka.
Therefore, the PR removes the dependency on ActorRef from the `InstanceManager`. The mapping from `ActorRef` to `InstanceID` is now kept in the `JobManager`.

This PR is a necessary refactoring for Flip-6.