### PR TITLE
Fix for [FLINK-4894] [network] Don't request buffer after writing to partition

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
@@ -188,7 +188,7 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 	@Override
 	public boolean hasData() {
 		// either data in current target buffer or intermediate buffers
-		return this.position > 0 || (this.lengthBuffer.hasRemaining() || this.dataBuffer.hasRemaining());
+		return (this.position > 0 && this.position < this.limit) || (this.lengthBuffer.hasRemaining() || this.dataBuffer.hasRemaining());
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
@@ -172,6 +172,8 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 	@Override
 	public void clearCurrentBuffer() {
 		targetBuffer = null;
+		position = 0;
+		limit = 0;
 	}
 
 	@Override
@@ -188,7 +190,7 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 	@Override
 	public boolean hasData() {
 		// either data in current target buffer or intermediate buffers
-		return (this.position > 0 && this.position < this.limit) || (this.lengthBuffer.hasRemaining() || this.dataBuffer.hasRemaining());
+		return this.position > 0 || (this.lengthBuffer.hasRemaining() || this.dataBuffer.hasRemaining());
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -47,7 +47,7 @@ import static org.apache.flink.runtime.io.network.api.serialization.RecordSerial
  */
 public class RecordWriter<T extends IOReadableWritable> {
 
-	protected final ResultPartitionWriter writer;
+	protected final ResultPartitionWriter targetPartition;
 
 	private final ChannelSelector<T> channelSelector;
 
@@ -64,7 +64,7 @@ public class RecordWriter<T extends IOReadableWritable> {
 
 	@SuppressWarnings("unchecked")
 	public RecordWriter(ResultPartitionWriter writer, ChannelSelector<T> channelSelector) {
-		this.writer = writer;
+		this.targetPartition = writer;
 		this.channelSelector = channelSelector;
 
 		this.numChannels = writer.getNumberOfOutputChannels();
@@ -108,15 +108,25 @@ public class RecordWriter<T extends IOReadableWritable> {
 
 		synchronized (serializer) {
 			SerializationResult result = serializer.addRecord(record);
+
 			while (result.isFullBuffer()) {
 				Buffer buffer = serializer.getCurrentBuffer();
 
 				if (buffer != null) {
-					writeBuffer(buffer, targetChannel, serializer);
-				}
+					writeAndClearBuffer(buffer, targetChannel, serializer);
 
-				buffer = writer.getBufferProvider().requestBufferBlocking();
-				result = serializer.setNextBuffer(buffer);
+					// If this was a full record, we are done. Not breaking
+					// out of the loop at this point will lead to another
+					// buffer request before breaking out (that would not be
+					// a problem per se, but it can lead to stalls in the
+					// pipeline).
+					if (result.isFullRecord()) {
+						break;
+					}
+				} else {
+					buffer = targetPartition.getBufferProvider().requestBufferBlocking();
+					result = serializer.setNextBuffer(buffer);
+				}
 			}
 		}
 	}
@@ -126,23 +136,14 @@ public class RecordWriter<T extends IOReadableWritable> {
 			RecordSerializer<T> serializer = serializers[targetChannel];
 
 			synchronized (serializer) {
-
-				if (serializer.hasData()) {
-					Buffer buffer = serializer.getCurrentBuffer();
-					if (buffer == null) {
-						throw new IllegalStateException("Serializer has data but no buffer.");
-					}
-
-					writeBuffer(buffer, targetChannel, serializer);
-
-					writer.writeEvent(event, targetChannel);
-
-					buffer = writer.getBufferProvider().requestBufferBlocking();
-					serializer.setNextBuffer(buffer);
+				Buffer buffer = serializer.getCurrentBuffer();
+				if (buffer != null) {
+					writeAndClearBuffer(buffer, targetChannel, serializer);
+				} else if (serializer.hasData()) {
+					throw new IllegalStateException("No buffer, but serializer has buffered data.");
 				}
-				else {
-					writer.writeEvent(event, targetChannel);
-				}
+
+				targetPartition.writeEvent(event, targetChannel);
 			}
 		}
 	}
@@ -154,15 +155,12 @@ public class RecordWriter<T extends IOReadableWritable> {
 			synchronized (serializer) {
 				Buffer buffer = serializer.getCurrentBuffer();
 				if (buffer != null) {
-					writeBuffer(buffer, targetChannel, serializer);
-
-					buffer = writer.getBufferProvider().requestBufferBlocking();
-					serializer.setNextBuffer(buffer);
+					writeAndClearBuffer(buffer, targetChannel, serializer);
 				}
 			}
 		}
 
-		writer.writeEndOfSuperstep();
+		targetPartition.writeEndOfSuperstep();
 	}
 
 	public void flush() throws IOException {
@@ -174,7 +172,7 @@ public class RecordWriter<T extends IOReadableWritable> {
 					Buffer buffer = serializer.getCurrentBuffer();
 
 					if (buffer != null) {
-						writeBuffer(buffer, targetChannel, serializer);
+						writeAndClearBuffer(buffer, targetChannel, serializer);
 					}
 				} finally {
 					serializer.clear();
@@ -224,13 +222,13 @@ public class RecordWriter<T extends IOReadableWritable> {
 	 *
 	 * <p> The buffer is cleared from the serializer state after a call to this method.
 	 */
-	private void writeBuffer(
+	private void writeAndClearBuffer(
 			Buffer buffer,
 			int targetChannel,
 			RecordSerializer<T> serializer) throws IOException {
 
 		try {
-			writer.writeBuffer(buffer, targetChannel);
+			targetPartition.writeBuffer(buffer, targetChannel);
 		}
 		finally {
 			serializer.clearCurrentBuffer();


### PR DESCRIPTION
This re-opens #2690.

After merging, we noticed that the test were broken by the changed `hasData` check. This is reverted here and the `clearCurrentBuffer` has been updated to correctly reset the position and limit.

I'm mainly re-opening this to wait for Travis. In release-1.1 it's already fixed. If someone has spare time and wants to look at the changes again, feel free to do so.
