### PR TITLE
[FLINK-4354]Implement TaskManager side of heartbeat from ResourceManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -77,8 +77,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * </ul>
  */
 public abstract class ResourceManager<WorkerType extends Serializable>
-	extends RpcEndpoint<ResourceManagerGateway>
-	implements LeaderContender {
+		extends RpcEndpoint<ResourceManagerGateway>
+		implements LeaderContender {
 
 	/** Configuration of the resource manager */
 	private final ResourceManagerConfiguration resourceManagerConfiguration;
@@ -120,13 +120,13 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 	private ConcurrentMap<String, InfoMessageListenerRpcGateway> infoMessageListeners;
 
 	public ResourceManager(
-		RpcService rpcService,
-		ResourceManagerConfiguration resourceManagerConfiguration,
-		HighAvailabilityServices highAvailabilityServices,
-		SlotManagerFactory slotManagerFactory,
-		MetricRegistry metricRegistry,
-		JobLeaderIdService jobLeaderIdService,
-		FatalErrorHandler fatalErrorHandler) {
+			RpcService rpcService,
+			ResourceManagerConfiguration resourceManagerConfiguration,
+			HighAvailabilityServices highAvailabilityServices,
+			SlotManagerFactory slotManagerFactory,
+			MetricRegistry metricRegistry,
+			JobLeaderIdService jobLeaderIdService,
+			FatalErrorHandler fatalErrorHandler) {
 
 		super(rpcService);
 
@@ -212,10 +212,10 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 
 	@RpcMethod
 	public Future<RegistrationResponse> registerJobManager(
-		final UUID resourceManagerLeaderId,
-		final UUID jobManagerLeaderId,
-		final String jobManagerAddress,
-		final JobID jobId) {
+			final UUID resourceManagerLeaderId,
+			final UUID jobManagerLeaderId,
+			final String jobManagerAddress,
+			final JobID jobId) {
 
 		checkNotNull(resourceManagerLeaderId);
 		checkNotNull(jobManagerLeaderId);
@@ -396,9 +396,9 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 	 */
 	@RpcMethod
 	public RMSlotRequestReply requestSlot(
-		UUID jobMasterLeaderID,
-		UUID resourceManagerLeaderID,
-		SlotRequest slotRequest) {
+			UUID jobMasterLeaderID,
+			UUID resourceManagerLeaderID,
+			SlotRequest slotRequest) {
 
 		log.info("Request slot with profile {} for job {} with allocation id {}.",
 			slotRequest.getResourceProfile(),
@@ -409,8 +409,8 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 		JobManagerRegistration jobManagerRegistration = jobManagerRegistrations.get(jobId);
 
 		if (jobManagerRegistration != null
-			&& jobMasterLeaderID.equals(jobManagerRegistration.getLeaderID())
-			&& resourceManagerLeaderID.equals(leaderSessionId)) {
+				&& jobMasterLeaderID.equals(jobManagerRegistration.getLeaderID())
+				&& resourceManagerLeaderID.equals(leaderSessionId)) {
 			return slotManager.requestSlot(slotRequest);
 		} else {
 			log.info("Ignoring slot request for unknown JobMaster with JobID {}", jobId);
@@ -427,9 +427,9 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 	 */
 	@RpcMethod
 	public void notifySlotAvailable(
-		final UUID resourceManagerLeaderId,
-		final InstanceID instanceID,
-		final SlotID slotId) {
+			final UUID resourceManagerLeaderId,
+			final InstanceID instanceID,
+			final SlotID slotId) {
 
 		if (resourceManagerLeaderId.equals(leaderSessionId)) {
 			final ResourceID resourceId = slotId.getResourceID();
@@ -450,7 +450,7 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 			}
 		} else {
 			log.debug("Discarding notify slot available message for slot {}, because the " +
-					"leader id {} did not match the expected leader id {}.", slotId,
+				"leader id {} did not match the expected leader id {}.", slotId,
 				resourceManagerLeaderId, leaderSessionId);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -122,4 +122,11 @@ public interface ResourceManagerGateway extends RpcGateway {
 	 * @param optionalDiagnostics
 	 */
 	void shutDownCluster(final ApplicationStatus finalStatus, final String optionalDiagnostics);
+
+	/**
+	 * sends the heartbeat to resource manager from task manager
+	 * @param resourceID unique id of the task manager
+	 * @param payload the payload information of the task manager
+	 */
+	void sendHeartbeatFromTaskManager(final ResourceID resourceID, final Object payload);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -457,8 +457,8 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 	// ----------------------------------------------------------------------
 
 	@RpcMethod
-	public void requestHeartbeatFromResourceManager(ResourceID resourceID, Object payload) {
-		heartbeatManager.requestHeartbeat(resourceID, payload);
+	public void requestHeartbeatFromResourceManager(ResourceID resourceID) {
+		heartbeatManager.requestHeartbeat(resourceID, null);
 	}
 
 	// ----------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -300,12 +300,12 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 		TaskMetricGroup taskMetricGroup = taskManagerMetricGroup.addTaskForJob(tdd);
 
 		InputSplitProvider inputSplitProvider = new RpcInputSplitProvider(
-			jobManagerConnection.getLeaderId(),
-			jobManagerConnection.getJobManagerGateway(),
-			tdd.getJobID(),
-			tdd.getVertexID(),
-			tdd.getExecutionId(),
-			taskManagerConfiguration.getTimeout());
+				jobManagerConnection.getLeaderId(),
+				jobManagerConnection.getJobManagerGateway(),
+				tdd.getJobID(),
+				tdd.getVertexID(),
+				tdd.getExecutionId(),
+				taskManagerConfiguration.getTimeout());
 
 		TaskManagerActions taskManagerActions = jobManagerConnection.getTaskManagerActions();
 		CheckpointResponder checkpointResponder = jobManagerConnection.getCheckpointResponder();
@@ -673,7 +673,7 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 										final String message = "Could not mark slot " + jobId + " active.";
 										log.debug(message);
 										jobMasterGateway.failSlot(getResourceID(), acceptedSlot.getAllocationId(),
-											leaderId, new Exception(message));
+												leaderId, new Exception(message));
 									}
 
 									// remove the assigned slots so that we can free the left overs
@@ -836,14 +836,14 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 	}
 
 	private void updateTaskExecutionState(
-		final UUID jobMasterLeaderId,
-		final JobMasterGateway jobMasterGateway,
-		final TaskExecutionState taskExecutionState)
+			final UUID jobMasterLeaderId,
+			final JobMasterGateway jobMasterGateway,
+			final TaskExecutionState taskExecutionState)
 	{
 		final ExecutionAttemptID executionAttemptID = taskExecutionState.getID();
 
 		Future<Acknowledge> futureAcknowledge = jobMasterGateway.updateTaskExecutionState(
-			jobMasterLeaderId, taskExecutionState);
+				jobMasterLeaderId, taskExecutionState);
 
 		futureAcknowledge.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
 			@Override
@@ -856,9 +856,9 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 	}
 
 	private void unregisterTaskAndNotifyFinalState(
-		final UUID jobMasterLeaderId,
-		final JobMasterGateway jobMasterGateway,
-		final ExecutionAttemptID executionAttemptID) {
+			final UUID jobMasterLeaderId,
+			final JobMasterGateway jobMasterGateway,
+			final ExecutionAttemptID executionAttemptID) {
 
 		Task task = taskSlotTable.removeTask(executionAttemptID);
 		if (task != null) {
@@ -876,15 +876,15 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 			AccumulatorSnapshot accumulatorSnapshot = task.getAccumulatorRegistry().getSnapshot();
 
 			updateTaskExecutionState(
-				jobMasterLeaderId,
-				jobMasterGateway,
-				new TaskExecutionState(
-					task.getJobID(),
-					task.getExecutionId(),
-					task.getExecutionState(),
-					task.getFailureCause(),
-					accumulatorSnapshot,
-					task.getMetricGroup().getIOMetricGroup().createSnapshot()));
+					jobMasterLeaderId,
+					jobMasterGateway,
+					new TaskExecutionState(
+						task.getJobID(),
+						task.getExecutionId(),
+						task.getExecutionState(),
+						task.getFailureCause(),
+						accumulatorSnapshot,
+						task.getMetricGroup().getIOMetricGroup().createSnapshot()));
 		} else {
 			log.error("Cannot find task with ID {} to unregister.", executionAttemptID);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -135,7 +135,6 @@ public interface TaskExecutorGateway extends RpcGateway {
 	 *  request heartbeat from the resource manager
 	 *
 	 * @param resourceID unique id of the resource manager
-	 * @param payload the payload information of the resource manager
 	 */
-	void requestHeartbeatFromResourceManager(ResourceID resourceID, Object payload);
+	void requestHeartbeatFromResourceManager(ResourceID resourceID);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestReply;
@@ -129,4 +130,12 @@ public interface TaskExecutorGateway extends RpcGateway {
 	 * @return Future acknowledge if the task is successfully canceled
 	 */
 	Future<Acknowledge> cancelTask(ExecutionAttemptID executionAttemptID, @RpcTimeout Time timeout);
+
+	/**
+	 *  request heartbeat from the resource manager
+	 *
+	 * @param resourceID unique id of the resource manager
+	 * @param payload the payload information of the resource manager
+	 */
+	void requestHeartbeatFromResourceManager(ResourceID resourceID, Object payload);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorRegistrationSuccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorRegistrationSuccess.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 
@@ -33,16 +34,19 @@ public final class TaskExecutorRegistrationSuccess extends RegistrationResponse.
 
 	private final InstanceID registrationId;
 
+	private final ResourceID resourceID;
+
 	private final long heartbeatInterval;
 
 	/**
 	 * Create a new {@code TaskExecutorRegistrationSuccess} message.
-	 * 
+	 *
 	 * @param registrationId     The ID that the ResourceManager assigned the registration.
 	 * @param heartbeatInterval  The interval in which the ResourceManager will heartbeat the TaskExecutor.
 	 */
-	public TaskExecutorRegistrationSuccess(InstanceID registrationId, long heartbeatInterval) {
+	public TaskExecutorRegistrationSuccess(InstanceID registrationId, ResourceID resourceID, long heartbeatInterval) {
 		this.registrationId = registrationId;
+		this.resourceID = resourceID;
 		this.heartbeatInterval = heartbeatInterval;
 	}
 
@@ -54,6 +58,11 @@ public final class TaskExecutorRegistrationSuccess extends RegistrationResponse.
 	}
 
 	/**
+	 * Gets the ResourceID of the ResourceManager
+	 */
+	public ResourceID getResourceID() { return resourceID; }
+
+	/**
 	 * Gets the interval in which the ResourceManager will heartbeat the TaskExecutor.
 	 */
 	public long getHeartbeatInterval() {
@@ -62,14 +71,7 @@ public final class TaskExecutorRegistrationSuccess extends RegistrationResponse.
 
 	@Override
 	public String toString() {
-		return "TaskExecutorRegistrationSuccess (" + registrationId + " / " + heartbeatInterval + ')';
+		return "TaskExecutorRegistrationSuccess (" + registrationId + " / " + resourceID + "/" + heartbeatInterval + ')';
 	}
 
 }
-
-
-
-
-
-
-

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
@@ -133,7 +133,7 @@ public class TaskExecutorToResourceManagerConnection
 	// ------------------------------------------------------------------------
 
 	private static class ResourceManagerRegistration
-		extends RetryingRegistration<ResourceManagerGateway, TaskExecutorRegistrationSuccess> {
+			extends RetryingRegistration<ResourceManagerGateway, TaskExecutorRegistrationSuccess> {
 
 		private final String taskExecutorAddress;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
@@ -43,7 +43,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * The connection between a TaskExecutor and the ResourceManager.
  */
 public class TaskExecutorToResourceManagerConnection
-	extends RegisteredRpcConnection<ResourceManagerGateway, TaskExecutorRegistrationSuccess> {
+		extends RegisteredRpcConnection<ResourceManagerGateway, TaskExecutorRegistrationSuccess> {
 
 	private final RpcService rpcService;
 
@@ -60,16 +60,16 @@ public class TaskExecutorToResourceManagerConnection
 	private InstanceID registrationId;
 
 	public TaskExecutorToResourceManagerConnection(
-		Logger log,
-		RpcService rpcService,
-		HeartbeatManagerImpl heartbeatManager,
-		String taskManagerAddress,
-		ResourceID taskManagerResourceId,
-		SlotReport slotReport,
-		String resourceManagerAddress,
-		UUID resourceManagerLeaderId,
-		Executor executor,
-		FatalErrorHandler fatalErrorHandler) {
+			Logger log,
+			RpcService rpcService,
+			HeartbeatManagerImpl heartbeatManager,
+			String taskManagerAddress,
+			ResourceID taskManagerResourceId,
+			SlotReport slotReport,
+			String resourceManagerAddress,
+			UUID resourceManagerLeaderId,
+			Executor executor,
+			FatalErrorHandler fatalErrorHandler) {
 
 		super(log, resourceManagerAddress, resourceManagerLeaderId, executor);
 
@@ -142,13 +142,13 @@ public class TaskExecutorToResourceManagerConnection
 		private final SlotReport slotReport;
 
 		ResourceManagerRegistration(
-			Logger log,
-			RpcService rpcService,
-			String targetAddress,
-			UUID leaderId,
-			String taskExecutorAddress,
-			ResourceID resourceID,
-			SlotReport slotReport) {
+				Logger log,
+				RpcService rpcService,
+				String targetAddress,
+				UUID leaderId,
+				String taskExecutorAddress,
+				ResourceID resourceID,
+				SlotReport slotReport) {
 
 			super(log, rpcService, "ResourceManager", ResourceManagerGateway.class, targetAddress, leaderId);
 			this.taskExecutorAddress = checkNotNull(taskExecutorAddress);
@@ -158,7 +158,7 @@ public class TaskExecutorToResourceManagerConnection
 
 		@Override
 		protected Future<RegistrationResponse> invokeRegistration(
-			ResourceManagerGateway resourceManager, UUID leaderId, long timeoutMillis) throws Exception {
+				ResourceManagerGateway resourceManager, UUID leaderId, long timeoutMillis) throws Exception {
 
 			Time timeout = Time.milliseconds(timeoutMillis);
 			return resourceManager.registerTaskExecutor(leaderId, taskExecutorAddress, resourceID, slotReport, timeout);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.filecache.FileCache;
+import org.apache.flink.runtime.heartbeat.HeartbeatManagerImpl;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
@@ -97,6 +98,7 @@ public class TaskExecutorITCase {
 		SlotManagerFactory slotManagerFactory = new DefaultSlotManager.Factory();
 		JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(testingHAServices);
 		MetricRegistry metricRegistry = mock(MetricRegistry.class);
+		HeartbeatManagerImpl heartbeatManager = mock(HeartbeatManagerImpl.class);
 
 		final TaskManagerConfiguration taskManagerConfiguration = TaskManagerConfiguration.fromConfiguration(configuration);
 		final TaskManagerLocation taskManagerLocation = new TaskManagerLocation(taskManagerResourceId, InetAddress.getLocalHost(), 1234);
@@ -128,6 +130,7 @@ public class TaskExecutorITCase {
 			networkEnvironment,
 			testingHAServices,
 			metricRegistry,
+			heartbeatManager,
 			taskManagerMetricGroup,
 			broadcastVariableManager,
 			fileCache,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -144,7 +144,7 @@ public class TaskExecutorTest extends TestLogger {
 			String taskManagerAddress = taskManager.getAddress();
 
 			verify(rmGateway).registerTaskExecutor(
-				any(UUID.class), eq(taskManagerAddress), eq(resourceID), eq(slotReport), any(Time.class));
+					any(UUID.class), eq(taskManagerAddress), eq(resourceID), eq(slotReport), any(Time.class));
 		}
 		finally {
 			rpc.stopService();
@@ -214,7 +214,7 @@ public class TaskExecutorTest extends TestLogger {
 			testLeaderService.notifyListener(address1, leaderId1);
 
 			verify(rmGateway1).registerTaskExecutor(
-				eq(leaderId1), eq(taskManagerAddress), eq(resourceID), any(SlotReport.class), any(Time.class));
+					eq(leaderId1), eq(taskManagerAddress), eq(resourceID), any(SlotReport.class), any(Time.class));
 			assertNotNull(taskManager.getResourceManagerConnection());
 
 			// cancel the leader
@@ -224,7 +224,7 @@ public class TaskExecutorTest extends TestLogger {
 			testLeaderService.notifyListener(address2, leaderId2);
 
 			verify(rmGateway2).registerTaskExecutor(
-				eq(leaderId2), eq(taskManagerAddress), eq(resourceID), eq(slotReport), any(Time.class));
+					eq(leaderId2), eq(taskManagerAddress), eq(resourceID), eq(slotReport), any(Time.class));
 			assertNotNull(taskManager.getResourceManagerConnection());
 		}
 		finally {
@@ -390,10 +390,10 @@ public class TaskExecutorTest extends TestLogger {
 		final JobMasterGateway jobMasterGateway = mock(JobMasterGateway.class);
 
 		when(jobMasterGateway.registerTaskManager(
-			any(String.class),
-			eq(taskManagerLocation),
-			eq(jobManagerLeaderId),
-			any(Time.class)
+				any(String.class),
+				eq(taskManagerLocation),
+				eq(jobManagerLeaderId),
+				any(Time.class)
 		)).thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(new JMTMRegistrationSuccess(jmResourceId, blobPort)));
 		when(jobMasterGateway.getAddress()).thenReturn(jobManagerAddress);
 
@@ -439,10 +439,10 @@ public class TaskExecutorTest extends TestLogger {
 
 			// the job leader should get the allocation id offered
 			verify(jobMasterGateway).offerSlots(
-				any(ResourceID.class),
-				(Iterable<SlotOffer>)Matchers.argThat(contains(slotOffer)),
-				eq(jobManagerLeaderId),
-				any(Time.class));
+					any(ResourceID.class),
+					(Iterable<SlotOffer>)Matchers.argThat(contains(slotOffer)),
+					eq(jobManagerLeaderId),
+					any(Time.class));
 		} finally {
 			// check if a concurrent error occurred
 			testingFatalErrorHandler.rethrowError();
@@ -505,15 +505,15 @@ public class TaskExecutorTest extends TestLogger {
 		final JobMasterGateway jobMasterGateway = mock(JobMasterGateway.class);
 
 		when(jobMasterGateway.registerTaskManager(
-			any(String.class),
-			eq(taskManagerLocation),
-			eq(jobManagerLeaderId),
-			any(Time.class)
+				any(String.class),
+				eq(taskManagerLocation),
+				eq(jobManagerLeaderId),
+				any(Time.class)
 		)).thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(new JMTMRegistrationSuccess(jmResourceId, blobPort)));
 		when(jobMasterGateway.getAddress()).thenReturn(jobManagerAddress);
 
 		when(jobMasterGateway.offerSlots(
-			any(ResourceID.class), any(Iterable.class), eq(jobManagerLeaderId), any(Time.class)))
+				any(ResourceID.class), any(Iterable.class), eq(jobManagerLeaderId), any(Time.class)))
 			.thenReturn(FlinkCompletableFuture.completed((Iterable<SlotOffer>)Collections.singleton(offer1)));
 
 		rpc.registerGateway(resourceManagerAddress, resourceManagerGateway);


### PR DESCRIPTION
When TaskManager registers at the new ResourceManager, the SlotReport will be attached in the message. In heartbeat process, it is no need to exchange SlotReport between TaskManager and ResourceManager, so the payload is null in heartbeat message.

When TaskManager' listener is notified of heartbeat timeout from ResourceManager, currently it does nothing in the event notification. And it will re-register the new ResourceManager by HA mechanism.