### PR TITLE
[FLINK-4898] Refactor HTTP handlers and Netty server/client

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -67,6 +67,12 @@ under the License.
 			<!-- Version is set in root POM -->
 		</dependency>
 
+		<dependency>
+			<groupId>tv.cntt</groupId>
+			<artifactId>netty-router</artifactId>
+			<version>1.10</version>
+		</dependency>
+
 		<!-- See: https://groups.google.com/forum/#!msg/netty/-aAPDBNUnDg/SkGOXL2Ma2QJ -->
 		<dependency>
 			<groupId>org.javassist</groupId>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 
 public class NettyConnectionManager implements ConnectionManager {
 
+	private final PartitionRequestNettyConfig nettyConfig;
+
 	private final NettyServer server;
 
 	private final NettyClient client;
@@ -36,7 +38,8 @@ public class NettyConnectionManager implements ConnectionManager {
 
 	private final PartitionRequestClientFactory partitionRequestClientFactory;
 
-	public NettyConnectionManager(NettyConfig nettyConfig) {
+	public NettyConnectionManager(PartitionRequestNettyConfig nettyConfig) {
+		this.nettyConfig = nettyConfig;
 		this.server = new NettyServer(nettyConfig);
 		this.client = new NettyClient(nettyConfig);
 		this.bufferPool = new NettyBufferPool(nettyConfig.getNumberOfArenas());
@@ -48,7 +51,7 @@ public class NettyConnectionManager implements ConnectionManager {
 	public void start(ResultPartitionProvider partitionProvider, TaskEventDispatcher taskEventDispatcher, NetworkBufferPool networkbufferPool)
 			throws IOException {
 		PartitionRequestProtocol partitionRequestProtocol =
-				new PartitionRequestProtocol(partitionProvider, taskEventDispatcher, networkbufferPool);
+				new PartitionRequestProtocol(nettyConfig, partitionProvider, taskEventDispatcher, networkbufferPool);
 
 		client.init(partitionRequestProtocol, bufferPool);
 		server.init(partitionRequestProtocol, bufferPool);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestNettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestNettyConfig.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Configuration for partition request client/server.
+ */
+public class PartitionRequestNettyConfig extends NettyConfig {
+
+	private static final Logger LOG = LoggerFactory.getLogger(PartitionRequestNettyConfig.class);
+
+	// - Config keys ----------------------------------------------------------
+
+	public static final String NUM_ARENAS = "taskmanager.net.num-arenas";
+
+	public static final String NUM_THREADS_SERVER = "taskmanager.net.server.numThreads";
+
+	public static final String NUM_THREADS_CLIENT = "taskmanager.net.client.numThreads";
+
+	public static final String CONNECT_BACKLOG = "taskmanager.net.server.backlog";
+
+	public static final String CLIENT_CONNECT_TIMEOUT_SECONDS = "taskmanager.net.client.connectTimeoutSec";
+
+	public static final String SEND_RECEIVE_BUFFER_SIZE = "taskmanager.net.sendReceiveBufferSize";
+
+	public static final String TRANSPORT_TYPE = "taskmanager.net.transport";
+
+	// ------------------------------------------------------------------------
+
+	final static String SERVER_THREAD_GROUP_NAME = "Flink Netty Server";
+
+	final static String CLIENT_THREAD_GROUP_NAME = "Flink Netty Client";
+
+	private final int memorySegmentSize;
+
+	private final int numberOfSlots;
+
+	private final Configuration config; // optional configuration
+
+	public PartitionRequestNettyConfig(
+		InetAddress serverAddress,
+		int serverPort,
+		int memorySegmentSize,
+		int numberOfSlots,
+		Configuration config) {
+
+		super(serverAddress, serverPort, config);
+
+		checkArgument(memorySegmentSize > 0, "Invalid memory segment size.");
+		this.memorySegmentSize = memorySegmentSize;
+
+		checkArgument(numberOfSlots > 0, "Number of slots");
+		this.numberOfSlots = numberOfSlots;
+
+		this.config = checkNotNull(config);
+
+		LOG.info(this.toString());
+	}
+
+	public int getNumberOfSlots() {
+		return numberOfSlots;
+	}
+
+	public int getMemorySegmentSize() {
+		return memorySegmentSize;
+	}
+
+	// ------------------------------------------------------------------------
+	// Setters
+	// ------------------------------------------------------------------------
+
+	public NettyConfig setServerConnectBacklog(int connectBacklog) {
+		checkArgument(connectBacklog >= 0);
+		config.setInteger(CONNECT_BACKLOG, connectBacklog);
+
+		return this;
+	}
+
+	public NettyConfig setServerNumThreads(int numThreads) {
+		checkArgument(numThreads >= 0);
+		config.setInteger(NUM_THREADS_SERVER, numThreads);
+
+		return this;
+	}
+
+	public NettyConfig setClientNumThreads(int numThreads) {
+		checkArgument(numThreads >= 0);
+		config.setInteger(NUM_THREADS_CLIENT, numThreads);
+
+		return this;
+	}
+
+	public NettyConfig setClientConnectTimeoutSeconds(int connectTimeoutSeconds) {
+		checkArgument(connectTimeoutSeconds >= 0);
+		config.setInteger(CLIENT_CONNECT_TIMEOUT_SECONDS, connectTimeoutSeconds);
+
+		return this;
+	}
+
+	public NettyConfig setSendAndReceiveBufferSize(int bufferSize) {
+		checkArgument(bufferSize >= 0);
+		config.setInteger(SEND_RECEIVE_BUFFER_SIZE, bufferSize);
+
+		return this;
+	}
+
+	public NettyConfig setTransportType(String transport) {
+		if (transport.equals("nio") || transport.equals("epoll") || transport.equals("auto")) {
+			config.setString(TRANSPORT_TYPE, transport);
+		}
+		else {
+			throw new IllegalArgumentException("Unknown transport type.");
+		}
+
+		return this;
+	}
+
+	public NettyConfig setSSLEnabled(boolean enabled) {
+		config.setBoolean(ConfigConstants.TASK_MANAGER_DATA_SSL_ENABLED, enabled);
+
+		return this;
+	}
+
+	// ------------------------------------------------------------------------
+	// Getters
+	// ------------------------------------------------------------------------
+
+	@Override
+	public Tuple2<Integer,Integer> getServerWriteBufferWatermark() {
+		return new Tuple2<>(getMemorySegmentSize() + 1, 2 * getMemorySegmentSize());
+	}
+
+	@Override
+	public int getServerConnectBacklog() {
+		return config.getInteger(CONNECT_BACKLOG, super.getServerConnectBacklog());
+	}
+
+	@Override
+	public int getNumberOfArenas() {
+		// default: number of slots
+		return config.getInteger(NUM_ARENAS, numberOfSlots);
+	}
+
+	@Override
+	public int getServerNumThreads() {
+		// default: number of task slots
+		return config.getInteger(NUM_THREADS_SERVER, numberOfSlots);
+	}
+
+	@Override
+	public String getServerThreadGroupName() {
+		// Add the server port number to the name in order to distinguish
+		// multiple servers running on the same host.
+		return PartitionRequestNettyConfig.SERVER_THREAD_GROUP_NAME + " (" + getServerPort() + ")";
+	}
+
+	@Override
+	public int getClientNumThreads() {
+		// default: number of task slots
+		return config.getInteger(NUM_THREADS_CLIENT, numberOfSlots);
+	}
+
+	@Override
+	public int getClientConnectTimeoutSeconds() {
+		return config.getInteger(CLIENT_CONNECT_TIMEOUT_SECONDS, super.getClientConnectTimeoutSeconds());
+	}
+
+	@Override
+	public String getClientThreadGroupName() {
+		// Add the server port number to the name in order to distinguish
+		// multiple clients running on the same host.
+		return PartitionRequestNettyConfig.CLIENT_THREAD_GROUP_NAME + " (" + getServerPort() + ")";
+	}
+
+	@Override
+	public int getSendAndReceiveBufferSize() {
+		return config.getInteger(SEND_RECEIVE_BUFFER_SIZE, super.getSendAndReceiveBufferSize());
+	}
+
+	@Override
+	public TransportType getTransportType() {
+		String transport = config.getString(TRANSPORT_TYPE, "nio");
+		return parseTransportType(transport);
+	}
+
+	@Override
+	public boolean getSSLEnabled() {
+		return config.getBoolean(ConfigConstants.TASK_MANAGER_DATA_SSL_ENABLED,
+			ConfigConstants.DEFAULT_TASK_MANAGER_DATA_SSL_ENABLED)
+			&& super.getSSLEnabled();
+	}
+
+	@Override
+	public String toString() {
+		String format = "NettyConfig [" +
+			"server address: %s, " +
+			"server port: %d, " +
+			"memory segment size (bytes): %d, " +
+			"transport type: %s, " +
+			"number of server threads: %d (%s), " +
+			"number of client threads: %d (%s), " +
+			"server connect backlog: %d (%s), " +
+			"client connect timeout (sec): %d, " +
+			"send/receive buffer size (bytes): %d (%s)]";
+
+		String def = "use Netty's default";
+		String man = "manual";
+
+		return String.format(format, getServerAddress(), getServerPort(), getMemorySegmentSize(),
+			getTransportType(), getServerNumThreads(), getServerNumThreads() == 0 ? def : man,
+			getClientNumThreads(), getClientNumThreads() == 0 ? def : man,
+			getServerConnectBacklog(), getServerConnectBacklog() == 0 ? def : man,
+			getClientConnectTimeoutSeconds(), getSendAndReceiveBufferSize(),
+			getSendAndReceiveBufferSize() == 0 ? def : man);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/SimpleNettyProtocol.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/SimpleNettyProtocol.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.socket.SocketChannel;
+
+/**
+ * A simple netty protocol, providing a set of client and server handlers.
+ */
+public abstract class SimpleNettyProtocol implements NettyProtocol {
+
+	@Override
+	public ChannelHandler getServerChannelHandler() {
+		return new ChannelInitializer<SocketChannel>() {
+			@Override
+			public void initChannel(SocketChannel channel) throws Exception {
+				channel.pipeline().addLast(getServerChannelHandlers());
+			}
+		};
+	}
+
+	@Override
+	public ChannelHandler getClientChannelHandler() {
+		return new ChannelInitializer<SocketChannel>() {
+			@Override
+			public void initChannel(SocketChannel channel) throws Exception {
+				channel.pipeline().addLast(getClientChannelHandlers());
+			}
+		};
+	}
+
+	/**
+	 * Get the server-side channel handlers.
+	 *
+	 * Invoked at channel initialization time.  The handlers need not be sharable.
+	 */
+	public abstract ChannelHandler[] getServerChannelHandlers();
+
+	/**
+	 * Get the client-side channel handlers.
+	 *
+	 * Invoked at channel initialization time.  The handlers need not be sharable.
+	 */
+	public abstract ChannelHandler[] getClientChannelHandlers();
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLProtocolHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLProtocolHandler.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.ssl.SslHandler;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.runtime.io.network.netty.NettyConfig;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+
+/**
+ * Provides SSL security.
+ *
+ * Note that the SSL handler should be added first in the pipeline.  This handler
+ * can (and should) be shared by numerous channels.
+ */
+@ChannelHandler.Sharable
+public class SSLProtocolHandler extends ChannelHandlerAdapter {
+
+	private final NettyConfig config;
+	private final boolean clientMode;
+	private final SSLContext sslContext;
+
+	public SSLProtocolHandler(NettyConfig config, boolean clientMode) {
+		this.config = config;
+		this.clientMode = clientMode;
+		try {
+			// initialize the shared SSL context, which acts as a factory
+			// for channel-specific objects.
+			if (clientMode) {
+				sslContext = config.createClientSSLContext();
+			} else {
+				sslContext = config.createServerSSLContext();
+			}
+		}
+		catch(Exception ex) {
+			throw new IllegalConfigurationException("Failed to initialize the SSL context", ex);
+		}
+	}
+
+	@Override
+	public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+		if (sslContext != null && (ctx.channel() instanceof SocketChannel)) {
+			SSLEngine sslEngine;
+			if(clientMode) {
+				sslEngine = sslContext.createSSLEngine(
+					config.getServerAddress().getHostAddress(),
+					config.getServerPort());
+				sslEngine.setUseClientMode(true);
+
+				// Enable hostname verification for remote SSL connections
+				if (!config.getServerAddress().isLoopbackAddress()) {
+					SSLParameters newSSLParameters = sslEngine.getSSLParameters();
+					config.setSSLVerifyHostname(newSSLParameters);
+					sslEngine.setSSLParameters(newSSLParameters);
+				}
+			}
+			else {
+				sslEngine = sslContext.createSSLEngine();
+				sslEngine.setUseClientMode(false);
+			}
+
+			// install a channel-specific instance of SSLHandler
+			ctx.pipeline().replace(ctx.name(), "ssl", new SslHandler(sslEngine));
+		}
+		else {
+			ctx.pipeline().remove(ctx.name());
+		}
+	}
+
+	public static SslHandler getSSLHandler(Channel ch) {
+		return (SslHandler) ch.pipeline().get("ssl");
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/BaseHttpRequestActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/BaseHttpRequestActor.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import akka.actor.ReceiveTimeout;
+import akka.actor.UntypedActor;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.router.KeepAliveWrite;
+import io.netty.util.ReferenceCountUtil;
+import scala.Option;
+
+/**
+ * An actor that handles a single HTTP request.
+ *
+ * Provides the following convenience functionality:
+ *  - stops itself after an HTTP response is sent
+ *  - ReceiveTimeout produces a 503 (Service Unavailable) response
+ *  - unhandled exceptions produce a 500 (Internal Server Error) response
+ */
+public class BaseHttpRequestActor extends UntypedActor {
+
+	private final Channel channel;
+	private final HttpRequest request;
+
+	public BaseHttpRequestActor(Channel channel, HttpRequest request) {
+		this.channel = channel;
+		this.request = request;
+	}
+
+	public Channel channel() {
+		return channel;
+	}
+
+	public HttpRequest request() {
+		return request;
+	}
+
+	@Override
+	public void onReceive(Object message) throws Exception {
+		if(message instanceof ReceiveTimeout) {
+			sendResponse(new DefaultFullHttpResponse(
+				request.getProtocolVersion(), HttpResponseStatus.SERVICE_UNAVAILABLE), true);
+		}
+		else {
+			unhandled(message);
+		}
+	}
+
+	@Override
+	public void preRestart(Throwable reason, Option<Object> message) throws Exception {
+		if(channel.isActive()) {
+			sendResponse(new DefaultFullHttpResponse(
+				request.getProtocolVersion(), HttpResponseStatus.INTERNAL_SERVER_ERROR), false);
+		}
+		super.preRestart(reason, message);
+	}
+
+	@Override
+	public void postStop() throws Exception {
+		ReferenceCountUtil.release(request);
+		super.postStop();
+	}
+
+	// utilities --------------------------------------------------
+
+	protected void sendBadRequest() {
+		sendResponse(new DefaultFullHttpResponse(
+			request.getProtocolVersion(), HttpResponseStatus.BAD_REQUEST), true);
+	}
+
+
+	protected void sendNotFound() {
+		sendResponse(new DefaultFullHttpResponse(
+			request.getProtocolVersion(), HttpResponseStatus.NOT_FOUND), true);
+	}
+
+	/**
+	 * Send an HTTP response and optionally stop the actor.
+	 * @param response the response to send.
+	 * @param stop indicates whether to stop.
+     */
+	protected void sendResponse(HttpResponse response, boolean stop) {
+		KeepAliveWrite
+			.flush(channel, request, response)
+			.addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
+
+		if(stop) {
+			context().stop(self());
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/BaseRestRequestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/BaseRestRequestHandler.java
@@ -183,8 +183,11 @@ public abstract class BaseRestRequestHandler<T,OUT>
 		return new DefaultRestResponse(request.getProtocolVersion(), HttpResponseStatus.NOT_FOUND);
 	}
 
-	private static String blockquote(String str) {
-		return String.join("\n> ", str.split("\n"));
+	static String blockquote(String str) {
+		StringBuilder sb = new StringBuilder();
+		for(String line : str.split("\n")) {
+			sb.append("> ").append(line).append("\n");
+		}
+		return sb.toString();
 	}
-
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/BaseRestRequestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/BaseRestRequestHandler.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import com.google.common.net.MediaType;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.router.KeepAliveWrite;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An abstract REST request handler.
+ *
+ * Provides a request-response abstraction for the implementing class.
+ */
+public abstract class BaseRestRequestHandler<T,OUT>
+	extends SimpleChannelInboundHandler<RestRequest<T>>
+	implements RestResponseHandler<OUT> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(BaseRestRequestHandler.class);
+
+	private final Class<OUT> responseType;
+	private long responseTimeout;
+	private TimeUnit unit;
+
+	public BaseRestRequestHandler(Class<OUT> responseType) {
+		this(responseType, 0, TimeUnit.SECONDS);
+	}
+
+	public BaseRestRequestHandler(Class<OUT> responseType, long responseTimeout, TimeUnit unit) {
+		this.responseType = responseType;
+		this.responseTimeout = responseTimeout;
+		this.unit = unit;
+	}
+
+	@Override
+	public Class<OUT> getContentType() {
+		return responseType;
+	}
+
+	@Override
+	protected void channelRead0(ChannelHandlerContext ctx, final RestRequest<T> request) throws Exception {
+
+		final Channel channel = ctx.channel();
+
+		if(LOG.isDebugEnabled()) {
+			LOG.debug(blockquote(request.toString()));
+		}
+
+		// validate the request
+		boolean valid = true;
+		if(!request.headers().contains(HttpHeaders.Names.ACCEPT)) {
+			valid = false;
+		}
+		else {
+			MediaType acceptType = MediaType.parse(request.headers().get(HttpHeaders.Names.ACCEPT));
+			if(!MediaType.JSON_UTF_8.is(acceptType)) {
+				valid = false;
+			}
+		}
+
+		if(!valid) {
+			RestResponse response = new DefaultRestResponse(request.getProtocolVersion(), HttpResponseStatus.NOT_ACCEPTABLE);
+			writeResponse(channel, request, response);
+			return;
+		}
+
+		// handle
+		final Future<RestResponse<OUT>> responseFuture = handleRequest(ctx, request);
+
+		// produce a response
+		ReferenceCountUtil.retain(request);
+		responseFuture.addListener(new GenericFutureListener<Future<RestResponse>>() {
+			@Override
+			public void operationComplete(Future<RestResponse> future) throws Exception {
+				try {
+					if(future.isCancelled()) {
+						return;
+					}
+
+					RestResponse response;
+					if(future.isSuccess()) {
+						response = future.getNow();
+					}
+					else {
+						LOG.error("Error occurred in processing HTTP request", future.cause());
+						response = new DefaultRestResponse<>(
+							request.getProtocolVersion(), HttpResponseStatus.INTERNAL_SERVER_ERROR, (T) null);
+					}
+					writeResponse(channel, request, response);
+				}
+				finally {
+					ReferenceCountUtil.release(request);
+				}
+			}
+		});
+
+		if(responseTimeout > 0 && responseFuture.isCancellable() && !responseFuture.isDone()) {
+			LOG.debug("Scheduling a timeout callback.");
+			ReferenceCountUtil.retain(request);
+			ctx.executor().schedule(new Runnable() {
+				@Override
+				public void run() {
+					try {
+						if (responseFuture.isDone()) {
+							return;
+						}
+
+						if (responseFuture.cancel(false)) {
+							LOG.warn("Took too long to generate a response.");
+							RestResponse response = new DefaultRestResponse<>(
+								request.getProtocolVersion(), HttpResponseStatus.SERVICE_UNAVAILABLE, (T) null);
+							writeResponse(channel, request, response);
+						}
+					}
+					finally {
+						ReferenceCountUtil.release(request);
+					}
+				}
+			}, responseTimeout, unit);
+		}
+	}
+
+	private void writeResponse(Channel channel, RestRequest<T> request, RestResponse<?> response) {
+		if(LOG.isDebugEnabled()) {
+			LOG.debug(blockquote(response.toString()));
+		}
+
+		KeepAliveWrite
+			.flush(channel, request, response)
+			.addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
+	}
+
+	/**
+	 * Handle the REST request to produce a response.
+	 * @param ctx the channel handler context.
+	 * @param request the REST request.
+     * @return the promise of a REST response.
+     */
+	protected abstract Future<RestResponse<OUT>> handleRequest(ChannelHandlerContext ctx, RestRequest<T> request);
+
+	// Utilities ------------------------------------------------
+
+	/**
+	 * Create a 400 "Bad Request" response.
+     */
+	protected RestResponse badRequest(RestRequest request) {
+		return new DefaultRestResponse(request.getProtocolVersion(), HttpResponseStatus.BAD_REQUEST);
+	}
+
+	/**
+	 * Create a 404 "Not Found" response.
+	 * @param request
+	 * @return
+     */
+	protected RestResponse notFound(RestRequest request) {
+		return new DefaultRestResponse(request.getProtocolVersion(), HttpResponseStatus.NOT_FOUND);
+	}
+
+	private static String blockquote(String str) {
+		return String.join("\n> ", str.split("\n"));
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/BaseWebSocketClientChannelInitializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/BaseWebSocketClientChannelInitializer.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler;
+import io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator;
+import io.netty.handler.codec.http.websocketx.WebSocketVersion;
+
+import java.net.URI;
+
+/**
+ * Default WebSocket channel initializer.
+ */
+public class BaseWebSocketClientChannelInitializer extends ChannelInitializer<Channel> {
+
+	private final URI webSocketURL;
+	private final int maxFramePayloadLength;
+
+	/**
+	 * @param webSocketURL the URL for the HTTP resource to handshake with.
+	 * @param maxFramePayloadLength the max length.
+	*/
+	public BaseWebSocketClientChannelInitializer(URI webSocketURL, int maxFramePayloadLength) {
+		this.webSocketURL = webSocketURL;
+		this.maxFramePayloadLength = maxFramePayloadLength;
+	}
+
+	@Override
+	protected void initChannel(Channel ch) throws Exception {
+		ch.pipeline().addLast(new HttpClientCodec());
+		ch.pipeline().addLast(new HttpObjectAggregator(maxFramePayloadLength));
+		ch.pipeline().addLast(new WebSocketClientProtocolHandler(
+			webSocketURL, WebSocketVersion.V13, null, false, HttpHeaders.EMPTY_HEADERS, maxFramePayloadLength));
+		ch.pipeline().addLast(new WebSocketFrameAggregator(maxFramePayloadLength));
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/DefaultRestRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/DefaultRestRequest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCounted;
+
+/**
+ * The default {@link RestRequest} implementation.
+ */
+public class DefaultRestRequest<T> extends DefaultHttpRequest implements RestRequest<T> {
+
+	private final T content;
+
+	private final ReferenceCounted contentAsReferenceCounted;
+
+	public DefaultRestRequest(HttpVersion httpVersion, HttpMethod method, String uri) {
+		this(httpVersion, method, uri, null);
+	}
+
+	public DefaultRestRequest(HttpVersion httpVersion, HttpMethod method, String uri, T content) {
+		this(httpVersion, method, uri, content, true);
+	}
+
+	public DefaultRestRequest(HttpVersion httpVersion, HttpMethod method, String uri,
+		T content, boolean validateHeaders) {
+		super(httpVersion, method, uri, validateHeaders);
+		this.content = content;
+		contentAsReferenceCounted = (content instanceof ReferenceCounted) ? (ReferenceCounted) content : null;
+	}
+
+	@Override
+	public T content() {
+		return content;
+	}
+
+	@Override
+	public int refCnt() {
+		return (contentAsReferenceCounted == null)? 0 : contentAsReferenceCounted.refCnt();
+	}
+
+	@Override
+	public boolean release() {
+		return (contentAsReferenceCounted == null)? true : contentAsReferenceCounted.release();
+	}
+
+	@Override
+	public boolean release(int decrement) {
+		return (contentAsReferenceCounted == null)? true : contentAsReferenceCounted.release(decrement);
+	}
+
+	@Override
+	public ReferenceCounted retain() {
+		if (contentAsReferenceCounted != null) {
+			contentAsReferenceCounted.retain();
+		}
+		return this;
+	}
+
+	@Override
+	public ReferenceCounted retain(int increment) {
+		if (contentAsReferenceCounted != null) {
+			contentAsReferenceCounted.retain(increment);
+		}
+		return this;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/DefaultRestResponse.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/DefaultRestResponse.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCounted;
+
+/**
+ * The default {@link RestResponse} implementation.
+ */
+public class DefaultRestResponse<T> extends DefaultHttpResponse implements RestResponse<T> {
+
+	private final T content;
+
+	private final ReferenceCounted contentAsReferenceCounted;
+
+	private final RestError error;
+
+	public DefaultRestResponse(HttpVersion version, HttpResponseStatus status) {
+		this(version, status, null);
+	}
+
+	public DefaultRestResponse(HttpVersion version, HttpResponseStatus status, T content) {
+		this(version, status, content, true, null);
+	}
+
+	public DefaultRestResponse(HttpVersion version, HttpResponseStatus status,
+		T content, boolean validateHeaders, RestError error) {
+		super(version, status, validateHeaders);
+		this.content = content;
+		this.error = error;
+		contentAsReferenceCounted = (content instanceof ReferenceCounted) ? (ReferenceCounted) content : null;
+	}
+
+	@Override
+	public T content() {
+		return content;
+	}
+
+	@Override
+	public RestError error() {
+		return error;
+	}
+
+	@Override
+	public int refCnt() {
+		return (contentAsReferenceCounted == null)? 0 : contentAsReferenceCounted.refCnt();
+	}
+
+	@Override
+	public boolean release() {
+		return (contentAsReferenceCounted == null)? true : contentAsReferenceCounted.release();
+	}
+
+	@Override
+	public boolean release(int decrement) {
+		return (contentAsReferenceCounted == null)? true : contentAsReferenceCounted.release(decrement);
+	}
+
+	@Override
+	public ReferenceCounted retain() {
+		if (contentAsReferenceCounted != null) {
+			contentAsReferenceCounted.retain();
+		}
+		return this;
+	}
+
+	@Override
+	public ReferenceCounted retain(int increment) {
+		if (contentAsReferenceCounted != null) {
+			contentAsReferenceCounted.retain(increment);
+		}
+		return this;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RestClientProtocolHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RestClientProtocolHandler.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.net.MediaType;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.util.CharsetUtil;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * REST protocol support handler, providing client-side message encoding and decoding.
+ */
+@ChannelHandler.Sharable
+public class RestClientProtocolHandler<T> extends ChannelHandlerAdapter {
+
+	private final ObjectMapper mapper;
+	private final Class<T> decoderValueType;
+
+	public RestClientProtocolHandler(ObjectMapper mapper, Class<T> decoderValueType) {
+		this.mapper = checkNotNull(mapper);
+		this.decoderValueType = checkNotNull(decoderValueType);
+	}
+
+	@Override
+	public void handlerAdded(ChannelHandlerContext ctx) {
+		ChannelPipeline cp = ctx.pipeline();
+
+		if (cp.get(RestDecoder.class) == null) {
+			ctx.pipeline().addBefore(ctx.name(), RestDecoder.class.getName(),
+				new RestDecoder<T>(mapper, decoderValueType));
+		}
+		if (cp.get(RestEncoder.class) == null) {
+			ctx.pipeline().addBefore(ctx.name(), RestEncoder.class.getName(),
+				new RestEncoder(mapper));
+		}
+	}
+
+	/**
+	 * Encodes {@link RestRequest} messages as {@link FullHttpRequest} messages,
+	 * using an {@link ObjectMapper} to serialize the content.
+	 */
+	@ChannelHandler.Sharable
+	static class RestEncoder extends MessageToMessageEncoder<RestRequest> {
+
+		private final ObjectMapper mapper;
+
+		public RestEncoder(ObjectMapper mapper) {
+			this.mapper = mapper;
+		}
+
+		@Override
+		protected void encode(ChannelHandlerContext ctx, RestRequest msg, List<Object> out) throws Exception {
+
+			ByteBuf contentBuf;
+			if(msg.content() != null) {
+				contentBuf = ctx.alloc().buffer();
+				try {
+					try (ByteBufOutputStream stream = new ByteBufOutputStream(contentBuf)) {
+						mapper.writeValue(stream, msg.content());
+					}
+				}
+				catch(Exception ex) {
+					throw new IOException("Unable to encode the REST request content body.", ex);
+				}
+			}
+			else {
+				contentBuf = Unpooled.buffer(0);
+			}
+
+			FullHttpRequest httpRequest = new DefaultFullHttpRequest(
+				msg.getProtocolVersion(), msg.getMethod(), msg.getUri(), contentBuf, false);
+			httpRequest.headers().add(HttpHeaders.Names.CONTENT_LENGTH, contentBuf.readableBytes());
+			httpRequest.headers().add(HttpHeaders.Names.CONTENT_TYPE, MediaType.JSON_UTF_8.toString());
+
+			out.add(httpRequest);
+		}
+	}
+
+	/**
+	 * Decodes {@link FullHttpResponse} messages as {@link RestResponse} messages,
+	 * using an {@link ObjectMapper} to deserialize the content.
+	 */
+	@ChannelHandler.Sharable
+	static class RestDecoder<T> extends MessageToMessageDecoder<FullHttpResponse> {
+
+		private final ObjectMapper mapper;
+		private final Class<T> valueType;
+
+		public RestDecoder(ObjectMapper mapper, Class<T> valueType) {
+			this.mapper = mapper;
+			this.valueType = valueType;
+		}
+
+		@Override
+		public boolean acceptInboundMessage(Object msg) throws Exception {
+			if(!super.acceptInboundMessage(msg)) {
+				return false;
+			}
+			FullHttpResponse response = (FullHttpResponse) msg;
+			if(response.content().readableBytes() > 0) {
+				if (!response.headers().contains(HttpHeaders.Names.CONTENT_TYPE)) {
+					return false;
+				}
+				MediaType contentType = MediaType.parse(response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
+				if(!contentType.is(MediaType.JSON_UTF_8.withoutParameters())) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		@Override
+		protected void decode(ChannelHandlerContext ctx, FullHttpResponse response, List<Object> out) throws Exception {
+
+			T content;
+			RestError error;
+			if(response.content().readableBytes() > 0) {
+				MediaType contentType = MediaType.parse(response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
+				Charset charset = contentType.charset().or(CharsetUtil.UTF_8);
+				try {
+					try (Reader reader = new InputStreamReader(new ByteBufInputStream(response.content()), charset)) {
+
+						if(RestUtils.isErrorResponse(response)) {
+							content = null;
+							error = mapper.readValue(reader, RestError.class);
+						}
+						else {
+							content = mapper.readValue(reader, valueType);
+							error = null;
+						}
+					}
+				}
+				catch(Exception ex) {
+					throw new IOException("Unable to decode the REST response content body.", ex);
+				}
+			}
+			else {
+				content = null;
+				error = null;
+			}
+
+			DefaultRestResponse restResponse = new DefaultRestResponse<T>(
+				response.getProtocolVersion(), response.getStatus(), content, true, error);
+			restResponse.headers().add(response.headers());
+
+			out.add(restResponse);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RestError.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RestError.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * A REST error response entity.
+ */
+@JsonPropertyOrder({"code", "detail"})
+public class RestError implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private int code;
+	private String detail;
+
+	@JsonCreator
+	public RestError(@JsonProperty("code") int code, @JsonProperty("detail") String detail) {
+		this.code = code;
+		this.detail = detail;
+	}
+
+	@JsonProperty("code")
+	public int code() {
+		return code;
+	}
+
+	@JsonProperty("detail")
+	public String detail() {
+		return detail;
+	}
+
+	@Override
+	public String toString() {
+		return "RestError{" +
+			"code=" + code +
+			", detail='" + detail + '\'' +
+			'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		RestError restError = (RestError) o;
+		return code == restError.code &&
+			Objects.equals(detail, restError.detail);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(code, detail);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RestRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RestRequest.java
@@ -16,28 +16,20 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.io.network.netty;
+package org.apache.flink.runtime.net.http;
 
-import io.netty.channel.ChannelHandler;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.util.ReferenceCounted;
 
 /**
- * An abstract Netty protocol.
+ * A RESTful HTTP request, with a typed content body.
+ *
+ * @param <T> the content type.
  */
-public interface NettyProtocol {
+public interface RestRequest<T> extends HttpRequest, ReferenceCounted {
 
 	/**
-	 * Get the server-side channel handler or initializer.
-	 *
-	 * The handler must be sharable.
-	 * @return a handler.
-	*/
-	ChannelHandler getServerChannelHandler();
-
-	/**
-	 * Get the client-side channel handler or initializer.
-	 *
-	 * The handler, if provided here, must be sharable.
-	 * @return a handler, or null if the handler is provided later (at connection time).
-	 */
-	ChannelHandler getClientChannelHandler();
+	 * The content associated with the request.
+     */
+	T content();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RestResponse.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RestResponse.java
@@ -16,28 +16,25 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.io.network.netty;
+package org.apache.flink.runtime.net.http;
 
-import io.netty.channel.ChannelHandler;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.util.ReferenceCounted;
 
 /**
- * An abstract Netty protocol.
+ * A RESTful HTTP response, with a typed content body or an error.
+ *
+ * @param <T> the content type.
  */
-public interface NettyProtocol {
+public interface RestResponse<T> extends HttpResponse, ReferenceCounted {
 
 	/**
-	 * Get the server-side channel handler or initializer.
-	 *
-	 * The handler must be sharable.
-	 * @return a handler.
-	*/
-	ChannelHandler getServerChannelHandler();
-
-	/**
-	 * Get the client-side channel handler or initializer.
-	 *
-	 * The handler, if provided here, must be sharable.
-	 * @return a handler, or null if the handler is provided later (at connection time).
+	 * The content associated with the response.
 	 */
-	ChannelHandler getClientChannelHandler();
+	T content();
+
+	/**
+	 * The error associated with the response.
+     */
+	RestError error();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RestResponseHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RestResponseHandler.java
@@ -16,28 +16,15 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.io.network.netty;
+package org.apache.flink.runtime.net.http;
 
 import io.netty.channel.ChannelHandler;
 
 /**
- * An abstract Netty protocol.
+ * An abstract REST request handler.
+ *
+ * @param <T> the response content type.
  */
-public interface NettyProtocol {
-
-	/**
-	 * Get the server-side channel handler or initializer.
-	 *
-	 * The handler must be sharable.
-	 * @return a handler.
-	*/
-	ChannelHandler getServerChannelHandler();
-
-	/**
-	 * Get the client-side channel handler or initializer.
-	 *
-	 * The handler, if provided here, must be sharable.
-	 * @return a handler, or null if the handler is provided later (at connection time).
-	 */
-	ChannelHandler getClientChannelHandler();
+public interface RestResponseHandler<T> extends ChannelHandler {
+	Class<T> getContentType();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RestServerProtocolHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RestServerProtocolHandler.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.net.MediaType;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.router.Routed;
+import io.netty.util.CharsetUtil;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.util.List;
+
+/**
+ * REST protocol support handler, providing server-side message encoding and decoding.
+ */
+@ChannelHandler.Sharable
+public class RestServerProtocolHandler<T> extends ChannelHandlerAdapter {
+
+	private final ObjectMapper mapper;
+	private final Class<T> decoderValueType;
+
+	public RestServerProtocolHandler(ObjectMapper mapper, Class<T> decoderValueType) {
+		this.mapper = mapper;
+		this.decoderValueType = decoderValueType;
+	}
+
+	@Override
+	public void handlerAdded(ChannelHandlerContext ctx) {
+		ChannelPipeline cp = ctx.pipeline();
+
+		if (cp.get(RestDecoder.class) == null) {
+			ctx.pipeline().addBefore(ctx.name(), RestDecoder.class.getName(),
+				new RestDecoder<T>(mapper, decoderValueType));
+		}
+		if (cp.get(RestEncoder.class) == null) {
+			ctx.pipeline().addBefore(ctx.name(), RestEncoder.class.getName(),
+				new RestEncoder(mapper));
+		}
+		cp.remove(ctx.name());
+	}
+
+	/**
+	 * Encodes {@link RestResponse} messages as {@link FullHttpResponse} messages,
+	 * using an {@link ObjectMapper} to serialize the content.
+	 */
+	@ChannelHandler.Sharable
+	static class RestEncoder extends MessageToMessageEncoder<RestResponse> {
+
+		private final ObjectMapper mapper;
+
+		public RestEncoder(ObjectMapper mapper) {
+			this.mapper = mapper;
+		}
+
+		@Override
+		protected void encode(ChannelHandlerContext ctx, RestResponse msg, List<Object> out) throws Exception {
+
+			ByteBuf contentBuf;
+			boolean isError = RestUtils.isErrorResponse(msg);
+			if((!isError && msg.content() != null) || (isError && msg.error() != null)) {
+				contentBuf = ctx.alloc().buffer();
+				try {
+					try (ByteBufOutputStream stream = new ByteBufOutputStream(contentBuf)) {
+						Object value = msg.content() != null ? msg.content() : msg.error();
+						mapper.writeValue(stream, value);
+					}
+				}
+				catch(Exception ex) {
+					throw new IOException("Unable to encode the REST response content body.", ex);
+				}
+			}
+			else {
+				contentBuf = Unpooled.buffer(0);
+			}
+
+			DefaultFullHttpResponse httpResponse = new DefaultFullHttpResponse(
+				msg.getProtocolVersion(), msg.getStatus(), contentBuf);
+			httpResponse.headers().add(msg.headers());
+			httpResponse.headers().set(HttpHeaders.Names.CONTENT_LENGTH, contentBuf.readableBytes());
+			if(contentBuf.readableBytes() > 0) {
+				httpResponse.headers().set(HttpHeaders.Names.CONTENT_TYPE, MediaType.JSON_UTF_8.toString());
+			}
+
+			out.add(httpResponse);
+		}
+	}
+
+	/**
+	 * Decodes {@link Routed} messages as {@link RestRequest} messages,
+	 * using an {@link ObjectMapper} to deserialize the content.
+	 */
+	@ChannelHandler.Sharable
+	static class RestDecoder<T> extends MessageToMessageDecoder<Routed> {
+
+		private final ObjectMapper mapper;
+		private final Class<T> valueType;
+
+		public RestDecoder(ObjectMapper mapper, Class<T> valueType) {
+			this.mapper = mapper;
+			this.valueType = valueType;
+		}
+
+		@Override
+		public boolean acceptInboundMessage(Object msg) throws Exception {
+			if(!super.acceptInboundMessage(msg)) {
+				return false;
+			}
+			Routed routed = (Routed) msg;
+			if(!(routed.request() instanceof FullHttpRequest)) {
+				return false;
+			}
+
+			FullHttpRequest request = (FullHttpRequest) routed.request();
+
+			if(request.content().readableBytes() > 0) {
+				if (!request.headers().contains(HttpHeaders.Names.CONTENT_TYPE)) {
+					return false;
+				}
+				MediaType contentType = MediaType.parse(request.headers().get(HttpHeaders.Names.CONTENT_TYPE));
+				if (!contentType.is(MediaType.JSON_UTF_8.withoutParameters())) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		@Override
+		protected void decode(ChannelHandlerContext ctx, Routed routed, List<Object> out) throws Exception {
+
+			FullHttpRequest request = (FullHttpRequest) routed.request();
+
+			T content;
+			if(request.content().readableBytes() > 0) {
+				MediaType contentType = MediaType.parse(request.headers().get(HttpHeaders.Names.CONTENT_TYPE));
+				Charset charset = contentType.charset().or(CharsetUtil.UTF_8);
+				try {
+					try (Reader reader = new InputStreamReader(new ByteBufInputStream(request.content()), charset)) {
+						content = mapper.readValue(reader, valueType);
+					}
+				}
+				catch(Exception ex) {
+					throw new IOException("Unable to decode the REST request content body.", ex);
+				}
+			}
+			else {
+				content = null;
+			}
+
+			DefaultRestRequest restRequest = new DefaultRestRequest<>(
+				request.getProtocolVersion(), request.getMethod(), request.getUri(), content);
+			restRequest.headers().add(request.headers());
+
+			out.add(restRequest);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RestUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RestUtils.java
@@ -16,28 +16,18 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.io.network.netty;
+package org.apache.flink.runtime.net.http;
 
-import io.netty.channel.ChannelHandler;
+import io.netty.handler.codec.http.HttpResponse;
 
 /**
- * An abstract Netty protocol.
+ * Utilities to work with REST requests and responses.
  */
-public interface NettyProtocol {
+public class RestUtils {
 
-	/**
-	 * Get the server-side channel handler or initializer.
-	 *
-	 * The handler must be sharable.
-	 * @return a handler.
-	*/
-	ChannelHandler getServerChannelHandler();
+	public static boolean isErrorResponse(HttpResponse response) {
+		return response.getStatus().code() >= 400;
+	}
 
-	/**
-	 * Get the client-side channel handler or initializer.
-	 *
-	 * The handler, if provided here, must be sharable.
-	 * @return a handler, or null if the handler is provided later (at connection time).
-	 */
-	ChannelHandler getClientChannelHandler();
+	private RestUtils() {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RoutedWebSocketHandshakeHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/RoutedWebSocketHandshakeHandler.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.router.Routed;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.util.ReferenceCountUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Upgrades a channel to a WebSocket connection in response to a routed HTTP request.
+ *
+ * For example, an HTTP request of "POST /subscribe" could be routed to this handler
+ * to upgrade the connection to a WebSocket.   The underlying (Netty-provided)
+ * {@link WebSocketServerProtocolHandler} blindly upgrades all channels; this class allows
+ * the upgrade to be selective.
+ */
+@ChannelHandler.Sharable
+public class RoutedWebSocketHandshakeHandler extends SimpleChannelInboundHandler<Routed> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(RoutedWebSocketHandshakeHandler.class);
+
+	private final ChannelHandler postHandshakeHandler;
+
+	private final ChannelGroup channelGroup;
+
+	/**
+	 * Construct a handshake handler that upgrades the request then installs the given
+	 * post-handshake handler.
+	 * @param postHandshakeHandler the post-handshake handler to install.
+	 * @param channelGroup (optional) a channel group to add the upgraded channels to.
+     */
+	public RoutedWebSocketHandshakeHandler(ChannelHandler postHandshakeHandler, ChannelGroup channelGroup) {
+		this.postHandshakeHandler = checkNotNull(postHandshakeHandler);
+		this.channelGroup = channelGroup;
+	}
+
+	/**
+	 * Get the channel group containing upgraded channels.
+     */
+	public ChannelGroup getChannelGroup() {
+		return channelGroup;
+	}
+
+	@Override
+	protected void channelRead0(ChannelHandlerContext ctx, Routed routed) throws Exception {
+		LOG.debug("Received handshake request at {} for channel {}",
+			routed.path(), ctx.channel().remoteAddress());
+
+		// inject the websocket protocol handler into this channel, to be active
+		// until the channel is closed.  note that the handshake may/or complete synchronously.
+		ctx.pipeline().addAfter(ctx.name(), WebSocketServerProtocolHandler.class.getName(),
+			new WebSocketServerProtocolHandler(routed.path()));
+
+		// inject a handler for handshake success
+		ctx.pipeline().addAfter(WebSocketServerProtocolHandler.class.getName(), HandshakeCompleteHandler.class.getName(),
+			new HandshakeCompleteHandler());
+
+		// forward the message to the installed handler
+		HttpRequest request = routed.request();
+		ReferenceCountUtil.retain(request);
+		ctx.fireChannelRead(request);
+	}
+
+	/**
+	 * Handles the HANDSHAKE_COMPLETE event by installing the provided post-handshake handler.
+	 */
+	class HandshakeCompleteHandler extends ChannelInboundHandlerAdapter {
+
+		@Override
+		public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+			if (evt instanceof WebSocketServerProtocolHandler.ServerHandshakeStateEvent) {
+				WebSocketServerProtocolHandler.ServerHandshakeStateEvent handshakeEvent =
+					(WebSocketServerProtocolHandler.ServerHandshakeStateEvent) evt;
+				if (handshakeEvent == WebSocketServerProtocolHandler.ServerHandshakeStateEvent.HANDSHAKE_COMPLETE) {
+					LOG.debug("Handshake completed for channel {}.", ctx.channel().remoteAddress());
+
+					if(channelGroup != null) {
+						// add the channel to the provided channel group, for bulk messaging purposes
+						channelGroup.add(ctx.channel());
+					}
+
+					// install the post-handshake handler
+					ctx.pipeline().replace(ctx.name(), ctx.name() + "-after", postHandshakeHandler);
+
+					return;
+				}
+			}
+
+			super.userEventTriggered(ctx, evt);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/WebSocketJsonMessageDecoder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/WebSocketJsonMessageDecoder.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Converts WebSocket text messages to user-defined objects.
+ */
+@ChannelHandler.Sharable
+public class WebSocketJsonMessageDecoder<T> extends MessageToMessageDecoder<TextWebSocketFrame> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(WebSocketJsonMessageDecoder.class);
+
+	private final ObjectMapper mapper;
+	private final Class<T> valueType;
+
+	/**
+	 * Construct an adapter to read WebSocket messages using the given mapper and value type.
+	 * @param mapper the mapper to deserialize the message with.
+	 * @param valueType the base type of the message.
+     */
+	public WebSocketJsonMessageDecoder(ObjectMapper mapper, Class<T> valueType) {
+		this.mapper = checkNotNull(mapper);
+		this.valueType = checkNotNull(valueType);
+	}
+
+	@Override
+	public boolean acceptInboundMessage(Object msg) throws Exception {
+		if(!(msg instanceof TextWebSocketFrame)) {
+			return false;
+		}
+		return ((TextWebSocketFrame) msg).isFinalFragment();
+	}
+
+	@Override
+	protected void decode(ChannelHandlerContext ctx, TextWebSocketFrame msg, List<Object> out) throws Exception {
+		String value = msg.text();
+		T obj;
+		try {
+			obj = mapper.readValue(value, valueType);
+		}
+		catch(Exception ex) {
+			throw new IOException("Unable to decode WebSocket message", ex);
+		}
+		out.add(obj);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/WebSocketJsonMessageEncoder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/http/WebSocketJsonMessageEncoder.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Converts user-defined objects to WebSocket messages.
+ */
+@ChannelHandler.Sharable
+public class WebSocketJsonMessageEncoder<T> extends MessageToMessageEncoder<T> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(WebSocketJsonMessageEncoder.class);
+
+	private final ObjectMapper mapper;
+	private final Class<T> valueType;
+
+	/**
+	 * Construct an encoder to write WebSocket messages using the given mapper and value type.
+	 * @param mapper the mapper to deserialize the message with.
+	 * @param valueType the base type of the message.
+     */
+	public WebSocketJsonMessageEncoder(ObjectMapper mapper, Class<T> valueType) {
+		super(valueType);
+		this.mapper = checkNotNull(mapper);
+		this.valueType = checkNotNull(valueType);
+	}
+
+	@Override
+	protected void encode(ChannelHandlerContext ctx, T msg, List<Object> out) throws Exception {
+		String value;
+		try {
+			value = mapper.writeValueAsString(msg);
+		}
+		catch(Exception ex) {
+			throw new IOException("Unable to encode WebSocket message", ex);
+		}
+		out.add(new TextWebSocketFrame(value));
+	}
+}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
@@ -33,7 +33,7 @@ import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory
 import org.apache.flink.runtime.instance.InstanceManager
 import org.apache.flink.runtime.io.disk.iomanager.IOManager
 import org.apache.flink.runtime.io.network.NetworkEnvironment
-import org.apache.flink.runtime.io.network.netty.NettyConfig
+import org.apache.flink.runtime.io.network.netty.{PartitionRequestNettyConfig, NettyConfig}
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler
 import org.apache.flink.runtime.jobmanager.{JobManager, MemoryArchivist, SubmittedJobGraphStore}
 import org.apache.flink.runtime.leaderelection.LeaderElectionService
@@ -371,8 +371,8 @@ class LocalFlinkMiniCluster(
       ConfigConstants.DEFAULT_LOCAL_NUMBER_TASK_MANAGER)
 
     // Reduce number of threads for local execution
-    config.setInteger(NettyConfig.NUM_THREADS_CLIENT, 1)
-    config.setInteger(NettyConfig.NUM_THREADS_SERVER, 2)
+    config.setInteger(PartitionRequestNettyConfig.NUM_THREADS_CLIENT, 1)
+    config.setInteger(PartitionRequestNettyConfig.NUM_THREADS_SERVER, 2)
 
     config
   }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.scala
@@ -20,13 +20,13 @@ package org.apache.flink.runtime.taskmanager
 
 import org.apache.flink.core.memory.MemoryType
 import org.apache.flink.runtime.io.disk.iomanager.IOManager.IOMode
-import org.apache.flink.runtime.io.network.netty.NettyConfig
+import org.apache.flink.runtime.io.network.netty.PartitionRequestNettyConfig
 
 case class NetworkEnvironmentConfiguration(
   numNetworkBuffers: Int,
   networkBufferSize: Int,
   memoryType: MemoryType,
   ioMode: IOMode,
-  nettyConfig: Option[NettyConfig] = None,
+  partitionRequestConfig: Option[PartitionRequestNettyConfig] = None,
   partitionRequestInitialBackoff: Int = 500,
   partitinRequestMaxBackoff: Int = 3000)

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -48,7 +48,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager.IOMode
 import org.apache.flink.runtime.io.disk.iomanager.{IOManager, IOManagerAsync}
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool
 import org.apache.flink.runtime.io.network.{LocalConnectionManager, NetworkEnvironment, TaskEventDispatcher}
-import org.apache.flink.runtime.io.network.netty.{NettyConfig, NettyConnectionManager, PartitionStateChecker}
+import org.apache.flink.runtime.io.network.netty.{NettyConfig, NettyConnectionManager, PartitionRequestNettyConfig, PartitionStateChecker}
 import org.apache.flink.runtime.io.network.partition.{ResultPartitionConsumableNotifier, ResultPartitionManager}
 import org.apache.flink.runtime.leaderretrieval.{LeaderRetrievalListener, LeaderRetrievalService}
 import org.apache.flink.runtime.memory.MemoryManager
@@ -1913,7 +1913,7 @@ object TaskManager {
       netConfig.networkBufferSize,
       netConfig.memoryType)
 
-    val connectionManager = netConfig.nettyConfig match {
+    val connectionManager = netConfig.partitionRequestConfig match {
       case Some(nettyConfig) => new NettyConnectionManager(nettyConfig)
       case None => new LocalConnectionManager()
     }
@@ -2219,7 +2219,7 @@ object TaskManager {
       None
     } else {
       Some(
-        new NettyConfig(
+        new PartitionRequestNettyConfig(
           taskManagerInetSocketAddress.getAddress(),
           taskManagerInetSocketAddress.getPort(),
           pageSize,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
-import org.apache.flink.runtime.io.network.netty.NettyConfig;
+import org.apache.flink.runtime.io.network.netty.PartitionRequestNettyConfig;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -72,7 +72,7 @@ public class NetworkEnvironmentTest {
 			1024,
 			MemoryType.HEAP,
 			IOManager.IOMode.SYNC,
-			Some.<NettyConfig>empty(),
+			Some.<PartitionRequestNettyConfig>empty(),
 			0,
 			0);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -39,9 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.CancelPartitionRequest;
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.PartitionRequest;
-import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.connect;
-import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.initServerAndClient;
-import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.shutdown;
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.*;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -62,6 +60,8 @@ public class CancelPartitionRequestTest {
 	@Test
 	public void testCancelPartitionRequest() throws Exception {
 
+		final PartitionRequestNettyConfig config = createConfig();
+
 		NettyServerAndClient serverAndClient = null;
 
 		try {
@@ -80,9 +80,9 @@ public class CancelPartitionRequestTest {
 					.thenReturn(view);
 
 			PartitionRequestProtocol protocol = new PartitionRequestProtocol(
-					partitions, mock(TaskEventDispatcher.class), mock(NetworkBufferPool.class));
+				config, partitions, mock(TaskEventDispatcher.class), mock(NetworkBufferPool.class));
 
-			serverAndClient = initServerAndClient(protocol);
+			serverAndClient = initServerAndClient(protocol, config);
 
 			Channel ch = connect(serverAndClient);
 
@@ -106,6 +106,8 @@ public class CancelPartitionRequestTest {
 	@Test
 	public void testDuplicateCancel() throws Exception {
 
+		final PartitionRequestNettyConfig config = createConfig();
+
 		NettyServerAndClient serverAndClient = null;
 
 		try {
@@ -124,9 +126,9 @@ public class CancelPartitionRequestTest {
 					.thenReturn(view);
 
 			PartitionRequestProtocol protocol = new PartitionRequestProtocol(
-					partitions, mock(TaskEventDispatcher.class), mock(NetworkBufferPool.class));
+				config, partitions, mock(TaskEventDispatcher.class), mock(NetworkBufferPool.class));
 
-			serverAndClient = initServerAndClient(protocol);
+			serverAndClient = initServerAndClient(protocol, config);
 
 			Channel ch = connect(serverAndClient);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
@@ -75,7 +75,9 @@ public class ClientTransportErrorHandlingTest {
 	@Test
 	public void testExceptionOnWrite() throws Exception {
 
-		NettyProtocol protocol = new NettyProtocol() {
+		final PartitionRequestNettyConfig config = createConfig();
+
+		NettyProtocol protocol = new SimpleNettyProtocol() {
 			@Override
 			public ChannelHandler[] getServerChannelHandlers() {
 				return new ChannelHandler[0];
@@ -84,6 +86,7 @@ public class ClientTransportErrorHandlingTest {
 			@Override
 			public ChannelHandler[] getClientChannelHandlers() {
 				return new PartitionRequestProtocol(
+						config,
 						mock(ResultPartitionProvider.class),
 						mock(TaskEventDispatcher.class),
 						mock(NetworkBufferPool.class)).getClientChannelHandlers();
@@ -92,7 +95,7 @@ public class ClientTransportErrorHandlingTest {
 
 		// We need a real server and client in this test, because Netty's EmbeddedChannel is
 		// not failing the ChannelPromise of failed writes.
-		NettyServerAndClient serverAndClient = initServerAndClient(protocol, createConfig());
+		NettyServerAndClient serverAndClient = initServerAndClient(protocol, config);
 
 		Channel ch = connect(serverAndClient);
 
@@ -215,7 +218,9 @@ public class ClientTransportErrorHandlingTest {
 	@Test
 	public void testExceptionOnRemoteClose() throws Exception {
 
-		NettyProtocol protocol = new NettyProtocol() {
+		final PartitionRequestNettyConfig config = createConfig();
+
+		NettyProtocol protocol = new SimpleNettyProtocol() {
 			@Override
 			public ChannelHandler[] getServerChannelHandlers() {
 				return new ChannelHandler[] {
@@ -234,13 +239,14 @@ public class ClientTransportErrorHandlingTest {
 			@Override
 			public ChannelHandler[] getClientChannelHandlers() {
 				return new PartitionRequestProtocol(
+						config,
 						mock(ResultPartitionProvider.class),
 						mock(TaskEventDispatcher.class),
 						mock(NetworkBufferPool.class)).getClientChannelHandlers();
 			}
 		};
 
-		NettyServerAndClient serverAndClient = initServerAndClient(protocol, createConfig());
+		NettyServerAndClient serverAndClient = initServerAndClient(protocol, config);
 
 		Channel ch = connect(serverAndClient);
 
@@ -380,8 +386,11 @@ public class ClientTransportErrorHandlingTest {
 	// Helpers
 	// ---------------------------------------------------------------------------------------------
 
-	private EmbeddedChannel createEmbeddedChannel() {
+	private EmbeddedChannel createEmbeddedChannel() throws Exception {
+		final PartitionRequestNettyConfig config = createConfig();
+
 		PartitionRequestProtocol protocol = new PartitionRequestProtocol(
+				config,
 				mock(ResultPartitionProvider.class),
 				mock(TaskEventDispatcher.class),
 				mock(NetworkBufferPool.class));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
@@ -18,12 +18,15 @@
 
 package org.apache.flink.runtime.io.network.netty;
 
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandler;
-import io.netty.handler.codec.string.StringDecoder;
-import io.netty.handler.codec.string.StringEncoder;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.*;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.net.SSLProtocolHandler;
 import org.apache.flink.util.NetUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,36 +38,38 @@ import static org.junit.Assert.assertTrue;
 
 public class NettyClientServerSslTest {
 
+	private static final byte[] TEST_PAYLOAD = "HELLO".getBytes();
+
 	/**
 	 * Verify valid ssl configuration and connection
 	 *
 	 */
 	@Test
 	public void testValidSslConnection() throws Exception {
-		NettyProtocol protocol = new NettyProtocol() {
-			@Override
-			public ChannelHandler[] getServerChannelHandlers() {
-				return new ChannelHandler[0];
-			}
-
-			@Override
-			public ChannelHandler[] getClientChannelHandlers() { return new ChannelHandler[0]; }
-		};
-
-		NettyConfig nettyConfig = new NettyConfig(
+		NettyConfig nettyConfig = new PartitionRequestNettyConfig(
 			InetAddress.getLoopbackAddress(),
 			NetUtils.getAvailablePort(),
 			NettyTestUtil.DEFAULT_SEGMENT_SIZE,
 			1,
 			createSslConfig());
 
+		TestProtocol protocol = createProtocol(nettyConfig);
+
 		NettyTestUtil.NettyServerAndClient serverAndClient = NettyTestUtil.initServerAndClient(protocol, nettyConfig);
 
-		Channel ch = NettyTestUtil.connect(serverAndClient);
+		Promise<ByteBuf> responsePromise = serverAndClient.client().newPromise();
+		Channel ch = NettyTestUtil.connect(serverAndClient, protocol.newClientChannelHandler(responsePromise));
 
-		// should be able to send text data
-		ch.pipeline().addLast(new StringDecoder()).addLast(new StringEncoder());
-		assertTrue(ch.writeAndFlush("test").await().isSuccess());
+		// verify that the SSL handshake was successful
+		assertTrue(SSLProtocolHandler.getSSLHandler(ch).handshakeFuture().sync().isSuccess());
+
+		// verify that data may be sent over the channel
+		ByteBuf expected = ch.alloc().buffer().writeBytes(TEST_PAYLOAD);
+		ReferenceCountUtil.retain(expected);
+		ch.writeAndFlush(expected).sync();
+		expected.resetReaderIndex();
+		ByteBuf actual = responsePromise.sync().getNow();
+		assertTrue(expected.equals(actual));
 
 		NettyTestUtil.shutdown(serverAndClient);
 	}
@@ -75,36 +80,24 @@ public class NettyClientServerSslTest {
 	 */
 	@Test
 	public void testInvalidSslConfiguration() throws Exception {
-		NettyProtocol protocol = new NettyProtocol() {
-			@Override
-			public ChannelHandler[] getServerChannelHandlers() {
-				return new ChannelHandler[0];
-			}
-
-			@Override
-			public ChannelHandler[] getClientChannelHandlers() { return new ChannelHandler[0]; }
-		};
 
 		Configuration config = createSslConfig();
 		// Modify the keystore password to an incorrect one
 		config.setString(ConfigConstants.SECURITY_SSL_KEYSTORE_PASSWORD, "invalidpassword");
 
-		NettyConfig nettyConfig = new NettyConfig(
+		NettyConfig nettyConfig = new PartitionRequestNettyConfig(
 			InetAddress.getLoopbackAddress(),
 			NetUtils.getAvailablePort(),
 			NettyTestUtil.DEFAULT_SEGMENT_SIZE,
 			1,
 			config);
 
-		NettyTestUtil.NettyServerAndClient serverAndClient = null;
 		try {
-			serverAndClient = NettyTestUtil.initServerAndClient(protocol, nettyConfig);
+			new SSLProtocolHandler(nettyConfig, false);
 			Assert.fail("Created server and client from invalid configuration");
 		} catch (Exception e) {
 			// Exception should be thrown as expected
 		}
-
-		NettyTestUtil.shutdown(serverAndClient);
 	}
 
 	/**
@@ -113,35 +106,28 @@ public class NettyClientServerSslTest {
 	 */
 	@Test
 	public void testSslHandshakeError() throws Exception {
-		NettyProtocol protocol = new NettyProtocol() {
-			@Override
-			public ChannelHandler[] getServerChannelHandlers() {
-				return new ChannelHandler[0];
-			}
-
-			@Override
-			public ChannelHandler[] getClientChannelHandlers() { return new ChannelHandler[0]; }
-		};
 
 		Configuration config = createSslConfig();
 
 		// Use a server certificate which is not present in the truststore
 		config.setString(ConfigConstants.SECURITY_SSL_KEYSTORE, "src/test/resources/untrusted.keystore");
 
-		NettyConfig nettyConfig = new NettyConfig(
+		NettyConfig nettyConfig = new PartitionRequestNettyConfig(
 			InetAddress.getLoopbackAddress(),
 			NetUtils.getAvailablePort(),
 			NettyTestUtil.DEFAULT_SEGMENT_SIZE,
 			1,
 			config);
 
+		TestProtocol protocol = createProtocol(nettyConfig);
+
 		NettyTestUtil.NettyServerAndClient serverAndClient = NettyTestUtil.initServerAndClient(protocol, nettyConfig);
+		Promise<ByteBuf> responsePromise = serverAndClient.client().newPromise();
+		Channel ch = NettyTestUtil.connect(serverAndClient, protocol.newClientChannelHandler(responsePromise));
 
-		Channel ch = NettyTestUtil.connect(serverAndClient);
-		ch.pipeline().addLast(new StringDecoder()).addLast(new StringEncoder());
-
-		// Attempting to write data over ssl should fail
-		assertFalse(ch.writeAndFlush("test").await().isSuccess());
+		Future<Channel> handshakeFuture = SSLProtocolHandler.getSSLHandler(ch).handshakeFuture().await();
+		assertFalse(handshakeFuture.isSuccess());
+		assertTrue(handshakeFuture.cause() instanceof javax.net.ssl.SSLHandshakeException);
 
 		NettyTestUtil.shutdown(serverAndClient);
 	}
@@ -156,5 +142,67 @@ public class NettyClientServerSslTest {
 		flinkConfig.setString(ConfigConstants.SECURITY_SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
 		flinkConfig.setString(ConfigConstants.SECURITY_SSL_TRUSTSTORE_PASSWORD, "password");
 		return flinkConfig;
+	}
+
+	private TestProtocol createProtocol(final NettyConfig nettyConfig) throws Exception {
+		return new TestProtocol(nettyConfig);
+	}
+
+	static class TestProtocol implements NettyProtocol {
+		private final NettyConfig nettyConfig;
+		public TestProtocol(NettyConfig nettyConfig) {
+			this.nettyConfig = nettyConfig;
+		}
+
+		@Override
+		public ChannelHandler getServerChannelHandler() {
+			return new ChannelInitializer<SocketChannel>() {
+				@Override
+				public void initChannel(SocketChannel channel) throws Exception {
+					channel.pipeline()
+						.addLast(new SSLProtocolHandler(nettyConfig, false))
+						.addLast(new ServerHandler());
+				}
+			};
+		}
+
+		class ServerHandler extends SimpleChannelInboundHandler<ByteBuf> {
+			@Override
+			protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) throws Exception {
+				// echo the message
+				ReferenceCountUtil.retain(msg);
+				ctx.writeAndFlush(msg).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+			}
+		}
+
+		@Override
+		public ChannelHandler getClientChannelHandler() {
+			return null;
+		}
+
+		public ChannelHandler newClientChannelHandler(final Promise<ByteBuf> promise) {
+			return new ChannelInitializer<SocketChannel>() {
+				@Override
+				public void initChannel(SocketChannel channel) throws Exception {
+					channel.pipeline()
+						.addLast(new SSLProtocolHandler(nettyConfig, true))
+						.addLast(new ClientHandler(promise));
+				}
+			};
+		}
+
+		class ClientHandler extends SimpleChannelInboundHandler<ByteBuf> {
+			private final Promise<ByteBuf> promise;
+			private ClientHandler(Promise<ByteBuf> promise) {
+				this.promise = promise;
+			}
+
+			@Override
+			protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) throws Exception {
+				ReferenceCountUtil.retain(msg);
+				promise.setSuccess(msg);
+				ctx.close();
+			}
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
@@ -49,7 +49,7 @@ public class NettyConnectionManagerTest {
 		// Expected number of arenas and threads
 		int numberOfSlots = 2;
 
-		NettyConfig config = new NettyConfig(
+		PartitionRequestNettyConfig config = new PartitionRequestNettyConfig(
 				InetAddress.getLocalHost(),
 				NetUtils.getAvailablePort(),
 				1024,
@@ -114,11 +114,11 @@ public class NettyConnectionManagerTest {
 
 		// Expected number of threads
 		Configuration flinkConfig = new Configuration();
-		flinkConfig.setInteger(NettyConfig.NUM_ARENAS, numberOfArenas);
-		flinkConfig.setInteger(NettyConfig.NUM_THREADS_CLIENT, 3);
-		flinkConfig.setInteger(NettyConfig.NUM_THREADS_SERVER, 4);
+		flinkConfig.setInteger(PartitionRequestNettyConfig.NUM_ARENAS, numberOfArenas);
+		flinkConfig.setInteger(PartitionRequestNettyConfig.NUM_THREADS_CLIENT, 3);
+		flinkConfig.setInteger(PartitionRequestNettyConfig.NUM_THREADS_SERVER, 4);
 
-		NettyConfig config = new NettyConfig(
+		PartitionRequestNettyConfig config = new PartitionRequestNettyConfig(
 				InetAddress.getLocalHost(),
 				NetUtils.getAvailablePort(),
 				1024,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyServerLowAndHighWatermarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyServerLowAndHighWatermarkTest.java
@@ -55,7 +55,7 @@ public class NettyServerLowAndHighWatermarkTest {
 	@Test
 	public void testLowAndHighWatermarks() throws Throwable {
 		final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
-		final NettyProtocol protocol = new NettyProtocol() {
+		final NettyProtocol protocol = new SimpleNettyProtocol() {
 			@Override
 			public ChannelHandler[] getServerChannelHandlers() {
 				// The channel handler implements the test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.netty;
 
 import io.netty.channel.Channel;
 
+import io.netty.channel.ChannelHandler;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.NetUtils;
 
@@ -90,11 +91,19 @@ public class NettyTestUtil {
 		return connect(serverAndClient.client(), serverAndClient.server());
 	}
 
+	static Channel connect(NettyServerAndClient serverAndClient, ChannelHandler handler) throws Exception {
+		return connect(serverAndClient.client(), serverAndClient.server(), handler);
+	}
+
 	static Channel connect(NettyClient client, NettyServer server) throws Exception {
+		return connect(client, server, null);
+	}
+
+	static Channel connect(NettyClient client, NettyServer server, ChannelHandler handler) throws Exception {
 		final NettyConfig config = server.getConfig();
 
 		return client
-				.connect(new InetSocketAddress(config.getServerAddress(), config.getServerPort()))
+				.connect(new InetSocketAddress(config.getServerAddress(), config.getServerPort()), handler)
 				.sync()
 				.channel();
 	}
@@ -119,26 +128,26 @@ public class NettyTestUtil {
 	}
 
 	// ---------------------------------------------------------------------------------------------
-	// NettyConfig
+	// PartitionRequestNettyConfig
 	// ---------------------------------------------------------------------------------------------
 
-	static NettyConfig createConfig() throws Exception {
+	static PartitionRequestNettyConfig createConfig() throws Exception {
 		return createConfig(DEFAULT_SEGMENT_SIZE, new Configuration());
 	}
 
-	static NettyConfig createConfig(int segmentSize) throws Exception {
+	static PartitionRequestNettyConfig createConfig(int segmentSize) throws Exception {
 		return createConfig(segmentSize, new Configuration());
 	}
 
-	static NettyConfig createConfig(Configuration config) throws Exception {
+	static PartitionRequestNettyConfig createConfig(Configuration config) throws Exception {
 		return createConfig(DEFAULT_SEGMENT_SIZE, config);
 	}
 
-	static NettyConfig createConfig(int segmentSize, Configuration config) throws Exception {
+	static PartitionRequestNettyConfig createConfig(int segmentSize, Configuration config) throws Exception {
 		checkArgument(segmentSize > 0);
 		checkNotNull(config);
 
-		return new NettyConfig(
+		return new PartitionRequestNettyConfig(
 				InetAddress.getLocalHost(),
 				NetUtils.getAvailablePort(),
 				segmentSize,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
@@ -55,7 +55,7 @@ public class PartitionRequestClientFactoryTest {
 		final CountDownLatch syncOnConnect = new CountDownLatch(1);
 
 		final Tuple2<NettyServer, NettyClient> netty = createNettyServerAndClient(
-				new NettyProtocol() {
+				new SimpleNettyProtocol() {
 					@Override
 					public ChannelHandler[] getServerChannelHandlers() {
 						return new ChannelHandler[0];
@@ -158,7 +158,7 @@ public class PartitionRequestClientFactoryTest {
 	// ------------------------------------------------------------------------
 
 	private static Tuple2<NettyServer, NettyClient> createNettyServerAndClient(NettyProtocol protocol) throws IOException {
-		final NettyConfig config = new NettyConfig(InetAddress.getLocalHost(), SERVER_PORT, 32 * 1024, 1, new Configuration());
+		final NettyConfig config = new PartitionRequestNettyConfig(InetAddress.getLocalHost(), SERVER_PORT, 32 * 1024, 1, new Configuration());
 
 		final NettyServer server = new NettyServer(config);
 		final NettyClient client = new NettyClient(config);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ServerTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ServerTransportErrorHandlingTest.java
@@ -66,10 +66,13 @@ public class ServerTransportErrorHandlingTest {
 				.createSubpartitionView(any(ResultPartitionID.class), anyInt(), any(BufferProvider.class)))
 				.thenReturn(new InfiniteSubpartitionView(outboundBuffers, sync));
 
-		NettyProtocol protocol = new NettyProtocol() {
+		final PartitionRequestNettyConfig config = createConfig();
+
+		NettyProtocol protocol = new SimpleNettyProtocol() {
 			@Override
 			public ChannelHandler[] getServerChannelHandlers() {
 				return new PartitionRequestProtocol(
+						config,
 						partitionManager,
 						mock(TaskEventDispatcher.class),
 						mock(NetworkBufferPool.class)).getServerChannelHandlers();
@@ -95,7 +98,7 @@ public class ServerTransportErrorHandlingTest {
 		NettyServerAndClient serverAndClient = null;
 
 		try {
-			serverAndClient = initServerAndClient(protocol, createConfig());
+			serverAndClient = initServerAndClient(protocol, config);
 
 			Channel ch = connect(serverAndClient);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/BaseRestRequestHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/BaseRestRequestHandlerTest.java
@@ -129,4 +129,11 @@ public class BaseRestRequestHandlerTest {
 		assertFalse(promise.tryFailure(new RuntimeException("expected")));
 		assertEquals(0, channel.outboundMessages().size());
 	}
+
+	@Test
+	public void testBlockQuote() {
+		assertEquals("> \n", BaseRestRequestHandler.blockquote(""));
+		assertEquals("> A\n", BaseRestRequestHandler.blockquote("A"));
+		assertEquals("> A\n> B\n> C\n", BaseRestRequestHandler.blockquote("A\nB\nC\n"));
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/BaseRestRequestHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/BaseRestRequestHandlerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import com.google.common.net.MediaType;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Tests the {@link BaseRestRequestHandler}.
+ */
+public class BaseRestRequestHandlerTest {
+
+	private static final int TIMEOUT = 1;
+
+	class TestHandler extends BaseRestRequestHandler<TestUtils.TestEntity,TestUtils.TestEntity> {
+		private Promise<RestResponse<TestUtils.TestEntity>> promise;
+		public TestHandler() {
+			super(TestUtils.TestEntity.class, TIMEOUT, TimeUnit.SECONDS);
+		}
+		public void setPromise(Promise<RestResponse<TestUtils.TestEntity>> promise) {
+			this.promise = promise;
+		}
+		@Override
+		protected Future<RestResponse<TestUtils.TestEntity>> handleRequest(
+			ChannelHandlerContext ctx, RestRequest<TestUtils.TestEntity> request) {
+			return promise;
+		}
+	}
+
+	@Test
+	public void testHandle() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(new TestHandler());
+		Promise<RestResponse<TestUtils.TestEntity>> promise = channel.eventLoop().newPromise();
+		channel.pipeline().get(TestHandler.class).setPromise(promise);
+
+		DefaultRestRequest request = new DefaultRestRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+		request.headers().add(HttpHeaders.Names.ACCEPT, MediaType.JSON_UTF_8.toString());
+		channel.writeInbound(request);
+		promise.setSuccess(new DefaultRestResponse<TestUtils.TestEntity>(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, null));
+
+		RestResponse response = (RestResponse) channel.outboundMessages().remove();
+		assertEquals(HttpResponseStatus.OK, response.getStatus());
+
+		// verify that the scheduled timeout has no unpleasant effect
+		Thread.sleep(TimeUnit.SECONDS.toMillis(TIMEOUT + 1));
+		channel.runScheduledPendingTasks();
+		assertEquals(0, channel.outboundMessages().size());
+	}
+
+	@Test
+	public void testHandleNotAcceptable() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(new TestHandler());
+
+		DefaultRestRequest request = new DefaultRestRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+		channel.writeInbound(request);
+
+		RestResponse response1 = (RestResponse) channel.outboundMessages().remove();
+		assertEquals(HttpResponseStatus.NOT_ACCEPTABLE, response1.getStatus());
+
+		request.headers().set(HttpHeaders.Names.ACCEPT, MediaType.XML_UTF_8.toString());
+		channel.writeInbound(request);
+
+		RestResponse response2 = (RestResponse) channel.outboundMessages().remove();
+		assertEquals(HttpResponseStatus.NOT_ACCEPTABLE, response2.getStatus());
+	}
+
+	@Test
+	public void testHandleException() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(new TestHandler());
+		Promise<RestResponse<TestUtils.TestEntity>> promise = channel.eventLoop().newPromise();
+		channel.pipeline().get(TestHandler.class).setPromise(promise);
+
+		DefaultRestRequest request = new DefaultRestRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+		request.headers().add(HttpHeaders.Names.ACCEPT, MediaType.JSON_UTF_8.toString());
+		channel.writeInbound(request);
+		promise.setFailure(new RuntimeException("expected"));
+
+		RestResponse response = (RestResponse) channel.outboundMessages().remove();
+		assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, response.getStatus());
+	}
+
+	@Test
+	public void testTimeout() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(new TestHandler());
+		Promise<RestResponse<TestUtils.TestEntity>> promise = channel.eventLoop().newPromise();
+		channel.pipeline().get(TestHandler.class).setPromise(promise);
+
+		DefaultRestRequest request = new DefaultRestRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+		request.headers().add(HttpHeaders.Names.ACCEPT, MediaType.JSON_UTF_8.toString());
+		channel.writeInbound(request);
+
+		// exercise the response timeout
+		Thread.sleep(TimeUnit.SECONDS.toMillis(TIMEOUT + 1));
+		channel.runScheduledPendingTasks();
+
+		RestResponse response = (RestResponse) channel.outboundMessages().remove();
+		assertEquals(HttpResponseStatus.SERVICE_UNAVAILABLE, response.getStatus());
+
+		// verify that a late completion of the response promise has no pleasant effect
+		assertFalse(promise.tryFailure(new RuntimeException("expected")));
+		assertEquals(0, channel.outboundMessages().size());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/RestClientProtocolHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/RestClientProtocolHandlerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import com.google.common.base.Charsets;
+import com.google.common.net.MediaType;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.*;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests the {@link RestClientProtocolHandler}.
+ */
+public class RestClientProtocolHandlerTest {
+
+	@Test
+	public void testHandlerAdded() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new RestClientProtocolHandler<>(TestUtils.mapper, TestUtils.TestEntity.class));
+		assertNotNull(channel.pipeline().get(RestClientProtocolHandler.RestDecoder.class));
+		assertNotNull(channel.pipeline().get(RestClientProtocolHandler.RestEncoder.class));
+		assertTrue(channel.isActive());
+	}
+
+	// encoder ---------------------------------------------------
+
+	@Test
+	public void testEncodeRestRequestContentSerialization() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new RestClientProtocolHandler<>(TestUtils.mapper, TestUtils.TestEntity.class));
+
+		TestUtils.TestEntity expectedContent = new TestUtils.TestEntity(1);
+		DefaultRestRequest<TestUtils.TestEntity> request = new DefaultRestRequest<>(
+			HttpVersion.HTTP_1_1, HttpMethod.GET, "/", expectedContent);
+		channel.writeOutbound(request);
+
+		FullHttpRequest encoded = (FullHttpRequest) channel.outboundMessages().remove();
+		assertEquals(encoded.content().readableBytes(), Integer.parseInt(encoded.headers().get(HttpHeaders.Names.CONTENT_LENGTH)));
+		assertEquals(MediaType.JSON_UTF_8, MediaType.parse(encoded.headers().get(HttpHeaders.Names.CONTENT_TYPE)));
+		assertEquals(expectedContent, TestUtils.deserialize(encoded.content(), Charsets.UTF_8, TestUtils.TestEntity.class));
+	}
+
+	// decoder ---------------------------------------------------
+
+	@Test
+	public void testDecodeRestResponseContentDeserialization() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new RestClientProtocolHandler<>(TestUtils.mapper, TestUtils.TestEntity.class));
+
+		TestUtils.TestEntity expectedContent = new TestUtils.TestEntity(1);
+		DefaultFullHttpResponse response = new DefaultFullHttpResponse(
+			HttpVersion.HTTP_1_1, HttpResponseStatus.OK, TestUtils.serialize(expectedContent, Charsets.UTF_8));
+		response.headers().add(HttpHeaders.Names.CONTENT_TYPE, MediaType.JSON_UTF_8.toString());
+		channel.writeInbound(response);
+
+		RestResponse<TestUtils.TestEntity> decoded =
+			(RestResponse<TestUtils.TestEntity>) channel.inboundMessages().remove();
+		assertEquals(expectedContent, decoded.content());
+	}
+
+	@Test
+	public void testDecodeRestResponseErrorDeserialization() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new RestClientProtocolHandler<>(TestUtils.mapper, TestUtils.TestEntity.class));
+
+		RestError expectedError = new RestError(1, "error");
+		DefaultFullHttpResponse response = new DefaultFullHttpResponse(
+			HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR,
+			TestUtils.serialize(expectedError, Charsets.UTF_8));
+		response.headers().add(HttpHeaders.Names.CONTENT_TYPE, MediaType.JSON_UTF_8.toString());
+		channel.writeInbound(response);
+
+		RestResponse<TestUtils.TestEntity> decoded =
+			(RestResponse<TestUtils.TestEntity>) channel.inboundMessages().remove();
+		assertNull(decoded.content());
+		assertEquals(expectedError, decoded.error());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/RestServerProtocolHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/RestServerProtocolHandlerTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import com.google.common.base.Charsets;
+import com.google.common.net.MediaType;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderException;
+import io.netty.handler.codec.EncoderException;
+import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.router.Handler;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests the RestServerProtocolHandler.
+ */
+public class RestServerProtocolHandlerTest {
+
+	@Test
+	public void testHandlerAdded() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new RestServerProtocolHandler<>(TestUtils.mapper, TestUtils.TestEntity.class));
+		assertNotNull(channel.pipeline().get(RestServerProtocolHandler.RestDecoder.class));
+		assertNotNull(channel.pipeline().get(RestServerProtocolHandler.RestEncoder.class));
+		assertTrue(channel.isActive());
+	}
+
+	// decoder ---------------------------------------------------
+
+	@Test
+	public void testDecodeRestRequestHeaderPassthru() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new Handler(TestUtils.router),
+			new RestServerProtocolHandler<>(TestUtils.mapper, TestUtils.TestEntity.class));
+
+		DefaultFullHttpRequest request = new DefaultFullHttpRequest(
+			HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+		request.headers().add(HttpHeaders.Names.CACHE_CONTROL, "private");
+		channel.writeInbound(request);
+
+		RestRequest decoded = (RestRequest) channel.inboundMessages().remove();
+		assertEquals(0, request.refCnt());
+		assertEquals(request.getMethod(), decoded.getMethod());
+		assertEquals(request.getUri(), decoded.getUri());
+		assertEquals("private", decoded.headers().get(HttpHeaders.Names.CACHE_CONTROL));
+	}
+
+	@Test
+	public void testDecodeRestRequestContentDeserialization() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new Handler(TestUtils.router),
+			new RestServerProtocolHandler<>(TestUtils.mapper, TestUtils.TestEntity.class));
+
+		TestUtils.TestEntity expectedContent = new TestUtils.TestEntity(1);
+		DefaultFullHttpRequest request = new DefaultFullHttpRequest(
+			HttpVersion.HTTP_1_1, HttpMethod.GET, "/", TestUtils.serialize(expectedContent, Charsets.UTF_8));
+		request.headers().add(HttpHeaders.Names.CONTENT_TYPE, MediaType.JSON_UTF_8.toString());
+		channel.writeInbound(request);
+
+		RestRequest decoded = (RestRequest) channel.inboundMessages().remove();
+		assertEquals(0, request.refCnt());
+		assertEquals(expectedContent, decoded.content());
+	}
+
+	@Test(expected = DecoderException.class)
+	public void testDecodeRestRequestInvalidContent() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new Handler(TestUtils.router),
+			new RestServerProtocolHandler<>(TestUtils.mapper, TestUtils.UnreadableTestEntity.class));
+
+		TestUtils.TestEntity badEntity = new TestUtils.TestEntity(1);
+		DefaultFullHttpRequest request = new DefaultFullHttpRequest(
+			HttpVersion.HTTP_1_1, HttpMethod.GET, "/", TestUtils.serialize(badEntity, Charsets.UTF_8));
+		request.headers().add(HttpHeaders.Names.CONTENT_TYPE, MediaType.JSON_UTF_8.toString());
+		channel.writeInbound(request);
+		channel.checkException();
+	}
+
+	// encoder ---------------------------------------------------
+
+	@Test
+	public void testEncodeRestResponseHeaderPassthru() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new RestServerProtocolHandler<>(TestUtils.mapper, TestUtils.TestEntity.class));
+
+		DefaultRestResponse<Void> response = new DefaultRestResponse<>(
+			HttpVersion.HTTP_1_1, HttpResponseStatus.OK, null);
+		response.headers().add(HttpHeaders.Names.CACHE_CONTROL, "private");
+		channel.writeOutbound(response);
+
+		DefaultFullHttpResponse encoded = (DefaultFullHttpResponse) channel.outboundMessages().remove();
+		assertEquals(1, encoded.refCnt());
+		assertEquals(response.getStatus(), encoded.getStatus());
+		assertEquals("private", encoded.headers().get(HttpHeaders.Names.CACHE_CONTROL));
+		assertEquals(0, Integer.parseInt(encoded.headers().get(HttpHeaders.Names.CONTENT_LENGTH)));
+		assertEquals(0, encoded.content().readableBytes());
+	}
+
+	@Test
+	public void testEncodeRestResponseContentSerialization() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new RestServerProtocolHandler<>(TestUtils.mapper, TestUtils.TestEntity.class));
+
+		TestUtils.TestEntity expectedContent = new TestUtils.TestEntity(1);
+		DefaultRestResponse<TestUtils.TestEntity> response = new DefaultRestResponse<>(
+			HttpVersion.HTTP_1_1, HttpResponseStatus.OK, expectedContent);
+		channel.writeOutbound(response);
+
+		DefaultFullHttpResponse encoded = (DefaultFullHttpResponse) channel.outboundMessages().remove();
+		assertEquals(1, encoded.refCnt());
+		assertEquals(encoded.content().readableBytes(), Integer.parseInt(encoded.headers().get(HttpHeaders.Names.CONTENT_LENGTH)));
+		assertEquals(MediaType.JSON_UTF_8, MediaType.parse(encoded.headers().get(HttpHeaders.Names.CONTENT_TYPE)));
+		assertEquals(expectedContent, TestUtils.deserialize(encoded.content(), Charsets.UTF_8, TestUtils.TestEntity.class));
+	}
+
+	@Test(expected = EncoderException.class)
+	public void testEncodeRestResponseInvalidContent() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new RestServerProtocolHandler<>(TestUtils.mapper, TestUtils.TestEntity.class));
+
+		DefaultRestResponse<TestUtils.UnwritableTestEntity> response = new DefaultRestResponse<>(
+			HttpVersion.HTTP_1_1, HttpResponseStatus.OK, new TestUtils.UnwritableTestEntity());
+		channel.writeOutbound(response);
+		channel.checkException();
+	}
+
+	@Test
+	public void testEncodeRestResponseErrorSerialization() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new RestServerProtocolHandler<>(TestUtils.mapper, TestUtils.TestEntity.class));
+
+		RestError expectedError = new RestError(1, "error");
+		DefaultRestResponse<TestUtils.TestEntity> response = new DefaultRestResponse<>(
+			HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR, null, true, expectedError);
+		channel.writeOutbound(response);
+
+		DefaultFullHttpResponse actual = (DefaultFullHttpResponse) channel.outboundMessages().remove();
+		assertEquals(1, actual.refCnt());
+		assertEquals(actual.content().readableBytes(), Integer.parseInt(actual.headers().get(HttpHeaders.Names.CONTENT_LENGTH)));
+		assertEquals(MediaType.JSON_UTF_8, MediaType.parse(actual.headers().get(HttpHeaders.Names.CONTENT_TYPE)));
+		assertEquals(expectedError, TestUtils.deserialize(actual.content(), Charsets.UTF_8, RestError.class));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/RoutedWebSocketHandshakeHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/RoutedWebSocketHandshakeHandlerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.router.Handler;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests the RoutedWebSocketHandshakeHandler.
+ */
+public class RoutedWebSocketHandshakeHandlerTest {
+
+	class TestClientHandler extends BaseWebSocketClientChannelInitializer {
+		public TestClientHandler(URI uri) {
+			super(uri, Short.MAX_VALUE);
+		}
+	}
+
+	class TestServerHandler extends ChannelHandlerAdapter {
+	}
+
+	@Test()
+	public void testHandshake() throws Exception {
+
+		ChannelGroup testGroup = new DefaultChannelGroup(ImmediateEventExecutor.INSTANCE);
+
+		TestServerHandler handler = new TestServerHandler();
+		EmbeddedChannel serverChannel = new EmbeddedChannel(
+			new HttpServerCodec(),
+			new HttpObjectAggregator(Short.MAX_VALUE),
+			new Handler(TestUtils.router),
+			new RoutedWebSocketHandshakeHandler(new TestServerHandler(), testGroup));
+
+		EmbeddedChannel clientChannel = new EmbeddedChannel(new TestClientHandler(new URI("/")));
+
+		assertNull(serverChannel.pipeline().get(TestServerHandler.class));
+
+		// pump the handshake messages to complete the connection
+		serverChannel.writeInbound(clientChannel.outboundMessages().remove());
+		clientChannel.writeInbound(serverChannel.outboundMessages().remove());
+
+		// verify
+		assertTrue(serverChannel.isActive());
+		assertTrue(testGroup.contains(serverChannel));
+		assertNotNull(serverChannel.pipeline().get(TestServerHandler.class));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/TestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/TestUtils.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.netty.buffer.*;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.handler.codec.http.router.Router;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.Objects;
+
+/**
+ */
+class TestUtils {
+	public static final ObjectMapper mapper = new ObjectMapper();
+
+	public static final ByteBufAllocator allocator = UnpooledByteBufAllocator.DEFAULT;
+
+	public static final Router router = new Router().ANY("/", (ChannelInboundHandler) null);
+
+	public static <T> T deserialize(ByteBuf byteBuf, Charset charset, Class<T> clazz) throws IOException {
+		try (Reader reader = new InputStreamReader(new ByteBufInputStream(byteBuf), charset)) {
+			return mapper.readValue(reader, clazz);
+		}
+	}
+
+	public static ByteBuf serialize(Object value, Charset charset) throws IOException {
+		ByteBuf byteBuf = allocator.buffer();
+		try (Writer stream = new OutputStreamWriter(new ByteBufOutputStream(byteBuf))) {
+			mapper.writeValue(stream, value);
+		}
+		return byteBuf;
+	}
+
+	public static class TestEntity {
+		private int x;
+		@JsonCreator
+		public TestEntity(@JsonProperty("x") int x) {
+			this.x = x;
+		}
+		@JsonProperty("x")
+		public int getX() { return x; }
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			TestEntity that = (TestEntity) o;
+			return x == that.x;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(x);
+		}
+	}
+
+	public static class UnreadableTestEntity extends TestEntity {
+		public UnreadableTestEntity(@JsonProperty("x") int x) {
+			super(x);
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	public static class UnwritableTestEntity extends TestEntity {
+		public UnwritableTestEntity() {
+			super(0);
+		}
+
+		@Override
+		public int getX() {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/WebSocketJsonMessageDecoderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/WebSocketJsonMessageDecoderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import com.google.common.base.Charsets;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderException;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the {@link WebSocketJsonMessageDecoder}.
+ */
+public class WebSocketJsonMessageDecoderTest {
+
+	@Test
+	public void testDecodeSuccess() throws Exception {
+
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new WebSocketJsonMessageDecoder<>(TestUtils.mapper, TestUtils.TestEntity.class));
+
+		TestUtils.TestEntity expected = new TestUtils.TestEntity(1);
+		TextWebSocketFrame msg = new TextWebSocketFrame(TestUtils.serialize(expected, Charsets.UTF_8));
+		channel.writeInbound(msg);
+
+		TestUtils.TestEntity actual = (TestUtils.TestEntity) channel.inboundMessages().remove();
+		assertEquals(0, msg.refCnt());
+		assertEquals(expected, actual);
+	}
+
+	@Test(expected = DecoderException.class)
+	public void testDecodeFailure() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new WebSocketJsonMessageDecoder<>(TestUtils.mapper, TestUtils.UnreadableTestEntity.class));
+
+		TestUtils.TestEntity expected = new TestUtils.TestEntity(1);
+		TextWebSocketFrame msg = new TextWebSocketFrame(TestUtils.serialize(expected, Charsets.UTF_8));
+		channel.writeInbound(msg);
+		channel.checkException();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/WebSocketJsonMessageEncoderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/http/WebSocketJsonMessageEncoderTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net.http;
+
+import com.google.common.base.Charsets;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.EncoderException;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the {@link WebSocketJsonMessageEncoder}.
+ */
+public class WebSocketJsonMessageEncoderTest {
+
+	@Test
+	public void testEncodeSuccess() throws Exception {
+
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new WebSocketJsonMessageEncoder<>(TestUtils.mapper, TestUtils.TestEntity.class));
+
+		TestUtils.TestEntity expected = new TestUtils.TestEntity(1);
+		channel.writeOutbound(expected);
+
+		TextWebSocketFrame encoded = (TextWebSocketFrame) channel.outboundMessages().remove();
+		TestUtils.TestEntity actual = TestUtils.deserialize(encoded.content(), Charsets.UTF_8, TestUtils.TestEntity.class);
+		assertEquals(expected, actual);
+	}
+
+	@Test(expected = EncoderException.class)
+	public void testEncodeFailure() throws Exception {
+		EmbeddedChannel channel = new EmbeddedChannel(
+			new WebSocketJsonMessageEncoder<>(TestUtils.mapper, TestUtils.TestEntity.class));
+
+		TestUtils.TestEntity expected = new TestUtils.UnwritableTestEntity();
+		channel.writeOutbound(expected);
+		channel.checkException();
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
@@ -39,7 +39,7 @@ import org.apache.flink.runtime.io.network.LocalConnectionManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
-import org.apache.flink.runtime.io.network.netty.NettyConfig;
+import org.apache.flink.runtime.io.network.netty.PartitionRequestNettyConfig;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.jobmanager.JobManager;
 import org.apache.flink.runtime.jobmanager.MemoryArchivist;
@@ -104,7 +104,7 @@ public class TaskManagerComponentsStartupShutdownTest {
 					config);
 
 			final NetworkEnvironmentConfiguration netConf = new NetworkEnvironmentConfiguration(
-					32, BUFFER_SIZE, MemoryType.HEAP, IOManager.IOMode.SYNC, Option.<NettyConfig>empty(), 0, 0);
+					32, BUFFER_SIZE, MemoryType.HEAP, IOManager.IOMode.SYNC, Option.<PartitionRequestNettyConfig>empty(), 0, 0);
 
 			ResourceID taskManagerId = ResourceID.generate();
 			


### PR DESCRIPTION
**Motivation:**
- Newer endpoints added to Flink (e.g. KvState, REST APIs, etc) should benefit from a common base of Netty client/server code.  The current code is specialized for the 'PartitionRequest' endpoint that shuffles data between taskmanagers, and this has led to some duplication.   This PR generalizes the Netty code but doesn't address any duplication.

- Given ongoing work on the dispatcher component (which uses REST) (FLINK-4897), some support classes are needed.

**Details:**
- added support classes for REST and WebSocket-based protocols

- generalized NettyClient/NettyServer: makes no assumptions about the
channel pipeline, facilitates providing the initializer at connection
time (to convey request-specific context such as a completion promise).

- moved SSL handling to a standalone handler for composability

- moved configuration constants related to the “partition request”
protocol from NettyConfig to PartitionRequestNettyConfig