### PR TITLE
[yarn] fix debug string displayed for failed applications

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
@@ -420,7 +420,7 @@ public class YarnClusterClient extends ClusterClient {
 				LOG.warn("Application failed. Diagnostics " + appReport.getDiagnostics());
 				LOG.warn("If log aggregation is activated in the Hadoop cluster, we recommend to retrieve "
 					+ "the full application log using this command:\n"
-					+ "\tyarn logs -appReport " + appReport.getApplicationId() + "\n"
+					+ "\tyarn logs -applicationId " + appReport.getApplicationId() + "\n"
 					+ "(It sometimes takes a few seconds until the logs are aggregated)");
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
Merging for `master` and `release-1.1`.