### PR TITLE
[FLINK-4939] GenericWriteAheadSink: Decouple the creating from the committing subtask for a pending checkpoint

### DIFF
--- a/flink-streaming-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-streaming-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -323,17 +323,14 @@ public class CassandraConnectorITCase extends WriteAheadSinkTestBase<Tuple3<Stri
 		CassandraCommitter cc1 = new CassandraCommitter(builder);
 		cc1.setJobId("job");
 		cc1.setOperatorId("operator");
-		cc1.setOperatorSubtaskId(0);
 
 		CassandraCommitter cc2 = new CassandraCommitter(builder);
 		cc2.setJobId("job");
 		cc2.setOperatorId("operator");
-		cc2.setOperatorSubtaskId(1);
 
 		CassandraCommitter cc3 = new CassandraCommitter(builder);
 		cc3.setJobId("job");
 		cc3.setOperatorId("operator1");
-		cc3.setOperatorSubtaskId(0);
 
 		cc1.createResource();
 
@@ -341,18 +338,18 @@ public class CassandraConnectorITCase extends WriteAheadSinkTestBase<Tuple3<Stri
 		cc2.open();
 		cc3.open();
 
-		Assert.assertFalse(cc1.isCheckpointCommitted(1));
-		Assert.assertFalse(cc2.isCheckpointCommitted(1));
-		Assert.assertFalse(cc3.isCheckpointCommitted(1));
+		Assert.assertFalse(cc1.isCheckpointCommitted(0, 1));
+		Assert.assertFalse(cc2.isCheckpointCommitted(1, 1));
+		Assert.assertFalse(cc3.isCheckpointCommitted(0, 1));
 
-		cc1.commitCheckpoint(1);
-		Assert.assertTrue(cc1.isCheckpointCommitted(1));
+		cc1.commitCheckpoint(0, 1);
+		Assert.assertTrue(cc1.isCheckpointCommitted(0, 1));
 		//verify that other sub-tasks aren't affected
-		Assert.assertFalse(cc2.isCheckpointCommitted(1));
+		Assert.assertFalse(cc2.isCheckpointCommitted(1, 1));
 		//verify that other tasks aren't affected
-		Assert.assertFalse(cc3.isCheckpointCommitted(1));
+		Assert.assertFalse(cc3.isCheckpointCommitted(0, 1));
 
-		Assert.assertFalse(cc1.isCheckpointCommitted(2));
+		Assert.assertFalse(cc1.isCheckpointCommitted(0, 2));
 
 		cc1.close();
 		cc2.close();
@@ -361,13 +358,12 @@ public class CassandraConnectorITCase extends WriteAheadSinkTestBase<Tuple3<Stri
 		cc1 = new CassandraCommitter(builder);
 		cc1.setJobId("job");
 		cc1.setOperatorId("operator");
-		cc1.setOperatorSubtaskId(0);
 
 		cc1.open();
 
 		//verify that checkpoint data is not destroyed within open/close and not reliant on internally cached data
