### PR TITLE
[FLINK-4814] [checkpointing] Use checkpoint directory for externalized checkpoints

### DIFF
--- a/docs/setup/cli.md
+++ b/docs/setup/cli.md
@@ -146,7 +146,7 @@ This allows the job to finish processing all inflight data.
 
 Returns the path of the created savepoint. You need this path to restore and dispose savepoints.
 
-You can optionally specify a `savepointDirectory` when triggering the savepoint. If you don't specify one here, you need to configure a default savepoint directory for the Flink installation (see [[savepoint.html#configuration]]).
+You can optionally specify a `savepointDirectory` when triggering the savepoint. If you don't specify one here, you need to configure a default savepoint directory for the Flink installation (see [Savepoints](savepoints.html#configuration)).
 
 ##### Cancel with a savepoint
 
@@ -156,7 +156,7 @@ You can atomically trigger a savepoint and cancel a job.
 ./bin/flink cancel -s  [savepointDirectory] <jobID>
 {% endhighlight %}
 
-If no savepoint directory is configured, you need to configure a default savepoint directory for the Flink installation (see [[savepoint.html#configuration]]).
+If no savepoint directory is configured, you need to configure a default savepoint directory for the Flink installation (see [Savepoints](savepoints.html#configuration)).
 
 The job will only be cancelled if the savepoint succeeds.
 

--- a/docs/setup/fault_tolerance.md
+++ b/docs/setup/fault_tolerance.md
@@ -98,6 +98,25 @@ env.getCheckpointConfig.setMaxConcurrentCheckpoints(1)
 
 {% top %}
 
+### Externalized Checkpoints
+
+You can configure periodic checkpoints to be persisted externally. Externalized checkpoints write their meta data out to persistent storage and are *not* automatically cleaned up when the job fails. This way, you will have a checkpoint around to resume from if your job fails.
+
+```java
+CheckpoingConfig config = env.getCheckpointConfig();
+config.enableExternalizedCheckpoints(ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
+```
+
+The `ExternalizedCheckpointCleanup` mode configures what happens with externalized checkpoints when you cancel the job:
+
+- **`ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION`**: Retain the externalized checkpoint when the job is cancelled. Note that you have to manually clean up the checkpoint state after cancellation in this case.
+
+- **`ExternalizedCheckpointCleanup.DELETE_ON_CANCELLATION`**: Delete the externalized checkpoint when the job is cancelled. The checkpoint state will only be available if the job fails.
+
+The target directory for the checkpoint is determined from the checkpoint directory of the state backend. For the file system based backends like `FsStateBackend` or `RocksDBStateBackend` this will be the configured checkpoint directory. For `MemoryStateBackend` you have to manually configure one via `setCheckpointDirectory(Path)`. Check out the [state backends section]({{ site.baseurl }}/dev/state_backends.html) for more details about the available backends.
+
+ Follow the [savepoint guide]({{ site.baseurl }}/setup/cli.html#savepoints) when you want to resume from a specific  checkpoint.
+
 ### Fault Tolerance Guarantees of Data Sources and Sinks
 
 Flink can guarantee exactly-once state updates to user-defined state only when the source participates in the

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.client.cli.CliFrontendParser;
 import org.apache.flink.client.cli.RunOptions;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -101,7 +102,7 @@ public class CliFrontendRunTest {
 				RunOptions options = CliFrontendParser.parseRunCommand(parameters);
 				SavepointRestoreSettings savepointSettings = options.getSavepointRestoreSettings();
 				assertTrue(savepointSettings.restoreSavepoint());
-				assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
+				assertEquals(new Path("expectedSavepointPath"), savepointSettings.getRestorePath());
 				assertFalse(savepointSettings.allowNonRestoredState());
 			}
 
@@ -111,7 +112,7 @@ public class CliFrontendRunTest {
 				RunOptions options = CliFrontendParser.parseRunCommand(parameters);
 				SavepointRestoreSettings savepointSettings = options.getSavepointRestoreSettings();
 				assertTrue(savepointSettings.restoreSavepoint());
-				assertEquals("expectedSavepointPath", savepointSettings.getRestorePath());
+				assertEquals(new Path("expectedSavepointPath"), savepointSettings.getRestorePath());
 				assertTrue(savepointSettings.allowNonRestoredState());
 			}
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -61,6 +61,7 @@ import static java.util.Objects.requireNonNull;
  * {@link #setOptions(OptionsFactory)}.
  */
 public class RocksDBStateBackend extends AbstractStateBackend {
+
 	private static final long serialVersionUID = 1L;
 
 	private static final Logger LOG = LoggerFactory.getLogger(RocksDBStateBackend.class);
@@ -139,7 +140,6 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 		this.checkpointStreamBackend = fsStateBackend;
 	}
 
-
 	public RocksDBStateBackend(String checkpointDataUri, AbstractStateBackend nonPartitionedStateBackend) throws IOException {
 		this(new Path(checkpointDataUri).toUri(), nonPartitionedStateBackend);
 	}
@@ -156,6 +156,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 		ois.defaultReadObject();
 		isInitialized = false;
 	}
+
 	// ------------------------------------------------------------------------
 	//  State backend methods
 	// ------------------------------------------------------------------------
@@ -277,6 +278,11 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 				numberOfKeyGroups,
 				keyGroupRange,
 				restoredState);
+	}
+
+	@Override
+	public Path getCheckpointDirectory() {
+		return checkpointStreamBackend.getCheckpointDirectory();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -937,10 +937,6 @@ public final class ConfigConstants {
 	@PublicEvolving
 	public static final String SAVEPOINT_DIRECTORY_KEY = "state.savepoints.dir";
 
-	/** The default directory used for persistent checkpoints. */
-	@PublicEvolving
-	public static final String CHECKPOINTS_DIRECTORY_KEY = "state.checkpoints.dir";
-
 	/**
 	 * This key was used in Flink versions <= 1.1.X with the savepoint backend
 	 * configuration. We now always use the FileSystem for savepoints. For this,

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobCheckpointsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobCheckpointsHandler.java
@@ -58,7 +58,7 @@ public class JobCheckpointsHandler extends AbstractExecutionGraphRequestHandler 
 
 				// Optional external path
 				if (jobStats.getExternalPath() != null) {
-					gen.writeStringField("external-path", jobStats.getExternalPath());
+					gen.writeStringField("external-path", jobStats.getExternalPath().toString());
 				}
 
 				// Duration

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobCheckpointsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobCheckpointsHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.webmonitor.handlers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.stats.CheckpointStats;
 import org.apache.flink.runtime.checkpoint.stats.CheckpointStatsTracker;
 import org.apache.flink.runtime.checkpoint.stats.JobCheckpointStats;
@@ -106,7 +107,7 @@ public class JobCheckpointsHandlerTest {
 			}
 
 			@Override
-			public String getExternalPath() {
+			public Path getExternalPath() {
 				return null;
 			}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.stats.CheckpointStatsTracker;
@@ -172,7 +173,9 @@ public class CheckpointCoordinator {
 		checkArgument(minPauseBetweenCheckpoints >= 0, "minPauseBetweenCheckpoints must be >= 0");
 		checkArgument(maxConcurrentCheckpointAttempts >= 1, "maxConcurrentCheckpointAttempts must be >= 1");
 
-		if (externalizeSettings.externalizeCheckpoints() && checkpointDirectory == null) {
+		if (externalizeSettings.externalizeCheckpoints() &&
+				tasksToTrigger.length != 0 &&
+				checkpointDirectory == null) {
 			throw new IllegalStateException("CheckpointConfig says to persist periodic " +
 					"checkpoints, but no checkpoint directory has been configured.");
 		}
@@ -853,6 +856,11 @@ public class CheckpointCoordinator {
 
 	public long getCheckpointTimeout() {
 		return checkpointTimeout;
+	}
+
+	@VisibleForTesting
+	public Path getCheckpointDirectory() {
+		return checkpointDirectory;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.stats.CheckpointStatsTracker;
 import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
@@ -96,7 +96,7 @@ public class CheckpointCoordinator {
 	private final CompletedCheckpointStore completedCheckpointStore;
 
 	/** Default directory for persistent checkpoints; <code>null</code> if none configured. */
-	private final String checkpointDirectory;
+	private final Path checkpointDirectory;
 
 	/** A list of recent checkpoint IDs, to identify late messages (vs invalid ones) */
 	private final ArrayDeque<Long> recentPendingCheckpoints;
@@ -163,7 +163,7 @@ public class CheckpointCoordinator {
 			ExecutionVertex[] tasksToCommitTo,
 			CheckpointIDCounter checkpointIDCounter,
 			CompletedCheckpointStore completedCheckpointStore,
-			String checkpointDirectory,
+			Path checkpointDirectory,
 			CheckpointStatsTracker statsTracker) {
 
 		// sanity checks
@@ -174,8 +174,7 @@ public class CheckpointCoordinator {
 
 		if (externalizeSettings.externalizeCheckpoints() && checkpointDirectory == null) {
 			throw new IllegalStateException("CheckpointConfig says to persist periodic " +
-					"checkpoints, but no checkpoint directory has been configured. You can " +
-					"configure configure one via key '" + ConfigConstants.CHECKPOINTS_DIRECTORY_KEY + "'.");
+					"checkpoints, but no checkpoint directory has been configured.");
 		}
 
 		// it does not make sense to schedule checkpoints more often then the desired
@@ -270,7 +269,7 @@ public class CheckpointCoordinator {
 	 *                               configured
 	 * @throws Exception             Failures during triggering are forwarded
 	 */
-	public Future<CompletedCheckpoint> triggerSavepoint(long timestamp, String targetDirectory) throws Exception {
+	public Future<CompletedCheckpoint> triggerSavepoint(long timestamp, Path targetDirectory) throws Exception {
 		checkNotNull(targetDirectory, "Savepoint target directory");
 
 		CheckpointProperties props = CheckpointProperties.forStandardSavepoint();
@@ -302,7 +301,7 @@ public class CheckpointCoordinator {
 	CheckpointTriggerResult triggerCheckpoint(
 			long timestamp,
 			CheckpointProperties props,
-			String targetDirectory,
+			Path targetDirectory,
 			boolean isPeriodic) throws Exception {
 
 		// Sanity check

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointStore;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -61,7 +62,7 @@ public class CompletedCheckpoint implements Serializable {
 	private final CheckpointProperties props;
 
 	/** External path if persisted checkpoint; <code>null</code> otherwise. */
-	private final String externalPath;
+	private final Path externalPath;
 
 	// ------------------------------------------------------------------------
 
@@ -82,7 +83,7 @@ public class CompletedCheckpoint implements Serializable {
 			long completionTimestamp,
 			Map<JobVertexID, TaskState> taskStates,
 			CheckpointProperties props,
-			String externalPath) {
+			Path externalPath) {
 
 		checkArgument(checkpointID >= 0);
 		checkArgument(timestamp >= 0);
@@ -182,7 +183,7 @@ public class CompletedCheckpoint implements Serializable {
 		return taskStates.get(jobVertexID);
 	}
 
-	public String getExternalPath() {
+	public Path getExternalPath() {
 		return externalPath;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -104,12 +104,12 @@ public class PendingCheckpoint {
 		this.targetDirectory = targetDirectory;
 
 		// Sanity check
+		checkArgument(verticesToConfirm.size() > 0,
+				"Checkpoint needs at least one vertex that commits the checkpoint");
+
 		if (props.externalizeCheckpoint() && targetDirectory == null) {
 			throw new NullPointerException("No target directory specified to persist checkpoint to.");
 		}
-
-		checkArgument(verticesToConfirm.size() > 0,
-				"Checkpoint needs at least one vertex that commits the checkpoint");
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoader.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint.savepoint;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.CheckpointProperties;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.TaskState;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoader.java
@@ -55,7 +55,7 @@ public class SavepointLoader {
 	public static CompletedCheckpoint loadAndValidateSavepoint(
 			JobID jobId,
 			Map<JobVertexID, ExecutionJobVertex> tasks,
-			String savepointPath,
+			Path savepointPath,
 			boolean allowNonRestoredState) throws IOException {
 
 		// (1) load the savepoint

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/stats/JobCheckpointStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/stats/JobCheckpointStats.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint.stats;
 
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.core.fs.Path;
 
 import java.io.Serializable;
 import java.util.List;
@@ -53,7 +54,7 @@ public interface JobCheckpointStats extends Serializable {
 	 *
 	 * @return External checkpoint path or <code>null</code> if none available.
 	 */
-	String getExternalPath();
+	Path getExternalPath();
 
 	// ------------------------------------------------------------------------
 	// Duration

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/stats/SimpleCheckpointStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/stats/SimpleCheckpointStatsTracker.java
@@ -279,7 +279,7 @@ public class SimpleCheckpointStatsTracker implements CheckpointStatsTracker {
 						// Need to clone in order to have a consistent snapshot.
 						// We can safely update it afterwards.
 						(List<CheckpointStats>) history.clone(),
-						latestCompletedCheckpoint.getExternalPath(),
+						latestCompletedCheckpoint.getExternalPath().toString(),
 						overallCount,
 						overallMinDuration,
 						overallMaxDuration,
@@ -459,7 +459,7 @@ public class SimpleCheckpointStatsTracker implements CheckpointStatsTracker {
 		public String getValue() {
 			CompletedCheckpoint checkpoint = latestCompletedCheckpoint;
 			if (checkpoint != null && checkpoint.getExternalPath() != null) {
-				return checkpoint.getExternalPath();
+				return checkpoint.getExternalPath().toString();
 			} else {
 				return "n/a";
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/stats/SimpleCheckpointStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/stats/SimpleCheckpointStatsTracker.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.checkpoint.stats;
 
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
@@ -279,7 +280,7 @@ public class SimpleCheckpointStatsTracker implements CheckpointStatsTracker {
 						// Need to clone in order to have a consistent snapshot.
 						// We can safely update it afterwards.
 						(List<CheckpointStats>) history.clone(),
-						latestCompletedCheckpoint.getExternalPath().toString(),
+						latestCompletedCheckpoint.getExternalPath(),
 						overallCount,
 						overallMinDuration,
 						overallMaxDuration,
@@ -353,7 +354,7 @@ public class SimpleCheckpointStatsTracker implements CheckpointStatsTracker {
 		// General
 		private final List<CheckpointStats> recentHistory;
 		private final long count;
-		private final String externalPath;
+		private final Path externalPath;
 
 		// Duration
 		private final long minDuration;
@@ -367,7 +368,7 @@ public class SimpleCheckpointStatsTracker implements CheckpointStatsTracker {
 
 		public JobCheckpointStatsSnapshot(
 				List<CheckpointStats> recentHistory,
-				String externalPath,
+				Path externalPath,
 				long count,
 				long minDuration,
 				long maxDuration,
@@ -379,6 +380,7 @@ public class SimpleCheckpointStatsTracker implements CheckpointStatsTracker {
 			this.recentHistory = recentHistory;
 			this.count = count;
 			this.externalPath = externalPath;
+
 
 			this.minDuration = minDuration;
 			this.maxDuration = maxDuration;
@@ -400,7 +402,7 @@ public class SimpleCheckpointStatsTracker implements CheckpointStatsTracker {
 		}
 
 		@Override
-		public String getExternalPath() {
+		public Path getExternalPath() {
 			return externalPath;
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.AccumulatorHelper;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
@@ -348,7 +349,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 			List<ExecutionJobVertex> verticesToCommitTo,
 			CheckpointIDCounter checkpointIDCounter,
 			CompletedCheckpointStore checkpointStore,
-			String checkpointDir,
+			Path checkpointDir,
 			CheckpointStatsTracker statsTracker) {
 
 		// simple sanity checks

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -185,6 +185,7 @@ public class ExecutionGraphBuilder {
 			}
 
 			/** The default directory for externalized checkpoints. */
+			// TODO create state backend and get directory
 			String externalizedCheckpointsDir = jobManagerConfig.getString(
 					ConfigConstants.CHECKPOINTS_DIRECTORY_KEY, null);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
@@ -39,6 +40,8 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.jsonplan.JsonPlanGenerator;
 import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
+import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.StateUtil;
 import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
@@ -184,10 +187,34 @@ public class ExecutionGraphBuilder {
 				checkpointStatsTracker = new SimpleCheckpointStatsTracker(historySize, ackVertices, metrics);
 			}
 
-			/** The default directory for externalized checkpoints. */
-			// TODO create state backend and get directory
-			String externalizedCheckpointsDir = jobManagerConfig.getString(
-					ConfigConstants.CHECKPOINTS_DIRECTORY_KEY, null);
+			// Directory for externalized checkpoints.
+			Path checkpointDirectory = null;
+
+			if (snapshotSettings.getExternalizedCheckpointSettings().externalizeCheckpoints()
+					&& !triggerVertices.isEmpty()) {
+
+				// The JobVertex config contains the StreamConfig (see StreamingJobGraphGenerator)
+				Configuration streamConfig = triggerVertices.get(0).getJobVertex().getConfiguration();
+
+				AbstractStateBackend backend = StateUtil.deserializeStateBackend(streamConfig, classLoader);
+
+				if (backend != null) {
+					log.debug("Using user-defined state backend: " + backend);
+				} else {
+					try {
+						backend = StateUtil.createStateBackend(log, jobManagerConfig, classLoader);
+					} catch (Exception e) {
+						throw new RuntimeException("Failed to instantiate StateBackend", e);
+					}
+
+					if (backend == null) {
+						throw new IllegalStateException("No state backend configured to " +
+								"determine checkpoint directory for externalized checkpoints.");
+					}
+				}
+
+				checkpointDirectory = backend.getCheckpointDirectory();
+			}
 
 			executionGraph.enableSnapshotCheckpointing(
 					snapshotSettings.getCheckpointInterval(),
@@ -200,7 +227,7 @@ public class ExecutionGraphBuilder {
 					confirmVertices,
 					checkpointIdCounter,
 					completedCheckpoints,
-					externalizedCheckpointsDir,
+					checkpointDirectory,
 					checkpointStatsTracker);
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.jobgraph;
 
+import org.apache.flink.core.fs.Path;
+
 import java.io.Serializable;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -36,7 +38,7 @@ public class SavepointRestoreSettings implements Serializable {
 	private final static boolean DEFAULT_ALLOW_NON_RESTORED_STATE = false;
 
 	/** Savepoint restore path. */
-	private final String restorePath;
+	private final Path restorePath;
 
 	/**
 	 * Flag indicating whether non restored state is allowed if the savepoint
@@ -50,7 +52,7 @@ public class SavepointRestoreSettings implements Serializable {
 	 * @param restorePath Savepoint restore path.
 	 * @param allowNonRestoredState Ignore unmapped state.
 	 */
-	private SavepointRestoreSettings(String restorePath, boolean allowNonRestoredState) {
+	private SavepointRestoreSettings(Path restorePath, boolean allowNonRestoredState) {
 		this.restorePath = restorePath;
 		this.allowNonRestoredState = allowNonRestoredState;
 	}
@@ -68,7 +70,7 @@ public class SavepointRestoreSettings implements Serializable {
 	 * @return Path to the savepoint to restore from or <code>null</code> if
 	 * should not restore.
 	 */
-	public String getRestorePath() {
+	public Path getRestorePath() {
 		return restorePath;
 	}
 
@@ -124,7 +126,7 @@ public class SavepointRestoreSettings implements Serializable {
 
 	public static SavepointRestoreSettings forPath(String savepointPath, boolean allowNonRestoredState) {
 		checkNotNull(savepointPath, "Savepoint restore path.");
-		return new SavepointRestoreSettings(savepointPath, allowNonRestoredState);
+		return new SavepointRestoreSettings(new Path(savepointPath), allowNonRestoredState);
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 
@@ -30,6 +31,7 @@ import java.util.Collection;
  * A state backend defines how state is stored and snapshotted during checkpoints.
  */
 public abstract class AbstractStateBackend implements java.io.Serializable {
+
 	private static final long serialVersionUID = 4620415814639230247L;
 
 	/**
@@ -73,6 +75,12 @@ public abstract class AbstractStateBackend implements java.io.Serializable {
 			TaskKvStateRegistry kvStateRegistry
 	) throws Exception;
 
+	/**
+	 * Returns the directory for externalized checkpoints.
+	 *
+	 * @return Path to target directory for externalized checkpoints.
+	 */
+	public abstract Path getCheckpointDirectory();
 
 	/**
 	 * Creates a new {@link OperatorStateBackend} that can be used for storing partitionable operator

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
@@ -18,10 +18,23 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.util.InstantiationUtil;
+import org.slf4j.Logger;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * Helpers for {@link StateObject} related code.
  */
 public class StateUtil {
+
+	private static final String STATE_BACKEND = "statebackend";
 
 	private StateUtil() {
 		throw new AssertionError();
@@ -61,4 +74,106 @@ public class StateUtil {
 			}
 		}
 	}
+
+	/**
+	 * Creates a state backend from the configuration.
+	 *
+	 * If no state backend is configured, the memory state backend will be used.
+	 *
+	 * @param logger Logger to sue.
+	 * @param flinkConfig Configuration to parse state backend configuration.
+	 * @param userCodeLoader User code class loader.
+	 * @return The configured state backend.
+	 * @throws IllegalConfigurationException If the configured backend cannot be instantiated.
+	 * @throws Exception State backend instantiation failures are forwarded.
+	 */
+	public static AbstractStateBackend createStateBackend(
+			Logger logger,
+			Configuration flinkConfig,
+			ClassLoader userCodeLoader) throws Exception {
+
+		checkNotNull(logger, "Logger");
+		checkNotNull(flinkConfig, "Flink Configuration");
+		checkNotNull(logger, "User Code ClassLoader");
+
+		// see if we have a backend specified in the configuration
+		String backendName = flinkConfig.getString(ConfigConstants.STATE_BACKEND, null);
+
+		if (backendName == null) {
+			logger.warn("No state backend has been specified, using default state backend (Memory / JobManager)");
+			backendName = "jobmanager";
+		}
+
+		AbstractStateBackend stateBackend;
+		switch (backendName.toLowerCase()) {
+			case "jobmanager":
+				logger.info("State backend is set to heap memory (checkpoint to jobmanager)");
+				stateBackend = new MemoryStateBackend();
+				break;
+
+			case "filesystem":
+				FsStateBackend backend = new FsStateBackendFactory().createFromConfig(flinkConfig);
+				logger.info("State backend is set to heap memory (checkpoints to filesystem \""
+						+ backend.getBasePath() + "\")");
+				stateBackend = backend;
+				break;
+
+			case "rocksdb":
+				backendName = "org.apache.flink.contrib.streaming.state.RocksDBStateBackendFactory";
+				// fall through to the 'default' case that uses reflection to load the backend
+				// that way we can keep RocksDB in a separate module
+
+			default:
+				try {
+					@SuppressWarnings("rawtypes")
+					Class<? extends StateBackendFactory> clazz =
+							Class.forName(backendName, false, userCodeLoader).
+									asSubclass(StateBackendFactory.class);
+
+					stateBackend = clazz.newInstance().createFromConfig(flinkConfig);
+				} catch (ClassNotFoundException e) {
+					throw new IllegalConfigurationException("Cannot find configured state backend: " + backendName);
+				} catch (ClassCastException e) {
+					throw new IllegalConfigurationException("The class configured under '" +
+							ConfigConstants.STATE_BACKEND + "' is not a valid state backend factory (" +
+							backendName + ')');
+				} catch (Throwable t) {
+					throw new IllegalConfigurationException("Cannot create configured state backend", t);
+				}
+		}
+
+		return stateBackend;
+	}
+
+	/**
+	 * Serializes a state backend into a config instance.
+	 *
+	 * @param config Configuration to serialized backend to.
+	 * @param stateBackend State backend to serialize.
+	 */
+	public static void serializeStateBackend(Configuration config, AbstractStateBackend stateBackend) {
+		if (stateBackend != null) {
+			try {
+				InstantiationUtil.writeObjectToConfig(stateBackend, config, StateUtil.STATE_BACKEND);
+			} catch (Exception e) {
+				throw new RuntimeException("Could not serialize stateHandle provider.", e);
+			}
+		}
+	}
+
+	/**
+	 * Deserialize a state backend from a config instance.
+	 *
+	 * @param config Configuration to deserialize backend from.
+	 * @param userCodeLoader User code class loader.
+	 * @return The deserialized state backend
+	 */
+	public static AbstractStateBackend deserializeStateBackend(Configuration config, ClassLoader userCodeLoader) {
+		try {
+			return InstantiationUtil.readObjectFromConfig(config, STATE_BACKEND, userCodeLoader);
+		} catch (Exception e) {
+			throw new RuntimeException("Could not instantiate statehandle provider.", e);
+		}
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -211,6 +211,11 @@ public class FsStateBackend extends AbstractStateBackend {
 	}
 
 	@Override
+	public Path getCheckpointDirectory() {
+		return basePath;
+	}
+
+	@Override
 	public String toString() {
 		return "File State Backend @ " + basePath;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -1260,7 +1260,7 @@ public class CheckpointCoordinatorTest {
 		assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
 
 		// trigger the first checkpoint. this should succeed
-		String savepointDir = tmpFolder.newFolder().getAbsolutePath();
+		Path savepointDir = new Path(tmpFolder.newFolder().getAbsolutePath());
 		Future<CompletedCheckpoint> savepointFuture = coord.triggerSavepoint(timestamp, savepointDir);
 		assertFalse(savepointFuture.isDone());
 
@@ -1393,7 +1393,7 @@ public class CheckpointCoordinatorTest {
 				null,
 				new DisabledCheckpointStatsTracker());
 
-		String savepointDir = tmpFolder.newFolder().getAbsolutePath();
+		Path savepointDir = new Path(tmpFolder.newFolder().getAbsolutePath());
 
 		// Trigger savepoint and checkpoint
 		Future<CompletedCheckpoint> savepointFuture1 = coord.triggerSavepoint(timestamp, savepointDir);
@@ -1707,7 +1707,7 @@ public class CheckpointCoordinatorTest {
 
 		int numSavepoints = 5;
 
-		String savepointDir = tmpFolder.newFolder().getAbsolutePath();
+		Path savepointDir = new Path(tmpFolder.newFolder().getAbsolutePath());
 
 		// Trigger savepoints
 		for (int i = 0; i < numSavepoints; i++) {
@@ -1756,7 +1756,7 @@ public class CheckpointCoordinatorTest {
 				null,
 				new DisabledCheckpointStatsTracker());
 
-		String savepointDir = tmpFolder.newFolder().getAbsolutePath();
+		Path savepointDir = new Path(tmpFolder.newFolder().getAbsolutePath());
 
 		Future<CompletedCheckpoint> savepoint0 = coord.triggerSavepoint(0, savepointDir);
 		assertFalse("Did not trigger savepoint", savepoint0.isDone());
@@ -2303,7 +2303,7 @@ public class CheckpointCoordinatorTest {
 					new ExecutionVertex[] { vertex1 },
 					new StandaloneCheckpointIDCounter(),
 					new StandaloneCompletedCheckpointStore(1),
-					"fake-directory",
+					new Path("fake-directory"),
 					new DisabledCheckpointStatsTracker());
 
 			assertTrue(coord.triggerCheckpoint(timestamp, false));
@@ -2878,7 +2878,7 @@ public class CheckpointCoordinatorTest {
 
 		// trigger the first checkpoint. this should succeed
 		CheckpointProperties props = CheckpointProperties.forStandardSavepoint();
-		String targetDirectory = "xjasdkjakshdmmmxna";
+		Path targetDirectory = new Path("xjasdkjakshdmmmxna");
 
 		CheckpointTriggerResult triggerResult = coord.triggerCheckpoint(timestamp, props, targetDirectory, false);
 		assertTrue(triggerResult.isSuccess());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.junit.Rule;
@@ -54,7 +55,7 @@ public class CompletedCheckpointTest {
 
 		// Verify discard call is forwarded to state
 		CompletedCheckpoint checkpoint = new CompletedCheckpoint(
-				new JobID(), 0, 0, 1, taskStates, CheckpointProperties.forStandardCheckpoint(), file.getAbsolutePath());
+				new JobID(), 0, 0, 1, taskStates, CheckpointProperties.forStandardCheckpoint(), new Path(file.getAbsolutePath()));
 
 		checkpoint.discard(JobStatus.FAILED);
 
@@ -103,7 +104,7 @@ public class CompletedCheckpointTest {
 			// Keep
 			CheckpointProperties props = new CheckpointProperties(false, true, false, false, false, false, false);
 			CompletedCheckpoint checkpoint = new CompletedCheckpoint(
-					new JobID(), 0, 0, 1, new HashMap<>(taskStates), props, externalPath);
+					new JobID(), 0, 0, 1, new HashMap<>(taskStates), props, new Path(externalPath));
 
 			checkpoint.discard(status);
 			verify(state, times(0)).discardState();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoaderTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint.savepoint;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.TaskState;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
@@ -66,7 +67,7 @@ public class SavepointLoaderTest {
 
 		// Store savepoint
 		SavepointV1 savepoint = new SavepointV1(checkpointId, taskStates.values());
-		String path = SavepointStore.storeSavepoint(tmp.getAbsolutePath(), savepoint);
+		Path path = SavepointStore.storeSavepoint(new Path(tmp.getAbsolutePath()), new JobID(), savepoint);
 
 		JobID jobId = new JobID();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointStoreTest.java
@@ -40,6 +40,7 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -74,7 +75,7 @@ public class SavepointStoreTest {
 		// Dispose
 		SavepointStore.removeSavepoint(path);
 
-		assertEquals(0, new File(path.getParent().toString()).listFiles().length);
+		assertFalse(new File(path.toString()).exists());
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointStoreTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.checkpoint.savepoint;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
@@ -29,6 +30,7 @@ import org.mockito.Matchers;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collection;
@@ -54,13 +56,13 @@ public class SavepointStoreTest {
 	 */
 	@Test
 	public void testStoreLoadDispose() throws Exception {
-		String target = tmp.getRoot().getAbsolutePath();
+		Path target = new Path(tmp.getRoot().getAbsolutePath());
 
 		assertEquals(0, tmp.getRoot().listFiles().length);
 
 		// Store
 		SavepointV1 stored = new SavepointV1(1929292, SavepointV1Test.createTaskStates(4, 24));
-		String path = SavepointStore.storeSavepoint(target, stored);
+		Path path = SavepointStore.storeSavepoint(target, new JobID(), stored);
 		assertEquals(1, tmp.getRoot().listFiles().length);
 
 		// Load
@@ -72,7 +74,7 @@ public class SavepointStoreTest {
 		// Dispose
 		SavepointStore.removeSavepoint(path);
 
-		assertEquals(0, tmp.getRoot().listFiles().length);
+		assertEquals(0, new File(path.getParent().toString()).listFiles().length);
 	}
 
 	/**
@@ -89,7 +91,7 @@ public class SavepointStoreTest {
 		}
 
 		try {
-			SavepointStore.loadSavepoint(filePath.toString());
+			SavepointStore.loadSavepoint(filePath);
 			fail("Did not throw expected Exception");
 		} catch (RuntimeException e) {
 			assertTrue(e.getMessage().contains("Flink 1.0") && e.getMessage().contains("Unexpected magic number"));
@@ -108,7 +110,7 @@ public class SavepointStoreTest {
 
 		assertTrue(serializers.size() >= 1);
 
-		String target = tmp.getRoot().getAbsolutePath();
+		Path target = new Path(tmp.getRoot().getAbsolutePath());
 		assertEquals(0, tmp.getRoot().listFiles().length);
 
 		// New savepoint type for test
@@ -119,12 +121,12 @@ public class SavepointStoreTest {
 		serializers.put(version, NewSavepointSerializer.INSTANCE);
 
 		TestSavepoint newSavepoint = new TestSavepoint(version, checkpointId);
-		String pathNewSavepoint = SavepointStore.storeSavepoint(target, newSavepoint);
+		Path pathNewSavepoint = SavepointStore.storeSavepoint(target, new JobID(), newSavepoint);
 		assertEquals(1, tmp.getRoot().listFiles().length);
 
 		// Savepoint v0
 		Savepoint savepoint = new SavepointV1(checkpointId, SavepointV1Test.createTaskStates(4, 32));
-		String pathSavepoint = SavepointStore.storeSavepoint(target, savepoint);
+		Path pathSavepoint = SavepointStore.storeSavepoint(target, new JobID(), savepoint);
 		assertEquals(2, tmp.getRoot().listFiles().length);
 
 		// Load
@@ -144,7 +146,7 @@ public class SavepointStoreTest {
 		field.setAccessible(true);
 		Map<Integer, SavepointSerializer<?>> serializers = (Map<Integer, SavepointSerializer<?>>) field.get(null);
 
-		String target = tmp.getRoot().getAbsolutePath();
+		Path target = new Path(tmp.getRoot().getAbsolutePath());
 
 		final int version = 123123;
 		SavepointSerializer<TestSavepoint> serializer = mock(SavepointSerializer.class);
@@ -158,7 +160,7 @@ public class SavepointStoreTest {
 		assertEquals(0, tmp.getRoot().listFiles().length);
 
 		try {
-			SavepointStore.storeSavepoint(target, savepoint);
+			SavepointStore.storeSavepoint(target, new JobID(), savepoint);
 		} catch (Throwable ignored) {
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.LongCounter;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -357,7 +358,7 @@ public class ArchivedExecutionGraphTest {
 		}
 
 		@Override
-		public String getExternalPath() {
+		public Path getExternalPath() {
 			return null;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilderTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.checkpoint.CoordinatorShutdownTest;
+import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.tasks.ExternalizedCheckpointSettings;
+import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupsStateHandle;
+import org.apache.flink.runtime.state.StateUtil;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+public class ExecutionGraphBuilderTest {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ExecutionGraphBuilderTest.class);
+
+	/**
+	 * Tests that the state backend checkpoint directory is forwarded to the
+	 * checkpoint coordinator.
+	 */
+	@Test
+	public void testExternalizedCheckpointsCheckpointDirectory() throws Exception {
+		JobVertex jobVertex = new JobVertex("TestVertex");
+		jobVertex.setParallelism(1);
+		jobVertex.setInvokableClass(CoordinatorShutdownTest.BlockingInvokable.class);
+
+		Path checkpointDirectory = new Path("expectedCheckpointDirectory");
+		AbstractStateBackend backend = new DummyCheckpointDirectoryTestStateBackend(checkpointDirectory);
+		StateUtil.serializeStateBackend(jobVertex.getConfiguration(), backend);
+
+		JobGraph jobGraph = new JobGraph(jobVertex);
+
+		List<JobVertexID> trigger = new ArrayList<>();
+		trigger.add(jobVertex.getID());
+
+		JobSnapshottingSettings snapshottingSettings = new JobSnapshottingSettings(
+				trigger,
+				Collections.<JobVertexID>emptyList(),
+				Collections.<JobVertexID>emptyList(),
+				Long.MAX_VALUE,
+				Integer.MAX_VALUE,
+				Integer.MAX_VALUE,
+				Integer.MAX_VALUE,
+				ExternalizedCheckpointSettings.externalizeCheckpoints(true));
+
+		jobGraph.setSnapshotSettings(snapshottingSettings);
+
+		Configuration jobManagerConfig = new Configuration();
+
+		ExecutionGraph eg = ExecutionGraphBuilder.buildGraph(
+				null,
+				jobGraph,
+				jobManagerConfig,
+				mock(Executor.class),
+				Thread.currentThread().getContextClassLoader(),
+				new StandaloneCheckpointRecoveryFactory(),
+				Time.seconds(30),
+				new NoRestartStrategy(),
+				mock(MetricGroup.class),
+				1,
+				LOG);
+
+		Path actual = eg.getCheckpointCoordinator().getCheckpointDirectory();
+		assertEquals(checkpointDirectory, actual);
+	}
+
+	/**
+	 * Tests that if no checkpoint directory is configured, but externalized
+	 * checkpoints are enabled, the execution graph building fails.
+	 */
+	@Test
+	public void testExternalizedCheckpointsNoCheckpointDirectoryConfigured() throws Exception {
+		JobVertex jobVertex = new JobVertex("TestVertex");
+		jobVertex.setParallelism(1);
+		jobVertex.setInvokableClass(CoordinatorShutdownTest.BlockingInvokable.class);
+
+		Path checkpointDirectory = null;
+		AbstractStateBackend backend = new DummyCheckpointDirectoryTestStateBackend(checkpointDirectory);
+		StateUtil.serializeStateBackend(jobVertex.getConfiguration(), backend);
+
+		JobGraph jobGraph = new JobGraph(jobVertex);
+
+		List<JobVertexID> trigger = new ArrayList<>();
+		trigger.add(jobVertex.getID());
+
+		JobSnapshottingSettings snapshottingSettings = new JobSnapshottingSettings(
+				trigger,
+				Collections.<JobVertexID>emptyList(),
+				Collections.<JobVertexID>emptyList(),
+				Long.MAX_VALUE,
+				Integer.MAX_VALUE,
+				Integer.MAX_VALUE,
+				Integer.MAX_VALUE,
+				ExternalizedCheckpointSettings.externalizeCheckpoints(true));
+
+		jobGraph.setSnapshotSettings(snapshottingSettings);
+
+		try {
+			ExecutionGraphBuilder.buildGraph(
+					null,
+					jobGraph,
+					new Configuration(),
+					mock(Executor.class),
+					Thread.currentThread().getContextClassLoader(),
+					new StandaloneCheckpointRecoveryFactory(),
+					Time.seconds(30),
+					new NoRestartStrategy(),
+					mock(MetricGroup.class),
+					1,
+					LOG);
+
+			fail("Did not throw expected IllegalStateException because of missing checkpoint directory");
+		} catch (IllegalStateException ignored) {
+		}
+	}
+
+	private static class DummyCheckpointDirectoryTestStateBackend extends AbstractStateBackend {
+
+		private final Path checkpointDirectory;
+
+		public DummyCheckpointDirectoryTestStateBackend(Path checkpointDirectory) {
+			this.checkpointDirectory = checkpointDirectory;
+		}
+
+		@Override
+		public CheckpointStreamFactory createStreamFactory(JobID jobId, String operatorIdentifier) throws IOException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(Environment env, JobID jobID, String operatorIdentifier, TypeSerializer<K> keySerializer, int numberOfKeyGroups, KeyGroupRange keyGroupRange, TaskKvStateRegistry kvStateRegistry) throws Exception {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public <K> AbstractKeyedStateBackend<K> restoreKeyedStateBackend(Environment env, JobID jobID, String operatorIdentifier, TypeSerializer<K> keySerializer, int numberOfKeyGroups, KeyGroupRange keyGroupRange, Collection<KeyGroupsStateHandle> restoredState, TaskKvStateRegistry kvStateRegistry) throws Exception {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Path getCheckpointDirectory() {
+			return checkpointDirectory;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/FileStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/FileStateBackendTest.java
@@ -151,6 +151,17 @@ public class FileStateBackendTest extends StateBackendTestBase<FsStateBackend> {
 		}
 	}
 
+	/**
+	 * Tests that the externalized checkpoint directory is set to the base
+	 * checkpoint directory.
+	 */
+	@Test
+	public void testExternalizedCheckpointsDirectoryConfiguration() throws Exception {
+		Path externalizedCheckpointsDirectory = FsStateBackend.validateAndNormalizeUri(URI.create("file://" + tempFolder.newFolder().getAbsolutePath()));
+		FsStateBackend backend = new FsStateBackend(externalizedCheckpointsDirectory);
+		assertEquals(externalizedCheckpointsDirectory, backend.getCheckpointDirectory());
+	}
+
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
@@ -22,6 +22,7 @@ import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import org.apache.flink.api.common.JobID
+import org.apache.flink.core.fs.Path
 import org.apache.flink.runtime.akka.ListeningBehaviour
 import org.apache.flink.runtime.checkpoint.{CheckpointCoordinator, CompletedCheckpoint}
 import org.apache.flink.runtime.client.JobExecutionException
@@ -831,7 +832,7 @@ class JobManagerITCase(_system: ActorSystem)
           val checkpointCoordinator = mock(classOf[CheckpointCoordinator])
           doThrow(new Exception("Expected Test Exception"))
             .when(checkpointCoordinator)
-            .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.anyString())
+            .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.any[Path]())
 
           // Update the savepoint coordinator field
           val field = executionGraph.getClass.getDeclaredField("checkpointCoordinator")
@@ -880,11 +881,11 @@ class JobManagerITCase(_system: ActorSystem)
           val checkpointCoordinator = mock(classOf[CheckpointCoordinator])
           doThrow(new Exception("Expected Test Exception"))
             .when(checkpointCoordinator)
-            .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.anyString())
+            .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.any[Path]())
           val savepointPathPromise = new FlinkCompletableFuture[CompletedCheckpoint]()
           doReturn(savepointPathPromise)
             .when(checkpointCoordinator)
-            .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.anyString())
+            .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.any[Path]())
 
           // Request the execution graph and set a checkpoint coordinator mock
           jobManager.tell(RequestExecutionGraph(jobGraph.getJobID), testActor)
@@ -942,12 +943,12 @@ class JobManagerITCase(_system: ActorSystem)
           val checkpointCoordinator = mock(classOf[CheckpointCoordinator])
           doThrow(new Exception("Expected Test Exception"))
             .when(checkpointCoordinator)
-            .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.anyString())
+            .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.any[Path]())
 
           val savepointPromise = new FlinkCompletableFuture[CompletedCheckpoint]()
           doReturn(savepointPromise)
             .when(checkpointCoordinator)
-            .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.anyString())
+            .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.any[Path]())
 
           // Request the execution graph and set a checkpoint coordinator mock
           jobManager.tell(RequestExecutionGraph(jobGraph.getJobID), testActor)
@@ -963,7 +964,7 @@ class JobManagerITCase(_system: ActorSystem)
           jobManager.tell(TriggerSavepoint(jobGraph.getJobID(), Option.apply("any")), testActor)
 
           val checkpoint = Mockito.mock(classOf[CompletedCheckpoint])
-          when(checkpoint.getExternalPath).thenReturn("Expected test savepoint path")
+          when(checkpoint.getExternalPath).thenReturn(new Path("Expected test savepoint path"))
 
           // Succeed the promise
           savepointPromise.complete(checkpoint)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerLike.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerLike.scala
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.testingUtils
 import akka.actor.{ActorRef, Cancellable, Terminated}
 import akka.pattern.{ask, pipe}
 import org.apache.flink.api.common.JobID
+import org.apache.flink.core.fs.Path
 import org.apache.flink.runtime.FlinkActor
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointStore
 import org.apache.flink.runtime.execution.ExecutionState
@@ -310,7 +311,7 @@ trait TestingJobManagerLike extends FlinkActor {
 
     case RequestSavepoint(savepointPath) =>
       try {
-        val savepoint = SavepointStore.loadSavepoint(savepointPath)
+        val savepoint = SavepointStore.loadSavepoint(new Path(savepointPath))
         sender ! ResponseSavepoint(savepoint)
       }
       catch {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.streaming.api.CheckpointingMode;
 
@@ -245,8 +244,10 @@ public class CheckpointConfig implements java.io.Serializable {
 	 * handle checkpoint clean up manually when you cancel the job as well
 	 * (terminating with job status {@link JobStatus#CANCELED}).
 	 *
-	 * <p>The target directory for externalized checkpoints is configured
-	 * via {@link ConfigConstants#CHECKPOINTS_DIRECTORY_KEY}.
+	 * <p>The target directory for the checkpoint is determined from the
+	 * checkpoint directory of the used state backend. If no default checkpoint
+	 * directory is available for the backend, you have to manually configure
+	 * it.
 	 *
 	 * @param cleanupMode Externalized checkpoint cleanup behaviour.
 	 */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.operators.util.CorruptConfigurationException;
+import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.util.ClassLoaderUtil;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -412,21 +413,11 @@ public class StreamConfig implements Serializable {
 	// ------------------------------------------------------------------------
 	
 	public void setStateBackend(AbstractStateBackend backend) {
-		if (backend != null) {
-			try {
-				InstantiationUtil.writeObjectToConfig(backend, this.config, STATE_BACKEND);
-			} catch (Exception e) {
-				throw new StreamTaskException("Could not serialize stateHandle provider.", e);
-			}
-		}
+		StateUtil.serializeStateBackend(this.config, backend);
 	}
 	
 	public AbstractStateBackend getStateBackend(ClassLoader cl) {
-		try {
-			return InstantiationUtil.readObjectFromConfig(this.config, STATE_BACKEND, cl);
-		} catch (Exception e) {
-			throw new StreamTaskException("Could not instantiate statehandle provider.", e);
-		}
+		return StateUtil.deserializeStateBackend(this.config, cl);
 	}
 
 	public byte[] getSerializedStateBackend() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -516,6 +516,17 @@ public class StreamingJobGraphGenerator {
 				cfg.getMaxConcurrentCheckpoints(),
 				externalizedCheckpointSettings);
 		jobGraph.setSnapshotSettings(settings);
+
+		// Sanity check externalized checkpoint configuration if a user
+		// specified state backend has been configured.
+		if (externalizedCheckpointSettings.externalizeCheckpoints() &&
+				streamGraph.getStateBackend() != null &&
+				streamGraph.getStateBackend().getCheckpointDirectory() == null) {
+
+			throw new IllegalStateException("Did not configure checkpoint directory for state " +
+					"backend, but enabled externalized checkpoints. Please configure a " +
+					"checkpoint directory for your state backend.");
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -20,9 +20,7 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.SubtaskState;
@@ -39,12 +37,9 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.OperatorStateHandle;
-import org.apache.flink.runtime.state.StateBackendFactory;
+import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TaskStateHandles;
-import org.apache.flink.runtime.state.filesystem.FsStateBackend;
-import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
-import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.taskmanager.DispatcherThreadFactory;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.graph.StreamConfig;
@@ -535,7 +530,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	}
 
 	private boolean performCheckpoint(CheckpointMetaData checkpointMetaData) throws Exception {
-
 		LOG.debug("Starting checkpoint {} on task {}", checkpointMetaData.getCheckpointId(), getName());
 
 		synchronized (lock) {
@@ -636,60 +630,17 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	// ------------------------------------------------------------------------
 
 	private AbstractStateBackend createStateBackend() throws Exception {
-		AbstractStateBackend stateBackend = configuration.getStateBackend(getUserCodeClassLoader());
+		Configuration streamConfig = configuration.getConfiguration();
+		AbstractStateBackend backend = StateUtil.deserializeStateBackend(streamConfig, getUserCodeClassLoader());
 
-		if (stateBackend != null) {
-			// backend has been configured on the environment
-			LOG.info("Using user-defined state backend: " + stateBackend);
+		if (backend != null) {
+			LOG.info("Using user-defined state backend: " + backend);
 		} else {
-			// see if we have a backend specified in the configuration
-			Configuration flinkConfig = getEnvironment().getTaskManagerInfo().getConfiguration();
-			String backendName = flinkConfig.getString(ConfigConstants.STATE_BACKEND, null);
-
-			if (backendName == null) {
-				LOG.warn("No state backend has been specified, using default state backend (Memory / JobManager)");
-				backendName = "jobmanager";
-			}
-
-			switch (backendName.toLowerCase()) {
-				case "jobmanager":
-					LOG.info("State backend is set to heap memory (checkpoint to jobmanager)");
-					stateBackend = new MemoryStateBackend();
-					break;
-
-				case "filesystem":
-					FsStateBackend backend = new FsStateBackendFactory().createFromConfig(flinkConfig);
-					LOG.info("State backend is set to heap memory (checkpoints to filesystem \""
-							+ backend.getBasePath() + "\")");
-					stateBackend = backend;
-					break;
-
-				case "rocksdb":
-					backendName = "org.apache.flink.contrib.streaming.state.RocksDBStateBackendFactory";
-					// fall through to the 'default' case that uses reflection to load the backend
-					// that way we can keep RocksDB in a separate module
-
-				default:
-					try {
-						@SuppressWarnings("rawtypes")
-						Class<? extends StateBackendFactory> clazz =
-								Class.forName(backendName, false, getUserCodeClassLoader()).
-										asSubclass(StateBackendFactory.class);
-
-						stateBackend = clazz.newInstance().createFromConfig(flinkConfig);
-					} catch (ClassNotFoundException e) {
-						throw new IllegalConfigurationException("Cannot find configured state backend: " + backendName);
-					} catch (ClassCastException e) {
-						throw new IllegalConfigurationException("The class configured under '" +
-								ConfigConstants.STATE_BACKEND + "' is not a valid state backend factory (" +
-								backendName + ')');
-					} catch (Throwable t) {
-						throw new IllegalConfigurationException("Cannot create configured state backend", t);
-					}
-			}
+			Configuration taskManagerConfig = getEnvironment().getTaskManagerInfo().getConfiguration();
+			backend = StateUtil.createStateBackend(LOG, taskManagerConfig, getUserCodeClassLoader());
 		}
 
-		return stateBackend;
+		return backend;
 	}
 
 	public OperatorStateBackend createOperatorStateBackend(

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.checkpoint.SubtaskState;
 import org.apache.flink.runtime.checkpoint.TaskState;
@@ -77,7 +78,6 @@ import scala.concurrent.duration.FiniteDuration;
 import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
@@ -240,8 +240,7 @@ public class SavepointITCase extends TestLogger {
 			files = checkpointDir.listFiles();
 			if (files != null) {
 				assertEquals(errMsg, 1, files.length);
-			}
-			else {
+			} else {
 				fail(errMsg);
 			}
 
@@ -390,10 +389,8 @@ public class SavepointITCase extends TestLogger {
 				assertFalse(errMsg, parent.exists());
 			}
 
-			// All savepoints should have been cleaned up
-			errMsg = "Savepoints directory not cleaned up properly: " +
-					Arrays.toString(savepointDir.listFiles()) + ".";
-			assertEquals(errMsg, 0, savepointDir.listFiles().length);
+			// Savepoints should have been cleaned up
+			assertFalse("Savepoint not cleaned up properly.", new File(savepointPath).exists());
 
 			// - Verification END ---------------------------------------------
 		}
@@ -454,7 +451,7 @@ public class SavepointITCase extends TestLogger {
 
 			// Set non-existing savepoint path
 			jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath("unknown path"));
-			assertEquals("unknown path", jobGraph.getSavepointRestoreSettings().getRestorePath());
+			assertEquals(new Path("unknown path"), jobGraph.getSavepointRestoreSettings().getRestorePath());
 
 			LOG.info("Submitting job " + jobGraph.getJobID() + " in detached mode.");
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
@@ -122,6 +123,11 @@ public class StateBackendITCase extends StreamingMultipleProgramsTestBase {
 				Collection<KeyGroupsStateHandle> restoredState,
 				TaskKvStateRegistry kvStateRegistry) throws Exception {
 			throw new SuccessException();
+		}
+
+		@Override
+		public Path getCheckpointDirectory() {
+			throw new UnsupportedOperationException();
 		}
 	}
 


### PR DESCRIPTION
This change drops the checkpoint directory configuration key and instead uses the configured checkpoint directory of the used backend (for `FsStateBackend` and `RocksDBBackend`). For backends without a checkpoint directory like the `MemoryStateBackend`, you have to explicitly configure a checkpoint directory. Otherwise, the job submission will fail.

The externalized checkpoints now use the `FsCheckpointOutputStream`, too. This makes the checkpoint layout very nice for externalized checkpoints, because you end up with the checkpoint meta data together with the actual checkpoint data:
```java
:checkpointDir/:jobId/chk-:checkpointId/
   +- :uuid // data
   .
   +- :uuid // data
   +- savepoint-:uuid // meta data
```
The checkpoint meta data and actual data is self-contained in a single directory.

---

This also changes the target file for savepoint though currently. Before this change you get
```java
:savepointDir/savepoint-:rand
```
After this change you get
```java
:savepointDir/:jobId/chk-:checkpointId/savepoint-:uuid
```
Is this OK to change?
