### PR TITLE
[FLINK-4174] Enhance evictor functionality

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/CountEvictor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/CountEvictor.java
@@ -19,7 +19,9 @@ package org.apache.flink.streaming.api.windowing.evictors;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.streaming.api.windowing.windows.Window;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.operators.windowing.TimestampedValue;
+
+import java.util.Iterator;
 
 /**
  * An {@link Evictor} that keeps up to a certain amount of elements.
@@ -31,26 +33,67 @@ public class CountEvictor<W extends Window> implements Evictor<Object, W> {
 	private static final long serialVersionUID = 1L;
 
 	private final long maxCount;
+	private final boolean doEvictAfter;
+
+	private CountEvictor(long count,boolean doEvictAfter) {
+		this.maxCount = count;
+		this.doEvictAfter = doEvictAfter;
+	}
 
 	private CountEvictor(long count) {
 		this.maxCount = count;
+		this.doEvictAfter = false;
 	}
 
 	@Override
-	public int evict(Iterable<StreamRecord<Object>> elements, int size, W window) {
-		if (size > maxCount) {
-			return (int) (size - maxCount);
+	public void evictBefore(Iterable<TimestampedValue<Object>> elements, int size, W window, EvictorContext ctx) {
+		if (!doEvictAfter) {
+			evict(elements, size, ctx);
+		}
+	}
+
+
+	@Override
+	public void evictAfter(Iterable<TimestampedValue<Object>> elements, int size,W window, EvictorContext ctx) {
+		if (doEvictAfter) {
+			evict(elements, size, ctx);
+		}
+	}
+
+	private void evict(Iterable<TimestampedValue<Object>> elements, int size, EvictorContext ctx) {
+		if (size <= maxCount) {
+			return;
 		} else {
-			return 0;
+			int evictedCount = 0;
+			for (Iterator<TimestampedValue<Object>> iterator = elements.iterator(); iterator.hasNext();){
+				iterator.next();
+				evictedCount++;
+				if (evictedCount > size - maxCount) {
+					break;
+				} else {
+					iterator.remove();
+				}
+			}
 		}
 	}
 
 	/**
 	 * Creates a {@code CountEvictor} that keeps the given number of elements.
-	 *
+	 * Eviction is done before the window function.
 	 * @param maxCount The number of elements to keep in the pane.
 	 */
 	public static <W extends Window> CountEvictor<W> of(long maxCount) {
 		return new CountEvictor<>(maxCount);
+	}
+
+	/**
+	 * Creates a {@code CountEvictor} that keeps the given number of elements in the pane
+	 * by evicting either before of after the window function
+	 * @param maxCount The number of elements to keep in the pane.
+	 * @param doEvictAfter Whether to do eviction after the window function
+     * @return
+     */
+	public static <W extends Window> CountEvictor<W> of(long maxCount, boolean doEvictAfter) {
+		return new CountEvictor<>(maxCount,doEvictAfter);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/CountEvictor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/CountEvictor.java
@@ -80,6 +80,7 @@ public class CountEvictor<W extends Window> implements Evictor<Object, W> {
 	/**
 	 * Creates a {@code CountEvictor} that keeps the given number of elements.
 	 * Eviction is done before the window function.
+	 *
 	 * @param maxCount The number of elements to keep in the pane.
 	 */
 	public static <W extends Window> CountEvictor<W> of(long maxCount) {
@@ -88,10 +89,10 @@ public class CountEvictor<W extends Window> implements Evictor<Object, W> {
 
 	/**
 	 * Creates a {@code CountEvictor} that keeps the given number of elements in the pane
-	 * by evicting either before of after the window function
+	 * Eviction is done before/after the window function based on the value of doEvictAfter.
+	 *
 	 * @param maxCount The number of elements to keep in the pane.
-	 * @param doEvictAfter Whether to do eviction after the window function
-     * @return
+	 * @param doEvictAfter Whether to do eviction after the window function.
      */
 	public static <W extends Window> CountEvictor<W> of(long maxCount, boolean doEvictAfter) {
 		return new CountEvictor<>(maxCount,doEvictAfter);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/DeltaEvictor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/DeltaEvictor.java
@@ -85,7 +85,8 @@ public class DeltaEvictor<T, W extends Window> implements Evictor<T, W> {
 
 	/**
 	 * Creates a {@code DeltaEvictor} from the given threshold and {@code DeltaFunction}.
-	 * Eviction is done before the window function
+	 * Eviction is done before the window function.
+	 *
 	 * @param threshold The threshold
 	 * @param deltaFunction The {@code DeltaFunction}
 	 */
@@ -94,6 +95,8 @@ public class DeltaEvictor<T, W extends Window> implements Evictor<T, W> {
 	}
 
 	/**
+	 * Creates a {@code DeltaEvictor} from the given threshold, {@code DeltaFunction}.
+	 * Eviction is done before/after the window function based on the value of doEvictAfter.
 	 *
 	 * @param threshold The threshold
 	 * @param deltaFunction The {@code DeltaFunction}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/DeltaEvictor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/DeltaEvictor.java
@@ -21,15 +21,16 @@ import com.google.common.collect.Iterables;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.streaming.api.functions.windowing.delta.DeltaFunction;
 import org.apache.flink.streaming.api.windowing.windows.Window;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.operators.windowing.TimestampedValue;
+
+import java.util.Iterator;
 
 /**
  * An {@link Evictor} that keeps elements based on a {@link DeltaFunction} and a threshold.
  *
  * <p>
  * Eviction starts from the first element of the buffer and removes all elements from the buffer
- * which have a higher delta then the threshold. As soon as there is an element with a lower delta,
- * the eviction stops.
+ * which have a higher delta then the threshold.
  *
  * @param <W> The type of {@link Window Windows} on which this {@code Evictor} can operate.
  */
@@ -39,24 +40,42 @@ public class DeltaEvictor<T, W extends Window> implements Evictor<T, W> {
 
 	DeltaFunction<T> deltaFunction;
 	private double threshold;
+	private final boolean doEvictAfter;
 
 	private DeltaEvictor(double threshold, DeltaFunction<T> deltaFunction) {
 		this.deltaFunction = deltaFunction;
 		this.threshold = threshold;
+		this.doEvictAfter = false;
+	}
+
+	private DeltaEvictor(double threshold, DeltaFunction<T> deltaFunction, boolean doEvictAfter) {
+		this.deltaFunction = deltaFunction;
+		this.threshold = threshold;
+		this.doEvictAfter = doEvictAfter;
 	}
 
 	@Override
-	public int evict(Iterable<StreamRecord<T>> elements, int size, W window) {
-		StreamRecord<T> lastElement = Iterables.getLast(elements);
-		int toEvict = 0;
-		for (StreamRecord<T> element : elements) {
-			if (deltaFunction.getDelta(element.getValue(), lastElement.getValue()) < this.threshold) {
-				break;
-			}
-			toEvict++;
+	public void evictBefore(Iterable<TimestampedValue<T>> elements, int size, W window, EvictorContext ctx) {
+		if (!doEvictAfter) {
+			evict(elements, size, ctx);
 		}
+	}
 
-		return toEvict;
+	@Override
+	public void evictAfter(Iterable<TimestampedValue<T>> elements, int size, W window, EvictorContext ctx) {
+		if (doEvictAfter) {
+			evict(elements, size, ctx);
+		}
+	}
+
+	private void evict(Iterable<TimestampedValue<T>> elements, int size, EvictorContext ctx) {
+		TimestampedValue<T> lastElement = Iterables.getLast(elements);
+		for (Iterator<TimestampedValue<T>> iterator = elements.iterator(); iterator.hasNext();){
+			TimestampedValue<T> element = iterator.next();
+			if (deltaFunction.getDelta(element.getValue(), lastElement.getValue()) >= this.threshold) {
+				iterator.remove();
+			}
+		}
 	}
 
 	@Override
@@ -66,11 +85,21 @@ public class DeltaEvictor<T, W extends Window> implements Evictor<T, W> {
 
 	/**
 	 * Creates a {@code DeltaEvictor} from the given threshold and {@code DeltaFunction}.
-	 *
+	 * Eviction is done before the window function
 	 * @param threshold The threshold
 	 * @param deltaFunction The {@code DeltaFunction}
 	 */
 	public static <T, W extends Window> DeltaEvictor<T, W> of(double threshold, DeltaFunction<T> deltaFunction) {
 		return new DeltaEvictor<>(threshold, deltaFunction);
+	}
+
+	/**
+	 *
+	 * @param threshold The threshold
+	 * @param deltaFunction The {@code DeltaFunction}
+	 * @param doEvictAfter Whether eviction should be done after window function
+     */
+	public static <T, W extends Window> DeltaEvictor<T, W> of(double threshold, DeltaFunction<T> deltaFunction, boolean doEvictAfter) {
+		return new DeltaEvictor<>(threshold, deltaFunction, doEvictAfter);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/Evictor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/Evictor.java
@@ -18,15 +18,17 @@
 package org.apache.flink.streaming.api.windowing.evictors;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.api.windowing.windows.Window;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.operators.windowing.TimestampedValue;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+
 import java.io.Serializable;
 
 /**
- * An {@code Evictor} can remove elements from a pane before it is being processed and after
- * window evaluation was triggered by a
- * {@link org.apache.flink.streaming.api.windowing.triggers.Trigger}.
- *
+ * An {@code Evictor} can remove elements from a pane before/after the evaluation of WindowFunction and
+ * after the window evaluation gets triggered by a {@link org.apache.flink.streaming.api.windowing.triggers.Trigger}
  * <p>
  * A pane is the bucket of elements that have the same key (assigned by the
  * {@link org.apache.flink.api.java.functions.KeySelector}) and same {@link Window}. An element can
@@ -41,13 +43,46 @@ import java.io.Serializable;
 public interface Evictor<T, W extends Window> extends Serializable {
 
 	/**
-	 * Computes how many elements should be removed from the pane. The result specifies how
-	 * many elements should be removed from the beginning.
-	 *
+	 * Optionally evicts elements. Called before windowing function.
 	 * @param elements The elements currently in the pane.
 	 * @param size The current number of elements in the pane.
 	 * @param window The {@link Window}
+	 * @param evictorContext The context for the Evictor
+     */
+	void evictBefore(Iterable<TimestampedValue<T>> elements, int size, W window, EvictorContext evictorContext);
+
+	/**
+	 * Optionally evicts elements. Called after windowing function.
+	 * @param elements The elements currently in the pane.
+	 * @param size The current number of elements in the pane.
+	 * @param window The {@link Window}
+	 * @param evictorContext The context for the Evictor
 	 */
-	int evict(Iterable<StreamRecord<T>> elements, int size, W window);
+	void evictAfter(Iterable<TimestampedValue<T>> elements, int size, W window, EvictorContext evictorContext);
+
+
+	/**
+	 * A context object that is given to {@link Evictor} methods
+	 */
+	interface EvictorContext {
+
+		/**
+		 * Returns the current processing time, as returned by
+		 * the {@link ProcessingTimeService#getCurrentProcessingTime}.
+		 */
+		long getCurrentProcessingTime();
+
+		/**
+		 * Returns the metric group for this {@link Evictor}. This is the same metric
+		 * group that would be returned from {@link RuntimeContext#getMetricGroup()} in a user
+		 * function.
+		 *
+		 * <p>You must not call methods that create metric objects
+		 * (such as {@link MetricGroup#counter(int)} multiple times but instead call once
+		 * and store the metric object in a field.
+		 */
+		MetricGroup getMetricGroup();
+
+	}
 }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/Evictor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/Evictor.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 /**
  * An {@code Evictor} can remove elements from a pane before/after the evaluation of WindowFunction and
  * after the window evaluation gets triggered by a {@link org.apache.flink.streaming.api.windowing.triggers.Trigger}
+ *
  * <p>
  * A pane is the bucket of elements that have the same key (assigned by the
  * {@link org.apache.flink.api.java.functions.KeySelector}) and same {@link Window}. An element can
@@ -44,6 +45,7 @@ public interface Evictor<T, W extends Window> extends Serializable {
 
 	/**
 	 * Optionally evicts elements. Called before windowing function.
+	 *
 	 * @param elements The elements currently in the pane.
 	 * @param size The current number of elements in the pane.
 	 * @param window The {@link Window}
@@ -53,6 +55,7 @@ public interface Evictor<T, W extends Window> extends Serializable {
 
 	/**
 	 * Optionally evicts elements. Called after windowing function.
+	 *
 	 * @param elements The elements currently in the pane.
 	 * @param size The current number of elements in the pane.
 	 * @param window The {@link Window}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/TimeEvictor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/TimeEvictor.java
@@ -17,16 +17,18 @@
  */
 package org.apache.flink.streaming.api.windowing.evictors;
 
-import com.google.common.collect.Iterables;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.Window;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.operators.windowing.TimestampedValue;
+
+import java.util.Iterator;
 
 /**
  * An {@link Evictor} that keeps elements for a certain amount of time. Elements older
- * than {@code current_time - keep_time} are evicted.
+ * than {@code current_time - keep_time} are evicted. The current_time is time associated
+ * with {@link TimestampedValue}
  *
  * @param <W> The type of {@link Window Windows} on which this {@code Evictor} can operate.
  */
@@ -35,23 +37,63 @@ public class TimeEvictor<W extends Window> implements Evictor<Object, W> {
 	private static final long serialVersionUID = 1L;
 
 	private final long windowSize;
+	private final boolean doEvictAfter;
 
 	public TimeEvictor(long windowSize) {
 		this.windowSize = windowSize;
+		this.doEvictAfter = false;
+	}
+
+	public TimeEvictor(long windowSize, boolean doEvictAfter) {
+		this.windowSize = windowSize;
+		this.doEvictAfter = doEvictAfter;
+	}
+
+
+	@Override
+	public void evictBefore(Iterable<TimestampedValue<Object>> elements, int size, W window, EvictorContext ctx) {
+		if(!doEvictAfter) {
+			evict(elements,size,ctx);
+		}
 	}
 
 	@Override
-	public int evict(Iterable<StreamRecord<Object>> elements, int size, W window) {
-		int toEvict = 0;
-		long currentTime = Iterables.getLast(elements).getTimestamp();
-		long evictCutoff = currentTime - windowSize;
-		for (StreamRecord<Object> record: elements) {
-			if (record.getTimestamp() > evictCutoff) {
-				break;
-			}
-			toEvict++;
+	public void evictAfter(Iterable<TimestampedValue<Object>> elements, int size, W window, EvictorContext ctx) {
+		if(doEvictAfter) {
+			evict(elements,size,ctx);
 		}
-		return toEvict;
+	}
+
+	private void evict(Iterable<TimestampedValue<Object>> elements, int size, EvictorContext ctx) {
+		long currentTime = getMaxTimestamp(elements);
+
+		if (currentTime < 0) {
+			//we don't evict any element if timestamp is not set in the record
+			return;
+		}
+		long evictCutoff = currentTime - windowSize;
+
+		for (Iterator<TimestampedValue<Object>> iterator = elements.iterator(); iterator.hasNext(); ) {
+			TimestampedValue<Object> record = iterator.next();
+			if (record.getTimestamp() <= evictCutoff) {
+				iterator.remove();
+			}
+		}
+	}
+
+	/**
+	 * @param elements The elements currently in the pane.
+	 * @return The maximum value of timestamp among the elements
+     */
+	private long getMaxTimestamp(Iterable<TimestampedValue<Object>> elements) {
+		long currentTime = Long.MIN_VALUE;
+		for (Iterator<TimestampedValue<Object>> iterator = elements.iterator(); iterator.hasNext();){
+			TimestampedValue<Object> record = iterator.next();
+			if (record.getTimestamp() > currentTime) {
+				currentTime  = record.getTimestamp();
+			}
+		}
+		return currentTime;
 	}
 
 	@Override
@@ -65,11 +107,23 @@ public class TimeEvictor<W extends Window> implements Evictor<Object, W> {
 	}
 
 	/**
-	 * Creates a {@code TimeEvictor} that keeps the given number of elements.
-	 *
+	 * Creates an {@code TimeEvictor} that keeps the given number of elements.
+	 * Eviction is done before the window function
 	 * @param windowSize The amount of time for which to keep elements.
 	 */
 	public static <W extends Window> TimeEvictor<W> of(Time windowSize) {
 		return new TimeEvictor<>(windowSize.toMilliseconds());
+	}
+
+	/**
+	 * Creates an {@code TimeEvictor} that keeps the given number of elements.
+	 * Eviction is done before/after the window function
+	 * @param windowSize The amount of time for which to keep elements.
+	 * @param doEvictAfter Whether eviction is done after window function
+	 *
+     * @return
+     */
+	public static <W extends Window> TimeEvictor<W> of(Time windowSize, boolean doEvictAfter) {
+		return new TimeEvictor<>(windowSize.toMilliseconds(),doEvictAfter);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/TimeEvictor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/TimeEvictor.java
@@ -65,12 +65,11 @@ public class TimeEvictor<W extends Window> implements Evictor<Object, W> {
 	}
 
 	private void evict(Iterable<TimestampedValue<Object>> elements, int size, EvictorContext ctx) {
-		long currentTime = getMaxTimestamp(elements);
-
-		if (currentTime < 0) {
-			//we don't evict any element if timestamp is not set in the record
+		if (!hasTimestamp(elements)) {
 			return;
 		}
+
+		long currentTime = getMaxTimestamp(elements);
 		long evictCutoff = currentTime - windowSize;
 
 		for (Iterator<TimestampedValue<Object>> iterator = elements.iterator(); iterator.hasNext(); ) {
@@ -79,6 +78,17 @@ public class TimeEvictor<W extends Window> implements Evictor<Object, W> {
 				iterator.remove();
 			}
 		}
+	}
+
+	/**
+	 * Returns true if the first element in the Iterable of {@link TimestampedValue} has a timestamp.
+     */
+	private boolean hasTimestamp(Iterable<TimestampedValue<Object>> elements) {
+		Iterator<TimestampedValue<Object>> it = elements.iterator();
+		if (it.hasNext()) {
+			return it.next().hasTimestamp();
+		}
+		return false;
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/TimeEvictor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/evictors/TimeEvictor.java
@@ -83,15 +83,13 @@ public class TimeEvictor<W extends Window> implements Evictor<Object, W> {
 
 	/**
 	 * @param elements The elements currently in the pane.
-	 * @return The maximum value of timestamp among the elements
+	 * @return The maximum value of timestamp among the elements.
      */
 	private long getMaxTimestamp(Iterable<TimestampedValue<Object>> elements) {
 		long currentTime = Long.MIN_VALUE;
 		for (Iterator<TimestampedValue<Object>> iterator = elements.iterator(); iterator.hasNext();){
 			TimestampedValue<Object> record = iterator.next();
-			if (record.getTimestamp() > currentTime) {
-				currentTime  = record.getTimestamp();
-			}
+			currentTime = Math.max(currentTime, record.getTimestamp());
 		}
 		return currentTime;
 	}
@@ -107,8 +105,9 @@ public class TimeEvictor<W extends Window> implements Evictor<Object, W> {
 	}
 
 	/**
-	 * Creates an {@code TimeEvictor} that keeps the given number of elements.
-	 * Eviction is done before the window function
+	 * Creates a {@code TimeEvictor} that keeps the given number of elements.
+	 * Eviction is done before the window function.
+	 *
 	 * @param windowSize The amount of time for which to keep elements.
 	 */
 	public static <W extends Window> TimeEvictor<W> of(Time windowSize) {
@@ -116,12 +115,11 @@ public class TimeEvictor<W extends Window> implements Evictor<Object, W> {
 	}
 
 	/**
-	 * Creates an {@code TimeEvictor} that keeps the given number of elements.
-	 * Eviction is done before/after the window function
-	 * @param windowSize The amount of time for which to keep elements.
-	 * @param doEvictAfter Whether eviction is done after window function
+	 * Creates a {@code TimeEvictor} that keeps the given number of elements.
+	 * Eviction is done before/after the window function based on the value of doEvictAfter.
 	 *
-     * @return
+	 * @param windowSize The amount of time for which to keep elements.
+	 * @param doEvictAfter Whether eviction is done after window function.
      */
 	public static <W extends Window> TimeEvictor<W> of(Time windowSize, boolean doEvictAfter) {
 		return new TimeEvictor<>(windowSize.toMilliseconds(),doEvictAfter);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
@@ -303,7 +303,7 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window> extends Window
 			.transform(new Function<StreamRecord<IN>, TimestampedValue<IN>>() {
 				@Override
 				public TimestampedValue<IN> apply(StreamRecord<IN> input) {
-					return new TimestampedValue<>(input.getValue(), input.getTimestamp());
+					return TimestampedValue.from(input);
 				}
 			});
 		evictorContext.evictBefore(recordsWithTimestamp, Iterables.size(recordsWithTimestamp));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
@@ -49,7 +49,7 @@ import static java.util.Objects.requireNonNull;
  *
  * <p>
  * The {@code Evictor} is used to remove elements from a pane before/after the evaluation of WindowFunction and
- * after the window evaluation gets triggered by a {@link org.apache.flink.streaming.api.windowing.triggers.Trigger}
+ * after the window evaluation gets triggered by a {@link org.apache.flink.streaming.api.windowing.triggers.Trigger}.
  *
  * @param <K> The type of key returned by the {@code KeySelector}.
  * @param <IN> The type of the incoming elements.
@@ -244,10 +244,10 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window> extends Window
 			return;
 		}
 
-				TriggerResult triggerResult = context.onEventTime(timer.getTimestamp());
-				if (triggerResult.isFire()) {
-					fire(context.window, contents, windowState);
-				}
+		TriggerResult triggerResult = context.onEventTime(timer.getTimestamp());
+		if (triggerResult.isFire()) {
+			fire(context.window, contents, windowState);
+		}
 
 		if (triggerResult.isPurge() || (windowAssigner.isEventTime() && isCleanupTime(context.window, timer.getTimestamp()))) {
 			cleanup(context.window, windowState, mergingWindows);
@@ -284,10 +284,10 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window> extends Window
 			return;
 		}
 
-				TriggerResult triggerResult = context.onProcessingTime(timer.getTimestamp());
-				if (triggerResult.isFire()) {
-					fire(context.window, contents, windowState);
-				}
+		TriggerResult triggerResult = context.onProcessingTime(timer.getTimestamp());
+		if (triggerResult.isFire()) {
+			fire(context.window, contents, windowState);
+		}
 
 		if (triggerResult.isPurge() || (!windowAssigner.isEventTime() && isCleanupTime(context.window, timer.getTimestamp()))) {
 			cleanup(context.window, windowState, mergingWindows);
@@ -324,11 +324,7 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window> extends Window
 		//this is inefficient, but there is no other way to remove elements from ListState, which is an AppendingState.
 		windowState.clear();
 		for(TimestampedValue<IN> record : recordsWithTimestamp) {
-			if (record.getTimestamp() < 0) {
-				windowState.add(new StreamRecord<>(record.getValue()));
-			} else {
-				windowState.add(new StreamRecord<>(record.getValue(), record.getTimestamp()));
-			}
+			windowState.add(record.getStreamRecord());
 		}
 	}
 
@@ -336,7 +332,7 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window> extends Window
 	/**
 	 * {@code EvictorContext} is a utility for handling {@code Evictor} invocations. It can be reused
 	 * by setting the {@code key} and {@code window} fields. No internal state must be kept in
-	 * the {@code EvictorContext}
+	 * the {@code EvictorContext}.
 	 */
 
 	class EvictorContext implements Evictor.EvictorContext {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/TimestampedValue.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/TimestampedValue.java
@@ -22,7 +22,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 /**
  * Stores the value and the timestamp of the record.
- * 
+ *
  * @param <T> The type encapsulated value
  */
 @PublicEvolving
@@ -68,7 +68,13 @@ public class TimestampedValue<T> {
 	 * @return The timestamp associated with this stream value in milliseconds.
      */
 	public long getTimestamp() {
-		return timestamp;
+		if (hasTimestamp) {
+			return timestamp;
+		} else {
+			throw new IllegalStateException(
+					"Record has no timestamp. Is the time characteristic set to 'ProcessingTime', or " +
+							"did you forget to call 'DataStream.assignTimestampsAndWatermarks(...)'?");
+		}
 	}
 
 	/**
@@ -91,4 +97,16 @@ public class TimestampedValue<T> {
 		return streamRecord;
 	}
 
+	/**
+	 * Creates a TimestampedValue from given {@link StreamRecord}.
+	 *
+	 * @param streamRecord The StreamRecord object from which TimestampedValue is to be created.
+     */
+	public static <T> TimestampedValue<T> from(StreamRecord<T> streamRecord) {
+		if (streamRecord.hasTimestamp()) {
+			return new TimestampedValue<>(streamRecord.getValue(), streamRecord.getTimestamp());
+		} else {
+			return new TimestampedValue<>(streamRecord.getValue());
+		}
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/TimestampedValue.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/TimestampedValue.java
@@ -18,28 +18,77 @@
 package org.apache.flink.streaming.runtime.operators.windowing;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 /**
  * Stores the value and the timestamp of the record.
+ * 
  * @param <T> The type encapsulated value
  */
 @PublicEvolving
 public class TimestampedValue<T> {
 
+	/** The actual value held by this record */
 	private T value;
+
+	/** The timestamp of the record */
 	private long timestamp;
 
+	/** Flag whether the timestamp is actually set */
+	private boolean hasTimestamp;
+
+	/**
+	 * Creates a new TimestampedValue. The record does not have a timestamp.
+	 */
+	public TimestampedValue(T value) {
+		this.value = value;
+	}
+
+	/**
+	 * Creates a new TimestampedValue wrapping the given value. The timestamp is set to the
+	 * given timestamp.
+	 *
+	 * @param value The value to wrap in this {@link TimestampedValue}
+	 * @param timestamp The timestamp in milliseconds
+	 */
 	public TimestampedValue(T value, long timestamp) {
 		this.value = value;
 		this.timestamp = timestamp;
+		this.hasTimestamp = true;
 	}
 
+	/**
+	 * @return The value wrapped in this {@link TimestampedValue}.
+	 */
 	public T getValue() {
 		return value;
 	}
 
+	/**
+	 * @return The timestamp associated with this stream value in milliseconds.
+     */
 	public long getTimestamp() {
 		return timestamp;
+	}
+
+	/**
+	 * Checks whether this record has a timestamp.
+	 *
+	 * @return True if the record has a timestamp, false if not.
+	 */
+	public boolean hasTimestamp() {
+		return hasTimestamp;
+	}
+
+	/**
+	 * Creates a {@link StreamRecord} from this TimestampedValue.
+     */
+	public StreamRecord<T> getStreamRecord() {
+		StreamRecord<T> streamRecord = new StreamRecord<>(value);
+		if (hasTimestamp) {
+			streamRecord.setTimestamp(timestamp);
+		}
+		return streamRecord;
 	}
 
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/TimestampedValue.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/TimestampedValue.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.runtime.operators.windowing;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Stores the value and the timestamp of the record.
+ * @param <T> The type encapsulated value
+ */
+@PublicEvolving
+public class TimestampedValue<T> {
+
+	private T value;
+	private long timestamp;
+
+	public TimestampedValue(T value, long timestamp) {
+		this.value = value;
+		this.timestamp = timestamp;
+	}
+
+	public T getValue() {
+		return value;
+	}
+
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -177,7 +177,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	}
 
 	@Override
-	public final void open() throws Exception {
+	public void open() throws Exception {
 		super.open();
 
 		timestampedCollector = new TimestampedCollector<>(output);
@@ -200,7 +200,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	}
 
 	@Override
-	public final void close() throws Exception {
+	public void close() throws Exception {
 		super.close();
 		timestampedCollector = null;
 		context = null;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorTest.java
@@ -130,6 +130,12 @@ public class EvictingWindowOperatorTest {
 
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
 
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 1000));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 1000));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 6), Long.MAX_VALUE));
+
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+
 		testHarness.close();
 
 		Assert.assertEquals("Close was not called.", 1, closeCalled.get());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorTest.java
@@ -29,10 +29,13 @@ import org.apache.flink.api.java.typeutils.TypeInfoParser;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.windowing.ReduceIterableWindowFunction;
 import org.apache.flink.streaming.api.functions.windowing.RichWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.delta.DeltaFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.GlobalWindows;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.evictors.CountEvictor;
+import org.apache.flink.streaming.api.windowing.evictors.DeltaEvictor;
+import org.apache.flink.streaming.api.windowing.evictors.TimeEvictor;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.CountTrigger;
 import org.apache.flink.streaming.api.windowing.triggers.EventTimeTrigger;
@@ -57,6 +60,458 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class EvictingWindowOperatorTest {
 
 	// For counting if close() is called the correct number of times on the SumReducer
+
+	/**
+	 * Tests CountEvictor evictAfter behavior
+	 * @throws Exception
+     */
+	@Test
+	public void testCountEvictorEvictAfter() throws Exception {
+		AtomicInteger closeCalled = new AtomicInteger(0);
+		final int WINDOW_SIZE = 4;
+		final int TRIGGER_COUNT = 2;
+		final boolean EVICT_AFTER = true;
+
+		TypeInformation<Tuple2<String, Integer>> inputType = TypeInfoParser.parse("Tuple2<String, Integer>");
+
+		@SuppressWarnings({"unchecked", "rawtypes"})
+		TypeSerializer<StreamRecord<Tuple2<String, Integer>>> streamRecordSerializer =
+			(TypeSerializer<StreamRecord<Tuple2<String, Integer>>>) new StreamElementSerializer(inputType.createSerializer(new ExecutionConfig()));
+
+		ListStateDescriptor<StreamRecord<Tuple2<String, Integer>>> stateDesc =
+			new ListStateDescriptor<>("window-contents", streamRecordSerializer);
+
+
+		EvictingWindowOperator<String, Tuple2<String, Integer>, Tuple2<String, Integer>, GlobalWindow> operator = new EvictingWindowOperator<>(
+			GlobalWindows.create(),
+			new GlobalWindow.Serializer(),
+			new TupleKeySelector(),
+			BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
+			stateDesc,
+			new InternalIterableWindowFunction<>(new RichSumReducer<GlobalWindow>(closeCalled)),
+			CountTrigger.of(TRIGGER_COUNT),
+			CountEvictor.of(WINDOW_SIZE,EVICT_AFTER),
+			0);
+
+
+		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
+			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
+
+
+		long initialTime = 0L;
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 3000));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 3999));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 20));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 999));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 1998));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 1999));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 1000));
+
+
+
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 2), Long.MAX_VALUE));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 4), Long.MAX_VALUE));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 2), Long.MAX_VALUE));
+
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 10999));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 1000));
+
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 4), Long.MAX_VALUE));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 6), Long.MAX_VALUE));
+
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+
+		testHarness.close();
+
+		Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+
+	}
+
+	/**
+	 * Tests TimeEvictor evictAfter behavior
+	 * @throws Exception
+	 */
+	@Test
+	public void testTimeEvictorEvictAfter() throws Exception {
+		AtomicInteger closeCalled = new AtomicInteger(0);
+		final int TRIGGER_COUNT = 2;
+		final boolean EVICT_AFTER = true;
+
+		TypeInformation<Tuple2<String, Integer>> inputType = TypeInfoParser.parse("Tuple2<String, Integer>");
+
+		@SuppressWarnings({"unchecked", "rawtypes"})
+		TypeSerializer<StreamRecord<Tuple2<String, Integer>>> streamRecordSerializer =
+			(TypeSerializer<StreamRecord<Tuple2<String, Integer>>>) new StreamElementSerializer(inputType.createSerializer(new ExecutionConfig()));
+
+		ListStateDescriptor<StreamRecord<Tuple2<String, Integer>>> stateDesc =
+			new ListStateDescriptor<>("window-contents", streamRecordSerializer);
+
+
+		EvictingWindowOperator<String, Tuple2<String, Integer>, Tuple2<String, Integer>, GlobalWindow> operator = new EvictingWindowOperator<>(
+			GlobalWindows.create(),
+			new GlobalWindow.Serializer(),
+			new TupleKeySelector(),
+			BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
+			stateDesc,
+			new InternalIterableWindowFunction<>(new RichSumReducer<GlobalWindow>(closeCalled)),
+			CountTrigger.of(TRIGGER_COUNT),
+			TimeEvictor.of(Time.seconds(2), EVICT_AFTER),
+			0);
+
+
+		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
+			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
+
+		long initialTime = 0L;
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 1000));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 4000));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 20));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 999));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 3500));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 2001));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 1001));
+
+
+
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 2), Long.MAX_VALUE));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 2), Long.MAX_VALUE));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 3), Long.MAX_VALUE));
+
+
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 10999));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 1002));
+
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 4), Long.MAX_VALUE));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 5), Long.MAX_VALUE));
+
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+
+		testHarness.close();
+
+		Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+
+	}
+
+	/**
+	 * Tests TimeEvictor evictBefore behavior
+	 * @throws Exception
+	 */
+	@Test
+	public void testTimeEvictorEvictBefore() throws Exception {
+		AtomicInteger closeCalled = new AtomicInteger(0);
+		final int TRIGGER_COUNT = 2;
+		final int WINDOW_SIZE = 4;
+
+		TypeInformation<Tuple2<String, Integer>> inputType = TypeInfoParser.parse("Tuple2<String, Integer>");
+
+		@SuppressWarnings({"unchecked", "rawtypes"})
+		TypeSerializer<StreamRecord<Tuple2<String, Integer>>> streamRecordSerializer =
+			(TypeSerializer<StreamRecord<Tuple2<String, Integer>>>) new StreamElementSerializer(inputType.createSerializer(new ExecutionConfig()));
+
+		ListStateDescriptor<StreamRecord<Tuple2<String, Integer>>> stateDesc =
+			new ListStateDescriptor<>("window-contents", streamRecordSerializer);
+
+
+		EvictingWindowOperator<String, Tuple2<String, Integer>, Tuple2<String, Integer>, TimeWindow> operator = new EvictingWindowOperator<>(
+			TumblingEventTimeWindows.of(Time.of(WINDOW_SIZE, TimeUnit.SECONDS)),
+			new TimeWindow.Serializer(),
+			new TupleKeySelector(),
+			BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
+			stateDesc,
+			new InternalIterableWindowFunction<>(new RichSumReducer<TimeWindow>(closeCalled)),
+			CountTrigger.of(TRIGGER_COUNT),
+			TimeEvictor.of(Time.seconds(2)),
+			0);
+
+
+		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
+			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
+
+		long initialTime = 0L;
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 1000));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 3999));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 20));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 999));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 5999));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 3500));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 2001));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 1001));
+
+
+
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 1), 3999));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 2), 3999));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 3), 3999));
+
+
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 6500));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 1002));
+
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 2), 7999));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 3), 3999));
+
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+
+		testHarness.close();
+
+		Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+
+	}
+
+	/**
+	 * Tests time evictor, if no timestamp information in the StreamRecord
+	 * No element will be evicted from the window
+	 * @throws Exception
+	 */
+	@Test
+	public void testTimeEvictorNoTimestamp() throws Exception {
+		AtomicInteger closeCalled = new AtomicInteger(0);
+		final int TRIGGER_COUNT = 2;
+		final boolean EVICT_AFTER = true;
+
+		TypeInformation<Tuple2<String, Integer>> inputType = TypeInfoParser.parse("Tuple2<String, Integer>");
+
+		@SuppressWarnings({"unchecked", "rawtypes"})
+		TypeSerializer<StreamRecord<Tuple2<String, Integer>>> streamRecordSerializer =
+			(TypeSerializer<StreamRecord<Tuple2<String, Integer>>>) new StreamElementSerializer(inputType.createSerializer(new ExecutionConfig()));
+
+		ListStateDescriptor<StreamRecord<Tuple2<String, Integer>>> stateDesc =
+			new ListStateDescriptor<>("window-contents", streamRecordSerializer);
+
+
+		EvictingWindowOperator<String, Tuple2<String, Integer>, Tuple2<String, Integer>, GlobalWindow> operator = new EvictingWindowOperator<>(
+			GlobalWindows.create(),
+			new GlobalWindow.Serializer(),
+			new TupleKeySelector(),
+			BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
+			stateDesc,
+			new InternalIterableWindowFunction<>(new RichSumReducer<GlobalWindow>(closeCalled)),
+			CountTrigger.of(TRIGGER_COUNT),
+			TimeEvictor.of(Time.seconds(2), EVICT_AFTER),
+			0);
+
+
+		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
+			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
+
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1)));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1)));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1)));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1)));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1)));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1)));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1)));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1)));
+
+
+
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 2), Long.MAX_VALUE));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 2), Long.MAX_VALUE));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 4), Long.MAX_VALUE));
+
+
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1)));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1)));
+
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 4), Long.MAX_VALUE));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 6), Long.MAX_VALUE));
+
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+
+		testHarness.close();
+
+		Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+
+	}
+
+	/**
+	 * Tests DeltaEvictor, evictBefore behavior
+	 * @throws Exception
+	 */
+	@Test
+	public void testDeltaEvictorEvictBefore() throws Exception {
+		AtomicInteger closeCalled = new AtomicInteger(0);
+		final int TRIGGER_COUNT = 2;
+		final boolean EVICT_AFTER = false;
+		final int THRESHOLD = 2;
+
+		TypeInformation<Tuple2<String, Integer>> inputType = TypeInfoParser.parse("Tuple2<String, Integer>");
+
+		@SuppressWarnings({"unchecked", "rawtypes"})
+		TypeSerializer<StreamRecord<Tuple2<String, Integer>>> streamRecordSerializer =
+			(TypeSerializer<StreamRecord<Tuple2<String, Integer>>>) new StreamElementSerializer(inputType.createSerializer(new ExecutionConfig()));
+
+		ListStateDescriptor<StreamRecord<Tuple2<String, Integer>>> stateDesc =
+			new ListStateDescriptor<>("window-contents", streamRecordSerializer);
+
+
+		EvictingWindowOperator<String, Tuple2<String, Integer>, Tuple2<String, Integer>, GlobalWindow> operator = new EvictingWindowOperator<>(
+			GlobalWindows.create(),
+			new GlobalWindow.Serializer(),
+			new TupleKeySelector(),
+			BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
+			stateDesc,
+			new InternalIterableWindowFunction<>(new RichSumReducer<GlobalWindow>(closeCalled)),
+			CountTrigger.of(TRIGGER_COUNT),
+			DeltaEvictor.of(THRESHOLD, new DeltaFunction<Tuple2<String, Integer>>() {
+				@Override
+				public double getDelta(Tuple2<String, Integer> oldDataPoint, Tuple2<String, Integer> newDataPoint) {
+					return newDataPoint.f1 - oldDataPoint.f1;
+				}
+			}, EVICT_AFTER),
+			0);
+
+
+
+		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
+			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
+
+		long initialTime = 0L;
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 3000));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 4), initialTime + 3999));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 20));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 5), initialTime + 999));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 5), initialTime + 1998));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 6), initialTime + 1999));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 1000));
+
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 4), Long.MAX_VALUE));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 11), Long.MAX_VALUE));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 2), Long.MAX_VALUE));
+
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 3), initialTime + 10999));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 10), initialTime + 1000));
+
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 8), Long.MAX_VALUE));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 10), Long.MAX_VALUE));
+
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+
+		testHarness.close();
+
+		Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+	}
+
+	/**
+	 * Tests DeltaEvictor, evictAfter behavior
+	 * @throws Exception
+	 */
+	@Test
+	public void testDeltaEvictorEvictAfter() throws Exception {
+		AtomicInteger closeCalled = new AtomicInteger(0);
+		final int TRIGGER_COUNT = 2;
+		final boolean EVICT_AFTER = true;
+		final int THRESHOLD = 2;
+
+		TypeInformation<Tuple2<String, Integer>> inputType = TypeInfoParser.parse("Tuple2<String, Integer>");
+
+		@SuppressWarnings({"unchecked", "rawtypes"})
+		TypeSerializer<StreamRecord<Tuple2<String, Integer>>> streamRecordSerializer =
+			(TypeSerializer<StreamRecord<Tuple2<String, Integer>>>) new StreamElementSerializer(inputType.createSerializer(new ExecutionConfig()));
+
+		ListStateDescriptor<StreamRecord<Tuple2<String, Integer>>> stateDesc =
+			new ListStateDescriptor<>("window-contents", streamRecordSerializer);
+
+
+		EvictingWindowOperator<String, Tuple2<String, Integer>, Tuple2<String, Integer>, GlobalWindow> operator = new EvictingWindowOperator<>(
+			GlobalWindows.create(),
+			new GlobalWindow.Serializer(),
+			new TupleKeySelector(),
+			BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
+			stateDesc,
+			new InternalIterableWindowFunction<>(new RichSumReducer<GlobalWindow>(closeCalled)),
+			CountTrigger.of(TRIGGER_COUNT),
+			DeltaEvictor.of(THRESHOLD, new DeltaFunction<Tuple2<String, Integer>>() {
+				@Override
+				public double getDelta(Tuple2<String, Integer> oldDataPoint, Tuple2<String, Integer> newDataPoint) {
+					return newDataPoint.f1 - oldDataPoint.f1;
+				}
+			}, EVICT_AFTER),
+			0);
+
+
+
+		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
+			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
+
+		long initialTime = 0L;
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 3000));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 4), initialTime + 3999));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime + 20));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), initialTime));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 5), initialTime + 999));
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 5), initialTime + 1998));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 6), initialTime + 1999));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), initialTime + 1000));
+
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 5), Long.MAX_VALUE));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 15), Long.MAX_VALUE));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 2), Long.MAX_VALUE));
+
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 9), initialTime + 10999));
+		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 10), initialTime + 1000));
+
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key1", 16), Long.MAX_VALUE));
+		expectedOutput.add(new StreamRecord<>(new Tuple2<>("key2", 22), Long.MAX_VALUE));
+
+		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new ResultSortComparator());
+
+		testHarness.close();
+
+		Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+	}
 
 	@Test
 	@SuppressWarnings("unchecked")
