### PR TITLE
[FLINK-2597][FLINK-4050] Add wrappers for Kafka serializers, test for partitioner and documentation

### DIFF
--- a/flink-streaming-connectors/flink-connector-kafka-0.10/pom.xml
+++ b/flink-streaming-connectors/flink-connector-kafka-0.10/pom.xml
@@ -40,6 +40,13 @@ under the License.
 		<kafka.version>0.10.0.1</kafka.version>
 	</properties>
 
+	<repositories>
+		<repository>
+			<id>confluent</id>
+			<url>http://packages.confluent.io/maven</url>
+		</repository>
+	</repositories>
+
 	<dependencies>
 
 		<!-- core dependencies -->
@@ -146,6 +153,26 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-avro-serializer</artifactId>
+			<version>3.0.0</version>
+            <scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.kafka</groupId>
+					<artifactId>kafka-clients</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
 	</dependencies>
 

--- a/flink-streaming-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010ITCase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010ITCase.java
@@ -131,6 +131,13 @@ public class Kafka010ITCase extends KafkaConsumerTestBase {
 		runEndOfStreamTest();
 	}
 
+	@Test(timeout = 60000)
+	public void testKafkaAvroSerializerTest() throws Exception {
+		runKafkaAvroSerializerTest();
+	}
+
+
+
 	// --- offset committing ---
 
 	@Test(timeout = 60000)

--- a/flink-streaming-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010ProducerITCase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010ProducerITCase.java
@@ -19,7 +19,33 @@
 package org.apache.flink.streaming.connectors.kafka;
 
 
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.accumulators.Accumulator;
+import org.apache.flink.api.common.accumulators.DoubleCounter;
+import org.apache.flink.api.common.accumulators.Histogram;
+import org.apache.flink.api.common.accumulators.IntCounter;
+import org.apache.flink.api.common.accumulators.LongCounter;
+import org.apache.flink.api.common.cache.DistributedCache;
+import org.apache.flink.api.common.functions.BroadcastVariableInitializer;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.operators.testutils.UnregisteredTaskMetricsGroup;
+import org.apache.flink.streaming.util.serialization.SimpleStringSchema;
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.common.Cluster;
 import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 
 @SuppressWarnings("serial")
@@ -30,4 +56,158 @@ public class Kafka010ProducerITCase extends KafkaProducerTestBase {
 		runCustomPartitioningTest();
 	}
 
