### PR TITLE
[FLINK-4887] [execution graph] Introduce TaskManagerGateway to encapsulate communcation logic

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
@@ -220,7 +220,7 @@ public class LocalExecutor extends PlanExecutor {
 	public void endSession(JobID jobID) throws Exception {
 		LocalFlinkMiniCluster flink = this.flink;
 		if (flink != null) {
-			ActorGateway leaderGateway = flink.getLeaderGateway(AkkaUtils.getDefaultTimeout());
+			ActorGateway leaderGateway = flink.getLeaderGateway(AkkaUtils.getDefaultTimeoutAsFiniteDuration());
 			leaderGateway.tell(new JobManagerMessages.RemoveCachedJob(jobID));
 		}
 	}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTracker.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTracker.java
@@ -18,10 +18,12 @@
 
 package org.apache.flink.runtime.webmonitor;
 
-import akka.dispatch.OnComplete;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Maps;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.BiFunction;
+import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
@@ -29,9 +31,6 @@ import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
-import scala.concurrent.ExecutionContext;
-import scala.concurrent.Future;
-import scala.concurrent.duration.FiniteDuration;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -39,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -97,7 +97,7 @@ public class BackPressureStatsTracker {
 
 	private final int numSamples;
 
-	private final FiniteDuration delayBetweenSamples;
+	private final Time delayBetweenSamples;
 
 	/** Flag indicating whether the stats tracker has been shut down. */
 	private boolean shutDown;
@@ -113,7 +113,7 @@ public class BackPressureStatsTracker {
 			StackTraceSampleCoordinator coordinator,
 			int cleanUpInterval,
 			int numSamples,
-			FiniteDuration delayBetweenSamples) {
+			Time delayBetweenSamples) {
 
 		this.coordinator = checkNotNull(coordinator, "Stack trace sample coordinator");
 
@@ -165,10 +165,10 @@ public class BackPressureStatsTracker {
 			if (!pendingStats.contains(vertex) &&
 					!vertex.getGraph().getState().isGloballyTerminalState()) {
 
-				ExecutionContext executionContext = vertex.getGraph().getExecutionContext();
+				Executor executor = vertex.getGraph().getExecutor();
 
 				// Only trigger if still active job
-				if (executionContext != null) {
+				if (executor != null) {
 					pendingStats.add(vertex);
 
 					if (LOG.isDebugEnabled()) {
@@ -181,7 +181,7 @@ public class BackPressureStatsTracker {
 							delayBetweenSamples,
 							MAX_STACK_TRACE_DEPTH);
 
-					sample.onComplete(new StackTraceSampleCompletionCallback(vertex), executionContext);
+					sample.handleAsync(new StackTraceSampleCompletionCallback(vertex), executor);
 
 					return true;
 				}
@@ -227,7 +227,7 @@ public class BackPressureStatsTracker {
 	/**
 	 * Callback on completed stack trace sample.
 	 */
-	class StackTraceSampleCompletionCallback extends OnComplete<StackTraceSample> {
+	class StackTraceSampleCompletionCallback implements BiFunction<StackTraceSample, Throwable, Void> {
 
 		private final ExecutionJobVertex vertex;
 
@@ -236,28 +236,30 @@ public class BackPressureStatsTracker {
 		}
 
 		@Override
-		public void onComplete(Throwable failure, StackTraceSample success) throws Throwable {
+		public Void apply(StackTraceSample stackTraceSample, Throwable throwable) {
 			synchronized (lock) {
 				try {
 					if (shutDown) {
-						return;
+						return null;
 					}
 
 					// Job finished, ignore.
 					JobStatus jobState = vertex.getGraph().getState();
 					if (jobState.isGloballyTerminalState()) {
 						LOG.debug("Ignoring sample, because job is in state " + jobState + ".");
-					} else if (success != null) {
-						OperatorBackPressureStats stats = createStatsFromSample(success);
+					} else if (stackTraceSample != null) {
+						OperatorBackPressureStats stats = createStatsFromSample(stackTraceSample);
 						operatorStatsCache.put(vertex, stats);
 					} else {
-						LOG.debug("Failed to gather stack trace sample.", failure);
+						LOG.debug("Failed to gather stack trace sample.", throwable);
 					}
 				} catch (Throwable t) {
 					LOG.error("Error during stats completion.", t);
 				} finally {
 					pendingStats.remove(vertex);
 				}
+
+				return null;
 			}
 		}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -31,6 +31,7 @@ import io.netty.handler.codec.http.router.Router;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import org.apache.commons.io.FileUtils;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -190,7 +191,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 
 		// - Back pressure stats ----------------------------------------------
 
-		stackTraceSamples = new StackTraceSampleCoordinator(actorSystem, 60000);
+		stackTraceSamples = new StackTraceSampleCoordinator(actorSystem.dispatcher(), 60000);
 
 		// Back pressure stats tracker config
 		int cleanUpInterval = config.getInteger(
@@ -209,7 +210,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 				ConfigConstants.JOB_MANAGER_WEB_BACK_PRESSURE_DELAY,
 				ConfigConstants.DEFAULT_JOB_MANAGER_WEB_BACK_PRESSURE_DELAY);
 
-		FiniteDuration delayBetweenSamples = new FiniteDuration(delay, TimeUnit.MILLISECONDS);
+		Time delayBetweenSamples = Time.milliseconds(delay);
 
 		backPressureStatsTracker = new BackPressureStatsTracker(
 				stackTraceSamples, cleanUpInterval, numSamples, delayBetweenSamples);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagerLogHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagerLogHandler.java
@@ -27,8 +27,6 @@ package org.apache.flink.runtime.webmonitor.handlers;
  *****************************************************************************/
 
 import akka.dispatch.Mapper;
-import akka.dispatch.OnFailure;
-import akka.dispatch.OnSuccess;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
@@ -46,24 +44,30 @@ import io.netty.handler.codec.http.router.Routed;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedFile;
 import io.netty.util.concurrent.GenericFutureListener;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.concurrent.AcceptFunction;
+import org.apache.flink.runtime.concurrent.ApplyFunction;
+import org.apache.flink.runtime.concurrent.BiFunction;
+import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
+import org.apache.flink.runtime.concurrent.impl.FlinkFuture;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.messages.JobManagerMessages;
-import org.apache.flink.runtime.messages.TaskManagerMessages;
 import org.apache.flink.runtime.webmonitor.JobManagerRetriever;
 import org.apache.flink.runtime.webmonitor.RuntimeMonitorHandlerBase;
 import org.apache.flink.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
-import scala.Tuple2;
 import scala.concurrent.ExecutionContextExecutor;
-import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
+import scala.reflect.ClassTag$;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -98,13 +102,15 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 	private final ConcurrentHashMap<String, Boolean> lastRequestPending = new ConcurrentHashMap<>();
 	private final Configuration config;
 
-	/** */
+	/** Future of the blob cache */
 	private Future<BlobCache> cache;
 
 	/** Indicates which log file should be displayed; true indicates .log, false indicates .out */
 	private boolean serveLogFile;
 
 	private final ExecutionContextExecutor executor;
+
+	private final Time timeTimeout;
 
 	public enum FileMode {
 		LOG,
@@ -114,11 +120,11 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 	public TaskManagerLogHandler(
 		JobManagerRetriever retriever,
 		ExecutionContextExecutor executor,
-		Future<String> localJobManagerAddressPromise,
+		scala.concurrent.Future<String> localJobManagerAddressPromise,
 		FiniteDuration timeout,
 		FileMode fileMode,
 		Configuration config,
-		boolean httpsEnabled) throws IOException {
+		boolean httpsEnabled) {
 		super(retriever, localJobManagerAddressPromise, timeout, httpsEnabled);
 
 		this.executor = checkNotNull(executor);
@@ -131,6 +137,8 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 				serveLogFile = false;
 				break;
 		}
+
+		timeTimeout = Time.milliseconds(timeout.toMillis());
 	}
 
 	/**
@@ -139,8 +147,8 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 	@Override
 	protected void respondAsLeader(final ChannelHandlerContext ctx, final Routed routed, final ActorGateway jobManager) {
 		if (cache == null) {
-			Future<Object> portFuture = jobManager.ask(JobManagerMessages.getRequestBlobManagerPort(), timeout);
-			cache = portFuture.map(new Mapper<Object, BlobCache>() {
+			scala.concurrent.Future<Object> portFuture = jobManager.ask(JobManagerMessages.getRequestBlobManagerPort(), timeout);
+			scala.concurrent.Future<BlobCache> cacheFuture = portFuture.map(new Mapper<Object, BlobCache>() {
 				@Override
 				public BlobCache apply(Object result) {
 					Option<String> hostOption = jobManager.actor().path().address().host();
@@ -149,6 +157,8 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 					return new BlobCache(new InetSocketAddress(host, port), config);
 				}
 			}, executor);
+
+			cache = new FlinkFuture<>(cacheFuture);
 		}
 
 		final String taskManagerID = routed.pathParams().get(TaskManagersHandler.TASK_MANAGER_ID_KEY);
@@ -158,53 +168,78 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 		if (lastRequestPending.putIfAbsent(taskManagerID, true) == null) {
 			try {
 				InstanceID instanceID = new InstanceID(StringUtils.hexStringToByte(taskManagerID));
-				Future<Object> taskManagerFuture = jobManager.ask(new JobManagerMessages.RequestTaskManagerInstance(instanceID), timeout);
+				scala.concurrent.Future<JobManagerMessages.TaskManagerInstance> scalaTaskManagerFuture = jobManager
+					.ask(new JobManagerMessages.RequestTaskManagerInstance(instanceID), timeout)
+					.mapTo(ClassTag$.MODULE$.<JobManagerMessages.TaskManagerInstance>apply(JobManagerMessages.TaskManagerInstance.class));
 
-				Future<Object> blobKeyFuture = taskManagerFuture.flatMap(new Mapper<Object, Future<Object>>() {
-					@Override
-					public Future<Object> apply(Object instance) {
-						Instance taskManager = ((JobManagerMessages.TaskManagerInstance) instance).instance().get();
-						return taskManager.getActorGateway().ask(serveLogFile ? TaskManagerMessages.getRequestTaskManagerLog() : TaskManagerMessages.getRequestTaskManagerStdout(), timeout);
-					}
-				}, executor);
+				Future<JobManagerMessages.TaskManagerInstance> taskManagerFuture = new FlinkFuture<>(scalaTaskManagerFuture);
 
-				Future<Object> logPathFuture = cache.zip(blobKeyFuture).map(new Mapper<Tuple2<BlobCache, Object>, Object>() {
+				Future<BlobKey> blobKeyFuture = taskManagerFuture.thenCompose(new ApplyFunction<JobManagerMessages.TaskManagerInstance, Future<BlobKey>>() {
 					@Override
-					public Object checkedApply(Tuple2<BlobCache, Object> instance) throws Exception {
-						BlobCache cache = instance._1();
-						if (instance._2() instanceof Exception) {
-							throw (Exception) instance._2();
+					public Future<BlobKey> apply(JobManagerMessages.TaskManagerInstance value) {
+						Instance taskManager = value.instance().get();
+
+						if (serveLogFile) {
+							return taskManager.getTaskManagerGateway().requestTaskManagerLog(timeTimeout);
+						} else {
+							return taskManager.getTaskManagerGateway().requestTaskManagerStdout(timeTimeout);
 						}
-						BlobKey blobKey = (BlobKey) instance._2();
+					}
+				});
 
-						//delete previous log file, if it is different than the current one
-						HashMap<String, BlobKey> lastSubmittedFile = serveLogFile ? lastSubmittedLog : lastSubmittedStdout;
-						if (lastSubmittedFile.containsKey(taskManagerID)) {
-							if (!blobKey.equals(lastSubmittedFile.get(taskManagerID))) {
-								cache.deleteGlobal(lastSubmittedFile.get(taskManagerID));
+				Future<String> logPathFuture = blobKeyFuture
+					.thenCombine(
+						cache,
+						new BiFunction<BlobKey, BlobCache, Tuple2<BlobKey, BlobCache>>() {
+							@Override
+							public Tuple2<BlobKey, BlobCache> apply(BlobKey blobKey, BlobCache blobCache) {
+								return Tuple2.of(blobKey, blobCache);
+							}
+						})
+					.thenComposeAsync(new ApplyFunction<Tuple2<BlobKey, BlobCache>, Future<String>>() {
+						@Override
+						public Future<String> apply(Tuple2<BlobKey, BlobCache> value) {
+							final BlobKey blobKey = value.f0;
+							final BlobCache blobCache = value.f1;
+
+							//delete previous log file, if it is different than the current one
+							HashMap<String, BlobKey> lastSubmittedFile = serveLogFile ? lastSubmittedLog : lastSubmittedStdout;
+							if (lastSubmittedFile.containsKey(taskManagerID)) {
+								if (!blobKey.equals(lastSubmittedFile.get(taskManagerID))) {
+									try {
+										blobCache.deleteGlobal(lastSubmittedFile.get(taskManagerID));
+									} catch (IOException e) {
+										return FlinkCompletableFuture.completedExceptionally(
+											new Exception("Could not delete file for " + taskManagerID + '.', e));
+									}
+									lastSubmittedFile.put(taskManagerID, blobKey);
+								}
+							} else {
 								lastSubmittedFile.put(taskManagerID, blobKey);
 							}
-						} else {
-							lastSubmittedFile.put(taskManagerID, blobKey);
+							try {
+								return FlinkCompletableFuture.completed(blobCache.getURL(blobKey).getFile());
+							} catch (IOException e) {
+								return FlinkCompletableFuture.completedExceptionally(
+									new Exception("Could not retrieve blob for " + blobKey + '.', e));
+							}
 						}
-						return cache.getURL(blobKey).getFile();
-					}
-				}, executor);
+					}, executor);
 
-				logPathFuture.onFailure(new OnFailure() {
+				logPathFuture.exceptionally(new ApplyFunction<Throwable, Void>() {
 					@Override
-					public void onFailure(Throwable failure) throws Throwable {
+					public Void apply(Throwable failure) {
 						display(ctx, request, "Fetching TaskManager log failed.");
 						LOG.error("Fetching TaskManager log failed.", failure);
 						lastRequestPending.remove(taskManagerID);
+
+						return null;
 					}
-				}, executor);
+				});
 
-				logPathFuture.onSuccess(new OnSuccess<Object>() {
+				logPathFuture.thenAccept(new AcceptFunction<String>() {
 					@Override
-					public void onSuccess(Object filePathOption) throws Throwable {
-						String filePath = (String) filePathOption;
-
+					public void accept(String filePath) {
 						File file = new File(filePath);
 						final RandomAccessFile raf;
 						try {
@@ -212,6 +247,7 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 						} catch (FileNotFoundException e) {
 							display(ctx, request, "Displaying TaskManager log failed.");
 							LOG.error("Displaying TaskManager log failed.", e);
+
 							return;
 						}
 						long fileLength;
@@ -220,8 +256,13 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 						} catch (IOException ioe) {
 							display(ctx, request, "Displaying TaskManager log failed.");
 							LOG.error("Displaying TaskManager log failed.", ioe);
-							raf.close();
-							throw ioe;
+							try {
+								raf.close();
+							} catch (IOException e) {
+								LOG.error("Could not close random access file.", e);
+							}
+
+							return;
 						}
 						final FileChannel fc = raf.getChannel();
 
@@ -243,22 +284,29 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 								@Override
 								public void operationComplete(
 									io.netty.util.concurrent.Future<? super Void> future) throws Exception {
-										lastRequestPending.remove(taskManagerID);
-										fc.close();
-										raf.close();
+									lastRequestPending.remove(taskManagerID);
+									fc.close();
+									raf.close();
 								}
 							};
 						if (ctx.pipeline().get(SslHandler.class) == null) {
 							ctx.write(
 								new DefaultFileRegion(fc, 0, fileLength), ctx.newProgressivePromise())
-									.addListener(completionListener);
+								.addListener(completionListener);
 							lastContentFuture = ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
 
 						} else {
-							lastContentFuture = ctx.writeAndFlush(
-								new HttpChunkedInput(new ChunkedFile(raf, 0, fileLength, 8192)),
-								ctx.newProgressivePromise())
+							try {
+								lastContentFuture = ctx.writeAndFlush(
+									new HttpChunkedInput(new ChunkedFile(raf, 0, fileLength, 8192)),
+									ctx.newProgressivePromise())
 									.addListener(completionListener);
+							} catch (IOException e) {
+								display(ctx, request, "Displaying TaskManager log failed.");
+								LOG.error("Could not write http data.", e);
+
+								return;
+							}
 							// HttpChunkedInput will write the end marker (LastHttpContent) for us.
 						}
 
@@ -267,7 +315,7 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 							lastContentFuture.addListener(ChannelFutureListener.CLOSE);
 						}
 					}
-				}, executor);
+				});
 			} catch (Exception e) {
 				display(ctx, request, "Error: " + e.getMessage());
 				LOG.error("Fetching TaskManager log failed.", e);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagersHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagersHandler.java
@@ -84,7 +84,7 @@ public class TaskManagersHandler implements RequestHandler {
 				for (Instance instance : instances) {
 					gen.writeStartObject();
 					gen.writeStringField("id", instance.getId().toString());
-					gen.writeStringField("path", instance.getActorGateway().path());
+					gen.writeStringField("path", instance.getTaskManagerGateway().getAddress());
 					gen.writeNumberField("dataPort", instance.getTaskManagerLocation().dataPort());
 					gen.writeNumberField("timeSinceLastHeartbeat", instance.getLastHeartBeat());
 					gen.writeNumberField("slotsNumber", instance.getTotalNumberOfSlots());

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricFetcher.java
@@ -147,7 +147,7 @@ public class MetricFetcher {
 							for (Instance taskManager : taskManagers) {
 								activeTaskManagers.add(taskManager.getId().toString());
 
-								String taskManagerPath = taskManager.getActorGateway().path();
+								String taskManagerPath = taskManager.getTaskManagerGateway().getAddress();
 								String queryServicePath = taskManagerPath.substring(0, taskManagerPath.lastIndexOf('/') + 1) + MetricQueryService.METRIC_QUERY_SERVICE_NAME + "_" + taskManager.getTaskManagerID().getResourceIdString();
 								ActorRef taskManagerQueryService = actorSystem.actorFor(queryServicePath);
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.webmonitor;
 
 import akka.actor.ActorSystem;
 import akka.testkit.JavaTestKit;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.MemoryType;
@@ -157,14 +158,14 @@ public class BackPressureStatsTrackerITCase extends TestLogger {
 							ExecutionJobVertex vertex = executionGraph.getJobVertex(task.getID());
 
 							StackTraceSampleCoordinator coordinator = new StackTraceSampleCoordinator(
-									testActorSystem, 60000);
+									testActorSystem.dispatcher(), 60000);
 
 							// Verify back pressure (clean up interval can be ignored)
 							BackPressureStatsTracker statsTracker = new BackPressureStatsTracker(
-									coordinator,
-									100 * 1000,
-									20,
-									new FiniteDuration(10, TimeUnit.MILLISECONDS));
+								coordinator,
+								100 * 1000,
+								20,
+								Time.milliseconds(10L));
 
 							int numAttempts = 10;
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerTest.java
@@ -19,6 +19,9 @@
 package org.apache.flink.runtime.webmonitor;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.CompletableFuture;
+import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
@@ -27,20 +30,16 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.junit.Test;
-import scala.concurrent.ExecutionContext;
-import scala.concurrent.duration.FiniteDuration;
-import scala.concurrent.impl.Promise;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Executor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
@@ -54,34 +53,24 @@ public class BackPressureStatsTrackerTest {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testTriggerStackTraceSample() throws Exception {
-		Promise<StackTraceSample> samplePromise = new Promise.DefaultPromise<>();
+		CompletableFuture<StackTraceSample> sampleFuture = new FlinkCompletableFuture<>();
 
 		StackTraceSampleCoordinator sampleCoordinator = mock(StackTraceSampleCoordinator.class);
 		when(sampleCoordinator.triggerStackTraceSample(
 				any(ExecutionVertex[].class),
 				anyInt(),
-				any(FiniteDuration.class),
-				anyInt())).thenReturn(samplePromise.future());
+				any(Time.class),
+				anyInt())).thenReturn(sampleFuture);
 
 		ExecutionGraph graph = mock(ExecutionGraph.class);
 		when(graph.getState()).thenReturn(JobStatus.RUNNING);
 
 		// Same Thread execution context
-		when(graph.getExecutionContext()).thenReturn(new ExecutionContext() {
+		when(graph.getExecutor()).thenReturn(new Executor() {
 
 			@Override
 			public void execute(Runnable runnable) {
 				runnable.run();
-			}
-
-			@Override
-			public void reportFailure(Throwable t) {
-				fail();
-			}
-
-			@Override
-			public ExecutionContext prepare() {
-				return this;
 			}
 		});
 
@@ -99,7 +88,7 @@ public class BackPressureStatsTrackerTest {
 		taskVertices[3] = mockExecutionVertex(jobVertex, 3);
 
 		int numSamples = 100;
-		FiniteDuration delayBetweenSamples = new FiniteDuration(100, TimeUnit.MILLISECONDS);
+		Time delayBetweenSamples = Time.milliseconds(100L);
 
 		BackPressureStatsTracker tracker = new BackPressureStatsTracker(
 				sampleCoordinator, 9999, numSamples, delayBetweenSamples);
@@ -149,7 +138,7 @@ public class BackPressureStatsTrackerTest {
 				traces);
 
 		// Succeed the promise
-		samplePromise.success(sample);
+		sampleFuture.complete(sample);
 
 		assertTrue(tracker.getOperatorBackPressureStats(jobVertex).isDefined());
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorTest.java
@@ -19,33 +19,40 @@
 package org.apache.flink.runtime.webmonitor;
 
 import akka.actor.ActorSystem;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.CompletableFuture;
+import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
-import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.messages.StackTraceSampleMessages.TriggerStackTraceSample;
+import org.apache.flink.runtime.messages.StackTraceSampleResponse;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import scala.concurrent.Future;
-import scala.concurrent.duration.FiniteDuration;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -74,7 +81,7 @@ public class StackTraceSampleCoordinatorTest {
 
 	@Before
 	public void init() throws Exception {
-		this.coord = new StackTraceSampleCoordinator(system, 60000);
+		this.coord = new StackTraceSampleCoordinator(system.dispatcher(), 60000);
 	}
 
 	/** Tests simple trigger and collect of stack trace samples. */
@@ -88,7 +95,7 @@ public class StackTraceSampleCoordinatorTest {
 		};
 
 		int numSamples = 1;
-		FiniteDuration delayBetweenSamples = new FiniteDuration(100, TimeUnit.MILLISECONDS);
+		Time delayBetweenSamples = Time.milliseconds(100L);
 		int maxStackTraceDepth = 0;
 
 		Future<StackTraceSample> sampleFuture = coord.triggerStackTraceSample(
@@ -106,11 +113,11 @@ public class StackTraceSampleCoordinatorTest {
 					delayBetweenSamples,
 					maxStackTraceDepth);
 
-			verify(vertex).sendMessageToCurrentExecution(
-					eq(expectedMsg), eq(expectedExecutionId), any(AkkaActorGateway.class));
+			verify(vertex.getCurrentExecutionAttempt())
+				.requestStackTraceSample(eq(0), eq(numSamples), eq(delayBetweenSamples), eq(maxStackTraceDepth), any(Time.class));
 		}
 
-		assertFalse(sampleFuture.isCompleted());
+		assertFalse(sampleFuture.isDone());
 
 		StackTraceElement[] stackTraceSample = Thread.currentThread().getStackTrace();
 		List<StackTraceElement[]> traces = new ArrayList<>();
@@ -124,14 +131,14 @@ public class StackTraceSampleCoordinatorTest {
 			coord.collectStackTraces(0, executionId, traces);
 
 			if (i == vertices.length - 1) {
-				assertTrue(sampleFuture.isCompleted());
+				assertTrue(sampleFuture.isDone());
 			} else {
-				assertFalse(sampleFuture.isCompleted());
+				assertFalse(sampleFuture.isDone());
 			}
 		}
 
 		// Verify completed stack trace sample
-		StackTraceSample sample = sampleFuture.value().get().get();
+		StackTraceSample sample = sampleFuture.get();
 
 		assertEquals(0, sample.getSampleId());
 		assertTrue(sample.getEndTime() >= sample.getStartTime());
@@ -162,19 +169,23 @@ public class StackTraceSampleCoordinatorTest {
 		};
 
 		Future<StackTraceSample> sampleFuture = coord.triggerStackTraceSample(
-				vertices,
-				1,
-				new FiniteDuration(100, TimeUnit.MILLISECONDS),
-				0);
+			vertices,
+			1,
+			Time.milliseconds(100L),
+			0);
 
-		assertTrue(sampleFuture.isCompleted());
-		assertTrue(sampleFuture.failed().isCompleted());
+		assertTrue(sampleFuture.isDone());
 
-		assertTrue(sampleFuture.failed().value().get().get() instanceof IllegalStateException);
+		try {
+			sampleFuture.get();
+			fail("Expected exception.");
+		} catch (ExecutionException e) {
+			assertTrue(e.getCause() instanceof IllegalStateException);
+		}
 	}
 
 	/** Tests triggering for reset tasks fails the future. */
-	@Test
+	@Test(timeout = 1000L)
 	public void testTriggerStackTraceSampleResetRunningTasks() throws Exception {
 		ExecutionVertex[] vertices = new ExecutionVertex[] {
 				mockExecutionVertex(new ExecutionAttemptID(), ExecutionState.RUNNING, true),
@@ -183,51 +194,70 @@ public class StackTraceSampleCoordinatorTest {
 		};
 
 		Future<StackTraceSample> sampleFuture = coord.triggerStackTraceSample(
-				vertices,
-				1,
-				new FiniteDuration(100, TimeUnit.MILLISECONDS),
-				0);
+			vertices,
+			1,
+			Time.milliseconds(100L),
+			0);
 
-		assertTrue(sampleFuture.isCompleted());
-		assertTrue(sampleFuture.failed().isCompleted());
-		assertTrue(sampleFuture.failed().value().get().get().getCause() instanceof RuntimeException);
+		try {
+			sampleFuture.get();
+			fail("Expected exception.");
+		} catch (ExecutionException e) {
+			assertTrue(e.getCause() instanceof RuntimeException);
+		}
 	}
 
 	/** Tests that samples time out if they don't finish in time. */
-	@Test
+	@Test(timeout = 1000L)
 	public void testTriggerStackTraceSampleTimeout() throws Exception {
 		int timeout = 100;
 
-		coord = new StackTraceSampleCoordinator(system, timeout);
+		coord = new StackTraceSampleCoordinator(system.dispatcher(), timeout);
 
-		ExecutionVertex[] vertices = new ExecutionVertex[] {
-				mockExecutionVertex(new ExecutionAttemptID(), ExecutionState.RUNNING, true),
-		};
+		final ScheduledExecutorService scheduledExecutorService = new ScheduledThreadPoolExecutor(1);
 
-		Future<StackTraceSample> sampleFuture = coord.triggerStackTraceSample(
-				vertices, 1, new FiniteDuration(100, TimeUnit.MILLISECONDS), 0);
+		try {
 
-		// Wait for the timeout
-		Thread.sleep(timeout * 2);
+			ExecutionVertex[] vertices = new ExecutionVertex[]{
+				mockExecutionVertexWithTimeout(
+					new ExecutionAttemptID(),
+					ExecutionState.RUNNING,
+					scheduledExecutorService,
+					timeout)
+			};
 
-		boolean success = false;
-		for (int i = 0; i < 10; i++) {
-			if (sampleFuture.isCompleted()) {
-				success = true;
-				break;
+			Future<StackTraceSample> sampleFuture = coord.triggerStackTraceSample(
+				vertices, 1, Time.milliseconds(100L), 0);
+
+			// Wait for the timeout
+			Thread.sleep(timeout * 2);
+
+			boolean success = false;
+			for (int i = 0; i < 10; i++) {
+				if (sampleFuture.isDone()) {
+					success = true;
+					break;
+				}
+
+				Thread.sleep(timeout);
 			}
 
-			Thread.sleep(timeout);
+			assertTrue("Sample did not time out", success);
+
+			try {
+				sampleFuture.get();
+				fail("Expected exception.");
+			} catch (ExecutionException e) {
+				assertTrue(e.getCause().getCause().getMessage().contains("Timeout"));
+			}
+
+
+			// Collect after the timeout (should be ignored)
+			ExecutionAttemptID executionId = vertices[0].getCurrentExecutionAttempt().getAttemptId();
+			coord.collectStackTraces(0, executionId, new ArrayList<StackTraceElement[]>());
+		} finally {
+			scheduledExecutorService.shutdownNow();
 		}
-
-		assertTrue("Sample did not time out", success);
-
-		Throwable cause = sampleFuture.failed().value().get().get();
-		assertTrue(cause.getCause().getMessage().contains("Time out"));
-
-		// Collect after the timeout (should be ignored)
-		ExecutionAttemptID executionId = vertices[0].getCurrentExecutionAttempt().getAttemptId();
-		coord.collectStackTraces(0, executionId, new ArrayList<StackTraceElement[]>());
 	}
 
 	/** Tests that collecting an unknown sample is ignored. */
@@ -244,15 +274,15 @@ public class StackTraceSampleCoordinatorTest {
 		};
 
 		Future<StackTraceSample> sampleFuture = coord.triggerStackTraceSample(
-				vertices, 1, new FiniteDuration(100, TimeUnit.MILLISECONDS), 0);
+				vertices, 1, Time.milliseconds(100L), 0);
 
-		assertFalse(sampleFuture.isCompleted());
+		assertFalse(sampleFuture.isDone());
 
 		// Cancel
 		coord.cancelStackTraceSample(0, null);
 
 		// Verify completed
-		assertTrue(sampleFuture.isCompleted());
+		assertTrue(sampleFuture.isDone());
 
 		// Verify no more pending samples
 		assertEquals(0, coord.getNumberOfPendingSamples());
@@ -266,13 +296,13 @@ public class StackTraceSampleCoordinatorTest {
 		};
 
 		Future<StackTraceSample> sampleFuture = coord.triggerStackTraceSample(
-				vertices, 1, new FiniteDuration(100, TimeUnit.MILLISECONDS), 0);
+				vertices, 1, Time.milliseconds(100L), 0);
 
-		assertFalse(sampleFuture.isCompleted());
+		assertFalse(sampleFuture.isDone());
 
 		coord.cancelStackTraceSample(0, null);
 
-		assertTrue(sampleFuture.isCompleted());
+		assertTrue(sampleFuture.isDone());
 
 		// Verify no error on late collect
 		ExecutionAttemptID executionId = vertices[0].getCurrentExecutionAttempt().getAttemptId();
@@ -287,13 +317,13 @@ public class StackTraceSampleCoordinatorTest {
 		};
 
 		Future<StackTraceSample> sampleFuture = coord.triggerStackTraceSample(
-				vertices, 1, new FiniteDuration(100, TimeUnit.MILLISECONDS), 0);
+				vertices, 1, Time.milliseconds(100L), 0);
 
-		assertFalse(sampleFuture.isCompleted());
+		assertFalse(sampleFuture.isDone());
 
 		coord.cancelStackTraceSample(0, null);
 
-		assertTrue(sampleFuture.isCompleted());
+		assertTrue(sampleFuture.isDone());
 
 		// Verify no error on late collect
 		ExecutionAttemptID executionId = vertices[0].getCurrentExecutionAttempt().getAttemptId();
@@ -308,7 +338,7 @@ public class StackTraceSampleCoordinatorTest {
 				mockExecutionVertex(new ExecutionAttemptID(), ExecutionState.RUNNING, true),
 		};
 
-		coord.triggerStackTraceSample(vertices, 1, new FiniteDuration(100, TimeUnit.MILLISECONDS), 0);
+		coord.triggerStackTraceSample(vertices, 1, Time.milliseconds(100L), 0);
 
 		coord.collectStackTraces(0, new ExecutionAttemptID(), new ArrayList<StackTraceElement[]>());
 	}
@@ -324,13 +354,13 @@ public class StackTraceSampleCoordinatorTest {
 
 		// Trigger
 		sampleFutures.add(coord.triggerStackTraceSample(
-				vertices, 1, new FiniteDuration(100, TimeUnit.MILLISECONDS), 0));
+				vertices, 1, Time.milliseconds(100L), 0));
 
 		sampleFutures.add(coord.triggerStackTraceSample(
-				vertices, 1, new FiniteDuration(100, TimeUnit.MILLISECONDS), 0));
+				vertices, 1, Time.milliseconds(100L), 0));
 
 		for (Future<StackTraceSample> future : sampleFutures) {
-			assertFalse(future.isCompleted());
+			assertFalse(future.isDone());
 		}
 
 		// Shut down
@@ -338,15 +368,22 @@ public class StackTraceSampleCoordinatorTest {
 
 		// Verify all completed
 		for (Future<StackTraceSample> future : sampleFutures) {
-			assertTrue(future.isCompleted());
+			assertTrue(future.isDone());
 		}
 
 		// Verify new trigger returns failed future
 		Future<StackTraceSample> future = coord.triggerStackTraceSample(
-				vertices, 1, new FiniteDuration(100, TimeUnit.MILLISECONDS), 0);
+				vertices, 1, Time.milliseconds(100L), 0);
 
-		assertTrue(future.isCompleted());
-		assertTrue(future.failed().isCompleted());
+		assertTrue(future.isDone());
+
+		try {
+			future.get();
+			fail("Expected exception.");
+		} catch (ExecutionException e) {
+			// we expected an exception here :-)
+		}
+
 	}
 
 	// ------------------------------------------------------------------------
@@ -359,13 +396,43 @@ public class StackTraceSampleCoordinatorTest {
 		Execution exec = mock(Execution.class);
 		when(exec.getAttemptId()).thenReturn(executionId);
 		when(exec.getState()).thenReturn(state);
+		when(exec.requestStackTraceSample(anyInt(), anyInt(), any(Time.class), anyInt(), any(Time.class)))
+			.thenReturn(
+				sendSuccess ?
+					FlinkCompletableFuture.completed(mock(StackTraceSampleResponse.class)) :
+					FlinkCompletableFuture.<StackTraceSampleResponse>completedExceptionally(new Exception("Send failed")));
 
 		ExecutionVertex vertex = mock(ExecutionVertex.class);
 		when(vertex.getJobvertexId()).thenReturn(new JobVertexID());
 		when(vertex.getCurrentExecutionAttempt()).thenReturn(exec);
-		when(vertex.sendMessageToCurrentExecution(
-				any(Serializable.class), any(ExecutionAttemptID.class), any(AkkaActorGateway.class)))
-				.thenReturn(sendSuccess);
+
+		return vertex;
+	}
+
+	private ExecutionVertex mockExecutionVertexWithTimeout(
+		ExecutionAttemptID executionId,
+		ExecutionState state,
+		ScheduledExecutorService scheduledExecutorService,
+		int timeout) {
+
+		final CompletableFuture<StackTraceSampleResponse> future = new FlinkCompletableFuture<>();
+
+		Execution exec = mock(Execution.class);
+		when(exec.getAttemptId()).thenReturn(executionId);
+		when(exec.getState()).thenReturn(state);
+		when(exec.requestStackTraceSample(anyInt(), anyInt(), any(Time.class), anyInt(), any(Time.class)))
+			.thenReturn(future);
+
+		scheduledExecutorService.schedule(new Runnable() {
+			@Override
+			public void run() {
+				future.completeExceptionally(new TimeoutException("Timeout"));
+			}
+		}, timeout, TimeUnit.MILLISECONDS);
+
+		ExecutionVertex vertex = mock(ExecutionVertex.class);
+		when(vertex.getJobvertexId()).thenReturn(new JobVertexID());
+		when(vertex.getCurrentExecutionAttempt()).thenReturn(exec);
 
 		return vertex;
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/MetricFetcherTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/metrics/MetricFetcherTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
@@ -38,6 +39,7 @@ import org.apache.flink.runtime.metrics.dump.MetricDumpSerialization;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.dump.MetricQueryService;
 import org.apache.flink.runtime.metrics.util.TestingHistogram;
+import org.apache.flink.runtime.taskmanager.TaskManager;
 import org.apache.flink.runtime.webmonitor.JobManagerRetriever;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
@@ -75,11 +77,11 @@ public class MetricFetcherTest extends TestLogger {
 		JobID jobID = new JobID();
 		InstanceID tmID = new InstanceID();
 		ResourceID tmRID = new ResourceID(tmID.toString());
-		ActorGateway taskManagerGateway = mock(ActorGateway.class);
-		when(taskManagerGateway.path()).thenReturn("/tm/address");
+		TaskManagerGateway taskManagerGateway = mock(TaskManagerGateway.class);
+		when(taskManagerGateway.getAddress()).thenReturn("/tm/address");
 
 		Instance taskManager = mock(Instance.class);
-		when(taskManager.getActorGateway()).thenReturn(taskManagerGateway);
+		when(taskManager.getTaskManagerGateway()).thenReturn(taskManagerGateway);
 		when(taskManager.getId()).thenReturn(tmID);
 		when(taskManager.getTaskManagerID()).thenReturn(tmRID);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
@@ -197,8 +197,8 @@ public class JobClient {
 			jmAnswer = Await.result(
 				jobManager.ask(
 					new JobManagerMessages.RequestClassloadingProps(jobID),
-					AkkaUtils.getDefaultTimeout()),
-				AkkaUtils.getDefaultTimeout());
+					AkkaUtils.getDefaultTimeoutAsFiniteDuration()),
+				AkkaUtils.getDefaultTimeoutAsFiniteDuration());
 		} catch (Exception e) {
 			throw new JobRetrievalException(jobID, "Couldn't retrieve class loading properties from JobManager.", e);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+
+public class FutureUtils {
+
+	/**
+	 * Retry the given operation the given number of times in case of a failure.
+	 *
+	 * @param operation to executed
+	 * @param retries if the operation failed
+	 * @param executor to use to run the futures
+	 * @param <T> type of the result
+	 * @return Future containing either the result of the operation or a {@link RetryException}
+	 */
+	public static <T> Future<T> retry(
+		final Callable<Future<T>> operation,
+		final int retries,
+		final Executor executor) {
+
+		Future<T> operationResultFuture;
+
+		try {
+			operationResultFuture = operation.call();
+		} catch (Exception e) {
+			return FlinkCompletableFuture.completedExceptionally(
+				new RetryException("Could not execute the provided operation.", e));
+		}
+
+		return operationResultFuture.handleAsync(new BiFunction<T, Throwable, Future<T>>() {
+			@Override
+			public Future<T> apply(T t, Throwable throwable) {
+				if (throwable != null) {
+					if (retries > 0) {
+						return retry(operation, retries - 1, executor);
+					} else {
+						return FlinkCompletableFuture.completedExceptionally(
+							new RetryException("Could not complete the operation. Number of retries " +
+								"has been exhausted.", throwable));
+					}
+				} else {
+					return FlinkCompletableFuture.completed(t);
+				}
+			}
+		}, executor)
+		.thenCompose(new ApplyFunction<Future<T>, Future<T>>() {
+			@Override
+			public Future<T> apply(Future<T> value) {
+				return value;
+			}
+		});
+	}
+
+	public static class RetryException extends Exception {
+
+		private static final long serialVersionUID = 3613470781274141862L;
+
+		public RetryException(String message) {
+			super(message);
+		}
+
+		public RetryException(String message, Throwable cause) {
+			super(message, cause);
+		}
+
+		public RetryException(Throwable cause) {
+			super(cause);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/impl/FlinkCompletableFuture.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/impl/FlinkCompletableFuture.java
@@ -52,8 +52,6 @@ public class FlinkCompletableFuture<T> extends FlinkFuture<T> implements Complet
 
 	@Override
 	public boolean complete(T value) {
-		Preconditions.checkNotNull(value);
-
 		try {
 			promise.success(value);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -18,50 +18,50 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import akka.dispatch.OnComplete;
-import akka.dispatch.OnFailure;
 import org.apache.flink.api.common.Archiveable;
 import org.apache.flink.api.common.accumulators.Accumulator;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.ApplyFunction;
 import org.apache.flink.runtime.concurrent.BiFunction;
-import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
+import org.apache.flink.runtime.concurrent.impl.FlinkFuture;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.PartialInputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionLocation;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.instance.SlotProvider;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
-import org.apache.flink.runtime.messages.Messages;
-import org.apache.flink.runtime.messages.TaskMessages.TaskOperationResult;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.StackTraceSampleResponse;
 import org.apache.flink.runtime.state.TaskStateHandles;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.ExceptionUtils;
 import org.slf4j.Logger;
-import scala.concurrent.ExecutionContext;
-import scala.concurrent.duration.FiniteDuration;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
-import static akka.dispatch.Futures.future;
 import static org.apache.flink.runtime.execution.ExecutionState.CANCELED;
 import static org.apache.flink.runtime.execution.ExecutionState.CANCELING;
 import static org.apache.flink.runtime.execution.ExecutionState.CREATED;
@@ -70,13 +70,6 @@ import static org.apache.flink.runtime.execution.ExecutionState.FAILED;
 import static org.apache.flink.runtime.execution.ExecutionState.FINISHED;
 import static org.apache.flink.runtime.execution.ExecutionState.RUNNING;
 import static org.apache.flink.runtime.execution.ExecutionState.SCHEDULED;
-import static org.apache.flink.runtime.messages.TaskMessages.CancelTask;
-import static org.apache.flink.runtime.messages.TaskMessages.FailIntermediateResultPartitions;
-import static org.apache.flink.runtime.messages.TaskMessages.StopTask;
-import static org.apache.flink.runtime.messages.TaskMessages.SubmitTask;
-import static org.apache.flink.runtime.messages.TaskMessages.UpdatePartitionInfo;
-import static org.apache.flink.runtime.messages.TaskMessages.UpdateTaskSinglePartitionInfo;
-import static org.apache.flink.runtime.messages.TaskMessages.createUpdateTaskMultiplePartitionInfos;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -118,7 +111,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 	private final int attemptNumber;
 
-	private final FiniteDuration timeout;
+	private final Time timeout;
 
 	private ConcurrentLinkedQueue<PartialInputChannelDeploymentDescriptor> partialInputChannelDeploymentDescriptors;
 
@@ -132,8 +125,8 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 	private TaskStateHandles taskStateHandles;
 
-	/** The execution context which is used to execute futures. */
-	private ExecutionContext executionContext;
+	/** The executor which is used to execute futures. */
+	private Executor executor;
 
 	// ------------------------- Accumulators ---------------------------------
 	
@@ -150,12 +143,12 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	// --------------------------------------------------------------------------------------------
 	
 	public Execution(
-			ExecutionContext executionContext,
+			Executor executor,
 			ExecutionVertex vertex,
 			int attemptNumber,
 			long startTimestamp,
-			FiniteDuration timeout) {
-		this.executionContext = checkNotNull(executionContext);
+			Time timeout) {
+		this.executor = checkNotNull(executor);
 
 		this.vertex = checkNotNull(vertex);
 		this.attemptId = new ExecutionAttemptID();
@@ -165,9 +158,9 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		this.stateTimestamps = new long[ExecutionState.values().length];
 		markTimestamp(ExecutionState.CREATED, startTimestamp);
 
-		this.timeout = timeout;
+		this.timeout = checkNotNull(timeout);
 
-		this.partialInputChannelDeploymentDescriptors = new ConcurrentLinkedQueue<PartialInputChannelDeploymentDescriptor>();
+		this.partialInputChannelDeploymentDescriptors = new ConcurrentLinkedQueue<>();
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -283,9 +276,10 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 			//     in all cases where the deployment failed. we use many try {} finally {} clauses to assure that
 			final Future<SimpleSlot> slotAllocationFuture = slotProvider.allocateSlot(toSchedule, queued);
 
-			// IMPORTANT: We have to use the direct executor here so that we directly deploy the tasks
-			// if the slot allocation future is completed. This is necessary for immediate deployment
-			final Future<Void> deploymentFuture = slotAllocationFuture.handleAsync(new BiFunction<SimpleSlot, Throwable, Void>() {
+			// IMPORTANT: We have to use the synchronous handle operation (direct executor) here so
+			// that we directly deploy the tasks if the slot allocation future is completed. This is
+			// necessary for immediate deployment.
+			final Future<Void> deploymentFuture = slotAllocationFuture.handle(new BiFunction<SimpleSlot, Throwable, Void>() {
 				@Override
 				public Void apply(SimpleSlot simpleSlot, Throwable throwable) {
 					if (simpleSlot != null) {
@@ -304,7 +298,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 					}
 					return null;
 				}
-			}, Executors.directExecutor());
+			});
 
 			// if tasks have to scheduled immediately check that the task has been deployed
 			if (!queued) {
@@ -373,34 +367,26 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 			// register this execution at the execution graph, to receive call backs
 			vertex.getExecutionGraph().registerExecution(this);
 			
-			final ActorGateway gateway = slot.getTaskManagerActorGateway();
+			final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
 
-			final scala.concurrent.Future<Object> deployAction = gateway.ask(new SubmitTask(deployment), timeout);
+			final Future<Acknowledge> submitResultFuture = taskManagerGateway.submitTask(deployment, timeout);
 
-			deployAction.onComplete(new OnComplete<Object>(){
-
+			submitResultFuture.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
 				@Override
-				public void onComplete(Throwable failure, Object success) throws Throwable {
-					if (failure != null) {
-						if (failure instanceof TimeoutException) {
-							String taskname = deployment.getTaskInfo().getTaskNameWithSubtasks() + " (" + attemptId + ')';
+				public Void apply(Throwable failure) {
+					if (failure instanceof TimeoutException) {
+						String taskname = deployment.getTaskInfo().getTaskNameWithSubtasks() + " (" + attemptId + ')';
 
-							markFailed(new Exception(
-									"Cannot deploy task " + taskname + " - TaskManager (" + assignedResourceLocation
-									+ ") not responding after a timeout of " + timeout, failure));
-						}
-						else {
-							markFailed(failure);
-						}
+						markFailed(new Exception(
+							"Cannot deploy task " + taskname + " - TaskManager (" + assignedResourceLocation
+								+ ") not responding after a timeout of " + timeout, failure));
 					}
 					else {
-						if (!(success.equals(Messages.getAcknowledge()))) {
-							markFailed(new Exception("Failed to deploy the task to slot. Response was not of type 'Acknowledge', but was " + success
-									+ "\nSlot Details: " + slot));
-						}
+						markFailed(failure);
 					}
+					return null;
 				}
-			}, executionContext);
+			}, executor);
 		}
 		catch (Throwable t) {
 			markFailed(t);
@@ -412,31 +398,29 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 * Sends stop RPC call.
 	 */
 	public void stop() {
-		final SimpleSlot slot = this.assignedResource;
+		final SimpleSlot slot = assignedResource;
 
 		if (slot != null) {
-			final ActorGateway gateway = slot.getTaskManagerActorGateway();
+			final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
 
-			scala.concurrent.Future<Object> stopResult = gateway.retry(
-				new StopTask(attemptId),
-				NUM_STOP_CALL_TRIES,
-				timeout,
-				executionContext);
+			Future<Acknowledge> stopResultFuture = FutureUtils.retry(
+				new Callable<Future<Acknowledge>>() {
 
-			stopResult.onComplete(new OnComplete<Object>() {
-				@Override
-				public void onComplete(Throwable failure, Object success) throws Throwable {
-					if (failure != null) {
-						fail(new Exception("Task could not be stopped.", failure));
-					} else {
-						TaskOperationResult result = (TaskOperationResult) success;
-						if (!result.success()) {
-							LOG.info("Stopping task was not successful. Description: {}",
-									result.description());
-						}
+					@Override
+					public Future<Acknowledge> call() throws Exception {
+						return taskManagerGateway.stopTask(attemptId, timeout);
 					}
+				},
+				NUM_STOP_CALL_TRIES,
+				executor);
+
+			stopResultFuture.exceptionally(new ApplyFunction<Throwable, Void>() {
+				@Override
+				public Void apply(Throwable failure) {
+					LOG.info("Stopping task was not successful.", failure);
+					return null;
 				}
-			}, executionContext);
+			});
 		}
 	}
 
@@ -535,9 +519,9 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 				// TODO The current approach may send many update messages even though the consuming
 				// task has already been deployed with all necessary information. We have to check
 				// whether this is a problem and fix it, if it is.
-				future(new Callable<Boolean>(){
+				FlinkFuture.supplyAsync(new Callable<Void>(){
 					@Override
-					public Boolean call() throws Exception {
+					public Void call() throws Exception {
 						try {
 							consumerVertex.scheduleForExecution(
 									consumerVertex.getExecutionGraph().getSlotProvider(),
@@ -547,9 +531,9 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 									"vertex " + consumerVertex, t));
 						}
 
-						return true;
+						return null;
 					}
-				}, executionContext);
+				}, executor);
 
 				// double check to resolve race conditions
 				if(consumerVertex.getExecutionState() == RUNNING){
@@ -595,12 +579,11 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 					final InputChannelDeploymentDescriptor descriptor = new InputChannelDeploymentDescriptor(
 							partitionId, partitionLocation);
 
-					final UpdatePartitionInfo updateTaskMessage = new UpdateTaskSinglePartitionInfo(
-						consumer.getAttemptId(),
-						partition.getIntermediateResult().getId(),
-						descriptor);
-
-					sendUpdatePartitionInfoRpcCall(consumerSlot, updateTaskMessage);
+					consumer.sendUpdatePartitionInfoRpcCall(
+						Collections.singleton(
+							new PartitionInfo(
+								partition.getIntermediateResult().getId(),
+								descriptor)));
 				}
 				// ----------------------------------------------------------------
 				// Consumer is scheduled or deploying => cache input channel
@@ -630,6 +613,78 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 */
 	public void fail(Throwable t) {
 		processFail(t, false);
+	}
+
+	/**
+	 * Request a stack trace sample from the task of this execution.
+	 *
+	 * @param sampleId of the stack trace sample
+	 * @param numSamples the sample should contain
+	 * @param delayBetweenSamples to wait
+	 * @param maxStrackTraceDepth of the samples
+	 * @param timeout until the request times out
+	 * @return Future stack trace sample response
+	 */
+	public Future<StackTraceSampleResponse> requestStackTraceSample(
+			int sampleId,
+			int numSamples,
+			Time delayBetweenSamples,
+			int maxStrackTraceDepth,
+			Time timeout) {
+
+		final SimpleSlot slot = assignedResource;
+
+		if (slot != null) {
+			final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
+
+			return taskManagerGateway.requestStackTraceSample(
+				attemptId,
+				sampleId,
+				numSamples,
+				delayBetweenSamples,
+				maxStrackTraceDepth,
+				timeout);
+		} else {
+			return FlinkCompletableFuture.completedExceptionally(new Exception("The execution has no slot assigned."));
+		}
+	}
+
+	/**
+	 * Notify the task of this execution about a completed checkpoint.
+	 *
+	 * @param checkpointId of the completed checkpoint
+	 * @param timestamp of the completed checkpoint
+	 */
+	public void notifyCheckpointComplete(long checkpointId, long timestamp) {
+		final SimpleSlot slot = assignedResource;
+
+		if (slot != null) {
+			final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
+
+			taskManagerGateway.notifyCheckpointComplete(attemptId, getVertex().getJobId(), checkpointId, timestamp);
+		} else {
+			LOG.debug("The execution has no slot assigned. This indicates that the execution is " +
+				"no longer running.");
+		}
+	}
+
+	/**
+	 * Trigger a new checkpoint on the task of this execution.
+	 *
+	 * @param checkpointId of th checkpoint to trigger
+	 * @param timestamp of the checkpoint to trigger
+	 */
+	public void triggerCheckpoint(long checkpointId, long timestamp) {
+		final SimpleSlot slot = assignedResource;
+
+		if (slot != null) {
+			final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
+
+			taskManagerGateway.triggerCheckpoint(attemptId, getVertex().getJobId(), checkpointId, timestamp);
+		} else {
+			LOG.debug("The execution has no slot assigned. This indicates that the execution is " +
+				"no longer running.");
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -757,20 +812,16 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 			PartialInputChannelDeploymentDescriptor partialInputChannelDeploymentDescriptor;
 
-			List<IntermediateDataSetID> resultIDs = new ArrayList<IntermediateDataSetID>();
-			List<InputChannelDeploymentDescriptor> inputChannelDeploymentDescriptors = new ArrayList<InputChannelDeploymentDescriptor>();
+			List<PartitionInfo> partitionInfos = new ArrayList<>(partialInputChannelDeploymentDescriptors.size());
 
 			while ((partialInputChannelDeploymentDescriptor = partialInputChannelDeploymentDescriptors.poll()) != null) {
-				resultIDs.add(partialInputChannelDeploymentDescriptor.getResultId());
-				inputChannelDeploymentDescriptors.add(partialInputChannelDeploymentDescriptor.createInputChannelDeploymentDescriptor(this));
+				partitionInfos.add(
+					new PartitionInfo(
+						partialInputChannelDeploymentDescriptor.getResultId(),
+						partialInputChannelDeploymentDescriptor.createInputChannelDeploymentDescriptor(this)));
 			}
 
-			UpdatePartitionInfo updateTaskMessage = createUpdateTaskMultiplePartitionInfos(
-				attemptId,
-				resultIDs,
-				inputChannelDeploymentDescriptors);
-
-			sendUpdatePartitionInfoRpcCall(assignedResource, updateTaskMessage);
+			sendUpdatePartitionInfoRpcCall(partitionInfos);
 		}
 	}
 
@@ -891,70 +942,66 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 * The sending is tried up to NUM_CANCEL_CALL_TRIES times.
 	 */
 	private void sendCancelRpcCall() {
-		final SimpleSlot slot = this.assignedResource;
+		final SimpleSlot slot = assignedResource;
 
 		if (slot != null) {
+			final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
 
-			final ActorGateway gateway = slot.getTaskManagerActorGateway();
-
-			scala.concurrent.Future<Object> cancelResult = gateway.retry(
-				new CancelTask(attemptId),
-				NUM_CANCEL_CALL_TRIES,
-				timeout,
-				executionContext);
-
-			cancelResult.onComplete(new OnComplete<Object>() {
-
-				@Override
-				public void onComplete(Throwable failure, Object success) throws Throwable {
-					if (failure != null) {
-						fail(new Exception("Task could not be canceled.", failure));
-					} else {
-						TaskOperationResult result = (TaskOperationResult) success;
-						if (!result.success()) {
-							LOG.debug("Cancel task call did not find task. Probably akka message call" +
-									" race.");
-						}
+			Future<Acknowledge> cancelResultFuture = FutureUtils.retry(
+				new Callable<Future<Acknowledge>>() {
+					@Override
+					public Future<Acknowledge> call() throws Exception {
+						return taskManagerGateway.cancelTask(attemptId, timeout);
 					}
+				},
+				NUM_CANCEL_CALL_TRIES,
+				executor);
+
+			cancelResultFuture.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
+				@Override
+				public Void apply(Throwable failure) {
+					fail(new Exception("Task could not be canceled.", failure));
+					return null;
 				}
-			}, executionContext);
+			}, executor);
 		}
 	}
 
 	private void sendFailIntermediateResultPartitionsRpcCall() {
-		final SimpleSlot slot = this.assignedResource;
+		final SimpleSlot slot = assignedResource;
 
 		if (slot != null) {
-			final ActorGateway gateway = slot.getTaskManagerActorGateway();
+			final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
 
 			// TODO For some tests this could be a problem when querying too early if all resources were released
-			gateway.tell(new FailIntermediateResultPartitions(attemptId));
+			taskManagerGateway.failPartition(attemptId);
 		}
 	}
 
 	/**
-	 * Sends an UpdatePartitionInfo message to the instance of the consumerSlot.
+	 * Update the partition infos on the assigned resource.
 	 *
-	 * @param consumerSlot Slot to whose instance the message will be sent
-	 * @param updatePartitionInfo UpdatePartitionInfo message
+	 * @param partitionInfos for the remote task
 	 */
 	private void sendUpdatePartitionInfoRpcCall(
-			final SimpleSlot consumerSlot,
-			final UpdatePartitionInfo updatePartitionInfo) {
+			final Iterable<PartitionInfo> partitionInfos) {
 
-		if (consumerSlot != null) {
-			final ActorGateway gateway = consumerSlot.getTaskManagerActorGateway();
-			final TaskManagerLocation taskManagerLocation = consumerSlot.getTaskManagerLocation();
+		final SimpleSlot slot = assignedResource;
 
-			scala.concurrent.Future<Object> futureUpdate = gateway.ask(updatePartitionInfo, timeout);
+		if (slot != null) {
+			final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
+			final TaskManagerLocation taskManagerLocation = slot.getTaskManagerLocation();
 
-			futureUpdate.onFailure(new OnFailure() {
+			Future<Acknowledge> updatePartitionsResultFuture = taskManagerGateway.updatePartitions(attemptId, partitionInfos, timeout);
+
+			updatePartitionsResultFuture.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
 				@Override
-				public void onFailure(Throwable failure) throws Throwable {
+				public Void apply(Throwable failure) {
 					fail(new IllegalStateException("Update task on TaskManager " + taskManagerLocation +
-							" failed due to:", failure));
+						" failed due to:", failure));
+					return null;
 				}
-			}, executionContext);
+			}, executor);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.AccumulatorHelper;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
@@ -62,8 +63,6 @@ import org.apache.flink.util.SerializedValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import scala.concurrent.ExecutionContext;
-import scala.concurrent.duration.FiniteDuration;
 import scala.Option;
 
 import java.io.IOException;
@@ -81,6 +80,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -169,7 +169,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	private final long[] stateTimestamps;
 
 	/** The timeout for all messages that require a response/acknowledgement */
-	private final FiniteDuration timeout;
+	private final Time timeout;
 
 	// ------ Configuration of the Execution -------
 
@@ -215,8 +215,8 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	 * available after archiving. */
 	private CheckpointStatsTracker checkpointStatsTracker;
 
-	/** The execution context which is used to execute futures. */
-	private ExecutionContext executionContext;
+	/** The executor which is used to execute futures. */
+	private Executor executor;
 
 	/** Registered KvState instances reported by the TaskManagers. */
 	private KvStateLocationRegistry kvStateLocationRegistry;
@@ -232,15 +232,15 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	 * This constructor is for tests only, because it does not include class loading information.
 	 */
 	ExecutionGraph(
-			ExecutionContext executionContext,
+			Executor executor,
 			JobID jobId,
 			String jobName,
 			Configuration jobConfig,
 			SerializedValue<ExecutionConfig> serializedConfig,
-			FiniteDuration timeout,
+			Time timeout,
 			RestartStrategy restartStrategy) {
 		this(
-			executionContext,
+			executor,
 			jobId,
 			jobName,
 			jobConfig,
@@ -255,25 +255,25 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	}
 
 	public ExecutionGraph(
-			ExecutionContext executionContext,
+			Executor executor,
 			JobID jobId,
 			String jobName,
 			Configuration jobConfig,
 			SerializedValue<ExecutionConfig> serializedConfig,
-			FiniteDuration timeout,
+			Time timeout,
 			RestartStrategy restartStrategy,
 			List<BlobKey> requiredJarFiles,
 			List<URL> requiredClasspaths,
 			ClassLoader userClassLoader,
 			MetricGroup metricGroup) {
 
-		checkNotNull(executionContext);
+		checkNotNull(executor);
 		checkNotNull(jobId);
 		checkNotNull(jobName);
 		checkNotNull(jobConfig);
 		checkNotNull(userClassLoader);
 
-		this.executionContext = executionContext;
+		this.executor = executor;
 
 		this.jobID = jobId;
 		this.jobName = jobName;
@@ -594,8 +594,8 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	 *
 	 * @return ExecutionContext associated with this ExecutionGraph
 	 */
-	public ExecutionContext getExecutionContext() {
-		return executionContext;
+	public Executor getExecutor() {
+		return executor;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -40,9 +40,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.jsonplan.JsonPlanGenerator;
 import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
 import org.slf4j.Logger;
-import scala.concurrent.ExecutionContext;
-import scala.concurrent.ExecutionContext$;
-import scala.concurrent.duration.FiniteDuration;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -55,8 +52,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * Utility class to encapsulate the logic of building an {@link ExecutionGraph} from a {@link JobGraph}.
  */
 public class ExecutionGraphBuilder {
-
-	/**
+		/**
 	 * Builds the ExecutionGraph from the JobGraph.
 	 * If a prior execution graph exists, the JobGraph will be attached. If no prior execution
 	 * graph exists, then the JobGraph will become attach to a new emoty execution graph.
@@ -66,32 +62,6 @@ public class ExecutionGraphBuilder {
 			JobGraph jobGraph,
 			Configuration jobManagerConfig,
 			Executor executor,
-			ClassLoader classLoader,
-			CheckpointRecoveryFactory recoveryFactory,
-			Time timeout,
-			RestartStrategy restartStrategy,
-			MetricGroup metrics,
-			int parallelismForAutoMax,
-			Logger log)
-			throws JobExecutionException, JobException
-	{
-		final ExecutionContext executionContext = ExecutionContext$.MODULE$.fromExecutor(executor);
-		
-		return buildGraph(prior, jobGraph, jobManagerConfig, executionContext,
-				classLoader, recoveryFactory, timeout, restartStrategy,
-				metrics, parallelismForAutoMax, log);
-	}
-
-	/**
-	 * Builds the ExecutionGraph from the JobGraph.
-	 * If a prior execution graph exists, the JobGraph will be attached. If no prior execution
-	 * graph exists, then the JobGraph will become attach to a new emoty execution graph.
-	 */
-	public static ExecutionGraph buildGraph(
-			@Nullable ExecutionGraph prior,
-			JobGraph jobGraph,
-			Configuration jobManagerConfig,
-			ExecutionContext executionContext,
 			ClassLoader classLoader,
 			CheckpointRecoveryFactory recoveryFactory,
 			Time timeout,
@@ -109,12 +79,12 @@ public class ExecutionGraphBuilder {
 		// create a new execution graph, if none exists so far
 		final ExecutionGraph executionGraph = (prior != null) ? prior :
 				new ExecutionGraph(
-						executionContext,
+						executor,
 						jobId,
 						jobName,
 						jobGraph.getJobConfiguration(),
 						jobGraph.getSerializedExecutionConfig(),
-						new FiniteDuration(timeout.getSize(), timeout.getUnit()),
+						timeout,
 						restartStrategy,
 						jobGraph.getUserJarBlobKeys(),
 						jobGraph.getClasspaths(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.executiongraph;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.AccumulatorHelper;
 import org.apache.flink.api.common.accumulators.LongCounter;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.core.io.InputSplitSource;
@@ -47,7 +48,6 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 
 import scala.Option;
-import scala.concurrent.duration.FiniteDuration;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -92,7 +92,7 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 		ExecutionGraph graph,
 		JobVertex jobVertex,
 		int defaultParallelism,
-		FiniteDuration timeout) throws JobException {
+		Time timeout) throws JobException {
 
 		this(graph, jobVertex, defaultParallelism, timeout, System.currentTimeMillis());
 	}
@@ -101,7 +101,7 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 		ExecutionGraph graph,
 		JobVertex jobVertex,
 		int defaultParallelism,
-		FiniteDuration timeout,
+		Time timeout,
 		long createTimestamp) throws JobException {
 
 		if (graph == null || jobVertex == null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/PartitionInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/PartitionInfo.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+
+/**
+ * Contains information where to find a partition. The partition is defined by the
+ * {@link IntermediateDataSetID} and the partition location is specified by
+ * {@link InputChannelDeploymentDescriptor}.
+ */
+public class PartitionInfo implements Serializable {
+
+	private static final long serialVersionUID = 1724490660830968430L;
+	
+	private final IntermediateDataSetID intermediateDataSetID;
+	private final InputChannelDeploymentDescriptor inputChannelDeploymentDescriptor;
+
+	public PartitionInfo(IntermediateDataSetID intermediateResultPartitionID, InputChannelDeploymentDescriptor inputChannelDeploymentDescriptor) {
+		this.intermediateDataSetID = Preconditions.checkNotNull(intermediateResultPartitionID);
+		this.inputChannelDeploymentDescriptor = Preconditions.checkNotNull(inputChannelDeploymentDescriptor);
+	}
+
+	public IntermediateDataSetID getIntermediateDataSetID() {
+		return intermediateDataSetID;
+	}
+
+	public InputChannelDeploymentDescriptor getInputChannelDeploymentDescriptor() {
+		return inputChannelDeploymentDescriptor;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FailureRateRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FailureRateRestartStrategy.java
@@ -21,14 +21,13 @@ package org.apache.flink.runtime.executiongraph.restart;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.concurrent.impl.FlinkFuture;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.util.Preconditions;
 import scala.concurrent.duration.Duration;
 
 import java.util.ArrayDeque;
 import java.util.concurrent.TimeUnit;
-
-import static akka.dispatch.Futures.future;
 
 /**
  * Restart strategy which tries to restart the given {@link ExecutionGraph} when failure rate exceeded
@@ -71,7 +70,7 @@ public class FailureRateRestartStrategy implements RestartStrategy {
 			restartTimestampsDeque.remove();
 		}
 		restartTimestampsDeque.add(System.currentTimeMillis());
-		future(ExecutionGraphRestarter.restartWithDelay(executionGraph, delayInterval.toMilliseconds()), executionGraph.getExecutionContext());
+		FlinkFuture.supplyAsync(ExecutionGraphRestarter.restartWithDelay(executionGraph, delayInterval.toMilliseconds()), executionGraph.getExecutor());
 	}
 
 	private boolean isRestartTimestampsQueueFull() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
@@ -20,11 +20,10 @@ package org.apache.flink.runtime.executiongraph.restart;
 
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.concurrent.impl.FlinkFuture;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.util.Preconditions;
 import scala.concurrent.duration.Duration;
-
-import static akka.dispatch.Futures.future;
 
 /**
  * Restart strategy which tries to restart the given {@link ExecutionGraph} a fixed number of times
@@ -59,7 +58,7 @@ public class FixedDelayRestartStrategy implements RestartStrategy {
 	@Override
 	public void restart(final ExecutionGraph executionGraph) {
 		currentRestartAttempt++;
-		future(ExecutionGraphRestarter.restartWithDelay(executionGraph, delayBetweenRestartAttempts), executionGraph.getExecutionContext());
+		FlinkFuture.supplyAsync(ExecutionGraphRestarter.restartWithDelay(executionGraph, delayBetweenRestartAttempts), executionGraph.getExecutor());
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Instance.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Instance.java
@@ -29,8 +29,10 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotAvailabilityListener;
 import org.apache.flink.runtime.jobmanager.slots.SlotOwner;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
+import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +51,7 @@ public class Instance implements SlotOwner {
 	private final Object instanceLock = new Object();
 
 	/** The instance gateway to communicate with the instance */
-	private final ActorGateway actorGateway;
+	private final TaskManagerGateway taskManagerGateway;
 
 	/** The instance connection information for the data transfer. */
 	private final TaskManagerLocation location;
@@ -86,25 +88,25 @@ public class Instance implements SlotOwner {
 	/**
 	 * Constructs an instance reflecting a registered TaskManager.
 	 *
-	 * @param actorGateway The actor gateway to communicate with the remote instance
+	 * @param taskManagerGateway The actor gateway to communicate with the remote instance
 	 * @param location The remote connection where the task manager receives requests.
 	 * @param id The id under which the taskManager is registered.
 	 * @param resources The resources available on the machine.
 	 * @param numberOfSlots The number of task slots offered by this taskManager.
 	 */
 	public Instance(
-			ActorGateway actorGateway,
+			TaskManagerGateway taskManagerGateway,
 			TaskManagerLocation location,
 			InstanceID id,
 			HardwareDescription resources,
 			int numberOfSlots) {
-		this.actorGateway = actorGateway;
-		this.location = location;
-		this.instanceId = id;
-		this.resources = resources;
+		this.taskManagerGateway = Preconditions.checkNotNull(taskManagerGateway);
+		this.location = Preconditions.checkNotNull(location);
+		this.instanceId = Preconditions.checkNotNull(id);
+		this.resources = Preconditions.checkNotNull(resources);
 		this.numberOfSlots = numberOfSlots;
 
-		this.availableSlots = new ArrayDeque<Integer>(numberOfSlots);
+		this.availableSlots = new ArrayDeque<>(numberOfSlots);
 		for (int i = 0; i < numberOfSlots; i++) {
 			this.availableSlots.add(i);
 		}
@@ -240,7 +242,7 @@ public class Instance implements SlotOwner {
 				return null;
 			}
 			else {
-				SimpleSlot slot = new SimpleSlot(jobID, this, location, nextSlot, actorGateway);
+				SimpleSlot slot = new SimpleSlot(jobID, this, location, nextSlot, taskManagerGateway);
 				allocatedSlots.add(slot);
 				return slot;
 			}
@@ -278,7 +280,7 @@ public class Instance implements SlotOwner {
 			}
 			else {
 				SharedSlot slot = new SharedSlot(
-						jobID, this, location, nextSlot, actorGateway, sharingGroupAssignment);
+						jobID, this, location, nextSlot, taskManagerGateway, sharingGroupAssignment);
 				allocatedSlots.add(slot);
 				return slot;
 			}
@@ -345,8 +347,8 @@ public class Instance implements SlotOwner {
 	 *
 	 * @return InstanceGateway associated with this instance
 	 */
-	public ActorGateway getActorGateway() {
-		return actorGateway;
+	public TaskManagerGateway getTaskManagerGateway() {
+		return taskManagerGateway;
 	}
 
 	public TaskManagerLocation getTaskManagerLocation() {
@@ -400,6 +402,6 @@ public class Instance implements SlotOwner {
 	@Override
 	public String toString() {
 		return String.format("%s @ %s - %d slots - URL: %s", instanceId, location.getHostname(),
-				numberOfSlots, (actorGateway != null ? actorGateway.path() : "No instance gateway"));
+				numberOfSlots, (taskManagerGateway != null ? taskManagerGateway.getAddress() : "No instance gateway"));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/InstanceManager.java
@@ -25,10 +25,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
-import akka.actor.ActorRef;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -132,19 +131,17 @@ public class InstanceManager {
 	 * Registers a task manager. Registration of a task manager makes it available to be used
 	 * for the job execution.
 	 *
-	 * @param taskManager ActorRef to the TaskManager which wants to be registered
+	 * @param taskManagerGateway gateway to the task manager
 	 * @param taskManagerLocation Location info of the TaskManager
 	 * @param resources Hardware description of the TaskManager
 	 * @param numberOfSlots Number of available slots on the TaskManager
-	 * @param leaderSessionID The current leader session ID of the JobManager
 	 * @return The assigned InstanceID of the registered task manager
 	 */
 	public InstanceID registerTaskManager(
-			ActorRef taskManager,
+			TaskManagerGateway taskManagerGateway,
 			TaskManagerLocation taskManagerLocation,
 			HardwareDescription resources,
-			int numberOfSlots,
-			UUID leaderSessionID) {
+			int numberOfSlots) {
 		
 		synchronized (this.lock) {
 			if (this.isShutdown) {
@@ -164,11 +161,14 @@ public class InstanceManager {
 						" which was marked as dead earlier because of a heart-beat timeout.");
 			}
 
-			ActorGateway actorGateway = new AkkaActorGateway(taskManager, leaderSessionID);
-
 			InstanceID instanceID = new InstanceID();
 
-			Instance host = new Instance(actorGateway, taskManagerLocation, instanceID, resources, numberOfSlots);
+			Instance host = new Instance(
+				taskManagerGateway,
+				taskManagerLocation,
+				instanceID,
+				resources,
+				numberOfSlots);
 
 			registeredHostsById.put(instanceID, host);
 			registeredHostsByResource.put(taskManagerLocation.getResourceID(), host);
@@ -180,7 +180,7 @@ public class InstanceManager {
 								"Current number of registered hosts is %d. " +
 								"Current number of alive task slots is %d.",
 						taskManagerLocation.getHostname(),
-						taskManager.path(),
+						taskManagerGateway.getAddress(),
 						instanceID,
 						registeredHostsById.size(),
 						totalNumberOfAliveTaskSlots));
@@ -196,7 +196,7 @@ public class InstanceManager {
 	}
 
 	/**
-	 * Unregisters the TaskManager with the given {@link ActorRef}. Unregistering means to mark
+	 * Unregisters the TaskManager with the given instance id. Unregistering means to mark
 	 * the given instance as dead and notify {@link InstanceListener} about the dead instance.
 	 *
 	 * @param instanceId TaskManager which is about to be marked dead.
@@ -205,8 +205,6 @@ public class InstanceManager {
 		Instance instance = registeredHostsById.get(instanceId);
 
 		if (instance != null){
-			ActorRef host = instance.getActorGateway().actor();
-
 			registeredHostsById.remove(instance.getId());
 			registeredHostsByResource.remove(instance.getTaskManagerID());
 
@@ -220,9 +218,10 @@ public class InstanceManager {
 
 			notifyDeadInstance(instance);
 
-			LOG.info("Unregistered task manager " + host.path() + ". Number of " +
-					"registered task managers " + getNumberOfRegisteredTaskManagers() + ". Number" +
-					" of available slots " + getTotalNumberOfSlots() + ".");
+			LOG.info(
+				"Unregistered task manager " + instance.getTaskManagerLocation().addressString() +
+				". Number of registered task managers " + getNumberOfRegisteredTaskManagers() +
+				". Number of available slots " + getTotalNumberOfSlots() + ".");
 		} else {
 			LOG.warn("Tried to unregister instance {} but it is not registered.", instanceId);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SharedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SharedSlot.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.instance;
 
 import org.apache.flink.runtime.jobmanager.slots.AllocatedSlot;
 import org.apache.flink.runtime.jobmanager.slots.SlotOwner;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.AbstractID;
 import org.apache.flink.api.common.JobID;
@@ -63,15 +64,15 @@ public class SharedSlot extends Slot {
 	 * @param owner The component from which this slot is allocated.
 	 * @param location The location info of the TaskManager where the slot was allocated from
 	 * @param slotNumber The number of the slot.
-	 * @param taskManagerActorGateway The actor gateway to communicate with the TaskManager   
+	 * @param taskManagerGateway The gateway to communicate with the TaskManager
 	 * @param assignmentGroup The assignment group that this shared slot belongs to.
 	 */
 	public SharedSlot(
 			JobID jobID, SlotOwner owner, TaskManagerLocation location, int slotNumber,
-			ActorGateway taskManagerActorGateway,
+			TaskManagerGateway taskManagerGateway,
 			SlotSharingGroupAssignment assignmentGroup) {
 
-		this(jobID, owner, location, slotNumber, taskManagerActorGateway, assignmentGroup, null, null);
+		this(jobID, owner, location, slotNumber, taskManagerGateway, assignmentGroup, null, null);
 	}
 
 	/**
@@ -82,18 +83,22 @@ public class SharedSlot extends Slot {
 	 * @param owner The component from which this slot is allocated.
 	 * @param location The location info of the TaskManager where the slot was allocated from
 	 * @param slotNumber The number of the slot.
-	 * @param taskManagerActorGateway The actor gateway to communicate with the TaskManager   
+	 * @param taskManagerGateway The gateway to communicate with the TaskManager
 	 * @param assignmentGroup The assignment group that this shared slot belongs to.
 	 * @param parent The parent slot of this slot.
 	 * @param groupId The assignment group of this slot.
 	 */
 	public SharedSlot(
-			JobID jobID, SlotOwner owner, TaskManagerLocation location, int slotNumber,
-			ActorGateway taskManagerActorGateway,
+			JobID jobID,
+			SlotOwner owner,
+			TaskManagerLocation location,
+			int slotNumber,
+			TaskManagerGateway taskManagerGateway,
 			SlotSharingGroupAssignment assignmentGroup,
-			@Nullable SharedSlot parent, @Nullable AbstractID groupId) {
+			@Nullable SharedSlot parent,
+			@Nullable AbstractID groupId) {
 
-		super(jobID, owner, location, slotNumber, taskManagerActorGateway, parent, groupId);
+		super(jobID, owner, location, slotNumber, taskManagerGateway, parent, groupId);
 
 		this.assignmentGroup = checkNotNull(assignmentGroup);
 		this.subSlots = new HashSet<Slot>();
@@ -218,7 +223,7 @@ public class SharedSlot extends Slot {
 		if (isAlive()) {
 			SimpleSlot slot = new SimpleSlot(
 					getJobID(), getOwner(), getTaskManagerLocation(), subSlots.size(), 
-					getTaskManagerActorGateway(), this, groupId);
+					getTaskManagerGateway(), this, groupId);
 			subSlots.add(slot);
 			return slot;
 		}
@@ -240,7 +245,7 @@ public class SharedSlot extends Slot {
 		if (isAlive()) {
 			SharedSlot slot = new SharedSlot(
 					getJobID(), getOwner(), getTaskManagerLocation(), subSlots.size(), 
-					getTaskManagerActorGateway(), assignmentGroup, this, groupId);
+					getTaskManagerGateway(), assignmentGroup, this, groupId);
 			subSlots.add(slot);
 			return slot;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SimpleSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SimpleSlot.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.runtime.jobmanager.slots.AllocatedSlot;
 import org.apache.flink.runtime.jobmanager.slots.SlotOwner;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.AbstractID;
 
@@ -61,12 +62,12 @@ public class SimpleSlot extends Slot {
 	 * @param owner The component from which this slot is allocated.
 	 * @param location The location info of the TaskManager where the slot was allocated from
 	 * @param slotNumber The number of the task slot on the instance.
-	 * @param taskManagerActorGateway The actor gateway to communicate with the TaskManager of this slot   
+	 * @param taskManagerGateway The gateway to communicate with the TaskManager of this slot
 	 */
 	public SimpleSlot(
 			JobID jobID, SlotOwner owner, TaskManagerLocation location, int slotNumber,
-			ActorGateway taskManagerActorGateway) {
-		this(jobID, owner, location, slotNumber, taskManagerActorGateway, null, null);
+			TaskManagerGateway taskManagerGateway) {
+		this(jobID, owner, location, slotNumber, taskManagerGateway, null, null);
 	}
 
 	/**
@@ -77,18 +78,19 @@ public class SimpleSlot extends Slot {
 	 * @param owner The component from which this slot is allocated.
 	 * @param location The location info of the TaskManager where the slot was allocated from
 	 * @param slotNumber The number of the simple slot in its parent shared slot.
+	 * @param taskManagerGateway to communicate with the associated task manager.
 	 * @param parent The parent shared slot.
 	 * @param groupID The ID that identifies the group that the slot belongs to.
 	 */
 	public SimpleSlot(
 			JobID jobID, SlotOwner owner, TaskManagerLocation location, int slotNumber,
-			ActorGateway taskManagerActorGateway,
+			TaskManagerGateway taskManagerGateway,
 			@Nullable SharedSlot parent, @Nullable AbstractID groupID) {
 
 		super(parent != null ?
 				parent.getAllocatedSlot() :
 				new AllocatedSlot(NO_ALLOCATION_ID, jobID, location, slotNumber,
-						ResourceProfile.UNKNOWN, taskManagerActorGateway),
+						ResourceProfile.UNKNOWN, taskManagerGateway),
 				owner, slotNumber, parent, groupID);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Slot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/Slot.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.jobmanager.slots.AllocatedSlot;
 import org.apache.flink.runtime.jobmanager.slots.SlotOwner;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.AbstractID;
 import org.apache.flink.api.common.JobID;
@@ -95,20 +96,29 @@ public abstract class Slot {
 	 * @param owner The component from which this slot is allocated.
 	 * @param location The location info of the TaskManager where the slot was allocated from
 	 * @param slotNumber The number of this slot.
-	 * @param taskManagerActorGateway The actor gateway to communicate with the TaskManager
+	 * @param taskManagerGateway The actor gateway to communicate with the TaskManager
 	 * @param parent The parent slot that contains this slot. May be null, if this slot is the root.
 	 * @param groupID The ID that identifies the task group for which this slot is allocated. May be null
 	 *                if the slot does not belong to any task group.   
 	 */
 	protected Slot(
-			JobID jobID, SlotOwner owner, TaskManagerLocation location, int slotNumber,
-			ActorGateway taskManagerActorGateway,
-			@Nullable SharedSlot parent, @Nullable AbstractID groupID) {
+			JobID jobID,
+			SlotOwner owner,
+			TaskManagerLocation location,
+			int slotNumber,
+			TaskManagerGateway taskManagerGateway,
+			@Nullable SharedSlot parent,
+			@Nullable AbstractID groupID) {
 
 		checkArgument(slotNumber >= 0);
 
 		this.allocatedSlot = new AllocatedSlot(
-				NO_ALLOCATION_ID, jobID, location, slotNumber, ResourceProfile.UNKNOWN, taskManagerActorGateway);
+			NO_ALLOCATION_ID,
+			jobID,
+			location,
+			slotNumber,
+			ResourceProfile.UNKNOWN,
+			taskManagerGateway);
 
 		this.owner = checkNotNull(owner);
 		this.parent = parent; // may be null
@@ -184,8 +194,8 @@ public abstract class Slot {
 	 *
 	 * @return The actor gateway that can be used to send messages to the TaskManager.
 	 */
-	public ActorGateway getTaskManagerActorGateway() {
-		return allocatedSlot.getTaskManagerActorGateway();
+	public TaskManagerGateway getTaskManagerGateway() {
+		return allocatedSlot.getTaskManagerGateway();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/ActorTaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/ActorTaskManagerGateway.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager.slots;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.clusterframework.messages.StopCluster;
+import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.concurrent.impl.FlinkFuture;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.PartitionInfo;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.Messages;
+import org.apache.flink.runtime.messages.StackTrace;
+import org.apache.flink.runtime.messages.StackTraceSampleMessages;
+import org.apache.flink.runtime.messages.StackTraceSampleResponse;
+import org.apache.flink.runtime.messages.TaskManagerMessages;
+import org.apache.flink.runtime.messages.TaskMessages;
+import org.apache.flink.runtime.messages.checkpoint.NotifyCheckpointComplete;
+import org.apache.flink.runtime.messages.checkpoint.TriggerCheckpoint;
+import org.apache.flink.util.Preconditions;
+import scala.concurrent.duration.FiniteDuration;
+import scala.reflect.ClassTag$;
+
+/**
+ * Implementation of the {@link TaskManagerGateway} for {@link ActorGateway}.
+ */
+public class ActorTaskManagerGateway implements TaskManagerGateway {
+	private final ActorGateway actorGateway;
+
+	public ActorTaskManagerGateway(ActorGateway actorGateway) {
+		this.actorGateway = Preconditions.checkNotNull(actorGateway);
+	}
+
+	public ActorGateway getActorGateway() {
+		return actorGateway;
+	}
+
+	//-------------------------------------------------------------------------------
+	// Task manager rpc methods
+	//-------------------------------------------------------------------------------
+
+	@Override
+	public String getAddress() {
+		return actorGateway.path();
+	}
+
+	@Override
+	public void disconnectFromJobManager(InstanceID instanceId, Exception cause) {
+		actorGateway.tell(new Messages.Disconnect(instanceId, cause));
+	}
+
+	@Override
+	public void stopCluster(final ApplicationStatus applicationStatus, final String message) {
+		actorGateway.tell(new StopCluster(applicationStatus, message));
+	}
+
+	@Override
+	public Future<StackTrace> requestStackTrace(final Time timeout) {
+		Preconditions.checkNotNull(timeout);
+
+		scala.concurrent.Future<StackTrace> stackTraceFuture = actorGateway.ask(
+			TaskManagerMessages.SendStackTrace$.MODULE$.get(),
+			new FiniteDuration(timeout.getSize(), timeout.getUnit()))
+			.mapTo(ClassTag$.MODULE$.<StackTrace>apply(StackTrace.class));
+
+		return new FlinkFuture<>(stackTraceFuture);
+	}
+
+	@Override
+	public Future<StackTraceSampleResponse> requestStackTraceSample(
+			ExecutionAttemptID executionAttemptID,
+			int sampleId,
+			int numSamples,
+			Time delayBetweenSamples,
+			int maxStackTraceDepth,
+			Time timeout) {
+		Preconditions.checkNotNull(executionAttemptID);
+		Preconditions.checkArgument(numSamples > 0, "The number of samples must be greater than 0.");
+		Preconditions.checkNotNull(delayBetweenSamples);
+		Preconditions.checkArgument(maxStackTraceDepth >= 0, "The max stack trace depth must be greater or equal than 0.");
+		Preconditions.checkNotNull(timeout);
+
+		scala.concurrent.Future<StackTraceSampleResponse> stackTraceSampleResponseFuture = actorGateway.ask(
+			new StackTraceSampleMessages.TriggerStackTraceSample(
+				sampleId,
+				executionAttemptID,
+				numSamples,
+				delayBetweenSamples,
+				maxStackTraceDepth),
+			new FiniteDuration(timeout.getSize(), timeout.getUnit()))
+			.mapTo(ClassTag$.MODULE$.<StackTraceSampleResponse>apply(StackTraceSampleResponse.class));
+
+		return new FlinkFuture<>(stackTraceSampleResponseFuture);
+	}
+
+	@Override
+	public Future<Acknowledge> submitTask(TaskDeploymentDescriptor tdd, Time timeout) {
+		Preconditions.checkNotNull(tdd);
+		Preconditions.checkNotNull(timeout);
+
+		scala.concurrent.Future<Acknowledge> submitResult = actorGateway.ask(
+			new TaskMessages.SubmitTask(tdd),
+			new FiniteDuration(timeout.getSize(), timeout.getUnit()))
+			.mapTo(ClassTag$.MODULE$.<Acknowledge>apply(Acknowledge.class));
+
+		return new FlinkFuture<>(submitResult);
+	}
+
+	@Override
+	public Future<Acknowledge> stopTask(ExecutionAttemptID executionAttemptID, Time timeout) {
+		Preconditions.checkNotNull(executionAttemptID);
+		Preconditions.checkNotNull(timeout);
+
+		scala.concurrent.Future<Acknowledge> stopResult = actorGateway.ask(
+			new TaskMessages.StopTask(executionAttemptID),
+			new FiniteDuration(timeout.getSize(), timeout.getUnit()))
+			.mapTo(ClassTag$.MODULE$.<Acknowledge>apply(Acknowledge.class));
+
+		return new FlinkFuture<>(stopResult);
+	}
+
+	@Override
+	public Future<Acknowledge> cancelTask(ExecutionAttemptID executionAttemptID, Time timeout) {
+		Preconditions.checkNotNull(executionAttemptID);
+		Preconditions.checkNotNull(timeout);
+
+		scala.concurrent.Future<Acknowledge> cancelResult = actorGateway.ask(
+			new TaskMessages.CancelTask(executionAttemptID),
+			new FiniteDuration(timeout.getSize(), timeout.getUnit()))
+			.mapTo(ClassTag$.MODULE$.<Acknowledge>apply(Acknowledge.class));
+
+		return new FlinkFuture<>(cancelResult);
+	}
+
+	@Override
+	public Future<Acknowledge> updatePartitions(ExecutionAttemptID executionAttemptID, Iterable<PartitionInfo> partitionInfos, Time timeout) {
+		Preconditions.checkNotNull(executionAttemptID);
+		Preconditions.checkNotNull(partitionInfos);
+
+		TaskMessages.UpdatePartitionInfo updatePartitionInfoMessage = new TaskMessages.UpdateTaskMultiplePartitionInfos(
+			executionAttemptID,
+			partitionInfos);
+
+		scala.concurrent.Future<Acknowledge> updatePartitionsResult = actorGateway.ask(
+			updatePartitionInfoMessage,
+			new FiniteDuration(timeout.getSize(), timeout.getUnit()))
+			.mapTo(ClassTag$.MODULE$.<Acknowledge>apply(Acknowledge.class));
+
+		return new FlinkFuture<>(updatePartitionsResult);
+	}
+
+	@Override
+	public void failPartition(ExecutionAttemptID executionAttemptID) {
+		Preconditions.checkNotNull(executionAttemptID);
+
+		actorGateway.tell(new TaskMessages.FailIntermediateResultPartitions(executionAttemptID));
+	}
+
+	@Override
+	public void notifyCheckpointComplete(
+			ExecutionAttemptID executionAttemptID,
+			JobID jobId,
+			long checkpointId,
+			long timestamp) {
+
+		Preconditions.checkNotNull(executionAttemptID);
+		Preconditions.checkNotNull(jobId);
+
+		actorGateway.tell(new NotifyCheckpointComplete(jobId, executionAttemptID, checkpointId, timestamp));
+	}
+
+	@Override
+	public void triggerCheckpoint(
+			ExecutionAttemptID executionAttemptID,
+			JobID jobId,
+			long checkpointId,
+			long timestamp) {
+
+		Preconditions.checkNotNull(executionAttemptID);
+		Preconditions.checkNotNull(jobId);
+
+		actorGateway.tell(new TriggerCheckpoint(jobId, executionAttemptID, checkpointId, timestamp));
+	}
+
+	@Override
+	public Future<BlobKey> requestTaskManagerLog(Time timeout) {
+		return requestTaskManagerLog((TaskManagerMessages.RequestTaskManagerLog) TaskManagerMessages.getRequestTaskManagerLog(), timeout);
+	}
+
+	@Override
+	public Future<BlobKey> requestTaskManagerStdout(Time timeout) {
+		return requestTaskManagerLog((TaskManagerMessages.RequestTaskManagerLog) TaskManagerMessages.getRequestTaskManagerStdout(), timeout);
+	}
+
+	private Future<BlobKey> requestTaskManagerLog(TaskManagerMessages.RequestTaskManagerLog request, Time timeout) {
+		Preconditions.checkNotNull(request);
+		Preconditions.checkNotNull(timeout);
+
+		scala.concurrent.Future<BlobKey> blobKeyFuture = actorGateway
+			.ask(
+				request,
+				new FiniteDuration(timeout.getSize(), timeout.getUnit()))
+			.mapTo(ClassTag$.MODULE$.<BlobKey>apply(BlobKey.class));
+
+		return new FlinkFuture<>(blobKeyFuture);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/AllocatedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/AllocatedSlot.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.jobmanager.slots;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -53,7 +52,7 @@ public class AllocatedSlot {
 	private final ResourceProfile resourceProfile;
 
 	/** TEMP until the new RPC is in place: The actor gateway to communicate with the TaskManager */
-	private final ActorGateway taskManagerActorGateway;
+	private final TaskManagerGateway taskManagerGateway;
 
 	/** The number of the slot on the TaskManager to which slot belongs. Purely informational. */
 	private final int slotNumber;
@@ -66,14 +65,14 @@ public class AllocatedSlot {
 			TaskManagerLocation location,
 			int slotNumber,
 			ResourceProfile resourceProfile,
-			ActorGateway actorGateway)
+			TaskManagerGateway taskManagerGateway)
 	{
 		this.slotAllocationId = checkNotNull(slotAllocationId);
 		this.jobID = checkNotNull(jobID);
 		this.taskManagerLocation = checkNotNull(location);
 		this.slotNumber = slotNumber;
 		this.resourceProfile = checkNotNull(resourceProfile);
-		this.taskManagerActorGateway = checkNotNull(actorGateway);
+		this.taskManagerGateway = checkNotNull(taskManagerGateway);
 	}
 
 	public AllocatedSlot(AllocatedSlot other) {
@@ -82,7 +81,7 @@ public class AllocatedSlot {
 		this.taskManagerLocation = other.taskManagerLocation;
 		this.slotNumber = other.slotNumber;
 		this.resourceProfile = other.resourceProfile;
-		this.taskManagerActorGateway = other.taskManagerActorGateway;
+		this.taskManagerGateway = other.taskManagerGateway;
 	}
 
 	// ------------------------------------------------------------------------
@@ -139,8 +138,8 @@ public class AllocatedSlot {
 	 *
 	 * @return The actor gateway that can be used to send messages to the TaskManager.
 	 */
-	public ActorGateway getTaskManagerActorGateway() {
-		return taskManagerActorGateway;
+	public TaskManagerGateway getTaskManagerGateway() {
+		return taskManagerGateway;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager.slots;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.PartitionInfo;
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.StackTrace;
+import org.apache.flink.runtime.messages.StackTraceSampleResponse;
+
+/**
+ * Task manager gateway interface to communicate with the task manager.
+ */
+public interface TaskManagerGateway {
+
+	/**
+	 * Return the address of the task manager with which the gateway is associated.
+	 *
+	 * @return Address of the task manager with which this gateway is associated.
+	 */
+	String getAddress();
+
+	/**
+	 * Disconnect the task manager from the job manager.
+	 *
+	 * @param instanceId identifying the task manager
+	 * @param cause of the disconnection
+	 */
+	void disconnectFromJobManager(InstanceID instanceId, Exception cause);
+
+	/**
+	 * Stop the cluster.
+	 *
+	 * @param applicationStatus to stop the cluster with
+	 * @param message to deliver
+	 */
+	void stopCluster(final ApplicationStatus applicationStatus, final String message);
+
+	/**
+	 * Request the stack trace from the task manager.
+	 *
+	 * @param timeout for the stack trace request
+	 * @return Future for a stack trace
+	 */
+	Future<StackTrace> requestStackTrace(final Time timeout);
+
+	/**
+	 * Request a stack trace sample from the given task.
+	 *
+	 * @param executionAttemptID identifying the task to sample
+	 * @param sampleId of the sample
+	 * @param numSamples to take from the given task
+	 * @param delayBetweenSamples to wait for
+	 * @param maxStackTraceDepth of the returned sample
+	 * @param timeout of the request
+	 * @return Future of stack trace sample response
+	 */
+	Future<StackTraceSampleResponse> requestStackTraceSample(
+		final ExecutionAttemptID executionAttemptID,
+		final int sampleId,
+		final int numSamples,
+		final Time delayBetweenSamples,
+		final int maxStackTraceDepth,
+		final Time timeout);
+
+	/**
+	 * Submit a task to the task manager.
+	 *
+	 * @param tdd describing the task to submit
+	 * @param timeout of the submit operation
+	 * @return Future acknowledge of the successful operation
+	 */
+	Future<Acknowledge> submitTask(
+		TaskDeploymentDescriptor tdd,
+		Time timeout);
+
+	/**
+	 * Stop the given task.
+	 *
+	 * @param executionAttemptID identifying the task
+	 * @param timeout of the submit operation
+	 * @return Future acknowledge if the task is successfully stopped
+	 */
+	Future<Acknowledge> stopTask(
+		ExecutionAttemptID executionAttemptID,
+		Time timeout);
+
+	/**
+	 * Cancel the given task.
+	 *
+	 * @param executionAttemptID identifying the task
+	 * @param timeout of the submit operation
+	 * @return Future acknowledge if the task is successfully canceled
+	 */
+	Future<Acknowledge> cancelTask(
+		ExecutionAttemptID executionAttemptID,
+		Time timeout);
+
+	/**
+	 * Update the task where the given partitions can be found.
+	 *
+	 * @param executionAttemptID identifying the task
+	 * @param partitionInfos telling where the partition can be retrieved from
+	 * @param timeout of the submit operation
+	 * @return Future acknowledge if the partitions have been successfully updated
+	 */
+	Future<Acknowledge> updatePartitions(
+		ExecutionAttemptID executionAttemptID,
+		Iterable<PartitionInfo> partitionInfos,
+		Time timeout);
+
+	/**
+	 * Fail all intermediate result partitions of the given task.
+	 *
+	 * @param executionAttemptID identifying the task
+	 */
+	void failPartition(ExecutionAttemptID executionAttemptID);
+
+	/**
+	 * Notify the given task about a completed checkpoint.
+	 *
+	 * @param executionAttemptID identifying the task
+	 * @param jobId identifying the job to which the task belongs
+	 * @param checkpointId of the completed checkpoint
+	 * @param timestamp of the completed checkpoint
+	 */
+	void notifyCheckpointComplete(
+		ExecutionAttemptID executionAttemptID,
+		JobID jobId,
+		long checkpointId,
+		long timestamp);
+
+	/**
+	 * Trigger for the given task a checkpoint.
+	 *
+	 * @param executionAttemptID identifying the task
+	 * @param jobId identifying the job to which the task belongs
+	 * @param checkpointId of the checkpoint to trigger
+	 * @param timestamp of the checkpoint to trigger
+	 */
+	void triggerCheckpoint(
+		ExecutionAttemptID executionAttemptID,
+		JobID jobId,
+		long checkpointId,
+		long timestamp);
+
+	/**
+	 * Request the task manager log from the task manager.
+	 *
+	 * @param timeout for the request
+	 * @return Future blob key under which the task manager log has been stored
+	 */
+	Future<BlobKey> requestTaskManagerLog(final Time timeout);
+
+	/**
+	 * Request the task manager stdout from the task manager.
+	 *
+	 * @param timeout for the request
+	 * @return Future blob key under which the task manager stdout file has been stored
+	 */
+	Future<BlobKey> requestTaskManagerStdout(final Time timeout);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/Acknowledge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/Acknowledge.java
@@ -18,10 +18,12 @@
 
 package org.apache.flink.runtime.messages;
 
+import java.io.Serializable;
+
 /**
  * A generic acknowledgement message.
  */
-public class Acknowledge implements RequiresLeaderSessionID, java.io.Serializable {
+public class Acknowledge implements Serializable {
 
 	private static final long serialVersionUID = 7808628311617273755L;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/StackTrace.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/StackTrace.java
@@ -16,25 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.messages
+package org.apache.flink.runtime.messages;
 
-import org.apache.flink.runtime.instance.InstanceID
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.util.Preconditions;
 
-/**
- * Generic messages between JobManager, TaskManager, JobClient.
- */
-object Messages {
+public class StackTrace {
 
-  /**
-   * Signals that the receiver (JobManager/TaskManager) shall disconnect the sender.
-   *
-   * The TaskManager may send this on shutdown to let the JobManager realize the TaskManager
-   * loss more quickly.
-   *
-   * The JobManager may send this message to its TaskManagers to let them clean up their
-   * tasks that depend on the JobManager and go into a clean state.
-   *
-   * @param cause The reason for disconnecting, to be displayed in log and error messages.
-   */
-  case class Disconnect(instanceId: InstanceID, cause: Exception) extends RequiresLeaderSessionID
+	private final InstanceID instanceId;
+	private final String stackTrace;
+
+	public StackTrace(InstanceID instanceId, String stackTrace) {
+		this.instanceId = Preconditions.checkNotNull(instanceId);
+		this.stackTrace = Preconditions.checkNotNull(stackTrace);
+	}
+
+	public InstanceID getInstanceId() {
+		return instanceId;
+	}
+
+	public String getStackTrace() {
+		return stackTrace;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/StackTrace.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/StackTrace.java
@@ -21,7 +21,11 @@ package org.apache.flink.runtime.messages;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.util.Preconditions;
 
-public class StackTrace {
+import java.io.Serializable;
+
+public class StackTrace implements Serializable {
+
+	private static final long serialVersionUID = -899464298250067416L;
 
 	private final InstanceID instanceId;
 	private final String stackTrace;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/StackTraceSampleResponse.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/StackTraceSampleResponse.java
@@ -21,12 +21,15 @@ package org.apache.flink.runtime.messages;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.util.Preconditions;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
  * Response to the TriggerStackTraceSample message.
  */
-public class StackTraceSampleResponse {
+public class StackTraceSampleResponse implements Serializable {
+
+	private static final long serialVersionUID = -4786454630050578031L;
 
 	private final int sampleId;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/StackTraceSampleResponse.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/StackTraceSampleResponse.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.messages;
+
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.util.Preconditions;
+
+import java.util.List;
+
+/**
+ * Response to the TriggerStackTraceSample message.
+ */
+public class StackTraceSampleResponse {
+
+	private final int sampleId;
+
+	private final ExecutionAttemptID executionAttemptID;
+
+	private final List<StackTraceElement[]> samples;
+
+	public StackTraceSampleResponse(
+			int sampleId,
+			ExecutionAttemptID executionAttemptID,
+			List<StackTraceElement[]> samples) {
+		this.sampleId = sampleId;
+		this.executionAttemptID = Preconditions.checkNotNull(executionAttemptID);
+		this.samples = Preconditions.checkNotNull(samples);
+	}
+
+	public int getSampleId() {
+		return sampleId;
+	}
+
+	public ExecutionAttemptID getExecutionAttemptID() {
+		return executionAttemptID;
+	}
+
+	public List<StackTraceElement[]> getSamples() {
+		return samples;
+	}
+}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -20,16 +20,18 @@ package org.apache.flink.runtime.akka
 
 import java.io.IOException
 import java.net._
-import java.util.concurrent.{TimeUnit, Callable}
+import java.util.concurrent.{Callable, TimeUnit}
 
 import akka.actor._
 import akka.pattern.{ask => akkaAsk}
-import com.typesafe.config.{ConfigValueFactory, ConfigParseOptions, Config, ConfigFactory}
+import com.typesafe.config.{Config, ConfigFactory, ConfigParseOptions, ConfigValueFactory}
+import org.apache.flink.api.common.time.Time
 import org.apache.flink.configuration.{ConfigConstants, Configuration}
 import org.apache.flink.runtime.net.SSLUtils
 import org.apache.flink.util.NetUtils
-import org.jboss.netty.logging.{Slf4JLoggerFactory, InternalLoggerFactory}
+import org.jboss.netty.logging.{InternalLoggerFactory, Slf4JLoggerFactory}
 import org.slf4j.LoggerFactory
+
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -545,10 +547,16 @@ object AkkaUtils {
     new FiniteDuration(duration.toMillis, TimeUnit.MILLISECONDS)
   }
 
-  def getDefaultTimeout: FiniteDuration = {
+  def getDefaultTimeout: Time = {
     val duration = Duration(ConfigConstants.DEFAULT_AKKA_ASK_TIMEOUT)
 
-    new FiniteDuration(duration.toMillis, TimeUnit.MILLISECONDS)
+    Time.milliseconds(duration.toMillis)
+  }
+
+  def getDefaultTimeoutAsFiniteDuration: FiniteDuration = {
+    val timeout = getDefaultTimeout
+
+    new FiniteDuration(timeout.toMilliseconds, TimeUnit.MILLISECONDS)
   }
 
   def getLookupTimeout(config: Configuration): FiniteDuration = {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/clusterframework/ContaineredJobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/clusterframework/ContaineredJobManager.scala
@@ -32,8 +32,8 @@ import org.apache.flink.runtime.jobgraph.JobStatus
 import org.apache.flink.runtime.jobmanager.scheduler.{Scheduler => FlinkScheduler}
 import org.apache.flink.runtime.jobmanager.{JobManager, SubmittedJobGraphStore}
 import org.apache.flink.runtime.leaderelection.LeaderElectionService
+import org.apache.flink.runtime.messages.Acknowledge
 import org.apache.flink.runtime.messages.JobManagerMessages.{CurrentJobStatus, JobNotFound, RequestJobStatus}
-import org.apache.flink.runtime.messages.Messages.Acknowledge
 import org.apache.flink.runtime.metrics.{MetricRegistry => FlinkMetricRegistry}
 
 import scala.concurrent.duration._
@@ -122,7 +122,7 @@ abstract class ContaineredJobManager(
         )(context.dispatcher)
       }
 
-      sender() ! decorateMessage(Acknowledge)
+      sender() ! decorateMessage(Acknowledge.get())
 
     case msg: GetClusterStatus =>
       sender() ! decorateMessage(

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -46,7 +46,7 @@ import org.apache.flink.runtime.clusterframework.FlinkResourceManager
 import org.apache.flink.runtime.clusterframework.messages._
 import org.apache.flink.runtime.clusterframework.standalone.StandaloneResourceManager
 import org.apache.flink.runtime.clusterframework.types.ResourceID
-import org.apache.flink.runtime.concurrent.BiFunction
+import org.apache.flink.runtime.concurrent.{AcceptFunction, BiFunction}
 import org.apache.flink.runtime.execution.SuppressRestartsException
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory
@@ -56,12 +56,14 @@ import org.apache.flink.runtime.io.network.PartitionState
 import org.apache.flink.runtime.jobgraph.{JobGraph, JobStatus}
 import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore.SubmittedJobGraphListener
 import org.apache.flink.runtime.jobmanager.scheduler.{Scheduler => FlinkScheduler}
+import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway
 import org.apache.flink.runtime.leaderelection.{LeaderContender, LeaderElectionService, StandaloneLeaderElectionService}
 import org.apache.flink.runtime.messages.ArchiveMessages.ArchiveExecutionGraph
 import org.apache.flink.runtime.messages.ExecutionGraphMessages.JobStatusChanged
 import org.apache.flink.runtime.messages.JobManagerMessages._
-import org.apache.flink.runtime.messages.Messages.{Acknowledge, Disconnect}
+import org.apache.flink.runtime.messages.Messages.Disconnect
 import org.apache.flink.runtime.messages.RegistrationMessages._
+import org.apache.flink.runtime.messages.{Acknowledge, StackTrace}
 import org.apache.flink.runtime.messages.TaskManagerMessages.{Heartbeat, SendStackTrace}
 import org.apache.flink.runtime.messages.TaskMessages.UpdateTaskExecutionState
 import org.apache.flink.runtime.messages.accumulators.{AccumulatorMessage, AccumulatorResultStringsFound, AccumulatorResultsErroneous, AccumulatorResultsFound, RequestAccumulatorResults, RequestAccumulatorResultsStringified}
@@ -137,15 +139,6 @@ class JobManager(
   with SubmittedJobGraphListener {
 
   override val log = Logger(getClass)
-
-  /** The extra execution context, for futures, with a custom logging reporter */
-  protected val executionContext: ExecutionContext = ExecutionContext.fromExecutor(
-    executorService,
-    (t: Throwable) => {
-      if (!context.system.isTerminated) {
-        log.error("Executor could not execute task", t)
-      }
-    })
 
   /** Either running or not yet archived jobs (session hasn't been ended). */
   protected val currentJobs = scala.collection.mutable.HashMap[JobID, (ExecutionGraph, JobInfo)]()
@@ -244,9 +237,8 @@ class JobManager(
 
     // disconnect the registered task managers
     instanceManager.getAllRegisteredInstances.asScala.foreach {
-      instance => instance.getActorGateway().tell(
-        Disconnect(instance.getId, "JobManager is shutting down"),
-        new AkkaActorGateway(self, leaderSessionID.orNull))
+      instance => instance.getTaskManagerGateway()
+      .disconnectFromJobManager(instance.getId, new Exception("JobManager is shuttind down."))
     }
 
     try {
@@ -334,9 +326,9 @@ class JobManager(
 
       // disconnect the registered task managers
       instanceManager.getAllRegisteredInstances.asScala.foreach {
-        instance => instance.getActorGateway().tell(
-          Disconnect(instance.getId, "JobManager is no longer the leader"),
-          new AkkaActorGateway(self, leaderSessionID.orNull))
+        instance => instance.getTaskManagerGateway().disconnectFromJobManager(
+          instance.getId(),
+          new Exception("JobManager is no longer the leader"))
       }
 
       instanceManager.unregisterAllTaskManagers()
@@ -425,12 +417,14 @@ class JobManager(
             libraryCacheManager.getBlobServerPort))
       } else {
         try {
+          val actorGateway = new AkkaActorGateway(taskManager, leaderSessionID.orNull)
+          val taskManagerGateway = new ActorTaskManagerGateway(actorGateway)
+
           val instanceID = instanceManager.registerTaskManager(
-            taskManager,
+            taskManagerGateway,
             connectionInfo,
             hardwareInformation,
-            numberOfSlots,
-            leaderSessionID.orNull)
+            numberOfSlots)
 
           taskManagerMap.put(taskManager, instanceID)
 
@@ -459,7 +453,15 @@ class JobManager(
       Option(instanceManager.getRegisteredInstance(resourceID)) match {
         case Some(instance) =>
           // trigger removal of task manager
-          handleTaskManagerTerminated(instance.getActorGateway.actor(), instance.getId)
+          val taskManagerGateway = instance.getTaskManagerGateway
+
+          taskManagerGateway match {
+            case x: ActorTaskManagerGateway =>
+              handleTaskManagerTerminated(x.getActorGateway().actor(), instance.getId)
+            case _ => log.debug(s"Cannot remove reosurce ${resourceID}, because there is " +
+                                  s"no ActorRef registered.")
+          }
+
         case None =>
           log.debug(s"Resource $resourceID has not been registered at job manager.")
       }
@@ -923,7 +925,7 @@ class JobManager(
     case ScheduleOrUpdateConsumers(jobId, partitionId) =>
       currentJobs.get(jobId) match {
         case Some((executionGraph, _)) =>
-          sender ! decorateMessage(Acknowledge)
+          sender ! decorateMessage(Acknowledge.get())
           executionGraph.scheduleOrUpdateConsumers(partitionId)
         case None =>
           log.error(s"Cannot find execution graph for job ID $jobId to schedule or update " +
@@ -1041,8 +1043,20 @@ class JobManager(
     case message: InfoMessage => handleInfoRequestMessage(message, sender())
 
     case RequestStackTrace(instanceID) =>
-      val gateway = instanceManager.getRegisteredInstanceById(instanceID).getActorGateway
-      gateway.forward(SendStackTrace, new AkkaActorGateway(sender, leaderSessionID.orNull))
+      val taskManagerGateway = instanceManager
+        .getRegisteredInstanceById(instanceID)
+        .getTaskManagerGateway
+
+      val stackTraceFuture = taskManagerGateway
+        .requestStackTrace(Time.milliseconds(timeout.toMillis))
+
+      val originalSender = new AkkaActorGateway(sender(), leaderSessionID.orNull)
+
+      stackTraceFuture.thenAccept(new AcceptFunction[StackTrace] {
+        override def accept(value: StackTrace): Unit = {
+          originalSender.tell(value)
+        }
+      })
 
     case Terminated(taskManagerActorRef) =>
       taskManagerMap.get(taskManagerActorRef) match {
@@ -1082,11 +1096,12 @@ class JobManager(
         case None =>
       }
 
-    case Disconnect(instanceId, msg) =>
+    case Disconnect(instanceId, cause) =>
       val taskManager = sender()
 
       if (instanceManager.isRegistered(instanceId)) {
-        log.info(s"Task manager ${taskManager.path} wants to disconnect, because $msg.")
+        log.info(s"Task manager ${taskManager.path} wants to disconnect, " +
+                   s"because ${cause.getMessage}.")
 
         instanceManager.unregisterTaskManager(instanceId, false)
         taskManagerMap.remove(taskManager)
@@ -1101,7 +1116,7 @@ class JobManager(
       // stop all task managers
       instanceManager.getAllRegisteredInstances.asScala foreach {
         instance =>
-          instance.getActorGateway.tell(msg)
+          instance.getTaskManagerGateway.stopCluster(msg.finalStatus(), msg.message())
       }
 
       // send resource manager the ok
@@ -1232,7 +1247,7 @@ class JobManager(
           executionGraph,
           jobGraph,
           flinkConfiguration,
-          executionContext,
+          executorService,
           userCodeLoader,
           checkpointRecoveryFactory,
           Time.of(timeout.length, timeout.unit),

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/StackTraceSampleMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/StackTraceSampleMessages.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.messages
 
 import akka.actor.ActorRef
+import org.apache.flink.api.common.time.Time
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID
 
 import scala.concurrent.duration.FiniteDuration
@@ -47,7 +48,7 @@ object StackTraceSampleMessages {
       sampleId: Int,
       executionId: ExecutionAttemptID,
       numSamples: Int,
-      delayBetweenSamples: FiniteDuration,
+      delayBetweenSamples: Time,
       maxStackTraceDepth: Int = 0)
     extends StackTraceSampleMessages with java.io.Serializable
 
@@ -100,7 +101,7 @@ object StackTraceSampleMessages {
   case class SampleTaskStackTrace(
       sampleId: Int,
       executionId: ExecutionAttemptID,
-      delayBetweenSamples: FiniteDuration,
+      delayBetweenSamples: Time,
       maxStackTraceDepth: Int,
       numRemainingSamples: Int,
       currentTraces: java.util.List[Array[StackTraceElement]],

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -23,7 +23,7 @@ import java.lang.management.{ManagementFactory, OperatingSystemMXBean}
 import java.lang.reflect.Method
 import java.net.{InetAddress, InetSocketAddress}
 import java.util
-import java.util.UUID
+import java.util.{Collections, UUID}
 import java.util.concurrent.TimeUnit
 import javax.management.ObjectName
 
@@ -46,10 +46,10 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID
 import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.blob.{BlobCache, BlobClient, BlobService}
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager
-import org.apache.flink.runtime.deployment.{InputChannelDeploymentDescriptor, TaskDeploymentDescriptor}
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor
 import org.apache.flink.runtime.execution.ExecutionState
 import org.apache.flink.runtime.execution.librarycache.{BlobLibraryCacheManager, FallbackLibraryCacheManager, LibraryCacheManager}
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID
+import org.apache.flink.runtime.executiongraph.{ExecutionAttemptID, PartitionInfo}
 import org.apache.flink.runtime.filecache.FileCache
 import org.apache.flink.runtime.instance.{AkkaActorGateway, HardwareDescription, InstanceID}
 import org.apache.flink.runtime.io.disk.iomanager.IOManager.IOMode
@@ -58,12 +58,12 @@ import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool
 import org.apache.flink.runtime.io.network.{LocalConnectionManager, NetworkEnvironment, TaskEventDispatcher}
 import org.apache.flink.runtime.io.network.netty.{NettyConfig, NettyConnectionManager, PartitionStateChecker}
 import org.apache.flink.runtime.io.network.partition.{ResultPartitionConsumableNotifier, ResultPartitionManager}
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID
 import org.apache.flink.runtime.leaderretrieval.{LeaderRetrievalListener, LeaderRetrievalService}
 import org.apache.flink.runtime.memory.MemoryManager
+import org.apache.flink.runtime.messages.{Acknowledge, StackTraceSampleResponse}
 import org.apache.flink.runtime.messages.Messages._
 import org.apache.flink.runtime.messages.RegistrationMessages._
-import org.apache.flink.runtime.messages.StackTraceSampleMessages.{ResponseStackTraceSampleFailure, ResponseStackTraceSampleSuccess, SampleTaskStackTrace, StackTraceSampleMessages, TriggerStackTraceSample}
+import org.apache.flink.runtime.messages.StackTraceSampleMessages.{SampleTaskStackTrace, StackTraceSampleMessages, TriggerStackTraceSample}
 import org.apache.flink.runtime.messages.TaskManagerMessages._
 import org.apache.flink.runtime.messages.TaskMessages._
 import org.apache.flink.runtime.messages.checkpoint.{AbstractCheckpointMessage, NotifyCheckpointComplete, TriggerCheckpoint}
@@ -329,16 +329,16 @@ class TaskManager(
     // this message indicates that some actor watched by this TaskManager has died
     case Terminated(actor: ActorRef) =>
       if (isConnected && actor == currentJobManager.orNull) {
-          handleJobManagerDisconnect(sender(), "JobManager is no longer reachable")
+          handleJobManagerDisconnect("JobManager is no longer reachable")
           triggerTaskManagerRegistration()
       } else {
         log.warn(s"Received unrecognized disconnect message " +
             s"from ${if (actor == null) null else actor.path}.")
       }
 
-    case Disconnect(instanceIdToDisconnect, msg) =>
+    case Disconnect(instanceIdToDisconnect, cause) =>
       if (instanceIdToDisconnect.equals(instanceID)) {
-        handleJobManagerDisconnect(sender(), s"JobManager requested disconnect: $msg")
+        handleJobManagerDisconnect(s"JobManager requested disconnect: ${cause.getMessage()}")
         triggerTaskManagerRegistration()
       } else {
         log.debug(s"Received disconnect message for wrong instance id ${instanceIdToDisconnect}.")
@@ -411,7 +411,9 @@ class TaskManager(
 
         // tell the task about the availability of a new input partition
         case UpdateTaskSinglePartitionInfo(executionID, resultID, partitionInfo) =>
-          updateTaskInputPartitions(executionID, List((resultID, partitionInfo)))
+          updateTaskInputPartitions(
+            executionID,
+            Collections.singletonList(new PartitionInfo(resultID, partitionInfo)))
 
         // tell the task about the availability of some new input partitions
         case UpdateTaskMultiplePartitionInfos(executionID, partitionInfos) =>
@@ -488,24 +490,14 @@ class TaskManager(
           if (task != null) {
             try {
               task.stopExecution()
-              sender ! decorateMessage(new TaskOperationResult(executionID, true))
+              sender ! decorateMessage(Acknowledge.get())
             } catch {
               case t: Throwable =>
-                        sender ! decorateMessage(
-                          new TaskOperationResult(
-                            executionID,
-                            false,
-                            t.getClass().getSimpleName() + ": " + t.getLocalizedMessage())
-                        )
+                sender ! decorateMessage(Failure(t))
             }
           } else {
             log.debug(s"Cannot find task to stop for execution ${executionID})")
-            sender ! decorateMessage(
-              new TaskOperationResult(
-               executionID,
-               false,
-               "No task with that execution ID was found.")
-            )
+            sender ! decorateMessage(Acknowledge.get())
           }
  
         // cancels a task
@@ -513,15 +505,10 @@ class TaskManager(
           val task = runningTasks.get(executionID)
           if (task != null) {
             task.cancelExecution()
-            sender ! decorateMessage(new TaskOperationResult(executionID, true))
+            sender ! decorateMessage(Acknowledge.get())
           } else {
             log.debug(s"Cannot find task to cancel for execution $executionID)")
-            sender ! decorateMessage(
-              new TaskOperationResult(
-                executionID,
-                false,
-              "No task with that execution ID was found.")
-            )
+            sender ! decorateMessage(Acknowledge.get())
           }
       }
       }
@@ -783,14 +770,16 @@ class TaskManager(
                     sender)
 
                   context.system.scheduler.scheduleOnce(
-                    delayBetweenSamples,
+                    new FiniteDuration(delayBetweenSamples.getSize, delayBetweenSamples.getUnit),
                     self,
                     msg)(context.dispatcher)
                 } else {
                   // ---- Done ----
                   log.debug(s"Done with stack trace sample $sampleId.")
 
-                  sender ! ResponseStackTraceSampleSuccess(sampleId, executionId, currentTraces)
+
+
+                  sender ! new StackTraceSampleResponse(sampleId, executionId, currentTraces)
                 }
 
               case None =>
@@ -799,7 +788,7 @@ class TaskManager(
                     s"Either the task is not known to the task manager or it is not running.")
                 } else {
                   // Task removed during sampling. Reply with partial result.
-                  sender ! ResponseStackTraceSampleSuccess(sampleId, executionId, currentTraces)
+                  sender ! new StackTraceSampleResponse(sampleId, executionId, currentTraces)
                 }
             }
           } else {
@@ -807,7 +796,7 @@ class TaskManager(
           }
         } catch {
           case e: Exception =>
-            sender ! ResponseStackTraceSampleFailure(sampleId, executionId, e)
+            sender ! Failure(e)
         }
 
       case _ => unhandled(message)
@@ -1047,7 +1036,10 @@ class TaskManager(
 
     // de-register from the JobManager (faster detection of disconnect)
     currentJobManager foreach {
-      _ ! decorateMessage(Disconnect(instanceID, s"TaskManager ${self.path} is disassociating"))
+      _ ! decorateMessage(
+        Disconnect(
+          instanceID,
+          new Exception(s"TaskManager ${self.path} is disassociating")))
     }
 
     currentJobManager = None
@@ -1079,31 +1071,26 @@ class TaskManager(
     }
   }
 
-  protected def handleJobManagerDisconnect(jobManager: ActorRef, msg: String): Unit = {
-    if (isConnected && jobManager != null) {
-
+  protected def handleJobManagerDisconnect(msg: String): Unit = {
+    if (isConnected) {
+      val jobManager = currentJobManager.orNull
       // check if it comes from our JobManager
-      if (jobManager == currentJobManager.orNull) {
-        try {
-          val message = s"TaskManager ${self.path} disconnects from JobManager " +
-            s"${jobManager.path}: " + msg
-          log.info(message)
+      try {
+        val message = s"TaskManager ${self.path} disconnects from JobManager " +
+          s"${jobManager.path}: " + msg
+        log.info(message)
 
-          // cancel all our tasks with a proper error message
-          cancelAndClearEverything(new Exception(message))
+        // cancel all our tasks with a proper error message
+        cancelAndClearEverything(new Exception(message))
 
-          // reset our state to disassociated
-          disassociateFromJobManager()
-        }
-        catch {
-          // this is pretty bad, it leaves the TaskManager in a state where it cannot
-          // cleanly reconnect
-          case t: Throwable =>
-            killTaskManagerFatal("Failed to disassociate from the JobManager", t)
-        }
+        // reset our state to disassociated
+        disassociateFromJobManager()
       }
-      else {
-        log.warn(s"Received erroneous JobManager disconnect message for ${jobManager.path}.")
+      catch {
+        // this is pretty bad, it leaves the TaskManager in a state where it cannot
+        // cleanly reconnect
+        case t: Throwable =>
+          killTaskManagerFatal("Failed to disassociate from the JobManager", t)
       }
     }
   }
@@ -1198,7 +1185,7 @@ class TaskManager(
       // all good, we kick off the task, which performs its own initialization
       task.startTaskThread()
 
-      sender ! decorateMessage(Acknowledge)
+      sender ! decorateMessage(Acknowledge.get())
     }
     catch {
       case t: Throwable =>
@@ -1215,15 +1202,16 @@ class TaskManager(
    */
   private def updateTaskInputPartitions(
        executionId: ExecutionAttemptID,
-       partitionInfos: Seq[(IntermediateDataSetID, InputChannelDeploymentDescriptor)])
+       partitionInfos: java.lang.Iterable[PartitionInfo])
     : Unit = {
 
     Option(runningTasks.get(executionId)) match {
       case Some(task) =>
 
-        val errors: Seq[String] = partitionInfos.flatMap { info =>
+        val errors: Iterable[String] = partitionInfos.asScala.flatMap { info =>
 
-          val (resultID, partitionInfo) = info
+          val resultID = info.getIntermediateDataSetID
+          val partitionInfo = info.getInputChannelDeploymentDescriptor
           val reader = task.getInputGateById(resultID)
 
           if (reader != null) {
@@ -1254,7 +1242,7 @@ class TaskManager(
         }
 
         if (errors.isEmpty) {
-          sender ! decorateMessage(Acknowledge)
+          sender ! decorateMessage(Acknowledge.get())
         } else {
           sender ! decorateMessage(Failure(new Exception(errors.mkString("\n"))))
         }
@@ -1262,7 +1250,7 @@ class TaskManager(
       case None =>
         log.debug(s"Discard update for input partitions of task $executionId : " +
           s"task is no longer running.")
-        sender ! decorateMessage(Acknowledge)
+        sender ! decorateMessage(Acknowledge.get())
     }
   }
 
@@ -1377,7 +1365,7 @@ class TaskManager(
           "Thread: " + thread.getName + '\n' + elements.mkString("\n")
         }.mkString("\n\n")
 
-      recipient ! decorateMessage(StackTrace(instanceID, stackTraceStr))
+      recipient ! decorateMessage(new StackTrace(instanceID, stackTraceStr))
     }
     catch {
       case e: Exception => log.error("Failed to send stack trace to " + recipient.path, e)
@@ -1420,9 +1408,9 @@ class TaskManager(
       case Some(jm) =>
         Option(newJobManagerAkkaURL) match {
           case Some(newJMAkkaURL) =>
-            handleJobManagerDisconnect(jm, s"JobManager $newJMAkkaURL was elected as leader.")
+            handleJobManagerDisconnect(s"JobManager $newJMAkkaURL was elected as leader.")
           case None =>
-            handleJobManagerDisconnect(jm, s"Old JobManager lost its leadership.")
+            handleJobManagerDisconnect(s"Old JobManager lost its leadership.")
         }
       case None =>
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -22,6 +22,7 @@ import akka.actor.ActorSystem;
 import akka.testkit.JavaTestKit;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -94,17 +95,17 @@ public class ExecutionGraphCheckpointCoordinatorTest {
 			CheckpointIDCounter counter,
 			CompletedCheckpointStore store) throws Exception {
 		ExecutionGraph executionGraph = new ExecutionGraph(
-				TestingUtils.defaultExecutionContext(),
-				new JobID(),
-				"test",
-				new Configuration(),
-				new SerializedValue<>(new ExecutionConfig()),
-				new FiniteDuration(1, TimeUnit.DAYS),
-				new NoRestartStrategy(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
-				ClassLoader.getSystemClassLoader(),
-				new UnregisteredMetricsGroup());
+			TestingUtils.defaultExecutionContext(),
+			new JobID(),
+			"test",
+			new Configuration(),
+			new SerializedValue<>(new ExecutionConfig()),
+			Time.days(1L),
+			new NoRestartStrategy(),
+			Collections.<BlobKey>emptyList(),
+			Collections.<URL>emptyList(),
+			ClassLoader.getSystemClassLoader(),
+			new UnregisteredMetricsGroup());
 
 		executionGraph.enableSnapshotCheckpointing(
 				100,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorTest.java
@@ -30,9 +30,9 @@ import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.FlinkUntypedActor;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.leaderelection.TestingLeaderRetrievalService;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.JobClientMessages;
 import org.apache.flink.runtime.messages.JobClientMessages.AttachToJobAndWait;
-import org.apache.flink.runtime.messages.Messages;
 import org.apache.flink.util.TestLogger;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -363,7 +363,7 @@ public class JobClientActorTest extends TestLogger {
 				jobAccepted = true;
 
 				if (testFuture != ActorRef.noSender()) {
-					testFuture.tell(Messages.getAcknowledge(), getSelf());
+					testFuture.tell(Acknowledge.get(), getSelf());
 				}
 			}
 			else if (message instanceof RegisterJobClient) {
@@ -374,14 +374,14 @@ public class JobClientActorTest extends TestLogger {
 				jobAccepted = true;
 
 				if (testFuture != ActorRef.noSender()) {
-					testFuture.tell(Messages.getAcknowledge(), getSelf());
+					testFuture.tell(Acknowledge.get(), getSelf());
 				}
 			}
 			else if (message instanceof RegisterTest) {
 				testFuture = getSender();
 
 				if (jobAccepted) {
-					testFuture.tell(Messages.getAcknowledge(), getSelf());
+					testFuture.tell(Acknowledge.get(), getSelf());
 				}
 			}
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AllVerticesIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AllVerticesIteratorTest.java
@@ -44,7 +44,7 @@ public class AllVerticesIteratorTest {
 			v4.setParallelism(2);
 			
 			ExecutionGraph eg = Mockito.mock(ExecutionGraph.class);
-			Mockito.when(eg.getExecutionContext()).thenReturn(TestingUtils.directExecutionContext());
+			Mockito.when(eg.getExecutor()).thenReturn(TestingUtils.directExecutionContext());
 					
 			ExecutionJobVertex ejv1 = new ExecutionJobVertex(eg, v1, 1,
 					AkkaUtils.getDefaultTimeout());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -50,8 +50,8 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
+import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
 import org.apache.flink.runtime.operators.BatchTask;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
@@ -108,7 +108,7 @@ public class ExecutionGraphDeploymentTest {
 
 			ExecutionGraphTestUtils.SimpleActorGateway instanceGateway = new ExecutionGraphTestUtils.SimpleActorGateway(TestingUtils.directExecutionContext());
 
-			final Instance instance = getInstance(instanceGateway);
+			final Instance instance = getInstance(new ActorTaskManagerGateway(instanceGateway));
 
 			final SimpleSlot slot = instance.allocateSimpleSlot(jobId);
 
@@ -325,8 +325,9 @@ public class ExecutionGraphDeploymentTest {
 		for (int i = 0; i < dop1; i++) {
 			scheduler.newInstanceAvailable(
 				ExecutionGraphTestUtils.getInstance(
-					new ExecutionGraphTestUtils.SimpleActorGateway(
-						TestingUtils.directExecutionContext())));
+					new ActorTaskManagerGateway(
+						new ExecutionGraphTestUtils.SimpleActorGateway(
+							TestingUtils.directExecutionContext()))));
 		}
 		assertEquals(dop1, scheduler.getNumberOfAvailableSlots());
 
@@ -367,9 +368,10 @@ public class ExecutionGraphDeploymentTest {
 		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 		for (int i = 0; i < dop1 + dop2; i++) {
 			scheduler.newInstanceAvailable(
-					ExecutionGraphTestUtils.getInstance(
-							new ExecutionGraphTestUtils.SimpleActorGateway(
-									TestingUtils.directExecutionContext())));
+				ExecutionGraphTestUtils.getInstance(
+					new ActorTaskManagerGateway(
+						new ExecutionGraphTestUtils.SimpleActorGateway(
+							TestingUtils.directExecutionContext()))));
 		}
 		assertEquals(dop1 + dop2, scheduler.getNumberOfAvailableSlots());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphMetricsTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Gauge;
@@ -30,10 +31,12 @@ import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
-import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.Instance;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.instance.SimpleSlot;
@@ -44,7 +47,6 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmanager.Tasks;
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
-import org.apache.flink.runtime.messages.Messages;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
@@ -53,10 +55,6 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 import org.mockito.Matchers;
-
-import scala.concurrent.ExecutionContext$;
-import scala.concurrent.Future$;
-import scala.concurrent.duration.FiniteDuration;
 
 import java.io.IOException;
 import java.net.URL;
@@ -67,7 +65,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -98,7 +95,7 @@ public class ExecutionGraphMetricsTest extends TestLogger {
 	
 			Configuration jobConfig = new Configuration();
 	
-			FiniteDuration timeout = new FiniteDuration(10, TimeUnit.SECONDS);
+			Time timeout = Time.seconds(10L);
 	
 			MetricRegistry metricRegistry = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(config));
 	
@@ -120,12 +117,12 @@ public class ExecutionGraphMetricsTest extends TestLogger {
 			when(taskManagerLocation.getResourceID()).thenReturn(taskManagerId);
 			when(taskManagerLocation.getHostname()).thenReturn("localhost");
 
-			ActorGateway actorGateway = mock(ActorGateway.class);
+			TaskManagerGateway taskManagerGateway = mock(TaskManagerGateway.class);
 
 			Instance instance = mock(Instance.class);
 			when(instance.getTaskManagerLocation()).thenReturn(taskManagerLocation);
 			when(instance.getTaskManagerID()).thenReturn(taskManagerId);
-			when(instance.getActorGateway()).thenReturn(actorGateway);
+			when(instance.getTaskManagerGateway()).thenReturn(taskManagerGateway);
 
 			Slot rootSlot = mock(Slot.class);
 
@@ -133,7 +130,7 @@ public class ExecutionGraphMetricsTest extends TestLogger {
 			when(simpleSlot.isAlive()).thenReturn(true);
 			when(simpleSlot.getTaskManagerLocation()).thenReturn(taskManagerLocation);
 			when(simpleSlot.getTaskManagerID()).thenReturn(taskManagerId);
-			when(simpleSlot.getTaskManagerActorGateway()).thenReturn(actorGateway);
+			when(simpleSlot.getTaskManagerGateway()).thenReturn(taskManagerGateway);
 			when(simpleSlot.setExecutedVertex(Matchers.any(Execution.class))).thenReturn(true);
 			when(simpleSlot.getRoot()).thenReturn(rootSlot);
 
@@ -143,12 +140,12 @@ public class ExecutionGraphMetricsTest extends TestLogger {
 
 			when(rootSlot.getSlotNumber()).thenReturn(0);
 
-			when(actorGateway.ask(Matchers.any(Object.class), Matchers.any(FiniteDuration.class))).thenReturn(Future$.MODULE$.<Object>successful(Messages.getAcknowledge()));
+			when(taskManagerGateway.submitTask(any(TaskDeploymentDescriptor.class), any(Time.class))).thenReturn(FlinkCompletableFuture.completed(Acknowledge.get()));
 
 			TestingRestartStrategy testingRestartStrategy = new TestingRestartStrategy();
 
 			ExecutionGraph executionGraph = new ExecutionGraph(
-				ExecutionContext$.MODULE$.fromExecutor(executor),
+				executor,
 				jobGraph.getJobID(),
 				jobGraph.getName(),
 				jobConfig,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.jobmanager.Tasks;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
@@ -97,7 +98,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		
 		//setting up
 		Instance instance = ExecutionGraphTestUtils.getInstance(
-			new SimpleActorGateway(TestingUtils.directExecutionContext()),
+			new ActorTaskManagerGateway(
+				new SimpleActorGateway(TestingUtils.directExecutionContext())),
 			NUM_TASKS);
 		
 		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
@@ -221,7 +223,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 
 		Instance instance = ExecutionGraphTestUtils.getInstance(
-			new SimpleActorGateway(TestingUtils.directExecutionContext()),
+			new ActorTaskManagerGateway(
+				new SimpleActorGateway(TestingUtils.directExecutionContext())),
 			NUM_TASKS);
 
 		scheduler.newInstanceAvailable(instance);
@@ -364,7 +367,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	@Test
 	public void testFailingExecutionAfterRestart() throws Exception {
 		Instance instance = ExecutionGraphTestUtils.getInstance(
-			new SimpleActorGateway(TestingUtils.directExecutionContext()),
+			new ActorTaskManagerGateway(
+				new SimpleActorGateway(TestingUtils.directExecutionContext())),
 			2);
 
 		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
@@ -427,8 +431,9 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	@Test
 	public void testFailExecutionAfterCancel() throws Exception {
 		Instance instance = ExecutionGraphTestUtils.getInstance(
-				new SimpleActorGateway(TestingUtils.directExecutionContext()),
-				2);
+			new ActorTaskManagerGateway(
+				new SimpleActorGateway(TestingUtils.directExecutionContext())),
+			2);
 
 		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 		scheduler.newInstanceAvailable(instance);
@@ -472,8 +477,9 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	@Test
 	public void testFailExecutionGraphAfterCancel() throws Exception {
 		Instance instance = ExecutionGraphTestUtils.getInstance(
-				new SimpleActorGateway(TestingUtils.directExecutionContext()),
-				2);
+			new ActorTaskManagerGateway(
+				new SimpleActorGateway(TestingUtils.directExecutionContext())),
+			2);
 
 		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 		scheduler.newInstanceAvailable(instance);
@@ -519,7 +525,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		Deadline deadline = timeout.fromNow();
 
 		Instance instance = ExecutionGraphTestUtils.getInstance(
-			new SimpleActorGateway(TestingUtils.directExecutionContext()),
+			new ActorTaskManagerGateway(
+				new SimpleActorGateway(TestingUtils.directExecutionContext())),
 			NUM_TASKS);
 
 		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
@@ -634,8 +641,9 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 	private static Tuple2<ExecutionGraph, Instance> createExecutionGraph(RestartStrategy restartStrategy, boolean isSpy) throws Exception {
 		Instance instance = ExecutionGraphTestUtils.getInstance(
-				new SimpleActorGateway(TestingUtils.directExecutionContext()),
-				NUM_TASKS);
+			new ActorTaskManagerGateway(
+				new SimpleActorGateway(TestingUtils.directExecutionContext())),
+			NUM_TASKS);
 
 		Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 		scheduler.newInstanceAvailable(instance);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionStateProgressTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionStateProgressTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
 import org.junit.Test;
@@ -67,8 +68,9 @@ public class ExecutionStateProgressTest {
 			// mock resources and mock taskmanager
 			for (ExecutionVertex ee : ejv.getTaskVertices()) {
 				SimpleSlot slot = getInstance(
+					new ActorTaskManagerGateway(
 						new SimpleActorGateway(
-								TestingUtils.defaultExecutionContext())
+							TestingUtils.defaultExecutionContext()))
 				).allocateSimpleSlot(jid);
 				ee.deployToSlot(slot);
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
+import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 
 import org.junit.Test;
@@ -51,7 +52,7 @@ public class ExecutionVertexSchedulingTest {
 					AkkaUtils.getDefaultTimeout());
 
 			// a slot than cannot be deployed to
-			final Instance instance = getInstance(DummyActorGateway.INSTANCE);
+			final Instance instance = getInstance(new ActorTaskManagerGateway(DummyActorGateway.INSTANCE));
 			final SimpleSlot slot = instance.allocateSimpleSlot(ejv.getJobId());
 			
 			slot.releaseSlot();
@@ -83,7 +84,7 @@ public class ExecutionVertexSchedulingTest {
 					AkkaUtils.getDefaultTimeout());
 
 			// a slot than cannot be deployed to
-			final Instance instance = getInstance(DummyActorGateway.INSTANCE);
+			final Instance instance = getInstance(new ActorTaskManagerGateway(DummyActorGateway.INSTANCE));
 			final SimpleSlot slot = instance.allocateSimpleSlot(ejv.getJobId());
 
 			slot.releaseSlot();
@@ -122,7 +123,8 @@ public class ExecutionVertexSchedulingTest {
 			final ExecutionVertex vertex = new ExecutionVertex(ejv, 0, new IntermediateResult[0],
 					AkkaUtils.getDefaultTimeout());
 
-			final Instance instance = getInstance(new ExecutionGraphTestUtils.SimpleActorGateway(TestingUtils.defaultExecutionContext()));
+			final Instance instance = getInstance(new ActorTaskManagerGateway(
+				new ExecutionGraphTestUtils.SimpleActorGateway(TestingUtils.defaultExecutionContext())));
 			final SimpleSlot slot = instance.allocateSimpleSlot(ejv.getJobId());
 
 			Scheduler scheduler = mock(Scheduler.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TerminalStateDeadlockTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TerminalStateDeadlockTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -27,6 +28,7 @@ import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy
 import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
+import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.instance.SimpleSlot;
@@ -41,8 +43,6 @@ import org.apache.flink.util.SerializedValue;
 
 import org.junit.Test;
 
-import scala.concurrent.duration.FiniteDuration;
-
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
@@ -50,7 +50,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
 
@@ -85,7 +84,8 @@ public class TerminalStateDeadlockTest {
 			TaskManagerLocation ci = new TaskManagerLocation(resourceId, address, 12345);
 				
 			HardwareDescription resources = new HardwareDescription(4, 4000000, 3000000, 2000000);
-			Instance instance = new Instance(DummyActorGateway.INSTANCE, ci, new InstanceID(), resources, 4);
+			Instance instance = new Instance(
+				new ActorTaskManagerGateway(DummyActorGateway.INSTANCE), ci, new InstanceID(), resources, 4);
 
 			this.resource = instance.allocateSimpleSlot(new JobID());
 		}
@@ -174,7 +174,7 @@ public class TerminalStateDeadlockTest {
 
 		private static final Configuration EMPTY_CONFIG = new Configuration();
 
-		private static final FiniteDuration TIMEOUT = new FiniteDuration(30, TimeUnit.SECONDS);
+		private static final Time TIMEOUT = Time.seconds(30L);
 
 		private volatile boolean done;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategyTest.java
@@ -39,7 +39,7 @@ public class FixedDelayRestartStrategyTest {
 			restartDelay);
 
 		ExecutionGraph executionGraph = mock(ExecutionGraph.class);
-		when(executionGraph.getExecutionContext())
+		when(executionGraph.getExecutor())
 			.thenReturn(ExecutionContext$.MODULE$.fromExecutor(MoreExecutors.directExecutor()));
 
 		while(fixedDelayRestartStrategy.canRestart()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceManagerTest.java
@@ -22,6 +22,7 @@ import akka.actor.ActorSystem;
 import akka.testkit.JavaTestKit;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
@@ -87,9 +88,21 @@ public class InstanceManagerTest{
 			final JavaTestKit probe2 = new JavaTestKit(system);
 			final JavaTestKit probe3 = new JavaTestKit(system);
 
-			cm.registerTaskManager(probe1.getRef(), ici1, hardwareDescription, 1, leaderSessionID);
-			cm.registerTaskManager(probe2.getRef(), ici2, hardwareDescription, 2, leaderSessionID);
-			cm.registerTaskManager(probe3.getRef(), ici3, hardwareDescription, 5, leaderSessionID);
+			cm.registerTaskManager(
+				new ActorTaskManagerGateway(new AkkaActorGateway(probe1.getRef(), leaderSessionID)),
+				ici1,
+				hardwareDescription,
+				1);
+			cm.registerTaskManager(
+				new ActorTaskManagerGateway(new AkkaActorGateway(probe2.getRef(), leaderSessionID)),
+				ici2,
+				hardwareDescription,
+				2);
+			cm.registerTaskManager(
+				new ActorTaskManagerGateway(new AkkaActorGateway(probe3.getRef(), leaderSessionID)),
+				ici3,
+				hardwareDescription,
+				5);
 
 			assertEquals(3, cm.getNumberOfRegisteredTaskManagers());
 			assertEquals(8, cm.getTotalNumberOfSlots());
@@ -130,13 +143,21 @@ public class InstanceManagerTest{
 			TaskManagerLocation ici = new TaskManagerLocation(resID1, address, dataPort);
 
 			JavaTestKit probe = new JavaTestKit(system);
-			cm.registerTaskManager(probe.getRef(), ici, resources, 1, leaderSessionID);
+			cm.registerTaskManager(
+				new ActorTaskManagerGateway(new AkkaActorGateway(probe.getRef(), leaderSessionID)),
+				ici,
+				resources,
+				1);
 
 			assertEquals(1, cm.getNumberOfRegisteredTaskManagers());
 			assertEquals(1, cm.getTotalNumberOfSlots());
 
 			try {
-				cm.registerTaskManager(probe.getRef(), ici, resources, 1, leaderSessionID);
+				cm.registerTaskManager(
+					new ActorTaskManagerGateway(new AkkaActorGateway(probe.getRef(), leaderSessionID)),
+					ici,
+					resources,
+					1);
 			} catch (Exception e) {
 				// good
 			}
@@ -179,11 +200,20 @@ public class InstanceManagerTest{
 			JavaTestKit probe3 = new JavaTestKit(system);
 
 			InstanceID instanceID1 = cm.registerTaskManager(
-					probe1.getRef(), ici1, hardwareDescription, 1, leaderSessionID);
+				new ActorTaskManagerGateway(new AkkaActorGateway(probe1.getRef(), leaderSessionID)),
+				ici1,
+				hardwareDescription,
+				1);
 			InstanceID instanceID2 = cm.registerTaskManager(
-					probe2.getRef(), ici2, hardwareDescription, 1, leaderSessionID);
+				new ActorTaskManagerGateway(new AkkaActorGateway(probe2.getRef(), leaderSessionID)),
+				ici2,
+				hardwareDescription,
+				1);
 			InstanceID instanceID3 = cm.registerTaskManager(
-					probe3.getRef(), ici3, hardwareDescription, 1, leaderSessionID);
+				new ActorTaskManagerGateway(new AkkaActorGateway(probe3.getRef(), leaderSessionID)),
+				ici3,
+				hardwareDescription,
+				1);
 
 			// report some immediate heart beats
 			assertTrue(cm.reportHeartBeat(instanceID1, new byte[] {}));
@@ -237,7 +267,11 @@ public class InstanceManagerTest{
 				TaskManagerLocation ici = new TaskManagerLocation(resID, address, 20000);
 
 				JavaTestKit probe = new JavaTestKit(system);
-				cm.registerTaskManager(probe.getRef(), ici, resources, 1, leaderSessionID);
+				cm.registerTaskManager(
+					new ActorTaskManagerGateway(new AkkaActorGateway(probe.getRef(), leaderSessionID)),
+					ici,
+					resources,
+					1);
 				fail("Should raise exception in shutdown state");
 			}
 			catch (IllegalStateException e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/InstanceTest.java
@@ -25,6 +25,7 @@ import java.net.InetAddress;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.junit.Test;
 
@@ -41,8 +42,12 @@ public class InstanceTest {
 			InetAddress address = InetAddress.getByName("127.0.0.1");
 			TaskManagerLocation connection = new TaskManagerLocation(resourceID, address, 10001);
 
-			Instance instance = new Instance(DummyActorGateway.INSTANCE, connection,
-					new InstanceID(), hardwareDescription, 4);
+			Instance instance = new Instance(
+				new ActorTaskManagerGateway(DummyActorGateway.INSTANCE),
+				connection,
+				new InstanceID(),
+				hardwareDescription,
+				4);
 
 			assertEquals(4, instance.getTotalNumberOfSlots());
 			assertEquals(4, instance.getNumberOfAvailableSlots());
@@ -104,8 +109,12 @@ public class InstanceTest {
 			InetAddress address = InetAddress.getByName("127.0.0.1");
 			TaskManagerLocation connection = new TaskManagerLocation(resourceID, address, 10001);
 
-			Instance instance = new Instance(DummyActorGateway.INSTANCE, connection,
-					new InstanceID(), hardwareDescription, 3);
+			Instance instance = new Instance(
+				new ActorTaskManagerGateway(DummyActorGateway.INSTANCE),
+				connection,
+				new InstanceID(),
+				hardwareDescription,
+				3);
 
 			assertEquals(3, instance.getNumberOfAvailableSlots());
 
@@ -136,8 +145,12 @@ public class InstanceTest {
 			InetAddress address = InetAddress.getByName("127.0.0.1");
 			TaskManagerLocation connection = new TaskManagerLocation(resourceID, address, 10001);
 
-			Instance instance = new Instance(DummyActorGateway.INSTANCE, connection,
-					new InstanceID(), hardwareDescription, 3);
+			Instance instance = new Instance(
+				new ActorTaskManagerGateway(DummyActorGateway.INSTANCE),
+				connection,
+				new InstanceID(),
+				hardwareDescription,
+				3);
 
 			assertEquals(3, instance.getNumberOfAvailableSlots());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SimpleSlotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SimpleSlotTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.api.common.JobID;
 
+import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.junit.Test;
 
@@ -149,8 +150,13 @@ public class SimpleSlotTest {
 		InetAddress address = InetAddress.getByName("127.0.0.1");
 		TaskManagerLocation connection = new TaskManagerLocation(resourceID, address, 10001);
 
-		Instance instance = new Instance(DummyActorGateway.INSTANCE, connection,
-				new InstanceID(), hardwareDescription, 1);
+		Instance instance = new Instance(
+			new ActorTaskManagerGateway(DummyActorGateway.INSTANCE),
+			connection,
+			new InstanceID(),
+			hardwareDescription,
+			1);
+
 		return instance.allocateSimpleSlot(new JobID());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.jobmanager.scheduler;
 
 import com.google.common.collect.Lists;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.JobVertex;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
+import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.api.common.JobID;
@@ -69,7 +70,12 @@ public class SchedulerTestUtils {
 		final long GB = 1024L*1024*1024;
 		HardwareDescription resources = new HardwareDescription(4, 4*GB, 3*GB, 2*GB);
 		
-		return new Instance(DummyActorGateway.INSTANCE, ci, new InstanceID(), resources, numSlots);
+		return new Instance(
+			new ActorTaskManagerGateway(DummyActorGateway.INSTANCE),
+			ci,
+			new InstanceID(),
+			resources,
+			numSlots);
 	}
 	
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
@@ -191,11 +191,11 @@ public class JobManagerLeaderElectionTest extends TestLogger {
 				new BlobLibraryCacheManager(new BlobServer(configuration), 10L),
 				ActorRef.noSender(),
 				new NoRestartStrategy.NoRestartStrategyFactory(),
-				AkkaUtils.getDefaultTimeout(),
+				AkkaUtils.getDefaultTimeoutAsFiniteDuration(),
 				leaderElectionService,
 				submittedJobGraphStore,
 				checkpointRecoveryFactory,
-				AkkaUtils.getDefaultTimeout(),
+				AkkaUtils.getDefaultTimeoutAsFiniteDuration(),
 				Option.apply(null)
 		);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ClusterShutdownITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ClusterShutdownITCase.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.messages.StopCluster;
 import org.apache.flink.runtime.clusterframework.messages.StopClusterSuccessful;
 import org.apache.flink.runtime.instance.ActorGateway;
-import org.apache.flink.runtime.messages.Messages;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.testingUtils.TestingMessages;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testutils.TestingResourceManager;
@@ -137,8 +137,7 @@ public class ClusterShutdownITCase extends TestLogger {
 			resourceManager.tell(new TestingResourceManager.NotifyWhenResourceManagerConnected(), me);
 
 			// Wait for resource manager
-			expectMsgEquals(Messages.getAcknowledge());
-
+			expectMsgEquals(Acknowledge.get());
 
 			// Shutdown cluster with resource manager connected
 			jobManager.tell(new StopCluster(ApplicationStatus.SUCCEEDED, "Shutting down."), me);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerITCase.java
@@ -25,8 +25,8 @@ import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
-import org.apache.flink.runtime.messages.Messages;
 import org.apache.flink.runtime.messages.RegistrationMessages;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testutils.TestingResourceManager;
@@ -102,7 +102,7 @@ public class ResourceManagerITCase extends TestLogger {
 			resourceManager.tell(new TestingResourceManager.NotifyWhenResourceManagerConnected(), me);
 
 			// Wait for resource manager
-			expectMsgEquals(Messages.getAcknowledge());
+			expectMsgEquals(Acknowledge.get());
 
 			// check if we registered the task manager resource
 			resourceManager.tell(new TestingResourceManager.GetRegisteredResources(), me);
@@ -141,7 +141,7 @@ public class ResourceManagerITCase extends TestLogger {
 			resourceManager.tell(new TestingResourceManager.NotifyWhenResourceManagerConnected(), me);
 
 			// Wait for resource manager
-			expectMsgEquals(Messages.getAcknowledge());
+			expectMsgEquals(Acknowledge.get());
 
 			// start task manager and wait for registration
 			ActorGateway taskManager =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -26,6 +26,7 @@ import akka.japi.Creator;
 import akka.testkit.JavaTestKit;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -51,18 +52,17 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.Tasks;
-import org.apache.flink.runtime.messages.Messages;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.RegistrationMessages;
 import org.apache.flink.runtime.messages.StackTraceSampleMessages.ResponseStackTraceSampleFailure;
-import org.apache.flink.runtime.messages.StackTraceSampleMessages.ResponseStackTraceSampleSuccess;
 import org.apache.flink.runtime.messages.StackTraceSampleMessages.TriggerStackTraceSample;
+import org.apache.flink.runtime.messages.StackTraceSampleResponse;
 import org.apache.flink.runtime.messages.TaskManagerMessages;
 import org.apache.flink.runtime.messages.TaskManagerMessages.FatalError;
 import org.apache.flink.runtime.messages.TaskMessages;
 import org.apache.flink.runtime.messages.TaskMessages.CancelTask;
 import org.apache.flink.runtime.messages.TaskMessages.StopTask;
 import org.apache.flink.runtime.messages.TaskMessages.SubmitTask;
-import org.apache.flink.runtime.messages.TaskMessages.TaskOperationResult;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
@@ -79,6 +79,7 @@ import scala.Option;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
+import scala.util.Failure;
 
 import java.net.InetSocketAddress;
 import java.net.URL;
@@ -107,6 +108,7 @@ public class TaskManagerTest extends TestLogger {
 	private static final FiniteDuration timeout = new FiniteDuration(1, TimeUnit.MINUTES);
 
 	private static final FiniteDuration d = new FiniteDuration(60, TimeUnit.SECONDS);
+	private static final Time timeD = Time.seconds(60L);
 
 	private static ActorSystem system;
 
@@ -182,7 +184,7 @@ public class TaskManagerTest extends TestLogger {
 						long deadline = System.currentTimeMillis() + 10000;
 						do {
 							Object message = receiveOne(d);
-							if (message == Messages.getAcknowledge()) {
+							if (message.equals(Acknowledge.get())) {
 								break;
 							}
 						} while (System.currentTimeMillis() < deadline);
@@ -299,8 +301,8 @@ public class TaskManagerTest extends TestLogger {
 							tm.tell(new SubmitTask(tdd1), testActorGateway);
 							tm.tell(new SubmitTask(tdd2), testActorGateway);
 
-							expectMsgEquals(Messages.getAcknowledge());
-							expectMsgEquals(Messages.getAcknowledge());
+							expectMsgEquals(Acknowledge.get());
+							expectMsgEquals(Acknowledge.get());
 
 							Await.ready(t1Running, d);
 							Await.ready(t2Running, d);
@@ -321,7 +323,7 @@ public class TaskManagerTest extends TestLogger {
 
 							tm.tell(new CancelTask(eid1), testActorGateway);
 
-							expectMsgEquals(new TaskOperationResult(eid1, true));
+							expectMsgEquals(Acknowledge.get());
 
 							Future<Object> response = tm.ask(new TestingTaskManagerMessages.NotifyWhenTaskRemoved(eid1),
 									timeout);
@@ -336,11 +338,10 @@ public class TaskManagerTest extends TestLogger {
 							assertEquals(1, runningTasks.size());
 
 							tm.tell(new CancelTask(eid1), testActorGateway);
-							expectMsgEquals(new TaskOperationResult(eid1, false, "No task with that execution ID was " +
-									"found."));
+							expectMsgEquals(Acknowledge.get());
 
 							tm.tell(new CancelTask(eid2), testActorGateway);
-							expectMsgEquals(new TaskOperationResult(eid2, true));
+							expectMsgEquals(Acknowledge.get());
 
 							response = tm.ask(new TestingTaskManagerMessages.NotifyWhenTaskRemoved(eid2),
 									timeout);
@@ -433,8 +434,8 @@ public class TaskManagerTest extends TestLogger {
 							tm.tell(new SubmitTask(tdd1), testActorGateway);
 							tm.tell(new SubmitTask(tdd2), testActorGateway);
 
-							expectMsgEquals(Messages.getAcknowledge());
-							expectMsgEquals(Messages.getAcknowledge());
+							expectMsgEquals(Acknowledge.get());
+							expectMsgEquals(Acknowledge.get());
 
 							Await.ready(t1Running, d);
 							Await.ready(t2Running, d);
@@ -455,7 +456,7 @@ public class TaskManagerTest extends TestLogger {
 
 							tm.tell(new StopTask(eid1), testActorGateway);
 
-							expectMsgEquals(new TaskOperationResult(eid1, true));
+							expectMsgEquals(Acknowledge.get());
 
 							Future<Object> response = tm.ask(
 									new TestingTaskManagerMessages.NotifyWhenTaskRemoved(eid1),
@@ -471,11 +472,10 @@ public class TaskManagerTest extends TestLogger {
 							assertEquals(1, runningTasks.size());
 
 							tm.tell(new StopTask(eid1), testActorGateway);
-							expectMsgEquals(new TaskOperationResult(eid1, false, "No task with that execution ID was " +
-									"found."));
+							expectMsgEquals(Acknowledge.get());
 
 							tm.tell(new StopTask(eid2), testActorGateway);
-							expectMsgEquals(new TaskOperationResult(eid2, false, "UnsupportedOperationException: Stopping not supported by this task."));
+							expectMsgClass(Failure.class);
 
 							assertEquals(ExecutionState.RUNNING, t2.getExecutionState());
 
@@ -556,8 +556,8 @@ public class TaskManagerTest extends TestLogger {
 							tm.tell(new SubmitTask(tdd1), testActorGateway);
 							tm.tell(new SubmitTask(tdd2), testActorGateway);
 
-							expectMsgEquals(Messages.getAcknowledge());
-							expectMsgEquals(Messages.getAcknowledge());
+							expectMsgEquals(Acknowledge.get());
+							expectMsgEquals(Acknowledge.get());
 
 							tm.tell(new TestingTaskManagerMessages.NotifyWhenTaskRemoved(eid1),
 									testActorGateway);
@@ -667,14 +667,14 @@ public class TaskManagerTest extends TestLogger {
 
 							// submit the sender task
 							tm.tell(new SubmitTask(tdd1), testActorGateway);
-							expectMsgEquals(Messages.getAcknowledge());
+							expectMsgEquals(Acknowledge.get());
 
 							// wait until the sender task is running
 							Await.ready(t1Running, d);
 
 							// only now (after the sender is running), submit the receiver task
 							tm.tell(new SubmitTask(tdd2), testActorGateway);
-							expectMsgEquals(Messages.getAcknowledge());
+							expectMsgEquals(Acknowledge.get());
 
 							// wait until the receiver task is running
 							Await.ready(t2Running, d);
@@ -813,8 +813,8 @@ public class TaskManagerTest extends TestLogger {
 							tm.tell(new SubmitTask(tdd2), testActorGateway);
 							tm.tell(new SubmitTask(tdd1), testActorGateway);
 
-							expectMsgEquals(Messages.getAcknowledge());
-							expectMsgEquals(Messages.getAcknowledge());
+							expectMsgEquals(Acknowledge.get());
+							expectMsgEquals(Acknowledge.get());
 
 							Await.ready(t1Running, d);
 							Await.ready(t2Running, d);
@@ -827,7 +827,7 @@ public class TaskManagerTest extends TestLogger {
 							Task t2 = tasks.get(eid2);
 
 							tm.tell(new CancelTask(eid2), testActorGateway);
-							expectMsgEquals(new TaskOperationResult(eid2, true));
+							expectMsgEquals(Acknowledge.get());
 
 							if (t2 != null) {
 								Future<Object> response = tm.ask(new TestingTaskManagerMessages.NotifyWhenTaskRemoved(eid2),
@@ -838,7 +838,7 @@ public class TaskManagerTest extends TestLogger {
 							if (t1 != null) {
 								if (t1.getExecutionState() == ExecutionState.RUNNING) {
 									tm.tell(new CancelTask(eid1), testActorGateway);
-									expectMsgEquals(new TaskOperationResult(eid1, true));
+									expectMsgEquals(Acknowledge.get());
 								}
 								Future<Object> response = tm.ask(
 										new TestingTaskManagerMessages.NotifyWhenTaskRemoved(eid1),
@@ -944,7 +944,7 @@ public class TaskManagerTest extends TestLogger {
 					protected void run() {
 						// Submit the task
 						tm.tell(new SubmitTask(tdd), testActorGateway);
-						expectMsgClass(Messages.getAcknowledge().getClass());
+						expectMsgClass(Acknowledge.get().getClass());
 
 						// Wait to be notified about the final execution state by the mock JM
 						TaskExecutionState msg = expectMsgClass(TaskExecutionState.class);
@@ -1037,7 +1037,7 @@ public class TaskManagerTest extends TestLogger {
 					protected void run() {
 						// Submit the task
 						tm.tell(new SubmitTask(tdd), testActorGateway);
-						expectMsgClass(Messages.getAcknowledge().getClass());
+						expectMsgClass(Acknowledge.get().getClass());
 
 						// Wait to be notified about the final execution state by the mock JM
 						TaskExecutionState msg = expectMsgClass(TaskExecutionState.class);
@@ -1154,21 +1154,19 @@ public class TaskManagerTest extends TestLogger {
 											112223,
 											taskId,
 											100,
-											d,
+											timeD,
 											0),
 									testActorGateway);
 
 							// Receive the expected message (heartbeat races possible)
 							Object[] msg = receiveN(1);
-							while (!(msg[0] instanceof ResponseStackTraceSampleFailure)) {
+							while (!(msg[0] instanceof Failure)) {
 								msg = receiveN(1);
 							}
 
-							ResponseStackTraceSampleFailure response = (ResponseStackTraceSampleFailure) msg[0];
+							Failure response = (Failure) msg[0];
 
-							assertEquals(112223, response.sampleId());
-							assertEquals(taskId, response.executionId());
-							assertEquals(IllegalStateException.class, response.cause().getClass());
+							assertEquals(IllegalStateException.class, response.exception().getClass());
 						} catch (Exception e) {
 							e.printStackTrace();
 							fail(e.getMessage());
@@ -1193,23 +1191,23 @@ public class TaskManagerTest extends TestLogger {
 												19230,
 												tdd.getExecutionId(),
 												numSamples,
-												new FiniteDuration(100, TimeUnit.MILLISECONDS),
+												Time.milliseconds(100L),
 												0),
 										testActorGateway);
 
 								// Receive the expected message (heartbeat races possible)
 								Object[] msg = receiveN(1);
-								while (!(msg[0] instanceof ResponseStackTraceSampleSuccess)) {
+								while (!(msg[0] instanceof StackTraceSampleResponse)) {
 									msg = receiveN(1);
 								}
 
-								ResponseStackTraceSampleSuccess response = (ResponseStackTraceSampleSuccess) msg[0];
+								StackTraceSampleResponse response = (StackTraceSampleResponse) msg[0];
 
 								// ---- Verify response ----
-								assertEquals(19230, response.sampleId());
-								assertEquals(tdd.getExecutionId(), response.executionId());
+								assertEquals(19230, response.getSampleId());
+								assertEquals(tdd.getExecutionId(), response.getExecutionAttemptID());
 
-								List<StackTraceElement[]> traces = response.samples();
+								List<StackTraceElement[]> traces = response.getSamples();
 
 								assertEquals("Number of samples", numSamples, traces.size());
 
@@ -1265,23 +1263,23 @@ public class TaskManagerTest extends TestLogger {
 											1337,
 											tdd.getExecutionId(),
 											numSamples,
-											new FiniteDuration(100, TimeUnit.MILLISECONDS),
+											Time.milliseconds(100L),
 											maxDepth),
 									testActorGateway);
 
 							// Receive the expected message (heartbeat races possible)
 							Object[] msg = receiveN(1);
-							while (!(msg[0] instanceof ResponseStackTraceSampleSuccess)) {
+							while (!(msg[0] instanceof StackTraceSampleResponse)) {
 								msg = receiveN(1);
 							}
 
-							ResponseStackTraceSampleSuccess response = (ResponseStackTraceSampleSuccess) msg[0];
+							StackTraceSampleResponse response = (StackTraceSampleResponse) msg[0];
 
 							// ---- Verify response ----
-							assertEquals(1337, response.sampleId());
-							assertEquals(tdd.getExecutionId(), response.executionId());
+							assertEquals(1337, response.getSampleId());
+							assertEquals(tdd.getExecutionId(), response.getExecutionAttemptID());
 
-							List<StackTraceElement[]> traces = response.samples();
+							List<StackTraceElement[]> traces = response.getSamples();
 
 							assertEquals("Number of samples", numSamples, traces.size());
 
@@ -1307,13 +1305,14 @@ public class TaskManagerTest extends TestLogger {
 							for (int i = 0; i < maxAttempts; i++, sleepTime *= 2) {
 								// Trigger many samples in order to cancel the task
 								// during a sample
-								taskManager.tell(new TriggerStackTraceSample(
-												44,
-												tdd.getExecutionId(),
-												Integer.MAX_VALUE,
-												new FiniteDuration(10, TimeUnit.MILLISECONDS),
-												0),
-										testActorGateway);
+								taskManager.tell(
+									new TriggerStackTraceSample(
+										44,
+										tdd.getExecutionId(),
+										Integer.MAX_VALUE,
+										Time.milliseconds(10L),
+										0),
+									testActorGateway);
 
 								Thread.sleep(sleepTime);
 
@@ -1327,11 +1326,11 @@ public class TaskManagerTest extends TestLogger {
 								// Receive the expected message (heartbeat races possible)
 								while (true) {
 									Object[] msg = receiveN(1);
-									if (msg[0] instanceof ResponseStackTraceSampleSuccess) {
-										ResponseStackTraceSampleSuccess response = (ResponseStackTraceSampleSuccess) msg[0];
+									if (msg[0] instanceof StackTraceSampleResponse) {
+										StackTraceSampleResponse response = (StackTraceSampleResponse) msg[0];
 
-										assertEquals(tdd.getExecutionId(), response.executionId());
-										assertEquals(44, response.sampleId());
+										assertEquals(tdd.getExecutionId(), response.getExecutionAttemptID());
+										assertEquals(44, response.getSampleId());
 
 										// Done
 										return;
@@ -1435,7 +1434,7 @@ public class TaskManagerTest extends TestLogger {
 		public void handleMessage(Object message) throws Exception {
 			if (message instanceof ScheduleOrUpdateConsumers) {
 				getSender().tell(
-						decorateMessage(Messages.getAcknowledge()),
+						decorateMessage(Acknowledge.get()),
 						getSelf()
 						);
 			} else {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingResourceManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingResourceManager.java
@@ -25,13 +25,12 @@ import org.apache.flink.runtime.clusterframework.messages.RegisterResourceManage
 import org.apache.flink.runtime.clusterframework.standalone.StandaloneResourceManager;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
-import org.apache.flink.runtime.messages.Messages;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.testingUtils.TestingMessages;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-
 
 /**
  * A testing resource manager which may alter the default standalone resource master's behavior.
@@ -66,7 +65,7 @@ public class TestingResourceManager extends StandaloneResourceManager {
 		} else if (message instanceof NotifyWhenResourceManagerConnected) {
 			if (isConnected) {
 				sender().tell(
-					Messages.getAcknowledge(),
+					Acknowledge.get(),
 					self());
 			} else {
 				waitForResourceManagerConnected.add(sender());
@@ -78,7 +77,7 @@ public class TestingResourceManager extends StandaloneResourceManager {
 
 			for (ActorRef ref : waitForResourceManagerConnected) {
 				ref.tell(
-					Messages.getAcknowledge(),
+					Acknowledge.get(),
 					self());
 			}
 			waitForResourceManagerConnected.clear();
@@ -86,7 +85,7 @@ public class TestingResourceManager extends StandaloneResourceManager {
 		} else if (message instanceof TestingMessages.NotifyOfComponentShutdown$) {
 			waitForShutdown.add(sender());
 		} else if (message instanceof TestingMessages.Alive$) {
-			sender().tell(Messages.getAcknowledge(), self());
+			sender().tell(Acknowledge.get(), self());
 		} else {
 			super.handleMessage(message);
 		}

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/TaskManagerLossFailsTasksTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/executiongraph/TaskManagerLossFailsTasksTest.scala
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy
 import org.apache.flink.runtime.jobgraph.{JobGraph, JobStatus, JobVertex}
 import org.apache.flink.runtime.jobmanager.Tasks
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler
+import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway
 import org.apache.flink.runtime.testingUtils.TestingUtils
 import org.apache.flink.util.SerializedValue
 import org.junit.runner.RunWith
@@ -39,9 +40,11 @@ class TaskManagerLossFailsTasksTest extends WordSpecLike with Matchers {
     "fail the assigned tasks" in {
       try {
         val instance1 = ExecutionGraphTestUtils.getInstance(
-          new SimpleActorGateway(TestingUtils.defaultExecutionContext), 10)
+          new ActorTaskManagerGateway(new SimpleActorGateway(TestingUtils.defaultExecutionContext)),
+          10)
         val instance2 = ExecutionGraphTestUtils.getInstance(
-          new SimpleActorGateway(TestingUtils.defaultExecutionContext), 10)
+          new ActorTaskManagerGateway(new SimpleActorGateway(TestingUtils.defaultExecutionContext)),
+          10)
 
         val scheduler = new Scheduler(TestingUtils.defaultExecutionContext)
         scheduler.newInstanceAvailable(instance1)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerLike.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerLike.scala
@@ -26,9 +26,11 @@ import org.apache.flink.runtime.checkpoint.savepoint.SavepointStore
 import org.apache.flink.runtime.execution.ExecutionState
 import org.apache.flink.runtime.jobgraph.JobStatus
 import org.apache.flink.runtime.jobmanager.JobManager
+import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway
+import org.apache.flink.runtime.messages.Acknowledge
 import org.apache.flink.runtime.messages.ExecutionGraphMessages.JobStatusChanged
 import org.apache.flink.runtime.messages.JobManagerMessages.{GrantLeadership, RegisterJobClient, RequestClassloadingProps}
-import org.apache.flink.runtime.messages.Messages.{Acknowledge, Disconnect}
+import org.apache.flink.runtime.messages.Messages.Disconnect
 import org.apache.flink.runtime.messages.RegistrationMessages.RegisterTaskManager
 import org.apache.flink.runtime.messages.TaskManagerMessages.Heartbeat
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages._
@@ -91,7 +93,7 @@ trait TestingJobManagerLike extends FlinkActor {
   }
 
   def handleTestingMessage: Receive = {
-    case Alive => sender() ! Acknowledge
+    case Alive => sender() ! Acknowledge.get()
 
     case RequestExecutionGraph(jobID) =>
       currentJobs.get(jobID) match {
@@ -155,10 +157,16 @@ trait TestingJobManagerLike extends FlinkActor {
 
 
     case NotifyWhenJobRemoved(jobID) =>
-      val gateways = instanceManager.getAllRegisteredInstances.asScala.map(_.getActorGateway)
+      val gateways = instanceManager.getAllRegisteredInstances.asScala.map(_.getTaskManagerGateway)
 
       val responses = gateways.map{
-        gateway => gateway.ask(NotifyWhenJobRemoved(jobID), timeout).mapTo[Boolean]
+        gateway =>  gateway match {
+          case actorGateway: ActorTaskManagerGateway =>
+            actorGateway.getActorGateway.ask(NotifyWhenJobRemoved(jobID), timeout).mapTo[Boolean]
+          case _ =>
+            throw new IllegalStateException("The task manager gateway is not of type " +
+                                             s"${classOf[ActorTaskManagerGateway].getSimpleName}")
+        }
       }
 
       val jobRemovedOnJobManager = (self ? CheckIfJobRemoved(jobID))(timeout).mapTo[Boolean]
@@ -250,7 +258,15 @@ trait TestingJobManagerLike extends FlinkActor {
             } else {
               sender ! decorateMessage(
                 WorkingTaskManager(
-                  Some(resource.getTaskManagerActorGateway())
+                  Some(
+                    resource.getTaskManagerGateway() match {
+                      case actorTaskManagerGateway: ActorTaskManagerGateway =>
+                        actorTaskManagerGateway.getActorGateway
+                      case _ => throw new IllegalStateException(
+                        "The task manager gateway is not of type " +
+                          s"${classOf[ActorTaskManagerGateway].getSimpleName}")
+                    }
+                  )
                 )
               )
             }
@@ -345,7 +361,7 @@ trait TestingJobManagerLike extends FlinkActor {
     case NotifyWhenAtLeastNumTaskManagerAreRegistered(numRegisteredTaskManager) =>
       if (that.instanceManager.getNumberOfRegisteredTaskManagers >= numRegisteredTaskManager) {
         // there are already at least numRegisteredTaskManager registered --> send Acknowledge
-        sender() ! Acknowledge
+        sender() ! Acknowledge.get()
       } else {
         // wait until we see at least numRegisteredTaskManager being registered at the JobManager
         waitForNumRegisteredTaskManagers += ((numRegisteredTaskManager, sender()))
@@ -361,7 +377,7 @@ trait TestingJobManagerLike extends FlinkActor {
         waitForNumRegisteredTaskManagers.head._1 <=
           instanceManager.getNumberOfRegisteredTaskManagers) {
         val receiver = waitForNumRegisteredTaskManagers.dequeue()._2
-        receiver ! Acknowledge
+        receiver ! Acknowledge.get()
       }
   }
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManagerMessages.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManagerMessages.scala
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.testingUtils
 
+import java.util.UUID
+
 import akka.actor.ActorRef
 import org.apache.flink.api.common.JobID
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor
@@ -40,9 +42,9 @@ object TestingTaskManagerMessages {
   
   case object RequestRunningTasks
 
-  case class NotifyWhenJobManagerTerminated(jobManager: ActorRef)
+  case class NotifyWhenJobManagerTerminated(leaderId: UUID)
 
-  case class JobManagerTerminated(jobManager: ActorRef)
+  case class JobManagerTerminated(leaderId: UUID)
 
   case class NotifyWhenRegisteredAtJobManager(resourceManager: ActorRef)
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.testingUtils
 
 import java.util.UUID
+import java.util.concurrent.Executor
 
 import akka.actor.{ActorRef, ActorSystem, Kill, Props}
 import akka.pattern.ask
@@ -111,7 +112,7 @@ object TestingUtils {
     * @param actionQueue
     */
   class QueuedActionExecutionContext private[testingUtils] (val actionQueue: ActionQueue)
-    extends ExecutionContext {
+    extends ExecutionContext with Executor {
 
     var automaticExecution = false
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
@@ -46,7 +46,6 @@ import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.TestLogger;
 
-import org.apache.flink.util.TestLogger;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;

--- a/flink-tests/src/test/resources/log4j-test.properties
+++ b/flink-tests/src/test/resources/log4j-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-log4j.rootLogger=OFF, testlogger
+log4j.rootLogger=INFO, testlogger
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.testlogger=org.apache.log4j.ConsoleAppender

--- a/flink-tests/src/test/resources/log4j-test.properties
+++ b/flink-tests/src/test/resources/log4j-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-log4j.rootLogger=INFO, testlogger
+log4j.rootLogger=OFF, testlogger
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.testlogger=org.apache.log4j.ConsoleAppender

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
@@ -24,8 +24,8 @@ import org.apache.flink.configuration.{ConfigConstants, Configuration}
 import org.apache.flink.runtime.akka.{AkkaUtils, ListeningBehaviour}
 import org.apache.flink.runtime.jobgraph.{JobGraph, JobVertex}
 import org.apache.flink.runtime.jobmanager.Tasks.{BlockingNoOpInvokable, NoOpInvokable}
+import org.apache.flink.runtime.messages.Acknowledge
 import org.apache.flink.runtime.messages.JobManagerMessages._
-import org.apache.flink.runtime.messages.Messages.Acknowledge
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.NotifyWhenAtLeastNumTaskManagerAreRegistered
 import org.apache.flink.runtime.testingUtils.TestingMessages.DisableDisconnect
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages.{JobManagerTerminated, NotifyWhenJobManagerTerminated}
@@ -66,7 +66,7 @@ class JobManagerFailsITCase(_system: ActorSystem)
           jmGateway.tell(RequestNumberRegisteredTaskManager, self)
           expectMsg(1)
 
-          tm ! NotifyWhenJobManagerTerminated(jmGateway.actor)
+          tm ! NotifyWhenJobManagerTerminated(jmGateway.leaderSessionID())
 
           jmGateway.tell(PoisonPill, self)
 
@@ -109,7 +109,7 @@ class JobManagerFailsITCase(_system: ActorSystem)
           jmGateway.tell(SubmitJob(jobGraph, ListeningBehaviour.DETACHED), self)
           expectMsg(JobSubmitSuccess(jobGraph.getJobID))
 
-          tm.tell(NotifyWhenJobManagerTerminated(jmGateway.actor()), self)
+          tm.tell(NotifyWhenJobManagerTerminated(jmGateway.leaderSessionID()), self)
 
           jmGateway.tell(PoisonPill, self)
 
@@ -122,7 +122,7 @@ class JobManagerFailsITCase(_system: ActorSystem)
           // Ask the job manager for the TMs. Don't ask the TMs, because they
           // can still have state associated with the old job manager.
           jmGateway.tell(NotifyWhenAtLeastNumTaskManagerAreRegistered(2), self)
-          expectMsg(Acknowledge)
+          expectMsg(Acknowledge.get())
 
           jmGateway.tell(SubmitJob(jobGraph2, ListeningBehaviour.EXECUTION_RESULT), self)
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -31,7 +31,7 @@ import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
-import org.apache.flink.runtime.messages.Messages;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
@@ -143,7 +143,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 
 								gateway.tell(new TestingJobManagerMessages.NotifyWhenAtLeastNumTaskManagerAreRegistered(1), selfGateway);
 
-								expectMsgEquals(Messages.getAcknowledge());
+								expectMsgEquals(Acknowledge.get());
 
 								gateway.tell(PoisonPill.getInstance());
 							} catch (Exception e) {
@@ -162,7 +162,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 							ActorGateway selfGateway = new AkkaActorGateway(getRef(), gateway2.leaderSessionID());
 							gateway2.tell(new TestingJobManagerMessages.NotifyWhenAtLeastNumTaskManagerAreRegistered(1), selfGateway);
 
-							expectMsgEquals(Messages.getAcknowledge());
+							expectMsgEquals(Acknowledge.get());
 						} catch (Exception e) {
 							throw new AssertionError("Could not complete test.", e);
 						}


### PR DESCRIPTION
This PR is based on #2689 and #2698.

This PR introduces the `TaskManagerGateway` which is an abstraction layer for rpc calls to the `TaskManager`. Before the rpcs were directly executed on the `ActorGateway`. This is problematic since it bakes the dependency on Akka directly into many Flink components. In order to make them compatible with the changes of Flip-6, the rpc implementation details are now hidden behind the `TaskManagerGateway` interface implementation.

The `ActorTaskManagerGateway` is the implementation which uses the `ActorGateways` to send the rpcs.

In the wake of refactoring the `ExecutionVertex` and the `Execution` of the `ExecutionGraph`, the `StackTraceSampleCoordinator` and `CheckpointCoordinator` were changed so that they now use mostly Flink's own future abstraction.

Furthermore, some of the TaskManager's rpcs such as `CancelTask` and `StopTask` were changed so that they now return an `Acknowledge` message in case of a success and otherwise send an exception back to the caller.

This PR is a refactoring for the integration of Flip-6.

@StephanEwen would be great if you could take a look.