@@ -316,6 +771,7 @@ public class EvictingWindowOperatorTest {
 			for (Tuple2<String, Integer> t: input) {
 				sum += t.f1;
 			}
+
 			out.collect(new Tuple2<>(key, sum));
 
 		}


### PR DESCRIPTION
The PR implements [FLINK-4174](https://issues.apache.org/jira/browse/FLINK-4174) Enhance window evictor as proposed in [FLIP-4](https://cwiki.apache.org/confluence/display/FLINK/FLIP-4+%3A+Enhance+Window+Evictor)

Changes made:

- Modified the Evictor API, added two new methods evictBefore and evictAfter. Removed existing evict method
- Modified the corresponding implementations of CountEvictor, DeltaEvictor and TimeEvictor
- Created EvictorContext in the class EvictingWindowOperator, which is passed to the evictor methods
- Created TimestampedValue class which holds the value with corresponding timestamp. This class is exposed to the user via the evictBefore and evictAfter methods.
- Modified EvictingWindowOperator class 
	- to call evictBefore before calling window function and evictAfter after calling window function.
	- create FluentIterable<TimestampedValue<IN>> from Iterable<StreamRecord<IN>> contents, which is passed to the evictor methods.
	- to clear the windowstate and add the remaining element(after the eviction) back to the state. (this fixes [FLINK-4369](https://issues.apache.org/jira/browse/FLINK-4369))
- Added test cases in EvictingWindowOperatorTest.