### PR TITLE
[FLINK-3617] Fixed NPE from CaseClassSerializer

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializer.java
@@ -117,6 +117,13 @@ public class TupleSerializer<T extends Tuple> extends TupleSerializerBase<T> {
 	}
 
 	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		for (int i = 0; i < arity; i++) {
+			fieldSerializers[i].copy(source, target);
+		}
+	}
+
+	@Override
 	public void serialize(T value, DataOutputView target) throws IOException {
 		for (int i = 0; i < arity; i++) {
 			Object o = value.getField(i);

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerBase.java
@@ -19,10 +19,7 @@
 package org.apache.flink.api.java.typeutils.runtime;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.memory.DataInputView;
-import org.apache.flink.core.memory.DataOutputView;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -83,13 +80,6 @@ public abstract class TupleSerializerBase<T> extends TypeSerializer<T> {
 
 	public abstract T createOrReuseInstance(Object[] fields, T reuse);
 
-	@Override
-	public void copy(DataInputView source, DataOutputView target) throws IOException {
-		for (int i = 0; i < arity; i++) {
-			fieldSerializers[i].copy(source, target);
-		}
-	}
-	
 	@Override
 	public int hashCode() {
 		return 31 * Arrays.hashCode(fieldSerializers) + Objects.hash(tupleClass, arity);

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
@@ -402,6 +402,11 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 			assertEquals(((Throwable)should).getMessage(), ((Throwable)is).getMessage());
 		}
 		else {
+			// if toString() was overridden we must check it
+			if (!should.toString().equals(should.getClass().getName() +
+										  "@" + Integer.toHexString(should.hashCode()))) {
+				assertEquals(message, should.toString(), is.toString());
+			}
 			assertEquals(message,  should, is);
 		}
 	}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
@@ -74,7 +74,7 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 			Class<T> type = getTypeClass();
 			assertNotNull("The test is corrupt: type class is null.", type);
 			
-			assertEquals("Type of the instantiated object is wrong.", type, instance.getClass());
+			checkClass("Type of the instantiated object is wrong.", type, instance.getClass());
 		}
 		catch (Exception e) {
 			System.err.println(e.getMessage());
@@ -104,7 +104,6 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 			
 			for (T datum : testData) {
 				T copy = serializer.copy(datum);
-				copy.toString();
 				deepEquals("Copied element is not equal to the original element.", datum, copy);
 			}
 		}
@@ -123,7 +122,6 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 			
 			for (T datum : testData) {
 				T copy = serializer.copy(datum, serializer.createInstance());
-				copy.toString();
 				deepEquals("Copied element is not equal to the original element.", datum, copy);
 			}
 		}
@@ -144,7 +142,6 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 			
 			for (T datum : testData) {
 				T copy = serializer.copy(datum, target);
-				copy.toString();
 				deepEquals("Copied element is not equal to the original element.", datum, copy);
 				target = copy;
 			}
@@ -170,7 +167,6 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 				assertTrue("No data available during deserialization.", in.available() > 0);
 				
 				T deserialized = serializer.deserialize(serializer.createInstance(), in);
- 				deserialized.toString();
 
 				deepEquals("Deserialized value if wrong.", value, deserialized);
 				
@@ -201,7 +197,6 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 				assertTrue("No data available during deserialization.", in.available() > 0);
 				
 				T deserialized = serializer.deserialize(reuseValue, in);
-				deserialized.toString();
 
 				deepEquals("Deserialized value if wrong.", value, deserialized);
 				
