### PR TITLE
[hotfix] fix duplicate "ms" time unit

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/restartstrategy/RestartStrategies.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/restartstrategy/RestartStrategies.java
@@ -141,7 +141,7 @@ public class RestartStrategies {
 
 		@Override
 		public String getDescription() {
-			return "Restart with fixed delay (" + delayBetweenAttemptsInterval + " ms). #"
+			return "Restart with fixed delay (" + delayBetweenAttemptsInterval + "). #"
 				+ restartAttempts + " restart attempts.";
 		}
 	}


### PR DESCRIPTION
as in "Restart with fixed delay (10000 ms ms)." in the web interface under "Max. number of execution retries"
(org.apache.flink.api.common.time.Time already prints the time unit)