### PR TITLE
[FLINK-4963] [gelly] Tabulate edge direction for directed VertexMetrics

### DIFF
--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/AnalyticHelper.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/AnalyticHelper.java
@@ -40,7 +40,7 @@ import java.io.Serializable;
  *
  * @param <T> element type
  */
-public abstract class GraphAnalyticHelper<T>
+public abstract class AnalyticHelper<T>
 extends RichOutputFormat<T> {
 
 	private static final String SEPARATOR = "-";

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/GraphAnalyticHelper.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/GraphAnalyticHelper.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph;
+
+import org.apache.flink.api.common.accumulators.Accumulator;
+import org.apache.flink.api.common.io.RichOutputFormat;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.AbstractID;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * A {@link GraphAnalytic} computes over a DataSet and returns the results via
+ * Flink accumulators. This computation is cheaply performed in a terminating
+ * {@link RichOutputFormat}.
+ *
+ * This class simplifies the creation of analytic helpers by providing pass-through
+ * methods for adding and getting accumulators. Each accumulator name is prefixed
+ * with a random string since Flink accumulators share a per-job global namespace.
+ * This class also provides empty implementations of {@link RichOutputFormat#open}
+ * and {@link RichOutputFormat#close}.
+ *
+ * @param <T> element type
+ */
+public abstract class GraphAnalyticHelper<T>
+extends RichOutputFormat<T> {
+
+	private static final String SEPARATOR = "-";
+
+	private String id = new AbstractID().toString();
+
+	@Override
+	public void configure(Configuration parameters) {}
+
+	@Override
+	public void open(int taskNumber, int numTasks) throws IOException {}
+
+	/**
+	 * Adds an accumulator by prepending the given name with a random string.
+	 *
+	 * @param name The name of the accumulator
+	 * @param accumulator The accumulator
+	 * @param <V> Type of values that are added to the accumulator
+	 * @param <A> Type of the accumulator result as it will be reported to the client
+	 */
+	public <V, A extends Serializable> void addAccumulator(String name, Accumulator<V, A> accumulator) {
+		getRuntimeContext().addAccumulator(id + SEPARATOR + name, accumulator);
+	}
+
+	/**
+	 * Gets the accumulator with the given name. Returns {@code null}, if no accumulator with
+	 * that name was produced.
+	 *
+	 * @param accumulatorName The name of the accumulator
+	 * @param <A> The generic type of the accumulator value
+	 * @return The value of the accumulator with the given name
+	 */
+	public <A> A getAccumulator(ExecutionEnvironment env, String accumulatorName) {
+		return env.getLastJobExecutionResult().getAccumulatorResult(id + SEPARATOR + accumulatorName);
+	}
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/AverageClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/AverageClusteringCoefficient.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.accumulators.LongCounter;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.graph.AbstractGraphAnalytic;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.GraphAnalyticHelper;
+import org.apache.flink.graph.AnalyticHelper;
 import org.apache.flink.graph.library.clustering.directed.AverageClusteringCoefficient.Result;
 import org.apache.flink.types.CopyableValue;
 
@@ -104,7 +104,7 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	 * @param <T> ID type
 	 */
 	private static class AverageClusteringCoefficientHelper<T>
-	extends GraphAnalyticHelper<LocalClusteringCoefficient.Result<T>> {
+	extends AnalyticHelper<LocalClusteringCoefficient.Result<T>> {
 		private long vertexCount;
 		private double sumOfLocalClusteringCoefficient;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/AverageClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/AverageClusteringCoefficient.java
@@ -44,6 +44,10 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
 public class AverageClusteringCoefficient<K extends Comparable<K> & CopyableValue<K>, VV, EV>
 extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
+	private static final String VERTEX_COUNT = "vertexCount";
+
+	private static final String SUM_OF_LOCAL_CLUSTERING_COEFFICIENT = "sumOfLocalClusteringCoefficient";
+
 	private AverageClusteringCoefficientHelper<K> averageClusteringCoefficientHelper;
 
 	// Optional configuration
@@ -88,8 +92,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 	@Override
 	public Result getResult() {
-		long vertexCount = averageClusteringCoefficientHelper.getAccumulator(env, "vertexCount");
-		double sumOfLocalClusteringCoefficient = averageClusteringCoefficientHelper.getAccumulator(env, "sumOfLocalClusteringCoefficient");
+		long vertexCount = averageClusteringCoefficientHelper.getAccumulator(env, VERTEX_COUNT);
+		double sumOfLocalClusteringCoefficient = averageClusteringCoefficientHelper.getAccumulator(env, SUM_OF_LOCAL_CLUSTERING_COEFFICIENT);
 
 		return new Result(vertexCount, sumOfLocalClusteringCoefficient);
 	}
@@ -117,8 +121,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 		@Override
 		public void close() throws IOException {
-			addAccumulator("vertexCount", new LongCounter(vertexCount));
-			addAccumulator("sumOfLocalClusteringCoefficient", new DoubleCounter(sumOfLocalClusteringCoefficient));
+			addAccumulator(VERTEX_COUNT, new LongCounter(vertexCount));
+			addAccumulator(SUM_OF_LOCAL_CLUSTERING_COEFFICIENT, new DoubleCounter(sumOfLocalClusteringCoefficient));
 		}
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/AverageClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/AverageClusteringCoefficient.java
@@ -20,17 +20,14 @@ package org.apache.flink.graph.library.clustering.directed;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.accumulators.DoubleCounter;
 import org.apache.flink.api.common.accumulators.LongCounter;
-import org.apache.flink.api.common.io.RichOutputFormat;
 import org.apache.flink.api.java.DataSet;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.graph.AbstractGraphAnalytic;
 import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.GraphAnalyticHelper;
 import org.apache.flink.graph.library.clustering.directed.AverageClusteringCoefficient.Result;
 import org.apache.flink.types.CopyableValue;
-import org.apache.flink.util.AbstractID;
 
 import java.io.IOException;
 
@@ -47,7 +44,7 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
 public class AverageClusteringCoefficient<K extends Comparable<K> & CopyableValue<K>, VV, EV>
 extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
-	private String id = new AbstractID().toString();
+	private AverageClusteringCoefficientHelper<K> averageClusteringCoefficientHelper;
 
 	// Optional configuration
 	private int littleParallelism = PARALLELISM_DEFAULT;
@@ -80,8 +77,10 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 			.run(new LocalClusteringCoefficient<K, VV, EV>()
 				.setLittleParallelism(littleParallelism));
 
+		averageClusteringCoefficientHelper = new AverageClusteringCoefficientHelper<>();
+
 		localClusteringCoefficient
-			.output(new AverageClusteringCoefficientHelper<K>(id))
+			.output(averageClusteringCoefficientHelper)
 				.name("Average clustering coefficient");
 
 		return this;
@@ -89,10 +88,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 	@Override
 	public Result getResult() {
-		JobExecutionResult res = env.getLastJobExecutionResult();
-
-		long vertexCount = res.getAccumulatorResult(id + "-0");
-		double sumOfLocalClusteringCoefficient = res.getAccumulatorResult(id + "-1");
+		long vertexCount = averageClusteringCoefficientHelper.getAccumulator(env, "vertexCount");
+		double sumOfLocalClusteringCoefficient = averageClusteringCoefficientHelper.getAccumulator(env, "sumOfLocalClusteringCoefficient");
 
 		return new Result(vertexCount, sumOfLocalClusteringCoefficient);
 	}
@@ -103,27 +100,9 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	 * @param <T> ID type
 	 */
 	private static class AverageClusteringCoefficientHelper<T>
-	extends RichOutputFormat<LocalClusteringCoefficient.Result<T>> {
-		private final String id;
-
+	extends GraphAnalyticHelper<LocalClusteringCoefficient.Result<T>> {
 		private long vertexCount;
 		private double sumOfLocalClusteringCoefficient;
-
-		/**
-		 * The unique id is required because Flink's accumulator namespace is
-		 * shared among all operators.
-		 *
-		 * @param id unique string used for accumulator names
-		 */
-		public AverageClusteringCoefficientHelper(String id) {
-			this.id = id;
-		}
-
-		@Override
-		public void configure(Configuration parameters) {}
-
-		@Override
-		public void open(int taskNumber, int numTasks) throws IOException {}
 
 		@Override
 		public void writeRecord(LocalClusteringCoefficient.Result<T> record) throws IOException {
@@ -138,8 +117,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 		@Override
 		public void close() throws IOException {
-			getRuntimeContext().addAccumulator(id + "-0", new LongCounter(vertexCount));
-			getRuntimeContext().addAccumulator(id + "-1", new DoubleCounter(sumOfLocalClusteringCoefficient));
+			addAccumulator("vertexCount", new LongCounter(vertexCount));
+			addAccumulator("sumOfLocalClusteringCoefficient", new DoubleCounter(sumOfLocalClusteringCoefficient));
 		}
 	}
 
@@ -148,7 +127,6 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	 */
 	public static class Result {
 		private long vertexCount;
-
 		private double averageLocalClusteringCoefficient;
 
 		/**

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/AverageClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/AverageClusteringCoefficient.java
@@ -20,17 +20,14 @@ package org.apache.flink.graph.library.clustering.undirected;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.accumulators.DoubleCounter;
 import org.apache.flink.api.common.accumulators.LongCounter;
-import org.apache.flink.api.common.io.RichOutputFormat;
 import org.apache.flink.api.java.DataSet;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.graph.AbstractGraphAnalytic;
 import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.GraphAnalyticHelper;
 import org.apache.flink.graph.library.clustering.undirected.AverageClusteringCoefficient.Result;
 import org.apache.flink.types.CopyableValue;
-import org.apache.flink.util.AbstractID;
 
 import java.io.IOException;
 
@@ -47,7 +44,7 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
 public class AverageClusteringCoefficient<K extends Comparable<K> & CopyableValue<K>, VV, EV>
 extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
-	private String id = new AbstractID().toString();
+	private AverageClusteringCoefficientHelper<K> averageClusteringCoefficientHelper;
 
 	// Optional configuration
 	private int littleParallelism = PARALLELISM_DEFAULT;
@@ -80,8 +77,10 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 			.run(new LocalClusteringCoefficient<K, VV, EV>()
 				.setLittleParallelism(littleParallelism));
 
+		averageClusteringCoefficientHelper = new AverageClusteringCoefficientHelper<>();
+
 		localClusteringCoefficient
-			.output(new AverageClusteringCoefficientHelper<K>(id))
+			.output(averageClusteringCoefficientHelper)
 				.name("Average clustering coefficient");
 
 		return this;
@@ -89,10 +88,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 	@Override
 	public Result getResult() {
-		JobExecutionResult res = env.getLastJobExecutionResult();
-
-		long vertexCount = res.getAccumulatorResult(id + "-0");
-		double sumOfLocalClusteringCoefficient = res.getAccumulatorResult(id + "-1");
+		long vertexCount = averageClusteringCoefficientHelper.getAccumulator(env, "vertexCount");
+		double sumOfLocalClusteringCoefficient = averageClusteringCoefficientHelper.getAccumulator(env, "sumOfLocalClusteringCoefficient");
 
 		return new Result(vertexCount, sumOfLocalClusteringCoefficient);
 	}
@@ -103,27 +100,9 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	 * @param <T> ID type
 	 */
 	private static class AverageClusteringCoefficientHelper<T>
-	extends RichOutputFormat<LocalClusteringCoefficient.Result<T>> {
-		private final String id;
-
+	extends GraphAnalyticHelper<LocalClusteringCoefficient.Result<T>> {
 		private long vertexCount;
 		private double sumOfLocalClusteringCoefficient;
-
-		/**
-		 * The unique id is required because Flink's accumulator namespace is
-		 * shared among all operators.
-		 *
-		 * @param id unique string used for accumulator names
-		 */
-		public AverageClusteringCoefficientHelper(String id) {
-			this.id = id;
-		}
-
-		@Override
-		public void configure(Configuration parameters) {}
-
-		@Override
-		public void open(int taskNumber, int numTasks) throws IOException {}
 
 		@Override
 		public void writeRecord(LocalClusteringCoefficient.Result<T> record) throws IOException {
@@ -138,8 +117,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 		@Override
 		public void close() throws IOException {
-			getRuntimeContext().addAccumulator(id + "-0", new LongCounter(vertexCount));
-			getRuntimeContext().addAccumulator(id + "-1", new DoubleCounter(sumOfLocalClusteringCoefficient));
+			addAccumulator("vertexCount", new LongCounter(vertexCount));
+			addAccumulator("sumOfLocalClusteringCoefficient", new DoubleCounter(sumOfLocalClusteringCoefficient));
 		}
 	}
 
@@ -148,7 +127,6 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	 */
 	public static class Result {
 		private long vertexCount;
-
 		private double averageLocalClusteringCoefficient;
 
 		/**

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/AverageClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/AverageClusteringCoefficient.java
@@ -44,6 +44,10 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
 public class AverageClusteringCoefficient<K extends Comparable<K> & CopyableValue<K>, VV, EV>
 extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
+	private static final String VERTEX_COUNT = "vertexCount";
+
+	private static final String SUM_OF_LOCAL_CLUSTERING_COEFFICIENT = "sumOfLocalClusteringCoefficient";
+
 	private AverageClusteringCoefficientHelper<K> averageClusteringCoefficientHelper;
 
 	// Optional configuration
@@ -88,8 +92,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 	@Override
 	public Result getResult() {
-		long vertexCount = averageClusteringCoefficientHelper.getAccumulator(env, "vertexCount");
-		double sumOfLocalClusteringCoefficient = averageClusteringCoefficientHelper.getAccumulator(env, "sumOfLocalClusteringCoefficient");
+		long vertexCount = averageClusteringCoefficientHelper.getAccumulator(env, VERTEX_COUNT);
+		double sumOfLocalClusteringCoefficient = averageClusteringCoefficientHelper.getAccumulator(env, SUM_OF_LOCAL_CLUSTERING_COEFFICIENT);
 
 		return new Result(vertexCount, sumOfLocalClusteringCoefficient);
 	}
@@ -117,8 +121,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 		@Override
 		public void close() throws IOException {
-			addAccumulator("vertexCount", new LongCounter(vertexCount));
-			addAccumulator("sumOfLocalClusteringCoefficient", new DoubleCounter(sumOfLocalClusteringCoefficient));
+			addAccumulator(VERTEX_COUNT, new LongCounter(vertexCount));
+			addAccumulator(SUM_OF_LOCAL_CLUSTERING_COEFFICIENT, new DoubleCounter(sumOfLocalClusteringCoefficient));
 		}
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/AverageClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/AverageClusteringCoefficient.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.accumulators.LongCounter;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.graph.AbstractGraphAnalytic;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.GraphAnalyticHelper;
+import org.apache.flink.graph.AnalyticHelper;
 import org.apache.flink.graph.library.clustering.undirected.AverageClusteringCoefficient.Result;
 import org.apache.flink.types.CopyableValue;
 
@@ -104,7 +104,7 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	 * @param <T> ID type
 	 */
 	private static class AverageClusteringCoefficientHelper<T>
-	extends GraphAnalyticHelper<LocalClusteringCoefficient.Result<T>> {
+	extends AnalyticHelper<LocalClusteringCoefficient.Result<T>> {
 		private long vertexCount;
 		private double sumOfLocalClusteringCoefficient;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/EdgeMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/EdgeMetrics.java
@@ -61,6 +61,14 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
 public class EdgeMetrics<K extends Comparable<K> & CopyableValue<K>, VV, EV>
 extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
+	private static final String TRIANGLE_TRIPLET_COUNT = "triangleTripletCount";
+
+	private static final String RECTANGLE_TRIPLET_COUNT = "rectangleTripletCount";
+
+	private static final String MAXIMUM_TRIANGLE_TRIPLETS = "maximumTriangleTriplets";
+
+	private static final String MAXIMUM_RECTANGLE_TRIPLETS = "maximumRectangleTriplets";
+
 	private EdgeMetricsHelper<K> edgeMetricsHelper;
 
 	private int parallelism = PARALLELISM_DEFAULT;
@@ -124,10 +132,10 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 	@Override
 	public Result getResult() {
-		long triangleTripletCount = edgeMetricsHelper.getAccumulator(env, "triangleTripletCount");
-		long rectangleTripletCount = edgeMetricsHelper.getAccumulator(env, "rectangleTripletCount");
-		long maximumTriangleTriplets = edgeMetricsHelper.getAccumulator(env, "maximumTriangleTriplets");
-		long maximumRectangleTriplets = edgeMetricsHelper.getAccumulator(env, "maximumRectangleTriplets");
+		long triangleTripletCount = edgeMetricsHelper.getAccumulator(env, TRIANGLE_TRIPLET_COUNT);
+		long rectangleTripletCount = edgeMetricsHelper.getAccumulator(env, RECTANGLE_TRIPLET_COUNT);
+		long maximumTriangleTriplets = edgeMetricsHelper.getAccumulator(env, MAXIMUM_TRIANGLE_TRIPLETS);
+		long maximumRectangleTriplets = edgeMetricsHelper.getAccumulator(env, MAXIMUM_RECTANGLE_TRIPLETS);
 
 		// each edge is counted twice, once from each vertex, so must be halved
 		return new Result(triangleTripletCount, rectangleTripletCount,
@@ -255,10 +263,10 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 		@Override
 		public void close() throws IOException {
-			addAccumulator("triangleTripletCount", new LongCounter(triangleTripletCount));
-			addAccumulator("rectangleTripletCount", new LongCounter(rectangleTripletCount));
-			addAccumulator("maximumTriangleTriplets", new LongMaximum(maximumTriangleTriplets));
-			addAccumulator("maximumRectangleTriplets", new LongMaximum(maximumRectangleTriplets));
+			addAccumulator(TRIANGLE_TRIPLET_COUNT, new LongCounter(triangleTripletCount));
+			addAccumulator(RECTANGLE_TRIPLET_COUNT, new LongCounter(rectangleTripletCount));
+			addAccumulator(MAXIMUM_TRIANGLE_TRIPLETS, new LongMaximum(maximumTriangleTriplets));
+			addAccumulator(MAXIMUM_RECTANGLE_TRIPLETS, new LongMaximum(maximumRectangleTriplets));
 		}
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/EdgeMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/EdgeMetrics.java
@@ -34,7 +34,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.graph.AbstractGraphAnalytic;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.GraphAnalyticHelper;
+import org.apache.flink.graph.AnalyticHelper;
 import org.apache.flink.graph.asm.degree.annotate.directed.EdgeDegreesPair;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees.Degrees;
 import org.apache.flink.graph.library.metric.directed.EdgeMetrics.Result;
@@ -231,7 +231,7 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	 * @param <T> ID type
 	 */
 	private static class EdgeMetricsHelper<T extends Comparable<T>>
-	extends GraphAnalyticHelper<Tuple3<T, Degrees, LongValue>> {
+	extends AnalyticHelper<Tuple3<T, Degrees, LongValue>> {
 		private long triangleTripletCount;
 		private long rectangleTripletCount;
 		private long maximumTriangleTriplets;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/VertexMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/VertexMetrics.java
@@ -57,6 +57,22 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
 public class VertexMetrics<K extends Comparable<K> & CopyableValue<K>, VV, EV>
 extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
+	private static final String VERTEX_COUNT = "vertexCount";
+
+	private static final String UNIDIRECTIONAL_EDGE_COUNT = "unidirectionalEdgeCount";
+
+	private static final String BIDIRECTIONAL_EDGE_COUNT = "bidirectionalEdgeCount";
+
+	private static final String TRIPLET_COUNT = "tripletCount";
+
+	private static final String MAXIMUM_DEGREE = "maximumDegree";
+
+	private static final String MAXIMUM_OUT_DEGREE = "maximumOutDegree";
+
+	private static final String MAXIMUM_IN_DEGREE = "maximumInDegree";
+
+	private static final String MAXIMUM_TRIPLETS = "maximumTriplets";
+
 	private VertexMetricsHelper<K> vertexMetricsHelper;
 
 	// Optional configuration
@@ -112,14 +128,14 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 	@Override
 	public Result getResult() {
-		long vertexCount = vertexMetricsHelper.getAccumulator(env, "vertexCount");
-		long unidirectionalEdgeCount = vertexMetricsHelper.getAccumulator(env, "unidirectionalEdgeCount");
-		long bidirectionalEdgeCount = vertexMetricsHelper.getAccumulator(env, "bidirectionalEdgeCount");
-		long tripletCount = vertexMetricsHelper.getAccumulator(env, "tripletCount");
-		long maximumDegree = vertexMetricsHelper.getAccumulator(env, "maximumDegree");
-		long maximumOutDegree = vertexMetricsHelper.getAccumulator(env, "maximumOutDegree");
-		long maximumInDegree = vertexMetricsHelper.getAccumulator(env, "maximumInDegree");
-		long maximumTriplets = vertexMetricsHelper.getAccumulator(env, "maximumTriplets");
+		long vertexCount = vertexMetricsHelper.getAccumulator(env, VERTEX_COUNT);
+		long unidirectionalEdgeCount = vertexMetricsHelper.getAccumulator(env, UNIDIRECTIONAL_EDGE_COUNT);
+		long bidirectionalEdgeCount = vertexMetricsHelper.getAccumulator(env, BIDIRECTIONAL_EDGE_COUNT);
+		long tripletCount = vertexMetricsHelper.getAccumulator(env, TRIPLET_COUNT);
+		long maximumDegree = vertexMetricsHelper.getAccumulator(env, MAXIMUM_DEGREE);
+		long maximumOutDegree = vertexMetricsHelper.getAccumulator(env, MAXIMUM_OUT_DEGREE);
+		long maximumInDegree = vertexMetricsHelper.getAccumulator(env, MAXIMUM_IN_DEGREE);
+		long maximumTriplets = vertexMetricsHelper.getAccumulator(env, MAXIMUM_TRIPLETS);
 
 		// each edge is counted twice, once from each vertex, so must be halved
 		return new Result(vertexCount, unidirectionalEdgeCount / 2, bidirectionalEdgeCount / 2, tripletCount,
@@ -163,14 +179,14 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 		@Override
 		public void close() throws IOException {
-			addAccumulator("vertexCount", new LongCounter(vertexCount));
-			addAccumulator("unidirectionalEdgeCount", new LongCounter(unidirectionalEdgeCount));
-			addAccumulator("bidirectionalEdgeCount", new LongCounter(bidirectionalEdgeCount));
-			addAccumulator("tripletCount", new LongCounter(tripletCount));
-			addAccumulator("maximumDegree", new LongMaximum(maximumDegree));
-			addAccumulator("maximumOutDegree", new LongMaximum(maximumOutDegree));
-			addAccumulator("maximumInDegree", new LongMaximum(maximumInDegree));
-			addAccumulator("maximumTriplets", new LongMaximum(maximumTriplets));
+			addAccumulator(VERTEX_COUNT, new LongCounter(vertexCount));
+			addAccumulator(UNIDIRECTIONAL_EDGE_COUNT, new LongCounter(unidirectionalEdgeCount));
+			addAccumulator(BIDIRECTIONAL_EDGE_COUNT, new LongCounter(bidirectionalEdgeCount));
+			addAccumulator(TRIPLET_COUNT, new LongCounter(tripletCount));
+			addAccumulator(MAXIMUM_DEGREE, new LongMaximum(maximumDegree));
+			addAccumulator(MAXIMUM_OUT_DEGREE, new LongMaximum(maximumOutDegree));
+			addAccumulator(MAXIMUM_IN_DEGREE, new LongMaximum(maximumInDegree));
+			addAccumulator(MAXIMUM_TRIPLETS, new LongMaximum(maximumTriplets));
 		}
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/VertexMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/VertexMetrics.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.accumulators.LongMaximum;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.graph.AbstractGraphAnalytic;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.GraphAnalyticHelper;
+import org.apache.flink.graph.AnalyticHelper;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees.Degrees;
@@ -148,7 +148,7 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	 * @param <T> ID type
 	 */
 	private static class VertexMetricsHelper<T>
-	extends GraphAnalyticHelper<Vertex<T, Degrees>> {
+	extends AnalyticHelper<Vertex<T, Degrees>> {
 		private long vertexCount;
 		private long unidirectionalEdgeCount;
 		private long bidirectionalEdgeCount;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/VertexMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/VertexMetrics.java
@@ -20,20 +20,17 @@ package org.apache.flink.graph.library.metric.directed;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.accumulators.LongCounter;
 import org.apache.flink.api.common.accumulators.LongMaximum;
-import org.apache.flink.api.common.io.RichOutputFormat;
 import org.apache.flink.api.java.DataSet;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.graph.AbstractGraphAnalytic;
 import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.GraphAnalyticHelper;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees.Degrees;
 import org.apache.flink.graph.library.metric.directed.VertexMetrics.Result;
 import org.apache.flink.types.CopyableValue;
-import org.apache.flink.util.AbstractID;
 
 import java.io.IOException;
 import java.text.NumberFormat;
@@ -44,6 +41,9 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
  * Compute the following vertex metrics in a directed graph:
  *  - number of vertices
  *  - number of edges
+ *  - number of unidirectional edges
+ *  - number of bidirectional edges
+ *  - average degree
  *  - number of triplets
  *  - maximum degree
  *  - maximum out degree
@@ -57,7 +57,7 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
 public class VertexMetrics<K extends Comparable<K> & CopyableValue<K>, VV, EV>
 extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
-	private String id = new AbstractID().toString();
+	private VertexMetricsHelper<K> vertexMetricsHelper;
 
 	// Optional configuration
 	private boolean includeZeroDegreeVertices = false;
@@ -101,8 +101,10 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 				.setIncludeZeroDegreeVertices(includeZeroDegreeVertices)
 				.setParallelism(parallelism));
 
+		vertexMetricsHelper = new VertexMetricsHelper<>();
+
 		vertexDegree
-			.output(new VertexMetricsHelper<K>(id))
+			.output(vertexMetricsHelper)
 				.name("Vertex metrics");
 
 		return this;
@@ -110,17 +112,18 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 	@Override
 	public Result getResult() {
-		JobExecutionResult res = env.getLastJobExecutionResult();
+		long vertexCount = vertexMetricsHelper.getAccumulator(env, "vertexCount");
+		long unidirectionalEdgeCount = vertexMetricsHelper.getAccumulator(env, "unidirectionalEdgeCount");
+		long bidirectionalEdgeCount = vertexMetricsHelper.getAccumulator(env, "bidirectionalEdgeCount");
+		long tripletCount = vertexMetricsHelper.getAccumulator(env, "tripletCount");
+		long maximumDegree = vertexMetricsHelper.getAccumulator(env, "maximumDegree");
+		long maximumOutDegree = vertexMetricsHelper.getAccumulator(env, "maximumOutDegree");
+		long maximumInDegree = vertexMetricsHelper.getAccumulator(env, "maximumInDegree");
+		long maximumTriplets = vertexMetricsHelper.getAccumulator(env, "maximumTriplets");
 
-		long vertexCount = res.getAccumulatorResult(id + "-0");
-		long edgeCount = res.getAccumulatorResult(id + "-1");
-		long tripletCount = res.getAccumulatorResult(id + "-2");
-		long maximumDegree = res.getAccumulatorResult(id + "-3");
-		long maximumOutDegree = res.getAccumulatorResult(id + "-4");
-		long maximumInDegree = res.getAccumulatorResult(id + "-5");
-		long maximumTriplets = res.getAccumulatorResult(id + "-6");
-
-		return new Result(vertexCount, edgeCount, tripletCount, maximumDegree, maximumOutDegree, maximumInDegree, maximumTriplets);
+		// each edge is counted twice, once from each vertex, so must be halved
+		return new Result(vertexCount, unidirectionalEdgeCount / 2, bidirectionalEdgeCount / 2, tripletCount,
+			maximumDegree, maximumOutDegree, maximumInDegree, maximumTriplets);
 	}
 
 	/**
@@ -129,45 +132,28 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	 * @param <T> ID type
 	 */
 	private static class VertexMetricsHelper<T>
-	extends RichOutputFormat<Vertex<T, Degrees>> {
-		private final String id;
-
+	extends GraphAnalyticHelper<Vertex<T, Degrees>> {
 		private long vertexCount;
-		private long edgeCount;
+		private long unidirectionalEdgeCount;
+		private long bidirectionalEdgeCount;
 		private long tripletCount;
 		private long maximumDegree;
 		private long maximumOutDegree;
 		private long maximumInDegree;
 		private long maximumTriplets;
 
-		/**
-		 * This helper class collects vertex metrics by scanning over and
-		 * discarding elements from the given DataSet.
-		 *
-		 * The unique id is required because Flink's accumulator namespace is
-		 * shared among all operators.
-		 *
-		 * @param id unique string used for accumulator names
-		 */
-		public VertexMetricsHelper(String id) {
-			this.id = id;
-		}
-
-		@Override
-		public void configure(Configuration parameters) {}
-
-		@Override
-		public void open(int taskNumber, int numTasks) throws IOException {}
-
 		@Override
 		public void writeRecord(Vertex<T, Degrees> record) throws IOException {
 			long degree = record.f1.getDegree().getValue();
 			long outDegree = record.f1.getOutDegree().getValue();
 			long inDegree = record.f1.getInDegree().getValue();
+
+			long bidirectionalEdges = outDegree + inDegree - degree;
 			long triplets = degree * (degree - 1) / 2;
 
 			vertexCount++;
-			edgeCount += outDegree;
+			unidirectionalEdgeCount += degree - bidirectionalEdges;
+			bidirectionalEdgeCount += bidirectionalEdges;
 			tripletCount += triplets;
 			maximumDegree = Math.max(maximumDegree, degree);
 			maximumOutDegree = Math.max(maximumOutDegree, outDegree);
@@ -177,13 +163,14 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 		@Override
 		public void close() throws IOException {
-			getRuntimeContext().addAccumulator(id + "-0", new LongCounter(vertexCount));
-			getRuntimeContext().addAccumulator(id + "-1", new LongCounter(edgeCount));
-			getRuntimeContext().addAccumulator(id + "-2", new LongCounter(tripletCount));
-			getRuntimeContext().addAccumulator(id + "-3", new LongMaximum(maximumDegree));
-			getRuntimeContext().addAccumulator(id + "-4", new LongMaximum(maximumOutDegree));
-			getRuntimeContext().addAccumulator(id + "-5", new LongMaximum(maximumInDegree));
-			getRuntimeContext().addAccumulator(id + "-6", new LongMaximum(maximumTriplets));
+			addAccumulator("vertexCount", new LongCounter(vertexCount));
+			addAccumulator("unidirectionalEdgeCount", new LongCounter(unidirectionalEdgeCount));
+			addAccumulator("bidirectionalEdgeCount", new LongCounter(bidirectionalEdgeCount));
+			addAccumulator("tripletCount", new LongCounter(tripletCount));
+			addAccumulator("maximumDegree", new LongMaximum(maximumDegree));
+			addAccumulator("maximumOutDegree", new LongMaximum(maximumOutDegree));
+			addAccumulator("maximumInDegree", new LongMaximum(maximumInDegree));
+			addAccumulator("maximumTriplets", new LongMaximum(maximumTriplets));
 		}
 	}
 
@@ -192,16 +179,19 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	 */
 	public static class Result {
 		private long vertexCount;
-		private long edgeCount;
+		private long unidirectionalEdgeCount;
+		private long bidirectionalEdgeCount;
 		private long tripletCount;
 		private long maximumDegree;
 		private long maximumOutDegree;
 		private long maximumInDegree;
 		private long maximumTriplets;
 
-		public Result(long vertexCount, long edgeCount, long tripletCount, long maximumDegree, long maximumOutDegree, long maximumInDegree, long maximumTriplets) {
+		public Result(long vertexCount, long unidirectionalEdgeCount, long bidirectionalEdgeCount, long tripletCount,
+				long maximumDegree, long maximumOutDegree, long maximumInDegree, long maximumTriplets) {
 			this.vertexCount = vertexCount;
-			this.edgeCount = edgeCount;
+			this.unidirectionalEdgeCount = unidirectionalEdgeCount;
+			this.bidirectionalEdgeCount = bidirectionalEdgeCount;
 			this.tripletCount = tripletCount;
 			this.maximumDegree = maximumDegree;
 			this.maximumOutDegree = maximumOutDegree;
@@ -224,7 +214,25 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 		 * @return number of edges
 		 */
 		public long getNumberOfEdges() {
-			return edgeCount;
+			return unidirectionalEdgeCount + 2 * bidirectionalEdgeCount;
+		}
+
+		/**
+		 * Get the number of unidirectional edges.
+		 *
+		 * @return number of unidirectional edges
+		 */
+		public long getNumberOfDirectedEdges() {
+			return unidirectionalEdgeCount;
+		}
+
+		/**
+		 * Get the number of bidirectional edges.
+		 *
+		 * @return number of bidirectional edges
+		 */
+		public long getNumberOfUndirectedEdges() {
+			return bidirectionalEdgeCount;
 		}
 
 		/**
@@ -233,7 +241,7 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 		 * @return average degree
 		 */
 		public float getAverageDegree() {
-			return edgeCount / (float)vertexCount;
+			return getNumberOfEdges() / (float)vertexCount;
 		}
 
 		/**
@@ -286,7 +294,9 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 			NumberFormat nf = NumberFormat.getInstance();
 
 			return "vertex count: " + nf.format(vertexCount)
-				+ "; edge count: " + nf.format(edgeCount)
+				+ "; edge count: " + nf.format(getNumberOfEdges())
+				+ "; unidirectional edge count: " + nf.format(unidirectionalEdgeCount)
+				+ "; bidirectional edge count: " + nf.format(bidirectionalEdgeCount)
 				+ "; average degree: " + nf.format(getAverageDegree())
 				+ "; triplet count: " + nf.format(tripletCount)
 				+ "; maximum degree: " + nf.format(maximumDegree)
@@ -299,7 +309,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 		public int hashCode() {
 			return new HashCodeBuilder()
 				.append(vertexCount)
-				.append(edgeCount)
+				.append(unidirectionalEdgeCount)
+				.append(bidirectionalEdgeCount)
 				.append(tripletCount)
 				.append(maximumDegree)
 				.append(maximumOutDegree)
@@ -318,7 +329,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 			return new EqualsBuilder()
 				.append(vertexCount, rhs.vertexCount)
-				.append(edgeCount, rhs.edgeCount)
+				.append(unidirectionalEdgeCount, rhs.unidirectionalEdgeCount)
+				.append(bidirectionalEdgeCount, rhs.bidirectionalEdgeCount)
 				.append(tripletCount, rhs.tripletCount)
 				.append(maximumDegree, rhs.maximumDegree)
 				.append(maximumOutDegree, rhs.maximumOutDegree)

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/EdgeMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/EdgeMetrics.java
@@ -56,6 +56,14 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
 public class EdgeMetrics<K extends Comparable<K> & CopyableValue<K>, VV, EV>
 extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
+	private static final String TRIANGLE_TRIPLET_COUNT = "triangleTripletCount";
+
+	private static final String RECTANGLE_TRIPLET_COUNT = "rectangleTripletCount";
+
+	private static final String MAXIMUM_TRIANGLE_TRIPLETS = "maximumTriangleTriplets";
+
+	private static final String MAXIMUM_RECTANGLE_TRIPLETS = "maximumRectangleTriplets";
+
 	private EdgeMetricsHelper<K> edgeMetricsHelper;
 
 	// Optional configuration
@@ -131,10 +139,10 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 	@Override
 	public Result getResult() {
-		long triangleTripletCount = edgeMetricsHelper.getAccumulator(env, "triangleTripletCount");
-		long rectangleTripletCount = edgeMetricsHelper.getAccumulator(env, "rectangleTripletCount");
-		long maximumTriangleTriplets = edgeMetricsHelper.getAccumulator(env, "maximumTriangleTriplets");
-		long maximumRectangleTriplets = edgeMetricsHelper.getAccumulator(env, "maximumRectangleTriplets");
+		long triangleTripletCount = edgeMetricsHelper.getAccumulator(env, TRIANGLE_TRIPLET_COUNT);
+		long rectangleTripletCount = edgeMetricsHelper.getAccumulator(env, RECTANGLE_TRIPLET_COUNT);
+		long maximumTriangleTriplets = edgeMetricsHelper.getAccumulator(env, MAXIMUM_TRIANGLE_TRIPLETS);
+		long maximumRectangleTriplets = edgeMetricsHelper.getAccumulator(env, MAXIMUM_RECTANGLE_TRIPLETS);
 
 		return new Result(triangleTripletCount, rectangleTripletCount,
 			maximumTriangleTriplets, maximumRectangleTriplets);
@@ -228,10 +236,10 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 		@Override
 		public void close() throws IOException {
-			addAccumulator("triangleTripletCount", new LongCounter(triangleTripletCount));
-			addAccumulator("rectangleTripletCount", new LongCounter(rectangleTripletCount));
-			addAccumulator("maximumTriangleTriplets", new LongMaximum(maximumTriangleTriplets));
-			addAccumulator("maximumRectangleTriplets", new LongMaximum(maximumRectangleTriplets));
+			addAccumulator(TRIANGLE_TRIPLET_COUNT, new LongCounter(triangleTripletCount));
+			addAccumulator(RECTANGLE_TRIPLET_COUNT, new LongCounter(rectangleTripletCount));
+			addAccumulator(MAXIMUM_TRIANGLE_TRIPLETS, new LongMaximum(maximumTriangleTriplets));
+			addAccumulator(MAXIMUM_RECTANGLE_TRIPLETS, new LongMaximum(maximumRectangleTriplets));
 		}
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/EdgeMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/EdgeMetrics.java
@@ -31,7 +31,7 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.graph.AbstractGraphAnalytic;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.GraphAnalyticHelper;
+import org.apache.flink.graph.AnalyticHelper;
 import org.apache.flink.graph.asm.degree.annotate.undirected.EdgeDegreePair;
 import org.apache.flink.graph.library.metric.undirected.EdgeMetrics.Result;
 import org.apache.flink.types.CopyableValue;
@@ -211,7 +211,7 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	 * @param <T> ID type
 	 */
 	private static class EdgeMetricsHelper<T extends Comparable<T>>
-	extends GraphAnalyticHelper<Tuple3<T, LongValue, LongValue>> {
+	extends AnalyticHelper<Tuple3<T, LongValue, LongValue>> {
 		private long triangleTripletCount;
 		private long rectangleTripletCount;
 		private long maximumTriangleTriplets;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/VertexMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/VertexMetrics.java
@@ -53,6 +53,16 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
 public class VertexMetrics<K extends Comparable<K> & CopyableValue<K>, VV, EV>
 extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
+	private static final String VERTEX_COUNT = "vertexCount";
+
+	private static final String EDGE_COUNT = "edgeCount";
+
+	private static final String TRIPLET_COUNT = "tripletCount";
+
+	private static final String MAXIMUM_DEGREE = "maximumDegree";
+
+	private static final String MAXIMUM_TRIPLETS = "maximumTriplets";
+
 	private VertexMetricsHelper<K> vertexMetricsHelper;
 
 	// Optional configuration
@@ -126,11 +136,11 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 	@Override
 	public Result getResult() {
-		long vertexCount = vertexMetricsHelper.getAccumulator(env, "vertexCount");
-		long edgeCount = vertexMetricsHelper.getAccumulator(env, "edgeCount");
-		long tripletCount = vertexMetricsHelper.getAccumulator(env, "tripletCount");
-		long maximumDegree = vertexMetricsHelper.getAccumulator(env, "maximumDegree");
-		long maximumTriplets = vertexMetricsHelper.getAccumulator(env, "maximumTriplets");
+		long vertexCount = vertexMetricsHelper.getAccumulator(env, VERTEX_COUNT);
+		long edgeCount = vertexMetricsHelper.getAccumulator(env, EDGE_COUNT);
+		long tripletCount = vertexMetricsHelper.getAccumulator(env, TRIPLET_COUNT);
+		long maximumDegree = vertexMetricsHelper.getAccumulator(env, MAXIMUM_DEGREE);
+		long maximumTriplets = vertexMetricsHelper.getAccumulator(env, MAXIMUM_TRIPLETS);
 
 		// each edge is counted twice, once from each vertex, so must be halved
 		return new Result(vertexCount, edgeCount / 2, tripletCount, maximumDegree, maximumTriplets);
@@ -163,11 +173,11 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 		@Override
 		public void close() throws IOException {
-			addAccumulator("vertexCount", new LongCounter(vertexCount));
-			addAccumulator("edgeCount", new LongCounter(edgeCount));
-			addAccumulator("tripletCount", new LongCounter(tripletCount));
-			addAccumulator("maximumDegree", new LongMaximum(maximumDegree));
-			addAccumulator("maximumTriplets", new LongMaximum(maximumTriplets));
+			addAccumulator(VERTEX_COUNT, new LongCounter(vertexCount));
+			addAccumulator(EDGE_COUNT, new LongCounter(edgeCount));
+			addAccumulator(TRIPLET_COUNT, new LongCounter(tripletCount));
+			addAccumulator(MAXIMUM_DEGREE, new LongMaximum(maximumDegree));
+			addAccumulator(MAXIMUM_TRIPLETS, new LongMaximum(maximumTriplets));
 		}
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/VertexMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/VertexMetrics.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.accumulators.LongMaximum;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.graph.AbstractGraphAnalytic;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.GraphAnalyticHelper;
+import org.apache.flink.graph.AnalyticHelper;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.asm.degree.annotate.undirected.VertexDegree;
 import org.apache.flink.graph.library.metric.undirected.VertexMetrics.Result;
@@ -152,7 +152,7 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	 * @param <T> ID type
 	 */
 	private static class VertexMetricsHelper<T>
-	extends GraphAnalyticHelper<Vertex<T, LongValue>> {
+	extends AnalyticHelper<Vertex<T, LongValue>> {
 		private long vertexCount;
 		private long edgeCount;
 		private long tripletCount;

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/directed/EdgeMetricsTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/directed/EdgeMetricsTest.java
@@ -34,7 +34,7 @@ extends AsmTestBase {
 	@Test
 	public void testWithSimpleGraph()
 			throws Exception {
-		Result expectedResult = new Result(6, 7, 2, 6, 13, 4, 2, 3, 1, 3, 6);
+		Result expectedResult = new Result(6, 7, 0, 2, 6, 13, 4, 2, 3, 1, 3, 6);
 
 		Result edgeMetrics = new EdgeMetrics<IntValue, NullValue, NullValue>()
 			.run(directedSimpleGraph)
@@ -47,11 +47,12 @@ extends AsmTestBase {
 	public void testWithCompleteGraph()
 			throws Exception {
 		long expectedDegree = completeGraphVertexCount - 1;
-		long expectedEdges = completeGraphVertexCount * expectedDegree;
+		long expectedBidirectionalEdges = completeGraphVertexCount * expectedDegree / 2;
 		long expectedMaximumTriplets = CombinatoricsUtils.binomialCoefficient((int)expectedDegree, 2);
 		long expectedTriplets = completeGraphVertexCount * expectedMaximumTriplets;
 
-		Result expectedResult = new Result(completeGraphVertexCount, expectedEdges, expectedTriplets / 3, 2 * expectedTriplets / 3, expectedTriplets,
+		Result expectedResult = new Result(completeGraphVertexCount, 0, expectedBidirectionalEdges,
+			expectedTriplets / 3, 2 * expectedTriplets / 3, expectedTriplets,
 			expectedDegree, expectedDegree, expectedDegree,
 			expectedMaximumTriplets, expectedMaximumTriplets, expectedMaximumTriplets);
 
@@ -67,7 +68,7 @@ extends AsmTestBase {
 			throws Exception {
 		Result expectedResult;
 
-		expectedResult = new Result(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+		expectedResult = new Result(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 
 		Result withoutZeroDegreeVertices = new EdgeMetrics<LongValue, NullValue, NullValue>()
 			.run(emptyGraph)
@@ -79,7 +80,7 @@ extends AsmTestBase {
 	@Test
 	public void testWithRMatGraph()
 			throws Exception {
-		Result expectedResult = new Result(902, 12009, 107817, 315537, 1003442, 463, 334, 342, 820, 3822, 106953);
+		Result expectedResult = new Result(902, 8875, 1567, 107817, 315537, 1003442, 463, 334, 342, 820, 3822, 106953);
 
 		Result withoutZeroDegreeVertices = new EdgeMetrics<LongValue, NullValue, NullValue>()
 			.run(directedRMatGraph)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/directed/EdgeMetricsTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/directed/EdgeMetricsTest.java
@@ -34,7 +34,7 @@ extends AsmTestBase {
 	@Test
 	public void testWithSimpleGraph()
 			throws Exception {
-		Result expectedResult = new Result(6, 7, 0, 2, 6, 13, 4, 2, 3, 1, 3, 6);
+		Result expectedResult = new Result(2, 6, 1, 3);
 
 		Result edgeMetrics = new EdgeMetrics<IntValue, NullValue, NullValue>()
 			.run(directedSimpleGraph)
@@ -47,14 +47,11 @@ extends AsmTestBase {
 	public void testWithCompleteGraph()
 			throws Exception {
 		long expectedDegree = completeGraphVertexCount - 1;
-		long expectedBidirectionalEdges = completeGraphVertexCount * expectedDegree / 2;
 		long expectedMaximumTriplets = CombinatoricsUtils.binomialCoefficient((int)expectedDegree, 2);
 		long expectedTriplets = completeGraphVertexCount * expectedMaximumTriplets;
 
-		Result expectedResult = new Result(completeGraphVertexCount, 0, expectedBidirectionalEdges,
-			expectedTriplets / 3, 2 * expectedTriplets / 3, expectedTriplets,
-			expectedDegree, expectedDegree, expectedDegree,
-			expectedMaximumTriplets, expectedMaximumTriplets, expectedMaximumTriplets);
+		Result expectedResult = new Result(expectedTriplets / 3, 2 * expectedTriplets / 3,
+			expectedMaximumTriplets, expectedMaximumTriplets);
 
 		Result edgeMetrics = new EdgeMetrics<LongValue, NullValue, NullValue>()
 			.run(completeGraph)
@@ -68,7 +65,7 @@ extends AsmTestBase {
 			throws Exception {
 		Result expectedResult;
 
-		expectedResult = new Result(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+		expectedResult = new Result(0, 0, 0, 0);
 
 		Result withoutZeroDegreeVertices = new EdgeMetrics<LongValue, NullValue, NullValue>()
 			.run(emptyGraph)
@@ -80,7 +77,7 @@ extends AsmTestBase {
 	@Test
 	public void testWithRMatGraph()
 			throws Exception {
-		Result expectedResult = new Result(902, 8875, 1567, 107817, 315537, 1003442, 463, 334, 342, 820, 3822, 106953);
+		Result expectedResult = new Result(107817, 315537, 820, 3822);
 
 		Result withoutZeroDegreeVertices = new EdgeMetrics<LongValue, NullValue, NullValue>()
 			.run(directedRMatGraph)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/directed/VertexMetricsTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/directed/VertexMetricsTest.java
@@ -34,7 +34,7 @@ extends AsmTestBase {
 	@Test
 	public void testWithSimpleGraph()
 			throws Exception {
-		Result expectedResult = new Result(6, 7, 13, 4, 2, 3, 6);
+		Result expectedResult = new Result(6, 7, 0, 13, 4, 2, 3, 6);
 
 		Result vertexMetrics = new VertexMetrics<IntValue, NullValue, NullValue>()
 			.run(directedSimpleGraph)
@@ -47,11 +47,12 @@ extends AsmTestBase {
 	public void testWithCompleteGraph()
 			throws Exception {
 		long expectedDegree = completeGraphVertexCount - 1;
-		long expectedEdges = completeGraphVertexCount * expectedDegree;
+		long expectedBidirectionalEdges = completeGraphVertexCount * expectedDegree / 2;
 		long expectedMaximumTriplets = CombinatoricsUtils.binomialCoefficient((int)expectedDegree, 2);
 		long expectedTriplets = completeGraphVertexCount * expectedMaximumTriplets;
 
-		Result expectedResult = new Result(completeGraphVertexCount, expectedEdges, expectedTriplets, expectedDegree, expectedDegree, expectedDegree, expectedMaximumTriplets);
+		Result expectedResult = new Result(completeGraphVertexCount, 0, expectedBidirectionalEdges,
+			expectedTriplets, expectedDegree, expectedDegree, expectedDegree, expectedMaximumTriplets);
 
 		Result vertexMetrics = new VertexMetrics<LongValue, NullValue, NullValue>()
 			.run(completeGraph)
@@ -65,7 +66,7 @@ extends AsmTestBase {
 			throws Exception {
 		Result expectedResult;
 
-		expectedResult = new Result(0, 0, 0, 0, 0, 0, 0);
+		expectedResult = new Result(0, 0, 0, 0, 0, 0, 0, 0);
 
 		Result withoutZeroDegreeVertices = new VertexMetrics<LongValue, NullValue, NullValue>()
 			.setIncludeZeroDegreeVertices(false)
@@ -74,7 +75,7 @@ extends AsmTestBase {
 
 		assertEquals(withoutZeroDegreeVertices, expectedResult);
 
-		expectedResult = new Result(3, 0, 0, 0, 0, 0, 0);
+		expectedResult = new Result(3, 0, 0, 0, 0, 0, 0, 0);
 
 		Result withZeroDegreeVertices = new VertexMetrics<LongValue, NullValue, NullValue>()
 			.setIncludeZeroDegreeVertices(true)
@@ -87,7 +88,7 @@ extends AsmTestBase {
 	@Test
 	public void testWithRMatGraph()
 			throws Exception {
-		Result expectedResult = new Result(902, 12009, 1003442, 463, 334, 342, 106953);
+		Result expectedResult = new Result(902, 8875, 1567, 1003442, 463, 334, 342, 106953);
 
 		Result withoutZeroDegreeVertices = new VertexMetrics<LongValue, NullValue, NullValue>()
 			.run(directedRMatGraph)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/undirected/EdgeMetricsTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/undirected/EdgeMetricsTest.java
@@ -34,7 +34,7 @@ extends AsmTestBase {
 	@Test
 	public void testWithSimpleGraph()
 			throws Exception {
-		Result expectedResult = new Result(6, 7, 2, 6, 13, 4, 1, 3, 6);
+		Result expectedResult = new Result(2, 6, 1, 3);
 
 		Result edgeMetrics = new EdgeMetrics<IntValue, NullValue, NullValue>()
 			.run(undirectedSimpleGraph)
@@ -47,12 +47,11 @@ extends AsmTestBase {
 	public void testWithCompleteGraph()
 			throws Exception {
 		long expectedDegree = completeGraphVertexCount - 1;
-		long expectedEdges = completeGraphVertexCount * expectedDegree / 2;
 		long expectedMaximumTriplets = CombinatoricsUtils.binomialCoefficient((int)expectedDegree, 2);
 		long expectedTriplets = completeGraphVertexCount * expectedMaximumTriplets;
 
-		Result expectedResult = new Result(completeGraphVertexCount, expectedEdges, expectedTriplets / 3, 2 * expectedTriplets / 3, expectedTriplets,
-			expectedDegree, expectedMaximumTriplets, expectedMaximumTriplets, expectedMaximumTriplets);
+		Result expectedResult = new Result(expectedTriplets / 3, 2 * expectedTriplets / 3,
+			expectedMaximumTriplets, expectedMaximumTriplets);
 
 		Result edgeMetrics = new EdgeMetrics<LongValue, NullValue, NullValue>()
 			.run(completeGraph)
@@ -66,7 +65,7 @@ extends AsmTestBase {
 			throws Exception {
 		Result expectedResult;
 
-		expectedResult = new Result(0, 0, 0, 0, 0, 0, 0, 0, 0);
+		expectedResult = new Result(0, 0, 0, 0);
 
 		Result withoutZeroDegreeVertices = new EdgeMetrics<LongValue, NullValue, NullValue>()
 			.run(emptyGraph)
@@ -78,7 +77,7 @@ extends AsmTestBase {
 	@Test
 	public void testWithRMatGraph()
 			throws Exception {
-		Result expectedResult = new Result(902, 10442, 107817, 315537, 1003442, 463, 820, 3822, 106953);
+		Result expectedResult = new Result(107817, 315537, 820, 3822);
 
 		Result withoutZeroDegreeVertices = new EdgeMetrics<LongValue, NullValue, NullValue>()
 			.run(undirectedRMatGraph)


### PR DESCRIPTION
The current implementation simply counts edges. We can do one better and tabulate unidirectional (u:v but no v:u) and bidirectional edges (u:v and v:u).

This is effectively the 'dyadic census'.
