### PR TITLE
[FLINK-4883]Prevent UDFs implementations through Scala singleton objects

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -91,6 +91,8 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
 	private boolean useClosureCleaner = true;
 
+	private boolean scalaObjectFunctionForbidden = true;
+
 	private int parallelism = PARALLELISM_DEFAULT;
 
 	/**
@@ -162,6 +164,34 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	private LinkedHashSet<Class<?>> registeredPojoTypes = new LinkedHashSet<>();
 
 	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Forbid Scala Object function,since for user defined functions defined by Scala Object,
+	 * Flink could use them across several operator instances, which leads to job failures.
+	 */
+	public ExecutionConfig forbidScalaObjectFunction() {
+		scalaObjectFunctionForbidden = true;
+		return this;
+	}
+
+	/**
+	 * allow use Scala Object function
+	 *
+	 * @see #forbidScalaObjectFunction()
+	 */
+	public ExecutionConfig allowScalaObjectFunction() {
+		scalaObjectFunctionForbidden = false;
+		return this;
+	}
+
+	/**
+	 * Returns whether Scala Object function is forbidden
+	 *
+	 * @see #forbidScalaObjectFunction()
+	 */
+	public boolean isScalaObjectFunctionForbidden() {
+		return scalaObjectFunctionForbidden;
+	}
 
 	/**
 	 * Enables the ClosureCleaner. This analyzes user code functions and sets fields to null

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/package.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/package.scala
@@ -54,20 +54,20 @@ package object ml {
         broadcastVariable: DataSet[B])(
         fun: (T, B) => O)
       : DataSet[O] = {
-      dataSet.map(new BroadcastSingleElementMapper[T, B, O](dataSet.clean(fun)))
+      dataSet.map(new BroadcastSingleElementMapper[T, B, O](dataSet.clean(dataSet.check(fun))))
         .withBroadcastSet(broadcastVariable, "broadcastVariable")
     }
 
     def filterWithBcVariable[B, O](broadcastVariable: DataSet[B])(fun: (T, B) => Boolean)
       : DataSet[T] = {
-      dataSet.filter(new BroadcastSingleElementFilter[T, B](dataSet.clean(fun)))
+      dataSet.filter(new BroadcastSingleElementFilter[T, B](dataSet.clean(dataSet.check(fun))))
         .withBroadcastSet(broadcastVariable, "broadcastVariable")
     }
 
     def mapWithBcVariableIteration[B, O: TypeInformation: ClassTag](
         broadcastVariable: DataSet[B])(fun: (T, B, Int) => O)
       : DataSet[O] = {
-      dataSet.map(new BroadcastSingleElementMapperWithIteration[T, B, O](dataSet.clean(fun)))
+      dataSet.map(new BroadcastSingleElementMapperWithIteration[T, B, O](dataSet.clean(dataSet.check(fun))))
         .withBroadcastSet(broadcastVariable, "broadcastVariable")
     }
   }

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/package.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/package.scala
@@ -54,20 +54,23 @@ package object ml {
         broadcastVariable: DataSet[B])(
         fun: (T, B) => O)
       : DataSet[O] = {
-      dataSet.map(new BroadcastSingleElementMapper[T, B, O](dataSet.clean(dataSet.check(fun))))
+      dataSet.map(new BroadcastSingleElementMapper[T, B, O](
+        dataSet.clean(dataSet.check(fun))))
         .withBroadcastSet(broadcastVariable, "broadcastVariable")
     }
 
     def filterWithBcVariable[B, O](broadcastVariable: DataSet[B])(fun: (T, B) => Boolean)
       : DataSet[T] = {
-      dataSet.filter(new BroadcastSingleElementFilter[T, B](dataSet.clean(dataSet.check(fun))))
+      dataSet.filter(new BroadcastSingleElementFilter[T, B](
+        dataSet.clean(dataSet.check(fun))))
         .withBroadcastSet(broadcastVariable, "broadcastVariable")
     }
 
     def mapWithBcVariableIteration[B, O: TypeInformation: ClassTag](
         broadcastVariable: DataSet[B])(fun: (T, B, Int) => O)
       : DataSet[O] = {
-      dataSet.map(new BroadcastSingleElementMapperWithIteration[T, B, O](dataSet.clean(dataSet.check(fun))))
+      dataSet.map(new BroadcastSingleElementMapperWithIteration[T, B, O](
+        dataSet.clean(dataSet.check(fun))))
         .withBroadcastSet(broadcastVariable, "broadcastVariable")
     }
   }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/CoGroupDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/CoGroupDataSet.scala
@@ -149,7 +149,7 @@ class CoGroupDataSet[L, R](
       rightInput.javaSet,
       leftKeys,
       rightKeys,
-      coGrouper,
+      check(coGrouper),
       implicitly[TypeInformation[O]],
       buildGroupSortList(leftInput.getType, groupSortKeyPositionsFirst, groupSortOrdersFirst),
       buildGroupSortList(rightInput.getType, groupSortKeyPositionsSecond, groupSortOrdersSecond),
@@ -164,6 +164,7 @@ class CoGroupDataSet[L, R](
   // ----------------------------------------------------------------------------------------------
   
   def withPartitioner[K : TypeInformation](partitioner : Partitioner[K]) : CoGroupDataSet[L, R] = {
+    check(partitioner)
     if (partitioner != null) {
       val typeInfo : TypeInformation[K] = implicitly[TypeInformation[K]]
       

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/CoGroupDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/CoGroupDataSet.scala
@@ -84,7 +84,7 @@ class CoGroupDataSet[L, R](
       fun: (Iterator[L], Iterator[R]) => O): DataSet[O] = {
     require(fun != null, "CoGroup function must not be null.")
     val coGrouper = new CoGroupFunction[L, R, O] {
-      val cleanFun = clean(fun)
+      val cleanFun = clean(check(fun))
       def coGroup(left: java.lang.Iterable[L], right: java.lang.Iterable[R], out: Collector[O]) = {
         out.collect(cleanFun(left.iterator().asScala, right.iterator().asScala))
       }
@@ -114,7 +114,7 @@ class CoGroupDataSet[L, R](
       fun: (Iterator[L], Iterator[R], Collector[O]) => Unit): DataSet[O] = {
     require(fun != null, "CoGroup function must not be null.")
     val coGrouper = new CoGroupFunction[L, R, O] {
-      val cleanFun = clean(fun)
+      val cleanFun = clean(check(fun))
       def coGroup(left: java.lang.Iterable[L], right: java.lang.Iterable[R], out: Collector[O]) = {
         cleanFun(left.iterator.asScala, right.iterator.asScala, out)
       }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/CrossDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/CrossDataSet.scala
@@ -58,7 +58,7 @@ class CrossDataSet[L, R](
   def apply[O: TypeInformation: ClassTag](fun: (L, R) => O): DataSet[O] = {
     require(fun != null, "Cross function must not be null.")
     val crosser = new CrossFunction[L, R, O] {
-      val cleanFun = clean(fun)
+      val cleanFun = clean(check(fun))
       def cross(left: L, right: R): O = {
         cleanFun(left, right)
       }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/CrossDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/CrossDataSet.scala
@@ -83,6 +83,7 @@ class CrossDataSet[L, R](
    */
   def apply[O: TypeInformation: ClassTag](crosser: CrossFunction[L, R, O]): DataSet[O] = {
     require(crosser != null, "Cross function must not be null.")
+    check(crosser)
     val crossOperator = new CrossOperator[L, R, O](
       leftInput.javaSet,
       rightInput.javaSet,

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
@@ -293,7 +293,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     }
     wrap(new MapOperator[T, R](javaSet,
       implicitly[TypeInformation[R]],
-      mapper,
+      check(mapper),
       getCallLocationName()))
   }
 
