### PR TITLE
[FLINK-4631] Avoided NPE in OneInputStreamTask.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -70,7 +70,9 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 
 	@Override
 	protected void cleanup() throws Exception {
-		inputProcessor.cleanup();
+		if (inputProcessor != null) {
+			inputProcessor.cleanup();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Added additional condition to check possible NPE. This PR solve [FLINK-4631](https://issues.apache.org/jira/browse/FLINK-4631).