### PR TITLE
[FLINK-4998][yarn] fail if too many task slots are configured

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -301,6 +301,14 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			throw new YarnDeploymentException("Flink configuration object has not been set");
 		}
 
+		int numYarnVcores = conf.getInt(YarnConfiguration.NM_VCORES, YarnConfiguration.DEFAULT_NM_VCORES);
+		// don't configure more than the maximum configured number of vcores
+		if (slots > numYarnVcores) {
+			throw new IllegalConfigurationException(
+				String.format("The number of task slots per node was configured with %d" +
+					" but Yarn only has %d virtual cores available.", slots, numYarnVcores));
+		}
+
 		// check if required Hadoop environment variables are set. If not, warn user
 		if(System.getenv("HADOOP_CONF_DIR") == null &&
 			System.getenv("YARN_CONF_DIR") == null) {
@@ -717,14 +725,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		appMasterEnv.putAll(Utils.getEnvironmentVariables(ConfigConstants.YARN_APPLICATION_MASTER_ENV_PREFIX, flinkConfiguration));
 		// set Flink app class path
 		appMasterEnv.put(YarnConfigKeys.ENV_FLINK_CLASSPATH, classPathBuilder.toString());
-
-		int numYarnVcores = conf.getInt(YarnConfiguration.NM_VCORES, YarnConfiguration.DEFAULT_NM_VCORES);
-		// don't configure more than the maximum configured number of vcores
-		if (slots > numYarnVcores) {
-			throw new IllegalConfigurationException(
-				String.format("The number of task slots per node was configured with %d" +
-					" but Yarn only has %d virtual cores available.", slots, numYarnVcores));
-		}
 
 		// set Flink on YARN internal configuration values
 		appMasterEnv.put(YarnConfigKeys.ENV_TM_COUNT, String.valueOf(taskManagerCount));

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.yarn;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+public class YarnClusterDescriptorTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private File flinkJar;
+	private File flinkConf;
+
+	@Before
+	public void beforeTest() throws IOException {
+		temporaryFolder.create();
+		flinkJar = temporaryFolder.newFile("flink.jar");
+		flinkConf = temporaryFolder.newFile("flink-conf.yaml");
+	}
+
+	@Test
+	public void testFailIfTaskSlotsHigherThanMaxVcores() {
+
+
+		YarnClusterDescriptor clusterDescriptor = new YarnClusterDescriptor();
+
+		clusterDescriptor.setLocalJarPath(new Path(flinkJar.getPath()));
+		clusterDescriptor.setFlinkConfiguration(new Configuration());
+		clusterDescriptor.setConfigurationDirectory(temporaryFolder.getRoot().getAbsolutePath());
+		clusterDescriptor.setConfigurationFilePath(new Path(flinkConf.getPath()));
+
+		// configure slots too high
+		clusterDescriptor.setTaskManagerSlots(Integer.MAX_VALUE);
+
+		try {
+			clusterDescriptor.deploy();
+		} catch (Exception e) {
+			Assert.assertTrue(e.getCause() instanceof IllegalConfigurationException);
+		}
+	}
+
+
+}


### PR DESCRIPTION
This fails the deployment of the Yarn application if the number of task
slots are configured to be larger than the maximum virtual cores of the
Yarn cluster.