-		Assert.assertTrue(cc1.isCheckpointCommitted(1));
-		Assert.assertFalse(cc1.isCheckpointCommitted(2));
+		Assert.assertTrue(cc1.isCheckpointCommitted(0, 1));
+		Assert.assertFalse(cc1.isCheckpointCommitted(0, 2));
 
 		cc1.close();
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/CheckpointCommitter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/CheckpointCommitter.java
@@ -90,7 +90,7 @@ public abstract class CheckpointCommitter implements Serializable {
 	 * Mark the given checkpoint as completed in the resource.
 	 *
 	 * @param subtaskIdx the index of the subtask responsible for committing the checkpoint.
-	 * @param checkpointID this id of the checkpoint to be committed.
+	 * @param checkpointID the id of the checkpoint to be committed.
 	 * @throws Exception
 	 */
 	public abstract void commitCheckpoint(int subtaskIdx, long checkpointID) throws Exception;
@@ -99,7 +99,7 @@ public abstract class CheckpointCommitter implements Serializable {
 	 * Checked the resource whether the given checkpoint was committed completely.
 	 *
 	 * @param subtaskIdx the index of the subtask responsible for committing the checkpoint.
-	 * @param checkpointID this id of the checkpoint we are interested in.
+	 * @param checkpointID the id of the checkpoint we are interested in.
 	 * @return true if the checkpoint was committed completely, false otherwise
 	 * @throws Exception
 	 */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/CheckpointCommitter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/CheckpointCommitter.java
@@ -40,10 +40,11 @@ import java.io.Serializable;
  * and as such should kept as small as possible.
  */
 public abstract class CheckpointCommitter implements Serializable {
+
 	protected static final Logger LOG = LoggerFactory.getLogger(CheckpointCommitter.class);
+
 	protected String jobId;
 	protected String operatorId;
-	protected int subtaskId;
 
 	/**
 	 * Internally used to set the job ID after instantiation.
@@ -63,16 +64,6 @@ public abstract class CheckpointCommitter implements Serializable {
 	 */
 	public void setOperatorId(String id) throws Exception {
 		this.operatorId = id;
-	}
-
-	/**
-	 * Internally used to set the operator subtask ID after instantiation.
-	 *
-	 * @param id
-	 * @throws Exception
-	 */
-	public void setOperatorSubtaskId(int id) throws Exception {
-		this.subtaskId = id;
 	}
 
 	/**
@@ -98,17 +89,19 @@ public abstract class CheckpointCommitter implements Serializable {
 	/**
 	 * Mark the given checkpoint as completed in the resource.
 	 *
-	 * @param checkpointID
+	 * @param subtaskIdx the index of the subtask responsible for committing the checkpoint.
+	 * @param checkpointID this id of the checkpoint to be committed.
 	 * @throws Exception
 	 */
-	public abstract void commitCheckpoint(long checkpointID) throws Exception;
+	public abstract void commitCheckpoint(int subtaskIdx, long checkpointID) throws Exception;
 
 	/**
 	 * Checked the resource whether the given checkpoint was committed completely.
 	 *
-	 * @param checkpointID
+	 * @param subtaskIdx the index of the subtask responsible for committing the checkpoint.
+	 * @param checkpointID this id of the checkpoint we are interested in.
 	 * @return true if the checkpoint was committed completely, false otherwise
 	 * @throws Exception
 	 */
-	public abstract boolean isCheckpointCommitted(long checkpointID) throws Exception;
+	public abstract boolean isCheckpointCommitted(int subtaskIdx, long checkpointID) throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.runtime.operators;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
@@ -27,27 +26,30 @@ import org.apache.flink.runtime.io.disk.InputViewIterator;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.util.ReusingMutableToRegularIteratorWrapper;
-import org.apache.flink.streaming.api.operators.StreamCheckpointedOperator;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamCheckpointedOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 
 /**
- * Generic Sink that emits its input elements into an arbitrary backend. This sink is integrated with the checkpointing
- * mechanism and can provide exactly-once guarantees; depending on the storage backend and sink/committer implementation.
+ * Generic Sink that emits its input elements into an arbitrary backend. This sink is integrated with
+ * Flink's checkpointing mechanism and can provide exactly-once guarantees; depending on the storage
+ * backend and sink/committer implementation.
  * <p/>
- * Incoming records are stored within a {@link org.apache.flink.runtime.state.AbstractStateBackend}, and only committed if a
- * checkpoint is completed.
+ * Incoming records are stored within a {@link org.apache.flink.runtime.state.AbstractStateBackend}, and
+ * only committed if a checkpoint is completed.
  *
  * @param <IN> Type of the elements emitted by this sink
  */
@@ -57,18 +59,25 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 	private static final long serialVersionUID = 1L;
 
 	protected static final Logger LOG = LoggerFactory.getLogger(GenericWriteAheadSink.class);
-	private final CheckpointCommitter committer;
-	private transient CheckpointStreamFactory.CheckpointStateOutputStream out;
-	protected final TypeSerializer<IN> serializer;
+
 	private final String id;
+	private final CheckpointCommitter committer;
+	protected final TypeSerializer<IN> serializer;
+
+	private transient CheckpointStreamFactory.CheckpointStateOutputStream out;
 	private transient CheckpointStreamFactory checkpointStreamFactory;
 
-	private ExactlyOnceState state = new ExactlyOnceState();
+	private final TreeMap<PendingCheckpointId, PendingHandle> pendingHandles = new TreeMap<>();
 
-	public GenericWriteAheadSink(CheckpointCommitter committer, TypeSerializer<IN> serializer, String jobID) throws Exception {
-		this.committer = committer;
-		this.serializer = serializer;
+	public GenericWriteAheadSink(
+			CheckpointCommitter committer,
+			TypeSerializer<IN> serializer,
+			String jobID) throws Exception {
+
+		this.committer = Preconditions.checkNotNull(committer);
+		this.serializer = Preconditions.checkNotNull(serializer);
 		this.id = UUID.randomUUID().toString();
+
 		this.committer.setJobId(jobID);
 		this.committer.createResource();
 	}
@@ -77,11 +86,12 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 	public void open() throws Exception {
 		super.open();
 		committer.setOperatorId(id);
-		committer.setOperatorSubtaskId(getRuntimeContext().getIndexOfThisSubtask());
 		committer.open();
-		cleanState();
-		checkpointStreamFactory =
-				getContainingTask().createCheckpointStreamFactory(this);
+
+		checkpointStreamFactory = getContainingTask()
+			.createCheckpointStreamFactory(this);
+
+		cleanRestoredHandles();
 	}
 
 	public void close() throws Exception {
@@ -89,51 +99,83 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 	}
 
 	/**
-	 * Saves a handle in the state.
+	 * Called when a checkpoint barrier arrives.
+	 * Closes any open streams to the backend and marks them as pending for
+	 * committing to the final output system, e.g. Cassandra.
 	 *
-	 * @param checkpointId
-	 * @throws IOException
+	 * @param checkpointId the id of the latest received checkpoint.
+	 * @throws IOException in case something went wrong when handling the stream to the backend.
 	 */
 	private void saveHandleInState(final long checkpointId, final long timestamp) throws Exception {
+		Preconditions.checkNotNull(this.pendingHandles, "The operator has not been properly initialized.");
+
 		//only add handle if a new OperatorState was created since the last snapshot
 		if (out != null) {
 			StreamStateHandle handle = out.closeAndGetHandle();
-			if (state.pendingHandles.containsKey(checkpointId)) {
+
+			PendingCheckpointId pendingCheckpoint = new PendingCheckpointId(
+				checkpointId, getRuntimeContext().getIndexOfThisSubtask());
+
+			if (pendingHandles.containsKey(pendingCheckpoint)) {
 				//we already have a checkpoint stored for that ID that may have been partially written,
 				//so we discard this "alternate version" and use the stored checkpoint
 				handle.discardState();
 			} else {
-				state.pendingHandles.put(checkpointId, new Tuple2<>(timestamp, handle));
+				this.pendingHandles.put(pendingCheckpoint, new PendingHandle(timestamp, handle));
 			}
 			out = null;
 		}
 	}
 
 	@Override
-	public void snapshotState(FSDataOutputStream out,
-			long checkpointId,
-			long timestamp) throws Exception {
+	public void snapshotState(FSDataOutputStream out, long checkpointId, long timestamp) throws Exception {
 		saveHandleInState(checkpointId, timestamp);
 
-		InstantiationUtil.serializeObject(out, state);
+		DataOutputViewStreamWrapper outStream = new DataOutputViewStreamWrapper(out);
+		outStream.writeInt(pendingHandles.size());
+		for (Map.Entry<PendingCheckpointId, PendingHandle> pendingCheckpoint : pendingHandles.entrySet()) {
+			pendingCheckpoint.getKey().serialize(outStream);
+			pendingCheckpoint.getValue().serialize(outStream);
+		}
 	}
 
 	@Override
 	public void restoreState(FSDataInputStream in) throws Exception {
-		this.state = InstantiationUtil.deserializeObject(in, getUserCodeClassloader());
+		final DataInputViewStreamWrapper inStream = new DataInputViewStreamWrapper(in);
+		int noOfPendingHandles = inStream.readInt();
+		for (int i = 0; i < noOfPendingHandles; i++) {
+			PendingCheckpointId id = PendingCheckpointId.restore(inStream);
+			PendingHandle handle = PendingHandle.restore(inStream, getUserCodeClassloader());
+			this.pendingHandles.put(id, handle);
+		}
 	}
 
-	private void cleanState() throws Exception {
-		synchronized (this.state.pendingHandles) { //remove all handles that were already committed
-			Set<Long> pastCheckpointIds = this.state.pendingHandles.keySet();
-			Set<Long> checkpointsToRemove = new HashSet<>();
-			for (Long pastCheckpointId : pastCheckpointIds) {
-				if (committer.isCheckpointCommitted(pastCheckpointId)) {
-					checkpointsToRemove.add(pastCheckpointId);
+	/**
+	 * Called at {@link #open()} to clean-up the pending handle list.
+	 * It iterates over all restored pending handles, checks which ones are already
+	 * committed to the outside storage system and removes them from the list.
+	 */
+	private void cleanRestoredHandles() throws Exception {
+		synchronized (pendingHandles) {
+
+			Set<PendingCheckpointId> checkpointIdsToRemove = new HashSet<>();
+
+			// for each of the pending handles...
+			for (Map.Entry<PendingCheckpointId, PendingHandle> restoredHandle : pendingHandles.entrySet()) {
+				PendingCheckpointId id = restoredHandle.getKey();
+				PendingHandle handle = restoredHandle.getValue();
+
+				//...check if the temporary buffer is already committed and if yes,
+				// add it in the list of checkpoints to be permanently removed...
+				if (committer.isCheckpointCommitted(id.subtaskId, id.checkpointId)) {
+					handle.stateHandle.discardState();
+					checkpointIdsToRemove.add(id);
 				}
 			}
-			for (Long toRemove : checkpointsToRemove) {
-				this.state.pendingHandles.remove(toRemove);
+
+			// ...finally cleanup the map of pending handles per checkpoint id.
+			for (PendingCheckpointId checkpointId: checkpointIdsToRemove) {
+				pendingHandles.remove(checkpointId);
 			}
 		}
 	}
@@ -142,15 +184,24 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 	public void notifyOfCompletedCheckpoint(long checkpointId) throws Exception {
 		super.notifyOfCompletedCheckpoint(checkpointId);
 
-		synchronized (state.pendingHandles) {
-			Set<Long> pastCheckpointIds = state.pendingHandles.keySet();
-			Set<Long> checkpointsToRemove = new HashSet<>();
-			for (Long pastCheckpointId : pastCheckpointIds) {
+		synchronized (pendingHandles) {
+			Set<PendingCheckpointId> checkpointsToRemove = new HashSet<>();
+
+			for (Map.Entry<PendingCheckpointId, PendingHandle> pendingHandle : pendingHandles.entrySet()) {
+
+				PendingCheckpointId pendingId = pendingHandle.getKey();
+				long pastCheckpointId = pendingId.checkpointId;
+				int subtaskId = pendingId.subtaskId;
+
 				if (pastCheckpointId <= checkpointId) {
+
+					PendingHandle handle = pendingHandle.getValue();
+					long timestamp = handle.timestamp;
+					StreamStateHandle streamHandle = handle.stateHandle;
+
 					try {
-						if (!committer.isCheckpointCommitted(pastCheckpointId)) {
-							Tuple2<Long, StreamStateHandle> handle = state.pendingHandles.get(pastCheckpointId);
-							try (FSDataInputStream in = handle.f1.openInputStream()) {
+						if (!committer.isCheckpointCommitted(subtaskId, pastCheckpointId)) {
+							try (FSDataInputStream in = streamHandle.openInputStream()) {
 								boolean success = sendValues(
 										new ReusingMutableToRegularIteratorWrapper<>(
 												new InputViewIterator<>(
@@ -158,29 +209,36 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 																in),
 														serializer),
 												serializer),
-										handle.f0);
-								if (success) { //if the sending has failed we will retry on the next notify
-									committer.commitCheckpoint(pastCheckpointId);
-									checkpointsToRemove.add(pastCheckpointId);
+										timestamp);
+								if (success) {
+									// in case the checkpoint was successfully committed, discard its state from the
+									// backend and mark it for removal
+									// in case it failed, we retry on the next checkpoint
+
+									committer.commitCheckpoint(subtaskId, pastCheckpointId);
+									streamHandle.discardState();
+									checkpointsToRemove.add(pendingId);
 								}
 							}
 						} else {
-							checkpointsToRemove.add(pastCheckpointId);
+							streamHandle.discardState();
+							checkpointsToRemove.add(pendingId);
 						}
 					} catch (Exception e) {
+						// we have to break here to prevent a new (later) checkpoint
+						// from being committed before this one
 						LOG.error("Could not commit checkpoint.", e);
-						break; // we have to break here to prevent a new checkpoint from being committed before this one
+						break;
 					}
 				}
 			}
-			for (Long toRemove : checkpointsToRemove) {
-				Tuple2<Long, StreamStateHandle> handle = state.pendingHandles.get(toRemove);
-				state.pendingHandles.remove(toRemove);
-				handle.f1.discardState();
+
+			// ...finally remove the checkpoints that are marked as committed
+			for (PendingCheckpointId toRemove : checkpointsToRemove) {
+				pendingHandles.remove(toRemove);
 			}
 		}
 	}
-
 
 	/**
 	 * Write the given element into the backend.
@@ -201,27 +259,83 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 		serializer.serialize(value, new DataOutputViewStreamWrapper(out));
 	}
 
-	/**
-	 * This state is used to keep a list of all StateHandles (essentially references to past OperatorStates) that were
-	 * used since the last completed checkpoint.
-	 **/
-	public static class ExactlyOnceState implements Serializable {
+	private static final class PendingCheckpointId implements Comparable<PendingCheckpointId>, Serializable {
 
-		private static final long serialVersionUID = -3571063495273460743L;
+		private static final long serialVersionUID = -3571036395734603443L;
 
-		protected TreeMap<Long, Tuple2<Long, StreamStateHandle>> pendingHandles;
+		private final long checkpointId;
+		private final int subtaskId;
 
-		public ExactlyOnceState() {
-			pendingHandles = new TreeMap<>();
+		PendingCheckpointId(long checkpointId, int subtaskId) {
+			this.checkpointId = checkpointId;
+			this.subtaskId = subtaskId;
 		}
 
-		public TreeMap<Long, Tuple2<Long, StreamStateHandle>> getState(ClassLoader userCodeClassLoader) throws Exception {
-			return pendingHandles;
+		void serialize(DataOutputViewStreamWrapper outputStream) throws IOException {
+			outputStream.writeLong(this.checkpointId);
+			outputStream.writeInt(this.subtaskId);
+		}
+
+		static PendingCheckpointId restore(DataInputViewStreamWrapper inputStream) throws IOException, ClassNotFoundException {
+			long checkpointId = inputStream.readLong();
+			int subtaskId = inputStream.readInt();
+			return new PendingCheckpointId(checkpointId, subtaskId);
 		}
 
 		@Override
-		public String toString() {
-			return this.pendingHandles.toString();
+		public int compareTo(PendingCheckpointId o) {
+			if (o == null) {
+				return -1;
+			}
+
+			long res = this.checkpointId - o.checkpointId;
+			if (res == 0) {
+				return this.subtaskId - o.subtaskId;
+			}
+
+			// we cannot just cast it to int as it may overflow
+			return res < 0 ? -1 : 1;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (o == null || !(o instanceof PendingCheckpointId)) {
+				return false;
+			}
+			PendingCheckpointId other = (PendingCheckpointId) o;
+			return this.checkpointId == other.checkpointId &&
+				this.subtaskId == other.subtaskId;
+		}
+
+		@Override
+		public int hashCode() {
+			return 37 * (int)(checkpointId ^ (checkpointId >>> 32)) + subtaskId;
+		}
+	}
+
+	private static final class PendingHandle implements Serializable {
+
+		private static final long serialVersionUID = -3571063495734603443L;
+
+		private final long timestamp;
+		private final StreamStateHandle stateHandle;
+
+		PendingHandle(long timestamp, StreamStateHandle handle) {
+			this.timestamp = timestamp;
+			this.stateHandle = handle;
+		}
+
+		void serialize(DataOutputViewStreamWrapper outputStream) throws IOException {
+			outputStream.writeLong(timestamp);
+			InstantiationUtil.serializeObject(outputStream, stateHandle);
+		}
+
+		static PendingHandle restore(
+			DataInputViewStreamWrapper inputStream, ClassLoader classLoader) throws IOException, ClassNotFoundException {
+
+			long timestamp = inputStream.readLong();
+			StreamStateHandle handle = InstantiationUtil.deserializeObject(inputStream, classLoader);
+			return new PendingHandle(timestamp, handle);
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
@@ -104,8 +104,7 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 	 * @throws IOException in case something went wrong when handling the stream to the backend.
 	 */
 	private void saveHandleInState(final long checkpointId, final long timestamp) throws Exception {
-		Preconditions.checkNotNull(this.pendingCheckpoints, "The operator has not been properly initialized.");
-
+		
 		//only add handle if a new OperatorState was created since the last snapshot
 		if (out != null) {
 			int subtaskIdx = getRuntimeContext().getIndexOfThisSubtask();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSinkTest.java
@@ -133,7 +133,7 @@ public class GenericWriteAheadSinkTest extends WriteAheadSinkTestBase<Tuple1<Int
 		testHarness.notifyOfCompletedCheckpoint(0);
 
 		//isCommitted should have failed, thus sendValues() should never have been called
-		Assert.assertTrue(sink.values.size() == 0);
+		Assert.assertEquals(0, sink.values.size());
 
 		for (int x = 0; x < 10; x++) {
 			testHarness.processElement(new StreamRecord<>(generateValue(elementCounter, 1)));
@@ -144,7 +144,7 @@ public class GenericWriteAheadSinkTest extends WriteAheadSinkTestBase<Tuple1<Int
 		testHarness.notifyOfCompletedCheckpoint(1);
 
 		//previous CP should be retried, but will fail the CP commit. Second CP should be skipped.
-		Assert.assertTrue(sink.values.size() == 10);
+		Assert.assertEquals(10, sink.values.size());
 
 		for (int x = 0; x < 10; x++) {
 			testHarness.processElement(new StreamRecord<>(generateValue(elementCounter, 2)));
@@ -155,7 +155,7 @@ public class GenericWriteAheadSinkTest extends WriteAheadSinkTestBase<Tuple1<Int
 		testHarness.notifyOfCompletedCheckpoint(2);
 
 		//all CP's should be retried and succeed; since one CP was written twice we have 2 * 10 + 10 + 10 = 40 values
-		Assert.assertTrue(sink.values.size() == 40);
+		Assert.assertEquals(40, sink.values.size());
 	}
 
 	/**
@@ -198,12 +198,12 @@ public class GenericWriteAheadSinkTest extends WriteAheadSinkTestBase<Tuple1<Int
 		}
 
 		@Override
-		public void commitCheckpoint(long checkpointID) {
+		public void commitCheckpoint(int subtaskIdx, long checkpointID) {
 			checkpoints.add(checkpointID);
 		}
 
 		@Override
-		public boolean isCheckpointCommitted(long checkpointID) {
+		public boolean isCheckpointCommitted(int subtaskIdx, long checkpointID) {
 			return checkpoints.contains(checkpointID);
 		}
 	}
@@ -250,7 +250,7 @@ public class GenericWriteAheadSinkTest extends WriteAheadSinkTestBase<Tuple1<Int
 		}
 
 		@Override
-		public void commitCheckpoint(long checkpointID) {
+		public void commitCheckpoint(int subtaskIdx, long checkpointID) {
 			if (failCommit) {
 				failCommit = false;
 				throw new RuntimeException("Expected exception");
@@ -260,7 +260,7 @@ public class GenericWriteAheadSinkTest extends WriteAheadSinkTestBase<Tuple1<Int
 		}
 
 		@Override
-		public boolean isCheckpointCommitted(long checkpointID) {
+		public boolean isCheckpointCommitted(int subtaskIdx, long checkpointID) {
 			if (failIsCommitted) {
 				failIsCommitted = false;
 				throw new RuntimeException("Expected exception");

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/WriteAheadSinkTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/WriteAheadSinkTestBase.java
@@ -155,7 +155,7 @@ public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink
 
 		sink = createSink();
 
-		testHarness =new OneInputStreamOperatorTestHarness<>(sink);
+		testHarness = new OneInputStreamOperatorTestHarness<>(sink);
 
 		testHarness.setup();
 		testHarness.restore(latestSnapshot);


### PR DESCRIPTION
So far the `GenericWriteAheadSink` expected that the subtask that wrote a temporary buffer to the state backend upon checkpointing, will be also the one to commit it to the third-party storage system.

This commit removes this assumption. To do this it changes the `CheckpointCommitter` to dynamically take the subtaskIdx as a parameter when committing something to the third-party storage system ( `void commitCheckpoint(int subtaskIdx, long checkpointID)` ) and when asking if a checkpoint was committed ( `boolean isCheckpointCommitted(int subtaskIdx, long checkpointID)` ) and also changes the state kept by the `GenericWriteAheadSink` to also
include that subtask index of the subtask that wrote the pending buffer. 
