### PR TITLE
[FLINK-4883]Prevent UDFs implementations through Scala singleton objects

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -91,6 +91,8 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
 	private boolean useClosureCleaner = true;
 
+	private boolean scalaObjectFunctionForbidden = true;
+
 	private int parallelism = PARALLELISM_DEFAULT;
 
 	/**
@@ -162,6 +164,34 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	private LinkedHashSet<Class<?>> registeredPojoTypes = new LinkedHashSet<>();
 
 	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Forbid Scala Object function,since for user defined functions defined by Scala Object,
+	 * Flink could use them across several operator instances, which leads to job failures.
+	 */
+	public ExecutionConfig forbidScalaObjectFunction() {
+		scalaObjectFunctionForbidden = true;
+		return this;
+	}
+
+	/**
+	 * allow use Scala Object function
+	 *
+	 * @see #forbidScalaObjectFunction()
+	 */
+	public ExecutionConfig allowScalaObjectFunction() {
+		scalaObjectFunctionForbidden = false;
+		return this;
+	}
+
+	/**
+	 * Returns whether Scala Object function is forbidden
+	 *
+	 * @see #forbidScalaObjectFunction()
+	 */
+	public boolean isScalaObjectFunctionForbidden() {
+		return scalaObjectFunctionForbidden;
+	}
 
 	/**
 	 * Enables the ClosureCleaner. This analyzes user code functions and sets fields to null

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/ScalaObjectChecker.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/ScalaObjectChecker.java
@@ -32,13 +32,15 @@ public class ScalaObjectChecker {
 		String clsName = cls.getCanonicalName();
 		if (clsName.length() > 0) {
 			char lastChar = clsName.charAt(clsName.length() - 1);
-			if (lastChar == '$') return true;
+			if (lastChar == '$') {
+				return true;
+			} else return false;
 		}
 		return false;
 	}
 
 	public static void assertScalaForbidScalaObjectFunction(Object o) {
-		if(isPotentialScalaObject(o)) {
+		if (isPotentialScalaObject(o)) {
 			String msg = "User defined function implemented by class " + o.getClass().getCanonicalName() +
 				" might be implemented by a Scala Object,it is forbidden by Flink since concurrent modification risks.";
 			throw new InvalidProgramException(msg);

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/ScalaObjectChecker.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/ScalaObjectChecker.java
@@ -34,7 +34,9 @@ public class ScalaObjectChecker {
 			char lastChar = clsName.charAt(clsName.length() - 1);
 			if (lastChar == '$') {
 				return true;
-			} else return false;
+			} else {
+				return false;
+			}
 		}
 		return false;
 	}

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/ScalaObjectChecker.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/ScalaObjectChecker.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.InvalidProgramException;
+
+/**
+ * Scala Object checker tries to verify if a class is implemented by
+ * Scala Object
+ */
+@Internal
+public class ScalaObjectChecker {
+	public static boolean isPotentialScalaObject(Object o) {
+		final Class<?> cls = o.getClass();
+		String clsName = cls.getCanonicalName();
+		if (clsName.length() > 0) {
+			char lastChar = clsName.charAt(clsName.length() - 1);
+			if (lastChar == '$') return true;
+		}
+		return false;
+	}
+
+	public static void assertScalaForbidScalaObjectFunction(Object o) {
+		if(isPotentialScalaObject(o)) {
+			String msg = "User defined function implemented by class " + o.getClass().getCanonicalName() +
+				" might be implemented by a Scala Object,it is forbidden by Flink since concurrent modification risks.";
+			throw new InvalidProgramException(msg);
+		}
+	}
+}

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/ScalaObjectCheckerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/ScalaObjectCheckerTest.scala
@@ -26,19 +26,19 @@ import org.junit.Test
 class ScalaObjectCheckerTest {
 
   @Test(expected = classOf[InvalidProgramException])
-  def testAssertScalaForbidScalaObjectFunction() = {
+  def testAssertScalaForbidScalaObjectFunction(): Unit = {
     object AScalaObject
     ScalaObjectChecker.assertScalaForbidScalaObjectFunction(AScalaObject)
   }
 
   @Test
-  def testAssertScalaForbidScalaObjectFunction2() = {
+  def testAssertScalaForbidScalaObjectFunction2(): Unit = {
     class AScalaClass
     ScalaObjectChecker.assertScalaForbidScalaObjectFunction(new AScalaClass)
   }
 
   @Test(expected = classOf[InvalidProgramException])
-  def testEnvForObject() = {
+  def testEnvForObject(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val src = env.fromCollection(Seq(1, 2, 3))
     object RichMapObject extends RichMapFunction[Int, Int] {
@@ -48,7 +48,7 @@ class ScalaObjectCheckerTest {
   }
 
   @Test
-  def testEnvForClass() = {
+  def testEnvForClass(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val src = env.fromCollection(Seq(1, 2, 3))
     class RichMapClass extends RichMapFunction[Int, Int] {

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/ScalaObjectCheckerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/ScalaObjectCheckerTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala
+
+import org.apache.flink.api.common.InvalidProgramException
+import org.apache.flink.api.common.functions.RichMapFunction
+import org.junit.Test
+
+
+class ScalaObjectCheckerTest {
+
+  @Test(expected = classOf[InvalidProgramException])
+  def testAssertScalaForbidScalaObjectFunction() = {
+    object AScalaObject
+    ScalaObjectChecker.assertScalaForbidScalaObjectFunction(AScalaObject)
+  }
+
+  @Test
+  def testAssertScalaForbidScalaObjectFunction2() = {
+    class AScalaClass
+    ScalaObjectChecker.assertScalaForbidScalaObjectFunction(new AScalaClass)
+  }
+
+  @Test(expected = classOf[InvalidProgramException])
+  def testEnvForObject() = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val src = env.fromCollection(Seq(1, 2, 3))
+    object RichMapObject extends RichMapFunction[Int, Int] {
+      override def map(value: Int): Int = value * 2
+    }
+    src.map(RichMapObject)
+  }
+
+  @Test
+  def testEnvForClass() = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val src = env.fromCollection(Seq(1, 2, 3))
+    class RichMapClass extends RichMapFunction[Int, Int] {
+      override def map(value: Int): Int = value * 2
+    }
+    src.map(new RichMapClass)
+  }
+}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
@@ -436,7 +436,7 @@ class AllWindowedStream[T, W <: Window](javaStream: JavaAllWStream[T, W]) {
    * is not disabled in the [[org.apache.flink.api.common.ExecutionConfig]].
    */
   private[flink] def clean[F <: AnyRef](f: F): F = {
-    new StreamExecutionEnvironment(javaStream.getExecutionEnvironment).scalaClean(f)
+    new StreamExecutionEnvironment(javaStream.getExecutionEnvironment).scalaCheckAndClean(f)
   }
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/CoGroupedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/CoGroupedStreams.scala
@@ -214,6 +214,6 @@ class CoGroupedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
    * is not disabled in the [[org.apache.flink.api.common.ExecutionConfig]].
    */
   private[flink] def clean[F <: AnyRef](f: F): F = {
-    new StreamExecutionEnvironment(input1.javaStream.getExecutionEnvironment).scalaClean(f)
+    new StreamExecutionEnvironment(input1.javaStream.getExecutionEnvironment).scalaCheckAndClean(f)
   }
 }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/ConnectedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/ConnectedStreams.scala
@@ -268,7 +268,7 @@ class ConnectedStreams[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
    * is not disabled in the [[org.apache.flink.api.common.ExecutionConfig]]
    */
   private[flink] def clean[F <: AnyRef](f: F): F = {
-    new StreamExecutionEnvironment(javaStream.getExecutionEnvironment).scalaClean(f)
+    new StreamExecutionEnvironment(javaStream.getExecutionEnvironment).scalaCheckAndClean(f)
   }
 
   @PublicEvolving

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -967,7 +967,7 @@ class DataStream[T](stream: JavaStream[T]) {
    * is not disabled in the [[org.apache.flink.api.common.ExecutionConfig]].
    */
   private[flink] def clean[F <: AnyRef](f: F): F = {
-    new StreamExecutionEnvironment(stream.getExecutionEnvironment).scalaClean(f)
+    new StreamExecutionEnvironment(stream.getExecutionEnvironment).scalaCheckAndClean(f)
   }
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/JoinedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/JoinedStreams.scala
@@ -219,6 +219,6 @@ class JoinedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
    * is not disabled in the [[org.apache.flink.api.common.ExecutionConfig]].
    */
   private[flink] def clean[F <: AnyRef](f: F): F = {
-    new StreamExecutionEnvironment(input1.javaStream.getExecutionEnvironment).scalaClean(f)
+    new StreamExecutionEnvironment(input1.javaStream.getExecutionEnvironment).scalaCheckAndClean(f)
   }
 }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.io.{FileInputFormat, FilePathFilter, InputFor
 import org.apache.flink.api.common.restartstrategy.RestartStrategies.RestartStrategyConfiguration
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
-import org.apache.flink.api.scala.ClosureCleaner
+import org.apache.flink.api.scala.{ClosureCleaner, ScalaObjectChecker}
 import org.apache.flink.runtime.state.AbstractStateBackend
 import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JavaEnv}
 import org.apache.flink.streaming.api.functions.source._
@@ -593,7 +593,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   def addSource[T: TypeInformation](function: SourceFunction[T]): DataStream[T] = {
     require(function != null, "Function must not be null.")
     
-    val cleanFun = scalaClean(function)
+    val cleanFun = scalaCheckAndClean(function)
     val typeInfo = implicitly[TypeInformation[T]]
     asScalaStream(javaEnv.addSource(cleanFun).returns(typeInfo))
   }
@@ -605,7 +605,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   def addSource[T: TypeInformation](function: SourceContext[T] => Unit): DataStream[T] = {
     require(function != null, "Function must not be null.")
     val sourceFunction = new SourceFunction[T] {
-      val cleanFun = scalaClean(function)
+      val cleanFun = scalaCheckAndClean(function)
       override def run(ctx: SourceContext[T]) {
         cleanFun(ctx)
       }
@@ -618,7 +618,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * Triggers the program execution. The environment will execute all parts of
    * the program that have resulted in a "sink" operation. Sink operations are
    * for example printing results or forwarding them to a message queue.
-   * 
+   *
    * The program execution will be logged and displayed with a generated
    * default name.
    */
@@ -628,7 +628,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * Triggers the program execution. The environment will execute all parts of
    * the program that have resulted in a "sink" operation. Sink operations are
    * for example printing results or forwarding them to a message queue.
-   * 
+   *
    * The program execution will be logged and displayed with the provided name.
    */
   def execute(jobName: String) = javaEnv.execute(jobName)
@@ -658,10 +658,18 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   def getWrappedStreamExecutionEnvironment = javaEnv
 
   /**
-   * Returns a "closure-cleaned" version of the given function. Cleans only if closure cleaning
-   * is not disabled in the [[org.apache.flink.api.common.ExecutionConfig]]
+    * 1. Check if the function is implemented by a scala object. Checks only if scala object function forbidden
+    *    is not disabled in the [[org.apache.flink.api.common.ExecutionConfig]]
+    *
+   *  2. Returns a "closure-cleaned" version of the given function. Cleans only if closure cleaning
+   *     is not disabled in the [[org.apache.flink.api.common.ExecutionConfig]]
    */
-  private[flink] def scalaClean[F <: AnyRef](f: F): F = {
+  private[flink] def scalaCheckAndClean[F <: AnyRef](f: F): F = {
+
+    if (getConfig.isScalaObjectFunctionForbidden) {
+      ScalaObjectChecker.assertScalaForbidScalaObjectFunction(f)
+    }
+
     if (getConfig.isClosureCleanerEnabled) {
       ClosureCleaner.clean(f, true)
     } else {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
@@ -437,7 +437,7 @@ class WindowedStream[T, K, W <: Window](javaStream: JavaWStream[T, K, W]) {
    * is not disabled in the [[org.apache.flink.api.common.ExecutionConfig]].
    */
   private[flink] def clean[F <: AnyRef](f: F): F = {
-    new StreamExecutionEnvironment(javaStream.getExecutionEnvironment).scalaClean(f)
+    new StreamExecutionEnvironment(javaStream.getExecutionEnvironment).scalaCheckAndClean(f)
   }
 
   /**


### PR DESCRIPTION
Ideas and code structure are basically copied from `org.apache.flink.api.java.ClosureCleaner`