### PR TITLE
[FLINK-5020] Make the GenericWriteAheadSink rescalable.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/CheckpointCommitter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/CheckpointCommitter.java
@@ -40,6 +40,7 @@ import java.io.Serializable;
  * and as such should kept as small as possible.
  */
 public abstract class CheckpointCommitter implements Serializable {
+
 	protected static final Logger LOG = LoggerFactory.getLogger(CheckpointCommitter.class);
 
 	protected String jobId;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
@@ -17,20 +17,20 @@
  */
 package org.apache.flink.streaming.runtime.operators;
 
+import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.FSDataInputStream;
-import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.io.disk.InputViewIterator;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.util.ReusingMutableToRegularIteratorWrapper;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-import org.apache.flink.streaming.api.operators.StreamCheckpointedOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +52,7 @@ import java.util.UUID;
  * @param <IN> Type of the elements emitted by this sink
  */
 public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<IN>
-		implements OneInputStreamOperator<IN, IN>, StreamCheckpointedOperator {
+		implements OneInputStreamOperator<IN, IN> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -65,9 +65,15 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 	private transient CheckpointStreamFactory.CheckpointStateOutputStream out;
 	private transient CheckpointStreamFactory checkpointStreamFactory;
 
+	private transient ListState<PendingCheckpoint> checkpointedState;
+
 	private final Set<PendingCheckpoint> pendingCheckpoints = new TreeSet<>();
 
-	public GenericWriteAheadSink(CheckpointCommitter committer,	TypeSerializer<IN> serializer, String jobID) throws Exception {
+	public GenericWriteAheadSink(
+			CheckpointCommitter committer,
+			TypeSerializer<IN> serializer,
+			String jobID) throws Exception {
+
 		this.committer = Preconditions.checkNotNull(committer);
 		this.serializer = Preconditions.checkNotNull(serializer);
 		this.id = UUID.randomUUID().toString();
@@ -77,12 +83,39 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 	}
 
 	@Override
+	public void initializeState(StateInitializationContext context) throws Exception {
+		super.initializeState(context);
+
+		Preconditions.checkState(this.checkpointedState == null,
+			"The reader state has already been initialized.");
+
+		checkpointedState = context.getManagedOperatorStateStore()
+			.getSerializableListState("pending-checkpoints");
+
+		int subtaskIdx = getRuntimeContext().getIndexOfThisSubtask();
+		if (context.isRestored()) {
+			LOG.info("Restoring state for the GenericWriteAheadSink (taskIdx={}).", subtaskIdx);
+
+			for (PendingCheckpoint pendingCheckpoint : checkpointedState.get()) {
+				this.pendingCheckpoints.add(pendingCheckpoint);
+			}
+
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("GenericWriteAheadSink idx {} restored {}.", subtaskIdx, this.pendingCheckpoints);
+			}
+		} else {
+			LOG.info("No state to restore for the GenericWriteAheadSink (taskIdx={}).", subtaskIdx);
+		}
+	}
+
+	@Override
 	public void open() throws Exception {
 		super.open();
 		committer.setOperatorId(id);
 		committer.open();
 
-		checkpointStreamFactory = getContainingTask().createCheckpointStreamFactory(this);
+		checkpointStreamFactory = getContainingTask()
+			.createCheckpointStreamFactory(this);
 
 		cleanRestoredHandles();
 	}
@@ -99,12 +132,14 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 	 * @throws IOException in case something went wrong when handling the stream to the backend.
 	 */
 	private void saveHandleInState(final long checkpointId, final long timestamp) throws Exception {
+
 		//only add handle if a new OperatorState was created since the last snapshot
 		if (out != null) {
 			int subtaskIdx = getRuntimeContext().getIndexOfThisSubtask();
 			StreamStateHandle handle = out.closeAndGetHandle();
 
-			PendingCheckpoint pendingCheckpoint = new PendingCheckpoint(checkpointId, subtaskIdx, timestamp, handle);
+			PendingCheckpoint pendingCheckpoint = new PendingCheckpoint(
+				checkpointId, subtaskIdx, timestamp, handle);
 
 			if (pendingCheckpoints.contains(pendingCheckpoint)) {
 				//we already have a checkpoint stored for that ID that may have been partially written,
@@ -118,22 +153,23 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 	}
 
 	@Override
-	public void snapshotState(FSDataOutputStream out, long checkpointId, long timestamp) throws Exception {
-		saveHandleInState(checkpointId, timestamp);
+	public void snapshotState(StateSnapshotContext context) throws Exception {
+		super.snapshotState(context);
 
-		DataOutputViewStreamWrapper outStream = new DataOutputViewStreamWrapper(out);
-		outStream.writeInt(pendingCheckpoints.size());
+		Preconditions.checkState(this.checkpointedState != null,
+			"The operator state has not been properly initialized.");
+
+		saveHandleInState(context.getCheckpointId(), context.getCheckpointTimestamp());
+
+		this.checkpointedState.clear();
 		for (PendingCheckpoint pendingCheckpoint : pendingCheckpoints) {
-			pendingCheckpoint.serialize(outStream);
+			// create a new partition for each entry.
+			this.checkpointedState.add(pendingCheckpoint);
 		}
-	}
 
-	@Override
-	public void restoreState(FSDataInputStream in) throws Exception {
-		final DataInputViewStreamWrapper inStream = new DataInputViewStreamWrapper(in);
-		int numPendingHandles = inStream.readInt();
-		for (int i = 0; i < numPendingHandles; i++) {
-			pendingCheckpoints.add(PendingCheckpoint.restore(inStream, getUserCodeClassloader()));
+		int subtaskIdx = getRuntimeContext().getIndexOfThisSubtask();
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("{} (taskIdx= {}) checkpointed {}.", getClass().getSimpleName(), subtaskIdx, this.pendingCheckpoints);
 		}
 	}
 
@@ -162,9 +198,12 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 		super.notifyOfCompletedCheckpoint(checkpointId);
 
 		synchronized (pendingCheckpoints) {
+
 			Iterator<PendingCheckpoint> pendingCheckpointIt = pendingCheckpoints.iterator();
 			while (pendingCheckpointIt.hasNext()) {
+
 				PendingCheckpoint pendingCheckpoint = pendingCheckpointIt.next();
+
 				long pastCheckpointId = pendingCheckpoint.checkpointId;
 				int subtaskId = pendingCheckpoint.subtaskId;
 				long timestamp = pendingCheckpoint.timestamp;
@@ -241,34 +280,15 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 			this.stateHandle = handle;
 		}
 
-		void serialize(DataOutputViewStreamWrapper outputStream) throws IOException {
-			outputStream.writeLong(checkpointId);
-			outputStream.writeInt(subtaskId);
-			outputStream.writeLong(timestamp);
-			InstantiationUtil.serializeObject(outputStream, stateHandle);
-		}
-
-		static PendingCheckpoint restore(
-				DataInputViewStreamWrapper inputStream,
-				ClassLoader classLoader) throws IOException, ClassNotFoundException {
-
-			long checkpointId = inputStream.readLong();
-			int subtaskId = inputStream.readInt();
-			long timestamp = inputStream.readLong();
-			StreamStateHandle handle = InstantiationUtil.deserializeObject(inputStream, classLoader);
-
-			return new PendingCheckpoint(checkpointId, subtaskId, timestamp, handle);
-		}
-
 		@Override
 		public int compareTo(PendingCheckpoint o) {
 			int res = Long.compare(this.checkpointId, o.checkpointId);
-			return res != 0 ? res : Integer.compare(this.subtaskId, o.subtaskId);
+			return res != 0 ? res : this.subtaskId - o.subtaskId;
 		}
 
 		@Override
 		public boolean equals(Object o) {
-			if (!(o instanceof GenericWriteAheadSink.PendingCheckpoint)) {
+			if (o == null || !(o instanceof GenericWriteAheadSink.PendingCheckpoint)) {
 				return false;
 			}
 			PendingCheckpoint other = (PendingCheckpoint) o;
@@ -284,6 +304,11 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 			hash = 31 * hash + subtaskId;
 			hash = 31 * hash + (int) (timestamp ^ (timestamp >>> 32));
 			return hash;
+		}
+
+		@Override
+		public String toString() {
+			return "Pending Checkpoint: id=" + checkpointId + "/" + subtaskId + "@" + timestamp;
 		}
 	}
 }


### PR DESCRIPTION
As the issue suggests, this is the final commit to make the GenericWriteAheadSink re-scalable.
In essence, what it does is that it replaces the old snapshot()/restore() cycle with the new snapshotState()/initializeState() and adds tests to show that it works as expected.

R: @zentol 