### PR TITLE
[FLINK-5021] Makes the ContinuousFileReaderOperator rescalable.

### DIFF
--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.hdfstests;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.io.FileInputFormat;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.io.TextInputFormat;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -36,7 +37,9 @@ import org.apache.flink.streaming.api.functions.source.FileProcessingMode;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.OperatorStateHandles;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.util.Preconditions;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
@@ -360,6 +363,149 @@ public class ContinuousFileProcessingTest {
 		}
 	}
 
+	@Test
+	public void testReaderSnapshotRestore() throws Exception {
+
+		TimestampedFileInputSplit split1 =
+			new TimestampedFileInputSplit(0, 3, new Path("test/test1"), 0, 100, null);
+
+		TimestampedFileInputSplit split2 =
+			new TimestampedFileInputSplit(10, 2, new Path("test/test2"), 101, 200, null);
+
+		TimestampedFileInputSplit split3 =
+			new TimestampedFileInputSplit(10, 1, new Path("test/test2"), 0, 100, null);
+
+		TimestampedFileInputSplit split4 =
+			new TimestampedFileInputSplit(11, 0, new Path("test/test3"), 0, 100, null);
+
+
+		final OneShotLatch latch = new OneShotLatch();
+
+		BlockingFileInputFormat format = new BlockingFileInputFormat(latch, new Path(hdfsURI));
+		TypeInformation<FileInputSplit> typeInfo = TypeExtractor.getInputFormatTypes(format);
+
+		ContinuousFileReaderOperator<FileInputSplit> initReader = new ContinuousFileReaderOperator<>(format);
+		initReader.setOutputType(typeInfo, new ExecutionConfig());
+
+		OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, FileInputSplit> initTestInstance =
+			new OneInputStreamOperatorTestHarness<>(initReader);
+		initTestInstance.setTimeCharacteristic(TimeCharacteristic.EventTime);
+		initTestInstance.open();
+
+		// create some state in the reader
+		initTestInstance.processElement(new StreamRecord<>(split1));
+		initTestInstance.processElement(new StreamRecord<>(split2));
+		initTestInstance.processElement(new StreamRecord<>(split3));
+		initTestInstance.processElement(new StreamRecord<>(split4));
+
+		// take a snapshot of the operator's state. This will be used
+		// to initialize another reader and compare the results of the
+		// two operators.
+
+		final OperatorStateHandles snapshot;
+		synchronized (initTestInstance.getCheckpointLock()) {
+			snapshot = initTestInstance.snapshot(0L, 0L);
+		}
+
+		ContinuousFileReaderOperator<FileInputSplit> restoredReader = new ContinuousFileReaderOperator<>(
+			new BlockingFileInputFormat(latch, new Path(hdfsURI)));
+		restoredReader.setOutputType(typeInfo, new ExecutionConfig());
+
+		OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, FileInputSplit> restoredTestInstance  =
+			new OneInputStreamOperatorTestHarness<>(restoredReader);
+		restoredTestInstance.setTimeCharacteristic(TimeCharacteristic.EventTime);
+
+		restoredTestInstance.initializeState(snapshot);
+		restoredTestInstance.open();
+
+		// now let computation start
+		latch.trigger();
+
+		// ... and wait for the operators to close gracefully
+
+		synchronized (initTestInstance.getCheckpointLock()) {
+			initTestInstance.close();
+		}
+
+		synchronized (restoredTestInstance.getCheckpointLock()) {
+			restoredTestInstance.close();
+		}
+
+		FileInputSplit fsSplit1 = createSplitFromTimestampedSplit(split1);
+		FileInputSplit fsSplit2 = createSplitFromTimestampedSplit(split2);
+		FileInputSplit fsSplit3 = createSplitFromTimestampedSplit(split3);
+		FileInputSplit fsSplit4 = createSplitFromTimestampedSplit(split4);
+
+		// compare if the results contain what they should contain and also if
+		// they are the same, as they should.
+
+		Assert.assertTrue(initTestInstance.getOutput().contains(new StreamRecord<>(fsSplit1)));
+		Assert.assertTrue(initTestInstance.getOutput().contains(new StreamRecord<>(fsSplit2)));
+		Assert.assertTrue(initTestInstance.getOutput().contains(new StreamRecord<>(fsSplit3)));
+		Assert.assertTrue(initTestInstance.getOutput().contains(new StreamRecord<>(fsSplit4)));
+
+		Assert.assertArrayEquals(
+			initTestInstance.getOutput().toArray(),
+			restoredTestInstance.getOutput().toArray()
+		);
+	}
+
+	private FileInputSplit createSplitFromTimestampedSplit(TimestampedFileInputSplit split) {
+		Preconditions.checkNotNull(split);
+
+		return new FileInputSplit(
+			split.getSplitNumber(),
+			split.getPath(),
+			split.getStart(),
+			split.getLength(),
+			split.getHostnames()
+		);
+	}
+
+	private static class BlockingFileInputFormat extends FileInputFormat<FileInputSplit> {
+
+		private final OneShotLatch latch;
+
+		private FileInputSplit split;
+
+		private boolean reachedEnd;
+
+		BlockingFileInputFormat(OneShotLatch latch, Path filePath) {
+			super(filePath);
+			this.latch = latch;
+			this.reachedEnd = false;
+		}
+
+		@Override
+		public void open(FileInputSplit fileSplit) throws IOException {
+			this.split = fileSplit;
+			this.reachedEnd = false;
+		}
+
+		@Override
+		public boolean reachedEnd() throws IOException {
+			if (!latch.isTriggered()) {
+				try {
+					latch.await();
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+			}
+			return reachedEnd;
+		}
+
+		@Override
+		public FileInputSplit nextRecord(FileInputSplit reuse) throws IOException {
+			this.reachedEnd = true;
+			return split;
+		}
+
+		@Override
+		public void close() {
+
+		}
+	}
+
 	////				Monitoring Function Tests				//////
 
 	@Test
@@ -394,7 +540,7 @@ public class ContinuousFileProcessingTest {
 				FileProcessingMode.PROCESS_ONCE, 1, INTERVAL);
 
 		final FileVerifyingSourceContext context =
-			new FileVerifyingSourceContext(new OneShotLatch(), monitoringFunction, 0, -1);
+			new FileVerifyingSourceContext(new OneShotLatch(), monitoringFunction);
 
 		monitoringFunction.open(new Configuration());
 		monitoringFunction.run(context);
@@ -463,8 +609,7 @@ public class ContinuousFileProcessingTest {
 			new ContinuousFileMonitoringFunction<>(format, hdfsURI,
 				FileProcessingMode.PROCESS_ONCE, 1, INTERVAL);
 
-		final FileVerifyingSourceContext context =
-			new FileVerifyingSourceContext(latch, monitoringFunction, 1, -1);
+		final FileVerifyingSourceContext context = new FileVerifyingSourceContext(latch, monitoringFunction);
 
 		final Thread t = new Thread() {
 			@Override
@@ -472,6 +617,13 @@ public class ContinuousFileProcessingTest {
 				try {
 					monitoringFunction.open(new Configuration());
 					monitoringFunction.run(context);
+
+					// we would never arrive here if we were in
+					// PROCESS_CONTINUOUSLY mode.
+
+					// this will trigger the latch
+					context.close();
+
 				} catch (Exception e) {
 					Assert.fail(e.getMessage());
 				}
@@ -572,9 +724,14 @@ public class ContinuousFileProcessingTest {
 		private final ContinuousFileMonitoringFunction src;
 		private final OneShotLatch latch;
 		private final Set<String> seenFiles;
-		private final int elementsBeforeNotifying;
 
+		private int elementsBeforeNotifying = -1;
 		private int elementsBeforeCanceling = -1;
+
+		FileVerifyingSourceContext(OneShotLatch latch,
+								   ContinuousFileMonitoringFunction src) {
+			this(latch, src, -1, -1);
+		}
 
 		FileVerifyingSourceContext(OneShotLatch latch,
 								ContinuousFileMonitoringFunction src,
@@ -594,15 +751,26 @@ public class ContinuousFileProcessingTest {
 		@Override
 		public void collect(TimestampedFileInputSplit element) {
 			String seenFileName = element.getPath().getName();
-
 			this.seenFiles.add(seenFileName);
-			if (seenFiles.size() == elementsBeforeNotifying) {
+
+			if (seenFiles.size() == elementsBeforeNotifying && !latch.isTriggered()) {
 				latch.trigger();
 			}
 
-			if (elementsBeforeCanceling != -1 && seenFiles.size() == elementsBeforeCanceling) {
+			if (seenFiles.size() == elementsBeforeCanceling) {
 				src.cancel();
 			}
+		}
+
+		@Override
+		public void close() {
+			// the context was terminated so trigger so
+			// that all threads that were waiting for this
+			// are un-blocked.
+			if (!latch.isTriggered()) {
+				latch.trigger();
+			}
+			src.cancel();
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
@@ -143,8 +143,15 @@ public class ContinuousFileMonitoringFunction<OUT>
 				break;
 			case PROCESS_ONCE:
 				synchronized (checkpointLock) {
-					monitorDirAndForwardSplits(fileSystem, context);
-					globalModificationTime = Long.MAX_VALUE;
+
+					// the following check guarantees that if we restart
+					// after a failure and we managed to have a successful
+					// checkpoint, we will not reprocess the directory.
+
+					if (globalModificationTime == Long.MIN_VALUE) {
+						monitorDirAndForwardSplits(fileSystem, context);
+						globalModificationTime = Long.MAX_VALUE;
+					}
 					isRunning = false;
 				}
 				break;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/TimestampedFileInputSplit.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/TimestampedFileInputSplit.java
@@ -44,10 +44,6 @@ public class TimestampedFileInputSplit extends FileInputSplit implements Compara
 	 * */
 	private Serializable splitState;
 
-	/** A special {@link TimestampedFileInputSplit} signaling the end of the stream of splits.*/
-	public static final TimestampedFileInputSplit EOS =
-		new TimestampedFileInputSplit(Long.MAX_VALUE, -1, null, -1, -1, null);
-
 	/**
 	 * Creates a {@link TimestampedFileInputSplit} based on the file modification time and
 	 * the rest of the information of the {@link FileInputSplit}, as returned by the
@@ -101,24 +97,23 @@ public class TimestampedFileInputSplit extends FileInputSplit implements Compara
 
 	@Override
 	public int compareTo(TimestampedFileInputSplit o) {
-		long modTimeComp = this.modificationTime - o.modificationTime;
+		int modTimeComp = Long.compare(this.modificationTime, o.modificationTime);
 		if (modTimeComp != 0L) {
-			// we cannot just cast the modTimeComp to int
-			// because it may overflow
-			return modTimeComp > 0 ? 1 : -1;
+			return modTimeComp;
 		}
 
-		// the file input split allows for null paths
-		if (this.getPath() == o.getPath()) {
-			return 0;
-		} else if (this.getPath() == null) {
+		// the file input split does not prevent null paths.
+		if (this.getPath() == null && o.getPath() != null) {
 			return 1;
-		} else if (o.getPath() == null) {
+		} else if (this.getPath() != null && o.getPath() == null) {
 			return -1;
 		}
 
-		int pathComp = this.getPath().compareTo(o.getPath());
-		return pathComp != 0 ? pathComp : this.getSplitNumber() - o.getSplitNumber();
+		int pathComp = this.getPath() == o.getPath() ? 0 :
+			this.getPath().compareTo(o.getPath());
+
+		return pathComp != 0 ? pathComp :
+			this.getSplitNumber() - o.getSplitNumber();
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/ContinuousFileProcessingRescalingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/ContinuousFileProcessingRescalingTest.java
@@ -1,0 +1,316 @@
+/*
+c * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.io.CheckpointableInputFormat;
+import org.apache.flink.api.common.io.FileInputFormat;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.functions.source.ContinuousFileReaderOperator;
+import org.apache.flink.streaming.api.functions.source.TimestampedFileInputSplit;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.OperatorStateHandles;
+import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.util.Preconditions;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+public class ContinuousFileProcessingRescalingTest {
+
+	@Test
+	public void testReaderScalingDown() throws Exception {
+		// simulates the scenario of scaling down from 2 to 1 instances
+
+		final OneShotLatch waitingLatch = new OneShotLatch();
+
+		// create the first instance and let it process the first split till element 5
+		final OneShotLatch triggerLatch1 = new OneShotLatch();
+		BlockingFileInputFormat format1 = new BlockingFileInputFormat(
+			triggerLatch1, waitingLatch, new Path("test"), 20, 5);
+		FileInputSplit[] splits = format1.createInputSplits(2);
+
+		OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, String> testHarness1 = getTestHarness(format1, 2, 0);
+		testHarness1.open();
+		testHarness1.processElement(new StreamRecord<>(getTimestampedSplit(0, splits[0])));
+
+		// wait until its arrives to element 5
+		if (!triggerLatch1.isTriggered()) {
+			triggerLatch1.await();
+		}
+
+		// create the second instance and let it process the second split till element 15
+		final OneShotLatch triggerLatch2 = new OneShotLatch();
+		BlockingFileInputFormat format2 = new BlockingFileInputFormat(
+			triggerLatch2, waitingLatch, new Path("test"), 20, 15);
+
+		OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, String> testHarness2 = getTestHarness(format2, 2, 1);
+		testHarness2.open();
+		testHarness2.processElement(new StreamRecord<>(getTimestampedSplit(0, splits[1])));
+
+		// wait until its arrives to element 15
+		if (!triggerLatch2.isTriggered()) {
+			triggerLatch2.await();
+		}
+
+		// 1) clear the outputs of the two previous instances so that
+		// we can compare their newly produced outputs with the merged one
+		testHarness1.getOutput().clear();
+		testHarness2.getOutput().clear();
+
+
+		// 2) and take the snapshots from the previous instances and merge them
+		// into a new one which will be then used to initialize a third instance
+		OperatorStateHandles mergedState = AbstractStreamOperatorTestHarness.
+			repackageState(
+				testHarness2.snapshot(0, 0),
+				testHarness1.snapshot(0, 0)
+			);
+
+		// create the third instance
+		final OneShotLatch wLatch = new OneShotLatch();
+		final OneShotLatch tLatch = new OneShotLatch();
+
+		BlockingFileInputFormat format = new BlockingFileInputFormat(wLatch, tLatch, new Path("test"), 20, 5);
+		OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, String> testHarness = getTestHarness(format, 1, 0);
+
+		// initialize the state of the new operator with the constructed by
+		// combining the partial states of the instances above.
+		testHarness.initializeState(mergedState);
+		testHarness.open();
+
+		// now restart the waiting operators
+		wLatch.trigger();
+		tLatch.trigger();
+		waitingLatch.trigger();
+
+		// and wait for the processing to finish
+		synchronized (testHarness1.getCheckpointLock()) {
+			testHarness1.close();
+		}
+		synchronized (testHarness2.getCheckpointLock()) {
+			testHarness2.close();
+		}
+		synchronized (testHarness.getCheckpointLock()) {
+			testHarness.close();
+		}
+
+		Queue<Object> expectedResult = new ArrayDeque<>();
+		putElementsInQ(expectedResult, testHarness1.getOutput());
+		putElementsInQ(expectedResult, testHarness2.getOutput());
+
+		Queue<Object> actualResult = new ArrayDeque<>();
+		putElementsInQ(actualResult, testHarness.getOutput());
+
+		Assert.assertEquals(20, actualResult.size());
+		Assert.assertArrayEquals(expectedResult.toArray(), actualResult.toArray());
+	}
+
+	@Test
+	public void testReaderScalingUp() throws Exception {
+		// simulates the scenario of scaling up from 1 to 2 instances
+
+		final OneShotLatch waitingLatch1 = new OneShotLatch();
+		final OneShotLatch triggerLatch1 = new OneShotLatch();
+
+		BlockingFileInputFormat format1 = new BlockingFileInputFormat(
+			triggerLatch1, waitingLatch1, new Path("test"), 20, 5);
+		FileInputSplit[] splits = format1.createInputSplits(2);
+
+		OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, String> testHarness1 = getTestHarness(format1, 1, 0);
+		testHarness1.open();
+
+		testHarness1.processElement(new StreamRecord<>(getTimestampedSplit(0, splits[0])));
+		testHarness1.processElement(new StreamRecord<>(getTimestampedSplit(1, splits[1])));
+
+		// wait until its arrives to element 5
+		if (!triggerLatch1.isTriggered()) {
+			triggerLatch1.await();
+		}
+
+		// this will be the state shared by the 2 new instances.
+		OperatorStateHandles snapshot = testHarness1.snapshot(0, 0);
+
+		// 1) clear the output of instance so that we can compare it with one created by the new instances, and
+		// 2) let the operator process the rest of its state
+		testHarness1.getOutput().clear();
+		waitingLatch1.trigger();
+
+		// create the second instance and let it process the second split till element 15
+		final OneShotLatch triggerLatch2 = new OneShotLatch();
+		final OneShotLatch waitingLatch2 = new OneShotLatch();
+
+		BlockingFileInputFormat format2 = new BlockingFileInputFormat(
+			triggerLatch2, waitingLatch2, new Path("test"), 20, 15);
+
+		OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, String> testHarness2 = getTestHarness(format2, 2, 0);
+		testHarness2.setup();
+		testHarness2.initializeState(snapshot);
+		testHarness2.open();
+
+		BlockingFileInputFormat format3 = new BlockingFileInputFormat(
+			triggerLatch2, waitingLatch2, new Path("test"), 20, 15);
+
+		OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, String> testHarness3 = getTestHarness(format3, 2, 1);
+		testHarness3.setup();
+		testHarness3.initializeState(snapshot);
+		testHarness3.open();
+
+		triggerLatch2.trigger();
+		waitingLatch2.trigger();
+
+		// and wait for the processing to finish
+		synchronized (testHarness1.getCheckpointLock()) {
+			testHarness1.close();
+		}
+		synchronized (testHarness2.getCheckpointLock()) {
+			testHarness2.close();
+		}
+		synchronized (testHarness3.getCheckpointLock()) {
+			testHarness3.close();
+		}
+
+		Queue<Object> expectedResult = new ArrayDeque<>();
+		putElementsInQ(expectedResult, testHarness1.getOutput());
+
+		Queue<Object> actualResult = new ArrayDeque<>();
+		putElementsInQ(actualResult, testHarness2.getOutput());
+		putElementsInQ(actualResult, testHarness3.getOutput());
+
+		Assert.assertEquals(35, actualResult.size());
+		Assert.assertArrayEquals(expectedResult.toArray(), actualResult.toArray());
+	}
+
+	private void putElementsInQ(Queue<Object> res, Queue<Object> partial) {
+		for (Object o : partial) {
+			if (o instanceof Watermark) {
+				continue;
+			}
+			res.add(o);
+		}
+	}
+
+	private OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, String> getTestHarness(
+		BlockingFileInputFormat format, int noOfTasks, int taksIdx) throws Exception {
+
+		ContinuousFileReaderOperator<String> reader = new ContinuousFileReaderOperator<>(format);
+		reader.setOutputType(TypeExtractor.getInputFormatTypes(format), new ExecutionConfig());
+
+		OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, String> testHarness =
+			new OneInputStreamOperatorTestHarness<>(reader, 10, noOfTasks, taksIdx);
+		testHarness.setTimeCharacteristic(TimeCharacteristic.EventTime);
+		return testHarness;
+	}
+
+	private TimestampedFileInputSplit getTimestampedSplit(long modTime, FileInputSplit split) {
+		Preconditions.checkNotNull(split);
+		return new TimestampedFileInputSplit(
+			modTime,
+			split.getSplitNumber(),
+			split.getPath(),
+			split.getStart(),
+			split.getLength(),
+			split.getHostnames());
+	}
+
+	private static class BlockingFileInputFormat
+		extends FileInputFormat<String>
+		implements CheckpointableInputFormat<FileInputSplit, Integer> {
+
+		private final OneShotLatch triggerLatch;
+		private final OneShotLatch waitingLatch;
+
+		private final int elementsBeforeCheckpoint;
+		private final int linesPerSplit;
+
+		private FileInputSplit split;
+
+		private int state;
+
+		BlockingFileInputFormat(OneShotLatch triggerLatch,
+								OneShotLatch waitingLatch,
+								Path filePath,
+								int sizeOfSplit,
+								int elementsBeforeCheckpoint) {
+			super(filePath);
+
+			this.triggerLatch = triggerLatch;
+			this.waitingLatch = waitingLatch;
+			this.elementsBeforeCheckpoint = elementsBeforeCheckpoint;
+			this.linesPerSplit = sizeOfSplit;
+
+			this.state = 0;
+		}
+
+		@Override
+		public FileInputSplit[] createInputSplits(int minNumSplits) throws IOException {
+			FileInputSplit[] splits = new FileInputSplit[minNumSplits];
+			for (int i = 0; i < minNumSplits; i++) {
+				splits[i] = new FileInputSplit(i, getFilePath(), i * linesPerSplit + 1, linesPerSplit, null);
+			}
+			return splits;
+		}
+
+		@Override
+		public void open(FileInputSplit fileSplit) throws IOException {
+			this.split = fileSplit;
+			this.state = 0;
+		}
+
+		@Override
+		public void reopen(FileInputSplit split, Integer state) throws IOException {
+			this.split = split;
+			this.state = state;
+		}
+
+		@Override
+		public Integer getCurrentState() throws IOException {
+			return state;
+		}
+
+		@Override
+		public boolean reachedEnd() throws IOException {
+			if (state == elementsBeforeCheckpoint) {
+				triggerLatch.trigger();
+				if (!waitingLatch.isTriggered()) {
+					try {
+						waitingLatch.await();
+					} catch (InterruptedException e) {
+						e.printStackTrace();
+					}
+				}
+			}
+			return state == linesPerSplit;
+		}
+
+		@Override
+		public String nextRecord(String reuse) throws IOException {
+			return reachedEnd() ? null : split.getSplitNumber() + ": test line " + state++;
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/TimestampedFileInputSplitTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/TimestampedFileInputSplitTest.java
@@ -23,7 +23,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Queue;
@@ -33,14 +32,8 @@ public class TimestampedFileInputSplitTest {
 	@Test
 	public void testSplitEquality() {
 
-		TimestampedFileInputSplit eos1 = TimestampedFileInputSplit.EOS;
-		TimestampedFileInputSplit eos2 = TimestampedFileInputSplit.EOS;
-
-		Assert.assertEquals(eos1, eos2);
-
 		TimestampedFileInputSplit richFirstSplit =
 			new TimestampedFileInputSplit(10, 2, new Path("test"), 0, 100, null);
-		Assert.assertNotEquals(eos1, richFirstSplit);
 
 		TimestampedFileInputSplit richSecondSplit =
 			new TimestampedFileInputSplit(10, 2, new Path("test"), 0, 100, null);
@@ -88,18 +81,6 @@ public class TimestampedFileInputSplitTest {
 
 		// smaller modification time first
 		Assert.assertTrue(richThirdSplit.compareTo(richForthSplit) < 0);
-
-		Assert.assertTrue(richFirstSplit.compareTo(TimestampedFileInputSplit.EOS) < 0);
-		Assert.assertTrue(richSecondSplit.compareTo(TimestampedFileInputSplit.EOS) < 0);
-		Assert.assertTrue(richThirdSplit.compareTo(TimestampedFileInputSplit.EOS) < 0);
-		Assert.assertTrue(richForthSplit.compareTo(TimestampedFileInputSplit.EOS) < 0);
-
-		Assert.assertEquals(0, TimestampedFileInputSplit.EOS.compareTo(TimestampedFileInputSplit.EOS));
-
-		Assert.assertTrue(TimestampedFileInputSplit.EOS.compareTo(richFirstSplit) > 0);
-		Assert.assertTrue(TimestampedFileInputSplit.EOS.compareTo(richSecondSplit) > 0);
-		Assert.assertTrue(TimestampedFileInputSplit.EOS.compareTo(richThirdSplit) > 0);
-		Assert.assertTrue(TimestampedFileInputSplit.EOS.compareTo(richForthSplit) > 0);
 	}
 
 	@Test
@@ -130,14 +111,10 @@ public class TimestampedFileInputSplitTest {
 		TimestampedFileInputSplit richFifthSplit =
 			new TimestampedFileInputSplit(11, 1, new Path("test/test3"), 0, 100, null);
 
-		TimestampedFileInputSplit eos = TimestampedFileInputSplit.EOS;
-
 		Queue<TimestampedFileInputSplit> pendingSplits = new PriorityQueue<>();
 
-		pendingSplits.add(eos);
 		pendingSplits.add(richSecondSplit);
 		pendingSplits.add(richForthSplit);
-		pendingSplits.add(eos);
 		pendingSplits.add(richFirstSplit);
 		pendingSplits.add(richFifthSplit);
 		pendingSplits.add(richFifthSplit);
@@ -158,8 +135,6 @@ public class TimestampedFileInputSplitTest {
 		expectedSortedSplits.add(richForthSplit);
 		expectedSortedSplits.add(richFifthSplit);
 		expectedSortedSplits.add(richFifthSplit);
-		expectedSortedSplits.add(eos);
-		expectedSortedSplits.add(eos);
 
 		Assert.assertArrayEquals(expectedSortedSplits.toArray(), actualSortedSplits.toArray());
 	}


### PR DESCRIPTION
 This is the last PR that completes the refactoring of the `ContinuousFileReaderOperator` so that it can be rescalable. With this, the reader can restart from a savepoint with a different parallelism without compromising the provided exactly-once guarantees.

The whole PR contains 3 commits. 

The first removes the EOS special split which was used to signal that no new splits are to be processed. This was useful in the `PROCESS_ONCE` mode. Now the reader closes by setting a flag and waiting for all the pending splits to be fully processed.

The second puts an additional check in the `ContinuousFileMonitoringFunction` that guarantees that in the case of the `PROCESS_ONCE`, the source will not reprocess the directory after recovering from a failure.

Finally, the third integrates the new rescalable state abstractions with the reader so that the reader can restart from a savepoint with different parallelism and still guarantee exactly-once semantics.

R: @aljoscha 