### PR TITLE
[backport] [FLINK-4445] Add option to ignore unmapped checkpoint state

### DIFF
--- a/docs/apis/cli.md
+++ b/docs/apis/cli.md
@@ -150,10 +150,10 @@ Returns the path of the created savepoint. You need this path to restore and dis
 
 The run command has a savepoint flag to submit a job, which restores its state from a savepoint. The savepoint path is returned by the savepoint trigger command.
 
-By default, we try to match all savepoint state to the job being submitted. If you want to ignore savepoint state that cannot be mapped to the new job, you can set the `ignoreUnmappedState` flag:
+By default, we try to match all savepoint state to the job being submitted. If you want to allow to skip savepoint state that cannot be restored with the new job you can set the `allowNonRestoredState` flag. You need to allow this if you removed an operator from your program that was part of the program when the savepoint was triggered and you still want to use the savepoint.
 
 {% highlight bash %}
-./bin/flink run -s <savepointPath> -i ...
+./bin/flink run -s <savepointPath> -a ...
 {% endhighlight %}
 
 This is useful if your program dropped an operator that was part of the savepoint.
@@ -187,6 +187,9 @@ Action "run" compiles and runs a program.
 
   Syntax: run [OPTIONS] <jar-file> <arguments>
   "run" action options:
+     -a,--allowNonRestoredState                     Allow non restored savepoint
+                                                    state in case an operator has
+                                                    been removed from the job.
      -c,--class <classname>                         Class with the program entry
                                                     point ("main" method or
                                                     "getPlan()" method. Only
@@ -207,10 +210,6 @@ Action "run" compiles and runs a program.
                                                     java.net.URLClassLoader}.
      -d,--detached                                  If present, runs the job in
                                                     detached mode
-     -i,--ignoreUnmappedState                       Flag indicating whether
-                                                    savepoint state that cannot
-                                                    be mapped to the job shall
-                                                    be ignored.
      -m,--jobmanager <host:port>                    Address of the JobManager
                                                     (master) to which to
                                                     connect. Use this flag to

--- a/docs/apis/cli.md
+++ b/docs/apis/cli.md
@@ -150,6 +150,14 @@ Returns the path of the created savepoint. You need this path to restore and dis
 
 The run command has a savepoint flag to submit a job, which restores its state from a savepoint. The savepoint path is returned by the savepoint trigger command.
 
+By default, we try to match all savepoint state to the job being submitted. If you want to ignore savepoint state that cannot be mapped to the new job, you can set the `ignoreUnmappedState` flag:
+
+{% highlight bash %}
+./bin/flink run -s <savepointPath> -i ...
+{% endhighlight %}
+
+This is useful if your program dropped an operator that was part of the savepoint.
+
 #### **Dispose a savepoint**
 
 {% highlight bash %}
@@ -179,41 +187,56 @@ Action "run" compiles and runs a program.
 
   Syntax: run [OPTIONS] <jar-file> <arguments>
   "run" action options:
