### PR TITLE
Keytab & TLS support for Flink on Mesos Setup

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -489,6 +489,12 @@ public final class ConfigConstants {
 	 */
 	public static final String MESOS_RESOURCEMANAGER_TASKS_CPUS = "mesos.resourcemanager.tasks.cpus";
 
+
+	/**
+	 * Config parameter to override SSL support for the Artifact Server
+	 */
+	public static final String MESOS_ARTIFACT_SERVER_SSL_ENABLED = "mesos.resourcemanager.artifactserver.ssl.enabled";
+
 	// ------------------------ Hadoop Configuration ------------------------
 
 	/**
@@ -1155,6 +1161,9 @@ public final class ConfigConstants {
 	public static final String DEFAULT_MESOS_RESOURCEMANAGER_FRAMEWORK_NAME = "Flink";
 
 	public static final String DEFAULT_MESOS_RESOURCEMANAGER_FRAMEWORK_ROLE = "*";
+
+	/** Default value to override SSL support for the Artifact Server */
+	public static final boolean DEFAULT_MESOS_ARTIFACT_SERVER_SSL_ENABLED = true;
 
 	// ------------------------ File System Behavior ------------------------
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
@@ -256,7 +256,7 @@ public class MesosApplicationMasterRunner {
 			LOG.debug("Starting Artifact Server");
 			final int artifactServerPort = config.getInteger(ConfigConstants.MESOS_ARTIFACT_SERVER_PORT_KEY,
 				ConfigConstants.DEFAULT_MESOS_ARTIFACT_SERVER_PORT);
-			artifactServer = new MesosArtifactServer(sessionID, akkaHostname, artifactServerPort);
+			artifactServer = new MesosArtifactServer(sessionID, akkaHostname, artifactServerPort, config);
 
 			// ----------------- (3) Generate the configuration for the TaskManagers -------------------
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosConfigKeys.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosConfigKeys.java
@@ -30,7 +30,7 @@ public class MesosConfigKeys {
 	public static final String ENV_TM_COUNT = "_CLIENT_TM_COUNT";
 	public static final String ENV_SLOTS = "_SLOTS";
 	public static final String ENV_CLIENT_SHIP_FILES = "_CLIENT_SHIP_FILES";
-	public static final String ENV_CLIENT_USERNAME = "_CLIENT_USERNAME";
+	public static final String ENV_HADOOP_USER_NAME = "HADOOP_USER_NAME";
 	public static final String ENV_DYNAMIC_PROPERTIES = "_DYNAMIC_PROPERTIES";
 	public static final String ENV_FLINK_CONTAINER_ID = "_FLINK_CONTAINER_ID";
 	public static final String ENV_FLINK_TMP_DIR = "_FLINK_TMP_DIR";
@@ -38,6 +38,9 @@ public class MesosConfigKeys {
 	public static final String ENV_CLASSPATH = "CLASSPATH";
 	public static final String ENV_MESOS_SANDBOX = "MESOS_SANDBOX";
 	public static final String ENV_SESSION_ID = "_CLIENT_SESSION_ID";
+	public static final String ENV_HADOOP_CONF_DIR = "HADOOP_CONF_DIR";
+	public static final String ENV_KEYTAB = "_KEYTAB_FILE";
+	public static final String ENV_KEYTAB_PRINCIPAL = "_KEYTAB_PRINCIPAL";
 
 	/** Private constructor to prevent instantiation */
 	private MesosConfigKeys() {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityContext.java
@@ -104,6 +104,7 @@ public class SecurityContext {
 
 		if(UserGroupInformation.isSecurityEnabled() &&
 				config.keytab != null && !StringUtils.isBlank(config.principal)) {
+			LOG.info("Hadoop security is enabled");
 			String keytabPath = (new File(config.keytab)).getAbsolutePath();
 
 			UserGroupInformation.loginUserFromKeytab(config.principal, keytabPath);


### PR DESCRIPTION
This PR addresses below issues
- FLINK-4826 (Keytab support on Mesos environment) 
- FLINK-4918 (TLS support for Mesos Artifact Server)

For Keytab support, the Hadoop configuration files (core-site & hdfs-site xml) are automatically uploaded to artifact server from the directory path provided through HADOOP_CONF_DIR environment variable, if hadoop security is enabled?

For Mesos Artifact Server TLS support, a new configuration is introduced "mesos.resourcemanager.artifactserver.ssl.enabled" which can be selectively used to toggle transport layer security for Mesos artifact server. 