### PR TITLE
[FLINK-5019] Proper isRestored result for tasks that did not write state

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -245,12 +245,10 @@ public class PendingCheckpoint {
 				return false;
 			}
 
-			if (null != checkpointedSubtaskState && checkpointedSubtaskState.hasState()) {
+			if (null != checkpointedSubtaskState) {
 
 				JobVertexID jobVertexID = vertex.getJobvertexId();
-
 				int subtaskIndex = vertex.getParallelSubtaskIndex();
-
 				TaskState taskState = taskStates.get(jobVertexID);
 
 				if (null == taskState) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskState.java
@@ -212,13 +212,6 @@ public class SubtaskState implements StateObject {
 
 	}
 
-	public boolean hasState() {
-		return (null != legacyOperatorState && !legacyOperatorState.isEmpty())
-				|| (null != managedOperatorState && !managedOperatorState.isEmpty())
-				|| null != managedKeyedState
-				|| null != rawKeyedState;
-	}
-
 	@Override
 	public int hashCode() {
 		int result = legacyOperatorState != null ? legacyOperatorState.hashCode() : 0;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateHandles.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateHandles.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.runtime.checkpoint.SubtaskState;
-import org.apache.flink.util.CollectionUtil;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -97,14 +96,6 @@ public class TaskStateHandles implements Serializable {
 
 	public List<Collection<OperatorStateHandle>> getManagedOperatorState() {
 		return managedOperatorState;
-	}
-
-	public boolean hasState() {
-		return !ChainedStateHandle.isNullOrEmpty(legacyOperatorState)
-				|| !CollectionUtil.isNullOrEmpty(managedKeyedState)
-				|| !CollectionUtil.isNullOrEmpty(rawKeyedState)
-				|| !CollectionUtil.isNullOrEmpty(rawOperatorState)
-				|| !CollectionUtil.isNullOrEmpty(managedOperatorState);
 	}
 
 	private static List<Collection<OperatorStateHandle>> transform(ChainedStateHandle<OperatorStateHandle> in) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -887,11 +887,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 						keyedStateHandleBackend,
 						keyedStateHandleStream);
 
-				if (subtaskState.hasState()) {
-					owner.getEnvironment().acknowledgeCheckpoint(checkpointMetaData, subtaskState);
-				} else {
-					owner.getEnvironment().acknowledgeCheckpoint(checkpointMetaData);
-				}
+				owner.getEnvironment().acknowledgeCheckpoint(checkpointMetaData, subtaskState);
 
 				if (LOG.isDebugEnabled()) {
 					LOG.debug("{} - finished asynchronous part of checkpoint {}. Asynchronous duration: {} ms",

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -232,6 +232,7 @@ public class SavepointITCase extends TestLogger {
 			// Shut down the Flink cluster (thereby canceling the job)
 			LOG.info("Shutting down Flink cluster.");
 			flink.shutdown();
+			flink.awaitTermination();
 
 			// - Verification START -------------------------------------------
 
@@ -339,6 +340,7 @@ public class SavepointITCase extends TestLogger {
 					SubtaskState subtaskState = taskState.getState(tdd.getIndexInSubtaskGroup());
 
 					assertNotNull(subtaskState);
+
 					errMsg = "Initial operator state mismatch.";
 					assertEquals(errMsg, subtaskState.getLegacyOperatorState(),
 							tdd.getTaskStateHandles().getLegacyOperatorState());


### PR DESCRIPTION
When a subtask is restored from a checkpoint that does not contain any state (e.g. because the subtask did not write state in the previous run), the result of ``StateInitializationContext::isRestored`` will incorrectly return false.
This PR ensures that empty state is reflected in a checkpoint and that true is returned from the method on restore, independent from the presence of state.

Furthermore, `SubtaskState::hasState` ignored raw operator state and returned false even if there was raw operator state. PR includes a unit test to catch this problem.