### PR TITLE
[FLINK-4445] Add option to ignore unmapped checkpoint state

### DIFF
--- a/docs/setup/cli.md
+++ b/docs/setup/cli.md
@@ -168,10 +168,10 @@ The job will only be cancelled if the savepoint succeeds.
 
 The run command has a savepoint flag to submit a job, which restores its state from a savepoint. The savepoint path is returned by the savepoint trigger command.
 
-By default, we try to match all savepoint state to the job being submitted. If you want to ignore savepoint state that cannot be mapped to the new job, you can set the `ignoreUnmappedState` flag:
+By default, we try to match all savepoint state to the job being submitted. If you want to allow to skip savepoint state that cannot be restored with the new job you can set the `allowNonRestoredState` flag. You need to allow this if you removed an operator from your program that was part of the program when the savepoint was triggered and you still want to use the savepoint.
 
 {% highlight bash %}
-./bin/flink run -s <savepointPath> -i ...
+./bin/flink run -s <savepointPath> -a ...
 {% endhighlight %}
 
 This is useful if your program dropped an operator that was part of the savepoint.
@@ -205,6 +205,9 @@ Action "run" compiles and runs a program.
 
   Syntax: run [OPTIONS] <jar-file> <arguments>
   "run" action options:
+     -a,--allowNonRestoredState                     Allow non restored savepoint
+                                                    state in case an operator has
+                                                    been removed from the job.
      -c,--class <classname>                         Class with the program entry
                                                     point ("main" method or
                                                     "getPlan()" method. Only
@@ -225,10 +228,6 @@ Action "run" compiles and runs a program.
                                                     java.net.URLClassLoader}.
      -d,--detached                                  If present, runs the job in
                                                     detached mode
-     -i,--ignoreUnmappedState                       Flag indicating whether
-                                                    savepoint state that cannot
-                                                    be mapped to the job shall
-                                                    be ignored.
      -m,--jobmanager <host:port>                    Address of the JobManager
                                                     (master) to which to
                                                     connect. Use this flag to

--- a/docs/setup/cli.md
+++ b/docs/setup/cli.md
@@ -168,6 +168,14 @@ The job will only be cancelled if the savepoint succeeds.
 
 The run command has a savepoint flag to submit a job, which restores its state from a savepoint. The savepoint path is returned by the savepoint trigger command.
 
+By default, we try to match all savepoint state to the job being submitted. If you want to ignore savepoint state that cannot be mapped to the new job, you can set the `ignoreUnmappedState` flag:
+
+{% highlight bash %}
+./bin/flink run -s <savepointPath> -i ...
+{% endhighlight %}
+
+This is useful if your program dropped an operator that was part of the savepoint.
+
 #### Dispose a savepoint
 
 {% highlight bash %}
@@ -217,6 +225,10 @@ Action "run" compiles and runs a program.
                                                     java.net.URLClassLoader}.
      -d,--detached                                  If present, runs the job in
                                                     detached mode
+     -i,--ignoreUnmappedState                       Flag indicating whether
+                                                    savepoint state that cannot
+                                                    be mapped to the job shall
+                                                    be ignored.
      -m,--jobmanager <host:port>                    Address of the JobManager
                                                     (master) to which to
                                                     connect. Use this flag to
@@ -231,13 +243,15 @@ Action "run" compiles and runs a program.
                                                     configuration.
      -q,--sysoutLogging                             If present, suppress logging
                                                     output to standard out.