-     -c,--class <classname>               Class with the program entry point
-                                          ("main" method or "getPlan()" method.
-                                          Only needed if the JAR file does not
-                                          specify the class in its manifest.
-     -C,--classpath <url>                 Adds a URL to each user code
-                                          classloader  on all nodes in the
-                                          cluster. The paths must specify a
-                                          protocol (e.g. file://) and be
-                                          accessible on all nodes (e.g. by means
-                                          of a NFS share). You can use this
-                                          option multiple times for specifying
-                                          more than one URL. The protocol must
-                                          be supported by the {@link
-                                          java.net.URLClassLoader}.
-     -d,--detached                        If present, runs the job in detached
-                                          mode
-     -m,--jobmanager <host:port>          Address of the JobManager (master) to
-                                          which to connect. Specify
-                                          'yarn-cluster' as the JobManager to
-                                          deploy a YARN cluster for the job. Use
-                                          this flag to connect to a different
-                                          JobManager than the one specified in
-                                          the configuration.
-     -p,--parallelism <parallelism>       The parallelism with which to run the
-                                          program. Optional flag to override the
-                                          default value specified in the
-                                          configuration.
-     -q,--sysoutLogging                   If present, supress logging output to
-                                          standard out.
-     -s,--fromSavepoint <savepointPath>   Path to a savepoint to reset the job
-                                          back to (for example
-                                          file:///flink/savepoint-1537).
-  Additional arguments if -m yarn-cluster is set:
+     -c,--class <classname>                         Class with the program entry
+                                                    point ("main" method or
+                                                    "getPlan()" method. Only
+                                                    needed if the JAR file does
+                                                    not specify the class in its
+                                                    manifest.
+     -C,--classpath <url>                           Adds a URL to each user code
+                                                    classloader  on all nodes in
+                                                    the cluster. The paths must
+                                                    specify a protocol (e.g.
+                                                    file://) and be accessible
+                                                    on all nodes (e.g. by means
+                                                    of a NFS share). You can use
+                                                    this option multiple times
+                                                    for specifying more than one
+                                                    URL. The protocol must be
+                                                    supported by the {@link
+                                                    java.net.URLClassLoader}.
+     -d,--detached                                  If present, runs the job in
+                                                    detached mode
+     -i,--ignoreUnmappedState                       Flag indicating whether
+                                                    savepoint state that cannot
+                                                    be mapped to the job shall
+                                                    be ignored.
+     -m,--jobmanager <host:port>                    Address of the JobManager
+                                                    (master) to which to
+                                                    connect. Use this flag to
+                                                    connect to a different
+                                                    JobManager than the one
+                                                    specified in the
+                                                    configuration.
+     -p,--parallelism <parallelism>                 The parallelism with which
+                                                    to run the program. Optional
+                                                    flag to override the default
+                                                    value specified in the
+                                                    configuration.
+     -q,--sysoutLogging                             If present, suppress logging
+                                                    output to standard out.
+     -s,--fromSavepoint <savepointPath>             Path to a savepoint to
+                                                    restore the job from (for
+                                                    example
+                                                    hdfs:///flink/savepoint-1537
+                                                    ).
+     -z,--zookeeperNamespace <zookeeperNamespace>   Namespace to create the
+                                                    Zookeeper sub-paths for high
+                                                    availability mode
+  Options for yarn-cluster mode:
      -yD <arg>                            Dynamic properties
      -yd,--yarndetached                   Start detached
+     -yid,--yarnapplicationId <arg>       Attach to running YARN session
      -yj,--yarnjar <arg>                  Path to Flink jar file
      -yjm,--yarnjobManagerMemory <arg>    Memory for JobManager Container [in
                                           MB]
@@ -230,6 +253,8 @@ Action "run" compiles and runs a program.
                                           (t for transfer)
      -ytm,--yarntaskManagerMemory <arg>   Memory per TaskManager Container [in
                                           MB]
+     -yz,--yarnzookeeperNamespace <arg>   Namespace to create the Zookeeper
+                                          sub-paths for high availability mode
 
 
 Action "info" shows the optimized execution plan of the program (JSON).

--- a/docs/apis/cli.md
+++ b/docs/apis/cli.md
@@ -153,7 +153,7 @@ The run command has a savepoint flag to submit a job, which restores its state f
 By default, we try to match all savepoint state to the job being submitted. If you want to allow to skip savepoint state that cannot be restored with the new job you can set the `allowNonRestoredState` flag. You need to allow this if you removed an operator from your program that was part of the program when the savepoint was triggered and you still want to use the savepoint.
 
 {% highlight bash %}
-./bin/flink run -s <savepointPath> -a ...
+./bin/flink run -s <savepointPath> -n ...
 {% endhighlight %}
 
 This is useful if your program dropped an operator that was part of the savepoint.
@@ -187,9 +187,6 @@ Action "run" compiles and runs a program.
 
   Syntax: run [OPTIONS] <jar-file> <arguments>
   "run" action options:
-     -a,--allowNonRestoredState                     Allow non restored savepoint
-                                                    state in case an operator has
-                                                    been removed from the job.
      -c,--class <classname>                         Class with the program entry
                                                     point ("main" method or
                                                     "getPlan()" method. Only
@@ -217,6 +214,9 @@ Action "run" compiles and runs a program.
                                                     JobManager than the one
                                                     specified in the
                                                     configuration.
+     -n,--allowNonRestoredState                     Allow non restored savepoint
+                                                    state in case an operator has
+                                                    been removed from the job.
      -p,--parallelism <parallelism>                 The parallelism with which
                                                     to run the program. Optional
                                                     flag to override the default

--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -239,7 +239,7 @@ public class CliFrontend {
 			client.setDetached(options.getDetachedMode());
 			LOG.debug("Client slots is set to {}", client.getMaxSlots());
 
-			LOG.debug("Savepoint path is set to {}", options.getSavepointPath());
+			LOG.debug(options.getSavepointRestoreSettings().toString());
 
 			int userParallelism = options.getParallelism();
 			LOG.debug("User parallelism is set to {}", userParallelism);
@@ -833,7 +833,7 @@ public class CliFrontend {
 				new PackagedProgram(jarFile, classpaths, programArgs) :
 				new PackagedProgram(jarFile, classpaths, entryPointClass, programArgs);
 
-		program.setSavepointPath(options.getSavepointPath());
+		program.setSavepointRestoreSettings(options.getSavepointRestoreSettings());
 
 		return program;
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -72,7 +72,7 @@ public class CliFrontendParser {
 	static final Option SAVEPOINT_PATH_OPTION = new Option("s", "fromSavepoint", true,
 			"Path to a savepoint to restore the job from (for example hdfs:///flink/savepoint-1537).");
 
-	static final Option SAVEPOINT_ALLOW_NON_RESTORED_OPTION = new Option("a", "allowNonRestoredState", false,
+	static final Option SAVEPOINT_ALLOW_NON_RESTORED_OPTION = new Option("n", "allowNonRestoredState", false,
 			"Allow to skip savepoint state that cannot be restored. " +
 					"You need to allow this if you removed an operator from your " +
 					"program that was part of the program when the savepoint was triggered.");

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -70,7 +70,10 @@ public class CliFrontendParser {
 			"Use this flag to connect to a different JobManager than the one specified in the configuration.");
 
 	static final Option SAVEPOINT_PATH_OPTION = new Option("s", "fromSavepoint", true,
-			"Path to a savepoint to reset the job back to (for example file:///flink/savepoint-1537).");
+			"Path to a savepoint to restore the job from (for example hdfs:///flink/savepoint-1537).");
+
+	static final Option SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION = new Option("i", "ignoreUnmappedState", false,
+			"Flag indicating whether savepoint state that cannot be mapped to the job shall be ignored.");
 
 	static final Option SAVEPOINT_DISPOSE_OPTION = new Option("d", "dispose", true,
 			"Path of savepoint to dispose.");
@@ -116,6 +119,8 @@ public class CliFrontendParser {
 		SAVEPOINT_PATH_OPTION.setRequired(false);
 		SAVEPOINT_PATH_OPTION.setArgName("savepointPath");
 
+		SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION.setRequired(false);
+
 		ZOOKEEPER_NAMESPACE_OPTION.setRequired(false);
 		ZOOKEEPER_NAMESPACE_OPTION.setArgName("zookeeperNamespace");
 	}
@@ -146,7 +151,6 @@ public class CliFrontendParser {
 		options.addOption(ARGS_OPTION);
 		options.addOption(LOGGING_OPTION);
 		options.addOption(DETACHED_OPTION);
-		options.addOption(SAVEPOINT_PATH_OPTION);
 		options.addOption(ZOOKEEPER_NAMESPACE_OPTION);
 		return options;
 	}
@@ -157,13 +161,15 @@ public class CliFrontendParser {
 		options.addOption(PARALLELISM_OPTION);
 		options.addOption(LOGGING_OPTION);
 		options.addOption(DETACHED_OPTION);
-		options.addOption(SAVEPOINT_PATH_OPTION);
 		options.addOption(ZOOKEEPER_NAMESPACE_OPTION);
 		return options;
 	}
 
 	private static Options getRunOptions(Options options) {
 		options = getProgramSpecificOptions(options);
+		options.addOption(SAVEPOINT_PATH_OPTION);
+		options.addOption(SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION);
+
 		options = getJobManagerAddressOption(options);
 		return addCustomCliOptions(options, true);
 	}
@@ -210,6 +216,9 @@ public class CliFrontendParser {
 
 	private static Options getRunOptionsWithoutDeprecatedOptions(Options options) {
 		Options o = getProgramSpecificOptionsWithoutDeprecatedOptions(options);
+		o.addOption(SAVEPOINT_PATH_OPTION);
+		o.addOption(SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION);
+
 		return getJobManagerAddressOption(o);
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -72,8 +72,10 @@ public class CliFrontendParser {
 	static final Option SAVEPOINT_PATH_OPTION = new Option("s", "fromSavepoint", true,
 			"Path to a savepoint to restore the job from (for example hdfs:///flink/savepoint-1537).");
 
-	static final Option SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION = new Option("i", "ignoreUnmappedState", false,
-			"Flag indicating whether savepoint state that cannot be mapped to the job shall be ignored.");
+	static final Option SAVEPOINT_ALLOW_NON_RESTORED_OPTION = new Option("a", "allowNonRestoredState", false,
+			"Allow to skip savepoint state that cannot be restored. " +
+					"You need to allow this if you removed an operator from your " +
+					"program that was part of the program when the savepoint was triggered.");
 
 	static final Option SAVEPOINT_DISPOSE_OPTION = new Option("d", "dispose", true,
 			"Path of savepoint to dispose.");
@@ -119,7 +121,7 @@ public class CliFrontendParser {
 		SAVEPOINT_PATH_OPTION.setRequired(false);
 		SAVEPOINT_PATH_OPTION.setArgName("savepointPath");
 
-		SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION.setRequired(false);
+		SAVEPOINT_ALLOW_NON_RESTORED_OPTION.setRequired(false);
 
 		ZOOKEEPER_NAMESPACE_OPTION.setRequired(false);
 		ZOOKEEPER_NAMESPACE_OPTION.setArgName("zookeeperNamespace");
@@ -168,7 +170,7 @@ public class CliFrontendParser {
 	private static Options getRunOptions(Options options) {
 		options = getProgramSpecificOptions(options);
 		options.addOption(SAVEPOINT_PATH_OPTION);
-		options.addOption(SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION);
+		options.addOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION);
 
 		options = getJobManagerAddressOption(options);
 		return addCustomCliOptions(options, true);
@@ -217,7 +219,7 @@ public class CliFrontendParser {
 	private static Options getRunOptionsWithoutDeprecatedOptions(Options options) {
 		Options o = getProgramSpecificOptionsWithoutDeprecatedOptions(options);
 		o.addOption(SAVEPOINT_PATH_OPTION);
-		o.addOption(SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION);
+		o.addOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION);
 
 		return getJobManagerAddressOption(o);
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
@@ -34,7 +34,7 @@ import static org.apache.flink.client.cli.CliFrontendParser.DETACHED_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.JAR_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.LOGGING_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PARALLELISM_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_ALLOW_NON_RESTORED_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_PATH_OPTION;
 
 /**
@@ -114,8 +114,8 @@ public abstract class ProgramOptions extends CommandLineOptions {
 
 		if (line.hasOption(SAVEPOINT_PATH_OPTION.getOpt())) {
 			String savepointPath = line.getOptionValue(SAVEPOINT_PATH_OPTION.getOpt());
-			boolean ignoreUnmappedState = line.hasOption(SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION.getOpt());
-			this.savepointSettings = SavepointRestoreSettings.forPath(savepointPath, ignoreUnmappedState);
+			boolean allowNonRestoredState = line.hasOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION.getOpt());
+			this.savepointSettings = SavepointRestoreSettings.forPath(savepointPath, allowNonRestoredState);
 		} else {
 			this.savepointSettings = SavepointRestoreSettings.none();
 		}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
@@ -19,6 +19,7 @@ package org.apache.flink.client.cli;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -33,6 +34,7 @@ import static org.apache.flink.client.cli.CliFrontendParser.DETACHED_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.JAR_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.LOGGING_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PARALLELISM_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_PATH_OPTION;
 
 /**
@@ -54,7 +56,7 @@ public abstract class ProgramOptions extends CommandLineOptions {
 
 	private final boolean detachedMode;
 
-	private final String savepointPath;
+	private final SavepointRestoreSettings savepointSettings;
 
 	protected ProgramOptions(CommandLine line) throws CliArgsException {
 		super(line);
@@ -111,9 +113,11 @@ public abstract class ProgramOptions extends CommandLineOptions {
 		detachedMode = line.hasOption(DETACHED_OPTION.getOpt());
 
 		if (line.hasOption(SAVEPOINT_PATH_OPTION.getOpt())) {
-			savepointPath = line.getOptionValue(SAVEPOINT_PATH_OPTION.getOpt());
+			String savepointPath = line.getOptionValue(SAVEPOINT_PATH_OPTION.getOpt());
+			boolean ignoreUnmappedState = line.hasOption(SAVEPOINT_IGNORE_UNMAPPED_STATE_OPTION.getOpt());
+			this.savepointSettings = SavepointRestoreSettings.forPath(savepointPath, ignoreUnmappedState);
 		} else {
-			savepointPath = null;
+			this.savepointSettings = SavepointRestoreSettings.none();
 		}
 	}
 
@@ -145,7 +149,7 @@ public abstract class ProgramOptions extends CommandLineOptions {
 		return detachedMode;
 	}
 
-	public String getSavepointPath() {
-		return savepointPath;
+	public SavepointRestoreSettings getSavepointRestoreSettings() {
+		return savepointSettings;
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
 import java.net.URL;
 import java.util.List;
@@ -42,15 +43,15 @@ public class ContextEnvironment extends ExecutionEnvironment {
 	
 	protected final ClassLoader userCodeClassLoader;
 
-	protected final String savepointPath;
+	protected final SavepointRestoreSettings savepointSettings;
 	
 	public ContextEnvironment(ClusterClient remoteConnection, List<URL> jarFiles, List<URL> classpaths,
-				ClassLoader userCodeClassLoader, String savepointPath) {
+				ClassLoader userCodeClassLoader, SavepointRestoreSettings savepointSettings) {
 		this.client = remoteConnection;
 		this.jarFilesToAttach = jarFiles;
 		this.classpathsToAttach = classpaths;
 		this.userCodeClassLoader = userCodeClassLoader;
-		this.savepointPath = savepointPath;
+		this.savepointSettings = savepointSettings;
 	}
 
 	@Override
@@ -58,7 +59,7 @@ public class ContextEnvironment extends ExecutionEnvironment {
 		Plan p = createProgramPlan(jobName);
 		JobWithJars toRun = new JobWithJars(p, this.jarFilesToAttach, this.classpathsToAttach,
 				this.userCodeClassLoader);
-		this.lastJobExecutionResult = client.run(toRun, getParallelism(), savepointPath).getJobExecutionResult();
+		this.lastJobExecutionResult = client.run(toRun, getParallelism(), savepointSettings).getJobExecutionResult();
 		return this.lastJobExecutionResult;
 	}
 
@@ -99,8 +100,8 @@ public class ContextEnvironment extends ExecutionEnvironment {
 		return userCodeClassLoader;
 	}
 
-	public String getSavepointPath() {
-		return savepointPath;
+	public SavepointRestoreSettings getSavepointRestoreSettings() {
+		return savepointSettings;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironmentFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironmentFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.client.program;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
 import java.net.URL;
 import java.util.List;
@@ -46,11 +47,11 @@ public class ContextEnvironmentFactory implements ExecutionEnvironmentFactory {
 
 	private ExecutionEnvironment lastEnvCreated;
 
-	private String savepointPath;
+	private SavepointRestoreSettings savepointSettings;
 
 	public ContextEnvironmentFactory(ClusterClient client, List<URL> jarFilesToAttach,
 			List<URL> classpathsToAttach, ClassLoader userCodeClassLoader, int defaultParallelism,
-			boolean isDetached, String savepointPath)
+			boolean isDetached, SavepointRestoreSettings savepointSettings)
 	{
 		this.client = client;
 		this.jarFilesToAttach = jarFilesToAttach;
@@ -58,7 +59,7 @@ public class ContextEnvironmentFactory implements ExecutionEnvironmentFactory {
 		this.userCodeClassLoader = userCodeClassLoader;
 		this.defaultParallelism = defaultParallelism;
 		this.isDetached = isDetached;
-		this.savepointPath = savepointPath;
+		this.savepointSettings = savepointSettings;
 	}
 
 	@Override
@@ -68,8 +69,8 @@ public class ContextEnvironmentFactory implements ExecutionEnvironmentFactory {
 		}
 
 		lastEnvCreated = isDetached ?
-				new DetachedEnvironment(client, jarFilesToAttach, classpathsToAttach, userCodeClassLoader, savepointPath):
-				new ContextEnvironment(client, jarFilesToAttach, classpathsToAttach, userCodeClassLoader, savepointPath);
+				new DetachedEnvironment(client, jarFilesToAttach, classpathsToAttach, userCodeClassLoader, savepointSettings):
+				new ContextEnvironment(client, jarFilesToAttach, classpathsToAttach, userCodeClassLoader, savepointSettings);
 		if (defaultParallelism > 0) {
 			lastEnvCreated.setParallelism(defaultParallelism);
 		}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/DetachedEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/DetachedEnvironment.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.optimizer.plan.FlinkPlan;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,8 +47,8 @@ public class DetachedEnvironment extends ContextEnvironment {
 			List<URL> jarFiles,
 			List<URL> classpaths,
 			ClassLoader userCodeClassLoader,
-			String savepointPath) {
-		super(remoteConnection, jarFiles, classpaths, userCodeClassLoader, savepointPath);
+			SavepointRestoreSettings savepointSettings) {
+		super(remoteConnection, jarFiles, classpaths, userCodeClassLoader, savepointSettings);
 	}
 
 	@Override
@@ -72,7 +73,7 @@ public class DetachedEnvironment extends ContextEnvironment {
 	 * Finishes this Context Environment's execution by explicitly running the plan constructed.
 	 */
 	JobSubmissionResult finalizeExecute() throws ProgramInvocationException {
-		return client.run(detachedPlan, jarFilesToAttach, classpathsToAttach, userCodeClassLoader, savepointPath);
+		return client.run(detachedPlan, jarFilesToAttach, classpathsToAttach, userCodeClassLoader, savepointSettings);
 	}
 
 	public static final class DetachedJobExecutionResult extends JobExecutionResult {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -49,6 +49,7 @@ import org.apache.flink.api.common.ProgramDescription;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.dag.DataSinkNode;
 import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.util.InstantiationUtil;
 
 /**
@@ -86,7 +87,7 @@ public class PackagedProgram {
 	
 	private Plan plan;
 
-	private String savepointPath;
+	private SavepointRestoreSettings savepointSettings = SavepointRestoreSettings.none();
 
 	/**
 	 * Creates an instance that wraps the plan defined in the jar file using the given
@@ -257,12 +258,12 @@ public class PackagedProgram {
 		}
 	}
 
-	public void setSavepointPath(String savepointPath) {
-		this.savepointPath = savepointPath;
+	public void setSavepointRestoreSettings(SavepointRestoreSettings savepointSettings) {
+		this.savepointSettings = savepointSettings;
 	}
 
-	public String getSavepointPath() {
-		return savepointPath;
+	public SavepointRestoreSettings getSavepointSettings() {
+		return savepointSettings;
 	}
 
 	public String[] getArguments() {

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
@@ -103,17 +103,17 @@ public class CliFrontendRunTest {
 				SavepointRestoreSettings savepointSettings = options.getSavepointRestoreSettings();
 				assertTrue(savepointSettings.restoreSavepoint());
 				assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
-				assertFalse(savepointSettings.ignoreUnmappedState());
+				assertFalse(savepointSettings.allowNonRestoredState());
 			}
 
 			// test configure savepoint path (with ignore flag)
 			{
-				String[] parameters = {"-s", "expectedSavepointPath", "-i", getTestJarPath()};
+				String[] parameters = {"-s", "expectedSavepointPath", "-a", getTestJarPath()};
 				RunOptions options = CliFrontendParser.parseRunCommand(parameters);
 				SavepointRestoreSettings savepointSettings = options.getSavepointRestoreSettings();
 				assertTrue(savepointSettings.restoreSavepoint());
 				assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
-				assertTrue(savepointSettings.ignoreUnmappedState());
+				assertTrue(savepointSettings.allowNonRestoredState());
 			}
 
 			// test jar arguments

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
@@ -108,7 +108,7 @@ public class CliFrontendRunTest {
 
 			// test configure savepoint path (with ignore flag)
 			{
-				String[] parameters = {"-s", "expectedSavepointPath", "-a", getTestJarPath()};
+				String[] parameters = {"-s", "expectedSavepointPath", "-n", getTestJarPath()};
 				RunOptions options = CliFrontendParser.parseRunCommand(parameters);
 				SavepointRestoreSettings savepointSettings = options.getSavepointRestoreSettings();
 				assertTrue(savepointSettings.restoreSavepoint());

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
@@ -19,16 +19,20 @@
 
 package org.apache.flink.client;
 
-import static org.apache.flink.client.CliFrontendTestUtils.*;
-import static org.junit.Assert.*;
-
 import org.apache.flink.client.cli.CliFrontendParser;
-import org.apache.flink.client.cli.CommandLineOptions;
 import org.apache.flink.client.cli.RunOptions;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static org.apache.flink.client.CliFrontendTestUtils.getTestJarPath;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 public class CliFrontendRunTest {
@@ -92,11 +96,24 @@ public class CliFrontendRunTest {
 				assertNotEquals(0, testFrontend.run(parameters));
 			}
 
-			// test configure savepoint path
+			// test configure savepoint path (no ignore flag)
 			{
 				String[] parameters = {"-s", "expectedSavepointPath", getTestJarPath()};
 				RunOptions options = CliFrontendParser.parseRunCommand(parameters);
-				assertEquals("expectedSavepointPath", options.getSavepointPath());
+				SavepointRestoreSettings savepointSettings = options.getSavepointRestoreSettings();
+				assertTrue(savepointSettings.restoreSavepoint());
+				assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
+				assertFalse(savepointSettings.ignoreUnmappedState());
+			}
+
+			// test configure savepoint path (with ignore flag)
+			{
+				String[] parameters = {"-s", "expectedSavepointPath", "-i", getTestJarPath()};
+				RunOptions options = CliFrontendParser.parseRunCommand(parameters);
+				SavepointRestoreSettings savepointSettings = options.getSavepointRestoreSettings();
+				assertTrue(savepointSettings.restoreSavepoint());
+				assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
+				assertTrue(savepointSettings.ignoreUnmappedState());
 			}
 
 			// test jar arguments

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointCoordinator.java
@@ -181,7 +181,7 @@ public class SavepointCoordinator extends CheckpointCoordinator {
 	 *
 	 * @param tasks         Tasks that will possibly be reset
 	 * @param savepointPath The path of the savepoint to rollback to
-	 * @param ignoreUnmappedState Ignore checkpoint state that cannot be mapped
+	 * @param allowNonRestoredState Allow to skip checkpoint state that cannot be mapped
 	 * to any job vertex in tasks.
 	 * @throws IllegalStateException If coordinator is shut down
 	 * @throws IllegalStateException If mismatch between program and savepoint state
@@ -190,7 +190,7 @@ public class SavepointCoordinator extends CheckpointCoordinator {
 	public void restoreSavepoint(
 			Map<JobVertexID, ExecutionJobVertex> tasks,
 			String savepointPath,
-			boolean ignoreUnmappedState) throws Exception {
+			boolean allowNonRestoredState) throws Exception {
 
 		checkNotNull(savepointPath, "Savepoint path");
 
@@ -242,13 +242,13 @@ public class SavepointCoordinator extends CheckpointCoordinator {
 
 						currentExecutionAttempt.setInitialState(state, kvStateForTaskMap);
 					}
-				} else if (ignoreUnmappedState) {
+				} else if (allowNonRestoredState) {
 					LOG.info("Ignoring checkpoint state for operator {}.", taskState.getJobVertexID());
 				} else {
 					String msg = String.format("Failed to rollback to savepoint %s. " +
 									"Cannot map savepoint state for operator %s to the new program, " +
 									"because the operator is not available in the new program. If " +
-									"you want to ignore this, you can set the --ignoreUnmappedState " +
+									"you want to allow this, you can set the --allowNonRestoredState " +
 									"option on the CLI.",
 							savepointPath, taskState.getJobVertexID());
 					throw new IllegalStateException(msg);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -953,7 +953,7 @@ public class ExecutionGraph implements Serializable {
 					if (!restored && savepointCoordinator != null) {
 						String savepointPath = savepointCoordinator.getSavepointRestorePath();
 						if (savepointPath != null) {
-							savepointCoordinator.restoreSavepoint(getAllVertices(), savepointPath);
+							savepointCoordinator.restoreSavepoint(getAllVertices(), savepointPath, false);
 						}
 					}
 				}
@@ -990,21 +990,20 @@ public class ExecutionGraph implements Serializable {
 	 * actor.
 	 *
 	 * @param savepointPath The path of the savepoint to rollback to.
+	 * @param ignoreUnmappedState Ignore checkpoint state that cannot be mapped
+	 * to any job vertex in tasks.
 	 * @throws IllegalStateException If checkpointing is disabled
 	 * @throws IllegalStateException If checkpoint coordinator is shut down
 	 * @throws Exception If failure during rollback
 	 */
-	public void restoreSavepoint(String savepointPath) throws Exception {
+	public void restoreSavepoint(String savepointPath, boolean ignoreUnmappedState) throws Exception {
 		synchronized (progressLock) {
 			if (savepointCoordinator != null) {
 				LOG.info("Restoring savepoint: " + savepointPath + ".");
-
 				savepointCoordinator.restoreSavepoint(
-						getAllVertices(), savepointPath);
-			}
-			else {
-				// Sanity check
-				throw new IllegalStateException("Checkpointing disabled.");
+						getAllVertices(), savepointPath, ignoreUnmappedState);
+			} else {
+				throw new IllegalStateException("Savepoints disabled.");
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -990,18 +990,18 @@ public class ExecutionGraph implements Serializable {
 	 * actor.
 	 *
 	 * @param savepointPath The path of the savepoint to rollback to.
-	 * @param ignoreUnmappedState Ignore checkpoint state that cannot be mapped
+	 * @param allowNonRestoredState Allow to skip checkpoint state that cannot be mapped
 	 * to any job vertex in tasks.
 	 * @throws IllegalStateException If checkpointing is disabled
 	 * @throws IllegalStateException If checkpoint coordinator is shut down
 	 * @throws Exception If failure during rollback
 	 */
-	public void restoreSavepoint(String savepointPath, boolean ignoreUnmappedState) throws Exception {
+	public void restoreSavepoint(String savepointPath, boolean allowNonRestoredState) throws Exception {
 		synchronized (progressLock) {
 			if (savepointCoordinator != null) {
 				LOG.info("Restoring savepoint: " + savepointPath + ".");
 				savepointCoordinator.restoreSavepoint(
-						getAllVertices(), savepointPath, ignoreUnmappedState);
+						getAllVertices(), savepointPath, allowNonRestoredState);
 			} else {
 				throw new IllegalStateException("Savepoints disabled.");
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph;
+
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Savepoint restore settings.
+ */
+public class SavepointRestoreSettings implements Serializable {
+
+	private static final long serialVersionUID = 87377506900849777L;
+
+	/** No restore should happen. */
+	private final static SavepointRestoreSettings NONE = new SavepointRestoreSettings(null, false);
+
+	/** By default, be strict when restoring from a savepoint.  */
+	private final static boolean DEFAULT_IGNORE_UNMAPPED_STATE = false;
+
+	/** Savepoint restore path. */
+	private final String restorePath;
+
+	/**
+	 * Flag indicating whether the restore should ignore if the savepoint contains
+	 * state for an operator that is not part of the job.
+	 */
+	private final boolean ignoreUnmappedState;
+
+	/**
+	 * Creates the restore settings.
+	 *
+	 * @param restorePath Savepoint restore path.
+	 * @param ignoreUnmappedState Ignore unmapped state.
+	 */
+	private SavepointRestoreSettings(String restorePath, boolean ignoreUnmappedState) {
+		this.restorePath = restorePath;
+		this.ignoreUnmappedState = ignoreUnmappedState;
+	}
+
+	/**
+	 * Returns whether to restore from savepoint.
+	 * @return <code>true</code> if should restore from savepoint.
+	 */
+	public boolean restoreSavepoint() {
+		return restorePath != null;
+	}
+
+	/**
+	 * Returns the path to the savepoint to restore from.
+	 * @return Path to the savepoint to restore from or <code>null</code> if
+	 * should not restore.
+	 */
+	public String getRestorePath() {
+		return restorePath;
+	}
+
+	/**
+	 * Returns whether the restore should ignore whether the savepoint contains
+	 * state that cannot be mapped to the job.
+	 *
+	 * @return <code>true</code> if restore should ignore whether the savepoint contains
+	 * state that cannot be mapped to the job.
+	 */
+	public boolean ignoreUnmappedState() {
+		return ignoreUnmappedState;
+	}
+
+	@Override
+	public String toString() {
+		if (restoreSavepoint()) {
+			return "SavepointRestoreSettings.forPath(" +
+					"restorePath='" + restorePath + '\'' +
+					", ignoreUnmappedState=" + ignoreUnmappedState +
+					')';
+		} else {
+			return "SavepointRestoreSettings.none()";
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	public static SavepointRestoreSettings none() {
+		return NONE;
+	}
+
+	public static SavepointRestoreSettings forPath(String savepointPath) {
+		return forPath(savepointPath, DEFAULT_IGNORE_UNMAPPED_STATE);
+	}
+
+	public static SavepointRestoreSettings forPath(String savepointPath, boolean ignoreUnmappedState) {
+		checkNotNull(savepointPath, "Savepoint restore path.");
+		return new SavepointRestoreSettings(savepointPath, ignoreUnmappedState);
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
@@ -33,26 +33,26 @@ public class SavepointRestoreSettings implements Serializable {
 	private final static SavepointRestoreSettings NONE = new SavepointRestoreSettings(null, false);
 
 	/** By default, be strict when restoring from a savepoint.  */
-	private final static boolean DEFAULT_IGNORE_UNMAPPED_STATE = false;
+	private final static boolean DEFAULT_ALLOW_NON_RESTORED_STATE = false;
 
 	/** Savepoint restore path. */
 	private final String restorePath;
 
 	/**
-	 * Flag indicating whether the restore should ignore if the savepoint contains
-	 * state for an operator that is not part of the job.
+	 * Flag indicating whether non restored state is allowed if the savepoint
+	 * contains state for an operator that is not part of the job.
 	 */
-	private final boolean ignoreUnmappedState;
+	private final boolean allowNonRestoredState;
 
 	/**
 	 * Creates the restore settings.
 	 *
 	 * @param restorePath Savepoint restore path.
-	 * @param ignoreUnmappedState Ignore unmapped state.
+	 * @param allowNonRestoredState Ignore unmapped state.
 	 */
-	private SavepointRestoreSettings(String restorePath, boolean ignoreUnmappedState) {
+	private SavepointRestoreSettings(String restorePath, boolean allowNonRestoredState) {
 		this.restorePath = restorePath;
-		this.ignoreUnmappedState = ignoreUnmappedState;
+		this.allowNonRestoredState = allowNonRestoredState;
 	}
 
 	/**
@@ -73,14 +73,14 @@ public class SavepointRestoreSettings implements Serializable {
 	}
 
 	/**
-	 * Returns whether the restore should ignore whether the savepoint contains
-	 * state that cannot be mapped to the job.
+	 * Returns whether non restored state is allowed if the savepoint contains
+	 * state that cannot be mapped back to the job.
 	 *
-	 * @return <code>true</code> if restore should ignore whether the savepoint contains
-	 * state that cannot be mapped to the job.
+	 * @return <code>true</code> if non restored state is allowed if the savepoint
+	 * contains state that cannot be mapped  back to the job.
 	 */
-	public boolean ignoreUnmappedState() {
-		return ignoreUnmappedState;
+	public boolean allowNonRestoredState() {
+		return allowNonRestoredState;
 	}
 
 	@Override
@@ -88,7 +88,7 @@ public class SavepointRestoreSettings implements Serializable {
 		if (restoreSavepoint()) {
 			return "SavepointRestoreSettings.forPath(" +
 					"restorePath='" + restorePath + '\'' +
-					", ignoreUnmappedState=" + ignoreUnmappedState +
+					", allowNonRestoredState=" + allowNonRestoredState +
 					')';
 		} else {
 			return "SavepointRestoreSettings.none()";
@@ -102,12 +102,12 @@ public class SavepointRestoreSettings implements Serializable {
 	}
 
 	public static SavepointRestoreSettings forPath(String savepointPath) {
-		return forPath(savepointPath, DEFAULT_IGNORE_UNMAPPED_STATE);
+		return forPath(savepointPath, DEFAULT_ALLOW_NON_RESTORED_STATE);
 	}
 
-	public static SavepointRestoreSettings forPath(String savepointPath, boolean ignoreUnmappedState) {
+	public static SavepointRestoreSettings forPath(String savepointPath, boolean allowNonRestoredState) {
 		checkNotNull(savepointPath, "Savepoint restore path.");
-		return new SavepointRestoreSettings(savepointPath, ignoreUnmappedState);
+		return new SavepointRestoreSettings(savepointPath, allowNonRestoredState);
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/JobSnapshottingSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/JobSnapshottingSettings.java
@@ -47,9 +47,6 @@ public class JobSnapshottingSettings implements java.io.Serializable{
 	private final long minPauseBetweenCheckpoints;
 	
 	private final int maxConcurrentCheckpoints;
-
-	/** Path to savepoint to reset state back to (optional, can be null) */
-	private String savepointPath;
 	
 	public JobSnapshottingSettings(List<JobVertexID> verticesToTrigger,
 									List<JobVertexID> verticesToAcknowledge,
@@ -101,26 +98,6 @@ public class JobSnapshottingSettings implements java.io.Serializable{
 
 	public int getMaxConcurrentCheckpoints() {
 		return maxConcurrentCheckpoints;
-	}
-
-	/**
-	 * Sets the savepoint path.
-	 *
-	 * This is only set if the job shall be resumed from a savepoint on submission.
-	 *
-	 * @param savepointPath The path of the savepoint to resume from.
-	 */
-	public void setSavepointPath(String savepointPath) {
-		this.savepointPath = savepointPath;
-	}
-
-	/**
-	 * Returns the configured savepoint path or <code>null</code> if none is configured.
-	 *
-	 * @return The configured savepoint path or <code>null</code> if none is configured.
-	 */
-	public String getSavepointPath() {
-		return savepointPath;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1299,7 +1299,9 @@ class JobManager(
               val savepointPath = savepointSettings.getRestorePath()
 
               try {
-                executionGraph.restoreSavepoint(savepointPath)
+                executionGraph.restoreSavepoint(
+                  savepointPath,
+                  savepointSettings.ignoreUnmappedState())
               } catch {
                 case e: Exception =>
                   jobInfo.client ! decorateMessage(JobResultFailure(new SerializedThrowable(e)))

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1301,7 +1301,7 @@ class JobManager(
               try {
                 executionGraph.restoreSavepoint(
                   savepointPath,
-                  savepointSettings.ignoreUnmappedState())
+                  savepointSettings.allowNonRestoredState())
               } catch {
                 case e: Exception =>
                   jobInfo.client ! decorateMessage(JobResultFailure(new SerializedThrowable(e)))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointCoordinatorRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointCoordinatorRestoreTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.savepoint;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.checkpoint.StandaloneCheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.TaskState;
+import org.apache.flink.runtime.checkpoint.stats.DisabledCheckpointStatsTracker;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests concerning the restoring of state from a savepoint to the task executions.
+ */
+public class SavepointCoordinatorRestoreTest {
+
+	/**
+	 * Tests that the unmapped state flag is correctly handled.
+	 *
+	 * The flag should only apply for state that is part of the checkpoint.
+	 */
+	@Test
+	public void testRestoreUnmappedCheckpointState() throws Exception {
+		// --- (1) Create tasks to restore checkpoint with ---
+		JobVertexID jobVertexId1 = new JobVertexID();
+		JobVertexID jobVertexId2 = new JobVertexID();
+
+		// 1st JobVertex
+		ExecutionVertex vertex11 = mockExecutionVertex(mockExecution(), jobVertexId1, 0, 3);
+		ExecutionVertex vertex12 = mockExecutionVertex(mockExecution(), jobVertexId1, 1, 3);
+		ExecutionVertex vertex13 = mockExecutionVertex(mockExecution(), jobVertexId1, 2, 3);
+		// 2nd JobVertex
+		ExecutionVertex vertex21 = mockExecutionVertex(mockExecution(), jobVertexId2, 0, 2);
+		ExecutionVertex vertex22 = mockExecutionVertex(mockExecution(), jobVertexId2, 1, 2);
+
+		ExecutionJobVertex jobVertex1 = mockExecutionJobVertex(jobVertexId1, new ExecutionVertex[] { vertex11, vertex12, vertex13 });
+		ExecutionJobVertex jobVertex2 = mockExecutionJobVertex(jobVertexId2, new ExecutionVertex[] { vertex21, vertex22 });
+
+		Map<JobVertexID, ExecutionJobVertex> tasks = new HashMap<>();
+		tasks.put(jobVertexId1, jobVertex1);
+		tasks.put(jobVertexId2, jobVertex2);
+
+		SavepointStore store = new HeapSavepointStore();
+
+		SavepointCoordinator coord = new SavepointCoordinator(
+				new JobID(),
+				Integer.MAX_VALUE,
+				Integer.MAX_VALUE,
+				0,
+				new ExecutionVertex[] {},
+				new ExecutionVertex[] {},
+				new ExecutionVertex[] {},
+				getClass().getClassLoader(),
+				new StandaloneCheckpointIDCounter(),
+				store,
+				new DisabledCheckpointStatsTracker());
+
+		// --- (2) Checkpoint misses state for a jobVertex (should work) ---
+		Map<JobVertexID, TaskState> checkpointTaskStates = new HashMap<>();
+		checkpointTaskStates.put(jobVertexId1, new TaskState(jobVertexId1, 3));
+
+		CompletedCheckpoint checkpoint = new CompletedCheckpoint(new JobID(), 0, 1, 2, new HashMap<>(checkpointTaskStates));
+
+		Savepoint savepoint = new SavepointV0(checkpoint.getCheckpointID(), checkpointTaskStates.values());
+		String savepointPath = store.storeSavepoint(savepoint);
+
+		coord.restoreSavepoint(tasks, savepointPath, false);
+		coord.restoreSavepoint(tasks, savepointPath, true);
+
+		// --- (3) JobVertex missing for task state that is part of the checkpoint ---
+		JobVertexID newJobVertexID = new JobVertexID();
+
+		// There is no task for this
+		checkpointTaskStates.put(newJobVertexID, new TaskState(newJobVertexID, 1));
+
+		checkpoint = new CompletedCheckpoint(new JobID(), 1, 2, 3, new HashMap<>(checkpointTaskStates));
+		savepoint = new SavepointV0(checkpoint.getCheckpointID(), checkpointTaskStates.values());
+		savepointPath = store.storeSavepoint(savepoint);
+
+		// (i) Ignore unmapped state (should succeed)
+		coord.restoreSavepoint(tasks, savepointPath, true);
+
+		// (ii) Don't ignore unmapped state (should fail)
+		try {
+			coord.restoreSavepoint(tasks, savepointPath, false);
+			fail("Did not throw the expected Exception.");
+		} catch (IllegalStateException ignored) {
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	private Execution mockExecution() {
+		return mockExecution(ExecutionState.RUNNING);
+	}
+
+	private Execution mockExecution(ExecutionState state) {
+		Execution mock = Mockito.mock(Execution.class);
+		when(mock.getAttemptId()).thenReturn(new ExecutionAttemptID());
+		when(mock.getState()).thenReturn(state);
+		return mock;
+	}
+
+	private ExecutionVertex mockExecutionVertex(Execution execution, JobVertexID vertexId, int subtask, int parallelism) {
+		ExecutionVertex mock = Mockito.mock(ExecutionVertex.class);
+		when(mock.getJobvertexId()).thenReturn(vertexId);
+		when(mock.getParallelSubtaskIndex()).thenReturn(subtask);
+		when(mock.getCurrentExecutionAttempt()).thenReturn(execution);
+		when(mock.getTotalNumberOfParallelSubtasks()).thenReturn(parallelism);
+		return mock;
+	}
+
+	private ExecutionJobVertex mockExecutionJobVertex(JobVertexID id, ExecutionVertex[] vertices) {
+		ExecutionJobVertex vertex = Mockito.mock(ExecutionJobVertex.class);
+		when(vertex.getParallelism()).thenReturn(vertices.length);
+		when(vertex.getJobVertexId()).thenReturn(id);
+		when(vertex.getTaskVertices()).thenReturn(vertices);
+		return vertex;
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointCoordinatorTest.java
@@ -271,7 +271,7 @@ public class SavepointCoordinatorTest extends TestLogger {
 		assertNotNull(savepointPath);
 
 		// Rollback
-		coordinator.restoreSavepoint(createExecutionJobVertexMap(jobVertices), savepointPath);
+		coordinator.restoreSavepoint(createExecutionJobVertexMap(jobVertices), savepointPath, false);
 
 		// Verify all executions have been reset
 		for (ExecutionVertex vertex : ackVertices) {
@@ -339,7 +339,7 @@ public class SavepointCoordinatorTest extends TestLogger {
 			// Rollback
 			coordinator.restoreSavepoint(
 					createExecutionJobVertexMap(jobVertices),
-					savepointPath);
+					savepointPath, false);
 			fail("Did not throw expected Exception after rollback with parallelism mismatch.");
 		}
 		catch (Exception ignored) {
@@ -385,7 +385,7 @@ public class SavepointCoordinatorTest extends TestLogger {
 			// Rollback
 			coordinator.restoreSavepoint(
 					createExecutionJobVertexMap(jobVertex),
-					savepointPath);
+					savepointPath, false);
 
 			fail("Did not throw expected Exception after rollback with savepoint store failure.");
 		}
@@ -416,7 +416,7 @@ public class SavepointCoordinatorTest extends TestLogger {
 				checkpointIdCounter,
 				savepointStore);
 
-		coordinator.restoreSavepoint(createExecutionJobVertexMap(), "any");
+		coordinator.restoreSavepoint(createExecutionJobVertexMap(), "any", false);
 
 		verify(checkpointIdCounter).setCount(eq(12312312L + 1));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
@@ -583,14 +583,14 @@ public class JobManagerTest extends TestLogger {
 			Throwable cause = failure.cause().deserializeError(ClassLoader.getSystemClassLoader());
 
 			assertTrue(cause instanceof IllegalStateException);
-			assertTrue(cause.getMessage().contains("ignoreUnmappedState"));
+			assertTrue(cause.getMessage().contains("allowNonRestoredState"));
 
 			// Wait until removed
 			msg = new TestingJobManagerMessages.NotifyWhenJobRemoved(newJobGraph.getJobID());
 
 			Await.ready(jobManager.ask(msg, timeout), timeout);
 
-			// Resubmit, but ignore unmapped state now
+			// Resubmit, but allow non restored state now
 			restoreSettings = SavepointRestoreSettings.forPath(savepointPath, true);
 			newJobGraph.setSavepointRestoreSettings(restoreSettings);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.messages.JobManagerMessages;
@@ -202,7 +203,7 @@ public class JobSubmitTest {
 	public void testAnswerFailureWhenSavepointReadFails() throws Exception {
 		// create a simple job graph
 		JobGraph jg = createSimpleJobGraph();
-		jg.setSavepointPath("pathThatReallyDoesNotExist...");
+		jg.setSavepointRestoreSettings(SavepointRestoreSettings.forPath("pathThatReallyDoesNotExist..."));
 
 		// submit the job
 		Future<Object> submitFuture = jmGateway.ask(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
@@ -65,7 +65,7 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
 		} else {
 			return ctx
 				.getClient()
-				.run(streamGraph, ctx.getJars(), ctx.getClasspaths(), ctx.getUserCodeClassLoader(), ctx.getSavepointPath())
+				.run(streamGraph, ctx.getJars(), ctx.getClasspaths(), ctx.getUserCodeClassLoader(), ctx.getSavepointRestoreSettings())
 				.getJobExecutionResult();
 		}
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.messages.JobManagerMessages.CancelJob;
 import org.apache.flink.runtime.messages.JobManagerMessages.DisposeSavepoint;
 import org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepoint;
@@ -278,7 +279,7 @@ public class SavepointITCase extends TestLogger {
 							}
 
 							// Set the savepoint path
-							jobGraph.setSavepointPath(savepointPath);
+							jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath));
 
 							LOG.info("Resubmitting job " + jobGraph.getJobID() + " with " +
 									"savepoint path " + savepointPath + " in detached mode.");
@@ -521,7 +522,7 @@ public class SavepointITCase extends TestLogger {
 			flink.start();
 
 			// Set the savepoint path
-			jobGraph.setSavepointPath(savepointPath);
+			jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath));
 
 			LOG.info("Resubmitting job " + jobGraph.getJobID() + " with " +
 					"savepoint path " + savepointPath + " in detached mode.");
@@ -733,8 +734,8 @@ public class SavepointITCase extends TestLogger {
 			final JobGraph jobGraph = createJobGraph(parallelism, numberOfRetries, 3600000, 1000);
 
 			// Set non-existing savepoint path
-			jobGraph.setSavepointPath("unknown path");
-			assertEquals("unknown path", jobGraph.getSnapshotSettings().getSavepointPath());
+			jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath("unknown path"));
+			assertEquals("unknown path", jobGraph.getSavepointRestoreSettings().getRestorePath());
 
 			LOG.info("Submitting job " + jobGraph.getJobID() + " in detached mode.");
 
@@ -847,7 +848,7 @@ public class SavepointITCase extends TestLogger {
 
 			// Set source to fail on restore calls and try to recover from savepoint
 			RestoreStateCountingAndFailingSource.failOnRestoreStateCall = true;
-			jobGraph.setSavepointPath(savepointPath);
+			jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath));
 
 			try {
 				flink.submitJobAndWait(jobGraph, false, deadline.timeLeft());


### PR DESCRIPTION
Backport of #2712 for `release-1.1`.

Technically, this adds new behaviour to a bugfix release, but the default behaviour is not changed and multiple users already ran into this. In such a case, there is no straight forward way to work around this issue.