@@ -233,7 +228,6 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 			int num = 0;
 			while (in.available() > 0) {
 				T deserialized = serializer.deserialize(in);
-				deserialized.toString();
 
 				deepEquals("Deserialized value if wrong.", testData[num], deserialized);
 				num++;
@@ -265,7 +259,6 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 			int num = 0;
 			while (in.available() > 0) {
 				T deserialized = serializer.deserialize(reuseValue, in);
-				deserialized.toString();
 
 				deepEquals("Deserialized value if wrong.", testData[num], deserialized);
 				reuseValue = deserialized;
@@ -300,7 +293,6 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 				assertTrue("No data available copying.", toVerify.available() > 0);
 				
 				T deserialized = serializer.deserialize(serializer.createInstance(), toVerify);
-				deserialized.toString();
 
 				deepEquals("Deserialized value if wrong.", value, deserialized);
 				
@@ -337,7 +329,6 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 			
 			while (toVerify.available() > 0) {
 				T deserialized = serializer.deserialize(serializer.createInstance(), toVerify);
-				deserialized.toString();
 
 				deepEquals("Deserialized value if wrong.", testData[num], deserialized);
 				num++;
@@ -376,7 +367,9 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 	// --------------------------------------------------------------------------------------------
 	
 	protected void deepEquals(String message, T should, T is) {
-		if (should.getClass().isArray()) {
+		if (should == null || is == null) {
+			assertEquals(message, should, is);
+		} else if (should.getClass().isArray()) {
 			if (should instanceof boolean[]) {
 				Assert.assertTrue(message, Arrays.equals((boolean[]) should, (boolean[]) is));
 			}
@@ -411,6 +404,18 @@ public abstract class SerializerTestBase<T> extends TestLogger {
 		else {
 			assertEquals(message,  should, is);
 		}
+	}
+
+	protected void checkClass(String message, Class<?> type, Class<?> instanceType) {
+		Class<?> clazz = instanceType;
+		do {
+			if (type.equals(clazz)) {
+				assertEquals(message, type, clazz);
+				return;
+			}
+			clazz = clazz.getSuperclass();
+		} while (clazz != null);
+		assertEquals(message, type, instanceType);
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionSerializer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionSerializer.scala
@@ -65,7 +65,7 @@ class OptionSerializer[A](val elemSerializer: TypeSerializer[A])
     case Some(a) =>
       target.writeBoolean(true)
       elemSerializer.serialize(a, target)
-    case None =>
+    case _ =>
       target.writeBoolean(false)
   }
 

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/OptionSerializerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/OptionSerializerTest.scala
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.api.scala.typeutils
 
 import org.apache.flink.api.common.typeutils.base.IntSerializer

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/OptionSerializerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/OptionSerializerTest.scala
@@ -1,0 +1,29 @@
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.api.common.typeutils.base.IntSerializer
+import org.apache.flink.api.common.typeutils.{SerializerTestBase, TypeSerializer}
+
+import scala.util.Random
+
+class OptionSerializerTest extends SerializerTestBase[Option[Integer]] {
+
+  override protected def createSerializer(): TypeSerializer[Option[Integer]] =
+    new OptionSerializer[Integer](new IntSerializer())
+
+  override protected def getLength: Int = -1
+
+  override protected def getTypeClass: Class[Option[Integer]] = classOf[Option[Integer]]
+
+  override protected def getTestData: Array[Option[Integer]] = {
+    val rnd = new Random(874597969123412341L)
+    val rndInt = rnd.nextInt
+
+    Array[Option[Integer]](
+      Option(Integer.valueOf(0)),
+      Option(Integer.valueOf(rndInt)),
+      Option(Integer.valueOf(-rndInt)),
+      Option.empty,
+      null
+    )
+  }
+}

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TupleSerializerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TupleSerializerTest.scala
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala.typeutils
+
+import org.apache.flink.api.common.typeutils._
+import org.apache.flink.api.common.typeutils.base._
+
+import scala.util.Random
+
+case class CaseClass(a: Int, b: String, c: (Long, Byte))
+
+class TupleSerializerTest
+  extends SerializerTestBase[(Int, Long, String, Option[Int], (Int, CaseClass))] {
+
+  override protected def createSerializer():
+  TypeSerializer[(Int, Long, String, Option[Int], (Int, CaseClass))] =
+    new CaseClassSerializer[(Int, Long, String, Option[Int], (Int, CaseClass))](
+      classOf[(Int, Long, String, Option[Int], (Int, CaseClass))],
+      Array(
+        new IntSerializer(),
+        new LongSerializer(),
+        new StringSerializer(),
+        new OptionSerializer[Int](new IntSerializer().asInstanceOf[TypeSerializer[Int]]),
+        new CaseClassSerializer[(Int, CaseClass)](
+          classOf[(Int, CaseClass)],
+          Array(
+            new IntSerializer(),
+            new CaseClassSerializer[CaseClass](
+              classOf[CaseClass],
+              Array(
+                new IntSerializer(),
+                new StringSerializer(),
+                new CaseClassSerializer[(Long, Byte)](
+                  classOf[(Long, Byte)],
+                  Array(
+                    new LongSerializer(),
+                    new ByteSerializer()
+                  )
+                ) {
+                  override def createInstance(fields: Array[AnyRef]): (Long, Byte) = (
+                    fields(0).asInstanceOf[Long],
+                    fields(1).asInstanceOf[Byte]
+                  )
+                }
+              )
+            ) {
+              override def createInstance(fields: Array[AnyRef]): CaseClass = CaseClass(
+                fields(0).asInstanceOf[Int],
+                fields(1).asInstanceOf[String],
+                fields(2).asInstanceOf[(Long, Byte)]
+              )
+            }
+          )
+        ) {
+          override def createInstance(fields: Array[AnyRef]): (Int, CaseClass) = (
+            fields(0).asInstanceOf[Int],
+            fields(1).asInstanceOf[CaseClass]
+          )
+        }
+      )
+    ) {
+      override def createInstance(fields: Array[AnyRef]):
+      (Int, Long, String, Option[Int], (Int, CaseClass)) = (
+        fields(0).asInstanceOf[Int],
+        fields(1).asInstanceOf[Long],
+        fields(2).asInstanceOf[String],
+        fields(3).asInstanceOf[Option[Int]],
+        fields(4).asInstanceOf[(Int, CaseClass)]
+      )
+    }
+
+  override protected def getLength: Int = -1
+
+  override protected def getTypeClass:
+  Class[(Int, Long, String, Option[Int], (Int, CaseClass))] =
+    classOf[(Int, Long, String, Option[Int], (Int, CaseClass))]
+
+  override protected def getTestData:
+  Array[(Int, Long, String, Option[Int], (Int, CaseClass))] = {
+
+    val rnd = new Random(874597969123412341L)
+    Array[(Int, Long, String, Option[Int], (Int, CaseClass))](
+      (rnd.nextInt(), rnd.nextLong(), rnd.nextDouble().toString,
+        Option(rnd.nextInt()), (rnd.nextInt(), CaseClass(
+        rnd.nextInt(), rnd.nextDouble().toString,
+        (rnd.nextLong(), rnd.nextInt().toByte)
+      ))),
+      (rnd.nextInt(), rnd.nextLong(), rnd.nextDouble().toString,
+        Option(rnd.nextInt()), (rnd.nextInt(), CaseClass(
+        rnd.nextInt(), null, null
+      ))),
+      (rnd.nextInt(), rnd.nextLong(), rnd.nextDouble().toString,
+        Option(rnd.nextInt()), (rnd.nextInt(), null)),
+      (rnd.nextInt(), rnd.nextLong(), rnd.nextDouble().toString, null, null),
+      (rnd.nextInt(), rnd.nextLong(), null, null, null),
+      null
+    )
+  }
+}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/CaseClassComparatorTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/CaseClassComparatorTest.scala
@@ -34,7 +34,7 @@ import org.mockito.Mockito
 
 class CaseClassComparatorTest {
 
-  case class CaseTestClass(a: Int, b: Int, c: Int, d: String)
+  case class CaseTestClass(a: Int, b: Int, c: Int, d: String, e: Option[Int])
   
   @Test
   def testNormalizedKeyGeneration(): Unit = {
@@ -85,7 +85,12 @@ class CaseClassComparatorTest {
       var num = 0
       
       while (moreToGo) {
-        val next = CaseTestClass(rnd.nextInt(), rnd.nextInt(), rnd.nextInt(), "")
+        val optional = num % 3 match {
+          case 0 => Option(rnd.nextInt)
+          case 1 => Option.empty
+          case 2 => null
+        }
+        val next = CaseTestClass(rnd.nextInt(), rnd.nextInt(), rnd.nextInt(), "", optional)
         moreToGo = sorter.write(next)
         num += 1
       }

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/CaseClassComparatorTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/CaseClassComparatorTest.scala
@@ -34,7 +34,7 @@ import org.mockito.Mockito
 
 class CaseClassComparatorTest {
 
-  case class CaseTestClass(a: Int, b: Int, c: Int, d: String, e: Option[Int])
+  case class CaseTestClass(a: Int, b: Int, c: Int, d: String)
   
   @Test
   def testNormalizedKeyGeneration(): Unit = {
@@ -85,12 +85,7 @@ class CaseClassComparatorTest {
       var num = 0
       
       while (moreToGo) {
-        val optional = num % 3 match {
-          case 0 => Option(rnd.nextInt)
-          case 1 => Option.empty
-          case 2 => null
-        }
-        val next = CaseTestClass(rnd.nextInt(), rnd.nextInt(), rnd.nextInt(), "", optional)
+        val next = CaseTestClass(rnd.nextInt(), rnd.nextInt(), rnd.nextInt(), "")
         moreToGo = sorter.write(next)
         num += 1
       }


### PR DESCRIPTION
This fix prevent possible NullPointerException at serialization process, but after deserialization Option variable will be initialized with None value and not null (as was before serialization). This decision was made for compatibility between versions. What thoughts about it?

This PR solve [FLINK-3617](https://issues.apache.org/jira/browse/FLINK-3617).
