### PR TITLE
[FLINK-4991] [taskmanager] Fix too aggressive timeout and improve logging in TaskTest

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -1267,6 +1267,7 @@ public class Task implements Runnable, TaskActions {
 			try {
 				if (watchDogThread != null) {
 					watchDogThread.start();
+					logger.info("Started cancellation watch dog");
 				}
 
 				// the user-defined cancel method may throw errors.
@@ -1357,6 +1358,8 @@ public class Task implements Runnable, TaskActions {
 								taskName,
 								duration,
 								bld.toString());
+
+						logger.info("Notifying TaskManager about fatal error. {}.", msg);
 
 						taskManager.notifyFatalError(msg, null);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -579,7 +579,7 @@ public class TaskTest extends TestLogger {
 	public void testWatchDogInterruptsTask() throws Exception {
 		Configuration config = new Configuration();
 		config.setLong(TaskManagerOptions.TASK_CANCELLATION_INTERVAL.key(), 5);
-		config.setLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT.key(), 50);
+		config.setLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT.key(), 60 * 1000);
 
 		Task task = createTask(InvokableBlockingInCancel.class, config);
 		task.startTaskThread();


### PR DESCRIPTION
The test failure was caused by a too aggressive cancellation timeout. If the watch dog interrupts the task a little later due to some CI system hick up the cancellation deadline passes and the test is stuck.

Waiting for Travis and then merging this.