@@ -329,7 +329,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     }
     wrap(new MapPartitionOperator[T, R](javaSet,
       implicitly[TypeInformation[R]],
-      partitionMapper,
+      check(partitionMapper),
       getCallLocationName()))
   }
 
@@ -393,7 +393,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     }
     wrap(new FlatMapOperator[T, R](javaSet,
       implicitly[TypeInformation[R]],
-      flatMapper,
+      check(flatMapper),
       getCallLocationName()))
   }
 
@@ -609,7 +609,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     }
     wrap(new GroupReduceOperator[T, R](javaSet,
       implicitly[TypeInformation[R]],
-      reducer,
+      check(reducer),
       getCallLocationName()))
   }
 
@@ -675,7 +675,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     }
     wrap(new GroupCombineOperator[T, R](javaSet,
       implicitly[TypeInformation[R]],
-      combiner,
+      check(combiner),
       getCallLocationName()))
   }
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
@@ -320,6 +320,7 @@ class GroupedDataSet[T: ClassTag](
     * using an associative reduce function.
     */
   def reduce(reducer: ReduceFunction[T]): DataSet[T] = {
+    set.check(reducer)
     reduce(getCallLocationName(), reducer, CombineHint.OPTIMIZER_CHOOSES)
   }
 
@@ -330,6 +331,7 @@ class GroupedDataSet[T: ClassTag](
     */
   @PublicEvolving
   def reduce(reducer: ReduceFunction[T], strategy: CombineHint): DataSet[T] = {
+    set.check(reducer)
     reduce(getCallLocationName(), reducer, strategy)
   }
 
@@ -337,6 +339,7 @@ class GroupedDataSet[T: ClassTag](
                      reducer: ReduceFunction[T],
                      strategy: CombineHint): DataSet[T] = {
     require(reducer != null, "Reduce function must not be null.")
+    set.check(reducer)
     wrap(new ReduceOperator[T](createUnsortedGrouping(), reducer, callLocationName).
       setCombineHint(strategy))
   }
@@ -386,6 +389,7 @@ class GroupedDataSet[T: ClassTag](
    */
   def reduceGroup[R: TypeInformation: ClassTag](reducer: GroupReduceFunction[T, R]): DataSet[R] = {
     require(reducer != null, "GroupReduce function must not be null.")
+    set.check(reducer)
     wrap(
       new GroupReduceOperator[T, R](maybeCreateSortedGrouping(),
         implicitly[TypeInformation[R]], reducer, getCallLocationName()))

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
@@ -307,7 +307,7 @@ class GroupedDataSet[T: ClassTag](
                      strategy: CombineHint): DataSet[T] = {
     require(fun != null, "Reduce function must not be null.")
     val reducer = new ReduceFunction[T] {
-      val cleanFun = set.clean(fun)
+      val cleanFun = set.clean(set.check(fun))
       def reduce(v1: T, v2: T) = {
         cleanFun(v1, v2)
       }
@@ -350,7 +350,7 @@ class GroupedDataSet[T: ClassTag](
       fun: (Iterator[T]) => R): DataSet[R] = {
     require(fun != null, "Group reduce function must not be null.")
     val reducer = new GroupReduceFunction[T, R] {
-      val cleanFun = set.clean(fun)
+      val cleanFun = set.clean(set.check(fun))
       def reduce(in: java.lang.Iterable[T], out: Collector[R]) {
         out.collect(cleanFun(in.iterator().asScala))
       }
@@ -369,7 +369,7 @@ class GroupedDataSet[T: ClassTag](
       fun: (Iterator[T], Collector[R]) => Unit): DataSet[R] = {
     require(fun != null, "Group reduce function must not be null.")
     val reducer = new GroupReduceFunction[T, R] {
-      val cleanFun = set.clean(fun)
+      val cleanFun = set.clean(set.check(fun))
       def reduce(in: java.lang.Iterable[T], out: Collector[R]) {
         cleanFun(in.iterator().asScala, out)
       }
@@ -437,7 +437,7 @@ class GroupedDataSet[T: ClassTag](
                                           fun: (Iterator[T], Collector[R]) => Unit): DataSet[R] = {
     require(fun != null, "GroupCombine function must not be null.")
     val combiner = new GroupCombineFunction[T, R] {
-      val cleanFun = set.clean(fun)
+      val cleanFun = set.clean(set.check(fun))
       def combine(in: java.lang.Iterable[T], out: Collector[R]) {
         cleanFun(in.iterator().asScala, out)
       }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ObjectChecker.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ObjectChecker.scala
@@ -45,7 +45,8 @@ object ObjectChecker {
   def assertScalaSingleton[A](a: A)(implicit ev: A <:< Singleton = null) = {
     if (isSingleton(a)) {
       val msg = "User defined function implemented by class " + a.getClass.getName +
-        " might be implemented by a Scala Object,it is forbidden by Flink since concurrent modification risks."
+        " might be implemented by a Scala Object," +
+        "it is forbidden by Flink since concurrent modification risks."
       throw new InvalidProgramException(msg)
     }
   }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ObjectChecker.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ObjectChecker.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala
+
+import org.apache.flink.annotation.Internal
+import org.apache.flink.api.common.InvalidProgramException
+
+/**
+  * Scala Object checker tries to verify if a class is implemented by
+  * Scala Object
+  */
+@Internal
+object ObjectChecker {
+  def isSingleton[A](a: A)(implicit ev: A <:< Singleton = null) =
+    Option(ev).isDefined
+
+  def assertScalaSingleton[A](a: A) = {
+    if (isSingleton(a)) {
+      val msg = "User defined function implemented by class " + a.getClass.getName +
+        " might be implemented by a Scala Object,it is forbidden by Flink since concurrent modification risks."
+      throw new InvalidProgramException(msg)
+    }
+  }
+}

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ObjectChecker.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ObjectChecker.scala
@@ -27,10 +27,22 @@ import org.apache.flink.api.common.InvalidProgramException
   */
 @Internal
 object ObjectChecker {
-  def isSingleton[A](a: A)(implicit ev: A <:< Singleton = null) =
-    Option(ev).isDefined
+  def isSingleton[A](a: A): Boolean = {
+    val cls = a.getClass
+    val clsName = cls.getName
+    if (clsName.length > 0) {
+      val lastChar = clsName.charAt(clsName.length() - 1);
+      if (lastChar == '$') {
+        true
+      } else {
+        false
+      }
+    } else {
+      false
+    }
+  }
 
-  def assertScalaSingleton[A](a: A) = {
+  def assertScalaSingleton[A](a: A)(implicit ev: A <:< Singleton = null) = {
     if (isSingleton(a)) {
       val msg = "User defined function implemented by class " + a.getClass.getName +
         " might be implemented by a Scala Object,it is forbidden by Flink since concurrent modification risks."

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ObjectChecker.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ObjectChecker.scala
@@ -27,22 +27,11 @@ import org.apache.flink.api.common.InvalidProgramException
   */
 @Internal
 object ObjectChecker {
-  def isSingleton[A](a: A): Boolean = {
-    val cls = a.getClass
-    val clsName = cls.getName
-    if (clsName.length > 0) {
-      val lastChar = clsName.charAt(clsName.length() - 1);
-      if (lastChar == '$') {
-        true
-      } else {
-        false
-      }
-    } else {
-      false
-    }
+  def isSingleton(obj: Any): Boolean = {
+    obj.getClass.getFields.map(_.getName) contains "MODULE$"
   }
 
-  def assertScalaSingleton[A](a: A)(implicit ev: A <:< Singleton = null) = {
+  def assertScalaSingleton(a: Any) = {
     if (isSingleton(a)) {
       val msg = "User defined function implemented by class " + a.getClass.getName +
         " might be implemented by a Scala Object," +

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/joinDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/joinDataSet.scala
@@ -75,7 +75,7 @@ class JoinDataSet[L, R](
   def apply[O: TypeInformation: ClassTag](fun: (L, R) => O): DataSet[O] = {
     require(fun != null, "Join function must not be null.")
     val joiner = new FlatJoinFunction[L, R, O] {
-      val cleanFun = clean(fun)
+      val cleanFun = clean(check(fun))
       def join(left: L, right: R, out: Collector[O]) = {
         out.collect(cleanFun(left, right))
       }
@@ -106,7 +106,7 @@ class JoinDataSet[L, R](
   def apply[O: TypeInformation: ClassTag](fun: (L, R, Collector[O]) => Unit): DataSet[O] = {
     require(fun != null, "Join function must not be null.")
     val joiner = new FlatJoinFunction[L, R, O] {
-      val cleanFun = clean(fun)
+      val cleanFun = clean(check(fun))
       def join(left: L, right: R, out: Collector[O]) = {
         cleanFun(left, right, out)
       }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/joinDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/joinDataSet.scala
@@ -139,7 +139,7 @@ class JoinDataSet[L, R](
    */
   def apply[O: TypeInformation: ClassTag](joiner: FlatJoinFunction[L, R, O]): DataSet[O] = {
     require(joiner != null, "Join function must not be null.")
-
+    check(joiner)
     val joinOperator = new EquiJoin[L, R, O](
       leftInput.javaSet,
       rightInput.javaSet,
@@ -167,7 +167,7 @@ class JoinDataSet[L, R](
    */
   def apply[O: TypeInformation: ClassTag](fun: JoinFunction[L, R, O]): DataSet[O] = {
     require(fun != null, "Join function must not be null.")
-
+    check(fun)
     val generatedFunction: FlatJoinFunction[L, R, O] = new WrappingFlatJoinFunction[L, R, O](fun)
 
     val joinOperator = new EquiJoin[L, R, O](
@@ -193,6 +193,7 @@ class JoinDataSet[L, R](
   // ----------------------------------------------------------------------------------------------
   
   def withPartitioner[K : TypeInformation](partitioner : Partitioner[K]) : JoinDataSet[L, R] = {
+    check(partitioner)
     if (partitioner != null) {
       val typeInfo : TypeInformation[K] = implicitly[TypeInformation[K]]
       

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/unfinishedKeyPairOperation.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/unfinishedKeyPairOperation.scala
@@ -84,7 +84,7 @@ private[flink] abstract class UnfinishedKeyPairOperation[L, R, O](
   def where[K: TypeInformation](fun: (L) => K) = {
     val keyType = implicitly[TypeInformation[K]]
     val keyExtractor = new KeySelector[L, K] {
-      val cleanFun = leftInput.clean(fun)
+      val cleanFun = leftInput.clean(leftInput.check(fun))
       def getKey(in: L) = cleanFun(in)
     }
     val leftKey = new Keys.SelectorFunctionKeys[L, K](keyExtractor, leftInput.getType, keyType)
@@ -133,7 +133,7 @@ private[flink] class HalfUnfinishedKeyPairOperation[L, R, O](
   def equalTo[K: TypeInformation](fun: (R) => K): O = {
     val keyType = implicitly[TypeInformation[K]]
     val keyExtractor = new KeySelector[R, K] {
-      val cleanFun = unfinished.leftInput.clean(fun)
+      val cleanFun = unfinished.leftInput.clean(unfinished.leftInput.check(fun))
       def getKey(in: R) = cleanFun(in)
     }
     val rightKey = new Keys.SelectorFunctionKeys[R, K](

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/ScalaObjectCheckerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/ScalaObjectCheckerTest.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala
+
+import org.apache.flink.api.common.InvalidProgramException
+import org.apache.flink.api.common.functions.RichMapFunction
+import org.apache.flink.api.scala.ScalaObjectCheckerTest.{AScalaObject, RichMapClass, RichMapObject}
+import org.junit.Test
+
+
+class ScalaObjectCheckerTest {
+
+
+  @Test(expected = classOf[InvalidProgramException])
+  def testAssertScalaForbidScalaObjectFunction(): Unit = {
+    ObjectChecker.assertScalaSingleton(AScalaObject)
+  }
+
+  @Test
+  def testAssertScalaForbidScalaObjectFunction2(): Unit = {
+    class AScalaClass
+    ObjectChecker.assertScalaSingleton(new AScalaClass)
+  }
+
+  @Test(expected = classOf[InvalidProgramException])
+  def testEnvForObject(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val src = env.fromElements(1, 2, 3, 4)
+
+    src.map(RichMapObject)
+  }
+
+  @Test
+  def testEnvForClass(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val src = env.fromCollection(Seq(1, 2, 3))
+
+    src.map(new RichMapClass)
+  }
+}
+
+object ScalaObjectCheckerTest {
+
+  object AScalaObject
+
+  object RichMapObject extends RichMapFunction[Int, Int] {
+    override def map(value: Int): Int = value * 2
+  }
+
+  class RichMapClass extends RichMapFunction[Int, Int] {
+    override def map(value: Int): Int = value * 2
+  }
+
+}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
@@ -211,6 +211,8 @@ class AllWindowedStream[T, W <: Window](javaStream: JavaAllWStream[T, W]) {
       throw new NullPointerException("Fold function must not be null.")
     }
 
+    check(function)
+
     val resultType : TypeInformation[R] = implicitly[TypeInformation[R]]
     asScalaStream(javaStream.fold(initialValue, function, resultType))
   }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/ConnectedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/ConnectedStreams.scala
@@ -65,8 +65,8 @@ class ConnectedStreams[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
     if (fun1 == null || fun2 == null) {
       throw new NullPointerException("Map function must not be null.")
     }
-    val cleanFun1 = clean(fun1)
-    val cleanFun2 = clean(fun2)
+    val cleanFun1 = clean(check(fun1))
+    val cleanFun2 = clean(check(fun2))
     val comapper = new CoMapFunction[IN1, IN2, R] {
       def map1(in1: IN1): R = cleanFun1(in1)
       def map2(in2: IN2): R = cleanFun2(in2)
@@ -176,8 +176,8 @@ class ConnectedStreams[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
     if (fun1 == null || fun2 == null) {
       throw new NullPointerException("FlatMap functions must not be null.")
     }
-    val cleanFun1 = clean(fun1)
-    val cleanFun2 = clean(fun2)
+    val cleanFun1 = clean(check(fun1))
+    val cleanFun2 = clean(check(fun2))
     val flatMapper = new CoFlatMapFunction[IN1, IN2, R] {
       def flatMap1(value: IN1, out: Collector[R]): Unit = cleanFun1(value, out)
       def flatMap2(value: IN2, out: Collector[R]): Unit = cleanFun2(value, out)
@@ -203,8 +203,8 @@ class ConnectedStreams[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
     if (fun1 == null || fun2 == null) {
       throw new NullPointerException("FlatMap functions must not be null.")
     }
-    val cleanFun1 = clean(fun1)
-    val cleanFun2 = clean(fun2)
+    val cleanFun1 = clean(check(fun1))
+    val cleanFun2 = clean(check(fun2))
     
     val flatMapper = new CoFlatMapFunction[IN1, IN2, R] {
       def flatMap1(value: IN1, out: Collector[R]) = { cleanFun1(value) foreach out.collect }
@@ -285,8 +285,8 @@ class ConnectedStreams[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
     val keyType1 = implicitly[TypeInformation[K1]]
     val keyType2 = implicitly[TypeInformation[K2]]
     
-    val cleanFun1 = clean(fun1)
-    val cleanFun2 = clean(fun2)
+    val cleanFun1 = clean(check(fun1))
+    val cleanFun2 = clean(check(fun2))
     
     val keyExtractor1 = new KeySelectorWithType[IN1, K1](cleanFun1, keyType1)
     val keyExtractor2 = new KeySelectorWithType[IN2, K2](cleanFun2, keyType2)
@@ -301,6 +301,14 @@ class ConnectedStreams[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
   private[flink] def clean[F <: AnyRef](f: F): F = {
     new StreamExecutionEnvironment(javaStream.getExecutionEnvironment).scalaClean(f)
   }
+
+  /**
+    * Check if the user defined function is a legal function.
+    */
+  private[flink] def check[F <: AnyRef](f: F): F = {
+    new StreamExecutionEnvironment(javaStream.getExecutionEnvironment).scalaCheck(f)
+  }
+
 
   @PublicEvolving
   def transform[R: TypeInformation](

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/ConnectedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/ConnectedStreams.scala
@@ -96,7 +96,9 @@ class ConnectedStreams[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
       throw new NullPointerException("Map function must not be null.")
     }
 
-    val outType : TypeInformation[R] = implicitly[TypeInformation[R]]    
+    check(coMapper)
+
+    val outType : TypeInformation[R] = implicitly[TypeInformation[R]]
     asScalaStream(javaStream.map(coMapper).returns(outType).asInstanceOf[JavaStream[R]])
   }
 
@@ -124,6 +126,8 @@ class ConnectedStreams[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
     if (coProcessFunction == null) {
       throw new NullPointerException("CoProcessFunction function must not be null.")
     }
+
+    check(coFlatMapper)
 
     val outType : TypeInformation[R] = implicitly[TypeInformation[R]]
 
@@ -153,8 +157,8 @@ class ConnectedStreams[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
     if (coFlatMapper == null) {
       throw new NullPointerException("FlatMap function must not be null.")
     }
-
-    val outType : TypeInformation[R] = implicitly[TypeInformation[R]]
+    check(coFlatMapper)
+    val outType : TypeInformation[R] = implicitly[TypeInformation[R]]    
     asScalaStream(javaStream.flatMap(coFlatMapper).returns(outType).asInstanceOf[JavaStream[R]])
   }
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/ConnectedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/ConnectedStreams.scala
@@ -127,7 +127,7 @@ class ConnectedStreams[IN1, IN2](javaStream: JavaCStream[IN1, IN2]) {
       throw new NullPointerException("CoProcessFunction function must not be null.")
     }
 
-    check(coFlatMapper)
+    check(coProcessFunction)
 
     val outType : TypeInformation[R] = implicitly[TypeInformation[R]]
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -508,6 +508,8 @@ class DataStream[T](stream: JavaStream[T]) {
       throw new NullPointerException("Map function must not be null.")
     }
 
+    check(mapper)
+
     val outType : TypeInformation[R] = implicitly[TypeInformation[R]]
     asScalaStream(stream.map(mapper).returns(outType).asInstanceOf[JavaStream[R]])
   }
@@ -520,6 +522,8 @@ class DataStream[T](stream: JavaStream[T]) {
     if (flatMapper == null) {
       throw new NullPointerException("FlatMap function must not be null.")
     }
+
+    check(flatMapper)
 
     val outType : TypeInformation[R] = implicitly[TypeInformation[R]]
     asScalaStream(stream.flatMap(flatMapper).returns(outType).asInstanceOf[JavaStream[R]])
@@ -562,6 +566,9 @@ class DataStream[T](stream: JavaStream[T]) {
     if (filter == null) {
       throw new NullPointerException("Filter function must not be null.")
     }
+
+    check(filter)
+
     asScalaStream(stream.filter(filter))
   }
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -176,7 +176,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
     if (fun == null) {
       throw new NullPointerException("Reduce function must not be null.")
     }
-    val cleanFun = clean(fun)
+    val cleanFun = clean(check(fun))
     val reducer = new ReduceFunction[T] {
       def reduce(v1: T, v2: T) : T = { cleanFun(v1, v2) }
     }
@@ -209,7 +209,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
     if (fun == null) {
       throw new NullPointerException("Fold function must not be null.")
     }
-    val cleanFun = clean(fun)
+    val cleanFun = clean(check(fun))
     val folder = new FoldFunction[T,R] {
       def fold(acc: R, v: T) = {
         cleanFun(acc, v)
@@ -390,7 +390,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
       throw new NullPointerException("Filter function must not be null.")
     }
 
-    val cleanFun = clean(fun)
+    val cleanFun = clean(check(fun))
     val stateTypeInfo: TypeInformation[S] = implicitly[TypeInformation[S]]
     val serializer: TypeSerializer[S] = stateTypeInfo.createSerializer(getExecutionConfig)
 
@@ -419,7 +419,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
       throw new NullPointerException("Map function must not be null.")
     }
 
-    val cleanFun = clean(fun)
+    val cleanFun = clean(check(fun))
     val stateTypeInfo: TypeInformation[S] = implicitly[TypeInformation[S]]
     val serializer: TypeSerializer[S] = stateTypeInfo.createSerializer(getExecutionConfig)
     
@@ -448,7 +448,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
       throw new NullPointerException("Flatmap function must not be null.")
     }
 
-    val cleanFun = clean(fun)
+    val cleanFun = clean(check(fun))
     val stateTypeInfo: TypeInformation[S] = implicitly[TypeInformation[S]]
     val serializer: TypeSerializer[S] = stateTypeInfo.createSerializer(getExecutionConfig)
     

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
@@ -210,7 +210,7 @@ class WindowedStream[T, K, W <: Window](javaStream: JavaWStream[T, K, W]) {
     if (function == null) {
       throw new NullPointerException("Fold function must not be null.")
     }
-
+    check(function)
     val resultType : TypeInformation[R] = implicitly[TypeInformation[R]]
 
     asScalaStream(javaStream.fold(initialValue, function, resultType))

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/ScalaObjectcheckerStreamTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/ScalaObjectcheckerStreamTest.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.api.scala
+
+import org.apache.flink.api.common.InvalidProgramException
+import org.apache.flink.api.common.functions.{MapFunction, RichMapFunction}
+import org.apache.flink.streaming.api.scala.ScalaObjectCheckStreamTest.{RichMapClass, RichMapObject}
+import org.junit.Test
+
+class ScalaObjectCheckStreamTest {
+
+  @Test(expected = classOf[InvalidProgramException])
+  def testStreamEnvForObject(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val src = env.fromElements(1, 2, 3, 4)
+    src.map(RichMapObject)
+  }
+
+
+  @Test
+  def testStreamEnvForClass(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val src = env.fromElements(1, 2, 3)
+    src.map(new RichMapClass)
+  }
+}
+
+object ScalaObjectCheckStreamTest {
+
+  object RichMapObject extends RichMapFunction[Int, Int] {
+    override def map(value: Int): Int = value * 2
+  }
+
+  class RichMapClass extends MapFunction[Int, Int] {
+    override def map(value: Int): Int = value * 2
+  }
+}


### PR DESCRIPTION
The code changes should be work, but I was quite a lot confused for these reasons

	1. The Scala wrapper for DataStream and DataSet do  almost the same thing, but they have a lot of differences in code style,name rule and code structures.
	2. Some of the DataSet operators are surrounded by clean function, while some else are not, I think they might they might be forgotten to add.
	3. Scala and Java have different version of  ClosureCleaner,I think one ClosureCleaner should be enough, or the Java version of ClosureCleaner be a basic version, Scala version can call the Java version directly and add some additional logics. 

I think the Scala wrapper of DataSet could be rewrite to make it harmonic with the wrapper of DataStream, maybe we can create another issue ticket to do it.