### PR TITLE
[FLINK-5007] [checkpointing] Retain externalized checkpoint on suspension

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointProperties.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointProperties.java
@@ -264,6 +264,8 @@ public class CheckpointProperties implements Serializable {
 	 * @return Checkpoint properties for an external checkpoint.
 	 */
 	public static CheckpointProperties forExternalizedCheckpoint(boolean deleteOnCancellation) {
-		return new CheckpointProperties(false, true, true, true, deleteOnCancellation, false, true);
+		// Handle suspension like cancellation as graceful cluster shut down
+		// suspends all jobs (non-HA).
+		return new CheckpointProperties(false, true, true, true, deleteOnCancellation, false, deleteOnCancellation);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointPropertiesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointPropertiesTest.java
@@ -48,7 +48,7 @@ public class CheckpointPropertiesTest {
 	 * Tests the external checkpoints properties.
 	 */
 	@Test
-	public void testPersistentCheckpointProperties() {
+	public void testExternalizedCheckpointProperties() {
 		CheckpointProperties props = CheckpointProperties.forExternalizedCheckpoint(true);
 
 		assertFalse(props.forceCheckpoint());
@@ -67,7 +67,7 @@ public class CheckpointPropertiesTest {
 		assertTrue(props.discardOnJobFinished());
 		assertFalse(props.discardOnJobCancelled());
 		assertFalse(props.discardOnJobFailed());
-		assertTrue(props.discardOnJobSuspended());
+		assertFalse(props.discardOnJobSuspended());
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -235,8 +235,9 @@ public class CheckpointConfig implements java.io.Serializable {
 	 *
 	 * <p>Externalized checkpoints write their meta data out to persistent
 	 * storage and are <strong>not</strong> automatically cleaned up when
-	 * the owning job fails (terminating with job status {@link JobStatus#FAILED}).
-	 * In this case, you have to manually clean up the checkpoint state, both
+	 * the owning job fails or is suspended (terminating with job status
+	 * {@link JobStatus#FAILED} or {@link JobStatus#SUSPENDED}). In this
+	 * case, you have to manually clean up the checkpoint state, both
 	 * the meta data and actual program state.
 	 *
 	 * <p>The {@link ExternalizedCheckpointCleanup} mode defines how an


### PR DESCRIPTION
Handles graceful cluster shut down (non-HA) like cancellation and respects the configured clean up behaviour.

```
ExternalizedCheckpointCleanup.DELETE_ON_CANCELLATION => delete on suspension

ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION => retain on suspension
```