### PR TITLE
[FLINK-4954] [rpc] Discard messages when AkkaRpcActor is in state Processing.STOP

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.rpc.akka;
 
 import akka.actor.ActorRef;
 import akka.actor.Status;
-import akka.actor.UntypedActorWithStash;
+import akka.actor.UntypedActor;
 import akka.dispatch.Futures;
 import akka.japi.Procedure;
 import akka.pattern.Patterns;
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.concurrent.impl.FlinkFuture;
 import org.apache.flink.runtime.rpc.MainThreadValidatorUtil;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.akka.exceptions.AkkaRpcException;
 import org.apache.flink.runtime.rpc.akka.messages.CallAsync;
 import org.apache.flink.runtime.rpc.akka.messages.LocalRpcInvocation;
 import org.apache.flink.runtime.rpc.akka.messages.Processing;
@@ -60,14 +61,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * in the context of the actor thread.
  * <p>
  * The {@link Processing} message controls the processing behaviour of the akka rpc actor. A
- * {@link Processing#START} message unstashes all stashed messages and starts processing incoming
- * messages. A {@link Processing#STOP} message stops processing messages and stashes incoming
- * messages.
+ * {@link Processing#START} starts processing incoming messages. A {@link Processing#STOP} message
+ * stops processing messages. All messages which arrive when the processing is stopped, will be
+ * discarded.
  *
  * @param <C> Type of the {@link RpcGateway} associated with the {@link RpcEndpoint}
  * @param <T> Type of the {@link RpcEndpoint}
  */
-class AkkaRpcActor<C extends RpcGateway, T extends RpcEndpoint<C>> extends UntypedActorWithStash {
+class AkkaRpcActor<C extends RpcGateway, T extends RpcEndpoint<C>> extends UntypedActor {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(AkkaRpcActor.class);
 
@@ -86,7 +87,7 @@ class AkkaRpcActor<C extends RpcGateway, T extends RpcEndpoint<C>> extends Untyp
 	}
 
 	@Override
-	public void postStop() {
+	public void postStop() throws Exception {
 		super.postStop();
 
 		// IMPORTANT: This only works if we don't use a restarting supervisor strategy. Otherwise
@@ -99,7 +100,6 @@ class AkkaRpcActor<C extends RpcGateway, T extends RpcEndpoint<C>> extends Untyp
 	@Override
 	public void onReceive(final Object message) {
 		if (message.equals(Processing.START)) {
-			unstashAll();
 			getContext().become(new Procedure<Object>() {
 				@Override
 				public void apply(Object msg) throws Exception {
@@ -111,10 +111,15 @@ class AkkaRpcActor<C extends RpcGateway, T extends RpcEndpoint<C>> extends Untyp
 				}
 			});
 		} else {
-			LOG.info("The rpc endpoint {} has not been started yet. Stashing message {} until processing is started.",
+			LOG.info("The rpc endpoint {} has not been started yet. Discarding message {} until processing is started.",
 				rpcEndpoint.getClass().getName(),
 				message.getClass().getName());
-			stash();
+
+			if (!getSender().equals(ActorRef.noSender())) {
+				// fail a possible future if we have a sender
+				getSender().tell(new Status.Failure(new AkkaRpcException("Discard message, because " +
+					"the rpc endpoint has not been started yet.")), getSelf());
+			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/exceptions/AkkaRpcException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/exceptions/AkkaRpcException.java
@@ -16,24 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc.exceptions;
+package org.apache.flink.runtime.rpc.akka.exceptions;
+
+import org.apache.flink.runtime.rpc.exceptions.RpcException;
 
 /**
- * Exception class which is thrown if a rpc connection failed. Usually this happens if the remote
- * host cannot be reached.
+ * Base class for Akka RPC related exceptions.
  */
-public class RpcConnectionException extends RpcException {
-	private static final long serialVersionUID = -5500560405481142472L;
+public class AkkaRpcException extends RpcException {
 
-	public RpcConnectionException(String message) {
+	private static final long serialVersionUID = -3796329968494146418L;
+
+	public AkkaRpcException(String message) {
 		super(message);
 	}
 
-	public RpcConnectionException(String message, Throwable cause) {
+	public AkkaRpcException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
-	public RpcConnectionException(Throwable cause) {
+	public AkkaRpcException(Throwable cause) {
 		super(cause);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/exceptions/RpcException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/exceptions/RpcException.java
@@ -19,21 +19,21 @@
 package org.apache.flink.runtime.rpc.exceptions;
 
 /**
- * Exception class which is thrown if a rpc connection failed. Usually this happens if the remote
- * host cannot be reached.
+ * Base class for RPC related exceptions.
  */
-public class RpcConnectionException extends RpcException {
-	private static final long serialVersionUID = -5500560405481142472L;
+public class RpcException extends Exception {
 
-	public RpcConnectionException(String message) {
+	private static final long serialVersionUID = -7163591879289483630L;
+
+	public RpcException(String message) {
 		super(message);
 	}
 
-	public RpcConnectionException(String message, Throwable cause) {
+	public RpcException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
-	public RpcConnectionException(Throwable cause) {
+	public RpcException(Throwable cause) {
 		super(cause);
 	}
 }


### PR DESCRIPTION
When the AkkaRpcActor receives a message while being in state Processing.STOP it will discard
it and send an AkkaRpcException back to the caller. This replaces the old stashing behaviour
which had the problem that it was just a best effort approach to keep all received messages.
Distributed components should not rely on this behaviour. That's why it was replaced with discarding messages. 