+	/**
+	 * Test that the Kafka producer supports a custom Kafka partitioner
+	 */
+	@Test
+	public void testKafkaPartitioner() throws Exception {
+		Properties props = new Properties();
+		props.putAll(FlinkKafkaProducerBase.getPropertiesFromBrokerList(brokerConnectionStrings));
+		props.putAll(secureProps);
+		props.setProperty("partitioner.class", "org.apache.flink.streaming.connectors.kafka.Kafka010ProducerITCase$CustomKafkaPartitioner");
+		FlinkKafkaProducer010<String> producer = new FlinkKafkaProducer010<>("topic", new SimpleStringSchema(), props, /* pass no partitioner*/ null);
+		producer.setRuntimeContext(new MockRuntimeContext());
+		producer.open(new Configuration());
+		try {
+			producer.invoke("abc");
+		} catch(RuntimeException re) {
+			if(!re.getMessage().equals("Success")) {
+				throw re;
+			}
+		}
+		producer.close();
+	}
+
+	public static class CustomKafkaPartitioner implements Partitioner {
+		boolean configureCalled = false;
+		@Override
+		public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
+			if(!configureCalled) {
+				throw new IllegalArgumentException("Configure has not been called");
+			}
+			throw new RuntimeException("Success");
+		}
+
+		@Override
+		public void close() {
+
+		}
+
+		@Override
+		public void configure(Map<String, ?> configs) {
+			configureCalled = true;
+		}
+	}
+
+	private static class MockRuntimeContext implements RuntimeContext {
+		@Override
+		public String getTaskName() {
+			return null;
+		}
+
+		@Override
+		public MetricGroup getMetricGroup() {
+			return new UnregisteredTaskMetricsGroup();
+		}
+
+		@Override
+		public int getNumberOfParallelSubtasks() {
+			return 2;
+		}
+
+		@Override
+		public int getIndexOfThisSubtask() {
+			return 0;
+		}
+
+		@Override
+		public int getAttemptNumber() {
+			return 0;
+		}
+
+		@Override
+		public String getTaskNameWithSubtasks() {
+			return null;
+		}
+
+		@Override
+		public ExecutionConfig getExecutionConfig() {
+			return null;
+		}
+
+		@Override
+		public ClassLoader getUserCodeClassLoader() {
+			return null;
+		}
+
+		@Override
+		public <V, A extends Serializable> void addAccumulator(String name, Accumulator<V, A> accumulator) {
+
+		}
+
+		@Override
+		public <V, A extends Serializable> Accumulator<V, A> getAccumulator(String name) {
+			return null;
+		}
+
+		@Override
+		public Map<String, Accumulator<?, ?>> getAllAccumulators() {
+			return null;
+		}
+
+		@Override
+		public IntCounter getIntCounter(String name) {
+			return null;
+		}
+
+		@Override
+		public LongCounter getLongCounter(String name) {
+			return null;
+		}
+
+		@Override
+		public DoubleCounter getDoubleCounter(String name) {
+			return null;
+		}
+
+		@Override
+		public Histogram getHistogram(String name) {
+			return null;
+		}
+
+		@Override
+		public boolean hasBroadcastVariable(String name) {
+			return false;
+		}
+
+		@Override
+		public <RT> List<RT> getBroadcastVariable(String name) {
+			return null;
+		}
+
+		@Override
+		public <T, C> C getBroadcastVariableWithInitializer(String name, BroadcastVariableInitializer<T, C> initializer) {
+			return null;
+		}
+
+		@Override
+		public DistributedCache getDistributedCache() {
+			return null;
+		}
+
+		@Override
+		public <T> ValueState<T> getState(ValueStateDescriptor<T> stateProperties) {
+			return null;
+		}
+
+		@Override
+		public <T> ListState<T> getListState(ListStateDescriptor<T> stateProperties) {
+			return null;
+		}
+
+		@Override
+		public <T> ReducingState<T> getReducingState(ReducingStateDescriptor<T> stateProperties) {
+			return null;
+		}
+	}
 }

--- a/flink-streaming-connectors/flink-connector-kafka-0.8/pom.xml
+++ b/flink-streaming-connectors/flink-connector-kafka-0.8/pom.xml
@@ -40,6 +40,14 @@ under the License.
 		<kafka.version>0.8.2.2</kafka.version>
 	</properties>
 
+
+	<repositories>
+		<repository>
+			<id>confluent</id>
+			<url>http://packages.confluent.io/maven</url>
+		</repository>
+	</repositories>
+
 	<dependencies>
 
 		<!-- core dependencies -->
@@ -171,6 +179,27 @@ under the License.
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-avro-serializer</artifactId>
+			<version>3.0.0</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.kafka</groupId>
+					<artifactId>kafka-clients</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 	</dependencies>

--- a/flink-streaming-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08ITCase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08ITCase.java
@@ -245,4 +245,9 @@ public class Kafka08ITCase extends KafkaConsumerTestBase {
 	public void testMetrics() throws Throwable {
 		runMetricsTest();
 	}
+
+	@Test(timeout = 60000)
+	public void testKafkaAvroSerializerTest() throws Exception {
+		runKafkaAvroSerializerTest();
+	}
 }

--- a/flink-streaming-connectors/flink-connector-kafka-0.9/pom.xml
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/pom.xml
@@ -40,6 +40,13 @@ under the License.
 		<kafka.version>0.9.0.1</kafka.version>
 	</properties>
 
+	<repositories>
+		<repository>
+			<id>confluent</id>
+			<url>http://packages.confluent.io/maven</url>
+		</repository>
+	</repositories>
+
 	<dependencies>
 
 		<!-- core dependencies -->
@@ -147,6 +154,27 @@ under the License.
 			<artifactId>hadoop-minikdc</artifactId>
 			<version>${minikdc.version}</version>
 			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-avro-serializer</artifactId>
+			<version>3.0.0</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.kafka</groupId>
+					<artifactId>kafka-clients</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 	</dependencies>

--- a/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ITCase.java
@@ -110,6 +110,11 @@ public class Kafka09ITCase extends KafkaConsumerTestBase {
 		runMetricsTest();
 	}
 
