### PR TITLE
[FLINK-4942] Improve processing performance of HeapInternalTimerService with key groups

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -56,7 +56,7 @@ public interface KeyedStateBackend<K> {
 	/**
 	 * Returns the key groups for this backend.
 	 */
-	KeyGroupsList getKeyGroupRange();
+	KeyGroupRange getKeyGroupRange();
 
 	/**
 	 * {@link TypeSerializer} for the state backend key type.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
@@ -387,7 +387,8 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 		int[] histogram = new int[range.getNumberOfKeyGroups() + 1];
 
 		for (InternalTimer<K, N> t : allTimers) {
-			int effectiveKgIdx = KeyGroupRangeAssignment.assignToKeyGroup(t.getKey(), totalKeyGroups) - baseKgIdx + 1;
+			int effectiveKgIdx =
+					KeyGroupRangeAssignment.computeKeyGroupForKeyHash(t.getKeyHashCode(), totalKeyGroups) - baseKgIdx + 1;
 			++histogram[effectiveKgIdx];
 		}
 
@@ -396,7 +397,8 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 		}
 
 		for (InternalTimer<K, N> t : allTimers) {
-			int effectiveKgIdx = KeyGroupRangeAssignment.assignToKeyGroup(t.getKey(), totalKeyGroups) - baseKgIdx;
+			int effectiveKgIdx =
+					KeyGroupRangeAssignment.computeKeyGroupForKeyHash(t.getKeyHashCode(), totalKeyGroups) - baseKgIdx;
 			keyGroupedTimers[histogram[effectiveKgIdx]++] = t;
 		}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimer.java
@@ -36,11 +36,14 @@ public class InternalTimer<K, N> implements Comparable<InternalTimer<K, N>> {
 	private final long timestamp;
 	private final K key;
 	private final N namespace;
+	private final int keyHashCode;
 
 	public InternalTimer(long timestamp, K key, N namespace) {
 		this.timestamp = timestamp;
 		this.key = key;
 		this.namespace = namespace;
+		//cache the key hash code, it may be expensive to compute
+		this.keyHashCode = key.hashCode();
 	}
 
 	public long getTimestamp() {
@@ -77,10 +80,14 @@ public class InternalTimer<K, N> implements Comparable<InternalTimer<K, N>> {
 
 	}
 
+	public int getKeyHashCode() {
+		return keyHashCode;
+	}
+
 	@Override
 	public int hashCode() {
 		int result = (int) (timestamp ^ (timestamp >>> 32));
-		result = 31 * result + key.hashCode();
+		result = 31 * result + keyHashCode;
 		result = 31 * result + namespace.hashCode();
 		return result;
 	}


### PR DESCRIPTION
This PR improves the performance of `HeapInternalTimerService`by pushing all key-group related overhead into the snapshot part. This is done by performing efficient online-partitioning w.r.t. key-group at the beginning of a snapshot.

While this adds small computational and space overhead (both linear in the number of registered timers), I believe this is well worth getting rid of nested sets on timer processing.

Furthermore, this can now be extended to perform the actual state writing asynchronously in a followup work.