-     -s,--fromSavepoint <savepointPath>             Path to a savepoint to reset
-                                                    the job back to (for example
-                                                    file:///flink/savepoint-1537
+     -s,--fromSavepoint <savepointPath>             Path to a savepoint to
+                                                    restore the job from (for
+                                                    example
+                                                    hdfs:///flink/savepoint-1537
                                                     ).
      -z,--zookeeperNamespace <zookeeperNamespace>   Namespace to create the
                                                     Zookeeper sub-paths for high
                                                     availability mode
+
   Options for yarn-cluster mode:
      -yD <arg>                            Dynamic properties
      -yd,--yarndetached                   Start detached

--- a/docs/setup/cli.md
+++ b/docs/setup/cli.md
@@ -171,7 +171,7 @@ The run command has a savepoint flag to submit a job, which restores its state f
 By default, we try to match all savepoint state to the job being submitted. If you want to allow to skip savepoint state that cannot be restored with the new job you can set the `allowNonRestoredState` flag. You need to allow this if you removed an operator from your program that was part of the program when the savepoint was triggered and you still want to use the savepoint.
 
 {% highlight bash %}
-./bin/flink run -s <savepointPath> -a ...
+./bin/flink run -s <savepointPath> -n ...
 {% endhighlight %}
 
 This is useful if your program dropped an operator that was part of the savepoint.
@@ -205,9 +205,6 @@ Action "run" compiles and runs a program.
 
   Syntax: run [OPTIONS] <jar-file> <arguments>
   "run" action options:
-     -a,--allowNonRestoredState                     Allow non restored savepoint
-                                                    state in case an operator has
-                                                    been removed from the job.
      -c,--class <classname>                         Class with the program entry
                                                     point ("main" method or
                                                     "getPlan()" method. Only
@@ -235,6 +232,9 @@ Action "run" compiles and runs a program.
                                                     JobManager than the one
                                                     specified in the
                                                     configuration.
+     -n,--allowNonRestoredState                     Allow non restored savepoint
+                                                    state in case an operator has
+                                                    been removed from the job.
      -p,--parallelism <parallelism>                 The parallelism with which
                                                     to run the program. Optional
                                                     flag to override the default

--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -241,7 +241,7 @@ public class CliFrontend {
 			client.setDetached(options.getDetachedMode());
 			LOG.debug("Client slots is set to {}", client.getMaxSlots());
 
-			LOG.debug("Savepoint path is set to {}", options.getSavepointPath());
+			LOG.debug(options.getSavepointRestoreSettings().toString());
 
 			int userParallelism = options.getParallelism();
 			LOG.debug("User parallelism is set to {}", userParallelism);
@@ -890,7 +890,7 @@ public class CliFrontend {
 				new PackagedProgram(jarFile, classpaths, programArgs) :
 				new PackagedProgram(jarFile, classpaths, entryPointClass, programArgs);
 
-		program.setSavepointPath(options.getSavepointPath());
+		program.setSavepointRestoreSettings(options.getSavepointRestoreSettings());
 
 		return program;
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -72,7 +72,7 @@ public class CliFrontendParser {
 	static final Option SAVEPOINT_PATH_OPTION = new Option("s", "fromSavepoint", true,
 			"Path to a savepoint to restore the job from (for example hdfs:///flink/savepoint-1537).");
 
-	static final Option SAVEPOINT_ALLOW_NON_RESTORED_OPTION = new Option("a", "allowNonRestoredState", false,
+	static final Option SAVEPOINT_ALLOW_NON_RESTORED_OPTION = new Option("n", "allowNonRestoredState", false,
 			"Allow to skip savepoint state that cannot be restored. " +
 					"You need to allow this if you removed an operator from your " +
 					"program that was part of the program when the savepoint was triggered.");

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -70,7 +70,10 @@ public class CliFrontendParser {
 			"Use this flag to connect to a different JobManager than the one specified in the configuration.");
 
 	static final Option SAVEPOINT_PATH_OPTION = new Option("s", "fromSavepoint", true,
-			"Path to a savepoint to reset the job back to (for example file:///flink/savepoint-1537).");
+			"Path to a savepoint to restore the job from (for example hdfs:///flink/savepoint-1537).");
+
+	static final Option SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION = new Option("i", "ignoreUnmappedState", false,
+			"Flag indicating whether savepoint state that cannot be mapped to the job shall be ignored.");
 
 	static final Option SAVEPOINT_DISPOSE_OPTION = new Option("d", "dispose", true,
 			"Path of savepoint to dispose.");
@@ -121,6 +124,8 @@ public class CliFrontendParser {
 		SAVEPOINT_PATH_OPTION.setRequired(false);
 		SAVEPOINT_PATH_OPTION.setArgName("savepointPath");
 
+		SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION.setRequired(false);
+
 		ZOOKEEPER_NAMESPACE_OPTION.setRequired(false);
 		ZOOKEEPER_NAMESPACE_OPTION.setArgName("zookeeperNamespace");
 
@@ -155,7 +160,6 @@ public class CliFrontendParser {
 		options.addOption(ARGS_OPTION);
 		options.addOption(LOGGING_OPTION);
 		options.addOption(DETACHED_OPTION);
-		options.addOption(SAVEPOINT_PATH_OPTION);
 		options.addOption(ZOOKEEPER_NAMESPACE_OPTION);
 		return options;
 	}
@@ -166,13 +170,15 @@ public class CliFrontendParser {
 		options.addOption(PARALLELISM_OPTION);
 		options.addOption(LOGGING_OPTION);
 		options.addOption(DETACHED_OPTION);
-		options.addOption(SAVEPOINT_PATH_OPTION);
 		options.addOption(ZOOKEEPER_NAMESPACE_OPTION);
 		return options;
 	}
 
 	private static Options getRunOptions(Options options) {
 		options = getProgramSpecificOptions(options);
+		options.addOption(SAVEPOINT_PATH_OPTION);
+		options.addOption(SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION);
+
 		options = getJobManagerAddressOption(options);
 		return addCustomCliOptions(options, true);
 	}
@@ -220,6 +226,9 @@ public class CliFrontendParser {
 
 	private static Options getRunOptionsWithoutDeprecatedOptions(Options options) {
 		Options o = getProgramSpecificOptionsWithoutDeprecatedOptions(options);
+		o.addOption(SAVEPOINT_PATH_OPTION);
+		o.addOption(SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION);
+
 		return getJobManagerAddressOption(o);
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -72,8 +72,10 @@ public class CliFrontendParser {
 	static final Option SAVEPOINT_PATH_OPTION = new Option("s", "fromSavepoint", true,
 			"Path to a savepoint to restore the job from (for example hdfs:///flink/savepoint-1537).");
 
-	static final Option SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION = new Option("i", "ignoreUnmappedState", false,
-			"Flag indicating whether savepoint state that cannot be mapped to the job shall be ignored.");
+	static final Option SAVEPOINT_ALLOW_NON_RESTORED_OPTION = new Option("a", "allowNonRestoredState", false,
+			"Allow to skip savepoint state that cannot be restored. " +
+					"You need to allow this if you removed an operator from your " +
+					"program that was part of the program when the savepoint was triggered.");
 
 	static final Option SAVEPOINT_DISPOSE_OPTION = new Option("d", "dispose", true,
 			"Path of savepoint to dispose.");
@@ -124,7 +126,7 @@ public class CliFrontendParser {
 		SAVEPOINT_PATH_OPTION.setRequired(false);
 		SAVEPOINT_PATH_OPTION.setArgName("savepointPath");
 
-		SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION.setRequired(false);
+		SAVEPOINT_ALLOW_NON_RESTORED_OPTION.setRequired(false);
 
 		ZOOKEEPER_NAMESPACE_OPTION.setRequired(false);
 		ZOOKEEPER_NAMESPACE_OPTION.setArgName("zookeeperNamespace");
@@ -177,7 +179,7 @@ public class CliFrontendParser {
 	private static Options getRunOptions(Options options) {
 		options = getProgramSpecificOptions(options);
 		options.addOption(SAVEPOINT_PATH_OPTION);
-		options.addOption(SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION);
+		options.addOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION);
 
 		options = getJobManagerAddressOption(options);
 		return addCustomCliOptions(options, true);
@@ -227,7 +229,7 @@ public class CliFrontendParser {
 	private static Options getRunOptionsWithoutDeprecatedOptions(Options options) {
 		Options o = getProgramSpecificOptionsWithoutDeprecatedOptions(options);
 		o.addOption(SAVEPOINT_PATH_OPTION);
-		o.addOption(SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION);
+		o.addOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION);
 
 		return getJobManagerAddressOption(o);
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
@@ -34,7 +34,7 @@ import static org.apache.flink.client.cli.CliFrontendParser.DETACHED_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.JAR_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.LOGGING_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PARALLELISM_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_ALLOW_NON_RESTORED_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_PATH_OPTION;
 
 /**
@@ -114,8 +114,8 @@ public abstract class ProgramOptions extends CommandLineOptions {
 
 		if (line.hasOption(SAVEPOINT_PATH_OPTION.getOpt())) {
 			String savepointPath = line.getOptionValue(SAVEPOINT_PATH_OPTION.getOpt());
-			boolean ignoreUnmappedState = line.hasOption(SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION.getOpt());
-			this.savepointSettings = SavepointRestoreSettings.forPath(savepointPath, ignoreUnmappedState);
+			boolean allowNonRestoredState = line.hasOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION.getOpt());
+			this.savepointSettings = SavepointRestoreSettings.forPath(savepointPath, allowNonRestoredState);
 		} else {
 			this.savepointSettings = SavepointRestoreSettings.none();
 		}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
@@ -19,6 +19,7 @@ package org.apache.flink.client.cli;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -33,6 +34,7 @@ import static org.apache.flink.client.cli.CliFrontendParser.DETACHED_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.JAR_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.LOGGING_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PARALLELISM_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_PATH_OPTION;
 
 /**
@@ -54,7 +56,7 @@ public abstract class ProgramOptions extends CommandLineOptions {
 
 	private final boolean detachedMode;
 
-	private final String savepointPath;
+	private final SavepointRestoreSettings savepointSettings;
 
 	protected ProgramOptions(CommandLine line) throws CliArgsException {
 		super(line);
@@ -111,9 +113,11 @@ public abstract class ProgramOptions extends CommandLineOptions {
 		detachedMode = line.hasOption(DETACHED_OPTION.getOpt());
 
 		if (line.hasOption(SAVEPOINT_PATH_OPTION.getOpt())) {
-			savepointPath = line.getOptionValue(SAVEPOINT_PATH_OPTION.getOpt());
+			String savepointPath = line.getOptionValue(SAVEPOINT_PATH_OPTION.getOpt());
+			boolean ignoreUnmappedState = line.hasOption(SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION.getOpt());
+			this.savepointSettings = SavepointRestoreSettings.forPath(savepointPath, ignoreUnmappedState);
 		} else {
-			savepointPath = null;
+			this.savepointSettings = SavepointRestoreSettings.none();
 		}
 	}
 
@@ -145,7 +149,7 @@ public abstract class ProgramOptions extends CommandLineOptions {
 		return detachedMode;
 	}
 
-	public String getSavepointPath() {
-		return savepointPath;
+	public SavepointRestoreSettings getSavepointRestoreSettings() {
+		return savepointSettings;
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
 import java.net.URL;
 import java.util.List;
@@ -42,15 +43,15 @@ public class ContextEnvironment extends ExecutionEnvironment {
 	
 	protected final ClassLoader userCodeClassLoader;
 
-	protected final String savepointPath;
+	protected final SavepointRestoreSettings savepointSettings;
 	
 	public ContextEnvironment(ClusterClient remoteConnection, List<URL> jarFiles, List<URL> classpaths,
-				ClassLoader userCodeClassLoader, String savepointPath) {
+				ClassLoader userCodeClassLoader, SavepointRestoreSettings savepointSettings) {
 		this.client = remoteConnection;
 		this.jarFilesToAttach = jarFiles;
 		this.classpathsToAttach = classpaths;
 		this.userCodeClassLoader = userCodeClassLoader;
-		this.savepointPath = savepointPath;
+		this.savepointSettings = savepointSettings;
 	}
 
 	@Override
@@ -58,7 +59,7 @@ public class ContextEnvironment extends ExecutionEnvironment {
 		Plan p = createProgramPlan(jobName);
 		JobWithJars toRun = new JobWithJars(p, this.jarFilesToAttach, this.classpathsToAttach,
 				this.userCodeClassLoader);
-		this.lastJobExecutionResult = client.run(toRun, getParallelism(), savepointPath).getJobExecutionResult();
+		this.lastJobExecutionResult = client.run(toRun, getParallelism(), savepointSettings).getJobExecutionResult();
 		return this.lastJobExecutionResult;
 	}
 
@@ -99,8 +100,8 @@ public class ContextEnvironment extends ExecutionEnvironment {
 		return userCodeClassLoader;
 	}
 
-	public String getSavepointPath() {
-		return savepointPath;
+	public SavepointRestoreSettings getSavepointRestoreSettings() {
+		return savepointSettings;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironmentFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironmentFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.client.program;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
 import java.net.URL;
 import java.util.List;
@@ -46,11 +47,11 @@ public class ContextEnvironmentFactory implements ExecutionEnvironmentFactory {
 
 	private ExecutionEnvironment lastEnvCreated;
 
-	private String savepointPath;
+	private SavepointRestoreSettings savepointSettings;
 
 	public ContextEnvironmentFactory(ClusterClient client, List<URL> jarFilesToAttach,
 			List<URL> classpathsToAttach, ClassLoader userCodeClassLoader, int defaultParallelism,
-			boolean isDetached, String savepointPath)
+			boolean isDetached, SavepointRestoreSettings savepointSettings)
 	{
 		this.client = client;
 		this.jarFilesToAttach = jarFilesToAttach;
@@ -58,7 +59,7 @@ public class ContextEnvironmentFactory implements ExecutionEnvironmentFactory {
 		this.userCodeClassLoader = userCodeClassLoader;
 		this.defaultParallelism = defaultParallelism;
 		this.isDetached = isDetached;
-		this.savepointPath = savepointPath;
+		this.savepointSettings = savepointSettings;
 	}
 
 	@Override
@@ -68,8 +69,8 @@ public class ContextEnvironmentFactory implements ExecutionEnvironmentFactory {
 		}
 
 		lastEnvCreated = isDetached ?
-				new DetachedEnvironment(client, jarFilesToAttach, classpathsToAttach, userCodeClassLoader, savepointPath):
-				new ContextEnvironment(client, jarFilesToAttach, classpathsToAttach, userCodeClassLoader, savepointPath);
+				new DetachedEnvironment(client, jarFilesToAttach, classpathsToAttach, userCodeClassLoader, savepointSettings):
+				new ContextEnvironment(client, jarFilesToAttach, classpathsToAttach, userCodeClassLoader, savepointSettings);
 		if (defaultParallelism > 0) {
 			lastEnvCreated.setParallelism(defaultParallelism);
 		}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/DetachedEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/DetachedEnvironment.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.optimizer.plan.FlinkPlan;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,8 +47,8 @@ public class DetachedEnvironment extends ContextEnvironment {
 			List<URL> jarFiles,
 			List<URL> classpaths,
 			ClassLoader userCodeClassLoader,
-			String savepointPath) {
-		super(remoteConnection, jarFiles, classpaths, userCodeClassLoader, savepointPath);
+			SavepointRestoreSettings savepointSettings) {
+		super(remoteConnection, jarFiles, classpaths, userCodeClassLoader, savepointSettings);
 	}
 
 	@Override
@@ -72,7 +73,7 @@ public class DetachedEnvironment extends ContextEnvironment {
 	 * Finishes this Context Environment's execution by explicitly running the plan constructed.
 	 */
 	JobSubmissionResult finalizeExecute() throws ProgramInvocationException {
-		return client.run(detachedPlan, jarFilesToAttach, classpathsToAttach, userCodeClassLoader, savepointPath);
+		return client.run(detachedPlan, jarFilesToAttach, classpathsToAttach, userCodeClassLoader, savepointSettings);
 	}
 
 	public static final class DetachedJobExecutionResult extends JobExecutionResult {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.ProgramDescription;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.dag.DataSinkNode;
 import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.util.InstantiationUtil;
 
 import java.io.BufferedInputStream;
@@ -86,7 +87,7 @@ public class PackagedProgram {
 	
 	private Plan plan;
 
-	private String savepointPath;
+	private SavepointRestoreSettings savepointSettings = SavepointRestoreSettings.none();
 
 	/**
 	 * Creates an instance that wraps the plan defined in the jar file using the given
@@ -257,12 +258,12 @@ public class PackagedProgram {
 		}
 	}
 
-	public void setSavepointPath(String savepointPath) {
-		this.savepointPath = savepointPath;
+	public void setSavepointRestoreSettings(SavepointRestoreSettings savepointSettings) {
+		this.savepointSettings = savepointSettings;
 	}
 
-	public String getSavepointPath() {
-		return savepointPath;
+	public SavepointRestoreSettings getSavepointSettings() {
+		return savepointSettings;
 	}
 
 	public String[] getArguments() {

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
@@ -107,7 +107,7 @@ public class CliFrontendRunTest {
 
 			// test configure savepoint path (with ignore flag)
 			{
-				String[] parameters = {"-s", "expectedSavepointPath", "-a", getTestJarPath()};
+				String[] parameters = {"-s", "expectedSavepointPath", "-n", getTestJarPath()};
 				RunOptions options = CliFrontendParser.parseRunCommand(parameters);
 				SavepointRestoreSettings savepointSettings = options.getSavepointRestoreSettings();
 				assertTrue(savepointSettings.restoreSavepoint());

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
@@ -19,16 +19,20 @@
 
 package org.apache.flink.client;
 
-import static org.apache.flink.client.CliFrontendTestUtils.*;
-import static org.junit.Assert.*;
-
 import org.apache.flink.client.cli.CliFrontendParser;
-import org.apache.flink.client.cli.CommandLineOptions;
 import org.apache.flink.client.cli.RunOptions;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static org.apache.flink.client.CliFrontendTestUtils.getTestJarPath;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 public class CliFrontendRunTest {
@@ -91,11 +95,24 @@ public class CliFrontendRunTest {
 				assertNotEquals(0, testFrontend.run(parameters));
 			}
 
-			// test configure savepoint path
+			// test configure savepoint path (no ignore flag)
 			{
 				String[] parameters = {"-s", "expectedSavepointPath", getTestJarPath()};
 				RunOptions options = CliFrontendParser.parseRunCommand(parameters);
-				assertEquals("expectedSavepointPath", options.getSavepointPath());
+				SavepointRestoreSettings savepointSettings = options.getSavepointRestoreSettings();
+				assertTrue(savepointSettings.restoreSavepoint());
+				assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
+				assertFalse(savepointSettings.ignoreUnmappedState());
+			}
+
+			// test configure savepoint path (with ignore flag)
+			{
+				String[] parameters = {"-s", "expectedSavepointPath", "-i", getTestJarPath()};
+				RunOptions options = CliFrontendParser.parseRunCommand(parameters);
+				SavepointRestoreSettings savepointSettings = options.getSavepointRestoreSettings();
+				assertTrue(savepointSettings.restoreSavepoint());
+				assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
+				assertTrue(savepointSettings.ignoreUnmappedState());
 			}
 
 			// test jar arguments

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
@@ -102,17 +102,17 @@ public class CliFrontendRunTest {
 				SavepointRestoreSettings savepointSettings = options.getSavepointRestoreSettings();
 				assertTrue(savepointSettings.restoreSavepoint());
 				assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
-				assertFalse(savepointSettings.ignoreUnmappedState());
+				assertFalse(savepointSettings.allowNonRestoredState());
 			}
 
 			// test configure savepoint path (with ignore flag)
 			{
-				String[] parameters = {"-s", "expectedSavepointPath", "-i", getTestJarPath()};
+				String[] parameters = {"-s", "expectedSavepointPath", "-a", getTestJarPath()};
 				RunOptions options = CliFrontendParser.parseRunCommand(parameters);
 				SavepointRestoreSettings savepointSettings = options.getSavepointRestoreSettings();
 				assertTrue(savepointSettings.restoreSavepoint());
 				assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
-				assertTrue(savepointSettings.ignoreUnmappedState());
+				assertTrue(savepointSettings.allowNonRestoredState());
 			}
 
 			// test jar arguments

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.ExternalizedCheckpointSettings;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
+import org.apache.flink.runtime.state.TaskStateHandles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -767,7 +768,7 @@ public class CheckpointCoordinator {
 	 * restored via {@link Execution#setInitialState(TaskStateHandles)}.
 	 * @param errorIfNoCheckpoint Fail if no completed checkpoint is available to
 	 * restore from.
-	 * @param ignoreUnmappedState Ignore checkpoint state that cannot be mapped
+	 * @param allowNonRestoredState Allow checkpoint state that cannot be mapped
 	 * to any job vertex in tasks.
 	 * @return <code>true</code> if state was restored, <code>false</code> otherwise.
 	 * @throws IllegalStateException If the CheckpointCoordinator is shut down.
@@ -775,7 +776,7 @@ public class CheckpointCoordinator {
 	 *                               the <code>failIfNoCheckpoint</code> flag has been set.
 	 * @throws IllegalStateException If the checkpoint contains state that cannot be
 	 *                               mapped to any job vertex in <code>tasks</code> and the
-	 *                               <code>ignoreUnmappedState</code> flag has not been set.
+	 *                               <code>allowNonRestoredState</code> flag has not been set.
 	 * @throws IllegalStateException If the max parallelism changed for an operator
 	 *                               that restores state from this checkpoint.
 	 * @throws IllegalStateException If the parallelism changed for an operator
@@ -785,7 +786,7 @@ public class CheckpointCoordinator {
 	public boolean restoreLatestCheckpointedState(
 			Map<JobVertexID, ExecutionJobVertex> tasks,
 			boolean errorIfNoCheckpoint,
-			boolean ignoreUnmappedState) throws Exception {
+			boolean allowNonRestoredState) throws Exception {
 
 		synchronized (lock) {
 			if (shutdown) {
@@ -809,7 +810,7 @@ public class CheckpointCoordinator {
 			LOG.info("Restoring from latest valid checkpoint: {}.", latest);
 
 			StateAssignmentOperation stateAssignmentOperation =
-					new StateAssignmentOperation(LOG, tasks, latest, ignoreUnmappedState);
+					new StateAssignmentOperation(LOG, tasks, latest, allowNonRestoredState);
 
 			stateAssignmentOperation.assignStates();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -760,10 +760,32 @@ public class CheckpointCoordinator {
 	//  Checkpoint State Restoring
 	// --------------------------------------------------------------------------------------------
 
+	/**
+	 * Restores the latest checkpointed state.
+	 *
+	 * @param tasks Map of job vertices to restore. State for these vertices is
+	 * restored via {@link Execution#setInitialState(TaskStateHandles)}.
+	 * @param errorIfNoCheckpoint Fail if no completed checkpoint is available to
+	 * restore from.
+	 * @param ignoreUnmappedState Ignore checkpoint state that cannot be mapped
+	 * to any job vertex in tasks.
+	 * @return <code>true</code> if state was restored, <code>false</code> otherwise.
+	 * @throws IllegalStateException If the CheckpointCoordinator is shut down.
+	 * @throws IllegalStateException If no completed checkpoint is available and
+	 *                               the <code>failIfNoCheckpoint</code> flag has been set.
+	 * @throws IllegalStateException If the checkpoint contains state that cannot be
+	 *                               mapped to any job vertex in <code>tasks</code> and the
+	 *                               <code>ignoreUnmappedState</code> flag has not been set.
+	 * @throws IllegalStateException If the max parallelism changed for an operator
+	 *                               that restores state from this checkpoint.
+	 * @throws IllegalStateException If the parallelism changed for an operator
+	 *                               that restores <i>non-partitioned</i> state from this
+	 *                               checkpoint.
+	 */
 	public boolean restoreLatestCheckpointedState(
 			Map<JobVertexID, ExecutionJobVertex> tasks,
 			boolean errorIfNoCheckpoint,
-			boolean allOrNothingState) throws Exception {
+			boolean ignoreUnmappedState) throws Exception {
 
 		synchronized (lock) {
 			if (shutdown) {
@@ -787,7 +809,7 @@ public class CheckpointCoordinator {
 			LOG.info("Restoring from latest valid checkpoint: {}.", latest);
 
 			StateAssignmentOperation stateAssignmentOperation =
-					new StateAssignmentOperation(tasks, latest, allOrNothingState);
+					new StateAssignmentOperation(LOG, tasks, latest, ignoreUnmappedState);
 
 			stateAssignmentOperation.assignStates();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
@@ -70,6 +70,16 @@ public class CompletedCheckpoint implements Serializable {
 			long checkpointID,
 			long timestamp,
 			long completionTimestamp,
+			Map<JobVertexID, TaskState> taskStates) {
+
+		this(job, checkpointID, timestamp, completionTimestamp, taskStates, CheckpointProperties.forStandardCheckpoint(), null);
+	}
+
+	public CompletedCheckpoint(
+			JobID job,
+			long checkpointID,
+			long timestamp,
+			long completionTimestamp,
 			Map<JobVertexID, TaskState> taskStates,
 			CheckpointProperties props,
 			String externalPath) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -46,18 +46,18 @@ public class StateAssignmentOperation {
 	private final Logger logger;
 	private final Map<JobVertexID, ExecutionJobVertex> tasks;
 	private final CompletedCheckpoint latest;
-	private final boolean ignoreUnmappedState;
+	private final boolean allowNonRestoredState;
 
 	public StateAssignmentOperation(
 			Logger logger,
 			Map<JobVertexID, ExecutionJobVertex> tasks,
 			CompletedCheckpoint latest,
-			boolean ignoreUnmappedState) {
+			boolean allowNonRestoredState) {
 
 		this.logger = logger;
 		this.tasks = tasks;
 		this.latest = latest;
-		this.ignoreUnmappedState = ignoreUnmappedState;
+		this.allowNonRestoredState = allowNonRestoredState;
 	}
 
 	public boolean assignStates() throws Exception {
@@ -216,8 +216,8 @@ public class StateAssignmentOperation {
 
 					currentExecutionAttempt.setInitialState(taskStateHandles);
 				}
-			} else if (ignoreUnmappedState) {
-				logger.info("Ignoring checkpoint state for operator {}.", taskState.getJobVertexID());
+			} else if (allowNonRestoredState) {
+				logger.info("Skipped checkpoint state for operator {}.", taskState.getJobVertexID());
 			} else {
 				throw new IllegalStateException("There is no execution job vertex for the job" +
 						" vertex ID " + taskGroupStateEntry.getKey());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TaskStateHandles;
 import org.apache.flink.util.Preconditions;
+import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,19 +43,22 @@ import java.util.Map;
  */
 public class StateAssignmentOperation {
 
-	public StateAssignmentOperation(
-			Map<JobVertexID, ExecutionJobVertex> tasks,
-			CompletedCheckpoint latest,
-			boolean allOrNothingState) {
-
-		this.tasks = tasks;
-		this.latest = latest;
-		this.allOrNothingState = allOrNothingState;
-	}
-
+	private final Logger logger;
 	private final Map<JobVertexID, ExecutionJobVertex> tasks;
 	private final CompletedCheckpoint latest;
-	private final boolean allOrNothingState;
+	private final boolean ignoreUnmappedState;
+
+	public StateAssignmentOperation(
+			Logger logger,
+			Map<JobVertexID, ExecutionJobVertex> tasks,
+			CompletedCheckpoint latest,
+			boolean ignoreUnmappedState) {
+
+		this.logger = logger;
+		this.tasks = tasks;
+		this.latest = latest;
+		this.ignoreUnmappedState = ignoreUnmappedState;
+	}
 
 	public boolean assignStates() throws Exception {
 
@@ -101,15 +105,10 @@ public class StateAssignmentOperation {
 				List<KeyGroupsStateHandle> parallelKeyedStatesBackend = new ArrayList<>(oldParallelism);
 				List<KeyGroupsStateHandle> parallelKeyedStateStream = new ArrayList<>(oldParallelism);
 
-				int counter = 0;
 				for (int p = 0; p < oldParallelism; ++p) {
-
 					SubtaskState subtaskState = taskState.getState(p);
 
 					if (null != subtaskState) {
-
-						++counter;
-
 						collectParallelStatesByChainOperator(
 								parallelOpStatesBackend, subtaskState.getManagedOperatorState());
 
@@ -126,11 +125,6 @@ public class StateAssignmentOperation {
 							parallelKeyedStateStream.add(keyedStateStream);
 						}
 					}
-				}
-
-				if (allOrNothingState && counter > 0 && counter < oldParallelism) {
-					throw new IllegalStateException("The checkpoint contained state only for " +
-							"a subset of tasks for vertex " + executionJobVertex);
 				}
 
 				// operator chain index -> lists with collected states (one collection for each parallel subtasks)
@@ -222,7 +216,8 @@ public class StateAssignmentOperation {
 
 					currentExecutionAttempt.setInitialState(taskStateHandles);
 				}
-
+			} else if (ignoreUnmappedState) {
+				logger.info("Ignoring checkpoint state for operator {}.", taskState.getJobVertexID());
 			} else {
 				throw new IllegalStateException("There is no execution job vertex for the job" +
 						" vertex ID " + taskGroupStateEntry.getKey());
@@ -230,7 +225,6 @@ public class StateAssignmentOperation {
 		}
 
 		return true;
-
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoader.java
@@ -24,6 +24,8 @@ import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.TaskState;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -34,6 +36,8 @@ import java.util.Map;
  */
 public class SavepointLoader {
 
+	private static final Logger LOG = LoggerFactory.getLogger(SavepointLoader.class);
+
 	/**
 	 * Loads a savepoint back as a {@link CompletedCheckpoint}.
 	 *
@@ -42,6 +46,8 @@ public class SavepointLoader {
 	 * @param jobId          The JobID of the job to load the savepoint for.
 	 * @param tasks          Tasks that will possibly be reset
 	 * @param savepointPath  The path of the savepoint to rollback to
+	 * @param ignoreUnmappedState Ignore checkpoint state that cannot be mapped
+	 * to any job vertex in tasks.
 	 *
 	 * @throws IllegalStateException If mismatch between program and savepoint state
 	 * @throws Exception             If savepoint store failure
@@ -49,7 +55,8 @@ public class SavepointLoader {
 	public static CompletedCheckpoint loadAndValidateSavepoint(
 			JobID jobId,
 			Map<JobVertexID, ExecutionJobVertex> tasks,
-			String savepointPath) throws IOException {
+			String savepointPath,
+			boolean ignoreUnmappedState) throws IOException {
 
 		// (1) load the savepoint
 		Savepoint savepoint = SavepointStore.loadSavepoint(savepointPath);
@@ -76,11 +83,14 @@ public class SavepointLoader {
 
 					throw new IllegalStateException(msg);
 				}
+			} else if (ignoreUnmappedState) {
+				LOG.info("Ignoring savepoint state for operator {}.", taskState.getJobVertexID());
 			} else {
 				String msg = String.format("Failed to rollback to savepoint %s. " +
-								"Cannot map old state for task %s to the new program. " +
-								"This indicates that the program has been changed in a " +
-								"non-compatible way  after the savepoint.",
+								"Cannot map savepoint state for operator %s to the new program, " +
+								"because the operator is not available in the new program. If " +
+								"you want to ignore this, you can set the --ignoreUnmappedState " +
+								"option on the CLI.",
 						savepointPath, taskState.getJobVertexID());
 				throw new IllegalStateException(msg);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoader.java
@@ -46,7 +46,7 @@ public class SavepointLoader {
 	 * @param jobId          The JobID of the job to load the savepoint for.
 	 * @param tasks          Tasks that will possibly be reset
 	 * @param savepointPath  The path of the savepoint to rollback to
-	 * @param ignoreUnmappedState Ignore checkpoint state that cannot be mapped
+	 * @param allowNonRestoredState Allow to skip checkpoint state that cannot be mapped
 	 * to any job vertex in tasks.
 	 *
 	 * @throws IllegalStateException If mismatch between program and savepoint state
@@ -56,7 +56,7 @@ public class SavepointLoader {
 			JobID jobId,
 			Map<JobVertexID, ExecutionJobVertex> tasks,
 			String savepointPath,
-			boolean ignoreUnmappedState) throws IOException {
+			boolean allowNonRestoredState) throws IOException {
 
 		// (1) load the savepoint
 		Savepoint savepoint = SavepointStore.loadSavepoint(savepointPath);
@@ -83,13 +83,13 @@ public class SavepointLoader {
 
 					throw new IllegalStateException(msg);
 				}
-			} else if (ignoreUnmappedState) {
-				LOG.info("Ignoring savepoint state for operator {}.", taskState.getJobVertexID());
+			} else if (allowNonRestoredState) {
+				LOG.info("Skipping savepoint state for operator {}.", taskState.getJobVertexID());
 			} else {
 				String msg = String.format("Failed to rollback to savepoint %s. " +
 								"Cannot map savepoint state for operator %s to the new program, " +
 								"because the operator is not available in the new program. If " +
-								"you want to ignore this, you can set the --ignoreUnmappedState " +
+								"you want to allow to skip this, you can set the --allowNonRestoredState " +
 								"option on the CLI.",
 						savepointPath, taskState.getJobVertexID());
 				throw new IllegalStateException(msg);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -913,14 +913,14 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	 * block the job manager actor and run asynchronously.
 	 *
 	 * @param errorIfNoCheckpoint Fail if there is no checkpoint available
-	 * @param ignoreUnmappedState Ignore any checkpoint state that cannot be mapped
+	 * @param allowNonRestoredState Allow to skip checkpoint state that cannot be mapped
 	 * to the the ExecutionGraph vertices (if the checkpoint contains state for a
 	 * job vertex that is not part of this ExecutionGraph).
 	 */
-	public void restoreLatestCheckpointedState(boolean errorIfNoCheckpoint, boolean ignoreUnmappedState) throws Exception {
+	public void restoreLatestCheckpointedState(boolean errorIfNoCheckpoint, boolean allowNonRestoredState) throws Exception {
 		synchronized (progressLock) {
 			if (checkpointCoordinator != null) {
-				checkpointCoordinator.restoreLatestCheckpointedState(getAllVertices(), errorIfNoCheckpoint, ignoreUnmappedState);
+				checkpointCoordinator.restoreLatestCheckpointedState(getAllVertices(), errorIfNoCheckpoint, allowNonRestoredState);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -911,12 +911,16 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	 *
 	 * <p>The recovery of checkpoints might block. Make sure that calls to this method don't
 	 * block the job manager actor and run asynchronously.
-	 * 
+	 *
+	 * @param errorIfNoCheckpoint Fail if there is no checkpoint available
+	 * @param ignoreUnmappedState Ignore any checkpoint state that cannot be mapped
+	 * to the the ExecutionGraph vertices (if the checkpoint contains state for a
+	 * job vertex that is not part of this ExecutionGraph).
 	 */
-	public void restoreLatestCheckpointedState() throws Exception {
+	public void restoreLatestCheckpointedState(boolean errorIfNoCheckpoint, boolean ignoreUnmappedState) throws Exception {
 		synchronized (progressLock) {
 			if (checkpointCoordinator != null) {
-				checkpointCoordinator.restoreLatestCheckpointedState(getAllVertices(), false, false);
+				checkpointCoordinator.restoreLatestCheckpointedState(getAllVertices(), errorIfNoCheckpoint, ignoreUnmappedState);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph;
+
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Savepoint restore settings.
+ */
+public class SavepointRestoreSettings implements Serializable {
+
+	private static final long serialVersionUID = 87377506900849777L;
+
+	/** No restore should happen. */
+	private final static SavepointRestoreSettings NONE = new SavepointRestoreSettings(null, false);
+
+	/** By default, be strict when restoring from a savepoint.  */
+	private final static boolean DEFAULT_IGNORE_UNMAPPED_STATE = false;
+
+	/** Savepoint restore path. */
+	private final String restorePath;
+
+	/**
+	 * Flag indicating whether the restore should ignore if the savepoint contains
+	 * state for an operator that is not part of the job.
+	 */
+	private final boolean ignoreUnmappedState;
+
+	/**
+	 * Creates the restore settings.
+	 *
+	 * @param restorePath Savepoint restore path.
+	 * @param ignoreUnmappedState Ignore unmapped state.
+	 */
+	private SavepointRestoreSettings(String restorePath, boolean ignoreUnmappedState) {
+		this.restorePath = restorePath;
+		this.ignoreUnmappedState = ignoreUnmappedState;
+	}
+
+	/**
+	 * Returns whether to restore from savepoint.
+	 * @return <code>true</code> if should restore from savepoint.
+	 */
+	public boolean restoreSavepoint() {
+		return restorePath != null;
+	}
+
+	/**
+	 * Returns the path to the savepoint to restore from.
+	 * @return Path to the savepoint to restore from or <code>null</code> if
+	 * should not restore.
+	 */
+	public String getRestorePath() {
+		return restorePath;
+	}
+
+	/**
+	 * Returns whether the restore should ignore whether the savepoint contains
+	 * state that cannot be mapped to the job.
+	 *
+	 * @return <code>true</code> if restore should ignore whether the savepoint contains
+	 * state that cannot be mapped to the job.
+	 */
+	public boolean ignoreUnmappedState() {
+		return ignoreUnmappedState;
+	}
+
+	@Override
+	public String toString() {
+		if (restoreSavepoint()) {
+			return "SavepointRestoreSettings.forPath(" +
+					"restorePath='" + restorePath + '\'' +
+					", ignoreUnmappedState=" + ignoreUnmappedState +
+					')';
+		} else {
+			return "SavepointRestoreSettings.none()";
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	public static SavepointRestoreSettings none() {
+		return NONE;
+	}
+
+	public static SavepointRestoreSettings forPath(String savepointPath) {
+		return forPath(savepointPath, DEFAULT_IGNORE_UNMAPPED_STATE);
+	}
+
+	public static SavepointRestoreSettings forPath(String savepointPath, boolean ignoreUnmappedState) {
+		checkNotNull(savepointPath, "Savepoint restore path.");
+		return new SavepointRestoreSettings(savepointPath, ignoreUnmappedState);
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
@@ -33,26 +33,26 @@ public class SavepointRestoreSettings implements Serializable {
 	private final static SavepointRestoreSettings NONE = new SavepointRestoreSettings(null, false);
 
 	/** By default, be strict when restoring from a savepoint.  */
-	private final static boolean DEFAULT_IGNORE_UNMAPPED_STATE = false;
+	private final static boolean DEFAULT_ALLOW_NON_RESTORED_STATE = false;
 
 	/** Savepoint restore path. */
 	private final String restorePath;
 
 	/**
-	 * Flag indicating whether the restore should ignore if the savepoint contains
-	 * state for an operator that is not part of the job.
+	 * Flag indicating whether non restored state is allowed if the savepoint
+	 * contains state for an operator that is not part of the job.
 	 */
-	private final boolean ignoreUnmappedState;
+	private final boolean allowNonRestoredState;
 
 	/**
 	 * Creates the restore settings.
 	 *
 	 * @param restorePath Savepoint restore path.
-	 * @param ignoreUnmappedState Ignore unmapped state.
+	 * @param allowNonRestoredState Ignore unmapped state.
 	 */
-	private SavepointRestoreSettings(String restorePath, boolean ignoreUnmappedState) {
+	private SavepointRestoreSettings(String restorePath, boolean allowNonRestoredState) {
 		this.restorePath = restorePath;
-		this.ignoreUnmappedState = ignoreUnmappedState;
+		this.allowNonRestoredState = allowNonRestoredState;
 	}
 
 	/**
@@ -73,14 +73,14 @@ public class SavepointRestoreSettings implements Serializable {
 	}
 
 	/**
-	 * Returns whether the restore should ignore whether the savepoint contains
-	 * state that cannot be mapped to the job.
+	 * Returns whether non restored state is allowed if the savepoint contains
+	 * state that cannot be mapped back to the job.
 	 *
-	 * @return <code>true</code> if restore should ignore whether the savepoint contains
-	 * state that cannot be mapped to the job.
+	 * @return <code>true</code> if non restored state is allowed if the savepoint
+	 * contains state that cannot be mapped  back to the job.
 	 */
-	public boolean ignoreUnmappedState() {
-		return ignoreUnmappedState;
+	public boolean allowNonRestoredState() {
+		return allowNonRestoredState;
 	}
 
 	@Override
@@ -88,7 +88,7 @@ public class SavepointRestoreSettings implements Serializable {
 		if (restoreSavepoint()) {
 			return "SavepointRestoreSettings.forPath(" +
 					"restorePath='" + restorePath + '\'' +
-					", ignoreUnmappedState=" + ignoreUnmappedState +
+					", allowNonRestoredState=" + allowNonRestoredState +
 					')';
 		} else {
 			return "SavepointRestoreSettings.none()";
@@ -102,12 +102,12 @@ public class SavepointRestoreSettings implements Serializable {
 	}
 
 	public static SavepointRestoreSettings forPath(String savepointPath) {
-		return forPath(savepointPath, DEFAULT_IGNORE_UNMAPPED_STATE);
+		return forPath(savepointPath, DEFAULT_ALLOW_NON_RESTORED_STATE);
 	}
 
-	public static SavepointRestoreSettings forPath(String savepointPath, boolean ignoreUnmappedState) {
+	public static SavepointRestoreSettings forPath(String savepointPath, boolean allowNonRestoredState) {
 		checkNotNull(savepointPath, "Savepoint restore path.");
-		return new SavepointRestoreSettings(savepointPath, ignoreUnmappedState);
+		return new SavepointRestoreSettings(savepointPath, allowNonRestoredState);
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/JobSnapshottingSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/JobSnapshottingSettings.java
@@ -29,7 +29,7 @@ import static java.util.Objects.requireNonNull;
  * for the asynchronous checkpoints of the JobGraph, such as interval, and which vertices
  * need to participate.
  */
-public class JobSnapshottingSettings implements java.io.Serializable{
+public class JobSnapshottingSettings implements java.io.Serializable {
 	
 	private static final long serialVersionUID = -2593319571078198180L;
 	
@@ -49,9 +49,6 @@ public class JobSnapshottingSettings implements java.io.Serializable{
 
 	/** Settings for externalized checkpoints. */
 	private final ExternalizedCheckpointSettings externalizedCheckpointSettings;
-
-	/** Path to savepoint to reset state back to (optional, can be null) */
-	private String savepointPath;
 	
 	public JobSnapshottingSettings(
 			List<JobVertexID> verticesToTrigger,
@@ -111,26 +108,6 @@ public class JobSnapshottingSettings implements java.io.Serializable{
 
 	public ExternalizedCheckpointSettings getExternalizedCheckpointSettings() {
 		return externalizedCheckpointSettings;
-	}
-
-	/**
-	 * Sets the savepoint path.
-	 *
-	 * This is only set if the job shall be resumed from a savepoint on submission.
-	 *
-	 * @param savepointPath The path of the savepoint to resume from.
-	 */
-	public void setSavepointPath(String savepointPath) {
-		this.savepointPath = savepointPath;
-	}
-
-	/**
-	 * Returns the configured savepoint path or <code>null</code> if none is configured.
-	 *
-	 * @return The configured savepoint path or <code>null</code> if none is configured.
-	 */
-	public String getSavepointPath() {
-		return savepointPath;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1341,6 +1341,8 @@ class JobManager(
                 executionGraph.restoreLatestCheckpointedState(true, ignoreUnmapped)
               } catch {
                 case e: Exception =>
+                  jobInfo.notifyClients(
+                    decorateMessage(JobResultFailure(new SerializedThrowable(e))))
                   throw new SuppressRestartsException(e)
               }
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -1868,7 +1868,7 @@ public class CheckpointCoordinatorTest {
 		tasks.put(jobVertexID1, jobVertex1);
 		tasks.put(jobVertexID2, jobVertex2);
 
-		coord.restoreLatestCheckpointedState(tasks, true, true);
+		coord.restoreLatestCheckpointedState(tasks, true, false);
 
 		// verify the restored state
 		verifiyStateRestore(jobVertexID1, jobVertex1, keyGroupPartitions1);
@@ -1984,7 +1984,7 @@ public class CheckpointCoordinatorTest {
 		tasks.put(jobVertexID1, newJobVertex1);
 		tasks.put(jobVertexID2, newJobVertex2);
 
-		coord.restoreLatestCheckpointedState(tasks, true, true);
+		coord.restoreLatestCheckpointedState(tasks, true, false);
 
 		fail("The restoration should have failed because the max parallelism changed.");
 	}
@@ -2106,7 +2106,7 @@ public class CheckpointCoordinatorTest {
 		tasks.put(jobVertexID1, newJobVertex1);
 		tasks.put(jobVertexID2, newJobVertex2);
 
-		coord.restoreLatestCheckpointedState(tasks, true, true);
+		coord.restoreLatestCheckpointedState(tasks, true, false);
 
 		fail("The restoration should have failed because the parallelism of an vertex with " +
 			"non-partitioned state changed.");
@@ -2249,7 +2249,7 @@ public class CheckpointCoordinatorTest {
 
 		tasks.put(jobVertexID1, newJobVertex1);
 		tasks.put(jobVertexID2, newJobVertex2);
-		coord.restoreLatestCheckpointedState(tasks, true, true);
+		coord.restoreLatestCheckpointedState(tasks, true, false);
 
 		// verify the restored state
 		verifiyStateRestore(jobVertexID1, newJobVertex1, keyGroupPartitions1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -201,12 +201,12 @@ public class CheckpointStateRestoreTest {
 	}
 
 	/**
-	 * Tests that the unmapped state flag is correctly handled.
+	 * Tests that the allow non restored state flag is correctly handled.
 	 *
-	 * The flag should only apply for state that is part of the checkpoint.
+	 * The flag only applies for state that is part of the checkpoint.
 	 */
 	@Test
-	public void testRestoreUnmappedCheckpointState() throws Exception {
+	public void testNonRestoredState() throws Exception {
 		// --- (1) Create tasks to restore checkpoint with ---
 		JobVertexID jobVertexId1 = new JobVertexID();
 		JobVertexID jobVertexId2 = new JobVertexID();
@@ -276,10 +276,10 @@ public class CheckpointStateRestoreTest {
 
 		coord.getCheckpointStore().addCheckpoint(checkpoint);
 
-		// (i) Ignore unmapped state (should succeed)
+		// (i) Allow non restored state (should succeed)
 		coord.restoreLatestCheckpointedState(tasks, true, true);
 
-		// (ii) Don't ignore unmapped state (should fail)
+		// (ii) Don't allow non restored state (should fail)
 		try {
 			coord.restoreLatestCheckpointedState(tasks, true, false);
 			fail("Did not throw the expected Exception.");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -59,6 +59,9 @@ import static org.mockito.Mockito.when;
  */
 public class CheckpointStateRestoreTest {
 
+	/**
+	 * Tests that on restore the task state is reset for each stateful task.
+	 */
 	@Test
 	public void testSetState() {
 		try {
@@ -92,7 +95,6 @@ public class CheckpointStateRestoreTest {
 			Map<JobVertexID, ExecutionJobVertex> map = new HashMap<JobVertexID, ExecutionJobVertex>();
 			map.put(statefulId, stateful);
 			map.put(statelessId, stateless);
-
 
 			CheckpointCoordinator coord = new CheckpointCoordinator(
 					jid,
@@ -167,92 +169,6 @@ public class CheckpointStateRestoreTest {
 	}
 
 	@Test
-	public void testStateOnlyPartiallyAvailable() {
-		try {
-			final ChainedStateHandle<StreamStateHandle> serializedState = CheckpointCoordinatorTest.generateChainedStateHandle(new SerializableObject());
-			KeyGroupRange keyGroupRange = KeyGroupRange.of(0,0);
-			List<SerializableObject> testStates = Collections.singletonList(new SerializableObject());
-			final KeyGroupsStateHandle serializedKeyGroupStates = CheckpointCoordinatorTest.generateKeyGroupState(keyGroupRange, testStates);
-
-			final JobID jid = new JobID();
-			final JobVertexID statefulId = new JobVertexID();
-			final JobVertexID statelessId = new JobVertexID();
-
-			Execution statefulExec1 = mockExecution();
-			Execution statefulExec2 = mockExecution();
-			Execution statefulExec3 = mockExecution();
-			Execution statelessExec1 = mockExecution();
-			Execution statelessExec2 = mockExecution();
-
-			ExecutionVertex stateful1 = mockExecutionVertex(statefulExec1, statefulId, 0, 3);
-			ExecutionVertex stateful2 = mockExecutionVertex(statefulExec2, statefulId, 1, 3);
-			ExecutionVertex stateful3 = mockExecutionVertex(statefulExec3, statefulId, 2, 3);
-			ExecutionVertex stateless1 = mockExecutionVertex(statelessExec1, statelessId, 0, 2);
-			ExecutionVertex stateless2 = mockExecutionVertex(statelessExec2, statelessId, 1, 2);
-
-			ExecutionJobVertex stateful = mockExecutionJobVertex(statefulId,
-					new ExecutionVertex[] { stateful1, stateful2, stateful3 });
-			ExecutionJobVertex stateless = mockExecutionJobVertex(statelessId,
-					new ExecutionVertex[] { stateless1, stateless2 });
-
-			Map<JobVertexID, ExecutionJobVertex> map = new HashMap<JobVertexID, ExecutionJobVertex>();
-			map.put(statefulId, stateful);
-			map.put(statelessId, stateless);
-
-
-			CheckpointCoordinator coord = new CheckpointCoordinator(
-					jid,
-					200000L,
-					200000L,
-					0,
-					Integer.MAX_VALUE,
-					ExternalizedCheckpointSettings.none(),
-					new ExecutionVertex[] { stateful1, stateful2, stateful3, stateless1, stateless2 },
-					new ExecutionVertex[] { stateful1, stateful2, stateful3, stateless1, stateless2 },
-					new ExecutionVertex[0],
-					new StandaloneCheckpointIDCounter(),
-					new StandaloneCompletedCheckpointStore(1),
-					null,
-					new DisabledCheckpointStatsTracker());
-
-			// create ourselves a checkpoint with state
-			final long timestamp = 34623786L;
-			coord.triggerCheckpoint(timestamp, false);
-
-			PendingCheckpoint pending = coord.getPendingCheckpoints().values().iterator().next();
-			final long checkpointId = pending.getCheckpointId();
-
-			// the difference to the test "testSetState" is that one stateful subtask does not report state
-			SubtaskState checkpointStateHandles =
-					new SubtaskState(serializedState, null, null, serializedKeyGroupStates, null, 0L);
-
-			CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, 0L);
-
-			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statefulExec1.getAttemptId(), checkpointMetaData, checkpointStateHandles));
-			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statefulExec2.getAttemptId(), checkpointMetaData));
-			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statefulExec3.getAttemptId(), checkpointMetaData, checkpointStateHandles));
-			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec1.getAttemptId(), checkpointMetaData));
-			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec2.getAttemptId(), checkpointMetaData));
-
-			assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
-			assertEquals(0, coord.getNumberOfPendingCheckpoints());
-
-			// let the coordinator inject the state
-			try {
-				coord.restoreLatestCheckpointedState(map, true, true);
-				fail("this should fail with an exception");
-			}
-			catch (IllegalStateException e) {
-				// swish!
-			}
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-	}
-
-	@Test
 	public void testNoCheckpointAvailable() {
 		try {
 			CheckpointCoordinator coord = new CheckpointCoordinator(
@@ -281,6 +197,93 @@ public class CheckpointStateRestoreTest {
 		catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
+		}
+	}
+
+	/**
+	 * Tests that the unmapped state flag is correctly handled.
+	 *
+	 * The flag should only apply for state that is part of the checkpoint.
+	 */
+	@Test
+	public void testRestoreUnmappedCheckpointState() throws Exception {
+		// --- (1) Create tasks to restore checkpoint with ---
+		JobVertexID jobVertexId1 = new JobVertexID();
+		JobVertexID jobVertexId2 = new JobVertexID();
+
+		// 1st JobVertex
+		ExecutionVertex vertex11 = mockExecutionVertex(mockExecution(), jobVertexId1, 0, 3);
+		ExecutionVertex vertex12 = mockExecutionVertex(mockExecution(), jobVertexId1, 1, 3);
+		ExecutionVertex vertex13 = mockExecutionVertex(mockExecution(), jobVertexId1, 2, 3);
+		// 2nd JobVertex
+		ExecutionVertex vertex21 = mockExecutionVertex(mockExecution(), jobVertexId2, 0, 2);
+		ExecutionVertex vertex22 = mockExecutionVertex(mockExecution(), jobVertexId2, 1, 2);
+
+		ExecutionJobVertex jobVertex1 = mockExecutionJobVertex(jobVertexId1, new ExecutionVertex[] { vertex11, vertex12, vertex13 });
+		ExecutionJobVertex jobVertex2 = mockExecutionJobVertex(jobVertexId2, new ExecutionVertex[] { vertex21, vertex22 });
+
+		Map<JobVertexID, ExecutionJobVertex> tasks = new HashMap<>();
+		tasks.put(jobVertexId1, jobVertex1);
+		tasks.put(jobVertexId2, jobVertex2);
+
+		CheckpointCoordinator coord = new CheckpointCoordinator(
+				new JobID(),
+				Integer.MAX_VALUE,
+				Integer.MAX_VALUE,
+				0,
+				Integer.MAX_VALUE,
+				ExternalizedCheckpointSettings.none(),
+				new ExecutionVertex[] {},
+				new ExecutionVertex[] {},
+				new ExecutionVertex[] {},
+				new StandaloneCheckpointIDCounter(),
+				new StandaloneCompletedCheckpointStore(1),
+				null,
+				new DisabledCheckpointStatsTracker());
+
+		ChainedStateHandle<StreamStateHandle> serializedState = CheckpointCoordinatorTest
+				.generateChainedStateHandle(new SerializableObject());
+
+		// --- (2) Checkpoint misses state for a jobVertex (should work) ---
+		Map<JobVertexID, TaskState> checkpointTaskStates = new HashMap<>();
+		{
+			TaskState taskState = new TaskState(jobVertexId1, 3, 3, 1);
+			taskState.putState(0, new SubtaskState(serializedState, null, null, null, null));
+			taskState.putState(1, new SubtaskState(serializedState, null, null, null, null));
+			taskState.putState(2, new SubtaskState(serializedState, null, null, null, null));
+
+			checkpointTaskStates.put(jobVertexId1, taskState);
+		}
+		CompletedCheckpoint checkpoint = new CompletedCheckpoint(new JobID(), 0, 1, 2, new HashMap<>(checkpointTaskStates));
+
+		coord.getCheckpointStore().addCheckpoint(checkpoint);
+
+		coord.restoreLatestCheckpointedState(tasks, true, false);
+		coord.restoreLatestCheckpointedState(tasks, true, true);
+
+		// --- (3) JobVertex missing for task state that is part of the checkpoint ---
+		JobVertexID newJobVertexID = new JobVertexID();
+
+		// There is no task for this
+		{
+			TaskState taskState = new TaskState(jobVertexId1, 1, 1, 1);
+			taskState.putState(0, new SubtaskState(serializedState, null, null, null, null));
+
+			checkpointTaskStates.put(newJobVertexID, taskState);
+		}
+
+		checkpoint = new CompletedCheckpoint(new JobID(), 1, 2, 3, new HashMap<>(checkpointTaskStates));
+
+		coord.getCheckpointStore().addCheckpoint(checkpoint);
+
+		// (i) Ignore unmapped state (should succeed)
+		coord.restoreLatestCheckpointedState(tasks, true, true);
+
+		// (ii) Don't ignore unmapped state (should fail)
+		try {
+			coord.restoreLatestCheckpointedState(tasks, true, false);
+			fail("Did not throw the expected Exception.");
+		} catch (IllegalStateException ignored) {
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoaderTest.java
@@ -100,7 +100,7 @@ public class SavepointLoaderTest {
 			SavepointLoader.loadAndValidateSavepoint(jobId, tasks, path, false);
 			fail("Did not throw expected Exception");
 		} catch (IllegalStateException expected) {
-			assertTrue(expected.getMessage().contains("ignoreUnmappedState"));
+			assertTrue(expected.getMessage().contains("allowNonRestoredState"));
 		}
 
 		// 4) Load and validate: ignore missing vertex

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoaderTest.java
@@ -78,7 +78,7 @@ public class SavepointLoaderTest {
 		tasks.put(vertexId, vertex);
 
 		// 1) Load and validate: everything correct
-		CompletedCheckpoint loaded = SavepointLoader.loadAndValidateSavepoint(jobId, tasks, path);
+		CompletedCheckpoint loaded = SavepointLoader.loadAndValidateSavepoint(jobId, tasks, path, false);
 
 		assertEquals(jobId, loaded.getJobId());
 		assertEquals(checkpointId, loaded.getCheckpointID());
@@ -87,20 +87,23 @@ public class SavepointLoaderTest {
 		when(vertex.getMaxParallelism()).thenReturn(222);
 
 		try {
-			SavepointLoader.loadAndValidateSavepoint(jobId, tasks, path);
+			SavepointLoader.loadAndValidateSavepoint(jobId, tasks, path, false);
 			fail("Did not throw expected Exception");
 		} catch (IllegalStateException expected) {
 			assertTrue(expected.getMessage().contains("Max parallelism mismatch"));
 		}
 
-		// 3) Load and validate: missing vertex (this should be relaxed)
+		// 3) Load and validate: missing vertex
 		assertNotNull(tasks.remove(vertexId));
 
 		try {
-			SavepointLoader.loadAndValidateSavepoint(jobId, tasks, path);
+			SavepointLoader.loadAndValidateSavepoint(jobId, tasks, path, false);
 			fail("Did not throw expected Exception");
 		} catch (IllegalStateException expected) {
-			assertTrue(expected.getMessage().contains("Cannot map old state"));
+			assertTrue(expected.getMessage().contains("ignoreUnmappedState"));
 		}
+
+		// 4) Load and validate: ignore missing vertex
+		SavepointLoader.loadAndValidateSavepoint(jobId, tasks, path, true);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
@@ -45,12 +45,14 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.tasks.ExternalizedCheckpointSettings;
 import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
 import org.apache.flink.runtime.jobmanager.JobManagerHARecoveryTest.BlockingStatefulInvokable;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.leaderretrieval.StandaloneLeaderRetrievalService;
 import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.messages.JobManagerMessages.CancelJob;
 import org.apache.flink.runtime.messages.JobManagerMessages.CancellationFailure;
 import org.apache.flink.runtime.messages.JobManagerMessages.CancellationResponse;
 import org.apache.flink.runtime.messages.JobManagerMessages.CancellationSuccess;
@@ -60,6 +62,7 @@ import org.apache.flink.runtime.messages.JobManagerMessages.StoppingFailure;
 import org.apache.flink.runtime.messages.JobManagerMessages.StoppingSuccess;
 import org.apache.flink.runtime.messages.JobManagerMessages.SubmitJob;
 import org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepoint;
+import org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepointSuccess;
 import org.apache.flink.runtime.query.KvStateID;
 import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.query.KvStateMessage.LookupKvStateLocation;
@@ -786,8 +789,161 @@ public class JobManagerTest {
 			Future<Object> future = jobManager.ask(msg, timeout);
 			Object result = Await.result(future, timeout);
 
-			assertTrue("Did not trigger savepoint", result instanceof JobManagerMessages.TriggerSavepointSuccess);
+			assertTrue("Did not trigger savepoint", result instanceof TriggerSavepointSuccess);
 			assertEquals(1, targetDirectory.listFiles().length);
+		} finally {
+			if (actorSystem != null) {
+				actorSystem.shutdown();
+			}
+
+			if (archiver != null) {
+				archiver.actor().tell(PoisonPill.getInstance(), ActorRef.noSender());
+			}
+
+			if (jobManager != null) {
+				jobManager.actor().tell(PoisonPill.getInstance(), ActorRef.noSender());
+			}
+
+			if (taskManager != null) {
+				taskManager.actor().tell(PoisonPill.getInstance(), ActorRef.noSender());
+			}
+		}
+	}
+
+	/**
+	 * Tests that configured {@link SavepointRestoreSettings} are respected.
+	 */
+	@Test
+	public void testSavepointRestoreSettings() throws Exception {
+		FiniteDuration timeout = new FiniteDuration(30, TimeUnit.SECONDS);
+
+		ActorSystem actorSystem = null;
+		ActorGateway jobManager = null;
+		ActorGateway archiver = null;
+		ActorGateway taskManager = null;
+		try {
+			actorSystem = AkkaUtils.createLocalActorSystem(new Configuration());
+
+			Tuple2<ActorRef, ActorRef> master = JobManager.startJobManagerActors(
+					new Configuration(),
+					actorSystem,
+					Option.apply("jm"),
+					Option.apply("arch"),
+					TestingJobManager.class,
+					TestingMemoryArchivist.class);
+
+			jobManager = new AkkaActorGateway(master._1(), null);
+			archiver = new AkkaActorGateway(master._2(), null);
+
+			Configuration tmConfig = new Configuration();
+			tmConfig.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 4);
+
+			ActorRef taskManagerRef = TaskManager.startTaskManagerComponentsAndActor(
+					tmConfig,
+					ResourceID.generate(),
+					actorSystem,
+					"localhost",
+					Option.apply("tm"),
+					Option.<LeaderRetrievalService>apply(new StandaloneLeaderRetrievalService(jobManager.path())),
+					true,
+					TestingTaskManager.class);
+
+			taskManager = new AkkaActorGateway(taskManagerRef, null);
+
+			// Wait until connected
+			Object msg = new TestingTaskManagerMessages.NotifyWhenRegisteredAtJobManager(jobManager.actor());
+			Await.ready(taskManager.ask(msg, timeout), timeout);
+
+			// Create job graph
+			JobVertex sourceVertex = new JobVertex("Source");
+			sourceVertex.setInvokableClass(BlockingStatefulInvokable.class);
+			sourceVertex.setParallelism(1);
+
+			JobGraph jobGraph = new JobGraph("TestingJob", sourceVertex);
+
+			JobSnapshottingSettings snapshottingSettings = new JobSnapshottingSettings(
+					Collections.singletonList(sourceVertex.getID()),
+					Collections.singletonList(sourceVertex.getID()),
+					Collections.singletonList(sourceVertex.getID()),
+					Long.MAX_VALUE, // deactivated checkpointing
+					360000,
+					0,
+					Integer.MAX_VALUE,
+					ExternalizedCheckpointSettings.none());
+
+			jobGraph.setSnapshotSettings(snapshottingSettings);
+
+			// Submit job graph
+			msg = new JobManagerMessages.SubmitJob(jobGraph, ListeningBehaviour.DETACHED);
+			Await.result(jobManager.ask(msg, timeout), timeout);
+
+			// Wait for all tasks to be running
+			msg = new TestingJobManagerMessages.WaitForAllVerticesToBeRunning(jobGraph.getJobID());
+			Await.result(jobManager.ask(msg, timeout), timeout);
+
+			// Trigger savepoint
+			File targetDirectory = tmpFolder.newFolder();
+			msg = new TriggerSavepoint(jobGraph.getJobID(), Option.apply(targetDirectory.getAbsolutePath()));
+			Future<Object> future = jobManager.ask(msg, timeout);
+			Object result = Await.result(future, timeout);
+
+			String savepointPath = ((TriggerSavepointSuccess) result).savepointPath();
+
+			// Cancel because of restarts
+			msg = new TestingJobManagerMessages.NotifyWhenJobRemoved(jobGraph.getJobID());
+			Future<?> removedFuture = jobManager.ask(msg, timeout);
+
+			Future<?> cancelFuture = jobManager.ask(new CancelJob(jobGraph.getJobID()), timeout);
+			Object response = Await.result(cancelFuture, timeout);
+			assertTrue("Unexpected response: " + response, response instanceof CancellationSuccess);
+
+			Await.ready(removedFuture, timeout);
+
+			// Adjust the job (we need a new operator ID)
+			JobVertex newSourceVertex = new JobVertex("NewSource");
+			newSourceVertex.setInvokableClass(BlockingStatefulInvokable.class);
+			newSourceVertex.setParallelism(1);
+
+			JobGraph newJobGraph = new JobGraph("NewTestingJob", newSourceVertex);
+
+			JobSnapshottingSettings newSnapshottingSettings = new JobSnapshottingSettings(
+					Collections.singletonList(newSourceVertex.getID()),
+					Collections.singletonList(newSourceVertex.getID()),
+					Collections.singletonList(newSourceVertex.getID()),
+					Long.MAX_VALUE, // deactivated checkpointing
+					360000,
+					0,
+					Integer.MAX_VALUE,
+					ExternalizedCheckpointSettings.none());
+
+			newJobGraph.setSnapshotSettings(newSnapshottingSettings);
+
+			SavepointRestoreSettings restoreSettings = SavepointRestoreSettings.forPath(savepointPath, false);
+			newJobGraph.setSavepointRestoreSettings(restoreSettings);
+
+			msg = new JobManagerMessages.SubmitJob(newJobGraph, ListeningBehaviour.DETACHED);
+			response = Await.result(jobManager.ask(msg, timeout), timeout);
+
+			assertTrue("Unexpected response: " + response, response instanceof JobManagerMessages.JobResultFailure);
+
+			JobManagerMessages.JobResultFailure failure = (JobManagerMessages.JobResultFailure) response;
+			Throwable cause = failure.cause().deserializeError(ClassLoader.getSystemClassLoader());
+
+			assertTrue(cause instanceof IllegalStateException);
+			assertTrue(cause.getMessage().contains("ignoreUnmappedState"));
+
+			// Wait until removed
+			msg = new TestingJobManagerMessages.NotifyWhenJobRemoved(newJobGraph.getJobID());
+			Await.ready(jobManager.ask(msg, timeout), timeout);
+
+			// Resubmit, but ignore unmapped state now
+			restoreSettings = SavepointRestoreSettings.forPath(savepointPath, true);
+			newJobGraph.setSavepointRestoreSettings(restoreSettings);
+
+			msg = new JobManagerMessages.SubmitJob(newJobGraph, ListeningBehaviour.DETACHED);
+			response = Await.result(jobManager.ask(msg, timeout), timeout);
+
+			assertTrue("Unexpected response: " + response, response instanceof JobManagerMessages.JobSubmitSuccess);
 		} finally {
 			if (actorSystem != null) {
 				actorSystem.shutdown();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
@@ -930,13 +930,13 @@ public class JobManagerTest {
 			Throwable cause = failure.cause().deserializeError(ClassLoader.getSystemClassLoader());
 
 			assertTrue(cause instanceof IllegalStateException);
-			assertTrue(cause.getMessage().contains("ignoreUnmappedState"));
+			assertTrue(cause.getMessage().contains("allowNonRestoredState"));
 
 			// Wait until removed
 			msg = new TestingJobManagerMessages.NotifyWhenJobRemoved(newJobGraph.getJobID());
 			Await.ready(jobManager.ask(msg, timeout), timeout);
 
-			// Resubmit, but ignore unmapped state now
+			// Resubmit, but allow non restored state now
 			restoreSettings = SavepointRestoreSettings.forPath(savepointPath, true);
 			newJobGraph.setSavepointRestoreSettings(restoreSettings);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.tasks.ExternalizedCheckpointSettings;
 import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
@@ -204,7 +205,7 @@ public class JobSubmitTest {
 	public void testAnswerFailureWhenSavepointReadFails() throws Exception {
 		// create a simple job graph
 		JobGraph jg = createSimpleJobGraph();
-		jg.setSavepointPath("pathThatReallyDoesNotExist...");
+		jg.setSavepointRestoreSettings(SavepointRestoreSettings.forPath("pathThatReallyDoesNotExist..."));
 
 		// submit the job
 		Future<Object> submitFuture = jmGateway.ask(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
@@ -65,7 +65,7 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
 		} else {
 			return ctx
 				.getClient()
-				.run(streamGraph, ctx.getJars(), ctx.getClasspaths(), ctx.getUserCodeClassLoader(), ctx.getSavepointPath())
+				.run(streamGraph, ctx.getJars(), ctx.getClasspaths(), ctx.getUserCodeClassLoader(), ctx.getSavepointRestoreSettings())
 				.getJobExecutionResult();
 		}
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
@@ -32,6 +32,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -192,7 +193,7 @@ public class RescalingITCase extends TestLogger {
 
 			JobGraph scaledJobGraph = createJobGraphWithKeyedState(parallelism2, maxParallelism, numberKeys, numberElements2, true, 100);
 
-			scaledJobGraph.setSavepointPath(savepointPath);
+			scaledJobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath));
 
 			jobID = scaledJobGraph.getJobID();
 
@@ -284,7 +285,7 @@ public class RescalingITCase extends TestLogger {
 
 			JobGraph scaledJobGraph = createJobGraphWithOperatorState(parallelism2, maxParallelism, OperatorCheckpointMethod.NON_PARTITIONED);
 
-			scaledJobGraph.setSavepointPath(savepointPath);
+			scaledJobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath));
 
 			jobID = scaledJobGraph.getJobID();
 
@@ -397,7 +398,7 @@ public class RescalingITCase extends TestLogger {
 				true,
 				100);
 
-			scaledJobGraph.setSavepointPath(savepointPath);
+			scaledJobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath));
 
 			jobID = scaledJobGraph.getJobID();
 
@@ -523,7 +524,7 @@ public class RescalingITCase extends TestLogger {
 
 			JobGraph scaledJobGraph = createJobGraphWithOperatorState(parallelism2, maxParallelism, checkpointMethod);
 
-			scaledJobGraph.setSavepointPath(savepointPath);
+			scaledJobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath));
 
 			jobID = scaledJobGraph.getJobID();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.messages.JobManagerMessages.CancelJob;
 import org.apache.flink.runtime.messages.JobManagerMessages.DisposeSavepoint;
 import org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepoint;
@@ -283,7 +284,7 @@ public class SavepointITCase extends TestLogger {
 							}
 
 							// Set the savepoint path
-							jobGraph.setSavepointPath(savepointPath);
+							jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath));
 
 							LOG.info("Resubmitting job " + jobGraph.getJobID() + " with " +
 									"savepoint path " + savepointPath + " in detached mode.");
@@ -452,8 +453,8 @@ public class SavepointITCase extends TestLogger {
 			final JobGraph jobGraph = createJobGraph(parallelism, numberOfRetries, 3600000, 1000);
 
 			// Set non-existing savepoint path
-			jobGraph.setSavepointPath("unknown path");
-			assertEquals("unknown path", jobGraph.getSnapshotSettings().getSavepointPath());
+			jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath("unknown path"));
+			assertEquals("unknown path", jobGraph.getSavepointRestoreSettings().getRestorePath());
 
 			LOG.info("Submitting job " + jobGraph.getJobID() + " in detached mode.");
 


### PR DESCRIPTION
When restoring from a checkpoint/savepoint, state for each operator has to be restored. For savepoints, this means that the user cannot remove an operator from her topology and still use the savepoint.

With this change, we will allow to ignore state that cannot be mapped back to the job being restored. The default behaviour does not change.
## Changes
- I've removed the `allOrNothingState` flag as it was only effecting non-partitioned operator state and never set to `true` anyways (except tests). The flag controlled whether each non-partitioned operator state  was restored.
- Moved the savepoint path from the `JobSnapshottingSettings` to the `JobGraph`
- Added the `--ignoreUnmappedState` (short `-i`) flag to the run command: `bin/flink run -s <savepointPath> -i ...`

I've tested this manually by triggering a savepoint for a job, adjusting the job (removing an operator), and then trying to resume from the savepoint. By default, restoring fails, but with the flag everything works.
