### PR TITLE
[FLINK-4272] Create a JobClient for job control and monitoring

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -19,6 +19,7 @@
 package org.apache.flink.client.program;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
@@ -55,11 +56,16 @@ public class ContextEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
+		this.lastJobExecutionResult = executeWithControl(jobName).waitForResult();
+		return this.lastJobExecutionResult;
+	}
+
+	@Override
+	public JobClient executeWithControl(String jobName) throws Exception {
 		Plan p = createProgramPlan(jobName);
 		JobWithJars toRun = new JobWithJars(p, this.jarFilesToAttach, this.classpathsToAttach,
-				this.userCodeClassLoader);
-		this.lastJobExecutionResult = client.run(toRun, getParallelism(), savepointPath).getJobExecutionResult();
-		return this.lastJobExecutionResult;
+			this.userCodeClassLoader);
+		return client.run(toRun, getParallelism(), savepointPath);
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/DetachedEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/DetachedEnvironment.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.client.program;
 
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.optimizer.plan.FlinkPlan;
 import org.slf4j.Logger;
@@ -71,7 +71,7 @@ public class DetachedEnvironment extends ContextEnvironment {
 	/**
 	 * Finishes this Context Environment's execution by explicitly running the plan constructed.
 	 */
-	JobSubmissionResult finalizeExecute() throws ProgramInvocationException {
+	JobClient finalizeExecute() throws ProgramInvocationException {
 		return client.run(detachedPlan, jarFilesToAttach, classpathsToAttach, userCodeClassLoader, savepointPath);
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/JobClientEager.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/JobClientEager.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.client.program;
+
+import org.apache.flink.api.common.JobClient;
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.accumulators.AccumulatorHelper;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.client.JobClientActorUtils;
+import org.apache.flink.runtime.client.JobClientActor;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.client.JobListeningContext;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.messages.accumulators.AccumulatorResultsErroneous;
+import org.apache.flink.runtime.messages.accumulators.AccumulatorResultsFound;
+import org.apache.flink.runtime.messages.accumulators.RequestAccumulatorResults;
+import org.apache.flink.util.SerializedValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A client to interact with a running Flink job.
+ */
+public class JobClientEager implements JobClient {
+
+	private final Logger LOG = LoggerFactory.getLogger(getClass());
+
+	/** The Job's listening context for monitoring and job interaction */
+	private final JobListeningContext jobListeningContext;
+
+	/** Finalization code to run upon shutting down the JobClient */
+	private final List<Runnable> finalizers;
+
+	public JobClientEager(JobListeningContext jobListeningContext) {
+		this.jobListeningContext = jobListeningContext;
+		this.finalizers = new LinkedList<>();
+	}
+
+	/**
+	 * Blocks until the job finishes and returns the {@link JobExecutionResult}
+	 * @return the result of the job execution
+	 */
+	@Override
+	public JobExecutionResult waitForResult() throws JobExecutionException {
+		LOG.info("Waiting for results of Job {}", jobListeningContext.getJobID());
+		JobExecutionResult result = JobClientActorUtils.awaitJobResult(jobListeningContext);
+		shutdown();
+		return result;
+	}
+
+	/**
+	 * Gets the job id that this client is bound to
+	 * @return The JobID of this JobClient
+	 */
+	public JobID getJobID() {
+		return jobListeningContext.getJobID();
+	}
+
+	@Override
+	public boolean hasFinished() {
+		return jobListeningContext.getJobResultFuture().isCompleted();
+	}
+
+	/**
+	 * Cancels a job identified by the job id.
+	 * @throws Exception In case an error occurred.
+	 */
+	@Override
+	public void cancel() throws Exception {
+		final ActorGateway jobClient = jobListeningContext.getJobClientGateway();
+
+		final Future<Object> response;
+		try {
+			response = jobClient.ask(
+				new JobClientActor.ClientMessage(
+					new JobManagerMessages.CancelJob(getJobID())),
+				AkkaUtils.getDefaultTimeoutAsFiniteDuration());
+		} catch (final Exception e) {
+			throw new ProgramInvocationException("Failed to query the job manager gateway.", e);
+		}
+
+		final Object result = Await.result(response, AkkaUtils.getDefaultTimeoutAsFiniteDuration());
+
+		if (result instanceof JobManagerMessages.CancellationSuccess) {
+			LOG.info("Job cancellation with ID " + getJobID() + " succeeded.");
+		} else if (result instanceof JobManagerMessages.CancellationFailure) {
+			final Throwable t = ((JobManagerMessages.CancellationFailure) result).cause();
+			LOG.info("Job cancellation with ID " + getJobID() + " failed.", t);
+			throw new Exception("Failed to cancel the job because of \n" + t.getMessage());
+		} else {
+			throw new Exception("Unknown message received while cancelling: " + result);
+		}
+	}
+
+	/**
+	 * Stops a program on Flink cluster whose job-manager is configured in this client's configuration.
+	 * Stopping works only for streaming programs. Be aware, that the program might continue to run for
+	 * a while after sending the stop command, because after sources stopped to emit data all operators
+	 * need to finish processing.
+	 *
+	 * @throws Exception
+	 *             If the job ID is invalid (ie, is unknown or refers to a batch job) or if sending the stop signal
+	 *             failed. That might be due to an I/O problem, ie, the job-manager is unreachable.
+	 */
+	@Override
+	public void stop() throws Exception {
+		final ActorGateway jobManagerGateway = jobListeningContext.getJobManager();
+
+		final Future<Object> response;
+		try {
+			response = jobManagerGateway.ask(
+				new JobClientActor.ClientMessage(
+					new JobManagerMessages.StopJob(getJobID())),
+				AkkaUtils.getDefaultTimeoutAsFiniteDuration());
+		} catch (final Exception e) {
+			throw new ProgramInvocationException("Failed to query the job manager gateway.", e);
+		}
+
+		final Object result = Await.result(response, AkkaUtils.getDefaultTimeoutAsFiniteDuration());
+
+		if (result instanceof JobManagerMessages.StoppingSuccess) {
+			LOG.info("Job stopping with ID " + getJobID() + " succeeded.");
+		} else if (result instanceof JobManagerMessages.StoppingFailure) {
+			final Throwable t = ((JobManagerMessages.StoppingFailure) result).cause();
+			LOG.info("Job stopping with ID " + getJobID() + " failed.", t);
+			throw new Exception("Failed to stop the job because of \n" + t.getMessage());
+		} else {
+			throw new Exception("Unknown message received while stopping: " + result);
+		}
+	}
+
+
+	/**
+	 * Requests and returns the accumulators for the given job identifier. Accumulators can be
+	 * requested while a job is running or after it has finished.
+	 * @return A Map containing the accumulator's name and its value.
+	 */
+	@Override
+	public Map<String, Object> getAccumulators() throws Exception {
+		ActorGateway jobManagerGateway = jobListeningContext.getJobManager();
+
+		Future<Object> response;
+		try {
+			response = jobManagerGateway.ask(
+				new JobClientActor.ClientMessage(
+					new RequestAccumulatorResults(getJobID())),
+				AkkaUtils.getDefaultTimeoutAsFiniteDuration());
+		} catch (Exception e) {
+			throw new Exception("Failed to query the job manager gateway for accumulators.", e);
+		}
+
+		Object result = Await.result(response, AkkaUtils.getDefaultTimeoutAsFiniteDuration());
+
+		if (result instanceof AccumulatorResultsFound) {
+			Map<String, SerializedValue<Object>> serializedAccumulators =
+				((AccumulatorResultsFound) result).result();
+
+			return AccumulatorHelper.deserializeAccumulators(
+				serializedAccumulators, jobListeningContext.getClassLoader());
+
+		} else if (result instanceof AccumulatorResultsErroneous) {
+			throw ((AccumulatorResultsErroneous) result).cause();
+		} else {
+			throw new Exception("Failed to fetch accumulators for the job " + getJobID());
+		}
+	}
+
+
+	@Override
+	public void addFinalizer(Runnable finalizer) {
+		finalizers.add(finalizer);
+	}
+
+	/**
+	 * Shuts down the JobClient and executes any finalizers.
+	 */
+	@Override
+	public void shutdown() {
+		synchronized (this) {
+			for (Runnable finalizer : finalizers) {
+				finalizer.run();
+			}
+			finalizers.clear();
+		}
+	}
+
+	/**
+	 * Perform cleanup on garbage collection.
+	 */
+	@Override
+	protected void finalize() throws Throwable {
+		shutdown();
+		super.finalize();
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/JobClientLazy.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/JobClientLazy.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.client.program;
+
+import org.apache.flink.api.common.JobClient;
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.client.JobExecutionException;
+
+import java.util.Map;
+
+/**
+ * A detached job client which lazily initiates the cluster connection.
+ */
+public class JobClientLazy implements JobClient {
+
+	/** The ClusterClient used for JobClient retrieval */
+	private final ClusterClient clusterClient;
+
+	/** The JobID to eventually retrieve the JobClient for */
+	private final JobID jobID;
+
+	/** The retrieved client */
+	private JobClientEager retrievedJobClient;
+
+	public JobClientLazy(JobID jobID, ClusterClient clusterClient) {
+		this.clusterClient = clusterClient;
+		this.jobID = jobID;
+	}
+
+	private JobClientEager getJobClient() throws JobExecutionException {
+		if (retrievedJobClient == null) {
+			retrievedJobClient = clusterClient.retrieveJob(jobID);
+		}
+		return retrievedJobClient;
+	}
+
+	@Override
+	public JobID getJobID() {
+		return jobID;
+	}
+
+	@Override
+	public boolean hasFinished() throws Exception {
+		return getJobClient().hasFinished();
+	}
+
+	@Override
+	public JobExecutionResult waitForResult() throws Exception {
+		return getJobClient().waitForResult();
+	}
+
+	@Override
+	public Map<String, Object> getAccumulators() throws Exception {
+		return getJobClient().getAccumulators();
+	}
+
+	@Override
+	public void cancel() throws Exception {
+		getJobClient().cancel();
+	}
+
+	@Override
+	public void stop() throws Exception {
+		getJobClient().stop();
+	}
+
+	@Override
+	public void addFinalizer(Runnable finalizer) throws Exception {
+		getJobClient().addFinalizer(finalizer);
+	}
+
+	@Override
+	public void shutdown() {
+		if (retrievedJobClient != null) {
+			retrievedJobClient.shutdown();
+		}
+	}
+
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/OptimizerPlanEnvironment.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.client.program;
 
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -49,6 +50,12 @@ public class OptimizerPlanEnvironment extends ExecutionEnvironment {
 
 		// do not go on with anything now!
 		throw new ProgramAbortException();
+	}
+
+	@Override
+	public JobClient executeWithControl(String jobName) {
+		throw new UnsupportedOperationException(
+			"The OptimizerPlanEnvironment does not support execution with control.");
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PreviewPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PreviewPlanEnvironment.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.client.program;
 
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -45,6 +46,11 @@ public final class PreviewPlanEnvironment extends ExecutionEnvironment {
 
 		// do not go on with anything now!
 		throw new OptimizerPlanEnvironment.ProgramAbortException();
+	}
+
+	@Override
+	public JobClient executeWithControl(String jobName) throws Exception {
+		throw new UnsupportedOperationException("The PreviewPlanEnvironment does not support execution with control.");
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.client.program;
 
-import org.apache.flink.api.common.JobSubmissionResult;
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatus;
@@ -93,7 +93,7 @@ public class StandaloneClusterClient extends ClusterClient {
 	}
 
 	@Override
-	protected JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader)
+	protected JobClient submitJob(JobGraph jobGraph, ClassLoader classLoader)
 			throws ProgramInvocationException {
 		if (isDetached()) {
 			return super.runDetached(jobGraph, classLoader);

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -201,9 +201,8 @@ public class ClientTest {
 
 			ClusterClient out = new StandaloneClusterClient(config);
 			out.setDetached(true);
-			JobSubmissionResult result = out.run(program.getPlanWithJars(), 1);
 
-			assertNotNull(result);
+			assertNotNull(out.run(program.getPlanWithJars(), 1));
 
 			program.deleteExtractedLibraries();
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/JobClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/JobClientTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.client.program;
+
+import akka.dispatch.Futures;
+import org.apache.flink.api.common.JobClient;
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.client.JobListeningContext;
+import org.apache.flink.runtime.client.SerializedJobExecutionResult;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.util.SerializedValue;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import scala.concurrent.Promise;
+
+import java.util.Collections;
+
+
+/**
+ * Tests the JobClient implementations.
+ *
+ * See also: JobRetrievalITCase
+ */
+public class JobClientTest {
+
+	private static boolean finalizeCalled;
+
+	private JobListeningContext listeningContext;
+	private JobID jobID;
+	private JobManagerMessages.JobResultSuccess successMessage;
+
+	private Runnable finalizer = new Runnable() {
+		@Override
+		public void run() {
+			finalizeCalled = true;
+		}
+	};
+
+	private Promise<Object> resultPromise;
+
+	@Before
+	public void beforeTest() throws Exception {
+		finalizeCalled = false;
+
+		this.jobID = JobID.generate();
+		this.listeningContext = Mockito.mock(JobListeningContext.class);
+		this.resultPromise = Futures.promise();
+		ActorGateway mockActorClientGateway = Mockito.mock(ActorGateway.class);
+		Mockito.when(listeningContext.getJobID()).thenReturn(jobID);
+		Mockito.when(listeningContext.getJobClientGateway()).thenReturn(mockActorClientGateway);
+		Mockito.when(listeningContext.getJobResultFuture()).thenReturn(resultPromise.future());
+		Mockito.when(listeningContext.getClassLoader()).thenReturn(JobClientTest.class.getClassLoader());
+
+		this.successMessage = new JobManagerMessages.JobResultSuccess(
+			new SerializedJobExecutionResult(
+				jobID,
+				42,
+				Collections.singletonMap("key", new SerializedValue<Object>("value"))));
+	}
+
+	@Test(timeout = 10000)
+	public void testEagerJobClient() throws Exception {
+
+		JobClient jobClient = new JobClientEager(listeningContext);
+
+		jobClient.addFinalizer(finalizer);
+
+		Assert.assertFalse(jobClient.hasFinished());
+
+		resultPromise.success(successMessage);
+
+		Assert.assertTrue(jobClient.hasFinished());
+
+		JobExecutionResult retrievedResult = jobClient.waitForResult();
+		Assert.assertNotNull(retrievedResult);
+
+		Assert.assertEquals(jobID, retrievedResult.getJobID());
+		Assert.assertEquals(42, retrievedResult.getNetRuntime());
+		Assert.assertEquals(1, retrievedResult.getAllAccumulatorResults().size());
+		Assert.assertEquals("value", retrievedResult.getAllAccumulatorResults().get("key"));
+
+		jobClient.shutdown();
+		Assert.assertTrue(finalizeCalled);
+
+		finalizeCalled = false;
+		jobClient.shutdown();
+		Assert.assertFalse(finalizeCalled);
+	}
+
+	@Test(timeout = 10000)
+	public void testLazyJobClient() throws Exception {
+
+		ClusterClient mockedClusterClient = Mockito.mock(ClusterClient.class);
+		JobClientEager eagerJobClient = new JobClientEager(listeningContext);
+		Mockito.when(mockedClusterClient.retrieveJob(jobID))
+			.thenReturn(eagerJobClient);
+
+		JobClient jobClient = new JobClientLazy(jobID, mockedClusterClient);
+		jobClient.addFinalizer(finalizer);
+
+		Assert.assertFalse(jobClient.hasFinished());
+
+		resultPromise.success(successMessage);
+
+		Assert.assertTrue(jobClient.hasFinished());
+
+		JobExecutionResult retrievedResult = jobClient.waitForResult();
+		Assert.assertNotNull(retrievedResult);
+
+		Assert.assertEquals(jobID, retrievedResult.getJobID());
+		Assert.assertEquals(42, retrievedResult.getNetRuntime());
+		Assert.assertEquals(1, retrievedResult.getAllAccumulatorResults().size());
+		Assert.assertEquals("value", retrievedResult.getAllAccumulatorResults().get("key"));
+
+		jobClient.shutdown();
+		Assert.assertTrue(finalizeCalled);
+
+		finalizeCalled = false;
+		jobClient.shutdown();
+		Assert.assertFalse(finalizeCalled);
+	}
+
+}

--- a/flink-contrib/flink-connector-wikiedits/src/test/resources/logback-test.xml
+++ b/flink-contrib/flink-connector-wikiedits/src/test/resources/logback-test.xml
@@ -26,5 +26,5 @@
     <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
-    <logger name="org.apache.flink.runtime.client.JobClient" level="OFF"/>
+    <logger name="org.apache.flink.runtime.client.JobClientActorUtils" level="OFF"/>
 </configuration>

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/resources/logback-test.xml
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/resources/logback-test.xml
@@ -26,5 +26,5 @@
     <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
-    <logger name="org.apache.flink.runtime.client.JobClient" level="OFF"/>
+    <logger name="org.apache.flink.runtime.client.JobClientActorUtils" level="OFF"/>
 </configuration>

--- a/flink-contrib/flink-storm-examples/src/test/resources/logback-test.xml
+++ b/flink-contrib/flink-storm-examples/src/test/resources/logback-test.xml
@@ -26,5 +26,5 @@
     <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
-    <logger name="org.apache.flink.runtime.client.JobClient" level="OFF"/>
+    <logger name="org.apache.flink.runtime.client.JobClientActorUtils" level="OFF"/>
 </configuration>

--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/api/FlinkClient.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/api/FlinkClient.java
@@ -255,7 +255,7 @@ public class FlinkClient {
 		}
 
 		try {
-			client.stop(jobId);
+			client.retrieveJob(jobId).stop();
 		} catch (final Exception e) {
 			throw new RuntimeException("Cannot stop job.", e);
 		}

--- a/flink-contrib/flink-storm/src/test/resources/logback-test.xml
+++ b/flink-contrib/flink-storm/src/test/resources/logback-test.xml
@@ -26,5 +26,5 @@
     <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
-    <logger name="org.apache.flink.runtime.client.JobClient" level="OFF"/>
+    <logger name="org.apache.flink.runtime.client.JobClientActorUtils" level="OFF"/>
 </configuration>

--- a/flink-contrib/flink-streaming-contrib/src/test/resources/logback-test.xml
+++ b/flink-contrib/flink-streaming-contrib/src/test/resources/logback-test.xml
@@ -26,5 +26,5 @@
     <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
-    <logger name="org.apache.flink.runtime.client.JobClient" level="OFF"/>
+    <logger name="org.apache.flink.runtime.client.JobClientActorUtils" level="OFF"/>
 </configuration>

--- a/flink-contrib/flink-tweet-inputformat/src/test/resources/logback-test.xml
+++ b/flink-contrib/flink-tweet-inputformat/src/test/resources/logback-test.xml
@@ -26,5 +26,5 @@
     <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
-    <logger name="org.apache.flink.runtime.client.JobClient" level="OFF"/>
+    <logger name="org.apache.flink.runtime.client.JobClientActorUtils" level="OFF"/>
 </configuration>

--- a/flink-core/src/main/java/org/apache/flink/api/common/JobClient.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/JobClient.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common;
+
+import java.util.Map;
+
+/*
+ * An Flink job client interface to interact with running Flink jobs.
+ */
+public interface JobClient {
+
+	/**
+	 * Gets the JobID associated with this JobClient.
+	 */
+	JobID getJobID();
+
+	/**
+	 * Returns a boolean indicating whether the job execution has finished.
+	 */
+	boolean hasFinished() throws Exception;
+
+	/**
+	 * Blocks until the result of the job execution is returned.
+	 */
+	JobExecutionResult waitForResult() throws Exception;
+
+	/**
+	 * Gets the accumulator map of a running job.
+	 */
+	Map<String, Object> getAccumulators() throws Exception;
+
+	/**
+	 * Cancels a running job.
+	 */
+	void cancel() throws Exception;
+
+	/**
+	 * Stops a running job if the job supports stopping.
+	 */
+	void stop() throws Exception;
+
+	/**
+	 * Adds a Runnable to this JobClient to be called
+	 * when the client is shut down. Runnables are called
+	 * in the order they are added.
+	 */
+	void addFinalizer(Runnable finalizer) throws Exception;
+
+	/**
+	 * Runs finalization code to shutdown the client
+	 * and its dependencies.
+	 */
+	void shutdown();
+
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/PlanExecutor.java
@@ -114,11 +114,11 @@ public abstract class PlanExecutor {
 	 * be available, because the executor immediately shut down after the execution.</p>
 	 * 
 	 * @param plan The plan of the program to execute.
-	 * @return The execution result, containing for example the net runtime of the program, and the accumulators.
+	 * @return The job client which can be used to retrieve the result of the execution.
 	 * 
 	 * @throws Exception Thrown, if job submission caused an exception.
 	 */
-	public abstract JobExecutionResult executePlan(Plan plan) throws Exception;
+	public abstract JobClient executePlan(Plan plan) throws Exception;
 	
 	/**
 	 * Gets the programs execution plan in a JSON format.

--- a/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.operators.CollectionExecutor;
@@ -34,6 +35,11 @@ public class CollectionEnvironment extends ExecutionEnvironment {
 		CollectionExecutor exec = new CollectionExecutor(getConfig());
 		this.lastJobExecutionResult = exec.execute(p);
 		return this.lastJobExecutionResult;
+	}
+
+	@Override
+	public JobClient executeWithControl(String jobName) {
+		throw new UnsupportedOperationException("CollectionEnvironment doesn't support execution with control.");
 	}
 
 	@Override

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -24,6 +24,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
@@ -909,6 +910,24 @@ public abstract class ExecutionEnvironment {
 	 * @throws Exception Thrown, if the program executions fails.
 	 */
 	public abstract JobExecutionResult execute(String jobName) throws Exception;
+
+	/**
+	 * Triggers the program execution, just like {@code execute()} but does not block.
+	 * Instead, it returns a JobClient which can be used to interact with the running job.
+	 * @return A JobClient for job interaction.
+	 * @throws Exception Thrown if the program submission fails.
+	 */
+	public JobClient executeWithControl() throws Exception {
+		return executeWithControl(getDefaultName());
+	}
+
+	/**
+	 * Triggers the program execution, just like {@code execute(String jobName)} but does not block.
+	 * Instead, it returns a JobClient which can be used to interact with the running job.
+	 * @return A JobClient for job interaction.
+	 * @throws Exception Thrown if the program submission fails.
+	 */
+	public abstract JobClient executeWithControl(String jobName) throws Exception;
 
 	/**
 	 * Creates the plan with which the system will execute the program, and returns it as 

--- a/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/LocalEnvironment.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.java;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
@@ -78,6 +79,13 @@ public class LocalEnvironment extends ExecutionEnvironment {
 	
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
+		JobClient jobClient = executeWithControl(jobName);
+		this.lastJobExecutionResult = jobClient.waitForResult();
+		return this.lastJobExecutionResult;
+	}
+
+	@Override
+	public JobClient executeWithControl(String jobName) throws Exception {
 		if (executor == null) {
 			startNewSession();
 		}
@@ -88,12 +96,9 @@ public class LocalEnvironment extends ExecutionEnvironment {
 		//p.setJobId(jobID);
 		//p.setSessionTimeout(sessionTimeout);
 
-		JobExecutionResult result = executor.executePlan(p);
-
-		this.lastJobExecutionResult = result;
-		return result;
+		return executor.executePlan(p);
 	}
-	
+
 	@Override
 	public String getExecutionPlan() throws Exception {
 		Plan p = createProgramPlan(null, false);

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Public;
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
@@ -161,6 +162,15 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
+
+		JobClient jobClient = executeWithControl(jobName);
+		this.lastJobExecutionResult = jobClient.waitForResult();
+
+		return this.lastJobExecutionResult;
+	}
+
+	@Override
+	public JobClient executeWithControl(String jobName) throws Exception {
 		PlanExecutor executor = getExecutor();
 
 		Plan p = createProgramPlan(jobName);
@@ -169,10 +179,7 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 		//p.setJobId(jobID);
 		//p.setSessionTimeout(sessionTimeout);
 
-		JobExecutionResult result = executor.executePlan(p);
-
-		this.lastJobExecutionResult = result;
-		return result;
+		return executor.executePlan(p);
 	}
 
 	@Override

--- a/flink-libraries/flink-ml/src/test/resources/logback-test.xml
+++ b/flink-libraries/flink-ml/src/test/resources/logback-test.xml
@@ -32,7 +32,7 @@
          <!---->
     <logger name="org.apache.flink.runtime.operators.DataSinkTask" level="OFF"/>
     <logger name="org.apache.flink.runtime.operators.BatchTask" level="OFF"/>
-    <logger name="org.apache.flink.runtime.client.JobClient" level="OFF"/>
+    <logger name="org.apache.flink.runtime.client.JobClientActorUtils" level="OFF"/>
     <logger name="org.apache.flink.runtime.taskmanager.Task" level="OFF"/>
     <logger name="org.apache.flink.runtime.jobmanager.JobManager" level="OFF"/>
     <logger name="org.apache.flink.runtime.testingUtils" level="OFF"/>

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.client.JobClient;
+import org.apache.flink.runtime.client.JobClientActorUtils;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -58,7 +58,7 @@ public class JarRunHandler extends JarActionHandler {
 			}
 
 			try {
-				JobClient.submitJobDetached(jobManager, clientConfig, graph.f0, timeout, graph.f1);
+				JobClientActorUtils.submitJobDetached(jobManager, clientConfig, graph.f0, timeout, graph.f1);
 			} catch (JobExecutionException e) {
 				throw new ProgramInvocationException("Failed to submit the job to the job manager", e);
 			}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerITCase.java
@@ -25,7 +25,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.client.JobClient;
+import org.apache.flink.runtime.client.JobClientActorUtils;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.instance.ActorGateway;
@@ -137,7 +137,7 @@ public class BackPressureStatsTrackerITCase extends TestLogger {
 							ActorGateway testActor = new AkkaActorGateway(getTestActor(), null);
 
 							// Submit the job and wait until it is running
-							JobClient.submitJobDetached(
+							JobClientActorUtils.submitJobDetached(
 									jm,
 									config,
 									jobGraph,

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorITCase.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.client.JobClient;
+import org.apache.flink.runtime.client.JobClientActorUtils;
 import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
@@ -111,7 +111,7 @@ public class StackTraceSampleCoordinatorITCase extends TestLogger {
 
 							for (int i = 0; i < maxAttempts; i++, sleepTime *= 2) {
 								// Submit the job and wait until it is running
-								JobClient.submitJobDetached(
+								JobClientActorUtils.submitJobDetached(
 										jm,
 										config,
 										jobGraph,

--- a/flink-runtime-web/src/test/resources/logback-test.xml
+++ b/flink-runtime-web/src/test/resources/logback-test.xml
@@ -32,7 +32,7 @@
          <!---->
     <logger name="org.apache.flink.runtime.operators.DataSinkTask" level="OFF"/>
     <logger name="org.apache.flink.runtime.operators.BatchTask" level="OFF"/>
-    <logger name="org.apache.flink.runtime.client.JobClient" level="OFF"/>
+    <logger name="org.apache.flink.runtime.client.JobClientActorUtils" level="OFF"/>
     <logger name="org.apache.flink.runtime.taskmanager.Task" level="OFF"/>
     <logger name="org.apache.flink.runtime.jobmanager.JobManager" level="OFF"/>
     <logger name="org.apache.flink.runtime.testingUtils" level="OFF"/>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobExecutionException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobExecutionException.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.JobID;
 /**
  * This exception is the base exception for all exceptions that denote any failure during
  * the execution of a job. The JobExecutionException and its subclasses are thrown by
- * the {@link JobClient}.
+ * the {@link JobClientActorUtils}.
  */
 public class JobExecutionException extends Exception {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobListeningContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobListeningContext.java
@@ -17,24 +17,33 @@
  */
 package org.apache.flink.runtime.client;
 
-import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.blob.BlobCache;
+import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.Option;
+import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
+
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * The JobListeningContext holds the state necessary to monitor a running job and receive its results.
  */
-public final class JobListeningContext {
+public class JobListeningContext {
 
 	private final Logger LOG = LoggerFactory.getLogger(getClass());
 
@@ -43,9 +52,11 @@ public final class JobListeningContext {
 	/** The Future which is completed upon job completion */
 	private final Future<Object> jobResultFuture;
 	/** The JobClientActor which handles communication and monitoring of the job */
-	private final ActorRef jobClientActor;
+	private final ActorGateway jobClientActor;
 	/** Timeout used Asks */
 	private final FiniteDuration timeout;
+	/** Finalization code to run when cleaning up */
+	private Runnable finalizer;
 
 	/** ActorSystem for leader retrieval */
 	private ActorSystem actorSystem;
@@ -59,15 +70,39 @@ public final class JobListeningContext {
 	 * Constructor to use when the class loader is available.
 	 */
 	public JobListeningContext(
-		JobID jobID,
-		Future<Object> jobResultFuture,
-		ActorRef jobClientActor,
-		FiniteDuration timeout,
-		ClassLoader classLoader) {
+			JobID jobID,
+			Configuration configuration,
+			Future<Object> jobResultFuture,
+			ActorGateway jobClientActor,
+			FiniteDuration timeout,
+			ClassLoader classLoader) {
+		this(
+			jobID,
+			configuration,
+			jobResultFuture,
+			jobClientActor,
+			timeout,
+			null,
+			classLoader);
+	}
+
+	/**
+	 * Constructor to use when the class loader is available.
+	 */
+	public JobListeningContext(
+			JobID jobID,
+			Configuration configuration,
+			Future<Object> jobResultFuture,
+			ActorGateway jobClientActor,
+			FiniteDuration timeout,
+			Runnable finalizer,
+			ClassLoader classLoader) {
 		this.jobID = checkNotNull(jobID);
 		this.jobResultFuture = checkNotNull(jobResultFuture);
 		this.jobClientActor = checkNotNull(jobClientActor);
 		this.timeout = checkNotNull(timeout);
+		this.configuration = checkNotNull(configuration);
+		this.finalizer = finalizer;
 		this.classLoader = checkNotNull(classLoader);
 	}
 
@@ -75,18 +110,40 @@ public final class JobListeningContext {
 	 * Constructor to use when the class loader is not available.
 	 */
 	public JobListeningContext(
-		JobID jobID,
-		Future<Object> jobResultFuture,
-		ActorRef jobClientActor,
-		FiniteDuration timeout,
-		ActorSystem actorSystem,
-		Configuration configuration) {
+			JobID jobID,
+			Future<Object> jobResultFuture,
+			ActorGateway jobClientActor,
+			FiniteDuration timeout,
+			ActorSystem actorSystem,
+			Configuration configuration) {
+		this(
+			jobID,
+			jobResultFuture,
+			jobClientActor,
+			timeout,
+			actorSystem,
+			configuration,
+			null);
+	}
+
+	/**
+	 * Constructor to use when the class loader is not available.
+	 */
+	public JobListeningContext(
+			JobID jobID,
+			Future<Object> jobResultFuture,
+			ActorGateway jobClientActor,
+			FiniteDuration timeout,
+			ActorSystem actorSystem,
+			Configuration configuration,
+			Runnable finalizer) {
 		this.jobID = checkNotNull(jobID);
 		this.jobResultFuture = checkNotNull(jobResultFuture);
 		this.jobClientActor = checkNotNull(jobClientActor);
 		this.timeout = checkNotNull(timeout);
 		this.actorSystem = checkNotNull(actorSystem);
 		this.configuration = checkNotNull(configuration);
+		this.finalizer = finalizer;
 	}
 
 	/**
@@ -106,7 +163,7 @@ public final class JobListeningContext {
 	/**
 	 * @return The Job Client actor which communicats with the JobManager.
 	 */
-	public ActorRef getJobClientActor() {
+	public ActorGateway getJobClientGateway() {
 		return jobClientActor;
 	}
 
@@ -118,6 +175,16 @@ public final class JobListeningContext {
 	}
 
 	/**
+	 * Runs the finalization Runnable.
+	 */
+	public void runFinalizer() {
+		if (finalizer != null) {
+			finalizer.run();
+			finalizer = null;
+		}
+	}
+
+	/**
 	 * The class loader necessary to deserialize the result of a job execution,
 	 * i.e. JobExecutionResult or Exceptions
 	 * @return The class loader for the job id
@@ -126,13 +193,13 @@ public final class JobListeningContext {
 	public ClassLoader getClassLoader() throws JobRetrievalException {
 		if (classLoader == null) {
 			// lazily initializes the class loader when it is needed
-			classLoader = JobClient.retrieveClassLoader(jobID, getJobManager(), configuration);
+			classLoader = retrieveClassLoader(jobID, getJobManager(), configuration);
 			LOG.info("Reconstructed class loader for Job {}", jobID);
 		}
 		return classLoader;
 	}
 
-	private ActorGateway getJobManager() throws JobRetrievalException {
+	public ActorGateway getJobManager() throws JobRetrievalException {
 		try {
 			return LeaderRetrievalUtils.retrieveLeaderGateway(
 				LeaderRetrievalUtils.createLeaderRetrievalService(configuration),
@@ -142,4 +209,66 @@ public final class JobListeningContext {
 			throw new JobRetrievalException(jobID, "Couldn't retrieve leading JobManager.", e);
 		}
 	}
+
+	/**
+	 * Reconstructs the class loader by first requesting information about it at the JobManager
+	 * and then downloading missing jar files.
+	 * @param jobID id of job
+	 * @param jobManager gateway to the JobManager
+	 * @param config the flink configuration
+	 * @return A classloader that should behave like the original classloader
+	 * @throws JobRetrievalException if anything goes wrong
+	 */
+	private static ClassLoader retrieveClassLoader(
+		JobID jobID,
+		ActorGateway jobManager,
+		Configuration config)
+		throws JobRetrievalException {
+
+		final Object jmAnswer;
+		try {
+			jmAnswer = Await.result(
+				jobManager.ask(
+					new JobManagerMessages.RequestClassloadingProps(jobID),
+					AkkaUtils.getDefaultTimeoutAsFiniteDuration()),
+				AkkaUtils.getDefaultTimeoutAsFiniteDuration());
+		} catch (Exception e) {
+			throw new JobRetrievalException(jobID, "Couldn't retrieve class loading properties from JobManager.", e);
+		}
+
+		if (jmAnswer instanceof JobManagerMessages.ClassloadingProps) {
+			JobManagerMessages.ClassloadingProps props = ((JobManagerMessages.ClassloadingProps) jmAnswer);
+
+			Option<String> jmHost = jobManager.actor().path().address().host();
+			String jmHostname = jmHost.isDefined() ? jmHost.get() : "localhost";
+			InetSocketAddress serverAddress = new InetSocketAddress(jmHostname, props.blobManagerPort());
+			final BlobCache blobClient = new BlobCache(serverAddress, config);
+
+			final List<BlobKey> requiredJarFiles = props.requiredJarFiles();
+			final List<URL> requiredClasspaths = props.requiredClasspaths();
+
+			final URL[] allURLs = new URL[requiredJarFiles.size() + requiredClasspaths.size()];
+
+			int pos = 0;
+			for (BlobKey blobKey : props.requiredJarFiles()) {
+				try {
+					allURLs[pos++] = blobClient.getURL(blobKey);
+				} catch (Exception e) {
+					blobClient.shutdown();
+					throw new JobRetrievalException(jobID, "Failed to download BlobKey " + blobKey);
+				}
+			}
+
+			for (URL url : requiredClasspaths) {
+				allURLs[pos++] = url;
+			}
+
+			return new URLClassLoader(allURLs, JobClientActorUtils.class.getClassLoader());
+		} else if (jmAnswer instanceof JobManagerMessages.JobNotFound) {
+			throw new JobRetrievalException(jobID, "Couldn't retrieve class loader. Job " + jobID + " not running.");
+		} else {
+			throw new JobRetrievalException(jobID, "Unknown response from JobManager: " + jmAnswer);
+		}
+	}
+
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1753,7 +1753,7 @@ class JobManager(
   }
 
   /** Fails all currently running jobs and empties the list of currently running jobs. If the
-    * [[JobClientActor]] waits for a result, then a [[JobExecutionException]] is sent.
+    * [[JobClientActorBase]] waits for a result, then a [[JobExecutionException]] is sent.
     *
     * @param cause Cause for the cancelling.
     */

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobClientMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobClientMessages.scala
@@ -22,10 +22,11 @@ import java.util.UUID
 
 import akka.actor.ActorRef
 import org.apache.flink.api.common.JobID
+import org.apache.flink.runtime.client.JobClientActorUtils
 import org.apache.flink.runtime.jobgraph.JobGraph
 
 /**
- * This object contains the [[org.apache.flink.runtime.client.JobClient]] specific messages
+ * This object contains the [[JobClientActorUtils]] specific messages
  */
 object JobClientMessages {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorTest.java
@@ -302,7 +302,7 @@ public class JobClientActorTest extends TestLogger {
 		);
 
 		JobListeningContext jobListeningContext =
-			JobClient.submitJob(
+			JobClientActorUtils.submitJob(
 				system,
 				clientConfig,
 				testingLeaderRetrievalService,
@@ -315,11 +315,11 @@ public class JobClientActorTest extends TestLogger {
 		Await.result(waitFuture, timeout);
 
 		// kill the job client actor which has been registered at the JobManager
-		jobListeningContext.getJobClientActor().tell(PoisonPill.getInstance(), ActorRef.noSender());
+		jobListeningContext.getJobClientGateway().tell(PoisonPill.getInstance());
 
 		try {
 			// should not block but return an error
-			JobClient.awaitJobResult(jobListeningContext);
+			JobClientActorUtils.awaitJobResult(jobListeningContext);
 			Assert.fail();
 		} catch (JobExecutionException e) {
 			// this is what we want

--- a/flink-runtime/src/test/resources/logback-test.xml
+++ b/flink-runtime/src/test/resources/logback-test.xml
@@ -32,7 +32,7 @@
          <!---->
     <logger name="org.apache.flink.runtime.operators.DataSinkTask" level="OFF"/>
     <logger name="org.apache.flink.runtime.operators.BatchTask" level="OFF"/>
-    <logger name="org.apache.flink.runtime.client.JobClient" level="OFF"/>
+    <logger name="org.apache.flink.runtime.client.JobClientActorUtils" level="OFF"/>
     <logger name="org.apache.flink.runtime.taskmanager.Task" level="OFF"/>
     <logger name="org.apache.flink.runtime.jobmanager.JobManager" level="OFF"/>
     <logger name="org.apache.flink.runtime.testingUtils" level="OFF"/>

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
@@ -29,7 +29,7 @@ import grizzled.slf4j.Logger
 import org.apache.flink.api.common.JobExecutionResult
 import org.apache.flink.configuration.{ConfigConstants, Configuration, HighAvailabilityOptions}
 import org.apache.flink.runtime.akka.AkkaUtils
-import org.apache.flink.runtime.client.JobClient
+import org.apache.flink.runtime.client.JobClientActorUtils
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager
 import org.apache.flink.runtime.clusterframework.types.ResourceID
 import org.apache.flink.runtime.instance.{ActorGateway, AkkaActorGateway}
@@ -479,7 +479,7 @@ object TestingUtils {
     val jobManagerURL = AkkaUtils.getAkkaURL(actorSystem, jobManager.actor)
     val leaderRetrievalService = new StandaloneLeaderRetrievalService(jobManagerURL)
 
-    JobClient.submitJobAndWait(
+    JobClientActorUtils.submitJobAndWait(
       actorSystem,
       config,
       leaderRetrievalService,

--- a/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellRemoteStreamEnvironment.java
+++ b/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellRemoteStreamEnvironment.java
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.api.java;
 
-import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.scala.FlinkILoop;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
@@ -72,7 +72,7 @@ public class ScalaShellRemoteStreamEnvironment extends RemoteStreamEnvironment {
 	 * @return The result of the job execution, containing elapsed time and accumulators.
 	 */
 	@Override
-	protected JobExecutionResult executeRemotely(StreamGraph streamGraph, List<URL> jarFiles) throws ProgramInvocationException {
+	protected JobClient executeRemotely(StreamGraph streamGraph, List<URL> jarFiles) throws ProgramInvocationException {
 		URL jarUrl;
 		try {
 			jarUrl = flinkILoop.writeFilesToDisk().getAbsoluteFile().toURI().toURL();

--- a/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
+++ b/flink-scala-shell/src/test/java/org/apache/flink/api/java/FlinkILoopTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.api.java;
 
-import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.PlanExecutor;
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.BDDMockito;
 import org.mockito.Matchers;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
@@ -137,8 +138,8 @@ public class FlinkILoopTest extends TestLogger {
 		}
 
 		@Override
-		public JobExecutionResult executePlan(Plan plan) throws Exception {
-			return null;
+		public JobClient executePlan(Plan plan) throws Exception {
+			return Mockito.mock(JobClient.class);
 		}
 
 		@Override

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -18,12 +18,12 @@
 package org.apache.flink.api.scala
 
 import com.esotericsoftware.kryo.Serializer
-import org.apache.flink.annotation.{PublicEvolving, Public}
+import org.apache.flink.annotation.{Public, PublicEvolving}
 import org.apache.flink.api.common.io.{FileInputFormat, InputFormat}
 import org.apache.flink.api.common.restartstrategy.RestartStrategies.RestartStrategyConfiguration
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.common.typeutils.CompositeType
-import org.apache.flink.api.common.{ExecutionConfig, JobExecutionResult, JobID}
+import org.apache.flink.api.common.{ExecutionConfig, JobClient, JobExecutionResult, JobID}
 import org.apache.flink.api.java.io._
 import org.apache.flink.api.java.operators.DataSource
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
@@ -35,9 +35,9 @@ import org.apache.flink.core.fs.Path
 import org.apache.flink.types.StringValue
 import org.apache.flink.util.{NumberSequenceIterator, Preconditions, SplittableIterator}
 import org.apache.hadoop.fs.{Path => HadoopPath}
-import org.apache.hadoop.mapred.{FileInputFormat => MapredFileInputFormat, InputFormat => MapredInputFormat, JobConf}
+import org.apache.hadoop.mapred.{JobConf, FileInputFormat => MapredFileInputFormat, InputFormat => MapredInputFormat}
 import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat => MapreduceFileInputFormat}
-import org.apache.hadoop.mapreduce.{InputFormat => MapreduceInputFormat, Job}
+import org.apache.hadoop.mapreduce.{Job, InputFormat => MapreduceInputFormat}
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
@@ -649,6 +649,34 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    */
   def execute(jobName: String): JobExecutionResult = {
     javaEnv.execute(jobName)
+  }
+
+  /**
+   * Triggers the program execution. The environment will execute all parts of the program that have
+   * resulted in a "sink" operation. Sink operations are for example printing results
+   * [[DataSet.print]], writing results (e.g. [[DataSet.writeAsText]], [[DataSet.write]], or other
+   * generic data sinks created with [[DataSet.output]].
+   *
+   * The program execution will be logged and displayed with a generated default name.
+   *
+   * @return The job client of the execution to interact with the running job.
+   */
+  def executeWithControl(): JobClient = {
+    javaEnv.executeWithControl()
+  }
+
+  /**
+   * Triggers the program execution. The environment will execute all parts of the program that have
+   * resulted in a "sink" operation. Sink operations are for example printing results
+   * [[DataSet.print]], writing results (e.g. [[DataSet.writeAsText]], [[DataSet.write]], or other
+   * generic data sinks created with [[DataSet.output]].
+   *
+   * The program execution will be logged and displayed with the given name.
+   *
+   * @return The job client of the execution to interact with the running job.
+   */
+  def executeWithControl(jobName: String): JobClient = {
+    javaEnv.executeWithControl(jobName)
   }
 
   /**

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -177,11 +177,8 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 			DataStream<String> stream = see.addSource(source);
 			stream.print();
 			see.execute("No broker test");
-		} catch(ProgramInvocationException pie) {
+		} catch(JobExecutionException jee) {
 			if(kafkaServer.getVersion().equals("0.9") || kafkaServer.getVersion().equals("0.10")) {
-				assertTrue(pie.getCause() instanceof JobExecutionException);
-
-				JobExecutionException jee = (JobExecutionException) pie.getCause();
 
 				assertTrue(jee.getCause() instanceof TimeoutException);
 
@@ -189,9 +186,6 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 
 				assertEquals("Timeout expired while fetching topic metadata", te.getMessage());
 			} else {
-				assertTrue(pie.getCause() instanceof JobExecutionException);
-
-				JobExecutionException jee = (JobExecutionException) pie.getCause();
 
 				assertTrue(jee.getCause() instanceof RuntimeException);
 
@@ -909,7 +903,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 			env.execute("test fail on deploy");
 			fail("this test should fail with an exception");
 		}
-		catch (ProgramInvocationException e) {
+		catch (JobExecutionException e) {
 
 			// validate that we failed due to a NoResourceAvailableException
 			Throwable cause = e.getCause();
@@ -1461,7 +1455,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 					props.putAll(secureProps);
 
 					TypeInformationSerializationSchema<Tuple2<Integer, Integer>> schema = new TypeInformationSerializationSchema<>(TypeInfoParser.<Tuple2<Integer, Integer>>parse("Tuple2<Integer, Integer>"), env1.getConfig());
-					DataStream<Tuple2<Integer, Integer>> fromKafka = env1.addSource(kafkaServer.getConsumer(topic, schema, standardProps));
+					DataStream<Tuple2<Integer, Integer>> fromKafka = env1.addSource(kafkaServer.getConsumer(topic, schema, props));
 					fromKafka.flatMap(new FlatMapFunction<Tuple2<Integer, Integer>, Void>() {
 						@Override
 						public void flatMap(Tuple2<Integer, Integer> value, Collector<Void> out) throws Exception {// no op
@@ -1491,7 +1485,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 					env1.execute("Metrics test job");
 				} catch(Throwable t) {
 					LOG.warn("Got exception during execution", t);
-					if(!(t.getCause() instanceof JobCancellationException)) { // we'll cancel the job
+					if(!(t instanceof JobCancellationException)) { // we'll cancel the job
 						error.f0 = t;
 					}
 				}

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
@@ -251,10 +251,10 @@ public class KafkaShortRetentionTestBase implements Serializable {
 		try {
 			env.execute("Test auto offset reset none");
 		} catch(Throwable e) {
-			System.out.println("MESSAGE: " + e.getCause().getCause().getMessage());
+			System.out.println("MESSAGE: " + e.getCause().getMessage());
 			// check if correct exception has been thrown
-			if(!e.getCause().getCause().getMessage().contains("Unable to find previous offset")  // kafka 0.8
-			 && !e.getCause().getCause().getMessage().contains("Undefined offset with no reset policy for partition") // kafka 0.9
+			if(!e.getCause().getMessage().contains("Unable to find previous offset")  // kafka 0.8
+			 && !e.getCause().getMessage().contains("Undefined offset with no reset policy for partition") // kafka 0.9
 					) {
 				throw e;
 			}

--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/DataGenerators.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/DataGenerators.java
@@ -18,15 +18,13 @@
 
 package org.apache.flink.streaming.connectors.kafka.testutils;
 
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.functions.RichFunction;
-import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.typeutils.TypeInfoParser;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
@@ -220,6 +218,11 @@ public class DataGenerators {
 
 			@Override
 			public JobExecutionResult execute(String jobName) throws Exception {
+				return null;
+			}
+
+			@Override
+			public JobClient executeWithControl(String jobName) throws Exception {
 				return null;
 			}
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamContextEnvironment.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.client.program.ContextEnvironment;
 import org.apache.flink.client.program.DetachedEnvironment;
@@ -66,7 +67,21 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
 			return ctx
 				.getClient()
 				.run(streamGraph, ctx.getJars(), ctx.getClasspaths(), ctx.getUserCodeClassLoader(), ctx.getSavepointPath())
-				.getJobExecutionResult();
+				.waitForResult();
 		}
+	}
+
+	@Override
+	public JobClient executeWithControl(String jobName) throws Exception {
+		Preconditions.checkNotNull("Streaming Job name should not be null.");
+
+		StreamGraph streamGraph = this.getStreamGraph();
+		streamGraph.setJobName(jobName);
+
+		transformations.clear();
+
+		return ctx
+			.getClient()
+			.run(streamGraph, ctx.getJars(), ctx.getClasspaths(), ctx.getUserCodeClassLoader(), ctx.getSavepointPath());
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.functions.InvalidTypesException;
@@ -1510,6 +1511,33 @@ public abstract class StreamExecutionEnvironment {
 	 * @throws Exception which occurs during job execution.
 	 */
 	public abstract JobExecutionResult execute(String jobName) throws Exception;
+
+	/**
+	 * Triggers the program execution. The environment will execute all parts of
+	 * the program that have resulted in a "sink" operation. Sink operations are
+	 * for example printing results or forwarding them to a message queue.
+	 * <p>
+	 * The program execution will be logged and displayed with the provided name
+	 *
+	 * @return The job client for controlling the execution and retrieving results.
+	 * @throws Exception which occurs during job execution.
+	 */
+	public JobClient executeWithControl() throws Exception {
+		return executeWithControl(DEFAULT_JOB_NAME);
+	}
+
+	/**
+	 * Triggers the program execution. The environment will execute all parts of
+	 * the program that have resulted in a "sink" operation. Sink operations are
+	 * for example printing results or forwarding them to a message queue.
+	 * <p>
+	 * The program execution will be logged and displayed with the provided name
+	 *
+	 * @param jobName
+	 * 		Desired name of the job
+	 * @return The job client for controlling the execution and retrieving results.
+	 * @throws Exception which occurs during job execution.
+	 */	public abstract JobClient executeWithControl(String jobName) throws Exception;
 
 	/**
 	 * Getter of the {@link org.apache.flink.streaming.api.graph.StreamGraph} of the streaming job.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPlanEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPlanEnvironment.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.client.program.OptimizerPlanEnvironment;
@@ -66,5 +67,10 @@ public class StreamPlanEnvironment extends StreamExecutionEnvironment {
 		}
 
 		throw new OptimizerPlanEnvironment.ProgramAbortException();
+	}
+
+	@Override
+	public JobClient executeWithControl(String jobName) throws Exception {
+		throw new UnsupportedOperationException("StreamPlanEnvironment does not support execution with control.");
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/FoldApplyWindowFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/FoldApplyWindowFunctionTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.operators;
 
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.functions.util.ListCollector;
@@ -139,6 +140,11 @@ public class FoldApplyWindowFunctionTest {
 
 		@Override
 		public JobExecutionResult execute(String jobName) throws Exception {
+			return null;
+		}
+
+		@Override
+		public JobClient executeWithControl(String jobName) throws Exception {
 			return null;
 		}
 	}

--- a/flink-streaming-java/src/test/resources/logback-test.xml
+++ b/flink-streaming-java/src/test/resources/logback-test.xml
@@ -26,5 +26,5 @@
     <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
-    <logger name="org.apache.flink.runtime.client.JobClient" level="OFF"/>
+    <logger name="org.apache.flink.runtime.client.JobClientActorUtils" level="OFF"/>
 </configuration>

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -634,6 +634,25 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   def execute(jobName: String) = javaEnv.execute(jobName)
 
   /**
+    * Triggers the program execution. The environment will execute all parts of
+    * the program that have resulted in a "sink" operation. Sink operations are
+    * for example printing results or forwarding them to a message queue.
+    *
+    * The program execution will be logged and displayed with a generated
+    * default name.
+    */
+  def executeWithControl() = javaEnv.executeWithControl()
+
+  /**
+    * Triggers the program execution. The environment will execute all parts of
+    * the program that have resulted in a "sink" operation. Sink operations are
+    * for example printing results or forwarding them to a message queue.
+    *
+    * The program execution will be logged and displayed with the provided name.
+    */
+  def executeWithControl(jobName: String) = javaEnv.executeWithControl(jobName)
+
+  /**
    * Creates the plan with which the system will execute the program, and
    * returns it as a String using a JSON representation of the execution data
    * flow graph. Note that this needs to be called, before the plan is

--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorErrorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorErrorITCase.java
@@ -91,11 +91,9 @@ public class AccumulatorErrorITCase {
 		try {
 			env.execute();
 			fail("Should have failed.");
-		} catch (ProgramInvocationException e) {
-			Assert.assertTrue("Exception should be passed:",
-					e.getCause() instanceof JobExecutionException);
+		} catch (JobExecutionException e) {
 			Assert.assertTrue("Root cause should be:",
-					e.getCause().getCause() instanceof CustomException);
+					e.getCause() instanceof CustomException);
 		}
 	}
 
@@ -117,13 +115,11 @@ public class AccumulatorErrorITCase {
 		try {
 			env.execute();
 			fail("Should have failed.");
-		} catch (ProgramInvocationException e) {
-			Assert.assertTrue("Exception should be passed:",
-					e.getCause() instanceof JobExecutionException);
+		} catch (JobExecutionException e) {
 			Assert.assertTrue("Root cause should be:",
-					e.getCause().getCause() instanceof Exception);
+					e.getCause() instanceof Exception);
 			Assert.assertTrue("Root cause should be:",
-					e.getCause().getCause().getCause() instanceof UnsupportedOperationException);
+					e.getCause().getCause() instanceof UnsupportedOperationException);
 		}
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorLiveITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorLiveITCase.java
@@ -24,6 +24,7 @@ import akka.pattern.Patterns;
 import akka.testkit.JavaTestKit;
 import akka.util.Timeout;
 
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
@@ -388,6 +389,11 @@ public class AccumulatorLiveITCase {
 
 		@Override
 		public JobExecutionResult execute(String jobName) throws Exception {
+			throw new RuntimeException("This should not be called.");
+		}
+
+		@Override
+		public JobClient executeWithControl(String jobName) throws Exception {
 			throw new RuntimeException("This should not be called.");
 		}
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/clients/examples/JobRetrievalITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/clients/examples/JobRetrievalITCase.java
@@ -83,7 +83,7 @@ public class JobRetrievalITCase extends TestLogger {
 			@Override
 			public void run() {
 				try {
-					assertNotNull(client.retrieveJob(jobID));
+					assertNotNull(client.retrieveJob(jobID).waitForResult());
 				} catch (Throwable e) {
 					fail(e.getMessage());
 				}
@@ -120,7 +120,7 @@ public class JobRetrievalITCase extends TestLogger {
 		ClusterClient client = new StandaloneClusterClient(cluster.configuration());
 
 		try {
-			client.retrieveJob(jobID);
+			client.retrieveJob(jobID).waitForResult();
 			fail();
 		} catch (JobRetrievalException e) {
 			// this is what we want

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/CustomSerializationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/CustomSerializationITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.apache.flink.types.Value;
 
@@ -94,8 +95,8 @@ public class CustomSerializationITCase {
 			
 			env.execute();
 		}
-		catch (ProgramInvocationException e) {
-			Throwable rootCause = e.getCause().getCause();
+		catch (JobExecutionException e) {
+			Throwable rootCause = e.getCause();
 			assertTrue(rootCause instanceof IOException);
 			assertTrue(rootCause.getMessage().contains("broken serialization"));
 		}
@@ -127,8 +128,8 @@ public class CustomSerializationITCase {
 
 			env.execute();
 		}
-		catch (ProgramInvocationException e) {
-			Throwable rootCause = e.getCause().getCause();
+		catch (JobExecutionException e) {
+			Throwable rootCause = e.getCause();
 			assertTrue(rootCause instanceof IOException);
 			assertTrue(rootCause.getMessage().contains("broken serialization"));
 		}
@@ -160,8 +161,8 @@ public class CustomSerializationITCase {
 
 			env.execute();
 		}
-		catch (ProgramInvocationException e) {
-			Throwable rootCause = e.getCause().getCause();
+		catch (JobExecutionException e) {
+			Throwable rootCause = e.getCause();
 			assertTrue(rootCause instanceof IOException);
 			assertTrue(rootCause.getMessage().contains("broken serialization"));
 		}
@@ -193,8 +194,8 @@ public class CustomSerializationITCase {
 
 			env.execute();
 		}
-		catch (ProgramInvocationException e) {
-			Throwable rootCause = e.getCause().getCause();
+		catch (JobExecutionException e) {
+			Throwable rootCause = e.getCause();
 			assertTrue(rootCause instanceof IOException);
 			assertTrue(rootCause.getMessage().contains("broken serialization"));
 		}

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/MiscellaneousIssuesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/MiscellaneousIssuesITCase.java
@@ -29,6 +29,7 @@ import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 
 import org.apache.flink.util.Collector;
@@ -105,10 +106,9 @@ public class MiscellaneousIssuesITCase {
 				env.execute();
 				fail("this should fail due to null values.");
 			}
-			catch (ProgramInvocationException e) {
+			catch (JobExecutionException e) {
 				assertNotNull(e.getCause());
-				assertNotNull(e.getCause().getCause());
-				assertTrue(e.getCause().getCause() instanceof NullPointerException);
+				assertTrue(e.getCause() instanceof NullPointerException);
 			}
 		}
 		catch (Exception e) {

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.examples.java.clustering.util.KMeansData;
 import org.apache.flink.examples.java.graph.ConnectedComponents;
 import org.apache.flink.examples.java.graph.util.ConnectedComponentsData;
 
+import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.junit.Test;
 
@@ -68,8 +69,8 @@ public class SuccessAfterNetworkBuffersFailureITCase {
 				runKMeans(cluster.getLeaderRPCPort());
 				fail("This program execution should have failed.");
 			}
-			catch (ProgramInvocationException e) {
-				assertTrue(e.getCause().getCause().getMessage().contains("Insufficient number of network buffers"));
+			catch (JobExecutionException e) {
+				assertTrue(e.getCause().getMessage().contains("Insufficient number of network buffers"));
 			}
 	
 			try {

--- a/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -347,6 +348,12 @@ public class JsonJobGraphGenerationTest {
 			validator.validateJson(jsonPlan);
 			
 			throw new AbortError();
+		}
+
+		@Override
+		public JobClient executeWithControl(String jobName) throws Exception {
+			throw new UnsupportedOperationException(
+				"The TestingExecutionEnvironment does not support execution with control.");
 		}
 
 		@Override

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -28,10 +28,10 @@ import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobmanager.JobManager;
 import org.apache.flink.runtime.jobmanager.MemoryArchivist;
@@ -185,7 +185,7 @@ public class ProcessFailureCancelingITCase {
 			Throwable error = errorRef[0];
 			assertNotNull("The program did not fail properly", error);
 			
-			assertTrue(error instanceof ProgramInvocationException);
+			assertTrue(error instanceof JobExecutionException);
 			// all seems well :-)
 		}
 		catch (Exception e) {

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.client.JobClient;
+import org.apache.flink.runtime.client.JobClientActorUtils;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -275,7 +275,7 @@ public class ZooKeeperLeaderElectionITCase extends TestLogger {
 						LeaderRetrievalUtils.createLeaderRetrievalService(
 								cluster.configuration());
 
-				JobExecutionResult result = JobClient.submitJobAndWait(
+				JobExecutionResult result = JobClientActorUtils.submitJobAndWait(
 						clientActorSystem,
 						cluster.configuration(),
 						lrService,

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -24,7 +24,7 @@ import com.google.common.base.Joiner;
 import org.apache.commons.io.FileUtils;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.GlobalConfiguration;
-import org.apache.flink.runtime.client.JobClient;
+import org.apache.flink.runtime.client.JobClientActorUtils;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.test.util.TestBaseUtils;
@@ -109,7 +109,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	@Test
 	public void perJobYarnCluster() {
 		LOG.info("Starting perJobYarnCluster()");
-		addTestAppender(JobClient.class, Level.INFO);
+		addTestAppender(JobClientActorUtils.class, Level.INFO);
 		File exampleJarLocation = YarnTestBase.findFile("..", new ContainsName(new String[] {"-WordCount.jar"} , "streaming")); // exclude streaming wordcount here.
 		Assert.assertNotNull("Could not find wordcount jar", exampleJarLocation);
 		runWithArgs(new String[]{"run", "-m", "yarn-cluster",
@@ -335,7 +335,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 		LOG.info("Starting perJobYarnClusterWithParallelism()");
 		// write log messages to stdout as well, so that the runWithArgs() method
 		// is catching the log output
-		addTestAppender(JobClient.class, Level.INFO);
+		addTestAppender(JobClientActorUtils.class, Level.INFO);
 		File exampleJarLocation = YarnTestBase.findFile("..", new ContainsName(new String[] {"-WordCount.jar"}, "streaming")); // exclude streaming wordcount here.
 		Assert.assertNotNull("Could not find wordcount jar", exampleJarLocation);
 		runWithArgs(new String[]{"run",

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
@@ -22,8 +22,8 @@ import akka.actor.ActorRef;
 import akka.actor.Props;
 import akka.pattern.Patterns;
 import akka.util.Timeout;
+import org.apache.flink.api.common.JobClient;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -200,7 +200,7 @@ public class YarnClusterClient extends ClusterClient {
 	}
 
 	@Override
-	protected JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader) throws ProgramInvocationException {
+	protected JobClient submitJob(JobGraph jobGraph, ClassLoader classLoader) throws ProgramInvocationException {
 		if (isDetached()) {
 			if (newlyCreatedCluster) {
 				stopAfterJob(jobGraph.getJobID());


### PR DESCRIPTION
Also includes: [FLINK-4274] Expose new JobClient in the DataSet/DataStream API

- rename JobClient class to JobClientActorUtils

- introduce JobClient interface with two implementations

  - JobClientEager: starts an actor system right away and monitors the job
    - Move ClusterClient#cancel, ClusterClient#stop,
      ClusterClient#getAccumulators to JobClient

  - JobClientLazy: starts an actor system when requests are made by
    encapsulating the eager job client

- Java and Scala API
  - JobClient integration
  - introduce ExecutionEnvironment#executeWithControl()
  - introduce StreamExecutionEnvironment#executeWithControl()

- report errors during job execution as JobExecutionException instead of
  ProgramInvocationException and adapt test cases

- provide finalizers to run code upon shutdown of client

- use ActorGateway in JobListeningContext

- add test case for JobClient implementations