### PR TITLE
[FLINK-5037] Fixed instability in AbstractUdfStreamOperatorLifecycleTest

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
@@ -231,19 +231,15 @@ public class AbstractUdfStreamOperatorLifecycleTest {
 				testCheckpointer = new Thread() {
 					@Override
 					public void run() {
-						long id = 0;
-						while (true) {
-							try {
-								Thread.sleep(50);
-								if (getContainingTask().isCanceled() || getContainingTask().triggerCheckpoint(
-										new CheckpointMetaData(id++, System.currentTimeMillis()))) {
-									LifecycleTrackingStreamSource.runFinish.trigger();
-									break;
-								}
-							} catch (Exception e) {
-								e.printStackTrace();
-								Assert.fail();
+						try {
+							runStarted.await();
+							if (getContainingTask().isCanceled() || getContainingTask().triggerCheckpoint(
+									new CheckpointMetaData(0, System.currentTimeMillis()))) {
+								LifecycleTrackingStreamSource.runFinish.trigger();
 							}
+						} catch (Exception e) {
+							e.printStackTrace();
+							Assert.fail();
 						}
 					}
 				};


### PR DESCRIPTION
This PR fixes a small test instability in AbstractUdfStreamOperatorLifecycleTest.

