### PR TITLE
[FLINK-5023][FLINK-5024] Add SimpleStateDescriptor to clarify the concepts

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -40,6 +40,7 @@ import org.mockito.Matchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -396,7 +397,7 @@ public class FlinkKafkaConsumerBaseTest {
 		}
 
 		@Override
-		public Iterable<T> get() throws Exception {
+		public Iterable<T> get() throws IOException {
 			return list;
 		}
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -72,11 +72,10 @@ public abstract class AbstractRocksDBState<K, N> implements KvState<N> {
 	 * Creates a new RocksDB backed state.
 	 *  @param namespaceSerializer The serializer for the namespace.
 	 */
-	protected AbstractRocksDBState(
-			ColumnFamilyHandle columnFamily,
+	protected AbstractRocksDBState(ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,
-			RocksDBKeyedStateBackend<K> backend
-	) {
+			RocksDBKeyedStateBackend<K> backend) {
+
 		this.namespaceSerializer = namespaceSerializer;
 		this.backend = backend;
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -17,8 +17,6 @@
 
 package org.apache.flink.contrib.streaming.state;
 
-import org.apache.flink.api.common.state.State;
-import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
@@ -29,7 +27,6 @@ import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.KvState;
 import org.apache.flink.util.Preconditions;
 import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.RocksDBException;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,18 +34,15 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 /**
- * Base class for {@link State} implementations that store state in a RocksDB database.
+ * Base class for {@link KvState} implementations that store state in a RocksDB database.
  *
  * <p>State is not stored in this class but in the {@link org.rocksdb.RocksDB} instance that
  * the {@link RocksDBStateBackend} manages and checkpoints.
  *
  * @param <K> The type of the key.
  * @param <N> The type of the namespace.
- * @param <S> The type of {@link State}.
- * @param <SD> The type of {@link StateDescriptor}.
  */
-public abstract class AbstractRocksDBState<K, N, S extends State, SD extends StateDescriptor<S, V>, V>
-		implements KvState<N>, State {
+public abstract class AbstractRocksDBState<K, N> implements KvState<N> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(AbstractRocksDBState.class);
 
@@ -63,9 +57,6 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 
 	/** The column family of this particular instance of state */
 	protected ColumnFamilyHandle columnFamily;
-
-	/** State descriptor from which to create this state instance */
-	protected final SD stateDesc;
 
 	/**
 	 * We disable writes to the write-ahead-log here.
@@ -84,9 +75,8 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 	protected AbstractRocksDBState(
 			ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,
-			SD stateDesc,
-			RocksDBKeyedStateBackend<K> backend) {
-
+			RocksDBKeyedStateBackend<K> backend
+	) {
 		this.namespaceSerializer = namespaceSerializer;
 		this.backend = backend;
 
@@ -94,7 +84,6 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 
 		writeOptions = new WriteOptions();
 		writeOptions.setDisableWAL(true);
-		this.stateDesc = Preconditions.checkNotNull(stateDesc, "State Descriptor");
 
 		this.keySerializationStream = new ByteArrayOutputStreamWithPos(128);
 		this.keySerializationDateDataOutputView = new DataOutputViewStreamWrapper(keySerializationStream);
@@ -103,18 +92,6 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 	}
 
 	// ------------------------------------------------------------------------
-
-	@Override
-	public void clear() {
-		try {
-			writeCurrentKeyWithGroupAndNamespace();
-			byte[] key = keySerializationStream.toByteArray();
-			backend.db.remove(columnFamily, writeOptions, key);
-		} catch (IOException|RocksDBException e) {
-			throw new RuntimeException("Error while removing entry from RocksDB", e);
-		}
-	}
-
 	@Override
 	public void setCurrentNamespace(N namespace) {
 		this.currentNamespace = Preconditions.checkNotNull(namespace, "Namespace");

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
@@ -32,12 +32,12 @@ import java.io.IOException;
 /**
  * {@link FoldingState} implementation that stores state in RocksDB.
  *
- * @param <K> The type of the key.
- * @param <N> The type of the namespace.
- * @param <T> The type of the values that can be folded into the state.
+ * @param <K>   The type of the key.
+ * @param <N>   The type of the namespace.
+ * @param <T>   The type of the values that can be folded into the state.
  * @param <ACC> The type of the value in the folding state.
  */
-public class RocksDBFoldingState<K, N, T, ACC> extends RocksDBSimpleState<K, N, ACC> implements FoldingState<T, ACC> {
+public class RocksDBFoldingState<K, N, T, ACC> extends RocksDBSimpleState<K, N, ACC, FoldingStateDescriptor<T, ACC>> implements FoldingState<T, ACC> {
 	/** User-specified initial value for folding */
 	private final ACC initialValue;
 
@@ -48,13 +48,14 @@ public class RocksDBFoldingState<K, N, T, ACC> extends RocksDBSimpleState<K, N, 
 	 * Creates a new {@code RocksDBFoldingState}.
 	 *
 	 * @param namespaceSerializer The serializer for the namespace.
-	 * @param stateDesc The state identifier for the state. This contains name
-	 *                     and can create a default state value.
+	 * @param stateDesc           The state identifier for the state. This contains name
+	 *                            and can create a default state value.
 	 */
 	public RocksDBFoldingState(ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,
 			FoldingStateDescriptor<T, ACC> stateDesc,
-			RocksDBKeyedStateBackend<K> backend) {
+			RocksDBKeyedStateBackend<K> backend)
+	{
 		super(columnFamily, namespaceSerializer, stateDesc, backend);
 
 		this.initialValue = stateDesc.getInitialValue();

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
@@ -52,9 +52,7 @@ public class RocksDBFoldingState<K, N, T, ACC> extends RocksDBSimpleState<K, N, 
 			TypeSerializer<N> namespaceSerializer,
 			FoldingStateDescriptor<T, ACC> stateDesc,
 			RocksDBKeyedStateBackend<K> backend) {
-
 		super(columnFamily, namespaceSerializer, stateDesc, backend);
-
 		this.foldFunction = stateDesc.getFoldFunction();
 	}
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -40,6 +40,7 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.migration.MigrationUtil;
 import org.apache.flink.migration.contrib.streaming.state.RocksDBStateBackend;
+import org.apache.flink.migration.util.MigrationInstantiationUtil;
 import org.apache.flink.runtime.io.async.AbstractAsyncIOCallable;
 import org.apache.flink.runtime.io.async.AsyncStoppableTaskWithCallback;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
@@ -141,7 +142,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			TypeSerializer<K> keySerializer,
 			int numberOfKeyGroups,
 			KeyGroupRange keyGroupRange
-	) throws Exception {
+	) throws Exception
+	{
 
 		super(kvStateRegistry, keySerializer, userCodeClassLoader, numberOfKeyGroups, keyGroupRange);
 		this.operatorIdentifier = operatorIdentifier;
@@ -233,7 +235,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	public RunnableFuture<KeyGroupsStateHandle> snapshot(
 			final long checkpointId,
 			final long timestamp,
-			final CheckpointStreamFactory streamFactory) throws Exception {
+			final CheckpointStreamFactory streamFactory) throws Exception
+	{
 
 		long startTime = System.currentTimeMillis();
 
@@ -331,7 +334,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		RocksDBSnapshotOperation(
 				RocksDBKeyedStateBackend<?> stateBackend,
-				CheckpointStreamFactory checkpointStreamFactory) {
+				CheckpointStreamFactory checkpointStreamFactory)
+		{
 
 			this.stateBackend = stateBackend;
 			this.checkpointStreamFactory = checkpointStreamFactory;
@@ -341,7 +345,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		/**
 		 * 1) Create a snapshot object from RocksDB.
 		 *
-		 * @param checkpointId id of the checkpoint for which we take the snapshot
+		 * @param checkpointId        id of the checkpoint for which we take the snapshot
 		 * @param checkpointTimeStamp timestamp of the checkpoint for which we take the snapshot
 		 */
 		public void takeDBSnapShot(long checkpointId, long checkpointTimeStamp) throws IOException {
@@ -397,7 +401,6 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		/**
 		 * 5) Release the snapshot object for RocksDB and clean up.
-		 *
 		 */
 		public void releaseSnapshotResources(boolean canceled) {
 			if (null != kvStateIterators) {
@@ -408,7 +411,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			}
 
 			if (null != snapshot) {
-				if(null != stateBackend.db) {
+				if (null != stateBackend.db) {
 					stateBackend.db.releaseSnapshot(snapshot);
 				}
 				snapshot.close();
@@ -580,7 +583,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		}
 
 		private static void checkInterrupted() throws InterruptedException {
-			if(Thread.currentThread().isInterrupted()) {
+			if (Thread.currentThread().isInterrupted()) {
 				throw new InterruptedException("RocksDB snapshot interrupted.");
 			}
 		}
@@ -642,7 +645,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		 * @throws RocksDBException
 		 */
 		public void doRestore(Collection<KeyGroupsStateHandle> keyGroupsStateHandles)
-				throws IOException, ClassNotFoundException, RocksDBException {
+				throws IOException, ClassNotFoundException, RocksDBException
+		{
 
 			for (KeyGroupsStateHandle keyGroupsStateHandle : keyGroupsStateHandles) {
 				if (keyGroupsStateHandle != null) {
@@ -660,7 +664,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		 * @throws ClassNotFoundException
 		 */
 		private void restoreKeyGroupsInStateHandle()
-				throws IOException, RocksDBException, ClassNotFoundException {
+				throws IOException, RocksDBException, ClassNotFoundException
+		{
 			try {
 				currentStateHandleInStream = currentKeyGroupsStateHandle.openInputStream();
 				rocksDBKeyedStateBackend.cancelStreamRegistry.registerClosable(currentStateHandleInStream);
@@ -769,21 +774,23 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	 * we don't restore the individual k/v states, just the global RocksDB data base and the
 	 * list of column families. When a k/v state is first requested we check here whether we
 	 * already have a column family for that and return it or create a new one if it doesn't exist.
-	 *
+	 * <p>
 	 * <p>This also checks whether the {@link StateDescriptor} for a state matches the one
 	 * that we checkpointed, i.e. is already in the map of column families.
 	 */
 	@SuppressWarnings("rawtypes, unchecked")
-	protected <N, S> ColumnFamilyHandle getColumnFamily(StateDescriptor<?, S> descriptor, TypeSerializer<N> namespaceSerializer) {
+	protected <N, S> ColumnFamilyHandle getColumnFamily(StateDescriptor.Type type, String name,
+			TypeSerializer<N> namespaceSerializer, TypeSerializer<S> stateSerializer)
+	{
 
 		Tuple2<ColumnFamilyHandle, RegisteredBackendStateMetaInfo<?, ?>> stateInfo =
-				kvStateInformation.get(descriptor.getName());
+				kvStateInformation.get(name);
 
 		RegisteredBackendStateMetaInfo<N, S> newMetaInfo = new RegisteredBackendStateMetaInfo<>(
-				descriptor.getType(),
-				descriptor.getName(),
+				type,
+				name,
 				namespaceSerializer,
-				descriptor.getSerializer());
+				stateSerializer);
 
 		if (stateInfo != null) {
 			if (!newMetaInfo.isCompatibleWith(stateInfo.f1)) {
@@ -795,14 +802,14 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		}
 
 		ColumnFamilyDescriptor columnDescriptor = new ColumnFamilyDescriptor(
-				descriptor.getName().getBytes(), columnOptions);
+				name.getBytes(), columnOptions);
 
 		try {
 			ColumnFamilyHandle columnFamily = db.createColumnFamily(columnDescriptor);
 			Tuple2<ColumnFamilyHandle, RegisteredBackendStateMetaInfo<N, S>> tuple =
 					new Tuple2<>(columnFamily, newMetaInfo);
 			Map rawAccess = kvStateInformation;
-			rawAccess.put(descriptor.getName(), tuple);
+			rawAccess.put(name, tuple);
 			return columnFamily;
 		} catch (RocksDBException e) {
 			throw new RuntimeException("Error creating ColumnFamilyHandle.", e);
@@ -811,36 +818,40 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 	@Override
 	protected <N, T> ValueState<T> createValueState(TypeSerializer<N> namespaceSerializer,
-			ValueStateDescriptor<T> stateDesc) throws Exception {
+			ValueStateDescriptor<T> stateDesc) throws Exception
+	{
 
-		ColumnFamilyHandle columnFamily = getColumnFamily(stateDesc, namespaceSerializer);
+		ColumnFamilyHandle columnFamily = getColumnFamily(stateDesc.getType(), stateDesc.getName(), namespaceSerializer, stateDesc.getSerializer());
 
-		return new RocksDBValueState<>(columnFamily, namespaceSerializer,  stateDesc, this);
+		return new RocksDBValueState<>(columnFamily, namespaceSerializer, stateDesc, this);
 	}
 
 	@Override
 	protected <N, T> ListState<T> createListState(TypeSerializer<N> namespaceSerializer,
-			ListStateDescriptor<T> stateDesc) throws Exception {
+			ListStateDescriptor<T> stateDesc) throws Exception
+	{
 
-		ColumnFamilyHandle columnFamily = getColumnFamily(stateDesc, namespaceSerializer);
+		ColumnFamilyHandle columnFamily = getColumnFamily(stateDesc.getType(), stateDesc.getName(), namespaceSerializer, stateDesc.getElemSerializer());
 
 		return new RocksDBListState<>(columnFamily, namespaceSerializer, stateDesc, this);
 	}
 
 	@Override
 	protected <N, T> ReducingState<T> createReducingState(TypeSerializer<N> namespaceSerializer,
-			ReducingStateDescriptor<T> stateDesc) throws Exception {
+			ReducingStateDescriptor<T> stateDesc) throws Exception
+	{
 
-		ColumnFamilyHandle columnFamily = getColumnFamily(stateDesc, namespaceSerializer);
+		ColumnFamilyHandle columnFamily = getColumnFamily(stateDesc.getType(), stateDesc.getName(), namespaceSerializer, stateDesc.getSerializer());
 
-		return new RocksDBReducingState<>(columnFamily, namespaceSerializer,  stateDesc, this);
+		return new RocksDBReducingState<>(columnFamily, namespaceSerializer, stateDesc, this);
 	}
 
 	@Override
 	protected <N, T, ACC> FoldingState<T, ACC> createFoldingState(TypeSerializer<N> namespaceSerializer,
-			FoldingStateDescriptor<T, ACC> stateDesc) throws Exception {
+			FoldingStateDescriptor<T, ACC> stateDesc) throws Exception
+	{
 
-		ColumnFamilyHandle columnFamily = getColumnFamily(stateDesc, namespaceSerializer);
+		ColumnFamilyHandle columnFamily = getColumnFamily(stateDesc.getType(), stateDesc.getName(), namespaceSerializer, stateDesc.getSerializer());
 
 		return new RocksDBFoldingState<>(columnFamily, namespaceSerializer, stateDesc, this);
 	}
@@ -852,8 +863,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	static final class MergeIterator {
 
 		/**
-		 *
-		 * @param iterator The #RocksIterator to wrap .
+		 * @param iterator  The #RocksIterator to wrap .
 		 * @param kvStateId Id of the K/V state to which this iterator belongs.
 		 */
 		public MergeIterator(RocksIterator iterator, int kvStateId) {
@@ -999,6 +1009,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		/**
 		 * Returns the key-group for the current key.
+		 *
 		 * @return key-group for the current key
 		 */
 		public int keyGroup() {
@@ -1021,6 +1032,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		/**
 		 * Returns the Id of the k/v state to which the current key belongs.
+		 *
 		 * @return Id of K/V state to which the current key belongs.
 		 */
 		public int kvStateId() {
@@ -1029,6 +1041,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		/**
 		 * Indicates if current key starts a new k/v-state, i.e. belong to a different k/v-state than it's predecessor.
+		 *
 		 * @return true iff the current key belong to a different k/v-state than it's predecessor.
 		 */
 		public boolean isNewKeyValueState() {
@@ -1037,6 +1050,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		/**
 		 * Indicates if current key starts a new key-group, i.e. belong to a different key-group than it's predecessor.
+		 *
 		 * @return true iff the current key belong to a different key-group than it's predecessor.
 		 */
 		public boolean isNewKeyGroup() {
@@ -1047,6 +1061,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		 * Check if the iterator is still valid. Getters like {@link #key()}, {@link #value()}, etc. as well as
 		 * {@link #next()} should only be called if valid returned true. Should be checked after each call to
 		 * {@link #next()} before accessing iterator state.
+		 *
 		 * @return True iff this iterator is valid.
 		 */
 		public boolean isValid() {
@@ -1110,20 +1125,21 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		// first get the column family mapping
 		int numColumns = inputView.readInt();
-		Map<Byte, StateDescriptor<?, ?>> columnFamilyMapping = new HashMap<>(numColumns);
+		Map<Byte, org.apache.flink.migration.api.common.state.StateDescriptor<?, ?>> columnFamilyMapping = new HashMap<>(numColumns);
 		for (int i = 0; i < numColumns; i++) {
 			byte mappingByte = inputView.readByte();
 
 			ObjectInputStream ooIn =
-					new InstantiationUtil.ClassLoaderObjectInputStream(
+					new MigrationInstantiationUtil.ClassLoaderObjectInputStream(
 							new DataInputViewStream(inputView), userCodeClassLoader);
 
-			StateDescriptor stateDescriptor = (StateDescriptor) ooIn.readObject();
+			org.apache.flink.migration.api.common.state.StateDescriptor<?, ?> stateDescriptor =
+					(org.apache.flink.migration.api.common.state.StateDescriptor<?, ?>) ooIn.readObject();
 
 			columnFamilyMapping.put(mappingByte, stateDescriptor);
 
 			// this will fill in the k/v state information
-			getColumnFamily(stateDescriptor, null);
+			getColumnFamily(stateDescriptor.getType(), stateDescriptor.getName(), null, stateDescriptor.getSerializer());
 		}
 
 		// try and read until EOF
@@ -1131,7 +1147,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			// the EOFException will get us out of this...
 			while (true) {
 				byte mappingByte = inputView.readByte();
-				ColumnFamilyHandle handle = getColumnFamily(columnFamilyMapping.get(mappingByte), null);
+				org.apache.flink.migration.api.common.state.StateDescriptor stateDescriptor = columnFamilyMapping.get(mappingByte);
+				ColumnFamilyHandle handle = getColumnFamily(stateDescriptor.getType(), stateDescriptor.getName(), null, stateDescriptor.getSerializer());
 				byte[] keyAndNamespace = BytePrimitiveArraySerializer.INSTANCE.deserialize(inputView);
 
 				ByteArrayInputStreamWithPos bis = new ByteArrayInputStreamWithPos(keyAndNamespace);

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -25,8 +25,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.RocksDBException;
-import org.rocksdb.WriteOptions;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -38,21 +36,9 @@ import java.io.IOException;
  * @param <N> The type of the namespace.
  * @param <V> The type of value that the state state stores.
  */
-public class RocksDBReducingState<K, N, V>
-	extends AbstractRocksDBState<K, N, ReducingState<V>, ReducingStateDescriptor<V>, V>
-	implements ReducingState<V> {
-
-	/** Serializer for the values */
-	private final TypeSerializer<V> valueSerializer;
-
+public class RocksDBReducingState<K, N, V> extends RocksDBSimpleState<K, N, V> implements ReducingState<V> {
 	/** User-specified reduce function */
 	private final ReduceFunction<V> reduceFunction;
-
-	/**
-	 * We disable writes to the write-ahead-log here. We can't have these in the base class
-	 * because JNI segfaults for some reason if they are.
-	 */
-	private final WriteOptions writeOptions;
 
 	/**
 	 * Creates a new {@code RocksDBReducingState}.
@@ -61,32 +47,16 @@ public class RocksDBReducingState<K, N, V>
 	 * @param stateDesc The state identifier for the state. This contains name
 	 *                     and can create a default state value.
 	 */
-	public RocksDBReducingState(ColumnFamilyHandle columnFamily,
-			TypeSerializer<N> namespaceSerializer,
-			ReducingStateDescriptor<V> stateDesc,
-			RocksDBKeyedStateBackend<K> backend) {
+	public RocksDBReducingState(
+		ColumnFamilyHandle columnFamily,
+		TypeSerializer<N> namespaceSerializer,
+		ReducingStateDescriptor<V> stateDesc,
+		RocksDBKeyedStateBackend<K> backend
+	) {
 
 		super(columnFamily, namespaceSerializer, stateDesc, backend);
-		this.valueSerializer = stateDesc.getSerializer();
+
 		this.reduceFunction = stateDesc.getReduceFunction();
-
-		writeOptions = new WriteOptions();
-		writeOptions.setDisableWAL(true);
-	}
-
-	@Override
-	public V get() {
-		try {
-			writeCurrentKeyWithGroupAndNamespace();
-			byte[] key = keySerializationStream.toByteArray();
-			byte[] valueBytes = backend.db.get(columnFamily, key);
-			if (valueBytes == null) {
-				return null;
-			}
-			return valueSerializer.deserialize(new DataInputViewStreamWrapper(new ByteArrayInputStream(valueBytes)));
-		} catch (IOException|RocksDBException e) {
-			throw new RuntimeException("Error while retrieving data from RocksDB", e);
-		}
 	}
 
 	@Override

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -47,12 +47,10 @@ public class RocksDBReducingState<K, N, V> extends RocksDBSimpleState<K, N, V> i
 	 * @param stateDesc The state identifier for the state. This contains name
 	 *                     and can create a default state value.
 	 */
-	public RocksDBReducingState(
-		ColumnFamilyHandle columnFamily,
-		TypeSerializer<N> namespaceSerializer,
-		ReducingStateDescriptor<V> stateDesc,
-		RocksDBKeyedStateBackend<K> backend
-	) {
+	public RocksDBReducingState(ColumnFamilyHandle columnFamily,
+			TypeSerializer<N> namespaceSerializer,
+			ReducingStateDescriptor<V> stateDesc,
+			RocksDBKeyedStateBackend<K> backend) {
 
 		super(columnFamily, namespaceSerializer, stateDesc, backend);
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -36,7 +36,7 @@ import java.io.IOException;
  * @param <N> The type of the namespace.
  * @param <V> The type of value that the state state stores.
  */
-public class RocksDBReducingState<K, N, V> extends RocksDBSimpleState<K, N, V> implements ReducingState<V> {
+public class RocksDBReducingState<K, N, V> extends RocksDBSimpleState<K, N, V, ReducingStateDescriptor<V>> implements ReducingState<V> {
 	/** User-specified reduce function */
 	private final ReduceFunction<V> reduceFunction;
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSimpleState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSimpleState.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.common.state.SimpleStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.util.Preconditions;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.WriteOptions;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+/**
+ * The implementation that stores simple states in RocksDB.
+ *
+ * @param <K> The type of the key.
+ * @param <N> The type of the namespace.
+ * @param <V> The type of value that the state state stores.
+ */
+public class RocksDBSimpleState<K, N, V> extends AbstractRocksDBState<K, N> implements State<V> {
+
+	/** State descriptor from which to create this state instance */
+	protected final SimpleStateDescriptor<V, ? extends State<V>> stateDesc;
+
+	/** Serializer for the values */
+	protected final TypeSerializer<V> valueSerializer;
+
+	/**
+	 * We disable writes to the write-ahead-log here. We can't have these in the base class
+	 * because JNI segfaults for some reason if they are.
+	 */
+	protected final WriteOptions writeOptions;
+
+	/**
+	 * Creates a new {@code RocksDBSimpleState}.
+	 *
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param stateDesc The state identifier for the state. This contains name and can create a default state value.
+	 */
+	public RocksDBSimpleState(ColumnFamilyHandle columnFamily,
+		TypeSerializer<N> namespaceSerializer,
+		SimpleStateDescriptor<V, ? extends State<V>> stateDesc,
+		RocksDBKeyedStateBackend<K> backend
+	) {
+		super(columnFamily, namespaceSerializer, backend);
+
+		this.stateDesc = Preconditions.checkNotNull(stateDesc, "State Descriptor");
+		this.valueSerializer = stateDesc.getSerializer();
+
+		writeOptions = new WriteOptions();
+		writeOptions.setDisableWAL(true);
+	}
+
+	@Override
+	public V get() {
+		try {
+			writeCurrentKeyWithGroupAndNamespace();
+			byte[] key = keySerializationStream.toByteArray();
+			byte[] valueBytes = backend.db.get(columnFamily, key);
+			if (valueBytes == null) {
+				return stateDesc.getDefaultValue();
+			}
+			return valueSerializer.deserialize(new DataInputViewStreamWrapper(new ByteArrayInputStream(valueBytes)));
+		} catch (IOException|RocksDBException e) {
+			throw new RuntimeException("Error while retrieving data from RocksDB.", e);
+		}
+	}
+
+	@Override
+	public void clear() {
+		try {
+			writeCurrentKeyWithGroupAndNamespace();
+			byte[] key = keySerializationStream.toByteArray();
+			backend.db.remove(columnFamily, writeOptions, key);
+		} catch (IOException|RocksDBException e) {
+			throw new RuntimeException("Error while removing entry from RocksDB", e);
+		}
+	}
+}

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSimpleState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBSimpleState.java
@@ -20,6 +20,7 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.state.SimpleStateDescriptor;
 import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.UpdatableState;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.util.Preconditions;
@@ -37,7 +38,7 @@ import java.io.IOException;
  * @param <N> The type of the namespace.
  * @param <V> The type of value that the state state stores.
  */
-public class RocksDBSimpleState<K, N, V> extends AbstractRocksDBState<K, N> implements State<V> {
+public class RocksDBSimpleState<K, N, V> extends AbstractRocksDBState<K, N> implements UpdatableState<V> {
 
 	/** State descriptor from which to create this state instance */
 	protected final SimpleStateDescriptor<V, ? extends State<V>> stateDesc;
@@ -58,10 +59,10 @@ public class RocksDBSimpleState<K, N, V> extends AbstractRocksDBState<K, N> impl
 	 * @param stateDesc The state identifier for the state. This contains name and can create a default state value.
 	 */
 	public RocksDBSimpleState(ColumnFamilyHandle columnFamily,
-		TypeSerializer<N> namespaceSerializer,
-		SimpleStateDescriptor<V, ? extends State<V>> stateDesc,
-		RocksDBKeyedStateBackend<K> backend
-	) {
+			TypeSerializer<N> namespaceSerializer,
+			SimpleStateDescriptor<V, ? extends State<V>> stateDesc,
+			RocksDBKeyedStateBackend<K> backend) {
+
 		super(columnFamily, namespaceSerializer, backend);
 
 		this.stateDesc = Preconditions.checkNotNull(stateDesc, "State Descriptor");

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -41,13 +41,10 @@ public class RocksDBValueState<K, N, V> extends RocksDBSimpleState<K, N, V> impl
 	 * @param namespaceSerializer The serializer for the namespace.
 	 * @param stateDesc The state identifier for the state. This contains name and can create a default state value.
 	 */
-	public RocksDBValueState(
-		ColumnFamilyHandle columnFamily,
-		TypeSerializer<N> namespaceSerializer,
-		ValueStateDescriptor<V> stateDesc,
-		RocksDBKeyedStateBackend<K> backend
-	) {
-
+	public RocksDBValueState(ColumnFamilyHandle columnFamily,
+			TypeSerializer<N> namespaceSerializer,
+			ValueStateDescriptor<V> stateDesc,
+			RocksDBKeyedStateBackend<K> backend) {
 		super(columnFamily, namespaceSerializer, stateDesc, backend);
 	}
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -21,14 +21,10 @@ package org.apache.flink.contrib.streaming.state;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
 import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.RocksDBException;
-import org.rocksdb.WriteOptions;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 /**
@@ -38,51 +34,26 @@ import java.io.IOException;
  * @param <N> The type of the namespace.
  * @param <V> The type of value that the state state stores.
  */
-public class RocksDBValueState<K, N, V>
-	extends AbstractRocksDBState<K, N, ValueState<V>, ValueStateDescriptor<V>, V>
-	implements ValueState<V> {
-
-	/** Serializer for the values */
-	private final TypeSerializer<V> valueSerializer;
-
-	/**
-	 * We disable writes to the write-ahead-log here. We can't have these in the base class
-	 * because JNI segfaults for some reason if they are.
-	 */
-	private final WriteOptions writeOptions;
-
+public class RocksDBValueState<K, N, V> extends RocksDBSimpleState<K, N, V> implements ValueState<V> {
 	/**
 	 * Creates a new {@code RocksDBValueState}.
 	 *
 	 * @param namespaceSerializer The serializer for the namespace.
-	 * @param stateDesc The state identifier for the state. This contains name
-	 *                           and can create a default state value.
+	 * @param stateDesc The state identifier for the state. This contains name and can create a default state value.
 	 */
-	public RocksDBValueState(ColumnFamilyHandle columnFamily,
-			TypeSerializer<N> namespaceSerializer,
-			ValueStateDescriptor<V> stateDesc,
-			RocksDBKeyedStateBackend<K> backend) {
+	public RocksDBValueState(
+		ColumnFamilyHandle columnFamily,
+		TypeSerializer<N> namespaceSerializer,
+		ValueStateDescriptor<V> stateDesc,
+		RocksDBKeyedStateBackend<K> backend
+	) {
 
 		super(columnFamily, namespaceSerializer, stateDesc, backend);
-		this.valueSerializer = stateDesc.getSerializer();
-
-		writeOptions = new WriteOptions();
-		writeOptions.setDisableWAL(true);
 	}
 
 	@Override
-	public V value() {
-		try {
-			writeCurrentKeyWithGroupAndNamespace();
-			byte[] key = keySerializationStream.toByteArray();
-			byte[] valueBytes = backend.db.get(columnFamily, key);
-			if (valueBytes == null) {
-				return stateDesc.getDefaultValue();
-			}
-			return valueSerializer.deserialize(new DataInputViewStreamWrapper(new ByteArrayInputStream(valueBytes)));
-		} catch (IOException|RocksDBException e) {
-			throw new RuntimeException("Error while retrieving data from RocksDB.", e);
-		}
+	public V value() throws IOException {
+		return get();
 	}
 
 	@Override

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/migration/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/migration/contrib/streaming/state/RocksDBStateBackend.java
@@ -18,8 +18,8 @@
 package org.apache.flink.migration.contrib.streaming.state;
 
 import org.apache.flink.api.common.state.ValueState;
-import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.migration.api.common.state.ValueStateDescriptor;
 import org.apache.flink.migration.runtime.state.AbstractStateBackend;
 import org.apache.flink.migration.runtime.state.KvStateSnapshot;
 import org.apache.flink.migration.runtime.state.StateHandle;

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
@@ -38,7 +38,7 @@ import java.io.IOException;
  * @param <OUT> Type of the value that can be retrieved from the state.
  */
 @PublicEvolving
-public interface AppendingState<IN, OUT> extends State<OUT> {
+public interface AppendingState<IN, OUT> extends UpdatableState<OUT> {
 	/**
 	 * Updates the operator state accessible by {@link #get()} by adding the given value
 	 * to the list of values. The next time {@link #get()} is called (for the same state

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
@@ -38,34 +38,13 @@ import java.io.IOException;
  * @param <OUT> Type of the value that can be retrieved from the state.
  */
 @PublicEvolving
-public interface AppendingState<IN, OUT> extends State {
-
-	/**
-	 * Returns the current value for the state. When the state is not
-	 * partitioned the returned value is the same for all inputs in a given
-	 * operator instance. If state partitioning is applied, the value returned
-	 * depends on the current operator input, as the operator maintains an
-	 * independent state for each partition.
-	 *
-	 * <p>
-	 *     <b>NOTE TO IMPLEMENTERS:</b> if the state is empty, then this method
-	 *     should return {@code null}.
-	 * </p>
-	 *
-	 * @return The operator state value corresponding to the current input or {@code null}
-	 * if the state is empty.
-	 * 
-	 * @throws Exception Thrown if the system cannot access the state.
-	 */
-	OUT get() throws Exception ;
-
+public interface AppendingState<IN, OUT> extends State<OUT> {
 	/**
 	 * Updates the operator state accessible by {@link #get()} by adding the given value
 	 * to the list of values. The next time {@link #get()} is called (for the same state
 	 * partition) the returned state will represent the updated list.
 	 * 
-	 * @param value
-	 *            The new value for the state.
+	 * @param value The new value for the state.
 	 *            
 	 * @throws IOException Thrown if the system cannot access the state.
 	 */

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/FoldingStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/FoldingStateDescriptor.java
@@ -37,7 +37,7 @@ import static java.util.Objects.requireNonNull;
 public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, FoldingState<T, ACC>> {
 	private static final long serialVersionUID = 1L;
 
-
+	private final ACC initialValue;
 	private final FoldFunction<T, ACC> foldFunction;
 
 	/**
@@ -52,12 +52,14 @@ public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, F
 	 * @param typeClass The type of the values in the state.
 	 */
 	public FoldingStateDescriptor(String name, ACC initialValue, FoldFunction<T, ACC> foldFunction, Class<ACC> typeClass) {
-		super(name, typeClass, initialValue);
-		this.foldFunction = requireNonNull(foldFunction);
+		super(name, typeClass, null);
 
 		if (foldFunction instanceof RichFunction) {
 			throw new UnsupportedOperationException("FoldFunction of FoldingState can not be a RichFunction.");
 		}
+
+		this.initialValue = initialValue;
+		this.foldFunction = requireNonNull(foldFunction);
 	}
 
 	/**
@@ -69,12 +71,14 @@ public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, F
 	 * @param typeInfo The type of the values in the state.
 	 */
 	public FoldingStateDescriptor(String name, ACC initialValue, FoldFunction<T, ACC> foldFunction, TypeInformation<ACC> typeInfo) {
-		super(name, typeInfo, initialValue);
-		this.foldFunction = requireNonNull(foldFunction);
+		super(name, typeInfo, null);
 
 		if (foldFunction instanceof RichFunction) {
 			throw new UnsupportedOperationException("FoldFunction of FoldingState can not be a RichFunction.");
 		}
+
+		this.initialValue = initialValue;
+		this.foldFunction = requireNonNull(foldFunction);
 	}
 
 	/**
@@ -86,12 +90,14 @@ public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, F
 	 * @param typeSerializer The type serializer of the values in the state.
 	 */
 	public FoldingStateDescriptor(String name, ACC initialValue, FoldFunction<T, ACC> foldFunction, TypeSerializer<ACC> typeSerializer) {
-		super(name, typeSerializer, initialValue);
-		this.foldFunction = requireNonNull(foldFunction);
+		super(name, typeSerializer, null);
 
 		if (foldFunction instanceof RichFunction) {
 			throw new UnsupportedOperationException("FoldFunction of FoldingState can not be a RichFunction.");
 		}
+
+		this.initialValue = initialValue;
+		this.foldFunction = requireNonNull(foldFunction);
 	}
 
 	// ------------------------------------------------------------------------
@@ -106,6 +112,13 @@ public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, F
 	 */
 	public FoldFunction<T, ACC> getFoldFunction() {
 		return foldFunction;
+	}
+
+	/**
+	 * Returns the initial value used in the folding.
+	 */
+	public ACC getInitialValue() {
+		return initialValue;
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/FoldingStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/FoldingStateDescriptor.java
@@ -23,6 +23,14 @@ import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.functions.RichFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 import static java.util.Objects.requireNonNull;
 
@@ -37,6 +45,7 @@ import static java.util.Objects.requireNonNull;
 public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, FoldingState<T, ACC>> {
 	private static final long serialVersionUID = 1L;
 
+	private transient ACC initialValue;
 	private final FoldFunction<T, ACC> foldFunction;
 
 	/**
@@ -51,13 +60,14 @@ public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, F
 	 * @param typeClass The type of the values in the state.
 	 */
 	public FoldingStateDescriptor(String name, ACC initialValue, FoldFunction<T, ACC> foldFunction, Class<ACC> typeClass) {
-		super(name, typeClass, initialValue);
+		super(name, typeClass);
 
 		if (foldFunction instanceof RichFunction) {
 			throw new UnsupportedOperationException("FoldFunction of FoldingState can not be a RichFunction.");
 		}
 
 		this.foldFunction = requireNonNull(foldFunction);
+		this.initialValue = initialValue;
 	}
 
 	/**
@@ -69,13 +79,14 @@ public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, F
 	 * @param typeInfo The type of the values in the state.
 	 */
 	public FoldingStateDescriptor(String name, ACC initialValue, FoldFunction<T, ACC> foldFunction, TypeInformation<ACC> typeInfo) {
-		super(name, typeInfo, initialValue);
+		super(name, typeInfo);
 
 		if (foldFunction instanceof RichFunction) {
 			throw new UnsupportedOperationException("FoldFunction of FoldingState can not be a RichFunction.");
 		}
 
 		this.foldFunction = requireNonNull(foldFunction);
+		this.initialValue = initialValue;
 	}
 
 	/**
@@ -87,20 +98,31 @@ public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, F
 	 * @param typeSerializer The type serializer of the values in the state.
 	 */
 	public FoldingStateDescriptor(String name, ACC initialValue, FoldFunction<T, ACC> foldFunction, TypeSerializer<ACC> typeSerializer) {
-		super(name, typeSerializer, initialValue);
+		super(name, typeSerializer);
 
 		if (foldFunction instanceof RichFunction) {
 			throw new UnsupportedOperationException("FoldFunction of FoldingState can not be a RichFunction.");
 		}
 
 		this.foldFunction = requireNonNull(foldFunction);
+		this.initialValue = initialValue;
 	}
 
 	// ------------------------------------------------------------------------
-	
-	@Override
-	public FoldingState<T, ACC> bind(StateBackend stateBackend) throws Exception {
-		return stateBackend.createFoldingState(this);
+
+	/**
+	 * Returns the initial value used in the folding.
+	 */
+	public ACC getInitialValue() {
+		if (initialValue != null) {
+			if (typeSerializer != null) {
+				return typeSerializer.copy(initialValue);
+			} else {
+				throw new IllegalStateException("Serializer not yet initialized.");
+			}
+		} else {
+			return null;
+		}
 	}
 
 	/**
@@ -110,16 +132,11 @@ public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, F
 		return foldFunction;
 	}
 
-	/**
-	 * Returns the initial value used in the folding.
-	 */
-	public ACC getInitialValue() {
-		return defaultValue;
-	}
+	// ------------------------------------------------------------------------
 
 	@Override
-	public ACC getDefaultValue() {
-		return null;
+	public FoldingState<T, ACC> bind(StateBackend stateBackend) throws Exception {
+		return stateBackend.createFoldingState(this);
 	}
 
 	@Override
@@ -148,9 +165,71 @@ public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, F
 	public String toString() {
 		return "FoldingStateDescriptor{" +
 				"serializer=" + typeSerializer +
-				", initialValue=" + defaultValue +
+				", initialValue=" + initialValue +
 				", foldFunction=" + foldFunction +
 				'}';
+	}
+
+	// ------------------------------------------------------------------------
+	//  Serialization
+	// ------------------------------------------------------------------------
+
+	private void writeObject(final ObjectOutputStream out) throws IOException {
+		// write the fold function
+		out.defaultWriteObject();
+
+		// write the non-serializable default value field
+		if (initialValue == null) {
+			// we don't have an initial value
+			out.writeBoolean(false);
+		} else {
+			// we have an initial value
+			out.writeBoolean(true);
+
+			byte[] serializedDefaultValue;
+			try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+				DataOutputViewStreamWrapper outView = new DataOutputViewStreamWrapper(baos))
+			{
+				TypeSerializer<ACC> duplicateSerializer = typeSerializer.duplicate();
+				duplicateSerializer.serialize(initialValue, outView);
+
+				outView.flush();
+				serializedDefaultValue = baos.toByteArray();
+			}
+			catch (Exception e) {
+				throw new IOException("Unable to serialize initial value of type " +
+					initialValue.getClass().getSimpleName() + ".", e);
+			}
+
+			out.writeInt(serializedDefaultValue.length);
+			out.write(serializedDefaultValue);
+		}
+	}
+
+	private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+		// read the fold function
+		in.defaultReadObject();
+
+		// read the initial value field
+		boolean hasInitialValue = in.readBoolean();
+		if (hasInitialValue) {
+			int size = in.readInt();
+
+			byte[] buffer = new byte[size];
+
+			in.readFully(buffer);
+
+			try (ByteArrayInputStream bais = new ByteArrayInputStream(buffer);
+				DataInputViewStreamWrapper inView = new DataInputViewStreamWrapper(bais))
+			{
+				initialValue = typeSerializer.deserialize(inView);
+			}
+			catch (Exception e) {
+				throw new IOException("Unable to deserialize initial value.", e);
+			}
+		} else {
+			initialValue = null;
+		}
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/FoldingStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/FoldingStateDescriptor.java
@@ -37,7 +37,6 @@ import static java.util.Objects.requireNonNull;
 public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, FoldingState<T, ACC>> {
 	private static final long serialVersionUID = 1L;
 
-	private final ACC initialValue;
 	private final FoldFunction<T, ACC> foldFunction;
 
 	/**
@@ -52,13 +51,12 @@ public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, F
 	 * @param typeClass The type of the values in the state.
 	 */
 	public FoldingStateDescriptor(String name, ACC initialValue, FoldFunction<T, ACC> foldFunction, Class<ACC> typeClass) {
-		super(name, typeClass, null);
+		super(name, typeClass, initialValue);
 
 		if (foldFunction instanceof RichFunction) {
 			throw new UnsupportedOperationException("FoldFunction of FoldingState can not be a RichFunction.");
 		}
 
-		this.initialValue = initialValue;
 		this.foldFunction = requireNonNull(foldFunction);
 	}
 
@@ -71,13 +69,12 @@ public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, F
 	 * @param typeInfo The type of the values in the state.
 	 */
 	public FoldingStateDescriptor(String name, ACC initialValue, FoldFunction<T, ACC> foldFunction, TypeInformation<ACC> typeInfo) {
-		super(name, typeInfo, null);
+		super(name, typeInfo, initialValue);
 
 		if (foldFunction instanceof RichFunction) {
 			throw new UnsupportedOperationException("FoldFunction of FoldingState can not be a RichFunction.");
 		}
 
-		this.initialValue = initialValue;
 		this.foldFunction = requireNonNull(foldFunction);
 	}
 
@@ -90,13 +87,12 @@ public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, F
 	 * @param typeSerializer The type serializer of the values in the state.
 	 */
 	public FoldingStateDescriptor(String name, ACC initialValue, FoldFunction<T, ACC> foldFunction, TypeSerializer<ACC> typeSerializer) {
-		super(name, typeSerializer, null);
+		super(name, typeSerializer, initialValue);
 
 		if (foldFunction instanceof RichFunction) {
 			throw new UnsupportedOperationException("FoldFunction of FoldingState can not be a RichFunction.");
 		}
 
-		this.initialValue = initialValue;
 		this.foldFunction = requireNonNull(foldFunction);
 	}
 
@@ -118,7 +114,12 @@ public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, F
 	 * Returns the initial value used in the folding.
 	 */
 	public ACC getInitialValue() {
-		return initialValue;
+		return defaultValue;
+	}
+
+	@Override
+	public ACC getDefaultValue() {
+		return null;
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/FoldingStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/FoldingStateDescriptor.java
@@ -34,7 +34,7 @@ import static java.util.Objects.requireNonNull;
  * @param <ACC> Type of the value in the state
  */
 @PublicEvolving
-public class FoldingStateDescriptor<T, ACC> extends StateDescriptor<FoldingState<T, ACC>, ACC> {
+public class FoldingStateDescriptor<T, ACC> extends SimpleStateDescriptor<ACC, FoldingState<T, ACC>> {
 	private static final long serialVersionUID = 1L;
 
 
@@ -119,13 +119,13 @@ public class FoldingStateDescriptor<T, ACC> extends StateDescriptor<FoldingState
 
 		FoldingStateDescriptor<?, ?> that = (FoldingStateDescriptor<?, ?>) o;
 
-		return serializer.equals(that.serializer) && name.equals(that.name);
+		return typeSerializer.equals(that.typeSerializer) && name.equals(that.name);
 
 	}
 
 	@Override
 	public int hashCode() {
-		int result = serializer.hashCode();
+		int result = typeSerializer.hashCode();
 		result = 31 * result + name.hashCode();
 		return result;
 	}
@@ -133,7 +133,7 @@ public class FoldingStateDescriptor<T, ACC> extends StateDescriptor<FoldingState
 	@Override
 	public String toString() {
 		return "FoldingStateDescriptor{" +
-				"serializer=" + serializer +
+				"serializer=" + typeSerializer +
 				", initialValue=" + defaultValue +
 				", foldFunction=" + foldFunction +
 				'}';

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ListStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ListStateDescriptor.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 
 import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 /**
@@ -158,18 +157,12 @@ public class ListStateDescriptor<T> extends StateDescriptor<ListState<T>> {
 	// ------------------------------------------------------------------------
 	//  Serialization
 	// ------------------------------------------------------------------------
-
 	private void writeObject(final ObjectOutputStream out) throws IOException {
 		// make sure we have a serializer before the type information gets lost
 		initializeSerializerUnlessSet(new ExecutionConfig());
 
 		// write all the non-transient fields
 		out.defaultWriteObject();
-	}
-
-	private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
-		// read the non-transient fields
-		in.defaultReadObject();
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ReducingStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ReducingStateDescriptor.java
@@ -34,7 +34,7 @@ import static java.util.Objects.requireNonNull;
  * @param <T> The type of the values that can be added to the list state.
  */
 @PublicEvolving
-public class ReducingStateDescriptor<T> extends StateDescriptor<ReducingState<T>, T> {
+public class ReducingStateDescriptor<T> extends SimpleStateDescriptor<T, ReducingState<T>> {
 	private static final long serialVersionUID = 1L;
 	
 	
@@ -108,13 +108,13 @@ public class ReducingStateDescriptor<T> extends StateDescriptor<ReducingState<T>
 
 		ReducingStateDescriptor<?> that = (ReducingStateDescriptor<?>) o;
 
-		return serializer.equals(that.serializer) && name.equals(that.name);
+		return typeSerializer.equals(that.typeSerializer) && name.equals(that.name);
 
 	}
 
 	@Override
 	public int hashCode() {
-		int result = serializer.hashCode();
+		int result = typeSerializer.hashCode();
 		result = 31 * result + name.hashCode();
 		return result;
 	}
@@ -122,7 +122,7 @@ public class ReducingStateDescriptor<T> extends StateDescriptor<ReducingState<T>
 	@Override
 	public String toString() {
 		return "ReducingStateDescriptor{" +
-				"serializer=" + serializer +
+				"serializer=" + typeSerializer +
 				", reduceFunction=" + reduceFunction +
 				'}';
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ReducingStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ReducingStateDescriptor.java
@@ -36,7 +36,7 @@ import static java.util.Objects.requireNonNull;
 @PublicEvolving
 public class ReducingStateDescriptor<T> extends SimpleStateDescriptor<T, ReducingState<T>> {
 	private static final long serialVersionUID = 1L;
-	
+
 	
 	private final ReduceFunction<T> reduceFunction;
 
@@ -51,12 +51,13 @@ public class ReducingStateDescriptor<T> extends SimpleStateDescriptor<T, Reducin
 	 * @param typeClass The type of the values in the state.
 	 */
 	public ReducingStateDescriptor(String name, ReduceFunction<T> reduceFunction, Class<T> typeClass) {
-		super(name, typeClass, null);
-		this.reduceFunction = requireNonNull(reduceFunction);
+		super(name, typeClass);
 
 		if (reduceFunction instanceof RichFunction) {
 			throw new UnsupportedOperationException("ReduceFunction of ReducingState can not be a RichFunction.");
 		}
+
+		this.reduceFunction = requireNonNull(reduceFunction);
 	}
 
 	/**
@@ -67,7 +68,12 @@ public class ReducingStateDescriptor<T> extends SimpleStateDescriptor<T, Reducin
 	 * @param typeInfo The type of the values in the state.
 	 */
 	public ReducingStateDescriptor(String name, ReduceFunction<T> reduceFunction, TypeInformation<T> typeInfo) {
-		super(name, typeInfo, null);
+		super(name, typeInfo);
+
+		if (reduceFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("ReduceFunction of ReducingState can not be a RichFunction.");
+		}
+
 		this.reduceFunction = requireNonNull(reduceFunction);
 	}
 
@@ -79,7 +85,12 @@ public class ReducingStateDescriptor<T> extends SimpleStateDescriptor<T, Reducin
 	 * @param typeSerializer The type serializer of the values in the state.
 	 */
 	public ReducingStateDescriptor(String name, ReduceFunction<T> reduceFunction, TypeSerializer<T> typeSerializer) {
-		super(name, typeSerializer, null);
+		super(name, typeSerializer);
+
+		if (reduceFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("ReduceFunction of ReducingState can not be a RichFunction.");
+		}
+
 		this.reduceFunction = requireNonNull(reduceFunction);
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/SimpleStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/SimpleStateDescriptor.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Base class for the descriptors of simple states. A {@code SimpleStateDescriptor} is used
+ * for creating partitioned simple states whose values are not composited.
+ *
+ * <p>Subclasses must correctly implement {@link #equals(Object)} and {@link #hashCode()}.
+ *
+ * @param <T> The type of the value in the state.
+ * @param <S> The type of the created state.
+ */
+@PublicEvolving
+public abstract class SimpleStateDescriptor<T, S extends State<T>> extends StateDescriptor<S> {
+	private static final long serialVersionUID = 1L;
+
+	/** The serializer for the type. May be eagerly initialized in the constructor,
+	 * or lazily once the type is serialized or an ExecutionConfig is provided. */
+	protected TypeSerializer<T> typeSerializer;
+
+	/** The type information describing the value type. Only used to lazily create the serializer
+	 * and dropped during serialization */
+	private transient TypeInformation<T> typeInfo;
+
+	/** The default value returned by the state when no other value is bound to a key */
+	protected transient T defaultValue;
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Create a new {@code SimpleStateDescriptor} with the given name and the given type serializer.
+	 *
+	 * @param name The name of the {@code SimpleStateDescriptor}.
+	 * @param serializer The type serializer for the values in the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting a value before.
+	 */
+	protected SimpleStateDescriptor(String name, TypeSerializer<T> serializer, T defaultValue) {
+		super(name);
+		this.typeSerializer = requireNonNull(serializer, "serializer must not be null");
+		this.defaultValue = defaultValue;
+	}
+
+	/**
+	 * Create a new {@code SimpleStateDescriptor} with the given name and the given type information.
+	 *
+	 * @param name The name of the {@code SimpleStateDescriptor}.
+	 * @param typeInfo The type information for the values in the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting a value before.
+	 */
+	protected SimpleStateDescriptor(String name, TypeInformation<T> typeInfo, T defaultValue) {
+		super(name);
+		this.typeInfo = requireNonNull(typeInfo, "type information must not be null");
+		this.defaultValue = defaultValue;
+	}
+
+	/**
+	 * Create a new {@code StateDescriptor} with the given name and the given type information.
+	 *
+	 * <p>If this constructor fails (because it is not possible to describe the type via a class),
+	 * consider using the {@link #SimpleStateDescriptor(String, TypeInformation, Object)} constructor.
+	 *
+	 * @param name The name of the {@code StateDescriptor}.
+	 * @param type The class of the type of values in the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting
+	 *                     a value before.
+	 */
+	protected SimpleStateDescriptor(String name, Class<T> type, T defaultValue) {
+		super(name);
+
+		requireNonNull(type, "type class must not be null");
+
+		try {
+			this.typeInfo = TypeExtractor.createTypeInfo(type);
+		} catch (Exception e) {
+			throw new RuntimeException("Cannot create full type information based on the given class. If the type has generics, please", e);
+		}
+
+		this.defaultValue = defaultValue;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Returns the default value.
+	 */
+	public T getDefaultValue() {
+		if (defaultValue != null) {
+			if (typeSerializer != null) {
+				return typeSerializer.copy(defaultValue);
+			} else {
+				throw new IllegalStateException("Serializer not yet initialized.");
+			}
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns the {@link TypeSerializer} that can be used to serialize the value in the state.
+	 * Note that the serializer may initialized lazily and is only guaranteed to exist after
+	 * calling {@link #initializeSerializerUnlessSet(ExecutionConfig)}.
+	 */
+	public TypeSerializer<T> getSerializer() {
+		if (typeSerializer != null) {
+			return typeSerializer;
+		} else {
+			throw new IllegalStateException("Serializer not yet initialized.");
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	@Override
+	public boolean isSerializerInitialized() {
+		return typeSerializer != null;
+	}
+
+	@Override
+	public void initializeSerializerUnlessSet(ExecutionConfig executionConfig) {
+		if (typeSerializer == null) {
+			if (typeInfo != null) {
+				typeSerializer = typeInfo.createSerializer(executionConfig);
+			} else {
+				throw new IllegalStateException(
+					"Cannot initialize serializer after TypeInformation was dropped during serialization");
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Serialization
+	// ------------------------------------------------------------------------
+
+	private void writeObject(final ObjectOutputStream out) throws IOException {
+		// make sure we have a serializer before the type information gets lost
+		initializeSerializerUnlessSet(new ExecutionConfig());
+
+		// write all the non-transient fields
+		out.defaultWriteObject();
+
+		// write the non-serializable default value field
+		if (defaultValue == null) {
+			// we don't have a default value
+			out.writeBoolean(false);
+		} else {
+			// we have a default value
+			out.writeBoolean(true);
+
+			byte[] serializedDefaultValue;
+			try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+				DataOutputViewStreamWrapper outView = new DataOutputViewStreamWrapper(baos))
+			{
+				TypeSerializer<T> duplicateSerializer = typeSerializer.duplicate();
+				duplicateSerializer.serialize(defaultValue, outView);
+
+				outView.flush();
+				serializedDefaultValue = baos.toByteArray();
+			}
+			catch (Exception e) {
+				throw new IOException("Unable to serialize default value of type " +
+					defaultValue.getClass().getSimpleName() + ".", e);
+			}
+
+			out.writeInt(serializedDefaultValue.length);
+			out.write(serializedDefaultValue);
+		}
+	}
+
+	private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+		// read the non-transient fields
+		in.defaultReadObject();
+
+		// read the default value field
+		boolean hasDefaultValue = in.readBoolean();
+		if (hasDefaultValue) {
+			int size = in.readInt();
+
+			byte[] buffer = new byte[size];
+
+			in.readFully(buffer);
+
+			try (ByteArrayInputStream bais = new ByteArrayInputStream(buffer);
+				DataInputViewStreamWrapper inView = new DataInputViewStreamWrapper(bais))
+			{
+				defaultValue = typeSerializer.deserialize(inView);
+			}
+			catch (Exception e) {
+				throw new IOException("Unable to deserialize default value.", e);
+			}
+		} else {
+			defaultValue = null;
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/State.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/State.java
@@ -20,6 +20,8 @@ package org.apache.flink.api.common.state;
 
 import org.apache.flink.annotation.PublicEvolving;
 
+import java.io.IOException;
+
 /**
  * Interface that different types of partitioned state must implement.
  *
@@ -27,9 +29,23 @@ import org.apache.flink.annotation.PublicEvolving;
  * automatically supplied by the system, so the function always sees the value mapped to the
  * key of the current element. That way, the system can handle stream and state partitioning
  * consistently together.
+ *
+ * @param <T> The type of the values in the state.
  */
 @PublicEvolving
-public interface State {
+public interface State<T> {
+	/**
+	 * Returns the current value for the state. When the state is not
+	 * partitioned the returned value is the same for all inputs in a given
+	 * operator instance. If state partitioning is applied, the value returned
+	 * depends on the current operator input, as the operator maintains an
+	 * independent state for each partition.
+	 *
+	 * @return The operator state value corresponding to the current input.
+	 *
+	 * @throws IOException Thrown if the system cannot access the state.
+	 */
+	T get() throws IOException;
 
 	/**
 	 * Removes the value mapped under the current key.

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/State.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/State.java
@@ -39,7 +39,7 @@ public interface State<T> {
 	 * partitioned the returned value is the same for all inputs in a given
 	 * operator instance. If state partitioning is applied, the value returned
 	 * depends on the current operator input, as the operator maintains an
-	 * independent state for each partition.
+	 * independent state for each key.
 	 *
 	 * @return The operator state value corresponding to the current input.
 	 *

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
@@ -20,18 +20,8 @@ package org.apache.flink.api.common.state;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.typeutils.TypeExtractor;
-import org.apache.flink.core.memory.DataInputViewStreamWrapper;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.util.Preconditions;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
 import static java.util.Objects.requireNonNull;
@@ -44,10 +34,9 @@ import static java.util.Objects.requireNonNull;
  * <p>Subclasses must correctly implement {@link #equals(Object)} and {@link #hashCode()}.
  *
  * @param <S> The type of the State objects created from this {@code StateDescriptor}.
- * @param <T> The type of the value of the state object described by this state descriptor.
  */
 @PublicEvolving
-public abstract class StateDescriptor<S extends State, T> implements Serializable {
+public abstract class StateDescriptor<S extends State<?>> implements Serializable {
 
 	// Do not change the order of the elements in this enum, ordinal is used in serialization
 	public enum Type {
@@ -59,19 +48,8 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	/** Name that uniquely identifies state created from this StateDescriptor. */
 	protected final String name;
 
-	/** The serializer for the type. May be eagerly initialized in the constructor,
-	 * or lazily once the type is serialized or an ExecutionConfig is provided. */
-	protected TypeSerializer<T> serializer;
-
 	/** Name for queries against state created from this StateDescriptor. */
 	private String queryableStateName;
-
-	/** The default value returned by the state when no other value is bound to a key */
-	protected transient T defaultValue;
-
-	/** The type information describing the value type. Only used to lazily create the serializer
-	 * and dropped during serialization */
-	private transient TypeInformation<T> typeInfo;
 
 	// ------------------------------------------------------------------------
 
@@ -79,52 +57,9 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	 * Create a new {@code StateDescriptor} with the given name and the given type serializer.
 	 *
 	 * @param name The name of the {@code StateDescriptor}.
-	 * @param serializer The type serializer for the values in the state.
-	 * @param defaultValue The default value that will be set when requesting state without setting
-	 *                     a value before.
 	 */
-	protected StateDescriptor(String name, TypeSerializer<T> serializer, T defaultValue) {
+	protected StateDescriptor(String name) {
 		this.name = requireNonNull(name, "name must not be null");
-		this.serializer = requireNonNull(serializer, "serializer must not be null");
-		this.defaultValue = defaultValue;
-	}
-
-	/**
-	 * Create a new {@code StateDescriptor} with the given name and the given type information.
-	 *
-	 * @param name The name of the {@code StateDescriptor}.
-	 * @param typeInfo The type information for the values in the state.
-	 * @param defaultValue The default value that will be set when requesting state without setting
-	 *                     a value before.   
-	 */
-	protected StateDescriptor(String name, TypeInformation<T> typeInfo, T defaultValue) {
-		this.name = requireNonNull(name, "name must not be null");
-		this.typeInfo = requireNonNull(typeInfo, "type information must not be null");
-		this.defaultValue = defaultValue;
-	}
-
-	/**
-	 * Create a new {@code StateDescriptor} with the given name and the given type information.
-	 *
-	 * <p>If this constructor fails (because it is not possible to describe the type via a class),
-	 * consider using the {@link #StateDescriptor(String, TypeInformation, Object)} constructor.
-	 *
-	 * @param name The name of the {@code StateDescriptor}.
-	 * @param type The class of the type of values in the state.
-	 * @param defaultValue The default value that will be set when requesting state without setting
-	 *                     a value before.   
-	 */
-	protected StateDescriptor(String name, Class<T> type, T defaultValue) {
-		this.name = requireNonNull(name, "name must not be null");
-		requireNonNull(type, "type class must not be null");
-
-		try {
-			this.typeInfo = TypeExtractor.createTypeInfo(type);
-		} catch (Exception e) {
-			throw new RuntimeException("Cannot create full type information based on the given class. If the type has generics, please", e);
-		}
-
-		this.defaultValue = defaultValue;
 	}
 
 	// ------------------------------------------------------------------------
@@ -134,34 +69,6 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	 */
 	public String getName() {
 		return name;
-	}
-
-	/**
-	 * Returns the default value.
-	 */
-	public T getDefaultValue() {
-		if (defaultValue != null) {
-			if (serializer != null) {
-				return serializer.copy(defaultValue);
-			} else {
-				throw new IllegalStateException("Serializer not yet initialized.");
-			}
-		} else {
-			return null;
-		}
-	}
-
-	/**
-	 * Returns the {@link TypeSerializer} that can be used to serialize the value in the state.
-	 * Note that the serializer may initialized lazily and is only guaranteed to exist after
-	 * calling {@link #initializeSerializerUnlessSet(ExecutionConfig)}.
-	 */
-	public TypeSerializer<T> getSerializer() {
-		if (serializer != null) {
-			return serializer;
-		} else {
-			throw new IllegalStateException("Serializer not yet initialized.");
-		}
 	}
 
 	/**
@@ -217,41 +124,14 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	 *
 	 * @return True if the serializers have been initialized, false otherwise.
 	 */
-	public boolean isSerializerInitialized() {
-		return serializer != null;
-	}
+	public abstract boolean isSerializerInitialized();
 
 	/**
 	 * Initializes the serializer, unless it has been initialized before.
 	 *
 	 * @param executionConfig The execution config to use when creating the serializer.
 	 */
-	public void initializeSerializerUnlessSet(ExecutionConfig executionConfig) {
-		if (serializer == null) {
-			if (typeInfo != null) {
-				serializer = typeInfo.createSerializer(executionConfig);
-			} else {
-				throw new IllegalStateException(
-						"Cannot initialize serializer after TypeInformation was dropped during serialization");
-			}
-		}
-	}
-
-	/**
-	 * This method should be called by subclasses prior to serialization. Because the TypeInformation is
-	 * not always serializable, it is 'transient' and dropped during serialization. Hence, the descriptor
-	 * needs to make sure that the serializer is created before the TypeInformation is dropped. 
-	 */
-	private void ensureSerializerCreated() {
-		if (serializer == null) {
-			if (typeInfo != null) {
-				serializer = typeInfo.createSerializer(new ExecutionConfig());
-			} else {
-				throw new IllegalStateException(
-						"Cannot initialize serializer after TypeInformation was dropped during serialization");
-			}
-		}
-	}
+	public abstract void initializeSerializerUnlessSet(ExecutionConfig executionConfig);
 
 	// ------------------------------------------------------------------------
 	//  Standard Utils
@@ -264,79 +144,7 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	public abstract boolean equals(Object o);
 
 	@Override
-	public String toString() {
-		return getClass().getSimpleName() +
-				"{name=" + name +
-				", defaultValue=" + defaultValue +
-				", serializer=" + serializer +
-				(isQueryable() ? ", queryableStateName=" + queryableStateName + "" : "") +
-				'}';
-	}
+	public abstract String toString();
 
 	public abstract Type getType();
-
-	// ------------------------------------------------------------------------
-	//  Serialization
-	// ------------------------------------------------------------------------
-
-	private void writeObject(final ObjectOutputStream out) throws IOException {
-		// make sure we have a serializer before the type information gets lost
-		ensureSerializerCreated();
-
-		// write all the non-transient fields
-		out.defaultWriteObject();
-
-		// write the non-serializable default value field
-		if (defaultValue == null) {
-			// we don't have a default value
-			out.writeBoolean(false);
-		} else {
-			// we have a default value
-			out.writeBoolean(true);
-
-			byte[] serializedDefaultValue;
-			try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-					DataOutputViewStreamWrapper outView = new DataOutputViewStreamWrapper(baos))
-			{
-				TypeSerializer<T> duplicateSerializer = serializer.duplicate();
-				duplicateSerializer.serialize(defaultValue, outView);
-
-				outView.flush();
-				serializedDefaultValue = baos.toByteArray();
-			}
-			catch (Exception e) {
-				throw new IOException("Unable to serialize default value of type " +
-						defaultValue.getClass().getSimpleName() + ".", e);
-			}
-
-			out.writeInt(serializedDefaultValue.length);
-			out.write(serializedDefaultValue);
-		}
-	}
-
-	private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
-		// read the non-transient fields
-		in.defaultReadObject();
-
-		// read the default value field
-		boolean hasDefaultValue = in.readBoolean();
-		if (hasDefaultValue) {
-			int size = in.readInt();
-
-			byte[] buffer = new byte[size];
-
-			in.readFully(buffer);
-
-			try (ByteArrayInputStream bais = new ByteArrayInputStream(buffer);
-					DataInputViewStreamWrapper inView = new DataInputViewStreamWrapper(bais))
-			{
-				defaultValue = serializer.deserialize(inView);
-			}
-			catch (Exception e) {
-				throw new IOException("Unable to deserialize default value.", e);
-			}
-		} else {
-			defaultValue = null;
-		}
-	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/UpdatableState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/UpdatableState.java
@@ -20,30 +20,18 @@ package org.apache.flink.api.common.state;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import java.io.IOException;
-
 /**
- * Interface that different types of partitioned state must implement.
+ * Interface of those states allowing updates.
  *
- * <p>The state is only accessible by functions applied on a KeyedDataStream. The key is
- * automatically supplied by the system, so the function always sees the value mapped to the
- * key of the current element. That way, the system can handle stream and state partitioning
- * consistently together.
+ * <p> By default, {@link State} is read-only. Those states allowing updates must
+ * implement this interface.
  *
  * @param <T> The type of the values in the state.
  */
 @PublicEvolving
-public interface State<T> {
+public interface UpdatableState<T> extends State<T> {
 	/**
-	 * Returns the current value for the state. When the state is not
-	 * partitioned the returned value is the same for all inputs in a given
-	 * operator instance. If state partitioning is applied, the value returned
-	 * depends on the current operator input, as the operator maintains an
-	 * independent state for each partition.
-	 *
-	 * @return The operator state value corresponding to the current input.
-	 *
-	 * @throws IOException Thrown if the system cannot access the state.
+	 * Removes the value mapped under the current key.
 	 */
-	T get() throws IOException;
+	void clear();
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ValueState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ValueState.java
@@ -39,8 +39,10 @@ import java.io.IOException;
 @PublicEvolving
 public interface ValueState<T> extends UpdatableState<T> {
 	/**
+	 * @deprecated Replaced by {@link State#get()}.
+	 *
 	 * Returns the current value for the state. The method performs the same
-	 * functionality as {@link State#get()}.
+	 * functionality as {@link State#get()}, and is kept for compatibility.
 	 *
 	 * <p>If you didn't specify a default value when creating the {@link ValueStateDescriptor}
 	 * this will return {@code null} when to value was previously set using {@link #update(Object)}.

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ValueState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ValueState.java
@@ -37,7 +37,7 @@ import java.io.IOException;
  * @param <T> Type of the value in the state.
  */
 @PublicEvolving
-public interface ValueState<T> extends State<T> {
+public interface ValueState<T> extends UpdatableState<T> {
 	/**
 	 * Returns the current value for the state. The method performs the same
 	 * functionality as {@link State#get()}.

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ValueState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ValueState.java
@@ -37,27 +37,24 @@ import java.io.IOException;
  * @param <T> Type of the value in the state.
  */
 @PublicEvolving
-public interface ValueState<T> extends State {
-
+public interface ValueState<T> extends State<T> {
 	/**
-	 * Returns the current value for the state. When the state is not
-	 * partitioned the returned value is the same for all inputs in a given
-	 * operator instance. If state partitioning is applied, the value returned
-	 * depends on the current operator input, as the operator maintains an
-	 * independent state for each partition.
+	 * Returns the current value for the state. The method performs the same
+	 * functionality as {@link State#get()}.
 	 *
 	 * <p>If you didn't specify a default value when creating the {@link ValueStateDescriptor}
 	 * this will return {@code null} when to value was previously set using {@link #update(Object)}.
 	 *
 	 * @return The state value corresponding to the current input.
-	 * 
+	 *
 	 * @throws IOException Thrown if the system cannot access the state.
 	 */
+	@Deprecated
 	T value() throws IOException;
 
 	/**
-	 * Updates the operator state accessible by {@link #value()} to the given
-	 * value. The next time {@link #value()} is called (for the same state
+	 * Updates the operator state accessible by {@link #get()} to the given
+	 * value. The next time {@link #get()} is called (for the same state
 	 * partition) the returned state will represent the updated value. When a
 	 * partitioned state is updated with null, the state for the current key 
 	 * will be removed and the default value is returned on the next access.

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ValueStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ValueStateDescriptor.java
@@ -132,7 +132,7 @@ public class ValueStateDescriptor<T> extends SimpleStateDescriptor<T, ValueState
 	 * @param typeClass The type of the values in the state.
 	 */
 	public ValueStateDescriptor(String name, Class<T> typeClass) {
-		super(name, typeClass, null);
+		super(name, typeClass);
 	}
 
 	/**
@@ -142,7 +142,7 @@ public class ValueStateDescriptor<T> extends SimpleStateDescriptor<T, ValueState
 	 * @param typeInfo The type of the values in the state.
 	 */
 	public ValueStateDescriptor(String name, TypeInformation<T> typeInfo) {
-		super(name, typeInfo, null);
+		super(name, typeInfo);
 	}
 
 	/**
@@ -152,7 +152,7 @@ public class ValueStateDescriptor<T> extends SimpleStateDescriptor<T, ValueState
 	 * @param typeSerializer The type serializer of the values in the state.
 	 */
 	public ValueStateDescriptor(String name, TypeSerializer<T> typeSerializer) {
-		super(name, typeSerializer, null);
+		super(name, typeSerializer);
 	}
 
 	// ------------------------------------------------------------------------
@@ -196,6 +196,8 @@ public class ValueStateDescriptor<T> extends SimpleStateDescriptor<T, ValueState
 	@Override
 	public Type getType() {
 		return Type.VALUE;
+	}
+
 	// ------------------------------------------------------------------------
 	//  Serialization
 	// ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ValueStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ValueStateDescriptor.java
@@ -21,6 +21,14 @@ package org.apache.flink.api.common.state;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 /**
  * {@link StateDescriptor} for {@link ValueState}. This can be used to create partitioned
@@ -35,6 +43,9 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 @PublicEvolving
 public class ValueStateDescriptor<T> extends SimpleStateDescriptor<T, ValueState<T>> {
 	private static final long serialVersionUID = 1L;
+
+	/** The default value returned by the state when no other value is bound to a key */
+	protected transient T defaultValue;
 	
 	/**
 	 * Creates a new {@code ValueStateDescriptor} with the given name, type, and default value.
@@ -52,7 +63,9 @@ public class ValueStateDescriptor<T> extends SimpleStateDescriptor<T, ValueState
 	 */
 	@Deprecated
 	public ValueStateDescriptor(String name, Class<T> typeClass, T defaultValue) {
-		super(name, typeClass, defaultValue);
+		super(name, typeClass);
+
+		this.defaultValue = defaultValue;
 	}
 
 	/**
@@ -68,7 +81,9 @@ public class ValueStateDescriptor<T> extends SimpleStateDescriptor<T, ValueState
 	 */
 	@Deprecated
 	public ValueStateDescriptor(String name, TypeInformation<T> typeInfo, T defaultValue) {
-		super(name, typeInfo, defaultValue);
+		super(name, typeInfo);
+
+		this.defaultValue = defaultValue;
 	}
 
 	/**
@@ -85,7 +100,26 @@ public class ValueStateDescriptor<T> extends SimpleStateDescriptor<T, ValueState
 	 */
 	@Deprecated
 	public ValueStateDescriptor(String name, TypeSerializer<T> typeSerializer, T defaultValue) {
-		super(name, typeSerializer, defaultValue);
+		super(name, typeSerializer);
+
+		this.defaultValue = defaultValue;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Returns the default value.
+	 */
+	public T getDefaultValue() {
+		if (defaultValue != null) {
+			if (typeSerializer != null) {
+				return typeSerializer.copy(defaultValue);
+			} else {
+				throw new IllegalStateException("Serializer not yet initialized.");
+			}
+		} else {
+			return null;
+		}
 	}
 
 	/**
@@ -162,5 +196,59 @@ public class ValueStateDescriptor<T> extends SimpleStateDescriptor<T, ValueState
 	@Override
 	public Type getType() {
 		return Type.VALUE;
+	// ------------------------------------------------------------------------
+	//  Serialization
+	// ------------------------------------------------------------------------
+
+	private void writeObject(final ObjectOutputStream out) throws IOException {
+		// write the non-serializable default value field
+		if (defaultValue == null) {
+			// we don't have a default value
+			out.writeBoolean(false);
+		} else {
+			// we have a default value
+			out.writeBoolean(true);
+
+			byte[] serializedDefaultValue;
+			try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+				DataOutputViewStreamWrapper outView = new DataOutputViewStreamWrapper(baos))
+			{
+				TypeSerializer<T> duplicateSerializer = typeSerializer.duplicate();
+				duplicateSerializer.serialize(defaultValue, outView);
+
+				outView.flush();
+				serializedDefaultValue = baos.toByteArray();
+			}
+			catch (Exception e) {
+				throw new IOException("Unable to serialize default value of type " +
+					defaultValue.getClass().getSimpleName() + ".", e);
+			}
+
+			out.writeInt(serializedDefaultValue.length);
+			out.write(serializedDefaultValue);
+		}
+	}
+
+	private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+		// read the default value field
+		boolean hasDefaultValue = in.readBoolean();
+		if (hasDefaultValue) {
+			int size = in.readInt();
+
+			byte[] buffer = new byte[size];
+
+			in.readFully(buffer);
+
+			try (ByteArrayInputStream bais = new ByteArrayInputStream(buffer);
+				DataInputViewStreamWrapper inView = new DataInputViewStreamWrapper(bais))
+			{
+				defaultValue = typeSerializer.deserialize(inView);
+			}
+			catch (Exception e) {
+				throw new IOException("Unable to deserialize default value.", e);
+			}
+		} else {
+			defaultValue = null;
+		}
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ValueStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ValueStateDescriptor.java
@@ -33,7 +33,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
  * @param <T> The type of the values that the value state can hold.
  */
 @PublicEvolving
-public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
+public class ValueStateDescriptor<T> extends SimpleStateDescriptor<T, ValueState<T>> {
 	private static final long serialVersionUID = 1L;
 	
 	/**
@@ -139,13 +139,13 @@ public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
 
 		ValueStateDescriptor<?> that = (ValueStateDescriptor<?>) o;
 
-		return serializer.equals(that.serializer) && name.equals(that.name);
+		return typeSerializer.equals(that.typeSerializer) && name.equals(that.name);
 
 	}
 
 	@Override
 	public int hashCode() {
-		int result = serializer.hashCode();
+		int result = typeSerializer.hashCode();
 		result = 31 * result + name.hashCode();
 		return result;
 	}
@@ -155,7 +155,7 @@ public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
 		return "ValueStateDescriptor{" +
 				"name=" + name +
 				", defaultValue=" + defaultValue +
-				", serializer=" + serializer +
+				", serializer=" + typeSerializer +
 				'}';
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/state/ListStateDescriptorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/state/ListStateDescriptorTest.java
@@ -44,14 +44,14 @@ public class ListStateDescriptorTest {
 				new ListStateDescriptor<String>("testName", serializer);
 		
 		assertEquals("testName", descr.getName());
-		assertNotNull(descr.getSerializer());
-		assertEquals(serializer, descr.getSerializer());
+		assertNotNull(descr.getElemSerializer());
+		assertEquals(serializer, descr.getElemSerializer());
 
 		ListStateDescriptor<String> copy = CommonTestUtils.createCopySerializable(descr);
 
 		assertEquals("testName", copy.getName());
-		assertNotNull(copy.getSerializer());
-		assertEquals(serializer, copy.getSerializer());
+		assertNotNull(copy.getElemSerializer());
+		assertEquals(serializer, copy.getElemSerializer());
 	}
 
 	@Test
@@ -64,16 +64,16 @@ public class ListStateDescriptorTest {
 				new ListStateDescriptor<Path>("testName", Path.class);
 		
 		try {
-			descr.getSerializer();
+			descr.getElemSerializer();
 			fail("should cause an exception");
 		} catch (IllegalStateException ignored) {}
 
 		descr.initializeSerializerUnlessSet(cfg);
 		
-		assertNotNull(descr.getSerializer());
-		assertTrue(descr.getSerializer() instanceof KryoSerializer);
+		assertNotNull(descr.getElemSerializer());
+		assertTrue(descr.getElemSerializer() instanceof KryoSerializer);
 
-		assertTrue(((KryoSerializer<?>) descr.getSerializer()).getKryo().getRegistration(TaskInfo.class).getId() > 0);
+		assertTrue(((KryoSerializer<?>) descr.getElemSerializer()).getKryo().getRegistration(TaskInfo.class).getId() > 0);
 	}
 
 	@Test
@@ -85,7 +85,7 @@ public class ListStateDescriptorTest {
 		ListStateDescriptor<String> copy = CommonTestUtils.createCopySerializable(descr);
 
 		assertEquals("testName", copy.getName());
-		assertNotNull(copy.getSerializer());
-		assertEquals(StringSerializer.INSTANCE, copy.getSerializer());
+		assertNotNull(copy.getElemSerializer());
+		assertEquals(StringSerializer.INSTANCE, copy.getElemSerializer());
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
@@ -121,7 +121,7 @@ abstract public class AbstractKeyedCEPPatternOperator<IN, KEY, OUT> extends Abst
 
 	@Override
 	protected NFA<IN> getNFA() throws IOException {
-		NFA<IN> nfa = nfaOperatorState.value();
+		NFA<IN> nfa = nfaOperatorState.get();
 
 		if (nfa == null) {
 			nfa = nfaFactory.createNFA();
@@ -139,7 +139,7 @@ abstract public class AbstractKeyedCEPPatternOperator<IN, KEY, OUT> extends Abst
 
 	@Override
 	protected PriorityQueue<StreamRecord<IN>> getPriorityQueue() throws IOException {
-		PriorityQueue<StreamRecord<IN>> priorityQueue = priorityQueueOperatorState.value();
+		PriorityQueue<StreamRecord<IN>> priorityQueue = priorityQueueOperatorState.get();
 
 		if (priorityQueue == null) {
 			priorityQueue = priorityQueueFactory.createPriorityQueue();

--- a/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/ListStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/ListStateDescriptor.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.migration.api.common.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+/**
+ * A {@link StateDescriptor} for {@link ListState}.
+ *
+ * @param <T> The type of the values that can be added to the list state.
+ */
+@PublicEvolving
+public class ListStateDescriptor<T> extends StateDescriptor<ListState<T>, T> {
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Creates a new {@code ListStateDescriptor} with the given name and list element type.
+	 *
+	 * <p>If this constructor fails (because it is not possible to describe the type via a class),
+	 * consider using the {@link #ListStateDescriptor(String, TypeInformation)} constructor.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param typeClass The type of the values in the state.
+	 */
+	public ListStateDescriptor(String name, Class<T> typeClass) {
+		super(name, typeClass, null);
+	}
+
+	/**
+	 * Creates a new {@code ListStateDescriptor} with the given name and list element type.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param typeInfo The type of the values in the state.
+	 */
+	public ListStateDescriptor(String name, TypeInformation<T> typeInfo) {
+		super(name, typeInfo, null);
+	}
+
+	/**
+	 * Creates a new {@code ListStateDescriptor} with the given name and list element type.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param typeSerializer The type serializer for the list values.
+	 */
+	public ListStateDescriptor(String name, TypeSerializer<T> typeSerializer) {
+		super(name, typeSerializer, null);
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public ListState<T> bind(StateBackend stateBackend) throws Exception {
+		return stateBackend.createListState(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		ListStateDescriptor<?> that = (ListStateDescriptor<?>) o;
+
+		return serializer.equals(that.serializer) && name.equals(that.name);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = serializer.hashCode();
+		result = 31 * result + name.hashCode();
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "ListStateDescriptor{" +
+				"serializer=" + serializer +
+				'}';
+	}
+
+	@Override
+	public org.apache.flink.api.common.state.StateDescriptor.Type getType() {
+		return org.apache.flink.api.common.state.StateDescriptor.Type.LIST;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/ReducingStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/ReducingStateDescriptor.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.migration.api.common.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * {@link StateDescriptor} for {@link ReducingState}.
+ *
+ * @param <T> The type of the values that can be added to the list state.
+ */
+@PublicEvolving
+public class ReducingStateDescriptor<T> extends StateDescriptor<ReducingState<T>, T> {
+	private static final long serialVersionUID = 1L;
+
+
+	private final ReduceFunction<T> reduceFunction;
+
+	/**
+	 * Creates a new {@code ReducingStateDescriptor} with the given name, type, and default value.
+	 *
+	 * <p>If this constructor fails (because it is not possible to describe the type via a class),
+	 * consider using the {@link #ReducingStateDescriptor(String, ReduceFunction, TypeInformation)} constructor.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param reduceFunction The {@code ReduceFunction} used to aggregate the state.
+	 * @param typeClass The type of the values in the state.
+	 */
+	public ReducingStateDescriptor(String name, ReduceFunction<T> reduceFunction, Class<T> typeClass) {
+		super(name, typeClass, null);
+		this.reduceFunction = requireNonNull(reduceFunction);
+
+		if (reduceFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("ReduceFunction of ReducingState can not be a RichFunction.");
+		}
+	}
+
+	/**
+	 * Creates a new {@code ReducingStateDescriptor} with the given name and default value.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param reduceFunction The {@code ReduceFunction} used to aggregate the state.
+	 * @param typeInfo The type of the values in the state.
+	 */
+	public ReducingStateDescriptor(String name, ReduceFunction<T> reduceFunction, TypeInformation<T> typeInfo) {
+		super(name, typeInfo, null);
+		this.reduceFunction = requireNonNull(reduceFunction);
+	}
+
+	/**
+	 * Creates a new {@code ValueStateDescriptor} with the given name and default value.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param reduceFunction The {@code ReduceFunction} used to aggregate the state.
+	 * @param typeSerializer The type serializer of the values in the state.
+	 */
+	public ReducingStateDescriptor(String name, ReduceFunction<T> reduceFunction, TypeSerializer<T> typeSerializer) {
+		super(name, typeSerializer, null);
+		this.reduceFunction = requireNonNull(reduceFunction);
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public ReducingState<T> bind(StateBackend stateBackend) throws Exception {
+		return stateBackend.createReducingState(this);
+	}
+
+	/**
+	 * Returns the reduce function to be used for the reducing state.
+	 */
+	public ReduceFunction<T> getReduceFunction() {
+		return reduceFunction;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		ReducingStateDescriptor<?> that = (ReducingStateDescriptor<?>) o;
+
+		return serializer.equals(that.serializer) && name.equals(that.name);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = serializer.hashCode();
+		result = 31 * result + name.hashCode();
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "ReducingStateDescriptor{" +
+				"serializer=" + serializer +
+				", reduceFunction=" + reduceFunction +
+				'}';
+	}
+
+	@Override
+	public org.apache.flink.api.common.state.StateDescriptor.Type getType() {
+		return org.apache.flink.api.common.state.StateDescriptor.Type.REDUCING;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/StateBackend.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.migration.api.common.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.FoldingState;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ValueState;
+
+/**
+ * The {@code StateBackend} is used by {@link StateDescriptor} instances to create actual state
+ * representations.
+ */
+@PublicEvolving
+public interface StateBackend {
+
+	/**
+	 * Creates and returns a new {@link ValueState}.
+	 * @param stateDesc The {@code StateDescriptor} that contains the name of the state.
+	 *
+	 * @param <T> The type of the value that the {@code ValueState} can store.
+	 */
+	<T> ValueState<T> createValueState(ValueStateDescriptor<T> stateDesc) throws Exception;
+
+	/**
+	 * Creates and returns a new {@link ListState}.
+	 * @param stateDesc The {@code StateDescriptor} that contains the name of the state.
+	 *
+	 * @param <T> The type of the values that the {@code ListState} can store.
+	 */
+	<T> ListState<T> createListState(ListStateDescriptor<T> stateDesc) throws Exception;
+
+	/**
+	 * Creates and returns a new {@link ReducingState}.
+	 * @param stateDesc The {@code StateDescriptor} that contains the name of the state.
+	 *
+	 * @param <T> The type of the values that the {@code ListState} can store.
+	 */
+	<T> ReducingState<T> createReducingState(ReducingStateDescriptor<T> stateDesc) throws Exception;
+
+	/**
+	 * Creates and returns a new {@link FoldingState}.
+	 * @param stateDesc The {@code StateDescriptor} that contains the name of the state.
+	 *
+	 * @param <T> Type of the values folded into the state
+	 * @param <ACC> Type of the value in the state
+	 */
+	<T, ACC> FoldingState<T, ACC> createFoldingState(FoldingStateDescriptor<T, ACC> stateDesc) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/StateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/StateDescriptor.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.migration.api.common.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.util.Preconditions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Base class for state descriptors. A {@code StateDescriptor} is used for creating partitioned
+ * {@link State} in stateful operations. This contains the name and can create an actual state
+ * object given a {@link StateBackend} using {@link #bind(StateBackend)}.
+ *
+ * <p>Subclasses must correctly implement {@link #equals(Object)} and {@link #hashCode()}.
+ *
+ * @param <S> The type of the State objects created from this {@code StateDescriptor}.
+ * @param <T> The type of the value of the state object described by this state descriptor.
+ */
+@PublicEvolving
+public abstract class StateDescriptor<S extends State<?>, T> implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/** Name that uniquely identifies state created from this StateDescriptor. */
+	protected final String name;
+
+	/** The serializer for the type. May be eagerly initialized in the constructor,
+	 * or lazily once the type is serialized or an ExecutionConfig is provided. */
+	protected TypeSerializer<T> serializer;
+
+	/** Name for queries against state created from this StateDescriptor. */
+	private String queryableStateName;
+
+	/** The default value returned by the state when no other value is bound to a key */
+	protected transient T defaultValue;
+
+	/** The type information describing the value type. Only used to lazily create the serializer
+	 * and dropped during serialization */
+	private transient TypeInformation<T> typeInfo;
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Create a new {@code StateDescriptor} with the given name and the given type serializer.
+	 *
+	 * @param name The name of the {@code StateDescriptor}.
+	 * @param serializer The type serializer for the values in the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting
+	 *                     a value before.
+	 */
+	protected StateDescriptor(String name, TypeSerializer<T> serializer, T defaultValue) {
+		this.name = requireNonNull(name, "name must not be null");
+		this.serializer = requireNonNull(serializer, "serializer must not be null");
+		this.defaultValue = defaultValue;
+	}
+
+	/**
+	 * Create a new {@code StateDescriptor} with the given name and the given type information.
+	 *
+	 * @param name The name of the {@code StateDescriptor}.
+	 * @param typeInfo The type information for the values in the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting
+	 *                     a value before.
+	 */
+	protected StateDescriptor(String name, TypeInformation<T> typeInfo, T defaultValue) {
+		this.name = requireNonNull(name, "name must not be null");
+		this.typeInfo = requireNonNull(typeInfo, "type information must not be null");
+		this.defaultValue = defaultValue;
+	}
+
+	/**
+	 * Create a new {@code StateDescriptor} with the given name and the given type information.
+	 *
+	 * <p>If this constructor fails (because it is not possible to describe the type via a class),
+	 * consider using the {@link #StateDescriptor(String, TypeInformation, Object)} constructor.
+	 *
+	 * @param name The name of the {@code StateDescriptor}.
+	 * @param type The class of the type of values in the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting
+	 *                     a value before.
+	 */
+	protected StateDescriptor(String name, Class<T> type, T defaultValue) {
+		this.name = requireNonNull(name, "name must not be null");
+		requireNonNull(type, "type class must not be null");
+
+		try {
+			this.typeInfo = TypeExtractor.createTypeInfo(type);
+		} catch (Exception e) {
+			throw new RuntimeException("Cannot create full type information based on the given class. If the type has generics, please", e);
+		}
+
+		this.defaultValue = defaultValue;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Returns the name of this {@code StateDescriptor}.
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Returns the default value.
+	 */
+	public T getDefaultValue() {
+		if (defaultValue != null) {
+			if (serializer != null) {
+				return serializer.copy(defaultValue);
+			} else {
+				throw new IllegalStateException("Serializer not yet initialized.");
+			}
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns the {@link TypeSerializer} that can be used to serialize the value in the state.
+	 * Note that the serializer may initialized lazily and is only guaranteed to exist after
+	 * calling {@link #initializeSerializerUnlessSet(ExecutionConfig)}.
+	 */
+	public TypeSerializer<T> getSerializer() {
+		if (serializer != null) {
+			return serializer;
+		} else {
+			throw new IllegalStateException("Serializer not yet initialized.");
+		}
+	}
+
+	/**
+	 * Sets the name for queries of state created from this descriptor.
+	 *
+	 * <p>If a name is set, the created state will be published for queries
+	 * during runtime. The name needs to be unique per job. If there is another
+	 * state instance published under the same name, the job will fail during runtime.
+	 *
+	 * @param queryableStateName State name for queries (unique name per job)
+	 * @throws IllegalStateException If queryable state name already set
+	 */
+	public void setQueryable(String queryableStateName) {
+		if (this.queryableStateName == null) {
+			this.queryableStateName = Preconditions.checkNotNull(queryableStateName, "Registration name");
+		} else {
+			throw new IllegalStateException("Queryable state name already set");
+		}
+	}
+
+	/**
+	 * Returns the queryable state name.
+	 *
+	 * @return Queryable state name or <code>null</code> if not set.
+	 */
+	public String getQueryableStateName() {
+		return queryableStateName;
+	}
+
+	/**
+	 * Returns whether the state created from this descriptor is queryable.
+	 *
+	 * @return <code>true</code> if state is queryable, <code>false</code>
+	 * otherwise.
+	 */
+	public boolean isQueryable() {
+		return queryableStateName != null;
+	}
+
+	/**
+	 * Creates a new {@link State} on the given {@link StateBackend}.
+	 *
+	 * @param stateBackend The {@code StateBackend} on which to create the {@link State}.
+	 */
+	public abstract S bind(StateBackend stateBackend) throws Exception;
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Checks whether the serializer has been initialized. Serializer initialization is lazy,
+	 * to allow parametrization of serializers with an {@link ExecutionConfig} via
+	 * {@link #initializeSerializerUnlessSet(ExecutionConfig)}.
+	 *
+	 * @return True if the serializers have been initialized, false otherwise.
+	 */
+	public boolean isSerializerInitialized() {
+		return serializer != null;
+	}
+
+	/**
+	 * Initializes the serializer, unless it has been initialized before.
+	 *
+	 * @param executionConfig The execution config to use when creating the serializer.
+	 */
+	public void initializeSerializerUnlessSet(ExecutionConfig executionConfig) {
+		if (serializer == null) {
+			if (typeInfo != null) {
+				serializer = typeInfo.createSerializer(executionConfig);
+			} else {
+				throw new IllegalStateException(
+						"Cannot initialize serializer after TypeInformation was dropped during serialization");
+			}
+		}
+	}
+
+	/**
+	 * This method should be called by subclasses prior to serialization. Because the TypeInformation is
+	 * not always serializable, it is 'transient' and dropped during serialization. Hence, the descriptor
+	 * needs to make sure that the serializer is created before the TypeInformation is dropped.
+	 */
+	private void ensureSerializerCreated() {
+		if (serializer == null) {
+			if (typeInfo != null) {
+				serializer = typeInfo.createSerializer(new ExecutionConfig());
+			} else {
+				throw new IllegalStateException(
+						"Cannot initialize serializer after TypeInformation was dropped during serialization");
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Standard Utils
+	// ------------------------------------------------------------------------
+
+	@Override
+	public abstract int hashCode();
+
+	@Override
+	public abstract boolean equals(Object o);
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() +
+				"{name=" + name +
+				", defaultValue=" + defaultValue +
+				", serializer=" + serializer +
+				(isQueryable() ? ", queryableStateName=" + queryableStateName + "" : "") +
+				'}';
+	}
+
+	public abstract org.apache.flink.api.common.state.StateDescriptor.Type getType();
+
+	// ------------------------------------------------------------------------
+	//  Serialization
+	// ------------------------------------------------------------------------
+
+	private void writeObject(final ObjectOutputStream out) throws IOException {
+		// make sure we have a serializer before the type information gets lost
+		ensureSerializerCreated();
+
+		// write all the non-transient fields
+		out.defaultWriteObject();
+
+		// write the non-serializable default value field
+		if (defaultValue == null) {
+			// we don't have a default value
+			out.writeBoolean(false);
+		} else {
+			// we have a default value
+			out.writeBoolean(true);
+
+			byte[] serializedDefaultValue;
+			try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+				DataOutputViewStreamWrapper outView = new DataOutputViewStreamWrapper(baos))
+			{
+				TypeSerializer<T> duplicateSerializer = serializer.duplicate();
+				duplicateSerializer.serialize(defaultValue, outView);
+
+				outView.flush();
+				serializedDefaultValue = baos.toByteArray();
+			}
+			catch (Exception e) {
+				throw new IOException("Unable to serialize default value of type " +
+						defaultValue.getClass().getSimpleName() + ".", e);
+			}
+
+			out.writeInt(serializedDefaultValue.length);
+			out.write(serializedDefaultValue);
+		}
+	}
+
+	private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+		// read the non-transient fields
+		in.defaultReadObject();
+
+		// read the default value field
+		boolean hasDefaultValue = in.readBoolean();
+		if (hasDefaultValue) {
+			int size = in.readInt();
+
+			byte[] buffer = new byte[size];
+
+			in.readFully(buffer);
+
+			try (ByteArrayInputStream bais = new ByteArrayInputStream(buffer);
+				DataInputViewStreamWrapper inView = new DataInputViewStreamWrapper(bais))
+			{
+				defaultValue = serializer.deserialize(inView);
+			}
+			catch (Exception e) {
+				throw new IOException("Unable to deserialize default value.", e);
+			}
+		} else {
+			defaultValue = null;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/ValueStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/ValueStateDescriptor.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.migration.api.common.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+/**
+ * {@link StateDescriptor} for {@link ValueState}.
+ *
+ * @param <T> The type of the values that the value state can hold.
+ */
+@PublicEvolving
+public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Creates a new {@code ValueStateDescriptor} with the given name, type, and default value.
+	 *
+	 * <p>If this constructor fails (because it is not possible to describe the type via a class),
+	 * consider using the {@link #ValueStateDescriptor(String, TypeInformation, Object)} constructor.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param typeClass The type of the values in the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting
+	 *                     a value before.
+	 */
+	public ValueStateDescriptor(String name, Class<T> typeClass, T defaultValue) {
+		super(name, typeClass, defaultValue);
+	}
+
+	/**
+	 * Creates a new {@code ValueStateDescriptor} with the given name and default value.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param typeInfo The type of the values in the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting
+	 *                     a value before.
+	 */
+	public ValueStateDescriptor(String name, TypeInformation<T> typeInfo, T defaultValue) {
+		super(name, typeInfo, defaultValue);
+	}
+
+	/**
+	 * Creates a new {@code ValueStateDescriptor} with the given name, default value, and the specific
+	 * serializer.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param typeSerializer The type serializer of the values in the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting
+	 *                     a value before.
+	 */
+	public ValueStateDescriptor(String name, TypeSerializer<T> typeSerializer, T defaultValue) {
+		super(name, typeSerializer, defaultValue);
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public ValueState<T> bind(StateBackend stateBackend) throws Exception {
+		return stateBackend.createValueState(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		ValueStateDescriptor<?> that = (ValueStateDescriptor<?>) o;
+
+		return serializer.equals(that.serializer) && name.equals(that.name);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = serializer.hashCode();
+		result = 31 * result + name.hashCode();
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "ValueStateDescriptor{" +
+				"name=" + name +
+				", defaultValue=" + defaultValue +
+				", serializer=" + serializer +
+				'}';
+	}
+
+	@Override
+	public org.apache.flink.api.common.state.StateDescriptor.Type getType() {
+		return org.apache.flink.api.common.state.StateDescriptor.Type.VALUE;
+	}
+}
+

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/KvStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/KvStateSnapshot.java
@@ -19,10 +19,10 @@
 package org.apache.flink.migration.runtime.state;
 
 import org.apache.flink.api.common.state.State;
-import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.migration.api.common.state.StateDescriptor;
 
 @Deprecated
-public interface KvStateSnapshot<K, N, S extends State, SD extends StateDescriptor<S, ?>>
+public interface KvStateSnapshot<K, N, S extends State<?>, SD extends StateDescriptor<S, ?>>
 		extends StateObject {
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/AbstractFsStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/AbstractFsStateSnapshot.java
@@ -19,9 +19,9 @@
 package org.apache.flink.migration.runtime.state.filesystem;
 
 import org.apache.flink.api.common.state.State;
-import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.migration.api.common.state.StateDescriptor;
 import org.apache.flink.migration.runtime.state.KvStateSnapshot;
 
 import java.io.IOException;
@@ -34,7 +34,7 @@ import java.io.IOException;
  * @param <SV> The type of the state value.
  */
 @Deprecated
-public abstract class AbstractFsStateSnapshot<K, N, SV, S extends State, SD extends StateDescriptor<S, ?>> 
+public abstract class AbstractFsStateSnapshot<K, N, SV, S extends State<?>, SD extends StateDescriptor<S, ?>>
 		extends AbstractFileStateHandle implements KvStateSnapshot<K, N, S, SD> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsFoldingState.java
@@ -19,9 +19,9 @@
 package org.apache.flink.migration.runtime.state.filesystem;
 
 import org.apache.flink.api.common.state.FoldingState;
-import org.apache.flink.api.common.state.FoldingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.migration.api.common.state.FoldingStateDescriptor;
 
 @Deprecated
 public class FsFoldingState<K, N, T, ACC> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsListState.java
@@ -19,9 +19,9 @@
 package org.apache.flink.migration.runtime.state.filesystem;
 
 import org.apache.flink.api.common.state.ListState;
-import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.migration.api.common.state.ListStateDescriptor;
 
 import java.util.ArrayList;
 

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsReducingState.java
@@ -19,9 +19,9 @@
 package org.apache.flink.migration.runtime.state.filesystem;
 
 import org.apache.flink.api.common.state.ReducingState;
-import org.apache.flink.api.common.state.ReducingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.migration.api.common.state.ReducingStateDescriptor;
 
 @Deprecated
 public class FsReducingState<K, N, V> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsValueState.java
@@ -19,9 +19,9 @@
 package org.apache.flink.migration.runtime.state.filesystem;
 
 import org.apache.flink.api.common.state.ValueState;
-import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.migration.api.common.state.ValueStateDescriptor;
 
 @Deprecated
 public class FsValueState<K, N, V> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/AbstractMemStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/AbstractMemStateSnapshot.java
@@ -19,8 +19,8 @@
 package org.apache.flink.migration.runtime.state.memory;
 
 import org.apache.flink.api.common.state.State;
-import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.migration.api.common.state.StateDescriptor;
 import org.apache.flink.migration.runtime.state.KvStateSnapshot;
 import org.apache.flink.runtime.util.DataInputDeserializer;
 
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Deprecated
-public abstract class AbstractMemStateSnapshot<K, N, SV, S extends State, SD extends StateDescriptor<S, ?>> 
+public abstract class AbstractMemStateSnapshot<K, N, SV, S extends State<?>, SD extends StateDescriptor<S, ?>>
 		implements KvStateSnapshot<K, N, S, SD> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemFoldingState.java
@@ -19,8 +19,8 @@
 package org.apache.flink.migration.runtime.state.memory;
 
 import org.apache.flink.api.common.state.FoldingState;
-import org.apache.flink.api.common.state.FoldingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.migration.api.common.state.FoldingStateDescriptor;
 
 @Deprecated
 public class MemFoldingState<K, N, T, ACC> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemListState.java
@@ -19,8 +19,8 @@
 package org.apache.flink.migration.runtime.state.memory;
 
 import org.apache.flink.api.common.state.ListState;
-import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.migration.api.common.state.ListStateDescriptor;
 
 import java.util.ArrayList;
 

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemReducingState.java
@@ -19,8 +19,8 @@
 package org.apache.flink.migration.runtime.state.memory;
 
 import org.apache.flink.api.common.state.ReducingState;
-import org.apache.flink.api.common.state.ReducingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.migration.api.common.state.ReducingStateDescriptor;
 
 /**
  * Heap-backed partitioned {@link ReducingState} that is

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemValueState.java
@@ -19,8 +19,8 @@
 package org.apache.flink.migration.runtime.state.memory;
 
 import org.apache.flink.api.common.state.ValueState;
-import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.migration.api.common.state.ValueStateDescriptor;
 
 /**
  * Heap-backed key/value state that is snapshotted into a serialized memory copy.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -214,7 +214,7 @@ public abstract class AbstractKeyedStateBackend<K>
 	 */
 	@Override
 	@SuppressWarnings({"rawtypes", "unchecked"})
-	public <N, V, S extends State<V>> S getPartitionedState(final N namespace, final TypeSerializer<N> namespaceSerializer, final StateDescriptor<S> stateDescriptor) throws Exception {
+	public <N, S extends State<?>> S getPartitionedState(final N namespace, final TypeSerializer<N> namespaceSerializer, final StateDescriptor<S> stateDescriptor) throws Exception {
 		Preconditions.checkNotNull(namespace, "Namespace");
 		Preconditions.checkNotNull(namespaceSerializer, "Namespace serializer");
 
@@ -292,7 +292,7 @@ public abstract class AbstractKeyedStateBackend<K>
 
 	@Override
 	@SuppressWarnings("unchecked,rawtypes")
-	public <N, V, S extends MergingState<?, V>> void mergePartitionedStates(final N target, Collection<N> sources, final TypeSerializer<N> namespaceSerializer, final StateDescriptor<S> stateDescriptor) throws Exception {
+	public <N, S extends MergingState<?, ?>> void mergePartitionedStates(final N target, Collection<N> sources, final TypeSerializer<N> namespaceSerializer, final StateDescriptor<S> stateDescriptor) throws Exception {
 		if (stateDescriptor instanceof ReducingStateDescriptor) {
 			ReducingStateDescriptor reducingStateDescriptor = (ReducingStateDescriptor) stateDescriptor;
 			ReduceFunction reduceFn = reducingStateDescriptor.getReduceFunction();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -214,7 +214,7 @@ public abstract class AbstractKeyedStateBackend<K>
 	 */
 	@Override
 	@SuppressWarnings({"rawtypes", "unchecked"})
-	public <N, S extends State> S getPartitionedState(final N namespace, final TypeSerializer<N> namespaceSerializer, final StateDescriptor<S, ?> stateDescriptor) throws Exception {
+	public <N, V, S extends State<V>> S getPartitionedState(final N namespace, final TypeSerializer<N> namespaceSerializer, final StateDescriptor<S> stateDescriptor) throws Exception {
 		Preconditions.checkNotNull(namespace, "Namespace");
 		Preconditions.checkNotNull(namespaceSerializer, "Namespace serializer");
 
@@ -292,7 +292,7 @@ public abstract class AbstractKeyedStateBackend<K>
 
 	@Override
 	@SuppressWarnings("unchecked,rawtypes")
-	public <N, S extends MergingState<?, ?>> void mergePartitionedStates(final N target, Collection<N> sources, final TypeSerializer<N> namespaceSerializer, final StateDescriptor<S, ?> stateDescriptor) throws Exception {
+	public <N, V, S extends MergingState<?, V>> void mergePartitionedStates(final N target, Collection<N> sources, final TypeSerializer<N> namespaceSerializer, final StateDescriptor<S> stateDescriptor) throws Exception {
 		if (stateDescriptor instanceof ReducingStateDescriptor) {
 			ReducingStateDescriptor reducingStateDescriptor = (ReducingStateDescriptor) stateDescriptor;
 			ReduceFunction reduceFn = reducingStateDescriptor.getReduceFunction();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultKeyedStateStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultKeyedStateStore.java
@@ -93,7 +93,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
 		}
 	}
 
-	private <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) throws Exception {
+	private <V, S extends State<V>> S getPartitionedState(StateDescriptor<S> stateDescriptor) throws Exception {
 		return keyedStateBackend.getPartitionedState(
 				VoidNamespace.INSTANCE,
 				VoidNamespaceSerializer.INSTANCE,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -106,7 +106,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 		Preconditions.checkNotNull(stateDescriptor);
 
 		String name = Preconditions.checkNotNull(stateDescriptor.getName());
-		TypeSerializer<S> partitionStateSerializer = Preconditions.checkNotNull(stateDescriptor.getSerializer());
+		TypeSerializer<S> partitionStateSerializer = Preconditions.checkNotNull(stateDescriptor.getElemSerializer());
 
 		@SuppressWarnings("unchecked")
 		PartitionableListState<S> partitionableListState = (PartitionableListState<S>) registeredStates.get(name);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -126,8 +126,8 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 							partitionableListState.getAssignmentMode());
 			Preconditions.checkState(
 					partitionableListState.getPartitionStateSerializer().
-							isCompatibleWith(stateDescriptor.getSerializer()),
-					"Incompatible type serializers. Provided: " + stateDescriptor.getSerializer() +
+							isCompatibleWith(stateDescriptor.getElemSerializer()),
+					"Incompatible type serializers. Provided: " + stateDescriptor.getElemSerializer() +
 							", found: " + partitionableListState.getPartitionStateSerializer());
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/GenericFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/GenericFoldingState.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.state.FoldingState;
 import org.apache.flink.api.common.state.ValueState;
 
+import java.io.IOException;
+
 /**
  * Generic implementation of {@link FoldingState} based on a wrapped {@link ValueState}.
  *
@@ -63,13 +65,13 @@ public class GenericFoldingState<N, T, ACC, W extends ValueState<ACC> & KvState<
 	}
 
 	@Override
-	public ACC get() throws Exception {
-		return wrappedState.value();
+	public ACC get() throws IOException {
+		return wrappedState.get();
 	}
 
 	@Override
 	public void add(T value) throws Exception {
-		ACC currentValue = wrappedState.value();
+		ACC currentValue = wrappedState.get();
 		wrappedState.update(foldFunction.fold(currentValue, value));
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/GenericListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/GenericListState.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ValueState;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 /**
@@ -60,13 +61,13 @@ public class GenericListState<N, T, W extends ValueState<ArrayList<T>> & KvState
 	}
 
 	@Override
-	public Iterable<T> get() throws Exception {
-		return wrappedState.value();
+	public Iterable<T> get() throws IOException {
+		return wrappedState.get();
 	}
 
 	@Override
 	public void add(T value) throws Exception {
-		ArrayList<T> currentValue = wrappedState.value();
+		ArrayList<T> currentValue = wrappedState.get();
 		if (currentValue == null) {
 			currentValue = new ArrayList<>();
 			currentValue.add(value);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/GenericReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/GenericReducingState.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.state.ReducingState;
 import org.apache.flink.api.common.state.ValueState;
 
+import java.io.IOException;
+
 /**
  * Generic implementation of {@link ReducingState} based on a wrapped {@link ValueState}.
  *
@@ -62,13 +64,13 @@ public class GenericReducingState<N, T, W extends ValueState<T> & KvState<N>>
 	}
 
 	@Override
-	public T get() throws Exception {
-		return wrappedState.value();
+	public T get() throws IOException {
+		return wrappedState.get();
 	}
 
 	@Override
 	public void add(T value) throws Exception {
-		T currentValue = wrappedState.value();
+		T currentValue = wrappedState.get();
 		if (currentValue == null) {
 			wrappedState.update(value);
 		} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -69,7 +69,6 @@ public interface KeyedStateBackend<K> {
 	 * @param stateDescriptor The identifier for the state. This contains name and can create a default state value.
 
 	 * @param <N> The type of the namespace.
-	 * @param <V> The type of the values in the state.
 	 * @param <S> The type of the state.
 	 *
 	 * @return A new key/value state backed by this backend.
@@ -77,14 +76,14 @@ public interface KeyedStateBackend<K> {
 	 * @throws Exception Exceptions may occur during initialization of the state and should be forwarded.
 	 */
 	@SuppressWarnings({"rawtypes", "unchecked"})
-	<N, V, S extends State<V>> S getPartitionedState(
+	<N, S extends State<?>> S getPartitionedState(
 			N namespace,
 			TypeSerializer<N> namespaceSerializer,
 			StateDescriptor<S> stateDescriptor) throws Exception;
 
 
 	@SuppressWarnings("unchecked,rawtypes")
-	<N, V, S extends MergingState<?, V>> void mergePartitionedStates(
+	<N, S extends MergingState<?, ?>> void mergePartitionedStates(
 			N target,
 			Collection<N> sources,
 			TypeSerializer<N> namespaceSerializer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -69,6 +69,7 @@ public interface KeyedStateBackend<K> {
 	 * @param stateDescriptor The identifier for the state. This contains name and can create a default state value.
 
 	 * @param <N> The type of the namespace.
+	 * @param <V> The type of the values in the state.
 	 * @param <S> The type of the state.
 	 *
 	 * @return A new key/value state backed by this backend.
@@ -76,18 +77,18 @@ public interface KeyedStateBackend<K> {
 	 * @throws Exception Exceptions may occur during initialization of the state and should be forwarded.
 	 */
 	@SuppressWarnings({"rawtypes", "unchecked"})
-	<N, S extends State> S getPartitionedState(
+	<N, V, S extends State<V>> S getPartitionedState(
 			N namespace,
 			TypeSerializer<N> namespaceSerializer,
-			StateDescriptor<S, ?> stateDescriptor) throws Exception;
+			StateDescriptor<S> stateDescriptor) throws Exception;
 
 
 	@SuppressWarnings("unchecked,rawtypes")
-	<N, S extends MergingState<?, ?>> void mergePartitionedStates(
+	<N, V, S extends MergingState<?, V>> void mergePartitionedStates(
 			N target,
 			Collection<N> sources,
 			TypeSerializer<N> namespaceSerializer,
-			StateDescriptor<S, ?> stateDescriptor) throws Exception;
+			StateDescriptor<S> stateDescriptor) throws Exception;
 
 	/**
 	 * Closes the backend and releases all resources.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingListState.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.state.ListState;
 
+import java.io.IOException;
 import java.util.Collections;
 
 /**
@@ -40,7 +41,7 @@ class UserFacingListState<T> implements ListState<T> {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public Iterable<T> get() throws Exception {
+	public Iterable<T> get() throws IOException {
 		Iterable<T> original = originalState.get();
 		return original != null ? original : emptyState;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapState.java
@@ -67,13 +67,11 @@ public abstract class AbstractHeapState<K, N, SV, SD extends StateDescriptor<?>>
 	 *                           and can create a default state value.
 	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
 	 */
-	protected AbstractHeapState(
-			KeyedStateBackend<K> backend,
+	protected AbstractHeapState(KeyedStateBackend<K> backend,
 			SD stateDesc,
 			StateTable<K, N, SV> stateTable,
 			TypeSerializer<K> keySerializer,
 			TypeSerializer<N> namespaceSerializer) {
-
 		Preconditions.checkNotNull(stateTable, "State table must not be null.");
 
 		this.backend = backend;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
@@ -48,13 +48,11 @@ public class HeapFoldingState<K, N, T, ACC> extends HeapSimpleState<K, N, ACC> i
 	 * @param stateDesc The state identifier for the state. This contains name and can create a default state value.
 	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
 	 */
-	public HeapFoldingState(
-		KeyedStateBackend<K> backend,
-		FoldingStateDescriptor<T, ACC> stateDesc,
-		StateTable<K, N, ACC> stateTable,
-		TypeSerializer<K> keySerializer,
-		TypeSerializer<N> namespaceSerializer
-	) {
+	public HeapFoldingState(KeyedStateBackend<K> backend,
+			FoldingStateDescriptor<T, ACC> stateDesc,
+			StateTable<K, N, ACC> stateTable,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer) {
 		super(backend, stateDesc, stateTable, keySerializer, namespaceSerializer);
 		this.foldFunction = stateDesc.getFoldFunction();
 	}
@@ -81,13 +79,12 @@ public class HeapFoldingState<K, N, T, ACC> extends HeapSimpleState<K, N, ACC> i
 			namespaceMap.put(currentNamespace, keyedMap);
 		}
 
-		ACC currentValue = keyedMap.get(backend.<K>getCurrentKey());
+		ACC currentValue = keyedMap.get(backend.getCurrentKey());
 		try {
-
 			if (currentValue == null) {
-				keyedMap.put(backend.<K>getCurrentKey(), foldFunction.fold(stateDesc.getDefaultValue(), value));
+				keyedMap.put(backend.getCurrentKey(), foldFunction.fold(stateDesc.getDefaultValue(), value));
 			} else {
-				keyedMap.put(backend.<K>getCurrentKey(), foldFunction.fold(currentValue, value));
+				keyedMap.put(backend.getCurrentKey(), foldFunction.fold(currentValue, value));
 			}
 		} catch (Exception e) {
 			throw new RuntimeException("Could not add value to folding state.", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
@@ -39,6 +39,7 @@ import java.util.Map;
  */
 public class HeapFoldingState<K, N, T, ACC> extends HeapSimpleState<K, N, ACC> implements FoldingState<T, ACC> {
 
+	private final ACC initialValue;
 	private final FoldFunction<T, ACC> foldFunction;
 
 	/**
@@ -54,6 +55,7 @@ public class HeapFoldingState<K, N, T, ACC> extends HeapSimpleState<K, N, ACC> i
 			TypeSerializer<K> keySerializer,
 			TypeSerializer<N> namespaceSerializer) {
 		super(backend, stateDesc, stateTable, keySerializer, namespaceSerializer);
+		this.initialValue = stateDesc.getInitialValue();
 		this.foldFunction = stateDesc.getFoldFunction();
 	}
 
@@ -82,7 +84,7 @@ public class HeapFoldingState<K, N, T, ACC> extends HeapSimpleState<K, N, ACC> i
 		ACC currentValue = keyedMap.get(backend.getCurrentKey());
 		try {
 			if (currentValue == null) {
-				keyedMap.put(backend.getCurrentKey(), foldFunction.fold(stateDesc.getDefaultValue(), value));
+				keyedMap.put(backend.getCurrentKey(), foldFunction.fold(initialValue, value));
 			} else {
 				keyedMap.put(backend.getCurrentKey(), foldFunction.fold(currentValue, value));
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
@@ -37,9 +37,7 @@ import java.util.Map;
  * @param <T> The type of the values that can be folded into the state.
  * @param <ACC> The type of the value in the folding state.
  */
-public class HeapFoldingState<K, N, T, ACC>
-		extends AbstractHeapState<K, N, ACC, FoldingState<T, ACC>, FoldingStateDescriptor<T, ACC>>
-		implements FoldingState<T, ACC> {
+public class HeapFoldingState<K, N, T, ACC> extends HeapSimpleState<K, N, ACC> implements FoldingState<T, ACC> {
 
 	private final FoldFunction<T, ACC> foldFunction;
 
@@ -47,39 +45,18 @@ public class HeapFoldingState<K, N, T, ACC>
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
 	 * @param backend The state backend backing that created this state.
-	 * @param stateDesc The state identifier for the state. This contains name
-	 *                           and can create a default state value.
+	 * @param stateDesc The state identifier for the state. This contains name and can create a default state value.
 	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
 	 */
 	public HeapFoldingState(
-			KeyedStateBackend<K> backend,
-			FoldingStateDescriptor<T, ACC> stateDesc,
-			StateTable<K, N, ACC> stateTable,
-			TypeSerializer<K> keySerializer,
-			TypeSerializer<N> namespaceSerializer) {
+		KeyedStateBackend<K> backend,
+		FoldingStateDescriptor<T, ACC> stateDesc,
+		StateTable<K, N, ACC> stateTable,
+		TypeSerializer<K> keySerializer,
+		TypeSerializer<N> namespaceSerializer
+	) {
 		super(backend, stateDesc, stateTable, keySerializer, namespaceSerializer);
 		this.foldFunction = stateDesc.getFoldFunction();
-	}
-
-	@Override
-	public ACC get() {
-		Preconditions.checkState(currentNamespace != null, "No namespace set.");
-		Preconditions.checkState(backend.getCurrentKey() != null, "No key set.");
-
-		Map<N, Map<K, ACC>> namespaceMap =
-				stateTable.get(backend.getCurrentKeyGroupIndex());
-
-		if (namespaceMap == null) {
-			return null;
-		}
-
-		Map<K, ACC> keyedMap = namespaceMap.get(currentNamespace);
-
-		if (keyedMap == null) {
-			return null;
-		}
-
-		return keyedMap.get(backend.<K>getCurrentKey());
 	}
 
 	@Override
@@ -92,28 +69,23 @@ public class HeapFoldingState<K, N, T, ACC>
 			return;
 		}
 
-		Map<N, Map<K, ACC>> namespaceMap =
-				stateTable.get(backend.getCurrentKeyGroupIndex());
-
+		Map<N, Map<K, ACC>> namespaceMap = stateTable.get(backend.getCurrentKeyGroupIndex());
 		if (namespaceMap == null) {
 			namespaceMap = createNewMap();
 			stateTable.set(backend.getCurrentKeyGroupIndex(), namespaceMap);
 		}
 
 		Map<K, ACC> keyedMap = namespaceMap.get(currentNamespace);
-
 		if (keyedMap == null) {
 			keyedMap = createNewMap();
 			namespaceMap.put(currentNamespace, keyedMap);
 		}
 
 		ACC currentValue = keyedMap.get(backend.<K>getCurrentKey());
-
 		try {
 
 			if (currentValue == null) {
-				keyedMap.put(backend.<K>getCurrentKey(),
-						foldFunction.fold(stateDesc.getDefaultValue(), value));
+				keyedMap.put(backend.<K>getCurrentKey(), foldFunction.fold(stateDesc.getDefaultValue(), value));
 			} else {
 				keyedMap.put(backend.<K>getCurrentKey(), foldFunction.fold(currentValue, value));
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -102,19 +102,6 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	//  state backend operations
 	// ------------------------------------------------------------------------
 
-	@SuppressWarnings("unchecked")
-	private <N, V> StateTable<K, N, V> tryRegisterStateTable(
-			TypeSerializer<N> namespaceSerializer, StateDescriptor<?, V> stateDesc) {
-
-		String name = stateDesc.getName();
-		StateTable<K, N, V> stateTable = (StateTable<K, N, V>) stateTables.get(name);
-
-		RegisteredBackendStateMetaInfo<N, V> newMetaInfo =
-				new RegisteredBackendStateMetaInfo<>(stateDesc.getType(), name, namespaceSerializer, stateDesc.getSerializer());
-
-		return tryRegisterStateTable(stateTable, newMetaInfo);
-	}
-
 	private <N, V> StateTable<K, N, V> tryRegisterStateTable(
 			StateTable<K, N, V> stateTable, RegisteredBackendStateMetaInfo<N, V> newMetaInfo) {
 
@@ -134,7 +121,13 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	@SuppressWarnings("unchecked")
 	@Override
 	public <N, V> ValueState<V> createValueState(TypeSerializer<N> namespaceSerializer, ValueStateDescriptor<V> stateDesc) throws Exception {
-		StateTable<K, N, V> stateTable = tryRegisterStateTable(namespaceSerializer, stateDesc);
+		String name = stateDesc.getName();
+		StateTable<K, N, V> stateTable = (StateTable<K, N, V>) stateTables.get(name);
+
+		RegisteredBackendStateMetaInfo<N, V> newMetaInfo =
+				new RegisteredBackendStateMetaInfo<>(stateDesc.getType(), name, namespaceSerializer, stateDesc.getSerializer());
+
+		stateTable = tryRegisterStateTable(stateTable, newMetaInfo);
 		return new HeapValueState<>(this, stateDesc, stateTable, keySerializer, namespaceSerializer);
 	}
 
@@ -145,7 +138,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		StateTable<K, N, ArrayList<T>> stateTable = (StateTable<K, N, ArrayList<T>>) stateTables.get(name);
 
 		RegisteredBackendStateMetaInfo<N, ArrayList<T>> newMetaInfo =
-				new RegisteredBackendStateMetaInfo<>(stateDesc.getType(), name, namespaceSerializer, new ArrayListSerializer<>(stateDesc.getSerializer()));
+				new RegisteredBackendStateMetaInfo<>(stateDesc.getType(), name, namespaceSerializer, new ArrayListSerializer<>(stateDesc.getElemSerializer()));
 
 		stateTable = tryRegisterStateTable(stateTable, newMetaInfo);
 		return new HeapListState<>(this, stateDesc, stateTable, keySerializer, namespaceSerializer);
@@ -154,13 +147,25 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	@SuppressWarnings("unchecked")
 	@Override
 	public <N, T> ReducingState<T> createReducingState(TypeSerializer<N> namespaceSerializer, ReducingStateDescriptor<T> stateDesc) throws Exception {
-		StateTable<K, N, T> stateTable = tryRegisterStateTable(namespaceSerializer, stateDesc);
+		String name = stateDesc.getName();
+		StateTable<K, N, T> stateTable = (StateTable<K, N, T>) stateTables.get(name);
+
+		RegisteredBackendStateMetaInfo<N, T> newMetaInfo =
+				new RegisteredBackendStateMetaInfo<>(stateDesc.getType(), name, namespaceSerializer, stateDesc.getSerializer());
+
+		stateTable = tryRegisterStateTable(stateTable, newMetaInfo);
 		return new HeapReducingState<>(this, stateDesc, stateTable, keySerializer, namespaceSerializer);
 	}
 	@SuppressWarnings("unchecked")
 	@Override
 	protected <N, T, ACC> FoldingState<T, ACC> createFoldingState(TypeSerializer<N> namespaceSerializer, FoldingStateDescriptor<T, ACC> stateDesc) throws Exception {
-		StateTable<K, N, ACC> stateTable = tryRegisterStateTable(namespaceSerializer, stateDesc);
+		String name = stateDesc.getName();
+		StateTable<K, N, ACC> stateTable = (StateTable<K, N, ACC>) stateTables.get(name);
+
+		RegisteredBackendStateMetaInfo<N, ACC> newMetaInfo =
+				new RegisteredBackendStateMetaInfo<>(stateDesc.getType(), name, namespaceSerializer, stateDesc.getSerializer());
+
+		stateTable = tryRegisterStateTable(stateTable, newMetaInfo);
 		return new HeapFoldingState<>(this, stateDesc, stateTable, keySerializer, namespaceSerializer);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -88,13 +88,11 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	 */
 	private final Map<String, StateTable<K, ?, ?>> stateTables = new HashMap<>();
 
-	public HeapKeyedStateBackend(
-			TaskKvStateRegistry kvStateRegistry,
+	public HeapKeyedStateBackend(TaskKvStateRegistry kvStateRegistry,
 			TypeSerializer<K> keySerializer,
 			ClassLoader userCodeClassLoader,
 			int numberOfKeyGroups,
 			KeyGroupRange keyGroupRange) {
-
 		super(kvStateRegistry, keySerializer, userCodeClassLoader, numberOfKeyGroups, keyGroupRange);
 
 		LOG.info("Initializing heap keyed state backend with stream factory.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
@@ -48,13 +48,11 @@ public class HeapListState<K, N, V>
 	 * @param stateDesc The state identifier for the state. This contains name and can create a default state value.
 	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
 	 */
-	public HeapListState(
-		KeyedStateBackend<K> backend,
-		ListStateDescriptor<V> stateDesc,
-		StateTable<K, N, ArrayList<V>> stateTable,
-		TypeSerializer<K> keySerializer,
-		TypeSerializer<N> namespaceSerializer
-	) {
+	public HeapListState(KeyedStateBackend<K> backend,
+			ListStateDescriptor<V> stateDesc,
+			StateTable<K, N, ArrayList<V>> stateTable,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer) {
 		super(backend, stateDesc, stateTable, keySerializer, namespaceSerializer);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.util.Preconditions;
 
@@ -39,23 +38,23 @@ import java.util.Map;
  * @param <V> The type of the value.
  */
 public class HeapListState<K, N, V>
-		extends AbstractHeapState<K, N, ArrayList<V>, ListState<V>, ListStateDescriptor<V>>
+		extends AbstractHeapState<K, N, ArrayList<V>, ListStateDescriptor<V>>
 		implements ListState<V> {
 
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
 	 * @param backend The state backend backing that created this state.
-	 * @param stateDesc The state identifier for the state. This contains name
-	 *                           and can create a default state value.
+	 * @param stateDesc The state identifier for the state. This contains name and can create a default state value.
 	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
 	 */
 	public HeapListState(
-			KeyedStateBackend<K> backend,
-			ListStateDescriptor<V> stateDesc,
-			StateTable<K, N, ArrayList<V>> stateTable,
-			TypeSerializer<K> keySerializer,
-			TypeSerializer<N> namespaceSerializer) {
+		KeyedStateBackend<K> backend,
+		ListStateDescriptor<V> stateDesc,
+		StateTable<K, N, ArrayList<V>> stateTable,
+		TypeSerializer<K> keySerializer,
+		TypeSerializer<N> namespaceSerializer
+	) {
 		super(backend, stateDesc, stateTable, keySerializer, namespaceSerializer);
 	}
 
@@ -64,20 +63,38 @@ public class HeapListState<K, N, V>
 		Preconditions.checkState(currentNamespace != null, "No namespace set.");
 		Preconditions.checkState(backend.getCurrentKey() != null, "No key set.");
 
-		Map<N, Map<K, ArrayList<V>>> namespaceMap =
-				stateTable.get(backend.getCurrentKeyGroupIndex());
-
+		Map<N, Map<K, ArrayList<V>>> namespaceMap = stateTable.get(backend.getCurrentKeyGroupIndex());
 		if (namespaceMap == null) {
 			return null;
 		}
 
 		Map<K, ArrayList<V>> keyedMap = namespaceMap.get(currentNamespace);
-
 		if (keyedMap == null) {
 			return null;
 		}
 
 		return keyedMap.get(backend.<K>getCurrentKey());
+	}
+
+	@Override
+	public void clear() {
+		Preconditions.checkState(currentNamespace != null, "No namespace set.");
+		Preconditions.checkState(backend.getCurrentKey() != null, "No key set.");
+
+		Map<N, Map<K, ArrayList<V>>> namespaceMap = stateTable.get(backend.getCurrentKeyGroupIndex());
+		if (namespaceMap == null) {
+			return;
+		}
+
+		Map<K, ArrayList<V>> keyedMap = namespaceMap.get(currentNamespace);
+		if (keyedMap == null) {
+			return;
+		}
+
+		keyedMap.remove(backend.getCurrentKey());
+		if (keyedMap.isEmpty()) {
+			namespaceMap.remove(currentNamespace);
+		}
 	}
 
 	@Override
@@ -90,55 +107,48 @@ public class HeapListState<K, N, V>
 			return;
 		}
 
-		Map<N, Map<K, ArrayList<V>>> namespaceMap =
-				stateTable.get(backend.getCurrentKeyGroupIndex());
-
+		Map<N, Map<K, ArrayList<V>>> namespaceMap = stateTable.get(backend.getCurrentKeyGroupIndex());
 		if (namespaceMap == null) {
 			namespaceMap = createNewMap();
 			stateTable.set(backend.getCurrentKeyGroupIndex(), namespaceMap);
 		}
 
 		Map<K, ArrayList<V>> keyedMap = namespaceMap.get(currentNamespace);
-
 		if (keyedMap == null) {
 			keyedMap = createNewMap();
 			namespaceMap.put(currentNamespace, keyedMap);
 		}
 
 		ArrayList<V> list = keyedMap.get(backend.<K>getCurrentKey());
-
 		if (list == null) {
 			list = new ArrayList<>();
 			keyedMap.put(backend.<K>getCurrentKey(), list);
 		}
+
 		list.add(value);
 	}
 	
 	@Override
-	public byte[] getSerializedValue(K key, N namespace) throws Exception {
+	public byte[] getSerializedValue(int keyGroup, K key, N namespace) throws Exception {
 		Preconditions.checkState(namespace != null, "No namespace given.");
 		Preconditions.checkState(key != null, "No key given.");
 
-		Map<N, Map<K, ArrayList<V>>> namespaceMap =
-				stateTable.get(KeyGroupRangeAssignment.assignToKeyGroup(key, backend.getNumberOfKeyGroups()));
-
+		Map<N, Map<K, ArrayList<V>>> namespaceMap = stateTable.get(keyGroup);
 		if (namespaceMap == null) {
 			return null;
 		}
 
 		Map<K, ArrayList<V>> keyedMap = namespaceMap.get(currentNamespace);
-
 		if (keyedMap == null) {
 			return null;
 		}
 
 		ArrayList<V> result = keyedMap.get(key);
-
 		if (result == null) {
 			return null;
 		}
 
-		TypeSerializer<V> serializer = stateDesc.getSerializer();
+		TypeSerializer<V> serializer = stateDesc.getElemSerializer();
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(baos);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
@@ -48,13 +48,11 @@ public class HeapReducingState<K, N, V> extends HeapSimpleState<K, N, V> impleme
 	 *                           and can create a default state value.
 	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
 	 */
-	public HeapReducingState(
-		KeyedStateBackend<K> backend,
-		ReducingStateDescriptor<V> stateDesc,
-		StateTable<K, N, V> stateTable,
-		TypeSerializer<K> keySerializer,
-		TypeSerializer<N> namespaceSerializer
-	) {
+	public HeapReducingState(KeyedStateBackend<K> backend,
+			ReducingStateDescriptor<V> stateDesc,
+			StateTable<K, N, V> stateTable,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer) {
 		super(backend, stateDesc, stateTable, keySerializer, namespaceSerializer);
 		this.reduceFunction = stateDesc.getReduceFunction();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
@@ -36,9 +36,7 @@ import java.util.Map;
  * @param <N> The type of the namespace.
  * @param <V> The type of the value.
  */
-public class HeapReducingState<K, N, V>
-		extends AbstractHeapState<K, N, V, ReducingState<V>, ReducingStateDescriptor<V>>
-		implements ReducingState<V> {
+public class HeapReducingState<K, N, V> extends HeapSimpleState<K, N, V> implements ReducingState<V> {
 
 	private final ReduceFunction<V> reduceFunction;
 
@@ -51,34 +49,14 @@ public class HeapReducingState<K, N, V>
 	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
 	 */
 	public HeapReducingState(
-			KeyedStateBackend<K> backend,
-			ReducingStateDescriptor<V> stateDesc,
-			StateTable<K, N, V> stateTable,
-			TypeSerializer<K> keySerializer,
-			TypeSerializer<N> namespaceSerializer) {
+		KeyedStateBackend<K> backend,
+		ReducingStateDescriptor<V> stateDesc,
+		StateTable<K, N, V> stateTable,
+		TypeSerializer<K> keySerializer,
+		TypeSerializer<N> namespaceSerializer
+	) {
 		super(backend, stateDesc, stateTable, keySerializer, namespaceSerializer);
 		this.reduceFunction = stateDesc.getReduceFunction();
-	}
-
-	@Override
-	public V get() {
-		Preconditions.checkState(currentNamespace != null, "No namespace set.");
-		Preconditions.checkState(backend.getCurrentKey() != null, "No key set.");
-
-		Map<N, Map<K, V>> namespaceMap =
-				stateTable.get(backend.getCurrentKeyGroupIndex());
-
-		if (namespaceMap == null) {
-			return null;
-		}
-
-		Map<K, V> keyedMap = namespaceMap.get(currentNamespace);
-
-		if (keyedMap == null) {
-			return null;
-		}
-
-		return keyedMap.get(backend.<K>getCurrentKey());
 	}
 
 	@Override
@@ -91,33 +69,25 @@ public class HeapReducingState<K, N, V>
 			return;
 		}
 
-		Map<N, Map<K, V>> namespaceMap =
-				stateTable.get(backend.getCurrentKeyGroupIndex());
-
+		Map<N, Map<K, V>> namespaceMap = stateTable.get(backend.getCurrentKeyGroupIndex());
 		if (namespaceMap == null) {
 			namespaceMap = createNewMap();
 			stateTable.set(backend.getCurrentKeyGroupIndex(), namespaceMap);
 		}
 
 		Map<K, V> keyedMap = namespaceMap.get(currentNamespace);
-
 		if (keyedMap == null) {
 			keyedMap = createNewMap();
 			namespaceMap.put(currentNamespace, keyedMap);
 		}
 
 		V currentValue = keyedMap.put(backend.<K>getCurrentKey(), value);
-
-		if (currentValue == null) {
-			// we're good, just added the new value
-		} else {
-			V reducedValue = null;
+		if (currentValue != null) {
 			try {
-				reducedValue = reduceFunction.reduce(currentValue, value);
+				keyedMap.put(backend.<K>getCurrentKey(), reduceFunction.reduce(currentValue, value));
 			} catch (Exception e) {
 				throw new RuntimeException("Could not add value to reducing state.", e);
 			}
-			keyedMap.put(backend.<K>getCurrentKey(), reducedValue);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSimpleState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSimpleState.java
@@ -29,7 +29,7 @@ import org.apache.flink.util.Preconditions;
 import java.util.Map;
 
 /**
- * Heap-backed partitioned states whose values are not composited and is snapshotted into files.
+ * Heap-backed partitioned states whose values are not composited.
  *
  * @param <K> The type of the key.
  * @param <N> The type of the namespace.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSimpleState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSimpleState.java
@@ -34,9 +34,10 @@ import java.util.Map;
  * @param <K> The type of the key.
  * @param <N> The type of the namespace.
  * @param <V> The type of the value.
+ * @param <SD> The type of the state descriptor.
  */
-public class HeapSimpleState<K, N, V>
-	extends AbstractHeapState<K, N, V, SimpleStateDescriptor<V, ? extends State<V>>>
+public class HeapSimpleState<K, N, V, SD extends SimpleStateDescriptor<V, ? extends State<V>>>
+	extends AbstractHeapState<K, N, V, SD>
 	implements UpdatableState<V> {
 
 	/**
@@ -47,7 +48,7 @@ public class HeapSimpleState<K, N, V>
 	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
 	 */
 	public HeapSimpleState(KeyedStateBackend<K> backend,
-		SimpleStateDescriptor<V, ? extends State<V>> stateDesc,
+		SD stateDesc,
 		StateTable<K, N, V> stateTable,
 		TypeSerializer<K> keySerializer,
 		TypeSerializer<N> namespaceSerializer) {
@@ -87,17 +88,17 @@ public class HeapSimpleState<K, N, V>
 
 		Map<N, Map<K, V>> namespaceMap = stateTable.get(backend.getCurrentKeyGroupIndex());
 		if (namespaceMap == null) {
-			return stateDesc.getDefaultValue();
+			return null;
 		}
 
 		Map<K, V> keyedMap = namespaceMap.get(currentNamespace);
 		if (keyedMap == null) {
-			return stateDesc.getDefaultValue();
+			return null;
 		}
 
 		V result = keyedMap.get(backend.getCurrentKey());
 		if (result == null) {
-			return stateDesc.getDefaultValue();
+			return null;
 		}
 
 		return result;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSimpleState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSimpleState.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.api.common.state.SimpleStateDescriptor;
 import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.UpdatableState;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
 import org.apache.flink.runtime.state.KeyedStateBackend;
@@ -36,7 +37,7 @@ import java.util.Map;
  */
 public class HeapSimpleState<K, N, V>
 	extends AbstractHeapState<K, N, V, SimpleStateDescriptor<V, ? extends State<V>>>
-	implements State<V> {
+	implements UpdatableState<V> {
 
 	/**
 	 * Creates a new simple state for the given hash map of key/value pairs.
@@ -45,12 +46,12 @@ public class HeapSimpleState<K, N, V>
 	 * @param stateDesc The state identifier for the state. This contains name and can create a default state value.
 	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
 	 */
-	public HeapSimpleState(
-		KeyedStateBackend<K> backend,
+	public HeapSimpleState(KeyedStateBackend<K> backend,
 		SimpleStateDescriptor<V, ? extends State<V>> stateDesc,
 		StateTable<K, N, V> stateTable,
 		TypeSerializer<K> keySerializer,
 		TypeSerializer<N> namespaceSerializer) {
+
 		super(backend, stateDesc, stateTable, keySerializer, namespaceSerializer);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSimpleState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSimpleState.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.heap;
+
+import org.apache.flink.api.common.state.SimpleStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Map;
+
+/**
+ * Heap-backed partitioned states whose values are not composited and is snapshotted into files.
+ *
+ * @param <K> The type of the key.
+ * @param <N> The type of the namespace.
+ * @param <V> The type of the value.
+ */
+public class HeapSimpleState<K, N, V>
+	extends AbstractHeapState<K, N, V, SimpleStateDescriptor<V, ? extends State<V>>>
+	implements State<V> {
+
+	/**
+	 * Creates a new simple state for the given hash map of key/value pairs.
+	 *
+	 * @param backend The state backend backing that created this state.
+	 * @param stateDesc The state identifier for the state. This contains name and can create a default state value.
+	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
+	 */
+	public HeapSimpleState(
+		KeyedStateBackend<K> backend,
+		SimpleStateDescriptor<V, ? extends State<V>> stateDesc,
+		StateTable<K, N, V> stateTable,
+		TypeSerializer<K> keySerializer,
+		TypeSerializer<N> namespaceSerializer) {
+		super(backend, stateDesc, stateTable, keySerializer, namespaceSerializer);
+	}
+
+	@Override
+	public byte[] getSerializedValue(int keyGroup, K key, N namespace) throws Exception {
+		Preconditions.checkState(namespace != null, "No namespace given.");
+		Preconditions.checkState(key != null, "No key given.");
+
+		Map<N, Map<K, V>> namespaceMap = stateTable.get(keyGroup);
+		if (namespaceMap == null) {
+			return null;
+		}
+
+		Map<K, V> keyedMap = namespaceMap.get(currentNamespace);
+		if (keyedMap == null) {
+			return null;
+		}
+
+		V result = keyedMap.get(key);
+		if (result == null) {
+			return null;
+		}
+
+		TypeSerializer serializer = stateDesc.getSerializer();
+
+		return KvStateRequestSerializer.serializeValue(result, serializer);
+	}
+
+	@Override
+	public V get() {
+		Preconditions.checkState(currentNamespace != null, "No namespace set.");
+		Preconditions.checkState(backend.getCurrentKey() != null, "No key set.");
+
+		Map<N, Map<K, V>> namespaceMap = stateTable.get(backend.getCurrentKeyGroupIndex());
+		if (namespaceMap == null) {
+			return stateDesc.getDefaultValue();
+		}
+
+		Map<K, V> keyedMap = namespaceMap.get(currentNamespace);
+		if (keyedMap == null) {
+			return stateDesc.getDefaultValue();
+		}
+
+		V result = keyedMap.get(backend.getCurrentKey());
+		if (result == null) {
+			return stateDesc.getDefaultValue();
+		}
+
+		return result;
+	}
+
+	@Override
+	public final void clear() {
+		Preconditions.checkState(currentNamespace != null, "No namespace set.");
+		Preconditions.checkState(backend.getCurrentKey() != null, "No key set.");
+
+		Map<N, Map<K, V>> namespaceMap = stateTable.get(backend.getCurrentKeyGroupIndex());
+		if (namespaceMap == null) {
+			return;
+		}
+
+		Map<K, V> keyedMap = namespaceMap.get(currentNamespace);
+		if (keyedMap == null) {
+			return;
+		}
+
+		keyedMap.remove(backend.getCurrentKey());
+		if (keyedMap.isEmpty()) {
+			namespaceMap.remove(currentNamespace);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapValueState.java
@@ -44,13 +44,11 @@ public class HeapValueState<K, N, V> extends HeapSimpleState<K, N, V> implements
 	 * @param stateDesc The state identifier for the state. This contains name and can create a default state value.
 	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
 	 */
-	public HeapValueState(
-		KeyedStateBackend<K> backend,
-		ValueStateDescriptor<V> stateDesc,
-		StateTable<K, N, V> stateTable,
-		TypeSerializer<K> keySerializer,
-		TypeSerializer<N> namespaceSerializer
-	) {
+	public HeapValueState(KeyedStateBackend<K> backend,
+			ValueStateDescriptor<V> stateDesc,
+			StateTable<K, N, V> stateTable,
+			TypeSerializer<K> keySerializer,
+			TypeSerializer<N> namespaceSerializer) {
 		super(backend, stateDesc, stateTable, keySerializer, namespaceSerializer);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/MigrationV0ToV1Test.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/MigrationV0ToV1Test.java
@@ -18,12 +18,13 @@
 
 package org.apache.flink.runtime.checkpoint.savepoint;
 
-import org.apache.flink.api.common.state.ValueStateDescriptor;
+
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.migration.api.common.state.ValueStateDescriptor;
 import org.apache.flink.migration.runtime.checkpoint.savepoint.SavepointV0;
 import org.apache.flink.migration.runtime.checkpoint.savepoint.SavepointV0Serializer;
 import org.apache.flink.migration.runtime.state.KvStateSnapshot;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -585,11 +585,11 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 			// some modifications to the state
 			backend.setCurrentKey(1);
-			assertEquals("Fold-Initial:", state.get());
+			assertEquals(null, state.get());
 			assertEquals(null, getSerializedValue(kvState, 1, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 			state.add(1);
 			backend.setCurrentKey(2);
-			assertEquals("Fold-Initial:", state.get());
+			assertEquals(null, state.get());
 			assertEquals(null, getSerializedValue(kvState, 2, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 			state.add(2);
 			backend.setCurrentKey(1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -168,15 +168,15 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 		// some modifications to the state
 		backend.setCurrentKey(1);
-		assertNull(state.value());
+		assertNull(state.get());
 		assertNull(getSerializedValue(kvState, 1, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 		state.update("1");
 		backend.setCurrentKey(2);
-		assertNull(state.value());
+		assertNull(state.get());
 		assertNull(getSerializedValue(kvState, 2, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 		state.update("2");
 		backend.setCurrentKey(1);
-		assertEquals("1", state.value());
+		assertEquals("1", state.get());
 		assertEquals("1", getSerializedValue(kvState, 1, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 
 		// draw a snapshot
@@ -195,13 +195,13 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 		// validate the original state
 		backend.setCurrentKey(1);
-		assertEquals("u1", state.value());
+		assertEquals("u1", state.get());
 		assertEquals("u1", getSerializedValue(kvState, 1, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 		backend.setCurrentKey(2);
-		assertEquals("u2", state.value());
+		assertEquals("u2", state.get());
 		assertEquals("u2", getSerializedValue(kvState, 2, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 		backend.setCurrentKey(3);
-		assertEquals("u3", state.value());
+		assertEquals("u3", state.get());
 		assertEquals("u3", getSerializedValue(kvState, 3, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 
 		backend.dispose();
@@ -214,10 +214,10 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		KvState<VoidNamespace> restoredKvState1 = (KvState<VoidNamespace>) restored1;
 
 		backend.setCurrentKey(1);
-		assertEquals("1", restored1.value());
+		assertEquals("1", restored1.get());
 		assertEquals("1", getSerializedValue(restoredKvState1, 1, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 		backend.setCurrentKey(2);
-		assertEquals("2", restored1.value());
+		assertEquals("2", restored1.get());
 		assertEquals("2", getSerializedValue(restoredKvState1, 2, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 
 		backend.dispose();
@@ -230,13 +230,13 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		KvState<VoidNamespace> restoredKvState2 = (KvState<VoidNamespace>) restored2;
 
 		backend.setCurrentKey(1);
-		assertEquals("u1", restored2.value());
+		assertEquals("u1", restored2.get());
 		assertEquals("u1", getSerializedValue(restoredKvState2, 1, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 		backend.setCurrentKey(2);
-		assertEquals("u2", restored2.value());
+		assertEquals("u2", restored2.get());
 		assertEquals("u2", getSerializedValue(restoredKvState2, 2, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 		backend.setCurrentKey(3);
-		assertEquals("u3", restored2.value());
+		assertEquals("u3", restored2.get());
 		assertEquals("u3", getSerializedValue(restoredKvState2, 3, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 
 		backend.dispose();
@@ -264,18 +264,18 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 		// some modifications to the state
 		backend.setCurrentKey(1);
-		assertNull(state1.value());
-		assertNull(state2.value());
+		assertNull(state1.get());
+		assertNull(state2.get());
 		state1.update("1");
 
 		// state2 should still have nothing
-		assertEquals("1", state1.value());
-		assertNull(state2.value());
+		assertEquals("1", state1.get());
+		assertNull(state2.get());
 		state2.update(13);
 
 		// both have some state now
-		assertEquals("1", state1.value());
-		assertEquals(13, (int) state2.value());
+		assertEquals("1", state1.get());
+		assertEquals(13, (int) state2.get());
 
 		// draw a snapshot
 		KeyGroupsStateHandle snapshot1 = runSnapshot(backend.snapshot(682375462378L, 2, streamFactory));
@@ -296,8 +296,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		state2 = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, desc2);
 
 		// verify that they are still the same
-		assertEquals("1", state1.value());
-		assertEquals(13, (int) state2.value());
+		assertEquals("1", state1.get());
+		assertEquals(13, (int) state2.get());
 
 		backend.dispose();
 	}
@@ -333,22 +333,22 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		backend.setCurrentKey(1);
 
 		// verify default value
-		assertEquals(42L, (long) state.value());
+		assertEquals(42L, (long) state.get());
 		state.update(1L);
-		assertEquals(1L, (long) state.value());
+		assertEquals(1L, (long) state.get());
 
 		backend.setCurrentKey(2);
-		assertEquals(42L, (long) state.value());
+		assertEquals(42L, (long) state.get());
 
 		backend.setCurrentKey(1);
 		state.clear();
-		assertEquals(42L, (long) state.value());
+		assertEquals(42L, (long) state.get());
 
 		state.update(17L);
-		assertEquals(17L, (long) state.value());
+		assertEquals(17L, (long) state.get());
 
 		state.update(null);
-		assertEquals(42L, (long) state.value());
+		assertEquals(42L, (long) state.get());
 
 		// draw a snapshot
 		KeyGroupsStateHandle snapshot1 = runSnapshot(backend.snapshot(682375462378L, 2, streamFactory));
@@ -375,7 +375,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 			TypeSerializer<Integer> keySerializer = IntSerializer.INSTANCE;
 			TypeSerializer<VoidNamespace> namespaceSerializer = VoidNamespaceSerializer.INSTANCE;
-			TypeSerializer<String> valueSerializer = kvId.getSerializer();
+			TypeSerializer<String> valueSerializer = kvId.getElemSerializer();
 
 			ListState<String> state = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
 			@SuppressWarnings("unchecked")
@@ -585,11 +585,11 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 			// some modifications to the state
 			backend.setCurrentKey(1);
-			assertEquals(null, state.get());
+			assertEquals("Fold-Initial:", state.get());
 			assertEquals(null, getSerializedValue(kvState, 1, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 			state.add(1);
 			backend.setCurrentKey(2);
-			assertEquals(null, state.get());
+			assertEquals("Fold-Initial:", state.get());
 			assertEquals(null, getSerializedValue(kvState, 2, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 			state.add(2);
 			backend.setCurrentKey(1);
@@ -880,18 +880,18 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		ValueState<String> firstHalfState = firstHalfBackend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
 
 		firstHalfBackend.setCurrentKey(keyInFirstHalf);
-		assertTrue(firstHalfState.value().equals("ShouldBeInFirstHalf"));
+		assertTrue(firstHalfState.get().equals("ShouldBeInFirstHalf"));
 
 		firstHalfBackend.setCurrentKey(keyInSecondHalf);
-		assertTrue(firstHalfState.value() == null);
+		assertTrue(firstHalfState.get() == null);
 
 		ValueState<String> secondHalfState = secondHalfBackend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
 
 		secondHalfBackend.setCurrentKey(keyInFirstHalf);
-		assertTrue(secondHalfState.value() == null);
+		assertTrue(secondHalfState.get() == null);
 
 		secondHalfBackend.setCurrentKey(keyInSecondHalf);
-		assertTrue(secondHalfState.value().equals("ShouldBeInSecondHalf"));
+		assertTrue(secondHalfState.get().equals("ShouldBeInSecondHalf"));
 
 		firstHalfBackend.dispose();
 		secondHalfBackend.dispose();
@@ -931,7 +931,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 				state = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
 
-				state.value();
+				state.get();
 
 				fail("should recognize wrong serializers");
 			} catch (RuntimeException e) {
@@ -1055,7 +1055,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 	}
 
 	@Test
-	public void testCopyDefaultValue() throws Exception {
+	public void testCopyDefaultget() throws Exception {
 		AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
 
 		ValueStateDescriptor<IntValue> kvId = new ValueStateDescriptor<>("id", IntValue.class, new IntValue(-1));
@@ -1064,10 +1064,10 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		ValueState<IntValue> state = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
 
 		backend.setCurrentKey(1);
-		IntValue default1 = state.value();
+		IntValue default1 = state.get();
 
 		backend.setCurrentKey(2);
-		IntValue default2 = state.value();
+		IntValue default2 = state.get();
 
 		assertNotNull(default1);
 		assertNotNull(default2);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/AbstractQueryableStateOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/AbstractQueryableStateOperator.java
@@ -28,12 +28,11 @@ import org.apache.flink.util.Preconditions;
 /**
  * Internal operator handling queryable state instances (setup and update).
  *
- * @param <V>  Value type
  * @param <S>  State type
  * @param <IN> Input type
  */
 @Internal
-abstract class AbstractQueryableStateOperator<V, S extends State<V>, IN>
+abstract class AbstractQueryableStateOperator<S extends State<?>, IN>
 		extends AbstractStreamOperator<IN>
 		implements OneInputStreamOperator<IN, IN> {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/AbstractQueryableStateOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/AbstractQueryableStateOperator.java
@@ -28,16 +28,17 @@ import org.apache.flink.util.Preconditions;
 /**
  * Internal operator handling queryable state instances (setup and update).
  *
+ * @param <V>  Value type
  * @param <S>  State type
  * @param <IN> Input type
  */
 @Internal
-abstract class AbstractQueryableStateOperator<S extends State, IN>
+abstract class AbstractQueryableStateOperator<V, S extends State<V>, IN>
 		extends AbstractStreamOperator<IN>
 		implements OneInputStreamOperator<IN, IN> {
 
 	/** State descriptor for the queryable state instance. */
-	protected final StateDescriptor<? extends S, ?> stateDescriptor;
+	protected final StateDescriptor<? extends S> stateDescriptor;
 
 	/**
 	 * Name under which the queryable state is registered.
@@ -53,7 +54,7 @@ abstract class AbstractQueryableStateOperator<S extends State, IN>
 
 	public AbstractQueryableStateOperator(
 			String registrationName,
-			StateDescriptor<? extends S, ?> stateDescriptor) {
+			StateDescriptor<? extends S> stateDescriptor) {
 
 		this.registrationName = Preconditions.checkNotNull(registrationName, "Registration name");
 		this.stateDescriptor = Preconditions.checkNotNull(stateDescriptor, "State descriptor");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableAppendingStateOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableAppendingStateOperator.java
@@ -29,11 +29,11 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
  * @param <IN> Input type
  */
 @Internal
-public class QueryableAppendingStateOperator<IN> extends AbstractQueryableStateOperator<AppendingState<IN, ?>, IN> {
+public class QueryableAppendingStateOperator<IN, OUT> extends AbstractQueryableStateOperator<OUT, AppendingState<IN, OUT>, IN> {
 
 	public QueryableAppendingStateOperator(
 			String registrationName,
-			StateDescriptor<? extends AppendingState<IN, ?>, ?> stateDescriptor) {
+			StateDescriptor<? extends AppendingState<IN, OUT>> stateDescriptor) {
 
 		super(registrationName, stateDescriptor);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableAppendingStateOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableAppendingStateOperator.java
@@ -29,7 +29,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
  * @param <IN> Input type
  */
 @Internal
-public class QueryableAppendingStateOperator<IN, OUT> extends AbstractQueryableStateOperator<OUT, AppendingState<IN, OUT>, IN> {
+public class QueryableAppendingStateOperator<IN, OUT> extends AbstractQueryableStateOperator<AppendingState<IN, OUT>, IN> {
 
 	public QueryableAppendingStateOperator(
 			String registrationName,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableValueStateOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableValueStateOperator.java
@@ -29,11 +29,11 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
  * @param <IN> Input type
  */
 @Internal
-public class QueryableValueStateOperator<IN> extends AbstractQueryableStateOperator<ValueState<IN>, IN> {
+public class QueryableValueStateOperator<IN> extends AbstractQueryableStateOperator<IN, ValueState<IN>, IN> {
 
 	public QueryableValueStateOperator(
 			String registrationName,
-			StateDescriptor<ValueState<IN>, IN> stateDescriptor) {
+			StateDescriptor<ValueState<IN>> stateDescriptor) {
 
 		super(registrationName, stateDescriptor);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableValueStateOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableValueStateOperator.java
@@ -29,7 +29,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
  * @param <IN> Input type
  */
 @Internal
-public class QueryableValueStateOperator<IN> extends AbstractQueryableStateOperator<IN, ValueState<IN>, IN> {
+public class QueryableValueStateOperator<IN> extends AbstractQueryableStateOperator<ValueState<IN>, IN> {
 
 	public QueryableValueStateOperator(
 			String registrationName,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -490,7 +490,7 @@ public abstract class AbstractStreamOperator<OUT>
 	 * @throws IllegalStateException Thrown, if the key/value state was already initialized.
 	 * @throws Exception Thrown, if the state backend cannot create the key/value state.
 	 */
-	protected <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) throws Exception {
+	protected <V, S extends State<V>> S getPartitionedState(StateDescriptor<S> stateDescriptor) throws Exception {
 		return getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
 	}
 
@@ -501,9 +501,9 @@ public abstract class AbstractStreamOperator<OUT>
 	 * @throws Exception Thrown, if the state backend cannot create the key/value state.
 	 */
 	@SuppressWarnings("unchecked")
-	protected <S extends State, N> S getPartitionedState(
+	protected <V, S extends State<V>, N> S getPartitionedState(
 			N namespace, TypeSerializer<N> namespaceSerializer,
-			StateDescriptor<S, ?> stateDescriptor) throws Exception {
+			StateDescriptor<S> stateDescriptor) throws Exception {
 
 		if (keyedStateStore != null) {
 			return keyedStateBackend.getPartitionedState(namespace, namespaceSerializer, stateDescriptor);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -490,7 +490,7 @@ public abstract class AbstractStreamOperator<OUT>
 	 * @throws IllegalStateException Thrown, if the key/value state was already initialized.
 	 * @throws Exception Thrown, if the state backend cannot create the key/value state.
 	 */
-	protected <V, S extends State<V>> S getPartitionedState(StateDescriptor<S> stateDescriptor) throws Exception {
+	protected <S extends State<?>> S getPartitionedState(StateDescriptor<S> stateDescriptor) throws Exception {
 		return getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
 	}
 
@@ -501,7 +501,7 @@ public abstract class AbstractStreamOperator<OUT>
 	 * @throws Exception Thrown, if the state backend cannot create the key/value state.
 	 */
 	@SuppressWarnings("unchecked")
-	protected <V, S extends State<V>, N> S getPartitionedState(
+	protected <S extends State<?>, N> S getPartitionedState(
 			N namespace, TypeSerializer<N> namespaceSerializer,
 			StateDescriptor<S> stateDescriptor) throws Exception {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedFold.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedFold.java
@@ -77,7 +77,7 @@ public class StreamGroupedFold<IN, OUT, KEY>
 
 	@Override
 	public void processElement(StreamRecord<IN> element) throws Exception {
-		OUT value = values.value();
+		OUT value = values.get();
 
 		if (value != null) {
 			OUT folded = userFunction.fold(outTypeSerializer.copy(value), element.getValue());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedReduce.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedReduce.java
@@ -52,7 +52,7 @@ public class StreamGroupedReduce<IN> extends AbstractUdfStreamOperator<IN, Reduc
 	@Override
 	public void processElement(StreamRecord<IN> element) throws Exception {
 		IN value = element.getValue();
-		IN currentValue = values.value();
+		IN currentValue = values.get();
 		
 		if (currentValue != null) {
 			IN reduced = userFunction.reduce(currentValue, value);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -137,7 +137,7 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
 		return keyedStateStore.getFoldingState(stateProperties);
 	}
 
-	private KeyedStateStore checkPreconditionsAndGetKeyedStateStore(StateDescriptor<?, ?> stateDescriptor) {
+	private KeyedStateStore checkPreconditionsAndGetKeyedStateStore(StateDescriptor<?> stateDescriptor) {
 		Preconditions.checkNotNull(stateDescriptor, "The state properties must not be null");
 		KeyedStateStore keyedStateStore = operator.getKeyedStateStore();
 		Preconditions.checkNotNull(keyedStateStore, "Keyed state can only be used on a 'keyed stream', i.e., after a 'keyBy()' operation.");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/DeltaTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/DeltaTrigger.java
@@ -53,11 +53,11 @@ public class DeltaTrigger<T, W extends Window> extends Trigger<T, W> {
 	@Override
 	public TriggerResult onElement(T element, long timestamp, W window, TriggerContext ctx) throws Exception {
 		ValueState<T> lastElementState = ctx.getPartitionedState(stateDesc);
-		if (lastElementState.value() == null) {
+		if (lastElementState.get() == null) {
 			lastElementState.update(element);
 			return TriggerResult.CONTINUE;
 		}
-		if (deltaFunction.getDelta(lastElementState.value(), element) > this.threshold) {
+		if (deltaFunction.getDelta(lastElementState.get(), element) > this.threshold) {
 			lastElementState.update(element);
 			return TriggerResult.FIRE;
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
@@ -179,13 +179,12 @@ public abstract class Trigger<T, W extends Window> implements Serializable {
 		 *
 		 * @param stateDescriptor The StateDescriptor that contains the name and type of the
 		 *                        state that is being accessed.
-		 * @param <V>             The type of the values in the state.
 		 * @param <S>             The type of the state.
 		 * @return The partitioned state object.
 		 * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
 		 *                                       function (function is not part os a KeyedStream).
 		 */
-		<V, S extends State<V>> S getPartitionedState(StateDescriptor<S> stateDescriptor);
+		<S extends State<?>> S getPartitionedState(StateDescriptor<S> stateDescriptor);
 	
 		/**
 		 * Retrieves a {@link ValueState} object that can be used to interact with
@@ -232,6 +231,6 @@ public abstract class Trigger<T, W extends Window> implements Serializable {
 	 * {@link Trigger#onMerge(Window, OnMergeContext)}.
 	 */
 	public interface OnMergeContext extends TriggerContext {
-		<V, S extends MergingState<?, V>> void mergePartitionedState(StateDescriptor<S> stateDescriptor);
+		<S extends MergingState<?, ?>> void mergePartitionedState(StateDescriptor<S> stateDescriptor);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
@@ -179,12 +179,13 @@ public abstract class Trigger<T, W extends Window> implements Serializable {
 		 *
 		 * @param stateDescriptor The StateDescriptor that contains the name and type of the
 		 *                        state that is being accessed.
+		 * @param <V>             The type of the values in the state.
 		 * @param <S>             The type of the state.
 		 * @return The partitioned state object.
 		 * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
 		 *                                       function (function is not part os a KeyedStream).
 		 */
-		<S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor);
+		<V, S extends State<V>> S getPartitionedState(StateDescriptor<S> stateDescriptor);
 	
 		/**
 		 * Retrieves a {@link ValueState} object that can be used to interact with
@@ -231,6 +232,6 @@ public abstract class Trigger<T, W extends Window> implements Serializable {
 	 * {@link Trigger#onMerge(Window, OnMergeContext)}.
 	 */
 	public interface OnMergeContext extends TriggerContext {
-		<S extends MergingState<?, ?>> void mergePartitionedState(StateDescriptor<S, ?> stateDescriptor);
+		<V, S extends MergingState<?, V>> void mergePartitionedState(StateDescriptor<S> stateDescriptor);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
@@ -24,7 +24,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.AppendingState;
-import org.apache.flink.api.common.state.MergingState;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -70,7 +69,7 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window> extends Window
 		TypeSerializer<W> windowSerializer,
 		KeySelector<IN, K> keySelector,
 		TypeSerializer<K> keySerializer,
-		StateDescriptor<? extends ListState<StreamRecord<IN>>, ?> windowStateDescriptor,
+		StateDescriptor<? extends ListState<StreamRecord<IN>>> windowStateDescriptor,
 		InternalWindowFunction<Iterable<IN>, OUT, K, W> windowFunction,
 		Trigger<? super IN, ? super W> trigger,
 		Evictor<? super IN, ? super W> evictor,
@@ -123,7 +122,7 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window> extends Window
 									stateWindowResult,
 									mergedStateWindows,
 									windowSerializer,
-									(StateDescriptor<? extends MergingState<?, ?>, ?>) windowStateDescriptor);
+									windowStateDescriptor);
 							}
 						});
 
@@ -408,7 +407,7 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window> extends Window
 	@Override
 	@VisibleForTesting
 	@SuppressWarnings("unchecked, rawtypes")
-	public StateDescriptor<? extends AppendingState<IN, Iterable<IN>>, ?> getStateDescriptor() {
-		return (StateDescriptor<? extends AppendingState<IN, Iterable<IN>>, ?>) windowStateDescriptor;
+	public StateDescriptor<? extends AppendingState<IN, Iterable<IN>>> getStateDescriptor() {
+		return (StateDescriptor<? extends AppendingState<IN, Iterable<IN>>>) windowStateDescriptor;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
@@ -63,7 +63,7 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window> extends Window
 
 	private transient EvictorContext evictorContext;
 
-	private final StateDescriptor<? extends ListState<StreamRecord<IN>>, ?> windowStateDescriptor;
+	private final StateDescriptor<? extends ListState<StreamRecord<IN>>> windowStateDescriptor;
 
 	public EvictingWindowOperator(WindowAssigner<? super IN, W> windowAssigner,
 		TypeSerializer<W> windowSerializer,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -111,7 +111,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 
 	protected final Trigger<? super IN, ? super W> trigger;
 
-	protected final StateDescriptor<? extends AppendingState<IN, ACC>, ?> windowStateDescriptor;
+	protected final StateDescriptor<? extends AppendingState<IN, ACC>> windowStateDescriptor;
 
 	protected final ListStateDescriptor<Tuple2<W, W>> mergingWindowsDescriptor;
 
@@ -190,7 +190,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 			TypeSerializer<W> windowSerializer,
 			KeySelector<IN, K> keySelector,
 			TypeSerializer<K> keySerializer,
-			StateDescriptor<? extends AppendingState<IN, ACC>, ?> windowStateDescriptor,
+			StateDescriptor<? extends AppendingState<IN, ACC>> windowStateDescriptor,
 			InternalWindowFunction<ACC, OUT, K, W> windowFunction,
 			Trigger<? super IN, ? super W> trigger,
 			long allowedLateness) {
@@ -319,7 +319,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 							stateWindowResult,
 							mergedStateWindows,
 							windowSerializer,
-							(StateDescriptor<? extends MergingState<?,?>, ?>) windowStateDescriptor);
+							(StateDescriptor<? extends MergingState<IN, OUT>>)windowStateDescriptor);
 					}
 				});
 
@@ -643,7 +643,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		}
 
 		@SuppressWarnings("unchecked")
-		public <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) {
+		public <V, S extends State<V>> S getPartitionedState(StateDescriptor<S> stateDescriptor) {
 			try {
 				return WindowOperator.this.getPartitionedState(window, windowSerializer, stateDescriptor);
 			} catch (Exception e) {
@@ -652,7 +652,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		}
 
 		@Override
-		public <S extends MergingState<?, ?>> void mergePartitionedState(StateDescriptor<S, ?> stateDescriptor) {
+		public <V, S extends MergingState<?, V>> void mergePartitionedState(StateDescriptor<S> stateDescriptor) {
 			if (mergedWindows != null && mergedWindows.size() > 0) {
 				try {
 					WindowOperator.this.getKeyedStateBackend().mergePartitionedStates(window,
@@ -1035,7 +1035,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	}
 
 	@VisibleForTesting
-	public StateDescriptor<? extends AppendingState<IN, ACC>, ?> getStateDescriptor() {
+	public StateDescriptor<? extends AppendingState<IN, ACC>> getStateDescriptor() {
 		return windowStateDescriptor;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.state.AppendingState;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.MergingState;
+import org.apache.flink.api.common.state.SimpleStateDescriptor;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
@@ -207,7 +208,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 			TypeSerializer<W> windowSerializer,
 			KeySelector<IN, K> keySelector,
 			TypeSerializer<K> keySerializer,
-			StateDescriptor<? extends AppendingState<IN, ACC>, ?> windowStateDescriptor,
+			StateDescriptor<? extends AppendingState<IN, ACC>> windowStateDescriptor,
 			InternalWindowFunction<ACC, OUT, K, W> windowFunction,
 			Trigger<? super IN, ? super W> trigger,
 			long allowedLateness,
@@ -858,8 +859,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		final long paneSize = getPaneSize();
 		long nextElementTimestamp = nextSlideTime - (numPanes * paneSize);
 
-		@SuppressWarnings("unchecked")
-		ArrayListSerializer<IN> ser = new ArrayListSerializer<>((TypeSerializer<IN>) getStateDescriptor().getSerializer());
+		ArrayListSerializer<IN> ser = new ArrayListSerializer<>(getStateSerializer(getStateDescriptor()));
 
 		while (numPanes > 0) {
 			validateMagicNumber(BEGIN_OF_PANE_MAGIC_NUMBER, in.readInt());
@@ -893,9 +893,8 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 			final int numElementsInPane = in.readInt();
 			for (int i = numElementsInPane - 1; i >= 0; i--) {
 				K key = keySerializer.deserialize(in);
+				IN value = getStateSerializer(getStateDescriptor()).deserialize(in);
 
-				@SuppressWarnings("unchecked")
-				IN value = (IN) getStateDescriptor().getSerializer().deserialize(in);
 				restoredFromLegacyAlignedOpRecords.add(new StreamRecord<>(value, nextElementTimestamp));
 			}
 			numPanes--;
@@ -923,6 +922,19 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 			throw new IOException("Corrupt state stream - wrong magic number. " +
 				"Expected '" + Integer.toHexString(expected) +
 				"', found '" + Integer.toHexString(found) + '\'');
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private TypeSerializer<IN> getStateSerializer(StateDescriptor<?> stateDescriptor) {
+		if (stateDescriptor instanceof SimpleStateDescriptor) {
+			SimpleStateDescriptor<IN, ?> simpleStateDescriptor = (SimpleStateDescriptor<IN, ?>) stateDescriptor;
+			return simpleStateDescriptor.getSerializer();
+		} else if (stateDescriptor instanceof ListStateDescriptor) {
+			ListStateDescriptor<IN> listStateDescriptor = (ListStateDescriptor<IN>) stateDescriptor;
+			return listStateDescriptor.getElemSerializer();
+		} else {
+			throw new IllegalStateException();
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -643,7 +643,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		}
 
 		@SuppressWarnings("unchecked")
-		public <V, S extends State<V>> S getPartitionedState(StateDescriptor<S> stateDescriptor) {
+		public <S extends State<?>> S getPartitionedState(StateDescriptor<S> stateDescriptor) {
 			try {
 				return WindowOperator.this.getPartitionedState(window, windowSerializer, stateDescriptor);
 			} catch (Exception e) {
@@ -652,7 +652,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		}
 
 		@Override
-		public <V, S extends MergingState<?, V>> void mergePartitionedState(StateDescriptor<S> stateDescriptor) {
+		public <S extends MergingState<?, ?>> void mergePartitionedState(StateDescriptor<S> stateDescriptor) {
 			if (mergedWindows != null && mergedWindows.size() > 0) {
 				try {
 					WindowOperator.this.getKeyedStateBackend().mergePartitionedStates(window,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
@@ -520,7 +520,7 @@ public class AbstractStreamOperatorTest {
 					timerService.registerProcessingTimeTimer(VoidNamespace.INSTANCE, Long.parseLong(command[1]));
 					break;
 				case "EMIT_STATE":
-					String stateValue = getPartitionedState(stateDescriptor).value();
+					String stateValue = getPartitionedState(stateDescriptor).get();
 					output.collect(new StreamRecord<>("ON_ELEMENT:" + element.getValue().f0 + ":" + stateValue));
 					break;
 				default:
@@ -530,13 +530,13 @@ public class AbstractStreamOperatorTest {
 
 		@Override
 		public void onEventTime(InternalTimer<Integer, VoidNamespace> timer) throws Exception {
-			String stateValue = getPartitionedState(stateDescriptor).value();
+			String stateValue = getPartitionedState(stateDescriptor).get();
 			output.collect(new StreamRecord<>("ON_EVENT_TIME:" + stateValue));
 		}
 
 		@Override
 		public void onProcessingTime(InternalTimer<Integer, VoidNamespace> timer) throws Exception {
-			String stateValue = getPartitionedState(stateDescriptor).value();
+			String stateValue = getPartitionedState(stateDescriptor).get();
 			output.collect(new StreamRecord<>("ON_PROC_TIME:" + stateValue));
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/ProcessOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/ProcessOperatorTest.java
@@ -374,7 +374,7 @@ public class ProcessOperatorTest extends TestLogger {
 				OnTimerContext ctx,
 				Collector<String> out) throws Exception {
 			assertEquals(this.timeDomain, ctx.timeDomain());
-			out.collect("STATE:" + getRuntimeContext().getState(state).value());
+			out.collect("STATE:" + getRuntimeContext().getState(state).get());
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateDescriptorPassingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateDescriptorPassingTest.java
@@ -23,6 +23,8 @@ import com.esotericsoftware.kryo.serializers.JavaSerializer;
 
 import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.SimpleStateDescriptor;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -200,10 +202,16 @@ public class StateDescriptorPassingTest {
 	private void validateStateDescriptorConfigured(SingleOutputStreamOperator<?> result) {
 		OneInputTransformation<?, ?> transform = (OneInputTransformation<?, ?>) result.getTransformation();
 		WindowOperator<?, ?, ?, ?, ?> op = (WindowOperator<?, ?, ?, ?, ?>) transform.getOperator();
-		StateDescriptor<?, ?> descr = op.getStateDescriptor();
+		StateDescriptor<?> descr = op.getStateDescriptor();
 
 		// this would be the first statement to fail if state descriptors were not properly initialized
-		TypeSerializer<?> serializer = descr.getSerializer();
+		TypeSerializer<?> serializer = null;
+		if (descr instanceof ListStateDescriptor) {
+			serializer = ((ListStateDescriptor<?>)descr).getElemSerializer();
+		} else if (descr instanceof SimpleStateDescriptor){
+			serializer = ((SimpleStateDescriptor<?, ?>)descr).getSerializer();
+		}
+
 		assertTrue(serializer instanceof KryoSerializer);
 
 		Kryo kryo = ((KryoSerializer<?>) serializer).getKryo();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorSnapshotRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorSnapshotRestoreTest.java
@@ -124,7 +124,7 @@ public class StreamOperatorSnapshotRestoreTest {
 			if (verifyRestore) {
 				// check restored managed keyed state
 				long exp = element.getValue() + 1;
-				long act = keyedState.value();
+				long act = keyedState.get();
 				Assert.assertEquals(exp, act);
 			} else {
 				// write managed keyed state that goes into snapshot

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
@@ -80,8 +80,10 @@ public class StreamingRuntimeContextTest {
 		ValueStateDescriptor<TaskInfo> descr = new ValueStateDescriptor<>("name", TaskInfo.class);
 		context.getState(descr);
 		
-		StateDescriptor<?, ?> descrIntercepted = (StateDescriptor<?, ?>) descriptorCapture.get();
-		TypeSerializer<?> serializer = descrIntercepted.getSerializer();
+		StateDescriptor<?> descrIntercepted = (StateDescriptor<?>) descriptorCapture.get();
+		assertTrue(descrIntercepted instanceof ValueStateDescriptor);
+
+		TypeSerializer<?> serializer = ((ValueStateDescriptor)descrIntercepted).getSerializer();
 		
 		// check that the Path class is really registered, i.e., the execution config was applied
 		assertTrue(serializer instanceof KryoSerializer);
@@ -109,8 +111,10 @@ public class StreamingRuntimeContextTest {
 		
 		context.getReducingState(descr);
 
-		StateDescriptor<?, ?> descrIntercepted = (StateDescriptor<?, ?>) descriptorCapture.get();
-		TypeSerializer<?> serializer = descrIntercepted.getSerializer();
+		StateDescriptor<?> descrIntercepted = (StateDescriptor<?>) descriptorCapture.get();
+		assertTrue(descrIntercepted instanceof ReducingStateDescriptor);
+
+		TypeSerializer<?> serializer = ((ReducingStateDescriptor)descrIntercepted).getSerializer();
 
 		// check that the Path class is really registered, i.e., the execution config was applied
 		assertTrue(serializer instanceof KryoSerializer);
@@ -162,8 +166,10 @@ public class StreamingRuntimeContextTest {
 		ListStateDescriptor<TaskInfo> descr = new ListStateDescriptor<>("name", TaskInfo.class);
 		context.getListState(descr);
 
-		StateDescriptor<?, ?> descrIntercepted = (StateDescriptor<?, ?>) descriptorCapture.get();
-		TypeSerializer<?> serializer = descrIntercepted.getSerializer();
+		StateDescriptor<?> descrIntercepted = (StateDescriptor<?>) descriptorCapture.get();
+		assertTrue(descrIntercepted instanceof ListStateDescriptor);
+
+		TypeSerializer<?> serializer = ((ListStateDescriptor<?>)descrIntercepted).getElemSerializer();
 
 		// check that the Path class is really registered, i.e., the execution config was applied
 		assertTrue(serializer instanceof KryoSerializer);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoProcessOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoProcessOperatorTest.java
@@ -421,7 +421,7 @@ public class CoProcessOperatorTest extends TestLogger {
 				OnTimerContext ctx,
 				Collector<String> out) throws Exception {
 			assertEquals(TimeDomain.EVENT_TIME, ctx.timeDomain());
-			out.collect("STATE:" + getRuntimeContext().getState(state).value());
+			out.collect("STATE:" + getRuntimeContext().getState(state).get());
 		}
 	}
 
@@ -502,7 +502,7 @@ public class CoProcessOperatorTest extends TestLogger {
 				OnTimerContext ctx,
 				Collector<String> out) throws Exception {
 			assertEquals(TimeDomain.PROCESSING_TIME, ctx.timeDomain());
-			out.collect("STATE:" + getRuntimeContext().getState(state).value());
+			out.collect("STATE:" + getRuntimeContext().getState(state).get());
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/AccumulatingAlignedProcessingTimeWindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/AccumulatingAlignedProcessingTimeWindowOperatorTest.java
@@ -685,8 +685,8 @@ public class AccumulatingAlignedProcessingTimeWindowOperatorTest {
 				// we need to update this state before emitting elements. Else, the test's main
 				// thread will have received all output elements before the state is updated and
 				// the checks may fail
-				state.update(state.value() + 1);
-				globalCounts.put(key, state.value());
+				state.update(state.get() + 1);
+				globalCounts.put(key, state.get());
 				
 				out.collect(i);
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/AggregatingAlignedProcessingTimeWindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/AggregatingAlignedProcessingTimeWindowOperatorTest.java
@@ -839,8 +839,8 @@ public class AggregatingAlignedProcessingTimeWindowOperatorTest {
 
 		@Override
 		public Tuple2<Integer, Integer> reduce(Tuple2<Integer, Integer> value1, Tuple2<Integer, Integer> value2) throws Exception {
-			state.update(state.value() + 1);
-			globalCounts.put(value1.f0, state.value());
+			state.update(state.get() + 1);
+			globalCounts.put(value1.f0, state.get());
 
 			return new Tuple2<>(value1.f0, value1.f1 + value2.f1);
 		}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -523,7 +523,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
 
     new QueryableStateStream(
       queryableStateName,
-      stateDescriptor.getSerializer,
+      stateDescriptor.getElemSerializer,
       getKeyType.createSerializer(executionConfig))
   }
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/StatefulFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/StatefulFunction.scala
@@ -38,7 +38,7 @@ trait StatefulFunction[I, O, S] extends RichFunction {
   
 
   def applyWithState(in: I, fun: (I, Option[S]) => (O, Option[S])): O = {
-    val (o, s: Option[S]) = fun(in, Option(state.value()))
+    val (o, s: Option[S]) = fun(in, Option(state.get()))
     s match {
       case Some(v) => state.update(v)
       case None => state.update(null.asInstanceOf[S])

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
@@ -254,15 +254,15 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 
 							// the window count state starts with the key, so that we get
 							// different count results for each key
-							if (count.value() == 0) {
+							if (count.get() == 0) {
 								count.update(tuple.<Long>getField(0).intValue());
 							}
 
 							// validate that the function has been opened properly
 							assertTrue(open);
 
-							count.update(count.value() + 1);
-							out.collect(new Tuple4<>(tuple.<Long>getField(0), window.getStart(), window.getEnd(), new IntType(count.value())));
+							count.update(count.get() + 1);
+							out.collect(new Tuple4<>(tuple.<Long>getField(0), window.getStart(), window.getEnd(), new IntType(count.get())));
 						}
 					})
 					.addSink(new CountValidatingSink(NUM_KEYS, NUM_ELEMENTS_PER_KEY / WINDOW_SIZE)).setParallelism(1);

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/PartitionedStateCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/PartitionedStateCheckpointingITCase.java
@@ -181,7 +181,7 @@ public class PartitionedStateCheckpointingITCase extends StreamFaultToleranceTes
 				throw new Exception("Test Failure");
 			}
 
-			long currentSum = sum.value() + value;
+			long currentSum = sum.get() + value;
 			sum.update(currentSum);
 			allSums.put(value, currentSum);
 			return new Tuple2<Integer, Long>(value, currentSum);
@@ -207,8 +207,8 @@ public class PartitionedStateCheckpointingITCase extends StreamFaultToleranceTes
 
 		@Override
 		public void invoke(Tuple2<Integer, Long> value) throws Exception {
-			long ac = aCounts.value().value;
-			long bc = bCounts.value();
+			long ac = aCounts.get().value;
+			long bc = bCounts.get();
 			assertEquals(ac, bc);
 			
 			long currentCount = ac + 1;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
@@ -800,10 +800,10 @@ public class RescalingITCase extends TestLogger {
 		@Override
 		public void flatMap(Integer value, Collector<Tuple2<Integer, Integer>> out) throws Exception {
 
-			int count = counter.value() + 1;
+			int count = counter.get() + 1;
 			counter.update(count);
 
-			int s = sum.value() + value;
+			int s = sum.get() + value;
 			sum.update(s);
 
 			if (count % numberElements == 0) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointingITCase.java
@@ -271,7 +271,7 @@ public class StreamCheckpointingITCase extends StreamFaultToleranceTestBase {
 			}
 			inputCount++;
 		
-			long currentPrefixCount = pCount.value() + value.count;
+			long currentPrefixCount = pCount.get() + value.count;
 			pCount.update(currentPrefixCount);
 			prefixCounts.put(value.prefix, currentPrefixCount);
 			value.count = currentPrefixCount;


### PR DESCRIPTION
Changes in the definition of `State` and `StateDescriptor`:
- Add `get()` in the `State` interface.
- Remove type serializers of state values from `StateDescriptor`s.
- Add `SimpleStateDescriptor` to simplify the construction of `ValueStateDescriptor`, `ReducingStateDescriptor` and `FoldingStateDescriptor`.
- Changes the definition of `KeyedStateBackend` and `AbstractKeyedStateBackend` accordingly.
- Modify the implementation of `ListStateDescriptor` accordingly.

Changes in HeapStateBackend:
- Let `AbstractHeapState` not implement the `State` interface. The `clear()` method now is removed from `AbstractHeapState`.
- Add `HeapSimpleState` to simplify the implementation of `HeapValueState`, `HeapReducingState` and `HeapFoldingState`.
- Change the implementation of `HeapValueState`, `HeapReducingState` and `HeapFoldingState` accordingly.

Changes in RocksDBStateBackend:
- Let `AbstractRocksDBState` not implement the `State` interface, removing the `clear()` method. Now, `AbstractRocksDBState` does not depend on the types of `State` and `StateDescriptor` any more.
- Add `RocksDBSimpleState` to simplify the implementation of `RocksDBValueState`, `RocksDBReducingState` and `RocksDBFoldingState`.
- Change the implementation of `RocksDBValueState`, `RocksDBReducingState` and `RocksDBFoldingState` accordingly.

Others:
- Update the usage of `State`s in the implementation of window operators.
- Update the usage of `State`s in unit tests.

=== UPDATE ===
- Remove `clear()` method from `State`
- Add a new interface called `UpdatableState`
- Reformat the code