### PR TITLE
[FLINK-5012] Expose Timestamp in Timely FlatMap Functions

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/TimelyFlatMapFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/TimelyFlatMapFunction.java
@@ -52,27 +52,59 @@ public interface TimelyFlatMapFunction<I, O> extends Function, Serializable {
 	 * it into zero, one, or more elements.
 	 *
 	 * @param value The input value.
-	 * @param timerService A {@link TimerService} that allows setting timers and querying the
-	 *                        current time.
+	 * @param ctx A {@link Context} that allows querying the timestamp of the element and getting
+	 *            a {@link TimerService} for registering timers and querying the time. The
+	 *            context is only valid during the invocation of this method, do not store it.
 	 * @param out The collector for returning result values.
 	 *
 	 * @throws Exception This method may throw exceptions. Throwing an exception will cause the operation
 	 *                   to fail and may trigger recovery.
 	 */
-	void flatMap(I value, TimerService timerService, Collector<O> out) throws Exception;
+	void flatMap(I value, Context ctx, Collector<O> out) throws Exception;
 
 	/**
 	 * Called when a timer set using {@link TimerService} fires.
 	 *
 	 * @param timestamp The timestamp of the firing timer.
-	 * @param timeDomain The {@link TimeDomain} of the firing timer.
-	 * @param timerService A {@link TimerService} that allows setting timers and querying the
-	 *                        current time.
+	 * @param ctx An {@link OnTimerContext} that allows querying the timestamp of the firing timer,
+	 *            querying the {@link TimeDomain} of the firing timer and getting a
+	 *            {@link TimerService} for registering timers and querying the time.
+	 *            The context is only valid during the invocation of this method, do not store it.
 	 * @param out The collector for returning result values.
 	 *
 	 * @throws Exception This method may throw exceptions. Throwing an exception will cause the operation
 	 *                   to fail and may trigger recovery.
 	 */
-	void onTimer(long timestamp, TimeDomain timeDomain, TimerService timerService, Collector<O> out) throws Exception ;
+	void onTimer(long timestamp, OnTimerContext ctx, Collector<O> out) throws Exception ;
+
+	/**
+	 * Information available in an invocation of {@link #flatMap(Object, Context, Collector)}
+	 * or {@link #onTimer(long, OnTimerContext, Collector)}.
+	 */
+	interface Context {
+
+		/**
+		 * Timestamp of the element currently being processed or timestamp of a firing timer.
+		 *
+		 * <p>This might be {@code null}, for example if the time characteristic of your program
+		 * is set to {@link org.apache.flink.streaming.api.TimeCharacteristic#ProcessingTime}.
+		 */
+		Long timestamp();
+
+		/**
+		 * A {@link TimerService} for querying timer and registering timers.
+		 */
+		TimerService timerService();
+	}
+
+	/**
+	 * Information available in an invocation of {@link #onTimer(long, OnTimerContext, Collector)}.
+	 */
+	interface OnTimerContext extends Context {
+		/**
+		 * The {@link TimeDomain} of the firing timer.
+		 */
+		TimeDomain timeDomain();
+	}
 
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/TimelyCoFlatMapFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/TimelyCoFlatMapFunction.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.streaming.api.TimeDomain;
 import org.apache.flink.streaming.api.TimerService;
+import org.apache.flink.streaming.api.functions.TimelyFlatMapFunction;
 import org.apache.flink.util.Collector;
 
 import java.io.Serializable;
@@ -55,38 +56,73 @@ public interface TimelyCoFlatMapFunction<IN1, IN2, OUT> extends Function, Serial
 	 * This method is called for each element in the first of the connected streams.
 	 * 
 	 * @param value The stream element
-	 * @param timerService A {@link TimerService} that allows setting timers and querying the
-	 *                        current time.
+	 * @param ctx An {@link OnTimerContext} that allows querying the timestamp of the element,
+	 *            querying the {@link TimeDomain} of the firing timer and getting a
+	 *            {@link TimerService} for registering timers and querying the time.
+	 *            The context is only valid during the invocation of this method, do not store it.
 	 * @param out The collector to emit resulting elements to
 	 * @throws Exception The function may throw exceptions which cause the streaming program
 	 *                   to fail and go into recovery.
 	 */
-	void flatMap1(IN1 value, TimerService timerService, Collector<OUT> out) throws Exception;
+	void flatMap1(IN1 value, Context ctx, Collector<OUT> out) throws Exception;
 
 	/**
 	 * This method is called for each element in the second of the connected streams.
 	 * 
 	 * @param value The stream element
-	 * @param timerService A {@link TimerService} that allows setting timers and querying the
-	 *                        current time.
+	 * @param ctx An {@link OnTimerContext} that allows querying the timestamp of the element,
+	 *            querying the {@link TimeDomain} of the firing timer and getting a
+	 *            {@link TimerService} for registering timers and querying the time.
+	 *            The context is only valid during the invocation of this method, do not store it.
 	 * @param out The collector to emit resulting elements to
 	 * @throws Exception The function may throw exceptions which cause the streaming program
 	 *                   to fail and go into recovery.
 	 */
-	void flatMap2(IN2 value, TimerService timerService, Collector<OUT> out) throws Exception;
+	void flatMap2(IN2 value, Context ctx, Collector<OUT> out) throws Exception;
 
 	/**
 	 * Called when a timer set using {@link TimerService} fires.
 	 *
 	 * @param timestamp The timestamp of the firing timer.
-	 * @param timeDomain The {@link TimeDomain} of the firing timer.
-	 * @param timerService A {@link TimerService} that allows setting timers and querying the
-	 *                        current time.
+	 * @param ctx An {@link OnTimerContext} that allows querying the timestamp of the firing timer,
+	 *            querying the {@link TimeDomain} of the firing timer and getting a
+	 *            {@link TimerService} for registering timers and querying the time.
+	 *            The context is only valid during the invocation of this method, do not store it.
 	 * @param out The collector for returning result values.
 	 *
 	 * @throws Exception This method may throw exceptions. Throwing an exception will cause the operation
 	 *                   to fail and may trigger recovery.
 	 */
-	void onTimer(long timestamp, TimeDomain timeDomain, TimerService timerService, Collector<OUT> out) throws Exception ;
+	void onTimer(long timestamp, OnTimerContext ctx, Collector<OUT> out) throws Exception ;
 
+	/**
+	 * Information available in an invocation of {@link #flatMap1(Object, Context, Collector)}/
+	 * {@link #flatMap2(Object, Context, Collector)}
+	 * or {@link #onTimer(long, OnTimerContext, Collector)}.
+	 */
+	interface Context {
+
+		/**
+		 * Timestamp of the element currently being processed or timestamp of a firing timer.
+		 *
+		 * <p>This might be {@code null}, for example if the time characteristic of your program
+		 * is set to {@link org.apache.flink.streaming.api.TimeCharacteristic#ProcessingTime}.
+		 */
+		Long timestamp();
+
+		/**
+		 * A {@link TimerService} for querying timer and registering timers.
+		 */
+		TimerService timerService();
+	}
+
+	/**
+	 * Information available in an invocation of {@link #onTimer(long, OnTimerContext, Collector)}.
+	 */
+	interface OnTimerContext extends TimelyFlatMapFunction.Context {
+		/**
+		 * The {@link TimeDomain} of the firing timer.
+		 */
+		TimeDomain timeDomain();
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTimelyFlatMap.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTimelyFlatMap.java
@@ -26,6 +26,9 @@ import org.apache.flink.streaming.api.TimerService;
 import org.apache.flink.streaming.api.functions.TimelyFlatMapFunction;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
 @Internal
 public class StreamTimelyFlatMap<K, IN, OUT>
 		extends AbstractUdfStreamOperator<OUT, TimelyFlatMapFunction<IN, OUT>>
@@ -36,6 +39,10 @@ public class StreamTimelyFlatMap<K, IN, OUT>
 	private transient TimestampedCollector<OUT> collector;
 
 	private transient TimerService timerService;
+
+	private transient ContextImpl<IN> context;
+
+	private transient OnTimerContextImpl onTimerContext;
 
 	public StreamTimelyFlatMap(TimelyFlatMapFunction<IN, OUT> flatMapper) {
 		super(flatMapper);
@@ -52,23 +59,93 @@ public class StreamTimelyFlatMap<K, IN, OUT>
 				getInternalTimerService("user-timers", VoidNamespaceSerializer.INSTANCE, this);
 
 		this.timerService = new SimpleTimerService(internalTimerService);
+
+		context = new ContextImpl<>(timerService);
+		onTimerContext = new OnTimerContextImpl(timerService);
 	}
 
 	@Override
 	public void onEventTime(InternalTimer<K, VoidNamespace> timer) throws Exception {
 		collector.setAbsoluteTimestamp(timer.getTimestamp());
-		userFunction.onTimer(timer.getTimestamp(), TimeDomain.EVENT_TIME, timerService, collector);
+		onTimerContext.timeDomain = TimeDomain.EVENT_TIME;
+		onTimerContext.timer = timer;
+		userFunction.onTimer(timer.getTimestamp(), onTimerContext, collector);
+		onTimerContext.timeDomain = null;
+		onTimerContext.timer = null;
 	}
 
 	@Override
 	public void onProcessingTime(InternalTimer<K, VoidNamespace> timer) throws Exception {
 		collector.setAbsoluteTimestamp(timer.getTimestamp());
-		userFunction.onTimer(timer.getTimestamp(), TimeDomain.PROCESSING_TIME, timerService, collector);
+		onTimerContext.timeDomain = TimeDomain.PROCESSING_TIME;
+		onTimerContext.timer = timer;
+		userFunction.onTimer(timer.getTimestamp(), onTimerContext, collector);
+		onTimerContext.timeDomain = null;
+		onTimerContext.timer = null;
 	}
 
 	@Override
 	public void processElement(StreamRecord<IN> element) throws Exception {
 		collector.setTimestamp(element);
-		userFunction.flatMap(element.getValue(), timerService, collector);
+		context.element = element;
+		userFunction.flatMap(element.getValue(), context, collector);
+		context.element = null;
+	}
+
+	private static class ContextImpl<T> implements TimelyFlatMapFunction.Context {
+
+		private final TimerService timerService;
+
+		private StreamRecord<T> element;
+
+		ContextImpl(TimerService timerService) {
+			this.timerService = checkNotNull(timerService);
+		}
+
+		@Override
+		public Long timestamp() {
+			checkState(element != null);
+
+			if (element.hasTimestamp()) {
+				return element.getTimestamp();
+			} else {
+				return null;
+			}
+		}
+
+		@Override
+		public TimerService timerService() {
+			return timerService;
+		}
+	}
+
+	private static class OnTimerContextImpl implements TimelyFlatMapFunction.OnTimerContext{
+
+		private final TimerService timerService;
+
+		private TimeDomain timeDomain;
+
+		private InternalTimer<?, VoidNamespace> timer;
+
+		OnTimerContextImpl(TimerService timerService) {
+			this.timerService = checkNotNull(timerService);
+		}
+
+		@Override
+		public TimeDomain timeDomain() {
+			checkState(timeDomain != null);
+			return timeDomain;
+		}
+
+		@Override
+		public Long timestamp() {
+			checkState(timer != null);
+			return timer.getTimestamp();
+		}
+
+		@Override
+		public TimerService timerService() {
+			return timerService;
+		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -560,7 +560,7 @@ public class DataStreamTest {
 			@Override
 			public void flatMap(
 					Long value,
-					TimerService timerService,
+					Context ctx,
 					Collector<Integer> out) throws Exception {
 
 			}
@@ -568,8 +568,7 @@ public class DataStreamTest {
 			@Override
 			public void onTimer(
 					long timestamp,
-					TimeDomain timeDomain,
-					TimerService timerService,
+					OnTimerContext ctx,
 					Collector<Integer> out) throws Exception {
 
 			}

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
@@ -22,9 +22,9 @@ import java.lang
 
 import org.apache.flink.api.common.functions._
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.streaming.api.{TimeDomain, TimerService}
 import org.apache.flink.streaming.api.collector.selector.OutputSelector
 import org.apache.flink.streaming.api.functions.TimelyFlatMapFunction
+import org.apache.flink.streaming.api.functions.TimelyFlatMapFunction.{Context, OnTimerContext}
 import org.apache.flink.streaming.api.functions.co.CoMapFunction
 import org.apache.flink.streaming.api.graph.{StreamEdge, StreamGraph}
 import org.apache.flink.streaming.api.operators.{AbstractUdfStreamOperator, StreamOperator, StreamTimelyFlatMap}
@@ -327,11 +327,10 @@ class DataStreamTest extends StreamingMultipleProgramsTestBase {
     val src = env.generateSequence(0, 0)
 
     val timelyFlatMapFunction = new TimelyFlatMapFunction[Long, Int] {
-      override def flatMap(value: Long, timerService: TimerService, out: Collector[Int]): Unit = ???
+      override def flatMap(value: Long, ctx: Context, out: Collector[Int]): Unit = ???
       override def onTimer(
           timestamp: Long,
-          timeDomain: TimeDomain,
-          timerService: TimerService,
+          ctx: OnTimerContext,
           out: Collector[Int]): Unit = ???
     }
 


### PR DESCRIPTION
This also adds a Context parameter that holds the timestamp, time domain
and TimerService to declutter the parameter list of the functions.

R: @StefanRRichter and @kl0u for review, please
CC: @jgrier