### PR TITLE
[FLINK-4970] [gelly] Parameterize vertex value for SSSP

### DIFF
--- a/docs/dev/libs/gelly/library_methods.md
+++ b/docs/dev/libs/gelly/library_methods.md
@@ -176,8 +176,8 @@ The algorithm is implemented using [scatter-gather iterations](#scatter-gather-i
 In each iteration, a vertex sends to its neighbors a message containing the sum its current distance and the edge weight connecting this vertex with the neighbor. Upon receiving candidate distance messages, a vertex calculates the minimum distance and, if a shorter path has been discovered, it updates its value. If a vertex does not change its value during a superstep, then it does not produce messages for its neighbors for the next superstep. The computation terminates after the specified maximum number of supersteps or when there are no value updates.
 
 #### Usage
-The algorithm takes as input a `Graph` with any vertex type, `Double` vertex values, and `Double` edge values. The output is a `DataSet` of vertices where the vertex values
-correspond to the minimum distances from the given source vertex.
+The algorithm takes as input a `Graph` with any vertex type and `Double` edge values. The vertex values can be any type and are not used by this algorithm. The vertex type must implement `equals()`.
+The output is a `DataSet` of vertices where the vertex values correspond to the minimum distances from the given source vertex.
 The constructor takes two parameters:
 
 * `srcVertexId` The vertex ID of the source vertex.

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/SingleSourceShortestPathsData.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/SingleSourceShortestPathsData.java
@@ -50,10 +50,10 @@ public class SingleSourceShortestPathsData {
 								"4,47.0\n" + "5,48.0";
 
 	public static DataSet<Edge<Long, Double>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
-		
-		List<Edge<Long, Double>> edgeList = new LinkedList<Edge<Long, Double>>();
+
+		List<Edge<Long, Double>> edgeList = new LinkedList<>();
 		for (Object[] edge : DEFAULT_EDGES) {
-			edgeList.add(new Edge<Long, Double>((Long) edge[0], (Long) edge[1], (Double) edge[2]));
+			edgeList.add(new Edge<>((Long) edge[0], (Long) edge[1], (Double) edge[2]));
 		}
 		return env.fromCollection(edgeList);
 	}

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/test/GatherSumApplyITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/test/GatherSumApplyITCase.java
@@ -74,12 +74,12 @@ public class GatherSumApplyITCase extends MultipleProgramsTestBase {
 	public void testSingleSourceShortestPaths() throws Exception {
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
-		Graph<Long, Double, Double> inputGraph = Graph.fromDataSet(
+		Graph<Long, NullValue, Double> inputGraph = Graph.fromDataSet(
 				SingleSourceShortestPathsData.getDefaultEdgeDataSet(env),
 				new InitMapperSSSP(), env);
 
         List<Vertex<Long, Double>> result = inputGraph.run(
-        		new GSASingleSourceShortestPaths<>(1L, 16)).collect();
+				new GSASingleSourceShortestPaths<Long, NullValue>(1L, 16)).collect();
 
 		expectedResult = "1,0.0\n" +
 				"2,12.0\n" +
@@ -98,9 +98,9 @@ public class GatherSumApplyITCase extends MultipleProgramsTestBase {
 	}
 
 	@SuppressWarnings("serial")
-	private static final class InitMapperSSSP implements MapFunction<Long, Double> {
-		public Double map(Long value) {
-			return 0.0;
+	private static final class InitMapperSSSP implements MapFunction<Long, NullValue> {
+		public NullValue map(Long value) {
+			return NullValue.getInstance();
 		}
 	}
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSASingleSourceShortestPaths.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSASingleSourceShortestPaths.java
@@ -31,8 +31,8 @@ import org.apache.flink.graph.gsa.SumFunction;
 /**
  * This is an implementation of the Single Source Shortest Paths algorithm, using a gather-sum-apply iteration
  */
-public class GSASingleSourceShortestPaths<K> implements
-	GraphAlgorithm<K, Double, Double, DataSet<Vertex<K, Double>>> {
+public class GSASingleSourceShortestPaths<K, VV> implements
+	GraphAlgorithm<K, VV, Double, DataSet<Vertex<K, Double>>> {
 
 	private final K srcVertexId;
 	private final Integer maxIterations;
@@ -49,16 +49,16 @@ public class GSASingleSourceShortestPaths<K> implements
 	}
 
 	@Override
-	public DataSet<Vertex<K, Double>> run(Graph<K, Double, Double> input) {
+	public DataSet<Vertex<K, Double>> run(Graph<K, VV, Double> input) {
 
-		return input.mapVertices(new InitVerticesMapper<>(srcVertexId))
+		return input.mapVertices(new InitVerticesMapper<K, VV>(srcVertexId))
 				.runGatherSumApplyIteration(new CalculateDistances(), new ChooseMinDistance(),
 						new UpdateDistance<K>(), maxIterations)
 						.getVertices();
 	}
 
 	@SuppressWarnings("serial")
-	public static final class InitVerticesMapper<K>	implements MapFunction<Vertex<K, Double>, Double> {
+	public static final class InitVerticesMapper<K, VV> implements MapFunction<Vertex<K, VV>, Double> {
 
 		private K srcVertexId;
 
@@ -66,7 +66,7 @@ public class GSASingleSourceShortestPaths<K> implements
 			this.srcVertexId = srcId;
 		}
 
-		public Double map(Vertex<K, Double> value) {
+		public Double map(Vertex<K, VV> value) {
 			if (value.f0.equals(srcVertexId)) {
 				return 0.0;
 			} else {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/SingleSourceShortestPaths.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/SingleSourceShortestPaths.java
@@ -32,7 +32,7 @@ import org.apache.flink.graph.spargel.ScatterFunction;
  * This is an implementation of the Single-Source-Shortest Paths algorithm, using a scatter-gather iteration.
  */
 @SuppressWarnings("serial")
-public class SingleSourceShortestPaths<K> implements GraphAlgorithm<K, Double, Double, DataSet<Vertex<K, Double>>> {
+public class SingleSourceShortestPaths<K, VV> implements GraphAlgorithm<K, VV, Double, DataSet<Vertex<K, Double>>> {
 
 	private final K srcVertexId;
 	private final Integer maxIterations;
@@ -49,14 +49,14 @@ public class SingleSourceShortestPaths<K> implements GraphAlgorithm<K, Double, D
 	}
 
 	@Override
-	public DataSet<Vertex<K, Double>> run(Graph<K, Double, Double> input) {
+	public DataSet<Vertex<K, Double>> run(Graph<K, VV, Double> input) {
 
-		return input.mapVertices(new InitVerticesMapper<>(srcVertexId))
+		return input.mapVertices(new InitVerticesMapper<K, VV>(srcVertexId))
 				.runScatterGatherIteration(new MinDistanceMessenger<K>(), new VertexDistanceUpdater<K>(),
 				maxIterations).getVertices();
 	}
 
-	public static final class InitVerticesMapper<K>	implements MapFunction<Vertex<K, Double>, Double> {
+	public static final class InitVerticesMapper<K, VV> implements MapFunction<Vertex<K, VV>, Double> {
 
 		private K srcVertexId;
 
@@ -64,7 +64,7 @@ public class SingleSourceShortestPaths<K> implements GraphAlgorithm<K, Double, D
 			this.srcVertexId = srcId;
 		}
 
-		public Double map(Vertex<K, Double> value) {
+		public Double map(Vertex<K, VV> value) {
 			if (value.f0.equals(srcVertexId)) {
 				return 0.0;
 			} else {


### PR DESCRIPTION
The input vertex values for SingleSourceShortestPaths and GSASingleSourceShortestPaths are unused and replaced with a parameterized type.