+	@Test(timeout = 60000)
+	public void testKafkaAvroSerializerTest() throws Exception {
+		runKafkaAvroSerializerTest();
+	}
+
 	// --- offset committing ---
 
 	@Test(timeout = 60000)

--- a/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-streaming-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -75,6 +75,7 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 	// 6 seconds is default. Seems to be too small for travis. 30 seconds
 	private String zkTimeout = "30000";
 
+	@Override
 	public String getBrokerConnectionString() {
 		return brokerConnectionString;
 	}

--- a/flink-streaming-connectors/flink-connector-kafka-base/pom.xml
+++ b/flink-streaming-connectors/flink-connector-kafka-base/pom.xml
@@ -40,6 +40,13 @@ under the License.
 		<kafka.version>0.8.2.2</kafka.version>
 	</properties>
 
+	<repositories>
+		<repository>
+			<id>confluent</id>
+			<url>http://packages.confluent.io/maven</url>
+		</repository>
+	</repositories>
+
 	<dependencies>
 
 		<!-- core dependencies -->
@@ -167,6 +174,27 @@ under the License.
 			<artifactId>hadoop-minikdc</artifactId>
 			<version>${minikdc.version}</version>
 			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-avro-serializer</artifactId>
+			<version>3.0.0</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.kafka</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 	</dependencies>

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KafkaDeserializerWrapper.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KafkaDeserializerWrapper.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util.serialization;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Wrapper for using a {@see org.apache.kafka.common.serialization.Deserializer} with Apache Flink.
+ */
+public class KafkaDeserializerWrapper<K, V> implements KeyedDeserializationSchema<Tuple2<K,V>> {
+
+	private final Class<Deserializer<K>> keyDeserializerClass;
+	private final Class<Deserializer<V>> valueDeserializerClass;
+	private final TupleTypeInfo<Tuple2<K,V>> producedType;
+	private Map<String, ?> configs;
+	private boolean isInitialized = false;
+	private Deserializer<K> keyDeserializer;
+	private Deserializer<V> valueDeserializer;
+
+	@SuppressWarnings("unchecked")
+	public KafkaDeserializerWrapper(Class keyDeserializerClass, Class valueDeserializerClass, Class<K> keyType, Class<V> valueType) {
+		InstantiationUtil.checkForInstantiation(keyDeserializerClass);
+		InstantiationUtil.checkForInstantiation(valueDeserializerClass);
+		if(!Deserializer.class.isAssignableFrom(keyDeserializerClass)) {
+			throw new IllegalArgumentException("Key serializer is not implementing the org.apache.kafka.common.serialization.Deserializer interface");
+		}
+		if(!Deserializer.class.isAssignableFrom(valueDeserializerClass)) {
+			throw new IllegalArgumentException("Value serializer is not implementing the org.apache.kafka.common.serialization.Deserializer interface");
+		}
+
+		this.keyDeserializerClass = Objects.requireNonNull(keyDeserializerClass, "Key deserializer is null");
+		this.valueDeserializerClass = Objects.requireNonNull(valueDeserializerClass, "Value deserializer is null");
+		this.producedType = new TupleTypeInfo<>(TypeExtractor.getForClass(keyType), TypeExtractor.getForClass(valueType));
+	}
+
+	public KafkaDeserializerWrapper(Class keyDeserializerClass, Class valueDeserializerClass, Class<K> keyType, Class<V> valueType, Map<String, ?> configs) {
+		this(keyDeserializerClass, valueDeserializerClass, keyType, valueType);
+		this.configs = configs;
+	}
+
+	// ------- Methods for deserialization -------
+
+	@Override
+	public TypeInformation<Tuple2<K,V>> getProducedType() {
+		return this.producedType;
+	}
+
+	@Override
+	public Tuple2<K, V> deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset) throws IOException {
+		if(!isInitialized) {
+			keyDeserializer = InstantiationUtil.instantiate(keyDeserializerClass, Deserializer.class);
+			keyDeserializer.configure(configs, true);
+			valueDeserializer = InstantiationUtil.instantiate(valueDeserializerClass, Deserializer.class);
+			valueDeserializer.configure(configs, false);
+			isInitialized = true;
+		}
+		K key = keyDeserializer.deserialize(topic, messageKey);
+		V value = valueDeserializer.deserialize(topic, message);
+		return Tuple2.of(key, value);
+	}
+
+
+	@Override
+	public boolean isEndOfStream(Tuple2<K, V> nextElement) {
+		return false;
+	}
+}

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KafkaSerializerWrapper.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KafkaSerializerWrapper.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util.serialization;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Wrapper for using a {@see org.apache.kafka.common.serialization.Serializer} with Apache Flink.
+ */
+public class KafkaSerializerWrapper<K, V> implements KeyedSerializationSchema<Tuple2<K,V>> {
+
+	private final Class<Serializer<K>> keySerializerClass;
+	private final Class<Serializer<V>> valueSerializerClass;
+	private Map<String, ?> configs;
+	private boolean isInitialized = false;
+	private Serializer<K> keySerializer;
+	private Serializer<V> valueSerializer;
+
+	// Kafka's Serializer.serialize(topic, message) method expects a topic-argument.
+	// Flink's serialize*() methods don't provide the topic.
+	// Some Kafka serializers expect the topic to be set. Therefore, there is a special
+	// configuration key to set the topic for the serializer through this wrapper.
+	private String topic = null;
+	public final static String SERIALIZER_TOPIC = "__FLINK_SERIALIZER_TOPIC";
+
+	@SuppressWarnings("unchecked")
+	public KafkaSerializerWrapper(Class keySerializerClass, Class valueSerializerClass) {
+		InstantiationUtil.checkForInstantiation(keySerializerClass);
+		InstantiationUtil.checkForInstantiation(valueSerializerClass);
+		if(!Serializer.class.isAssignableFrom(keySerializerClass)) {
+			throw new IllegalArgumentException("Key serializer is not implementing the org.apache.kafka.common.serialization.Serializer interface");
+		}
+		if(!Serializer.class.isAssignableFrom(valueSerializerClass)) {
+			throw new IllegalArgumentException("Value serializer is not implementing the org.apache.kafka.common.serialization.Serializer interface");
+		}
+
+		this.keySerializerClass = Objects.requireNonNull(keySerializerClass, "Key serializer is null");
+		this.valueSerializerClass = Objects.requireNonNull(valueSerializerClass, "Value serializer is null");
+	}
+
+	public KafkaSerializerWrapper(Class keySerializerClass, Class valueSerializerClass, Map<String, ?> configs) {
+		this(keySerializerClass, valueSerializerClass);
+		this.configs = configs;
+		Object topic = configs.get(SERIALIZER_TOPIC);
+		if(topic != null) {
+			if(!(topic instanceof String)) {
+				throw new IllegalArgumentException("The provided topic is not of type String");
+			}
+			this.topic = (String) topic;
+		}
+	}
+
+	private void initialize() {
+		keySerializer = InstantiationUtil.instantiate(keySerializerClass, Serializer.class);
+		keySerializer.configure(configs, true);
+		valueSerializer = InstantiationUtil.instantiate(valueSerializerClass, Serializer.class);
+		valueSerializer.configure(configs, false);
+		isInitialized = true;
+	}
+
+	@Override
+	public byte[] serializeKey(Tuple2<K, V> element) {
+		if(!isInitialized) {
+			initialize();
+		}
+		return keySerializer.serialize(this.topic, element.f0);
+	}
+
+	@Override
+	public byte[] serializeValue(Tuple2<K, V> element) {
+		if(!isInitialized) {
+			initialize();
+		}
+		return valueSerializer.serialize(this.topic, element.f1);
+	}
+
+	@Override
+	public String getTargetTopic(Tuple2<K, V> element) {
+		return null;
+	}
+}


### PR DESCRIPTION
This pull requests addresses the following JIRAs:
- [FLINK-2597
  Add a test for Avro-serialized Kafka messages](https://issues.apache.org/jira/browse/FLINK-2597)
- [FLINK-4050 FlinkKafkaProducer API Refactor](https://issues.apache.org/jira/browse/FLINK-4050)

The PR adds:
- `KafkaSerializerWrapper` and `KafkaDeserializerWrapper` wrappers for using Kafka serializers with Flink
- A test case involving Confluent's `KafkaAvroSerializer` and `KafkaAvroDeserializer`. They also use the schema registry from confluent (which I'm mocking with a simple test http server in the test).
- A test validating that we are properly calling Kafka partitioners with the producer
- Documentation for everything mentioned above.
