### PR TITLE
[FLINK-5014] [RocksDB backend] add toString for RocksDBStateBackend

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -40,6 +40,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
@@ -446,5 +447,15 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 			columnOptions = opt;
 		}
 		return columnOptions;
+	}
+
+	@Override
+	public String toString() {
+		return "RocksDB State Backend {" +
+			"isInitialized=" + isInitialized +
+			", configuredDbBasePaths=" + Arrays.toString(configuredDbBasePaths) +
+			", initializedDbBasePaths=" + Arrays.toString(initializedDbBasePaths) +
+			", checkpointStreamBackend=" + checkpointStreamBackend +
+			'}';
 	}
 }


### PR DESCRIPTION
Adding toString() for RocksDBStateBackend.

Example output 1:

> RocksDB State Backend {isInitialized=false, configuredDbBasePaths=null, initializedDbBasePaths=null, checkpointStreamBackend=File State Backend @ file:/Users/melentye/tmp/flink-checkpoints}

Example output 2:

> RocksDB State Backend {isInitialized=true, configuredDbBasePaths=[/var/folders/k_/t4spznpj543cgt7vt59_6jp00000gn/T/junit6807913496462961318/junit8522690214676090832], initializedDbBasePaths=[/var/folders/k_/t4spznpj543cgt7vt59_6jp00000gn/T/junit6807913496462961318/junit8522690214676090832], checkpointStreamBackend=File State Backend @ file:/var/folders/k_/t4spznpj543cgt7vt59_6jp00000gn/T/junit6807913496462961318/junit3625485689993452525}

Normally I wouldn't cover toString method with unit tests, let me know if that's something we'd like to have in this particular case.