### PR TITLE
[FLINK-5027] FileSource finishes successfully with a wrong path

### DIFF
--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingTest.java
@@ -46,6 +46,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -122,13 +123,17 @@ public class ContinuousFileProcessingTest {
 			monitoringFunction.run(new DummySourceContext() {
 				@Override
 				public void collect(TimestampedFileInputSplit element) {
-					// do nothing as we are not expected to arrive here with an invalid path.
+					// we should never arrive here with an invalid path
+					Assert.fail("Test passes with an invalid path.");
 				}
 			});
-		} catch (IOException e) {
+
+			// we should never arrive here with an invalid path
+			Assert.fail("Test passed with an invalid path.");
+
+		} catch (FileNotFoundException e) {
 			Assert.assertEquals("The provided file path " + invalidPath + " does not exist.", e.getMessage());
 		}
-
 	}
 
 	@Test

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingTest.java
@@ -110,6 +110,28 @@ public class ContinuousFileProcessingTest {
 	//						TESTS
 
 	@Test
+	public void testInvalidPathSpecification() throws Exception {
+
+		String invalidPath = "hdfs://" + hdfsCluster.getURI().getHost() + ":" + hdfsCluster.getNameNodePort() +"/invalid/";
+		TextInputFormat format = new TextInputFormat(new Path(hdfsURI));
+
+		ContinuousFileMonitoringFunction<String> monitoringFunction =
+			new ContinuousFileMonitoringFunction<>(format, invalidPath,
+				FileProcessingMode.PROCESS_ONCE, 1, INTERVAL);
+		try {
+			monitoringFunction.run(new DummySourceContext() {
+				@Override
+				public void collect(TimestampedFileInputSplit element) {
+					// do nothing as we are not expected to arrive here with an invalid path.
+				}
+			});
+		} catch (IOException e) {
+			Assert.assertEquals("The provided file path " + invalidPath + " does not exist.", e.getMessage());
+		}
+
+	}
+
+	@Test
 	public void testFileReadingOperatorWithIngestionTime() throws Exception {
 		Set<org.apache.hadoop.fs.Path> filesCreated = new HashSet<>();
 		Map<Integer, String> expectedFileContents = new HashMap<>();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
@@ -124,6 +124,9 @@ public class ContinuousFileMonitoringFunction<OUT>
 	@Override
 	public void run(SourceFunction.SourceContext<TimestampedFileInputSplit> context) throws Exception {
 		FileSystem fileSystem = FileSystem.get(new URI(path));
+		if (!fileSystem.exists(new Path(path))) {
+			throw new IOException("The provided file path " + path + " does not exist.");
+		}
 
 		checkpointLock = context.getCheckpointLock();
 		switch (watchType) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
@@ -29,6 +29,7 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -125,7 +126,7 @@ public class ContinuousFileMonitoringFunction<OUT>
 	public void run(SourceFunction.SourceContext<TimestampedFileInputSplit> context) throws Exception {
 		FileSystem fileSystem = FileSystem.get(new URI(path));
 		if (!fileSystem.exists(new Path(path))) {
-			throw new IOException("The provided file path " + path + " does not exist.");
+			throw new FileNotFoundException("The provided file path " + path + " does not exist.");
 		}
 
 		checkpointLock = context.getCheckpointLock();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -311,7 +311,7 @@ public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OU
 
 			} finally {
 				synchronized (checkpointLock) {
-					LOG.info("Reader terminated, and exiting...");
+					LOG.debug("Reader terminated, and exiting...");
 
 					try {
 						this.format.closeInputFormat();


### PR DESCRIPTION
Adds a test in the `run()` of the `ContinuousFileMonitoringFunction` that checks if the user-specified path is valid. If not, the job will throw an IOException at runtime. We cannot throw the exception at compile time as we may not have access to the cluster.

R: @tillrohrmann 