### PR TITLE
[FLINK-4975] [checkpointing] Add a limit for how much data may be buffered in alignment

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -56,9 +56,19 @@ public class TaskManagerOptions {
 			key("task.cancellation.timeout")
 					.defaultValue(180000L);
 
+	/**
+	 * The maximum number of bytes that a checkpoint alignment may buffer.
+	 * If the checkpoint alignment buffers more than the configured amount of
+	 * data, the checkpoint is aborted (skipped).
+	 * 
+	 * <p>The default value of {@code -1} indicates that there is no limit.
+	 */
+	public static final ConfigOption<Long> TASK_CHECKPOINT_ALIGNMENT_BYTES_LIMIT =
+			key("task.checkpoint.alignment.max-size")
+			.defaultValue(-1L);
+	
 	// ------------------------------------------------------------------------
 
 	/** Not intended to be instantiated */
-	private TaskManagerOptions() {
-	}
+	private TaskManagerOptions() {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.runtime.checkpoint.stats.CheckpointStatsTracker;
@@ -278,10 +279,10 @@ public class CheckpointCoordinator {
 
 		if (result.isSuccess()) {
 			return result.getPendingCheckpoint().getCompletionFuture();
-		} else {
+		}
+		else {
 			Throwable cause = new Exception("Failed to trigger savepoint: " + result.getFailureReason().message());
-			Future<CompletedCheckpoint> failed = FlinkCompletableFuture.completedExceptionally(cause);
-			return failed;
+			return FlinkCompletableFuture.completedExceptionally(cause);
 		}
 	}
 
@@ -299,6 +300,7 @@ public class CheckpointCoordinator {
 		return triggerCheckpoint(timestamp, checkpointProperties, checkpointDirectory, isPeriodic).isSuccess();
 	}
 
+	@VisibleForTesting
 	CheckpointTriggerResult triggerCheckpoint(
 			long timestamp,
 			CheckpointProperties props,
@@ -397,7 +399,7 @@ public class CheckpointCoordinator {
 
 		// we lock with a special lock to make sure that trigger requests do not overtake each other.
 		// this is not done with the coordinator-wide lock, because the 'checkpointIdCounter'
-		// may issue blocking operations. Using a different lock than teh coordinator-wide lock,
+		// may issue blocking operations. Using a different lock than the coordinator-wide lock,
 		// we avoid blocking the processing of 'acknowledge/decline' messages during that time.
 		synchronized (triggerLock) {
 			final long checkpointID;
@@ -525,81 +527,74 @@ public class CheckpointCoordinator {
 	}
 
 	/**
-	 * Receives a {@link DeclineCheckpoint} message and returns whether the
-	 * message was associated with a pending checkpoint.
+	 * Receives a {@link DeclineCheckpoint} message for a pending checkpoint.
 	 *
 	 * @param message Checkpoint decline from the task manager
-	 *
-	 * @return Flag indicating whether the declined checkpoint was associated
-	 * with a pending checkpoint.
 	 */
-	public boolean receiveDeclineMessage(DeclineCheckpoint message) throws Exception {
+	public void receiveDeclineMessage(DeclineCheckpoint message) throws Exception {
 		if (shutdown || message == null) {
-			return false;
+			return;
 		}
 		if (!job.equals(message.getJob())) {
-			LOG.error("Received DeclineCheckpoint message for wrong job: {}", message);
-			return false;
+			throw new IllegalArgumentException("Received DeclineCheckpoint message for job " +
+				message.getJob() + " while this coordinator handles job " + job);
 		}
 
 		final long checkpointId = message.getCheckpointId();
+		final String reason = (message.getReason() != null ? message.getReason().getMessage() : "");
 
 		PendingCheckpoint checkpoint;
-
-		// Flag indicating whether the ack message was for a known pending
-		// checkpoint.
-		boolean isPendingCheckpoint;
 
 		synchronized (lock) {
 			// we need to check inside the lock for being shutdown as well, otherwise we
 			// get races and invalid error log messages
 			if (shutdown) {
-				return false;
+				return;
 			}
 
 			checkpoint = pendingCheckpoints.get(checkpointId);
 
 			if (checkpoint != null && !checkpoint.isDiscarded()) {
-				isPendingCheckpoint = true;
-
-				LOG.info("Discarding checkpoint " + checkpointId
-						+ " because of checkpoint decline from task " + message.getTaskExecutionId());
+				LOG.info("Discarding checkpoint " + checkpointId + " because of checkpoint decline from task " + 
+						message.getTaskExecutionId() + " : " + reason);
 
 				pendingCheckpoints.remove(checkpointId);
 				checkpoint.abortDeclined();
 				rememberRecentCheckpointId(checkpointId);
 
-				boolean haveMoreRecentPending = false;
+				// we don't have to schedule another "dissolving" checkpoint any more because the
+				// cancellation barriers take care of breaking downstream alignments
+				// we only need to make sure that suspended queued requests are resumed
 
+				boolean haveMoreRecentPending = false;
 				for (PendingCheckpoint p : pendingCheckpoints.values()) {
-					if (!p.isDiscarded() && p.getCheckpointTimestamp() >= checkpoint.getCheckpointTimestamp()) {
+					if (!p.isDiscarded() && p.getCheckpointId() >= checkpoint.getCheckpointId()) {
 						haveMoreRecentPending = true;
 						break;
 					}
 				}
-				if (!haveMoreRecentPending && !triggerRequestQueued) {
-					LOG.info("Triggering new checkpoint because of discarded checkpoint " + checkpointId);
-					triggerCheckpoint(System.currentTimeMillis(), checkpoint.getProps(), checkpoint.getTargetDirectory(), checkpoint.isPeriodic());
-				} else if (!haveMoreRecentPending) {
-					LOG.info("Promoting queued checkpoint request because of discarded checkpoint " + checkpointId);
+
+				if (!haveMoreRecentPending) {
 					triggerQueuedRequests();
 				}
-			} else if (checkpoint != null) {
+			}
+			else if (checkpoint != null) {
 				// this should not happen
 				throw new IllegalStateException(
 						"Received message for discarded but non-removed checkpoint " + checkpointId);
-			} else {
-				// message is for an unknown checkpoint, or comes too late (checkpoint disposed)
+			}
+			else if (LOG.isDebugEnabled()) {
 				if (recentPendingCheckpoints.contains(checkpointId)) {
-					isPendingCheckpoint = true;
-					LOG.info("Received another decline checkpoint message for now expired checkpoint attempt " + checkpointId);
+					// message is for an unknown checkpoint, or comes too late (checkpoint disposed)
+					LOG.debug("Received another decline message for now expired checkpoint attempt {} : {}",
+							checkpointId, reason);
 				} else {
-					isPendingCheckpoint = false;
+					// message is for an unknown checkpoint. might be so old that we don't even remember it any more
+					LOG.debug("Received decline message for unknown (too old?) checkpoint attempt {} : {}",
+							checkpointId, reason);
 				}
 			}
 		}
-
-		return isPendingCheckpoint;
 	}
 
 	/**
@@ -643,9 +638,7 @@ public class CheckpointCoordinator {
 			if (checkpoint != null && !checkpoint.isDiscarded()) {
 				isPendingCheckpoint = true;
 
-				if (checkpoint.acknowledgeTask(
-						message.getTaskExecutionId(),
-						message.getSubtaskState())) {
+				if (checkpoint.acknowledgeTask(message.getTaskExecutionId(), message.getSubtaskState())) {
 					if (checkpoint.isFullyAcknowledged()) {
 						completed = checkpoint.finalizeCheckpoint();
 
@@ -672,8 +665,8 @@ public class CheckpointCoordinator {
 					}
 				} else {
 					// checkpoint did not accept message
-					LOG.error("Received duplicate or invalid acknowledge message for checkpoint " + checkpointId
-							+ " , task " + message.getTaskExecutionId());
+					LOG.error("Received duplicate or invalid acknowledge message for checkpoint {} , task {}",
+							checkpointId, message.getTaskExecutionId());
 				}
 			}
 			else if (checkpoint != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -555,8 +555,8 @@ public class CheckpointCoordinator {
 			checkpoint = pendingCheckpoints.get(checkpointId);
 
 			if (checkpoint != null && !checkpoint.isDiscarded()) {
-				LOG.info("Discarding checkpoint " + checkpointId + " because of checkpoint decline from task " + 
-						message.getTaskExecutionId() + " : " + reason);
+				LOG.info("Discarding checkpoint {} because of checkpoint decline from task {} : {}",
+						checkpointId, message.getTaskExecutionId(), reason);
 
 				pendingCheckpoints.remove(checkpointId);
 				checkpoint.abortDeclined();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetrics.java
@@ -20,16 +20,17 @@ package org.apache.flink.runtime.checkpoint;
 
 import java.io.Serializable;
 
+/**
+ * A collection of simple metrics, around the triggering of a checkpoint.
+ */
 public class CheckpointMetrics implements Serializable {
 
-	/**
-	 * The number of bytes that were buffered during the checkpoint alignment phase
-	 */
+	private static final long serialVersionUID = 1L;
+
+	/** The number of bytes that were buffered during the checkpoint alignment phase */
 	private long bytesBufferedInAlignment;
 
-	/**
-	 * The duration (in nanoseconds) that the stream alignment for the checkpoint took
-	 */
+	/** The duration (in nanoseconds) that the stream alignment for the checkpoint took */
 	private long alignmentDurationNanos;
 
 	/* The duration (in milliseconds) of the synchronous part of the operator checkpoint */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/AlignmentLimitExceededException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/AlignmentLimitExceededException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.decline;
+
+/**
+ * Exception indicating that a checkpoint was declined because a task was not
+ * ready to perform a checkpoint.
+ */
+public final class AlignmentLimitExceededException extends CheckpointDeclineException {
+
+	private static final long serialVersionUID = 1L;
+
+	public AlignmentLimitExceededException(long numBytes) {
+		super("The checkpoint alignment phase needed to buffer more than the configured maximum ("
+				+ numBytes + " bytes).");
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/AlignmentLimitExceededException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/AlignmentLimitExceededException.java
@@ -19,8 +19,8 @@
 package org.apache.flink.runtime.checkpoint.decline;
 
 /**
- * Exception indicating that a checkpoint was declined because a task was not
- * ready to perform a checkpoint.
+ * Exception indicating that a checkpoint was declined because too many bytes were
+ * buffered in the alignment phase.
  */
 public final class AlignmentLimitExceededException extends CheckpointDeclineException {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/CheckpointDeclineException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/CheckpointDeclineException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.decline;
+
+/**
+ * Base class of all exceptions that indicate a declined checkpoint.
+ */
+public abstract class CheckpointDeclineException extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	public CheckpointDeclineException(String message) {
+		super(message);
+	}
+
+	public CheckpointDeclineException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/CheckpointDeclineOnCancellationBarrierException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/CheckpointDeclineOnCancellationBarrierException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.decline;
+
+/**
+ * Exception indicating that a checkpoint was declined because a task was not
+ * ready to perform a checkpoint.
+ */
+public final class CheckpointDeclineOnCancellationBarrierException extends CheckpointDeclineException {
+
+	private static final long serialVersionUID = 1L;
+
+	public CheckpointDeclineOnCancellationBarrierException() {
+		super("Task received cancellation from one of its inputs");
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/CheckpointDeclineOnCancellationBarrierException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/CheckpointDeclineOnCancellationBarrierException.java
@@ -19,8 +19,8 @@
 package org.apache.flink.runtime.checkpoint.decline;
 
 /**
- * Exception indicating that a checkpoint was declined because a task was not
- * ready to perform a checkpoint.
+ * Exception indicating that a checkpoint was declined because a cancellation
+ * barrier was received.
  */
 public final class CheckpointDeclineOnCancellationBarrierException extends CheckpointDeclineException {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/CheckpointDeclineSubsumedException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/CheckpointDeclineSubsumedException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.decline;
+
+/**
+ * Exception indicating that a checkpoint was declined because a task was not
+ * ready to perform a checkpoint.
+ */
+public final class CheckpointDeclineSubsumedException extends CheckpointDeclineException {
+
+	private static final long serialVersionUID = 1L;
+
+	public CheckpointDeclineSubsumedException(long newCheckpointId) {
+		super("Checkpoint was canceled because a barrier from newer checkpoint " + newCheckpointId + " was received.");
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/CheckpointDeclineSubsumedException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/CheckpointDeclineSubsumedException.java
@@ -19,8 +19,8 @@
 package org.apache.flink.runtime.checkpoint.decline;
 
 /**
- * Exception indicating that a checkpoint was declined because a task was not
- * ready to perform a checkpoint.
+ * Exception indicating that a checkpoint was declined because a newer checkpoint
+ * barrier was received on an input before the pending checkpoint's barrier. 
  */
 public final class CheckpointDeclineSubsumedException extends CheckpointDeclineException {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/CheckpointDeclineTaskNotCheckpointingException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/CheckpointDeclineTaskNotCheckpointingException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.decline;
+
+/**
+ * Exception indicating that a checkpoint was declined because a task does not support
+ * checkpointing.
+ */
+public final class CheckpointDeclineTaskNotCheckpointingException extends CheckpointDeclineException {
+
+	private static final long serialVersionUID = 1L;
+
+	public CheckpointDeclineTaskNotCheckpointingException(String taskName) {
+		super("Task '" + taskName + "'does not support checkpointing");
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/CheckpointDeclineTaskNotReadyException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/CheckpointDeclineTaskNotReadyException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.decline;
+
+/**
+ * Exception indicating that a checkpoint was declined because a task was not
+ * ready to perform a checkpoint.
+ */
+public final class CheckpointDeclineTaskNotReadyException extends CheckpointDeclineException {
+
+	private static final long serialVersionUID = 1L;
+
+	public CheckpointDeclineTaskNotReadyException(String taskName) {
+		super("Task " + taskName + " was not running");
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/InputEndOfStreamException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/InputEndOfStreamException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.decline;
+
+/**
+ * Exception indicating that a checkpoint was declined because a task was not
+ * ready to perform a checkpoint.
+ */
+public final class InputEndOfStreamException extends CheckpointDeclineException {
+
+	private static final long serialVersionUID = 1L;
+
+	public InputEndOfStreamException() {
+		super("Checkpoint was declined because one input stream is finished");
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/InputEndOfStreamException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/decline/InputEndOfStreamException.java
@@ -19,8 +19,8 @@
 package org.apache.flink.runtime.checkpoint.decline;
 
 /**
- * Exception indicating that a checkpoint was declined because a task was not
- * ready to perform a checkpoint.
+ * Exception indicating that a checkpoint was declined because one of the input
+ * stream reached its end before the alignment was complete.
  */
 public final class InputEndOfStreamException extends CheckpointDeclineException {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
@@ -174,9 +174,16 @@ public interface Environment {
 	 * @param checkpointMetaData the meta data for this checkpoint
 	 * @param subtaskState All state handles for the checkpointed state
 	 */
-	void acknowledgeCheckpoint(
-			CheckpointMetaData checkpointMetaData,
-			SubtaskState subtaskState);
+	void acknowledgeCheckpoint(CheckpointMetaData checkpointMetaData, SubtaskState subtaskState);
+
+	/**
+	 * Declines a checkpoint. This tells the checkpoint coordinator that this task will
+	 * not be able to successfully complete a certain checkpoint.
+	 * 
+	 * @param checkpointId The ID of the declined checkpoint.
+	 * @param cause An optional reason why the checkpoint was declined.
+	 */
+	void declineCheckpoint(long checkpointId, Throwable cause);
 
 	/**
 	 * Marks task execution failed for an external reason (a reason other than the task code itself

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/CancelCheckpointMarker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/CancelCheckpointMarker.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.api;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.runtime.event.RuntimeEvent;
+
+import java.io.IOException;
+
+/**
+ * The CancelCheckpointMarker travels through the data streams, similar to the {@link CheckpointBarrier},
+ * but signals that a certain checkpoint should be canceled. Any in-progress alignment for that
+ * checkpoint needs to be canceled and regular processing should be resumed.
+ */
+public class CancelCheckpointMarker extends RuntimeEvent {
+
+	/** The id of the checkpoint to be canceled */
+	private final long checkpointId;
+
+	public CancelCheckpointMarker(long checkpointId) {
+		this.checkpointId = checkpointId;
+	}
+
+	public long getCheckpointId() {
+		return checkpointId;
+	}
+
+	// ------------------------------------------------------------------------
+	// These known and common event go through special code paths, rather than
+	// through generic serialization 
+
+	@Override
+	public void write(DataOutputView out) throws IOException {
+		throw new UnsupportedOperationException("this method should never be called");
+	}
+
+	@Override
+	public void read(DataInputView in) throws IOException {
+		throw new UnsupportedOperationException("this method should never be called");
+	}
+	
+	// ------------------------------------------------------------------------
+
+	@Override
+	public int hashCode() {
+		return (int) (checkpointId ^ (checkpointId >>> 32));
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		return other != null && 
+				other.getClass() == CancelCheckpointMarker.class &&
+				this.checkpointId == ((CancelCheckpointMarker) other).checkpointId;
+	}
+
+	@Override
+	public String toString() {
+		return "CancelCheckpointMarker " + checkpointId;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -440,7 +440,7 @@ abstract class NettyMessage {
 		}
 
 		@Override
-		public void readFrom(ByteBuf buffer) {
+		public void readFrom(ByteBuf buffer) throws IOException {
 			// TODO Directly deserialize fromNetty's buffer
 			int length = buffer.readInt();
 			ByteBuffer serializedEvent = ByteBuffer.allocate(length);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.util.event.NotificationListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayDeque;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -88,7 +89,7 @@ class PipelinedSubpartition extends ResultSubpartition {
 	}
 
 	@Override
-	public void finish() {
+	public void finish() throws IOException {
 		final NotificationListener listener;
 
 		synchronized (buffers) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/StatefulTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/StatefulTask.java
@@ -61,6 +61,17 @@ public interface StatefulTask {
 	void triggerCheckpointOnBarrier(CheckpointMetaData checkpointMetaData) throws Exception;
 
 	/**
+	 * Aborts a checkpoint as the result of receiving possibly some checkpoint barriers,
+	 * but at least one {@link org.apache.flink.runtime.io.network.api.CancelCheckpointMarker}.
+	 * 
+	 * <p>This requires implementing tasks to forward a
+	 * {@link org.apache.flink.runtime.io.network.api.CancelCheckpointMarker} to their outputs.
+	 * 
+	 * @param checkpointId The ID of the checkpoint to be aborted.
+	 */
+	void abortCheckpointOnBarrier(long checkpointId) throws Exception;
+
+	/**
 	 * Invoked when a checkpoint has been completed, i.e., when the checkpoint coordinator has received
 	 * the notification from all participating tasks.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/StatefulTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/StatefulTask.java
@@ -69,7 +69,7 @@ public interface StatefulTask {
 	 * 
 	 * @param checkpointId The ID of the checkpoint to be aborted.
 	 */
-	void abortCheckpointOnBarrier(long checkpointId) throws Exception;
+	void abortCheckpointOnBarrier(long checkpointId, Throwable cause) throws Exception;
 
 	/**
 	 * Invoked when a checkpoint has been completed, i.e., when the checkpoint coordinator has received

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/StatefulTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/StatefulTask.java
@@ -68,6 +68,7 @@ public interface StatefulTask {
 	 * {@link org.apache.flink.runtime.io.network.api.CancelCheckpointMarker} to their outputs.
 	 * 
 	 * @param checkpointId The ID of the checkpoint to be aborted.
+	 * @param cause The reason why the checkpoint was aborted during alignment   
 	 */
 	void abortCheckpointOnBarrier(long checkpointId, Throwable cause) throws Exception;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ActorGatewayCheckpointResponder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ActorGatewayCheckpointResponder.java
@@ -54,17 +54,17 @@ public class ActorGatewayCheckpointResponder implements CheckpointResponder {
 
 	@Override
 	public void declineCheckpoint(
-		JobID jobID,
-		ExecutionAttemptID executionAttemptID,
-		CheckpointMetaData checkpointMetaData) {
+			JobID jobID,
+			ExecutionAttemptID executionAttemptID,
+			long checkpointId,
+			Throwable reason) {
 
 		DeclineCheckpoint decline = new DeclineCheckpoint(
 			jobID,
 			executionAttemptID,
-			checkpointMetaData.getCheckpointId(),
-			checkpointMetaData.getTimestamp());
+			checkpointId,
+			reason);
 
 		actorGateway.tell(decline);
-
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/CheckpointResponder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/CheckpointResponder.java
@@ -52,10 +52,12 @@ public interface CheckpointResponder {
 	 *
 	 * @param jobID Job ID of the running job
 	 * @param executionAttemptID Execution attempt ID of the running task
-	 * @param checkpointMetaData Meta data for this checkpoint
+	 * @param checkpointId The ID of the declined checkpoint
+	 * @param cause The optional cause why the checkpoint was declined   
 	 */
 	void declineCheckpoint(
 		JobID jobID,
 		ExecutionAttemptID executionAttemptID,
-		CheckpointMetaData checkpointMetaData);
+		long checkpointId,
+		Throwable cause);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
@@ -254,6 +254,11 @@ public class RuntimeEnvironment implements Environment {
 	}
 
 	@Override
+	public void declineCheckpoint(long checkpointId, Throwable cause) {
+		checkpointResponder.declineCheckpoint(jobId, executionId, checkpointId, cause);
+	}
+
+	@Override
 	public void failExternally(Throwable cause) {
 		this.containingTask.failExternally(cause);
 	}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1435,10 +1435,7 @@ class JobManager(
             if (checkpointCoordinator != null) {
               future {
                 try {
-                  if (!checkpointCoordinator.receiveDeclineMessage(declineMessage)) {
-                    log.info("Received message for non-existing checkpoint " +
-                      declineMessage.getCheckpointId)
-                  }
+                 checkpointCoordinator.receiveDeclineMessage(declineMessage)
                 }
                 catch {
                   case t: Throwable =>

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.api.serialization;
 
 import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.EndOfSuperstepEvent;
@@ -28,34 +29,30 @@ import org.junit.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class EventSerializerTest {
 
 	@Test
-	public void testSerializeDeserializeEvent() {
-		try {
-			AbstractEvent[] events = {
-					EndOfPartitionEvent.INSTANCE,
-					EndOfSuperstepEvent.INSTANCE,
-					new CheckpointBarrier(1678L, 4623784L),
-					new TestTaskEvent(Math.random(), 12361231273L)
-			};
-			
-			for (AbstractEvent evt : events) {
-				ByteBuffer serializedEvent = EventSerializer.toSerializedEvent(evt);
-				assertTrue(serializedEvent.hasRemaining());
+	public void testSerializeDeserializeEvent() throws Exception {
+		AbstractEvent[] events = {
+				EndOfPartitionEvent.INSTANCE,
+				EndOfSuperstepEvent.INSTANCE,
+				new CheckpointBarrier(1678L, 4623784L),
+				new TestTaskEvent(Math.random(), 12361231273L),
+				new CancelCheckpointMarker(287087987329842L)
+		};
+		
+		for (AbstractEvent evt : events) {
+			ByteBuffer serializedEvent = EventSerializer.toSerializedEvent(evt);
+			assertTrue(serializedEvent.hasRemaining());
 
-				AbstractEvent deserialized = 
-						EventSerializer.fromSerializedEvent(serializedEvent, getClass().getClassLoader());
-				assertNotNull(deserialized);
-				assertEquals(evt, deserialized);
-			}
-			
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
+			AbstractEvent deserialized = 
+					EventSerializer.fromSerializedEvent(serializedEvent, getClass().getClassLoader());
+			assertNotNull(deserialized);
+			assertEquals(evt, deserialized);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -476,7 +476,7 @@ public class JobManagerHARecoveryTest {
 		}
 
 		@Override
-		public void abortCheckpointOnBarrier(long checkpointId) {
+		public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) {
 			throw new UnsupportedOperationException("should not be called!");
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -454,28 +454,29 @@ public class JobManagerHARecoveryTest {
 		}
 
 		@Override
-		public boolean triggerCheckpoint(CheckpointMetaData checkpointMetaData) {
-			try {
-				ByteStreamStateHandle byteStreamStateHandle = new TestByteStreamStateHandleDeepCompare(
-						String.valueOf(UUID.randomUUID()),
-						InstantiationUtil.serializeObject(checkpointMetaData.getCheckpointId()));
+		public boolean triggerCheckpoint(CheckpointMetaData checkpointMetaData) throws Exception {
+			ByteStreamStateHandle byteStreamStateHandle = new TestByteStreamStateHandleDeepCompare(
+					String.valueOf(UUID.randomUUID()),
+					InstantiationUtil.serializeObject(checkpointMetaData.getCheckpointId()));
 
-				ChainedStateHandle<StreamStateHandle> chainedStateHandle =
-						new ChainedStateHandle<StreamStateHandle>(Collections.singletonList(byteStreamStateHandle));
-				SubtaskState checkpointStateHandles =
-						new SubtaskState(chainedStateHandle, null, null, null, null, 0L);
+			ChainedStateHandle<StreamStateHandle> chainedStateHandle =
+					new ChainedStateHandle<StreamStateHandle>(Collections.singletonList(byteStreamStateHandle));
+			SubtaskState checkpointStateHandles =
+					new SubtaskState(chainedStateHandle, null, null, null, null, 0L);
 
-				getEnvironment().acknowledgeCheckpoint(
-						new CheckpointMetaData(checkpointMetaData.getCheckpointId(), -1, 0L, 0L, 0L, 0L),
-						checkpointStateHandles);
-				return true;
-			} catch (Exception ex) {
-				throw new RuntimeException(ex);
-			}
+			getEnvironment().acknowledgeCheckpoint(
+					new CheckpointMetaData(checkpointMetaData.getCheckpointId(), -1, 0L, 0L, 0L, 0L),
+					checkpointStateHandles);
+			return true;
 		}
 
 		@Override
 		public void triggerCheckpointOnBarrier(CheckpointMetaData checkpointMetaData) throws Exception {
+			throw new UnsupportedOperationException("should not be called!");
+		}
+
+		@Override
+		public void abortCheckpointOnBarrier(long checkpointId) {
 			throw new UnsupportedOperationException("should not be called!");
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
@@ -159,6 +159,11 @@ public class DummyEnvironment implements Environment {
 	}
 
 	@Override
+	public void declineCheckpoint(long checkpointId, Throwable cause) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public void failExternally(Throwable cause) {
 		throw new UnsupportedOperationException("DummyEnvironment does not support external task failure.");
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -313,10 +313,17 @@ public class MockEnvironment implements Environment {
 
 	@Override
 	public void acknowledgeCheckpoint(CheckpointMetaData checkpointMetaData) {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public void acknowledgeCheckpoint(CheckpointMetaData checkpointMetaData, SubtaskState subtaskState) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void declineCheckpoint(long checkpointId, Throwable cause) {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -232,6 +232,11 @@ public class TaskAsyncCallTest {
 		}
 
 		@Override
+		public void abortCheckpointOnBarrier(long checkpointId) {
+			throw new UnsupportedOperationException("Should not be called");
+		}
+
+		@Override
 		public void notifyCheckpointComplete(long checkpointId) {
 			if (checkpointId != lastCheckpointId && this.error == null) {
 				this.error = new Exception("calls out of order");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -205,9 +205,7 @@ public class TaskAsyncCallTest {
 		}
 
 		@Override
-		public void setInitialState(TaskStateHandles taskStateHandles) throws Exception {
-
-		}
+		public void setInitialState(TaskStateHandles taskStateHandles) throws Exception {}
 
 		@Override
 		public boolean triggerCheckpoint(CheckpointMetaData checkpointMetaData) {
@@ -232,7 +230,7 @@ public class TaskAsyncCallTest {
 		}
 
 		@Override
-		public void abortCheckpointOnBarrier(long checkpointId) {
+		public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) {
 			throw new UnsupportedOperationException("Should not be called");
 		}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
@@ -20,11 +20,13 @@ package org.apache.flink.streaming.runtime.io;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.jobgraph.tasks.StatefulTask;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,7 +72,8 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 	/** The ID of the checkpoint for which we expect barriers */
 	private long currentCheckpointId = -1L;
 
-	/** The number of received barriers (= number of blocked/buffered channels) */
+	/** The number of received barriers (= number of blocked/buffered channels)
+	 * IMPORTANT: A canceled checkpoint must always have 0 barriers */
 	private int numBarriersReceived;
 
 	/** The number of already closed channels */
@@ -96,7 +99,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 		this.inputGate = inputGate;
 		this.totalNumberOfInputChannels = inputGate.getNumberOfInputChannels();
 		this.blockedChannels = new boolean[this.totalNumberOfInputChannels];
-		
+
 		this.bufferSpiller = new BufferSpiller(ioManager, inputGate.getPageSize());
 		this.queuedBuffered = new ArrayDeque<BufferSpiller.SpilledBufferOrEventSequence>();
 	}
@@ -135,11 +138,12 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 						processBarrier((CheckpointBarrier) next.getEvent(), next.getChannelIndex());
 					}
 				}
+				else if (next.getEvent().getClass() == CancelCheckpointMarker.class) {
+					processCancellationBarrier((CancelCheckpointMarker) next.getEvent());
+				}
 				else {
 					if (next.getEvent().getClass() == EndOfPartitionEvent.class) {
-						numClosedChannels++;
-						// no chance to complete this checkpoint
-						releaseBlocks();
+						processEndOfPartition(next.getChannelIndex());
 					}
 					return next;
 				}
@@ -147,7 +151,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 			else if (!endOfStream) {
 				// end of input stream. stream continues with the buffered data
 				endOfStream = true;
-				releaseBlocks();
+				releaseBlocksAndResetBarriers();
 				return getNextNonBlocked();
 			}
 			else {
@@ -156,7 +160,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 			}
 		}
 	}
-	
+
 	private void completeBufferedSequence() throws IOException {
 		currentBuffered.cleanup();
 		currentBuffered = queuedBuffered.pollFirst();
@@ -164,72 +168,171 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 			currentBuffered.open();
 		}
 	}
-	
+
 	private void processBarrier(CheckpointBarrier receivedBarrier, int channelIndex) throws Exception {
 		final long barrierId = receivedBarrier.getId();
 
+		// fast path for single channel cases
+		if (totalNumberOfInputChannels == 1) {
+			if (barrierId > currentCheckpointId) {
+				// new checkpoint
+				currentCheckpointId = barrierId;
+				notifyCheckpoint(receivedBarrier);
+			}
+			return;
+		}
+
+		// -- general code path for multiple input channels --
+
 		if (numBarriersReceived > 0) {
-			// subsequent barrier of a checkpoint.
+			// this is only true if some alignment is already progress and was not canceled
+
 			if (barrierId == currentCheckpointId) {
 				// regular case
 				onBarrier(channelIndex);
 			}
 			else if (barrierId > currentCheckpointId) {
-				// we did not complete the current checkpoint
+				// we did not complete the current checkpoint, another started before
 				LOG.warn("Received checkpoint barrier for checkpoint {} before completing current checkpoint {}. " +
 						"Skipping current checkpoint.", barrierId, currentCheckpointId);
 
-				releaseBlocks();
-				currentCheckpointId = barrierId;
-				onBarrier(channelIndex);
+				// let the task know we are not completing this
+				notifyAbort(currentCheckpointId);
 
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("Starting stream alignment for checkpoint {}", barrierId);
-				}
-				startOfAlignmentTimestamp = System.nanoTime();
+				// abort the current checkpoint
+				releaseBlocksAndResetBarriers();
+
+				// begin a the new checkpoint
+				beginNewAlignment(barrierId, channelIndex);
 			}
 			else {
-				// ignore trailing barrier from aborted checkpoint
+				// ignore trailing barrier from an earlier checkpoint (obsolete now)
 				return;
 			}
-			
 		}
 		else if (barrierId > currentCheckpointId) {
 			// first barrier of a new checkpoint
-			currentCheckpointId = barrierId;
-			onBarrier(channelIndex);
-
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("Starting stream alignment for checkpoint {}", barrierId);
-			}
-			startOfAlignmentTimestamp = System.nanoTime();
+			beginNewAlignment(barrierId, channelIndex);
 		}
 		else {
-			// trailing barrier from previous (skipped) checkpoint
+			// either the current checkpoint was canceled (numBarriers == 0) or
+			// this barrier is from an old subsumed checkpoint
 			return;
 		}
 
-		// check if we have all barriers
+		// check if we have all barriers - since canceled checkpoints always have zero barriers
+		// this can only happen on a non canceled checkpoint
 		if (numBarriersReceived + numClosedChannels == totalNumberOfInputChannels) {
+			// actually trigger checkpoint
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Received all barrier, triggering checkpoint {} at {}",
+				LOG.debug("Received all barriers, triggering checkpoint {} at {}",
 						receivedBarrier.getId(), receivedBarrier.getTimestamp());
 			}
 
-			releaseBlocks();
-
-			if (toNotifyOnCheckpoint != null) {
-				CheckpointMetaData checkpointMetaData =
-						new CheckpointMetaData(receivedBarrier.getId(), receivedBarrier.getTimestamp());
-				checkpointMetaData.
-						setBytesBufferedInAlignment(bufferSpiller.getBytesWritten()).
-						setAlignmentDurationNanos(latestAlignmentDurationNanos);
-
-				toNotifyOnCheckpoint.triggerCheckpointOnBarrier(checkpointMetaData);
-			}
+			releaseBlocksAndResetBarriers();
+			notifyCheckpoint(receivedBarrier);
 		}
 	}
-	
+
+	private void processCancellationBarrier(CancelCheckpointMarker cancelBarrier) throws Exception {
+		final long barrierId = cancelBarrier.getCheckpointId();
+
+		// fast path for single channel cases
+		if (totalNumberOfInputChannels == 1) {
+			if (barrierId > currentCheckpointId) {
+				// new checkpoint
+				currentCheckpointId = barrierId;
+				notifyAbort(barrierId);
+			}
+			return;
+		}
+
+		// -- general code path for multiple input channels --
+
+		if (numBarriersReceived > 0) {
+			// this is only true if some alignment is in progress and nothing was canceled
+
+			if (barrierId == currentCheckpointId) {
+				// cancel this alignment
+				if (LOG.isDebugEnabled()) {
+					LOG.debug("Checkpoint {} canceled, aborting alignment", barrierId);
+				}
+
+				releaseBlocksAndResetBarriers();
+				notifyAbort(barrierId);
+			}
+			else if (barrierId > currentCheckpointId) {
+				// we canceled the next which also cancels the current
+				LOG.warn("Received cancellation barrier for checkpoint {} before completing current checkpoint {}. " +
+						"Skipping current checkpoint.", barrierId, currentCheckpointId);
+
+				// this stops the current alignment
+				releaseBlocksAndResetBarriers();
+
+				// the next checkpoint starts as canceled
+				currentCheckpointId = barrierId;
+				startOfAlignmentTimestamp = 0L;
+				latestAlignmentDurationNanos = 0L;
+				notifyAbort(barrierId);
+			}
+
+			// else: ignore trailing (cancellation) barrier from an earlier checkpoint (obsolete now)
+
+		}
+		else if (barrierId > currentCheckpointId) {
+			// first barrier of a new checkpoint is directly a cancellation
+
+			// by setting the currentCheckpointId to this checkpoint while keeping the numBarriers
+			// at zero means that no checkpoint barrier can start a new alignment
+			currentCheckpointId = barrierId;
+
+			startOfAlignmentTimestamp = 0L;
+			latestAlignmentDurationNanos = 0L;
+
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Checkpoint {} canceled, skipping alignment", barrierId);
+			}
+
+			notifyAbort(barrierId);
+		}
+
+		// else: trailing barrier from either
+		//   - a previous (subsumed) checkpoint
+		//   - the current checkpoint if it was already canceled
+	}
+
+	private void processEndOfPartition(int channel) throws Exception {
+		numClosedChannels++;
+
+		if (numBarriersReceived > 0) {
+			// let the task know we skip a checkpoint
+			notifyAbort(currentCheckpointId);
+
+			// no chance to complete this checkpoint
+			releaseBlocksAndResetBarriers();
+		}
+	}
+
+	private void notifyCheckpoint(CheckpointBarrier checkpointBarrier) throws Exception {
+		if (toNotifyOnCheckpoint != null) {
+			CheckpointMetaData checkpointMetaData =
+					new CheckpointMetaData(checkpointBarrier.getId(), checkpointBarrier.getTimestamp());
+
+			checkpointMetaData
+					.setBytesBufferedInAlignment(bufferSpiller.getBytesWritten())
+					.setAlignmentDurationNanos(latestAlignmentDurationNanos);
+
+			toNotifyOnCheckpoint.triggerCheckpointOnBarrier(checkpointMetaData);
+		}
+	}
+
+	private void notifyAbort(long checkpointId) throws Exception {
+		if (toNotifyOnCheckpoint != null) {
+			toNotifyOnCheckpoint.abortCheckpointOnBarrier(checkpointId);
+		}
+	}
+
+
 	@Override
 	public void registerCheckpointEventHandler(StatefulTask toNotifyOnCheckpoint) {
 		if (this.toNotifyOnCheckpoint == null) {
@@ -239,7 +342,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 			throw new IllegalStateException("BarrierBuffer already has a registered checkpoint notifyee");
 		}
 	}
-	
+
 	@Override
 	public boolean isEmpty() {
 		return currentBuffered == null;
@@ -254,8 +357,20 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 		for (BufferSpiller.SpilledBufferOrEventSequence seq : queuedBuffered) {
 			seq.cleanup();
 		}
+		queuedBuffered.clear();
 	}
-	
+
+	private void beginNewAlignment(long checkpointId, int channelIndex) throws IOException {
+		currentCheckpointId = checkpointId;
+		onBarrier(channelIndex);
+
+		startOfAlignmentTimestamp = System.nanoTime();
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Starting stream alignment for checkpoint " + checkpointId);
+		}
+	}
+
 	/**
 	 * Checks whether the channel with the given index is blocked.
 	 * 
@@ -265,7 +380,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 	private boolean isBlocked(int channelIndex) {
 		return blockedChannels[channelIndex];
 	}
-	
+
 	/**
 	 * Blocks the given channel index, from which a barrier has been received.
 	 * 
@@ -274,28 +389,28 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 	private void onBarrier(int channelIndex) throws IOException {
 		if (!blockedChannels[channelIndex]) {
 			blockedChannels[channelIndex] = true;
+
 			numBarriersReceived++;
-			
+
 			if (LOG.isDebugEnabled()) {
 				LOG.debug("Received barrier from channel " + channelIndex);
 			}
 		}
 		else {
-			throw new IOException("Stream corrupt: Repeated barrier for same checkpoint and input stream");
+			throw new IOException("Stream corrupt: Repeated barrier for same checkpoint on input " + channelIndex);
 		}
 	}
 
 	/**
-	 * Releases the blocks on all channels. Makes sure the just written data
-	 * is the next to be consumed.
+	 * Releases the blocks on all channels and resets the barrier count.
+	 * Makes sure the just written data is the next to be consumed.
 	 */
-	private void releaseBlocks() throws IOException {
+	private void releaseBlocksAndResetBarriers() throws IOException {
 		LOG.debug("End of stream alignment, feeding buffered data back");
 
 		for (int i = 0; i < blockedChannels.length; i++) {
 			blockedChannels[i] = false;
 		}
-		numBarriersReceived = 0;
 
 		if (currentBuffered == null) {
 			// common case: no more buffered data
@@ -317,9 +432,11 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 			}
 		}
 
-		final long now = System.nanoTime();
+		// the next barrier that comes must assume it is the first
+		numBarriersReceived = 0;
+
 		if (startOfAlignmentTimestamp > 0) {
-			latestAlignmentDurationNanos = now - startOfAlignmentTimestamp;
+			latestAlignmentDurationNanos = System.nanoTime() - startOfAlignmentTimestamp;
 			startOfAlignmentTimestamp = 0;
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
@@ -18,7 +18,11 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.decline.CheckpointDeclineException;
+import org.apache.flink.runtime.checkpoint.decline.CheckpointDeclineOnCancellationBarrierException;
+import org.apache.flink.runtime.checkpoint.decline.CheckpointDeclineSubsumedException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.decline.InputEndOfStreamException;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
@@ -143,7 +147,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 				}
 				else {
 					if (next.getEvent().getClass() == EndOfPartitionEvent.class) {
-						processEndOfPartition(next.getChannelIndex());
+						processEndOfPartition();
 					}
 					return next;
 				}
@@ -197,7 +201,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 						"Skipping current checkpoint.", barrierId, currentCheckpointId);
 
 				// let the task know we are not completing this
-				notifyAbort(currentCheckpointId);
+				notifyAbort(currentCheckpointId, new CheckpointDeclineSubsumedException(barrierId));
 
 				// abort the current checkpoint
 				releaseBlocksAndResetBarriers();
@@ -242,7 +246,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 			if (barrierId > currentCheckpointId) {
 				// new checkpoint
 				currentCheckpointId = barrierId;
-				notifyAbort(barrierId);
+				notifyAbortOnCancellationBarrier(barrierId);
 			}
 			return;
 		}
@@ -259,7 +263,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 				}
 
 				releaseBlocksAndResetBarriers();
-				notifyAbort(barrierId);
+				notifyAbortOnCancellationBarrier(barrierId);
 			}
 			else if (barrierId > currentCheckpointId) {
 				// we canceled the next which also cancels the current
@@ -273,7 +277,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 				currentCheckpointId = barrierId;
 				startOfAlignmentTimestamp = 0L;
 				latestAlignmentDurationNanos = 0L;
-				notifyAbort(barrierId);
+				notifyAbortOnCancellationBarrier(barrierId);
 			}
 
 			// else: ignore trailing (cancellation) barrier from an earlier checkpoint (obsolete now)
@@ -293,7 +297,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 				LOG.debug("Checkpoint {} canceled, skipping alignment", barrierId);
 			}
 
-			notifyAbort(barrierId);
+			notifyAbortOnCancellationBarrier(barrierId);
 		}
 
 		// else: trailing barrier from either
@@ -301,12 +305,12 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 		//   - the current checkpoint if it was already canceled
 	}
 
-	private void processEndOfPartition(int channel) throws Exception {
+	private void processEndOfPartition() throws Exception {
 		numClosedChannels++;
 
 		if (numBarriersReceived > 0) {
 			// let the task know we skip a checkpoint
-			notifyAbort(currentCheckpointId);
+			notifyAbort(currentCheckpointId, new InputEndOfStreamException());
 
 			// no chance to complete this checkpoint
 			releaseBlocksAndResetBarriers();
@@ -326,9 +330,13 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 		}
 	}
 
-	private void notifyAbort(long checkpointId) throws Exception {
+	private void notifyAbortOnCancellationBarrier(long checkpointId) throws Exception {
+		notifyAbort(checkpointId, new CheckpointDeclineOnCancellationBarrierException());
+	}
+
+	private void notifyAbort(long checkpointId, CheckpointDeclineException cause) throws Exception {
 		if (toNotifyOnCheckpoint != null) {
-			toNotifyOnCheckpoint.abortCheckpointOnBarrier(checkpointId);
+			toNotifyOnCheckpoint.abortCheckpointOnBarrier(checkpointId, cause);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierTracker.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.decline.CheckpointDeclineOnCancellationBarrierException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
@@ -234,7 +235,8 @@ public class BarrierTracker implements CheckpointBarrierHandler {
 
 	private void notifyAbort(long checkpointId) throws Exception {
 		if (toNotifyOnCheckpoint != null) {
-			toNotifyOnCheckpoint.abortCheckpointOnBarrier(checkpointId);
+			toNotifyOnCheckpoint.abortCheckpointOnBarrier(
+					checkpointId, new CheckpointDeclineOnCancellationBarrierException());
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierTracker.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
@@ -34,9 +35,9 @@ import java.util.ArrayDeque;
  * 
  * <p>Unlike the {@link BarrierBuffer}, the BarrierTracker does not block the input
  * channels that have sent barriers, so it cannot be used to gain "exactly-once" processing
- * guarantees. It can, however, be used to gain "at least once" processing guarantees.</p>
+ * guarantees. It can, however, be used to gain "at least once" processing guarantees.
  * 
- * <p>NOTE: This implementation strictly assumes that newer checkpoints have higher checkpoint IDs.</p>
+ * <p>NOTE: This implementation strictly assumes that newer checkpoints have higher checkpoint IDs.
  */
 @Internal
 public class BarrierTracker implements CheckpointBarrierHandler {
@@ -74,14 +75,19 @@ public class BarrierTracker implements CheckpointBarrierHandler {
 	public BufferOrEvent getNextNonBlocked() throws Exception {
 		while (true) {
 			BufferOrEvent next = inputGate.getNextBufferOrEvent();
-			if (next == null) {
-				return null;
-			}
-			else if (next.isBuffer() || next.getEvent().getClass() != CheckpointBarrier.class) {
+			if (next == null || next.isBuffer()) {
+				// buffer or input exhausted
 				return next;
 			}
-			else {
+			else if (next.getEvent().getClass() == CheckpointBarrier.class) {
 				processBarrier((CheckpointBarrier) next.getEvent());
+			}
+			else if (next.getEvent().getClass() == CancelCheckpointMarker.class) {
+				processCheckpointAbortBarrier((CancelCheckpointMarker) next.getEvent());
+			}
+			else {
+				// some other event
+				return next;
 			}
 		}
 	}
@@ -113,23 +119,15 @@ public class BarrierTracker implements CheckpointBarrierHandler {
 	}
 
 	private void processBarrier(CheckpointBarrier receivedBarrier) throws Exception {
+		final long barrierId = receivedBarrier.getId();
+
 		// fast path for single channel trackers
 		if (totalNumberOfInputChannels == 1) {
-			if (toNotifyOnCheckpoint != null) {
-				CheckpointMetaData checkpointMetaData =
-						new CheckpointMetaData(receivedBarrier.getId(), receivedBarrier.getTimestamp());
-
-				checkpointMetaData.
-						setBytesBufferedInAlignment(0L).
-						setAlignmentDurationNanos(0L);
-
-				toNotifyOnCheckpoint.triggerCheckpointOnBarrier(checkpointMetaData);
-			}
+			notifyCheckpoint(barrierId, receivedBarrier.getTimestamp());
 			return;
 		}
 
 		// general path for multiple input channels
-		final long barrierId = receivedBarrier.getId();
 
 		// find the checkpoint barrier in the queue of bending barriers
 		CheckpointBarrierCount cbc = null;
@@ -147,22 +145,16 @@ public class BarrierTracker implements CheckpointBarrierHandler {
 			// add one to the count to that barrier and check for completion
 			int numBarriersNew = cbc.incrementBarrierCount();
 			if (numBarriersNew == totalNumberOfInputChannels) {
-				// checkpoint can be triggered
+				// checkpoint can be triggered (or is aborted and all barriers have been seen)
 				// first, remove this checkpoint and all all prior pending
 				// checkpoints (which are now subsumed)
 				for (int i = 0; i <= pos; i++) {
 					pendingCheckpoints.pollFirst();
 				}
-				
-				// notify the listener
-				if (toNotifyOnCheckpoint != null) {
-					CheckpointMetaData checkpointMetaData =
-							new CheckpointMetaData(receivedBarrier.getId(), receivedBarrier.getTimestamp());
-					checkpointMetaData.
-							setBytesBufferedInAlignment(0L).
-							setAlignmentDurationNanos(0L);
 
-					toNotifyOnCheckpoint.triggerCheckpointOnBarrier(checkpointMetaData);
+				// notify the listener
+				if (!cbc.isAborted()) {
+					notifyCheckpoint(receivedBarrier.getId(), receivedBarrier.getTimestamp());
 				}
 			}
 		}
@@ -183,45 +175,110 @@ public class BarrierTracker implements CheckpointBarrierHandler {
 		}
 	}
 
+	private void processCheckpointAbortBarrier(CancelCheckpointMarker barrier) throws Exception {
+		final long checkpointId = barrier.getCheckpointId();
+
+		// fast path for single channel trackers
+		if (totalNumberOfInputChannels == 1) {
+			notifyAbort(checkpointId);
+			return;
+		}
+
+		// -- general path for multiple input channels --
+
+		// find the checkpoint barrier in the queue of pending barriers
+		// while doing this we "abort" all checkpoints before that one
+		CheckpointBarrierCount cbc;
+		while ((cbc = pendingCheckpoints.peekFirst()) != null && cbc.checkpointId() < checkpointId) {
+			pendingCheckpoints.removeFirst();
+		}
+
+		if (cbc != null && cbc.checkpointId() == checkpointId) {
+			// make sure the checkpoint is remembered as aborted
+			if (cbc.markAborted()) {
+				// this was the first time the checkpoint was aborted - notify
+				notifyAbort(checkpointId);
+			}
+
+			// we still count the barriers to be able to remove the entry once all barriers have been seen
+			if (cbc.incrementBarrierCount() == totalNumberOfInputChannels) {
+				// we can remove this entry
+				pendingCheckpoints.removeFirst();
+			}
+		}
+		else {
+			notifyAbort(checkpointId);
+
+			// first barrier for this checkpoint - remember it as aborted
+			// since we polled away all entries with lower checkpoint IDs
+			// this entry will become the new first entry
+			if (pendingCheckpoints.size() < MAX_CHECKPOINTS_TO_TRACK) {
+				CheckpointBarrierCount abortedMarker = new CheckpointBarrierCount(checkpointId);
+				abortedMarker.markAborted();
+				pendingCheckpoints.addFirst(abortedMarker);
+			}
+		}
+	}
+
+	private void notifyCheckpoint(long checkpointId, long timestamp) throws Exception {
+		if (toNotifyOnCheckpoint != null) {
+			CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, timestamp);
+
+			checkpointMetaData
+					.setBytesBufferedInAlignment(0L)
+					.setAlignmentDurationNanos(0L);
+
+			toNotifyOnCheckpoint.triggerCheckpointOnBarrier(checkpointMetaData);
+		}
+	}
+
+	private void notifyAbort(long checkpointId) throws Exception {
+		if (toNotifyOnCheckpoint != null) {
+			toNotifyOnCheckpoint.abortCheckpointOnBarrier(checkpointId);
+		}
+	}
+
 	// ------------------------------------------------------------------------
 
 	/**
 	 * Simple class for a checkpoint ID with a barrier counter.
 	 */
 	private static final class CheckpointBarrierCount {
-		
+
 		private final long checkpointId;
-		
+
 		private int barrierCount;
-		
-		private CheckpointBarrierCount(long checkpointId) {
+
+		private boolean aborted;
+
+		CheckpointBarrierCount(long checkpointId) {
 			this.checkpointId = checkpointId;
 			this.barrierCount = 1;
+		}
+
+		public long checkpointId() {
+			return checkpointId;
 		}
 
 		public int incrementBarrierCount() {
 			return ++barrierCount;
 		}
 
-		@Override
-		public int hashCode() {
-			return (int) ((checkpointId >>> 32) ^ checkpointId) + 17 * barrierCount; 
+		public boolean isAborted() {
+			return aborted;
 		}
 
-		@Override
-		public boolean equals(Object obj) {
-			if (obj instanceof  CheckpointBarrierCount) {
-				CheckpointBarrierCount that = (CheckpointBarrierCount) obj;
-				return this.checkpointId == that.checkpointId && this.barrierCount == that.barrierCount;
-			}
-			else {
-				return false;
-			}
+		public boolean markAborted() {
+			boolean firstAbort = !this.aborted;
+			this.aborted = true;
+			return firstAbort;
 		}
 
 		@Override
 		public String toString() {
-			return String.format("checkpointID=%d, count=%d", checkpointId, barrierCount);
+			return isAborted() ?
+				String.format("checkpointID=%d - ABORTED", checkpointId) :
+				String.format("checkpointID=%d, count=%d", checkpointId, barrierCount);
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BufferSpiller.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BufferSpiller.java
@@ -132,9 +132,8 @@ public class BufferSpiller {
 			}
 			else {
 				contents = EventSerializer.toSerializedEvent(boe.getEvent());
-				
 			}
-			
+
 			headBuffer.clear();
 			headBuffer.putInt(boe.getChannelIndex());
 			headBuffer.putInt(contents.remaining());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BufferSpiller.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BufferSpiller.java
@@ -277,6 +277,9 @@ public class BufferSpiller {
 		/** The byte buffer for bulk reading */
 		private final ByteBuffer buffer;
 
+		/** We store this size as a constant because it is crucial it never changes */
+		private final long size;
+
 		/** The page size to instantiate properly sized memory segments */
 		private final int pageSize;
 
@@ -291,11 +294,13 @@ public class BufferSpiller {
 		 * @param buffer The buffer used for bulk reading.
 		 * @param pageSize The page size to use for the created memory segments.
 		 */
-		SpilledBufferOrEventSequence(File file, FileChannel fileChannel, ByteBuffer buffer, int pageSize) {
+		SpilledBufferOrEventSequence(File file, FileChannel fileChannel, ByteBuffer buffer, int pageSize)
+				throws IOException {
 			this.file = file;
 			this.fileChannel = fileChannel;
 			this.buffer = buffer;
 			this.pageSize = pageSize;
+			this.size = fileChannel.size();
 		}
 
 		/**
@@ -416,6 +421,13 @@ public class BufferSpiller {
 			if (!file.delete()) {
 				throw new IOException("Cannot remove temp file for stream alignment writer");
 			}
+		}
+
+		/**
+		 * Gets the size of this spilled sequence.
+		 */
+		public long size() throws IOException {
+			return size;
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
@@ -100,8 +100,8 @@ public class RecordWriterOutput<OUT> implements Output<StreamRecord<OUT>> {
 		}
 	}
 
-	public void broadcastEvent(AbstractEvent barrier) throws IOException, InterruptedException {
-		recordWriter.broadcastEvent(barrier);
+	public void broadcastEvent(AbstractEvent event) throws IOException, InterruptedException {
+		recordWriter.broadcastEvent(event);
 	}
 	
 	

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamInputProcessor.java
@@ -22,6 +22,9 @@ import java.io.IOException;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.runtime.jobgraph.tasks.StatefulTask;
@@ -87,12 +90,19 @@ public class StreamInputProcessor<IN> {
 			TypeSerializer<IN> inputSerializer,
 			StatefulTask checkpointedTask,
 			CheckpointingMode checkpointMode,
-			IOManager ioManager) throws IOException {
+			IOManager ioManager,
+			Configuration taskManagerConfig) throws IOException {
 
 		InputGate inputGate = InputGateUtil.createInputGate(inputGates);
 
 		if (checkpointMode == CheckpointingMode.EXACTLY_ONCE) {
-			this.barrierHandler = new BarrierBuffer(inputGate, ioManager);
+			long maxAlign = taskManagerConfig.getLong(TaskManagerOptions.TASK_CHECKPOINT_ALIGNMENT_BYTES_LIMIT);
+			if (!(maxAlign == -1 || maxAlign > 0)) {
+				throw new IllegalConfigurationException(
+						TaskManagerOptions.TASK_CHECKPOINT_ALIGNMENT_BYTES_LIMIT.key()
+						+ " must be positive or -1 (infinite)");
+			}
+			this.barrierHandler = new BarrierBuffer(inputGate, ioManager, maxAlign);
 		}
 		else if (checkpointMode == CheckpointingMode.AT_LEAST_ONCE) {
 			this.barrierHandler = new BarrierTracker(inputGate);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -20,6 +20,9 @@ package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.runtime.jobgraph.tasks.StatefulTask;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
@@ -93,12 +96,19 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 			TypeSerializer<IN2> inputSerializer2,
 			StatefulTask checkpointedTask,
 			CheckpointingMode checkpointMode,
-			IOManager ioManager) throws IOException {
-		
+			IOManager ioManager,
+			Configuration taskManagerConfig) throws IOException {
+
 		final InputGate inputGate = InputGateUtil.createInputGate(inputGates1, inputGates2);
 
 		if (checkpointMode == CheckpointingMode.EXACTLY_ONCE) {
-			this.barrierHandler = new BarrierBuffer(inputGate, ioManager);
+			long maxAlign = taskManagerConfig.getLong(TaskManagerOptions.TASK_CHECKPOINT_ALIGNMENT_BYTES_LIMIT);
+			if (!(maxAlign == -1 || maxAlign > 0)) {
+				throw new IllegalConfigurationException(
+						TaskManagerOptions.TASK_CHECKPOINT_ALIGNMENT_BYTES_LIMIT.key()
+								+ " must be positive or -1 (infinite)");
+			}
+			this.barrierHandler = new BarrierBuffer(inputGate, ioManager, maxAlign);
 		}
 		else if (checkpointMode == CheckpointingMode.AT_LEAST_ONCE) {
 			this.barrierHandler = new BarrierTracker(inputGate);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -41,10 +41,12 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 
 		if (numberOfInputs > 0) {
 			InputGate[] inputGates = getEnvironment().getAllInputGates();
-			inputProcessor = new StreamInputProcessor<IN>(inputGates, inSerializer,
+			inputProcessor = new StreamInputProcessor<IN>(
+					inputGates, inSerializer,
 					this, 
 					configuration.getCheckpointMode(),
-					getEnvironment().getIOManager());
+					getEnvironment().getIOManager(),
+					getEnvironment().getTaskManagerInfo().getConfiguration());
 
 			// make sure that stream tasks report their I/O statistics
 			inputProcessor.setMetricGroup(getEnvironment().getMetricGroup().getIOMetricGroup());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -528,7 +528,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 	@Override
 	public void triggerCheckpointOnBarrier(CheckpointMetaData checkpointMetaData) throws Exception {
-
 		try {
 			performCheckpoint(checkpointMetaData);
 		}
@@ -537,6 +536,17 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		}
 		catch (Exception e) {
 			throw new Exception("Error while performing a checkpoint", e);
+		}
+	}
+
+	@Override
+	public void abortCheckpointOnBarrier(long checkpointId) throws Exception {
+		LOG.debug("Aborting checkpoint via cancel-barrier {} for task {}", checkpointId, getName());
+
+		synchronized (lock) {
+			if (isRunning) {
+				operatorChain.broadcastCheckpointCancelMarker(checkpointId);
+			}
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -28,6 +28,8 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.SubtaskState;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.StatefulTask;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
@@ -540,22 +542,24 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	}
 
 	@Override
-	public void abortCheckpointOnBarrier(long checkpointId) throws Exception {
+	public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) throws Exception {
 		LOG.debug("Aborting checkpoint via cancel-barrier {} for task {}", checkpointId, getName());
 
+		// notify the coordinator that we decline this checkpoint
+		getEnvironment().declineCheckpoint(checkpointId, cause);
+
+		// notify all downstream operators that they should not wait for a barrier from us
 		synchronized (lock) {
-			if (isRunning) {
-				operatorChain.broadcastCheckpointCancelMarker(checkpointId);
-			}
+			operatorChain.broadcastCheckpointCancelMarker(checkpointId);
 		}
 	}
 
 	private boolean performCheckpoint(CheckpointMetaData checkpointMetaData) throws Exception {
-
 		LOG.debug("Starting checkpoint {} on task {}", checkpointMetaData.getCheckpointId(), getName());
 
 		synchronized (lock) {
 			if (isRunning) {
+				// we can do a checkpoint
 
 				// Since both state checkpointing and downstream barrier emission occurs in this
 				// lock scope, they are an atomic operation regardless of the order in which they occur.
@@ -566,7 +570,18 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 				checkpointState(checkpointMetaData);
 				return true;
-			} else {
+			}
+			else {
+				// we cannot perform our checkpoint - let the downstream operators know that they
+				// should not wait for any input from this operator
+
+				// we cannot broadcast the cancellation markers on the 'operator chain', because it may not
+				// yet be created
+				final CancelCheckpointMarker message = new CancelCheckpointMarker(checkpointMetaData.getCheckpointId());
+				for (ResultPartitionWriter output : getEnvironment().getAllWriters()) {
+					output.writeEventToAllChannels(message);
+				}
+
 				return false;
 			}
 		}
@@ -832,10 +847,10 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 		private final List<OperatorSnapshotResult> snapshotInProgressList;
 
-		RunnableFuture<KeyGroupsStateHandle> futureKeyedBackendStateHandles;
-		RunnableFuture<KeyGroupsStateHandle> futureKeyedStreamStateHandles;
+		private RunnableFuture<KeyGroupsStateHandle> futureKeyedBackendStateHandles;
+		private RunnableFuture<KeyGroupsStateHandle> futureKeyedStreamStateHandles;
 
-		List<StreamStateHandle> nonPartitionedStateHandles;
+		private List<StreamStateHandle> nonPartitionedStateHandles;
 
 		private final CheckpointMetaData checkpointMetaData;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -65,11 +65,13 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends StreamTask<OUT, TwoInputS
 			}
 		}
 	
-		this.inputProcessor = new StreamTwoInputProcessor<IN1, IN2>(inputList1, inputList2,
+		this.inputProcessor = new StreamTwoInputProcessor<IN1, IN2>(
+				inputList1, inputList2,
 				inputDeserializer1, inputDeserializer2,
 				this,
 				configuration.getCheckpointMode(),
-				getEnvironment().getIOManager());
+				getEnvironment().getIOManager(),
+				getEnvironment().getTaskManagerInfo().getConfiguration());
 
 		// make sure that stream tasks report their I/O statistics
 		inputProcessor.setMetricGroup(getEnvironment().getMetricGroup().getIOMetricGroup());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferAlignmentLimitTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferAlignmentLimitTest.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.checkpoint.decline.AlignmentLimitExceededException;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.jobgraph.tasks.StatefulTask;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for the barrier buffer's maximum limit of buffered/spilled bytes 
+ */
+public class BarrierBufferAlignmentLimitTest {
+
+	private static final int PAGE_SIZE = 512;
+
+	private static final Random RND = new Random();
+
+	private static IOManager IO_MANAGER;
+
+	// ------------------------------------------------------------------------
+	//  Setup
+	// ------------------------------------------------------------------------
+
+	@BeforeClass
+	public static void setup() {
+		IO_MANAGER = new IOManagerAsync();
+	}
+
+	@AfterClass
+	public static void shutdownIOManager() {
+		IO_MANAGER.shutdown();
+	}
+
+	// ------------------------------------------------------------------------
+	//  Tests
+	// ------------------------------------------------------------------------
+
+	/**
+	 * This tests that a single alignment that buffers too much data cancels
+	 */
+	@Test
+	public void testBreakCheckpointAtAlignmentLimit() throws Exception {
+		BufferOrEvent[] sequence = {
+				// some initial buffers
+				/*  0 */ createBuffer(1, 100), createBuffer(2, 70),
+				/*  2 */ createBuffer(0, 42), createBuffer(2, 111),
+
+				// starting a checkpoint
+				/*  4 */ createBarrier(7, 1), 
+				/*  5 */ createBuffer(1, 100), createBuffer(2, 200), createBuffer(1, 300), createBuffer(0, 50),
+				/*  9 */ createBarrier(7, 0),
+				/* 10 */ createBuffer(2, 100), createBuffer(0, 100), createBuffer(1, 200), createBuffer(0, 200),
+
+				// this buffer makes the alignment spill too large
+				/* 14 */ createBuffer(0, 101),
+
+				// additional data
+				/* 15 */ createBuffer(0, 100), createBuffer(1, 100), createBuffer(2, 100),
+				
+				// checkpoint completes - this should not result in a "completion notification"
+				/* 18 */ createBarrier(7, 2),
+
+				// trailing buffers
+				/* 19 */ createBuffer(0, 100), createBuffer(1, 100), createBuffer(2, 100)
+		};
+
+		// the barrier buffer has a limit that only 1000 bytes may be spilled in alignment
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		BarrierBuffer buffer = new BarrierBuffer(gate, IO_MANAGER, 1000);
+
+		StatefulTask toNotify = mock(StatefulTask.class);
+		buffer.registerCheckpointEventHandler(toNotify);
+
+		// validating the sequence of buffers
+
+		check(sequence[0], buffer.getNextNonBlocked());
+		check(sequence[1], buffer.getNextNonBlocked());
+		check(sequence[2], buffer.getNextNonBlocked());
+		check(sequence[3], buffer.getNextNonBlocked());
+
+		// start of checkpoint
+		long startTs = System.nanoTime();
+		check(sequence[6], buffer.getNextNonBlocked());
+		check(sequence[8], buffer.getNextNonBlocked());
+		check(sequence[10], buffer.getNextNonBlocked());
+
+		// trying to pull the next makes the alignment overflow - so buffered buffers are replayed
+		check(sequence[5], buffer.getNextNonBlocked());
+		validateAlignmentTime(startTs, buffer);
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(7L), any(AlignmentLimitExceededException.class));
+
+		// playing back buffered events
+		check(sequence[7], buffer.getNextNonBlocked());
+		check(sequence[11], buffer.getNextNonBlocked());
+		check(sequence[12], buffer.getNextNonBlocked());
+		check(sequence[13], buffer.getNextNonBlocked());
+		check(sequence[14], buffer.getNextNonBlocked());
+
+		// the additional data
+		check(sequence[15], buffer.getNextNonBlocked());
+		check(sequence[16], buffer.getNextNonBlocked());
+		check(sequence[17], buffer.getNextNonBlocked());
+
+		check(sequence[19], buffer.getNextNonBlocked());
+		check(sequence[20], buffer.getNextNonBlocked());
+		check(sequence[21], buffer.getNextNonBlocked());
+
+		// no call for a completed checkpoint must have happened
+		verify(toNotify, times(0)).triggerCheckpointOnBarrier(any(CheckpointMetaData.class));
+
+		assertNull(buffer.getNextNonBlocked());
+		assertNull(buffer.getNextNonBlocked());
+
+		buffer.cleanup();
+		checkNoTempFilesRemain();
+	}
+
+	/**
+	 * This tests the following case:
+	 *   - an alignment starts
+	 *   - barriers from a second checkpoint queue before the first completes
+	 *   - together they are larger than the threshold
+	 *   - after the first checkpoint (with second checkpoint data queued) aborts, the second completes 
+	 */
+	@Test
+	public void testAlignmentLimitWithQueuedAlignments() throws Exception {
+		BufferOrEvent[] sequence = {
+				// some initial buffers
+				/*  0 */ createBuffer(1, 100), createBuffer(2, 70),
+
+				// starting a checkpoint
+				/*  2 */ createBarrier(3, 2), 
+				/*  3 */ createBuffer(1, 100), createBuffer(2, 100), 
+				/*  5 */ createBarrier(3, 0),
+				/*  6 */ createBuffer(0, 100), createBuffer(1, 100),
+
+				// queue some data from the next checkpoint
+				/*  8 */ createBarrier(4, 0),
+				/*  9 */ createBuffer(0, 100), createBuffer(0, 120), createBuffer(1, 100),
+
+				// this one makes the alignment overflow
+				/* 12 */ createBuffer(2, 100),
+
+				// checkpoint completed
+				/* 13 */ createBarrier(3, 1),
+
+				// more for the next checkpoint
+				/* 14 */ createBarrier(4, 1),
+				/* 15 */ createBuffer(0, 100), createBuffer(1, 100), createBuffer(2, 100),
+
+				// next checkpoint completes
+				/* 18 */ createBarrier(4, 2),
+
+				// trailing data
+				/* 19 */ createBuffer(0, 100), createBuffer(1, 100), createBuffer(2, 100)
+		};
+
+		// the barrier buffer has a limit that only 1000 bytes may be spilled in alignment
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		BarrierBuffer buffer = new BarrierBuffer(gate, IO_MANAGER, 500);
+
+		StatefulTask toNotify = mock(StatefulTask.class);
+		buffer.registerCheckpointEventHandler(toNotify);
+
+		// validating the sequence of buffers
+		long startTs;
+
+		check(sequence[0], buffer.getNextNonBlocked());
+		check(sequence[1], buffer.getNextNonBlocked());
+
+		// start of checkpoint
+		startTs = System.nanoTime();
+		check(sequence[3], buffer.getNextNonBlocked());
+		check(sequence[7], buffer.getNextNonBlocked());
+
+		// next checkpoint also in progress
+		check(sequence[11], buffer.getNextNonBlocked());
+
+		// checkpoint alignment aborted due to too much data
+		check(sequence[4], buffer.getNextNonBlocked());
+		validateAlignmentTime(startTs, buffer);
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(3L), any(AlignmentLimitExceededException.class));
+
+		// replay buffered data - in the middle, the alignment for checkpoint 4 starts
+		check(sequence[6], buffer.getNextNonBlocked());
+		startTs = System.nanoTime();
+		check(sequence[12], buffer.getNextNonBlocked());
+
+		// only checkpoint 4 is pending now - the last checkpoint 3 barrier will not trigger success 
+		check(sequence[17], buffer.getNextNonBlocked());
+
+		// checkpoint 4 completed - check and validate buffered replay
+		check(sequence[9], buffer.getNextNonBlocked());
+		validateAlignmentTime(startTs, buffer);
+		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(4L)));
+
+		check(sequence[10], buffer.getNextNonBlocked());
+		check(sequence[15], buffer.getNextNonBlocked());
+		check(sequence[16], buffer.getNextNonBlocked());
+
+		// trailing data
+		check(sequence[19], buffer.getNextNonBlocked());
+		check(sequence[20], buffer.getNextNonBlocked());
+		check(sequence[21], buffer.getNextNonBlocked());
+
+		// only checkpoint 4 was successfully completed, not checkpoint 3
+		verify(toNotify, times(0)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(3L)));
+
+		assertNull(buffer.getNextNonBlocked());
+		assertNull(buffer.getNextNonBlocked());
+
+		buffer.cleanup();
+		checkNoTempFilesRemain();
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utilities
+	// ------------------------------------------------------------------------
+
+	private static BufferOrEvent createBuffer(int channel, int size) {
+		byte[] bytes = new byte[size];
+		RND.nextBytes(bytes);
+
+		MemorySegment memory = MemorySegmentFactory.allocateUnpooledSegment(PAGE_SIZE);
+		memory.put(0, bytes);
+
+		Buffer buf = new Buffer(memory, FreeingBufferRecycler.INSTANCE);
+		buf.setSize(size);
+
+		// retain an additional time so it does not get disposed after being read by the input gate
+		buf.retain();
+
+		return new BufferOrEvent(buf, channel);
+	}
+
+	private static BufferOrEvent createBarrier(long id, int channel) {
+		return new BufferOrEvent(new CheckpointBarrier(id, System.currentTimeMillis()), channel);
+	}
+
+	private static void check(BufferOrEvent expected, BufferOrEvent present) {
+		assertNotNull(expected);
+		assertNotNull(present);
+		assertEquals(expected.isBuffer(), present.isBuffer());
+
+		if (expected.isBuffer()) {
+			assertEquals(expected.getBuffer().getSize(), present.getBuffer().getSize());
+			MemorySegment expectedMem = expected.getBuffer().getMemorySegment();
+			MemorySegment presentMem = present.getBuffer().getMemorySegment();
+			assertTrue("memory contents differs", expectedMem.compare(presentMem, 0, 0, PAGE_SIZE) == 0);
+		}
+		else {
+			assertEquals(expected.getEvent(), present.getEvent());
+		}
+	}
+
+	private static void validateAlignmentTime(long startTimestamp, BarrierBuffer buffer) {
+		final long elapsed = System.nanoTime() - startTimestamp;
+		assertTrue("wrong alignment time", buffer.getAlignmentDurationNanos() <= elapsed);
+	}
+
+	private static void checkNoTempFilesRemain() {
+		// validate that all temp files have been removed
+		for (File dir : IO_MANAGER.getSpillingDirectories()) {
+			for (String file : dir.list()) {
+				if (file != null && !(file.equals(".") || file.equals(".."))) {
+					fail("barrier buffer did not clean up temp files. remaining file: " + file);
+				}
+			}
+		}
+	}
+
+	/**
+	 * A validation matcher for checkpoint metadata against checkpoint IDs
+	 */
+	private static class CheckpointMatcher extends BaseMatcher<CheckpointMetaData> {
+
+		private final long checkpointId;
+
+		CheckpointMatcher(long checkpointId) {
+			this.checkpointId = checkpointId;
+		}
+
+		@Override
+		public boolean matches(Object o) {
+			return o != null &&
+					o.getClass() == CheckpointMetaData.class &&
+					((CheckpointMetaData) o).getCheckpointId() == checkpointId;
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText("CheckpointMetaData - id = " + checkpointId);
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.checkpoint.decline.CheckpointDeclineOnCancellationBarrierException;
+import org.apache.flink.runtime.checkpoint.decline.CheckpointDeclineSubsumedException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
@@ -52,6 +54,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -571,7 +574,7 @@ public class BarrierBufferTest {
 			check(sequence[12], buffer.getNextNonBlocked());
 			assertEquals(3L, buffer.getCurrentCheckpointId());
 			validateAlignmentTime(startTs, buffer);
-			verify(toNotify).abortCheckpointOnBarrier(2L);
+			verify(toNotify).abortCheckpointOnBarrier(eq(2L), any(CheckpointDeclineSubsumedException.class));
 			check(sequence[16], buffer.getNextNonBlocked());
 
 			// checkpoint 3 alignment in progress
@@ -579,7 +582,7 @@ public class BarrierBufferTest {
 
 			// checkpoint 3 aborted (end of partition)
 			check(sequence[20], buffer.getNextNonBlocked());
-			verify(toNotify).abortCheckpointOnBarrier(3L);
+			verify(toNotify).abortCheckpointOnBarrier(eq(3L), any(CheckpointDeclineSubsumedException.class));
 
 			// replay buffered data from checkpoint 3
 			check(sequence[18], buffer.getNextNonBlocked());
@@ -1004,13 +1007,13 @@ public class BarrierBufferTest {
 		check(sequence[6], buffer.getNextNonBlocked());
 		assertEquals(5L, buffer.getCurrentCheckpointId());
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(2L)));
-		verify(toNotify, times(1)).abortCheckpointOnBarrier(4L);
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(4L), any(CheckpointDeclineOnCancellationBarrierException.class));
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(5L)));
 		assertEquals(0L, buffer.getAlignmentDurationNanos());
 
 		check(sequence[8], buffer.getNextNonBlocked());
 		assertEquals(6L, buffer.getCurrentCheckpointId());
-		verify(toNotify, times(1)).abortCheckpointOnBarrier(6L);
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(6L), any(CheckpointDeclineOnCancellationBarrierException.class));
 		assertEquals(0L, buffer.getAlignmentDurationNanos());
 		
 		buffer.cleanup();
@@ -1078,7 +1081,7 @@ public class BarrierBufferTest {
 		// canceled checkpoint on last barrier
 		startTs = System.nanoTime();
 		check(sequence[12], buffer.getNextNonBlocked());
-		verify(toNotify, times(1)).abortCheckpointOnBarrier(2L);
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(2L), any(CheckpointDeclineOnCancellationBarrierException.class));
 		validateAlignmentTime(startTs, buffer);
 		check(sequence[13], buffer.getNextNonBlocked());
 
@@ -1093,7 +1096,7 @@ public class BarrierBufferTest {
 
 		// this checkpoint gets immediately canceled
 		check(sequence[24], buffer.getNextNonBlocked());
-		verify(toNotify, times(1)).abortCheckpointOnBarrier(4L);
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(4L), any(CheckpointDeclineOnCancellationBarrierException.class));
 		assertEquals(0L, buffer.getAlignmentDurationNanos());
 
 		// some buffers
@@ -1109,7 +1112,7 @@ public class BarrierBufferTest {
 		check(sequence[33], buffer.getNextNonBlocked());
 
 		check(sequence[37], buffer.getNextNonBlocked());
-		verify(toNotify, times(1)).abortCheckpointOnBarrier(6L);
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(6L), any(CheckpointDeclineOnCancellationBarrierException.class));
 		assertEquals(0L, buffer.getAlignmentDurationNanos());
 
 		// all done
@@ -1172,7 +1175,7 @@ public class BarrierBufferTest {
 
 		// re-read the queued cancellation barriers
 		check(sequence[9], buffer.getNextNonBlocked());
-		verify(toNotify, times(1)).abortCheckpointOnBarrier(2L);
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(2L), any(CheckpointDeclineOnCancellationBarrierException.class));
 		assertEquals(0L, buffer.getAlignmentDurationNanos());
 
 		check(sequence[10], buffer.getNextNonBlocked());
@@ -1189,7 +1192,7 @@ public class BarrierBufferTest {
 
 		// no further checkpoint (abort) notifications
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(any(CheckpointMetaData.class));
-		verify(toNotify, times(1)).abortCheckpointOnBarrier(anyLong());
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(anyLong(), any(CheckpointDeclineOnCancellationBarrierException.class));
 
 		// all done
 		assertNull(buffer.getNextNonBlocked());
@@ -1258,7 +1261,7 @@ public class BarrierBufferTest {
 		// cancelled by cancellation barrier
 		check(sequence[4], buffer.getNextNonBlocked());
 		validateAlignmentTime(startTs, buffer);
-		verify(toNotify, times(1)).abortCheckpointOnBarrier(1L);
+		verify(toNotify).abortCheckpointOnBarrier(eq(1L), any(CheckpointDeclineOnCancellationBarrierException.class));
 
 		// the next checkpoint alignment starts now
 		startTs = System.nanoTime();
@@ -1270,7 +1273,7 @@ public class BarrierBufferTest {
 		// checkpoint done
 		check(sequence[7], buffer.getNextNonBlocked());
 		validateAlignmentTime(startTs, buffer);
-		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(2L)));
+		verify(toNotify).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(2L)));
 
 		// queued data
 		check(sequence[10], buffer.getNextNonBlocked());
@@ -1290,7 +1293,7 @@ public class BarrierBufferTest {
 
 		// check overall notifications
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(any(CheckpointMetaData.class));
-		verify(toNotify, times(1)).abortCheckpointOnBarrier(anyLong());
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(anyLong(), any(Throwable.class));
 	}
 
 	/**
@@ -1342,7 +1345,7 @@ public class BarrierBufferTest {
 		// future barrier aborts checkpoint
 		startTs = System.nanoTime();
 		check(sequence[3], buffer.getNextNonBlocked());
-		verify(toNotify, times(1)).abortCheckpointOnBarrier(3L);
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(eq(3L), any(CheckpointDeclineSubsumedException.class));
 		check(sequence[4], buffer.getNextNonBlocked());
 
 		// alignment of next checkpoint
@@ -1371,7 +1374,7 @@ public class BarrierBufferTest {
 
 		// check overall notifications
 		verify(toNotify, times(1)).triggerCheckpointOnBarrier(any(CheckpointMetaData.class));
-		verify(toNotify, times(1)).abortCheckpointOnBarrier(anyLong());
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(anyLong(), any(Throwable.class));
 	}
 
 	// ------------------------------------------------------------------------
@@ -1479,7 +1482,7 @@ public class BarrierBufferTest {
 		}
 
 		@Override
-		public void abortCheckpointOnBarrier(long checkpointId) {}
+		public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) {}
 
 		@Override
 		public void notifyCheckpointComplete(long checkpointId) throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTest.java
@@ -18,29 +18,30 @@
 
 package org.apache.flink.streaming.runtime.io;
 
+import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.jobgraph.tasks.StatefulTask;
-import org.apache.flink.runtime.state.ChainedStateHandle;
-import org.apache.flink.runtime.state.KeyGroupsStateHandle;
-import org.apache.flink.runtime.state.OperatorStateHandle;
-import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TaskStateHandles;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
+import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -48,15 +49,24 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 /**
  * Tests for the behavior of the {@link BarrierBuffer}.
  */
 public class BarrierBufferTest {
 
+	private static final Random RND = new Random();
+
 	private static final int PAGE_SIZE = 512;
-	
+
 	private static int SIZE_COUNTER = 0;
-	
+
 	private static IOManager IO_MANAGER;
 
 	@BeforeClass
@@ -528,36 +538,53 @@ public class BarrierBufferTest {
 			MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
 			BarrierBuffer buffer = new BarrierBuffer(gate, IO_MANAGER);
 
-			ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler();
-			buffer.registerCheckpointEventHandler(handler);
-			handler.setNextExpectedCheckpointId(1L);
+			StatefulTask toNotify = mock(StatefulTask.class);
+			buffer.registerCheckpointEventHandler(toNotify);
 
-			// checkpoint 1
+			long startTs;
+
+			// initial data
 			check(sequence[0], buffer.getNextNonBlocked());
 			check(sequence[1], buffer.getNextNonBlocked());
 			check(sequence[2], buffer.getNextNonBlocked());
+
+			// align checkpoint 1
+			startTs = System.nanoTime();
 			check(sequence[7], buffer.getNextNonBlocked());
 			assertEquals(1L, buffer.getCurrentCheckpointId());
-			
+
+			// checkpoint done - replay buffered
 			check(sequence[5], buffer.getNextNonBlocked());
+			validateAlignmentTime(startTs, buffer);
+			verify(toNotify).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(1L)));
 			check(sequence[6], buffer.getNextNonBlocked());
+
 			check(sequence[9], buffer.getNextNonBlocked());
 			check(sequence[10], buffer.getNextNonBlocked());
 
 			// alignment of checkpoint 2
+			startTs = System.nanoTime();
 			check(sequence[13], buffer.getNextNonBlocked());
-			assertEquals(2L, buffer.getCurrentCheckpointId());
 			check(sequence[15], buffer.getNextNonBlocked());
 
 			// checkpoint 2 aborted, checkpoint 3 started
 			check(sequence[12], buffer.getNextNonBlocked());
 			assertEquals(3L, buffer.getCurrentCheckpointId());
+			validateAlignmentTime(startTs, buffer);
+			verify(toNotify).abortCheckpointOnBarrier(2L);
 			check(sequence[16], buffer.getNextNonBlocked());
+
+			// checkpoint 3 alignment in progress
 			check(sequence[19], buffer.getNextNonBlocked());
-			check(sequence[20], buffer.getNextNonBlocked());
-			
+
 			// checkpoint 3 aborted (end of partition)
+			check(sequence[20], buffer.getNextNonBlocked());
+			verify(toNotify).abortCheckpointOnBarrier(3L);
+
+			// replay buffered data from checkpoint 3
 			check(sequence[18], buffer.getNextNonBlocked());
+
+			// all the remaining messages
 			check(sequence[21], buffer.getNextNonBlocked());
 			check(sequence[22], buffer.getNextNonBlocked());
 			check(sequence[23], buffer.getNextNonBlocked());
@@ -887,9 +914,9 @@ public class BarrierBufferTest {
 
 			assertNull(buffer.getNextNonBlocked());
 			assertNull(buffer.getNextNonBlocked());
-			
+
 			buffer.cleanup();
-			
+
 			checkNoTempFilesRemain();
 		}
 		catch (Exception e) {
@@ -899,26 +926,480 @@ public class BarrierBufferTest {
 	}
 
 	@Test
-	public void testEndOfStreamWhileCheckpoint() {
+	public void testEndOfStreamWhileCheckpoint() throws Exception {
+		BufferOrEvent[] sequence = {
+				// one checkpoint
+				createBarrier(1, 0), createBarrier(1, 1), createBarrier(1, 2),
+
+				// some buffers
+				createBuffer(0), createBuffer(0), createBuffer(2),
+
+				// start the checkpoint that will be incomplete
+				createBarrier(2, 2), createBarrier(2, 0),
+				createBuffer(0), createBuffer(2), createBuffer(1),
+
+				// close one after the barrier one before the barrier
+				createEndOfPartition(2), createEndOfPartition(1),
+				createBuffer(0),
+
+				// final end of stream
+				createEndOfPartition(0)
+		};
+
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		BarrierBuffer buffer = new BarrierBuffer(gate, IO_MANAGER);
+
+		// data after first checkpoint
+		check(sequence[3], buffer.getNextNonBlocked());
+		check(sequence[4], buffer.getNextNonBlocked());
+		check(sequence[5], buffer.getNextNonBlocked());
+		assertEquals(1L, buffer.getCurrentCheckpointId());
+
+		// alignment of second checkpoint
+		check(sequence[10], buffer.getNextNonBlocked());
+		assertEquals(2L, buffer.getCurrentCheckpointId());
+
+		// first end-of-partition encountered: checkpoint will not be completed
+		check(sequence[12], buffer.getNextNonBlocked());
+		check(sequence[8], buffer.getNextNonBlocked());
+		check(sequence[9], buffer.getNextNonBlocked());
+		check(sequence[11], buffer.getNextNonBlocked());
+		check(sequence[13], buffer.getNextNonBlocked());
+		check(sequence[14], buffer.getNextNonBlocked());
+
+		// all done
+		assertNull(buffer.getNextNonBlocked());
+		assertNull(buffer.getNextNonBlocked());
+
+		buffer.cleanup();
+
+		checkNoTempFilesRemain();
+	}
+
+	@Test
+	public void testSingleChannelAbortCheckpoint() throws Exception {
+		BufferOrEvent[] sequence = {
+				createBuffer(0),
+				createBarrier(1, 0),
+				createBuffer(0),
+				createBarrier(2, 0),
+				createCancellationBarrier(4, 0),
+				createBarrier(5, 0),
+				createBuffer(0),
+				createCancellationBarrier(6, 0),
+				createBuffer(0)
+		};
+
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 1, Arrays.asList(sequence));
+		BarrierBuffer buffer = new BarrierBuffer(gate, IO_MANAGER);
+
+		StatefulTask toNotify = mock(StatefulTask.class);
+		buffer.registerCheckpointEventHandler(toNotify);
+
+		check(sequence[0], buffer.getNextNonBlocked());
+		check(sequence[2], buffer.getNextNonBlocked());
+		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(1L)));
+		assertEquals(0L, buffer.getAlignmentDurationNanos());
+
+		check(sequence[6], buffer.getNextNonBlocked());
+		assertEquals(5L, buffer.getCurrentCheckpointId());
+		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(2L)));
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(4L);
+		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(5L)));
+		assertEquals(0L, buffer.getAlignmentDurationNanos());
+
+		check(sequence[8], buffer.getNextNonBlocked());
+		assertEquals(6L, buffer.getCurrentCheckpointId());
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(6L);
+		assertEquals(0L, buffer.getAlignmentDurationNanos());
 		
+		buffer.cleanup();
+		checkNoTempFilesRemain();
+	}
+
+	@Test
+	public void testMultiChannelAbortCheckpoint() throws Exception {
+		BufferOrEvent[] sequence = {
+				// some buffers and a successful checkpoint
+				/* 0 */ createBuffer(0), createBuffer(2), createBuffer(0),
+				/* 3 */ createBarrier(1, 1), createBarrier(1, 2),
+				/* 5 */ createBuffer(2), createBuffer(1),
+				/* 7 */ createBarrier(1, 0),
+				/* 8 */ createBuffer(0), createBuffer(2),
+
+				// aborted on last barrier
+				/* 10 */ createBarrier(2, 0), createBarrier(2, 2),
+				/* 12 */ createBuffer(0), createBuffer(2),
+				/* 14 */ createCancellationBarrier(2, 1),
+
+				// successful checkpoint
+				/* 15 */ createBuffer(2), createBuffer(1),
+				/* 17 */ createBarrier(3, 1), createBarrier(3, 2), createBarrier(3, 0),
+
+				// abort on first barrier
+				/* 20 */ createBuffer(0), createBuffer(1),
+				/* 22 */ createCancellationBarrier(4, 1), createBarrier(4, 2),
+				/* 24 */ createBuffer(0),
+				/* 25 */ createBarrier(4, 0),
+
+				// another successful checkpoint
+				/* 26 */ createBuffer(0), createBuffer(1), createBuffer(2),
+				/* 29 */ createBarrier(5, 2), createBarrier(5, 1), createBarrier(5, 0),
+				/* 32 */ createBuffer(0), createBuffer(1),
+
+				// abort multiple cancellations and a barrier after the cancellations
+				/* 34 */ createCancellationBarrier(6, 1), createCancellationBarrier(6, 2),
+				/* 36 */ createBarrier(6, 0),
+
+				/* 37 */ createBuffer(0)
+		};
+
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		BarrierBuffer buffer = new BarrierBuffer(gate, IO_MANAGER);
+
+		StatefulTask toNotify = mock(StatefulTask.class);
+		buffer.registerCheckpointEventHandler(toNotify);
+
+		long startTs;
+
+		// successful first checkpoint, with some aligned buffers
+		check(sequence[0], buffer.getNextNonBlocked());
+		check(sequence[1], buffer.getNextNonBlocked());
+		check(sequence[2], buffer.getNextNonBlocked());
+		startTs = System.nanoTime();
+		check(sequence[5], buffer.getNextNonBlocked());
+		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(1L)));
+		validateAlignmentTime(startTs, buffer);
+
+		check(sequence[6], buffer.getNextNonBlocked());
+		check(sequence[8], buffer.getNextNonBlocked());
+		check(sequence[9], buffer.getNextNonBlocked());
+
+		// canceled checkpoint on last barrier
+		startTs = System.nanoTime();
+		check(sequence[12], buffer.getNextNonBlocked());
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(2L);
+		validateAlignmentTime(startTs, buffer);
+		check(sequence[13], buffer.getNextNonBlocked());
+
+		// one more successful checkpoint
+		check(sequence[15], buffer.getNextNonBlocked());
+		check(sequence[16], buffer.getNextNonBlocked());
+		startTs = System.nanoTime();
+		check(sequence[20], buffer.getNextNonBlocked());
+		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(3L)));
+		validateAlignmentTime(startTs, buffer);
+		check(sequence[21], buffer.getNextNonBlocked());
+
+		// this checkpoint gets immediately canceled
+		check(sequence[24], buffer.getNextNonBlocked());
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(4L);
+		assertEquals(0L, buffer.getAlignmentDurationNanos());
+
+		// some buffers
+		check(sequence[26], buffer.getNextNonBlocked());
+		check(sequence[27], buffer.getNextNonBlocked());
+		check(sequence[28], buffer.getNextNonBlocked());
+
+		// a simple successful checkpoint
+		startTs = System.nanoTime();
+		check(sequence[32], buffer.getNextNonBlocked());
+		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(5L)));
+		validateAlignmentTime(startTs, buffer);
+		check(sequence[33], buffer.getNextNonBlocked());
+
+		check(sequence[37], buffer.getNextNonBlocked());
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(6L);
+		assertEquals(0L, buffer.getAlignmentDurationNanos());
+
+		// all done
+		assertNull(buffer.getNextNonBlocked());
+		assertNull(buffer.getNextNonBlocked());
+
+		buffer.cleanup();
+		checkNoTempFilesRemain();
+	}
+
+	@Test
+	public void testAbortViaQueuedBarriers() throws Exception {
+		BufferOrEvent[] sequence = {
+				// starting a checkpoint
+				/* 0 */ createBuffer(1),
+				/* 1 */ createBarrier(1, 1), createBarrier(1, 2),
+				/* 3 */ createBuffer(2), createBuffer(0), createBuffer(1),
+
+				// queued barrier and cancellation barrier
+				/* 6 */ createCancellationBarrier(2, 2),
+				/* 7 */ createBarrier(2, 1),
+
+				// some intermediate buffers (some queued)
+				/* 8 */ createBuffer(0), createBuffer(1), createBuffer(2),
+
+				// complete initial checkpoint
+				/* 11 */ createBarrier(1, 0),
+
+				// some buffers (none queued, since checkpoint is aborted)
+				/* 12 */ createBuffer(2), createBuffer(1), createBuffer(0),
+
+				// final barrier of aborted checkpoint
+				/* 15 */ createBarrier(1, 2),
+
+				// some more buffers
+				/* 16 */ createBuffer(0), createBuffer(1), createBuffer(2)
+		};
+
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		BarrierBuffer buffer = new BarrierBuffer(gate, IO_MANAGER);
+
+		StatefulTask toNotify = mock(StatefulTask.class);
+		buffer.registerCheckpointEventHandler(toNotify);
+
+		long startTs;
+
+		check(sequence[0], buffer.getNextNonBlocked());
+
+		// starting first checkpoint
+		startTs = System.nanoTime();
+		check(sequence[4], buffer.getNextNonBlocked());
+		check(sequence[8], buffer.getNextNonBlocked());
+
+		// finished first checkpoint
+		check(sequence[3], buffer.getNextNonBlocked());
+		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(1L)));
+		validateAlignmentTime(startTs, buffer);
+
+		check(sequence[5], buffer.getNextNonBlocked());
+
+		// re-read the queued cancellation barriers
+		check(sequence[9], buffer.getNextNonBlocked());
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(2L);
+		assertEquals(0L, buffer.getAlignmentDurationNanos());
+
+		check(sequence[10], buffer.getNextNonBlocked());
+		check(sequence[12], buffer.getNextNonBlocked());
+		check(sequence[13], buffer.getNextNonBlocked());
+		check(sequence[14], buffer.getNextNonBlocked());
+
+		check(sequence[16], buffer.getNextNonBlocked());
+		check(sequence[17], buffer.getNextNonBlocked());
+		check(sequence[18], buffer.getNextNonBlocked());
+
+		// no further alignment should have happened
+		assertEquals(0L, buffer.getAlignmentDurationNanos());
+
+		// no further checkpoint (abort) notifications
+		verify(toNotify, times(1)).triggerCheckpointOnBarrier(any(CheckpointMetaData.class));
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(anyLong());
+
+		// all done
+		assertNull(buffer.getNextNonBlocked());
+		assertNull(buffer.getNextNonBlocked());
+
+		buffer.cleanup();
+		checkNoTempFilesRemain();
+	}
+
+	/**
+	 * This tests the where a replay of queued checkpoint barriers meets
+	 * a canceled checkpoint.
+	 *
+	 * The replayed newer checkpoint barrier must not try to cancel the
+	 * already canceled checkpoint.
+	 */
+	@Test
+	public void testAbortWhileHavingQueuedBarriers() throws Exception {
+		BufferOrEvent[] sequence = {
+				// starting a checkpoint
+				/*  0 */ createBuffer(1),
+				/*  1 */ createBarrier(1, 1),
+				/*  2 */ createBuffer(2), createBuffer(0), createBuffer(1),
+
+				// queued barrier and cancellation barrier
+				/*  5 */ createBarrier(2, 1),
+
+				// some queued buffers
+				/*  6 */ createBuffer(2), createBuffer(1),
+
+				// cancel the initial checkpoint
+				/*  8 */ createCancellationBarrier(1, 0),
+
+				// some more buffers
+				/*  9 */ createBuffer(2), createBuffer(1), createBuffer(0),
+
+				// ignored barrier - already canceled and moved to next checkpoint
+				/* 12 */ createBarrier(1, 2),
+
+				// some more buffers
+				/* 13 */ createBuffer(0), createBuffer(1), createBuffer(2),
+
+				// complete next checkpoint regularly
+				/* 16 */ createBarrier(2, 0), createBarrier(2, 2),
+
+				// some more buffers
+				/* 18 */ createBuffer(0), createBuffer(1), createBuffer(2)
+		};
+
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		BarrierBuffer buffer = new BarrierBuffer(gate, IO_MANAGER);
+
+		StatefulTask toNotify = mock(StatefulTask.class);
+		buffer.registerCheckpointEventHandler(toNotify);
+
+		long startTs;
+
+		check(sequence[0], buffer.getNextNonBlocked());
+
+		// starting first checkpoint
+		startTs = System.nanoTime();
+		check(sequence[2], buffer.getNextNonBlocked());
+		check(sequence[3], buffer.getNextNonBlocked());
+		check(sequence[6], buffer.getNextNonBlocked());
+
+		// cancelled by cancellation barrier
+		check(sequence[4], buffer.getNextNonBlocked());
+		validateAlignmentTime(startTs, buffer);
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(1L);
+
+		// the next checkpoint alignment starts now
+		startTs = System.nanoTime();
+		check(sequence[9], buffer.getNextNonBlocked());
+		check(sequence[11], buffer.getNextNonBlocked());
+		check(sequence[13], buffer.getNextNonBlocked());
+		check(sequence[15], buffer.getNextNonBlocked());
+
+		// checkpoint done
+		check(sequence[7], buffer.getNextNonBlocked());
+		validateAlignmentTime(startTs, buffer);
+		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(2L)));
+
+		// queued data
+		check(sequence[10], buffer.getNextNonBlocked());
+		check(sequence[14], buffer.getNextNonBlocked());
+
+		// trailing data
+		check(sequence[18], buffer.getNextNonBlocked());
+		check(sequence[19], buffer.getNextNonBlocked());
+		check(sequence[20], buffer.getNextNonBlocked());
+
+		// all done
+		assertNull(buffer.getNextNonBlocked());
+		assertNull(buffer.getNextNonBlocked());
+
+		buffer.cleanup();
+		checkNoTempFilesRemain();
+
+		// check overall notifications
+		verify(toNotify, times(1)).triggerCheckpointOnBarrier(any(CheckpointMetaData.class));
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(anyLong());
+	}
+
+	/**
+	 * This tests the where a cancellation barrier is received for a checkpoint already
+	 * canceled due to receiving a newer checkpoint barrier.
+	 */
+	@Test
+	public void testIgnoreCancelBarrierIfCheckpointSubsumed() throws Exception {
+		BufferOrEvent[] sequence = {
+				// starting a checkpoint
+				/*  0 */ createBuffer(2),
+				/*  1 */ createBarrier(3, 1), createBarrier(3, 0),
+				/*  3 */ createBuffer(0), createBuffer(1), createBuffer(2),
+
+				// newer checkpoint barrier cancels/subsumes pending checkpoint
+				/*  6 */ createBarrier(5, 2),
+
+				// some queued buffers
+				/*  7 */ createBuffer(2), createBuffer(1), createBuffer(0),
+
+				// cancel barrier the initial checkpoint /it is already canceled)
+				/* 10 */ createCancellationBarrier(3, 2),
+
+				// some more buffers
+				/* 11 */ createBuffer(2), createBuffer(0), createBuffer(1),
+
+				// complete next checkpoint regularly
+				/* 14 */ createBarrier(5, 0), createBarrier(5, 1),
+
+				// some more buffers
+				/* 16 */ createBuffer(0), createBuffer(1), createBuffer(2)
+		};
+
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		BarrierBuffer buffer = new BarrierBuffer(gate, IO_MANAGER);
+
+		StatefulTask toNotify = mock(StatefulTask.class);
+		buffer.registerCheckpointEventHandler(toNotify);
+
+		long startTs;
+
+		// validate the sequence
+
+		check(sequence[0], buffer.getNextNonBlocked());
+
+		// beginning of first checkpoint
+		check(sequence[5], buffer.getNextNonBlocked());
+
+		// future barrier aborts checkpoint
+		startTs = System.nanoTime();
+		check(sequence[3], buffer.getNextNonBlocked());
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(3L);
+		check(sequence[4], buffer.getNextNonBlocked());
+
+		// alignment of next checkpoint
+		check(sequence[8], buffer.getNextNonBlocked());
+		check(sequence[9], buffer.getNextNonBlocked());
+		check(sequence[12], buffer.getNextNonBlocked());
+		check(sequence[13], buffer.getNextNonBlocked());
+
+		// checkpoint finished
+		check(sequence[7], buffer.getNextNonBlocked());
+		validateAlignmentTime(startTs, buffer);
+		verify(toNotify, times(1)).triggerCheckpointOnBarrier(argThat(new CheckpointMatcher(5L)));
+		check(sequence[11], buffer.getNextNonBlocked());
+
+		// remaining data
+		check(sequence[16], buffer.getNextNonBlocked());
+		check(sequence[17], buffer.getNextNonBlocked());
+		check(sequence[18], buffer.getNextNonBlocked());
+
+		// all done
+		assertNull(buffer.getNextNonBlocked());
+		assertNull(buffer.getNextNonBlocked());
+
+		buffer.cleanup();
+		checkNoTempFilesRemain();
+
+		// check overall notifications
+		verify(toNotify, times(1)).triggerCheckpointOnBarrier(any(CheckpointMetaData.class));
+		verify(toNotify, times(1)).abortCheckpointOnBarrier(anyLong());
 	}
 
 	// ------------------------------------------------------------------------
 	//  Utils
 	// ------------------------------------------------------------------------
 
-	private static BufferOrEvent createBarrier(long id, int channel) {
-		return new BufferOrEvent(new CheckpointBarrier(id, System.currentTimeMillis()), channel);
+	private static BufferOrEvent createBarrier(long checkpointId, int channel) {
+		return new BufferOrEvent(new CheckpointBarrier(checkpointId, System.currentTimeMillis()), channel);
+	}
+
+	private static BufferOrEvent createCancellationBarrier(long checkpointId, int channel) {
+		return new BufferOrEvent(new CancelCheckpointMarker(checkpointId), channel);
 	}
 
 	private static BufferOrEvent createBuffer(int channel) {
-		// since we have no access to the contents, we need to use the size as an
-		// identifier to validate correctness here
-		Buffer buf = new Buffer(
-				MemorySegmentFactory.allocateUnpooledSegment(PAGE_SIZE),
-				FreeingBufferRecycler.INSTANCE);
-		
-		buf.setSize(SIZE_COUNTER++);
+		final int size = SIZE_COUNTER++;
+		byte[] bytes = new byte[size];
+		RND.nextBytes(bytes);
+
+		MemorySegment memory = MemorySegmentFactory.allocateUnpooledSegment(PAGE_SIZE);
+		memory.put(0, bytes);
+
+		Buffer buf = new Buffer(memory, FreeingBufferRecycler.INSTANCE);
+		buf.setSize(size);
+
+		// retain an additional time so it does not get disposed after being read by the input gate
+		buf.retain();
+
 		return new BufferOrEvent(buf, channel);
 	}
 
@@ -932,15 +1413,16 @@ public class BarrierBufferTest {
 		assertEquals(expected.isBuffer(), present.isBuffer());
 		
 		if (expected.isBuffer()) {
-			// since we have no access to the contents, we need to use the size as an
-			// identifier to validate correctness here
 			assertEquals(expected.getBuffer().getSize(), present.getBuffer().getSize());
+			MemorySegment expectedMem = expected.getBuffer().getMemorySegment();
+			MemorySegment presentMem = present.getBuffer().getMemorySegment();
+			assertTrue("memory contents differs", expectedMem.compare(presentMem, 0, 0, PAGE_SIZE) == 0);
 		}
 		else {
 			assertEquals(expected.getEvent(), present.getEvent());
 		}
 	}
-	
+
 	private static void checkNoTempFilesRemain() {
 		// validate that all temp files have been removed
 		for (File dir : IO_MANAGER.getSpillingDirectories()) {
@@ -985,8 +1467,10 @@ public class BarrierBufferTest {
 
 		@Override
 		public void triggerCheckpointOnBarrier(CheckpointMetaData checkpointMetaData) throws Exception {
+			assertTrue("wrong checkpoint id",
+					nextExpectedCheckpointId == -1L || 
+					nextExpectedCheckpointId == checkpointMetaData.getCheckpointId());
 
-			assertTrue("wrong checkpoint id", nextExpectedCheckpointId == -1L || nextExpectedCheckpointId == checkpointMetaData.getCheckpointId());
 			assertTrue(checkpointMetaData.getTimestamp() > 0);
 			assertTrue(checkpointMetaData.getBytesBufferedInAlignment() >= 0);
 			assertTrue(checkpointMetaData.getAlignmentDurationNanos() >= 0);
@@ -995,8 +1479,32 @@ public class BarrierBufferTest {
 		}
 
 		@Override
+		public void abortCheckpointOnBarrier(long checkpointId) {}
+
+		@Override
 		public void notifyCheckpointComplete(long checkpointId) throws Exception {
 			throw new UnsupportedOperationException("should never be called");
+		}
+	}
+
+	private static class CheckpointMatcher extends BaseMatcher<CheckpointMetaData> {
+
+		private final long checkpointId;
+
+		CheckpointMatcher(long checkpointId) {
+			this.checkpointId = checkpointId;
+		}
+
+		@Override
+		public boolean matches(Object o) {
+			return o != null &&
+					o.getClass() == CheckpointMetaData.class &&
+					((CheckpointMetaData) o).getCheckpointId() == checkpointId;
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText("CheckpointMetaData - id = " + checkpointId);
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTest.java
@@ -1145,7 +1145,7 @@ public class BarrierBufferTest {
 				/* 12 */ createBuffer(2), createBuffer(1), createBuffer(0),
 
 				// final barrier of aborted checkpoint
-				/* 15 */ createBarrier(1, 2),
+				/* 15 */ createBarrier(2, 0),
 
 				// some more buffers
 				/* 16 */ createBuffer(0), createBuffer(1), createBuffer(2)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
@@ -482,7 +482,7 @@ public class BarrierTrackerTest {
 		}
 
 		@Override
-		public void abortCheckpointOnBarrier(long checkpointId) {
+		public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) {
 			assertTrue("More checkpoints than expected", i < checkpointIDs.length);
 
 			final long expectedId = checkpointIDs[i++];

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
@@ -20,21 +20,17 @@ package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.jobgraph.tasks.StatefulTask;
-import org.apache.flink.runtime.state.ChainedStateHandle;
-import org.apache.flink.runtime.state.KeyGroupsStateHandle;
-import org.apache.flink.runtime.state.OperatorStateHandle;
-import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TaskStateHandles;
+
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -45,9 +41,9 @@ import static org.junit.Assert.fail;
  * Tests for the behavior of the barrier tracker.
  */
 public class BarrierTrackerTest {
-	
+
 	private static final int PAGE_SIZE = 512;
-	
+
 	@Test
 	public void testSingleChannelNoBarriers() {
 		try {
@@ -339,12 +335,108 @@ public class BarrierTrackerTest {
 		}
 	}
 
+	@Test
+	public void testSingleChannelAbortCheckpoint() throws Exception {
+		BufferOrEvent[] sequence = {
+				createBuffer(0),
+				createBarrier(1, 0),
+				createBuffer(0),
+				createBarrier(2, 0),
+				createCancellationBarrier(4, 0),
+				createBarrier(5, 0),
+				createBuffer(0),
+				createCancellationBarrier(6, 0),
+				createBuffer(0)
+		};
+
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 1, Arrays.asList(sequence));
+		BarrierTracker tracker = new BarrierTracker(gate);
+
+		// negative values mean an expected cancellation call!
+		CheckpointSequenceValidator validator =
+				new CheckpointSequenceValidator(1, 2, -4, 5, -6);
+		tracker.registerCheckpointEventHandler(validator);
+
+		for (BufferOrEvent boe : sequence) {
+			if (boe.isBuffer()) {
+				assertEquals(boe, tracker.getNextNonBlocked());
+			}
+			assertTrue(tracker.isEmpty());
+		}
+
+		assertNull(tracker.getNextNonBlocked());
+		assertNull(tracker.getNextNonBlocked());
+	}
+
+	@Test
+	public void testMultiChannelAbortCheckpoint() throws Exception {
+		BufferOrEvent[] sequence = {
+				// some buffers and a successful checkpoint
+				createBuffer(0), createBuffer(2), createBuffer(0),
+				createBarrier(1, 1), createBarrier(1, 2),
+				createBuffer(2), createBuffer(1),
+				createBarrier(1, 0),
+
+				// aborted on last barrier
+				createBuffer(0), createBuffer(2),
+				createBarrier(2, 0), createBarrier(2, 2),
+				createBuffer(0), createBuffer(2),
+				createCancellationBarrier(2, 1),
+
+				// successful checkpoint
+				createBuffer(2), createBuffer(1),
+				createBarrier(3, 1), createBarrier(3, 2), createBarrier(3, 0),
+
+				// abort on first barrier
+				createBuffer(0), createBuffer(1),
+				createCancellationBarrier(4, 1), createBarrier(4, 2),
+				createBuffer(0),
+				createBarrier(4, 0),
+
+				// another successful checkpoint
+				createBuffer(0), createBuffer(1), createBuffer(2),
+				createBarrier(5, 2), createBarrier(5, 1), createBarrier(5, 0),
+
+				// abort multiple cancellations and a barrier after the cancellations 
+				createBuffer(0), createBuffer(1),
+				createCancellationBarrier(6, 1), createCancellationBarrier(6, 2),
+				createBarrier(6, 0),
+
+				createBuffer(0)
+		};
+
+		MockInputGate gate = new MockInputGate(PAGE_SIZE, 3, Arrays.asList(sequence));
+		BarrierTracker tracker = new BarrierTracker(gate);
+
+		// negative values mean an expected cancellation call!
+		CheckpointSequenceValidator validator =
+				new CheckpointSequenceValidator(1, -2, 3, -4, 5, -6);
+		tracker.registerCheckpointEventHandler(validator);
+
+		for (BufferOrEvent boe : sequence) {
+			if (boe.isBuffer()) {
+				assertEquals(boe, tracker.getNextNonBlocked());
+			}
+		}
+
+		assertTrue(tracker.isEmpty());
+
+		assertNull(tracker.getNextNonBlocked());
+		assertNull(tracker.getNextNonBlocked());
+
+		assertTrue(tracker.isEmpty());
+	}
+	
 	// ------------------------------------------------------------------------
 	//  Utils
 	// ------------------------------------------------------------------------
 
 	private static BufferOrEvent createBarrier(long id, int channel) {
 		return new BufferOrEvent(new CheckpointBarrier(id, System.currentTimeMillis()), channel);
+	}
+
+	private static BufferOrEvent createCancellationBarrier(long id, int channel) {
+		return new BufferOrEvent(new CancelCheckpointMarker(id), channel);
 	}
 
 	private static BufferOrEvent createBuffer(int channel) {
@@ -368,7 +460,6 @@ public class BarrierTrackerTest {
 
 		@Override
 		public void setInitialState(TaskStateHandles taskStateHandles) throws Exception {
-
 			throw new UnsupportedOperationException("should never be called");
 		}
 
@@ -379,10 +470,27 @@ public class BarrierTrackerTest {
 
 		@Override
 		public void triggerCheckpointOnBarrier(CheckpointMetaData checkpointMetaData) throws Exception {
-
 			assertTrue("More checkpoints than expected", i < checkpointIDs.length);
-			assertEquals("wrong checkpoint id", checkpointIDs[i++], checkpointMetaData.getCheckpointId());
-			assertTrue(checkpointMetaData.getTimestamp() > 0);
+
+			final long expectedId = checkpointIDs[i++];
+			if (expectedId >= 0) {
+				assertEquals("wrong checkpoint id", expectedId, checkpointMetaData.getCheckpointId());
+				assertTrue(checkpointMetaData.getTimestamp() > 0);
+			} else {
+				fail("got 'triggerCheckpointOnBarrier()' when expecting an 'abortCheckpointOnBarrier()'");
+			}
+		}
+
+		@Override
+		public void abortCheckpointOnBarrier(long checkpointId) {
+			assertTrue("More checkpoints than expected", i < checkpointIDs.length);
+
+			final long expectedId = checkpointIDs[i++];
+			if (expectedId < 0) {
+				assertEquals("wrong checkpoint id for checkoint abort", -expectedId, checkpointId);
+			} else {
+				fail("got 'abortCheckpointOnBarrier()' when expecting an 'triggerCheckpointOnBarrier()'");
+			}
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -32,6 +32,7 @@ import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.SubtaskState;
+import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.state.StateInitializationContext;
@@ -305,6 +306,7 @@ public class OneInputStreamTaskTest extends TestLogger {
 		testHarness.processEvent(new CheckpointBarrier(1, 1), 1, 0);
 		testHarness.processEvent(new CheckpointBarrier(1, 1), 1, 1);
 
+		expectedOutput.add(new CancelCheckpointMarker(0));
 		expectedOutput.add(new StreamRecord<String>("Hello-0-0", initialTime));
 		expectedOutput.add(new StreamRecord<String>("Ciao-0-0", initialTime));
 		expectedOutput.add(new CheckpointBarrier(1, 1));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -322,6 +322,9 @@ public class StreamMockEnvironment implements Environment {
 	}
 
 	@Override
+	public void declineCheckpoint(long checkpointId, Throwable cause) {}
+
+	@Override
 	public void failExternally(Throwable cause) {
 		this.wasFailedExternally = true;
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationBarrierTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationBarrierTest.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.runtime.checkpoint.decline.CheckpointDeclineOnCancellationBarrierException;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
+import org.apache.flink.streaming.api.functions.co.CoMapFunction;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamMap;
+import org.apache.flink.streaming.api.operators.co.CoStreamMap;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class StreamTaskCancellationBarrierTest {
+
+	/**
+	 * This test checks that tasks emit a proper cancel checkpoint barrier, if a "trigger checkpoint" message
+	 * comes before they are ready.
+	 */
+	@Test
+	public void testEmitCancellationBarrierWhenNotReady() throws Exception {
+		StreamTask<String, ?> task = new InitBlockingTask();
+		StreamTaskTestHarness<String> testHarness = new StreamTaskTestHarness<>(task, BasicTypeInfo.STRING_TYPE_INFO);
+
+		// start the test - this cannot succeed across the 'init()' method
+		testHarness.invoke();
+
+		// tell the task to commence a checkpoint
+		boolean result = task.triggerCheckpoint(new CheckpointMetaData(41L, System.currentTimeMillis()));
+		assertFalse("task triggered checkpoint though not ready", result);
+
+		// a cancellation barrier should be downstream
+		Object emitted = testHarness.getOutput().poll();
+		assertNotNull("nothing emitted", emitted);
+		assertTrue("wrong type emitted", emitted instanceof CancelCheckpointMarker);
+		assertEquals("wrong checkpoint id", 41L, ((CancelCheckpointMarker) emitted).getCheckpointId());
+	}
+
+	/**
+	 * This test verifies (for onw input tasks) that the Stream tasks react the following way to
+	 * receiving a checkpoint cancellation barrier:
+	 * 
+	 *   - send a "decline checkpoint" notification out (to the JobManager)
+	 *   - emit a cancellation barrier downstream
+	 */
+	@Test
+	public void testDeclineCallOnCancelBarrierOneInput() throws Exception {
+
+		OneInputStreamTask<String, String> task = new OneInputStreamTask<String, String>();
+		OneInputStreamTaskTestHarness<String, String> testHarness = new OneInputStreamTaskTestHarness<>(
+				task,
+				1, 2,
+				BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO);
+
+		StreamConfig streamConfig = testHarness.getStreamConfig();
+		StreamMap<String, String> mapOperator = new StreamMap<>(new IdentityMap());
+		streamConfig.setStreamOperator(mapOperator);
+
+		StreamMockEnvironment environment = spy(testHarness.createEnvironment());
+
+		// start the task
+		testHarness.invoke(environment);
+		testHarness.waitForTaskRunning();
+
+		// emit cancellation barriers
+		testHarness.processEvent(new CancelCheckpointMarker(2L), 0, 1);
+		testHarness.processEvent(new CancelCheckpointMarker(2L), 0, 0);
+		testHarness.waitForInputProcessing();
+
+		// the decline call should go to the coordinator
+		verify(environment, times(1)).declineCheckpoint(eq(2L), any(CheckpointDeclineOnCancellationBarrierException.class));
+
+		// a cancellation barrier should be downstream
+		Object result = testHarness.getOutput().poll();
+		assertNotNull("nothing emitted", result);
+		assertTrue("wrong type emitted", result instanceof CancelCheckpointMarker);
+		assertEquals("wrong checkpoint id", 2L, ((CancelCheckpointMarker) result).getCheckpointId());
+
+		// cancel and shutdown
+		testHarness.endInput();
+		testHarness.waitForTaskCompletion();
+	}
+
+	/**
+	 * This test verifies (for onw input tasks) that the Stream tasks react the following way to
+	 * receiving a checkpoint cancellation barrier:
+	 *
+	 *   - send a "decline checkpoint" notification out (to the JobManager)
+	 *   - emit a cancellation barrier downstream
+	 */
+	@Test
+	public void testDeclineCallOnCancelBarrierTwoInputs() throws Exception {
+
+		TwoInputStreamTask<String, String, String> task = new TwoInputStreamTask<String, String, String>();
+		TwoInputStreamTaskTestHarness<String, String, String> testHarness = new TwoInputStreamTaskTestHarness<>(
+				task,
+				BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO);
+
+		StreamConfig streamConfig = testHarness.getStreamConfig();
+		CoStreamMap<String, String, String> op = new CoStreamMap<>(new UnionCoMap());
+		streamConfig.setStreamOperator(op);
+
+		StreamMockEnvironment environment = spy(testHarness.createEnvironment());
+
+		// start the task
+		testHarness.invoke(environment);
+		testHarness.waitForTaskRunning();
+
+		// emit cancellation barriers
+		testHarness.processEvent(new CancelCheckpointMarker(2L), 0, 0);
+		testHarness.processEvent(new CancelCheckpointMarker(2L), 1, 0);
+		testHarness.waitForInputProcessing();
+
+		// the decline call should go to the coordinator
+		verify(environment, times(1)).declineCheckpoint(eq(2L), any(CheckpointDeclineOnCancellationBarrierException.class));
+
+		// a cancellation barrier should be downstream
+		Object result = testHarness.getOutput().poll();
+		assertNotNull("nothing emitted", result);
+		assertTrue("wrong type emitted", result instanceof CancelCheckpointMarker);
+		assertEquals("wrong checkpoint id", 2L, ((CancelCheckpointMarker) result).getCheckpointId());
+
+		// cancel and shutdown
+		testHarness.endInput();
+		testHarness.waitForTaskCompletion();
+	}
+
+	// ------------------------------------------------------------------------
+	//  test tasks / functions
+	// ------------------------------------------------------------------------
+
+	private static class InitBlockingTask extends StreamTask<String, AbstractStreamOperator<String>> {
+
+		private final Object lock = new Object();
+		private volatile boolean running = true;
+		
+		@Override
+		protected void init() throws Exception {
+			synchronized (lock) {
+				while (running) {
+					lock.wait();
+				}
+			}
+		}
+
+		@Override
+		protected void run() throws Exception {}
+
+		@Override
+		protected void cleanup() throws Exception {}
+
+		@Override
+		protected void cancelTask() throws Exception {
+			running = false;
+			synchronized (lock) {
+				lock.notifyAll();
+			}
+		}
+	}
+
+	private static class IdentityMap implements MapFunction<String, String> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public String map(String value) throws Exception {
+			return value;
+		}
+	}
+
+	private static class UnionCoMap implements CoMapFunction<String, String, String> {
+		private static final long serialVersionUID = 1L;
+		
+		@Override
+		public String map1(String value) throws Exception {
+			return value;
+		}
+
+		@Override
+		public String map2(String value) throws Exception {
+			return value;
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -37,6 +37,7 @@ import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+
 import org.junit.Assert;
 
 import java.io.IOException;
@@ -150,21 +151,18 @@ public class StreamTaskTestHarness<OUT> {
 
 	}
 
+	public StreamMockEnvironment createEnvironment() {
+		return new StreamMockEnvironment(
+				jobConfig, taskConfig, executionConfig, memorySize, new MockInputSplitProvider(), bufferSize);
+	}
+
 	/**
 	 * Invoke the Task. This resets the output of any previous invocation. This will start a new
 	 * Thread to execute the Task in. Use {@link #waitForTaskCompletion()} to wait for the
 	 * Task thread to finish running.
 	 */
 	public void invoke() throws Exception {
-		mockEnv = new StreamMockEnvironment(jobConfig, taskConfig, executionConfig,
-			memorySize, new MockInputSplitProvider(), bufferSize);
-		task.setEnvironment(mockEnv);
-
-		initializeInputs();
-		initializeOutput();
-
-		taskThread = new TaskThread(task);
-		taskThread.start();
+		invoke(createEnvironment());
 	}
 
 	/**
@@ -237,7 +235,7 @@ public class StreamTaskTestHarness<OUT> {
 			if (taskThread.task instanceof StreamTask) {
 				StreamTask<?, ?> streamTask = (StreamTask<?, ?>) taskThread.task;
 				while (!streamTask.isRunning()) {
-					Thread.sleep(100);
+					Thread.sleep(10);
 					if (!taskThread.isAlive()) {
 						if (taskThread.getError() != null) {
 							throw new Exception("Task Thread failed due to an error.", taskThread.getError());
@@ -314,15 +312,14 @@ public class StreamTaskTestHarness<OUT> {
 	/**
 	 * This only returns after all input queues are empty.
 	 */
-	public void waitForInputProcessing() {
+	public void waitForInputProcessing() throws Exception {
 
-
-		// first wait for all input queues to be empty
-		try {
-			Thread.sleep(1);
-		} catch (InterruptedException ignored) {}
-		
 		while (true) {
+			Throwable error = taskThread.getError();
+			if (error != null) {
+				throw new Exception("Exception in the task thread", error);
+			}
+
 			boolean allEmpty = true;
 			for (int i = 0; i < numInputGates; i++) {
 				if (!inputGates[i].allQueuesEmpty()) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.streaming.api.functions.co.CoMapFunction;
 import org.apache.flink.streaming.api.functions.co.RichCoMapFunction;
@@ -294,6 +295,7 @@ public class TwoInputStreamTaskTest {
 		testHarness.processEvent(new CheckpointBarrier(1, 1), 1, 0);
 		testHarness.processEvent(new CheckpointBarrier(1, 1), 1, 1);
 
+		expectedOutput.add(new CancelCheckpointMarker(0));
 		expectedOutput.add(new StreamRecord<String>("Hello-0-0", initialTime));
 		expectedOutput.add(new StreamRecord<String>("Ciao-0-0", initialTime));
 		expectedOutput.add(new CheckpointBarrier(1, 1));

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
@@ -201,7 +201,7 @@ public class EventTimeAllWindowCheckpointingITCase extends TestLogger {
 					.addSink(new ValidatingSink(NUM_KEYS, NUM_ELEMENTS_PER_KEY / WINDOW_SLIDE)).setParallelism(1);
 
 
-			tryExecute(env, "Tumbling Window Test");
+			tryExecute(env, "Sliding Window Test");
 		}
 		catch (Exception e) {
 			e.printStackTrace();


### PR DESCRIPTION
In corner case situations, checkpoint alignment can take very long and buffer/spill a lot of data. This PR introduces setting a limit to how much data may be buffered during alignments. If that volume is exceeded, the checkpoint will abort.

While these overly large alignment situation should not occur in a healthy environment, it is an important safety net to have.

This Pull Request consists of three parts:

### Introduce Cancellation Barriers

These *Cancellation Barriers* are like checkpoint barriers, flowing with the data, but signalling that a checkpoint should be aborted rather that the position of that stream in the checkpoint.

This adds extensive tests to the `BarrierBuffer` and `BarrierTracker` that these Cancellation Barriers are correctly interpreted and interplay well with other situations of alignment starts and cancellations (such as when newer barriers come early).

### Adjust and Checkpoint Coordinator

Tasks emit cancellation barriers whenever they cannot start a checkpoint or whenever a checkpoint alignment was canceled. That lets downstream tasks know earlier that they should stop the alignment for that checkpoint, because it will not be able to complete.

Tasks also explicitly send "decline" messages to the checkpoint coordinator for checkpoints they "skipped" due to alignment being cancelled or superseded.

Previously the assumptions were:
  - When a Source Task cannot start a checkpoint, a new checkpoint must be triggered immediately, to dissolve any started downstream alignments that otherwise would not be able to complete. 
  - Whenever an alignment is aborted by a newer checkpoint barrier coming in, that newer barrier will eventually reach the downstream task and break outdated pending alignments. The cancellation barrier will not break the outdated alignment earlier.

### Alignment Size Limit

When the `BarrierBuffer` has buffered more than a certain number of bytes, it aborts the alignment and signals the Task that the checkpoint was aborted. The Task sends a cancellation barrier for that checkpoint downstream, to signal the downstream tasks that they should not wait for a proper barrier.

The maximum alignment size is a config option: `task.checkpoint.alignment.max-size`