### PR TITLE
[FLINK-5046] [tdd] Preserialize TaskDeploymentDescriptor information

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
@@ -55,7 +55,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URL;
-import java.util.List;
+import java.util.Collection;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -211,8 +211,8 @@ public class JobClient {
 			InetSocketAddress serverAddress = new InetSocketAddress(jmHostname, props.blobManagerPort());
 			final BlobCache blobClient = new BlobCache(serverAddress, config);
 
-			final List<BlobKey> requiredJarFiles = props.requiredJarFiles();
-			final List<URL> requiredClasspaths = props.requiredClasspaths();
+			final Collection<BlobKey> requiredJarFiles = props.requiredJarFiles();
+			final Collection<URL> requiredClasspaths = props.requiredClasspaths();
 
 			final URL[] allURLs = new URL[requiredJarFiles.size() + requiredClasspaths.size()];
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
@@ -18,23 +18,15 @@
 
 package org.apache.flink.runtime.deployment;
 
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.TaskInfo;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.state.TaskStateHandles;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
 
 import java.io.Serializable;
-import java.net.URL;
 import java.util.Collection;
-import java.util.List;
-
-import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A task deployment descriptor contains all the information necessary to deploy a task on a task manager.
@@ -43,191 +35,83 @@ public final class TaskDeploymentDescriptor implements Serializable {
 
 	private static final long serialVersionUID = -3233562176034358530L;
 
-	/** The ID of the job the tasks belongs to. */
-	private final JobID jobID;
-	private final String jobName;
+	/** Serialized job information */
+	private final SerializedValue<JobInformation> serializedJobInformation;
 
-	/** The task's job vertex ID. */
-	private final JobVertexID vertexID;
+	/** Serialized task information */
+	private final SerializedValue<TaskInformation> serializedTaskInformation;
 
 	/** The ID referencing the attempt to execute the task. */
 	private final ExecutionAttemptID executionId;
 
-	/** The task's name. */
-	private final String taskName;
-
-	/** The number of key groups aka the max parallelism aka the max number of subtasks. */
-	private final int numberOfKeyGroups;
-
 	/** The task's index in the subtask group. */
-	private final int indexInSubtaskGroup;
-
-	/** The number of sub tasks. */
-	private final int numberOfSubtasks;
+	private final int subtaskIndex;
 
 	/** Attempt number the task */
 	private final int attemptNumber;
 
-	/** The configuration of the job the task belongs to. */
-	private final Configuration jobConfiguration;
-
-	/** The task's configuration object. */
-	private final Configuration taskConfiguration;
-
-	/** The name of the class containing the task code to be executed. */
-	private final String invokableClassName;
-
 	/** The list of produced intermediate result partition deployment descriptors. */
-	private final List<ResultPartitionDeploymentDescriptor> producedPartitions;
+	private final Collection<ResultPartitionDeploymentDescriptor> producedPartitions;
 
 	/** The list of consumed intermediate result partitions. */
-	private final List<InputGateDeploymentDescriptor> inputGates;
+	private final Collection<InputGateDeploymentDescriptor> inputGates;
 
+	/** Slot number to run the sub task in on the target machine */
 	private final int targetSlotNumber;
 
-	/** The list of JAR files required to run this task. */
-	private final List<BlobKey> requiredJarFiles;
-	
-	/** The list of classpaths required to run this task. */
-	private final List<URL> requiredClasspaths;
-
+	/** State handles for the sub task */
 	private final TaskStateHandles taskStateHandles;
 
-	/** The execution configuration (see {@link ExecutionConfig}) related to the specific job. */
-	private final SerializedValue<ExecutionConfig> serializedExecutionConfig;
-
-	/**
-	 * Constructs a task deployment descriptor.
-	 */
 	public TaskDeploymentDescriptor(
-		JobID jobID,
-		String jobName,
-		JobVertexID vertexID,
-		ExecutionAttemptID executionId,
-		SerializedValue<ExecutionConfig> serializedExecutionConfig,
-		String taskName,
-		int numberOfKeyGroups,
-		int indexInSubtaskGroup,
-		int numberOfSubtasks,
-		int attemptNumber,
-		Configuration jobConfiguration,
-		Configuration taskConfiguration,
-		String invokableClassName,
-		List<ResultPartitionDeploymentDescriptor> producedPartitions,
-		List<InputGateDeploymentDescriptor> inputGates,
-		List<BlobKey> requiredJarFiles,
-		List<URL> requiredClasspaths,
-		int targetSlotNumber,
-		TaskStateHandles taskStateHandles) {
+			SerializedValue<JobInformation> serializedJobInformation,
+			SerializedValue<TaskInformation> serializedTaskInformation,
+			ExecutionAttemptID executionAttemptId,
+			int subtaskIndex,
+			int attemptNumber,
+			int targetSlotNumber,
+			TaskStateHandles taskStateHandles,
+			Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
+			Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors) {
 
-		checkArgument(indexInSubtaskGroup >= 0);
-		checkArgument(numberOfSubtasks > indexInSubtaskGroup);
-		checkArgument(targetSlotNumber >= 0);
-		checkArgument(attemptNumber >= 0);
+		this.serializedJobInformation = Preconditions.checkNotNull(serializedJobInformation);
+		this.serializedTaskInformation = Preconditions.checkNotNull(serializedTaskInformation);
+		this.executionId = Preconditions.checkNotNull(executionAttemptId);
 
-		this.jobID = checkNotNull(jobID);
-		this.jobName = checkNotNull(jobName);
-		this.vertexID = checkNotNull(vertexID);
-		this.executionId = checkNotNull(executionId);
-		this.serializedExecutionConfig = checkNotNull(serializedExecutionConfig);
-		this.taskName = checkNotNull(taskName);
-		this.numberOfKeyGroups = numberOfKeyGroups;
-		this.indexInSubtaskGroup = indexInSubtaskGroup;
-		this.numberOfSubtasks = numberOfSubtasks;
+		Preconditions.checkArgument(0 <= subtaskIndex, "The subtask index must be positive.");
+		this.subtaskIndex = subtaskIndex;
+
+		Preconditions.checkArgument(0 <= attemptNumber, "The attempt number must be positive.");
 		this.attemptNumber = attemptNumber;
-		this.jobConfiguration = checkNotNull(jobConfiguration);
-		this.taskConfiguration = checkNotNull(taskConfiguration);
-		this.invokableClassName = checkNotNull(invokableClassName);
-		this.producedPartitions = checkNotNull(producedPartitions);
-		this.inputGates = checkNotNull(inputGates);
-		this.requiredJarFiles = checkNotNull(requiredJarFiles);
-		this.requiredClasspaths = checkNotNull(requiredClasspaths);
+
+		Preconditions.checkArgument(0 <= targetSlotNumber, "The target slot number must be positive.");
 		this.targetSlotNumber = targetSlotNumber;
+
 		this.taskStateHandles = taskStateHandles;
-	}
 
-	public TaskDeploymentDescriptor(
-		JobID jobID,
-		String jobName,
-		JobVertexID vertexID,
-		ExecutionAttemptID executionId,
-		SerializedValue<ExecutionConfig> serializedExecutionConfig,
-		String taskName,
-		int numberOfKeyGroups,
-		int indexInSubtaskGroup,
-		int numberOfSubtasks,
-		int attemptNumber,
-		Configuration jobConfiguration,
-		Configuration taskConfiguration,
-		String invokableClassName,
-		List<ResultPartitionDeploymentDescriptor> producedPartitions,
-		List<InputGateDeploymentDescriptor> inputGates,
-		List<BlobKey> requiredJarFiles,
-		List<URL> requiredClasspaths,
-		int targetSlotNumber) {
-
-		this(
-			jobID,
-			jobName,
-			vertexID,
-			executionId,
-			serializedExecutionConfig,
-			taskName,
-			numberOfKeyGroups,
-			indexInSubtaskGroup,
-			numberOfSubtasks,
-			attemptNumber,
-			jobConfiguration,
-			taskConfiguration,
-			invokableClassName,
-			producedPartitions,
-			inputGates,
-			requiredJarFiles,
-			requiredClasspaths,
-			targetSlotNumber,
-			null);
+		this.producedPartitions = Preconditions.checkNotNull(resultPartitionDeploymentDescriptors);
+		this.inputGates = Preconditions.checkNotNull(inputGateDeploymentDescriptors);
 	}
 
 	/**
-	 * Returns the execution configuration (see {@link ExecutionConfig}) related to the
-	 * specific job.
+	 * Return the sub task's serialized job information.
+	 *
+	 * @return serialized job information
 	 */
-	public SerializedValue<ExecutionConfig> getSerializedExecutionConfig() {
-		return serializedExecutionConfig;
+	public SerializedValue<JobInformation> getSerializedJobInformation() {
+		return serializedJobInformation;
 	}
 
 	/**
-	 * Returns the ID of the job the tasks belongs to.
+	 * Return the sub task's serialized task information.
+	 *
+	 * @return serialized task information
 	 */
-	public JobID getJobID() {
-		return jobID;
-	}
-	
-	public String getJobName() { return jobName; }
-
-	/**
-	 * Returns the task's execution vertex ID.
-	 */
-	public JobVertexID getVertexID() {
-		return vertexID;
+	public SerializedValue<TaskInformation> getSerializedTaskInformation() {
+		return serializedTaskInformation;
 	}
 
-	public ExecutionAttemptID getExecutionId() {
+	public ExecutionAttemptID getExecutionAttemptId() {
 		return executionId;
-	}
-
-	/**
-	 * Returns the task's name.
-	 */
-	public String getTaskName() {
-		return taskName;
-	}
-
-	/**
-	 * Returns the task's number of key groups.
-	 */
-	public int getNumberOfKeyGroups() {
-		return numberOfKeyGroups;
 	}
 
 	/**
@@ -235,15 +119,8 @@ public final class TaskDeploymentDescriptor implements Serializable {
 	 *
 	 * @return the task's index in the subtask group
 	 */
-	public int getIndexInSubtaskGroup() {
-		return indexInSubtaskGroup;
-	}
-
-	/**
-	 * Returns the current number of subtasks.
-	 */
-	public int getNumberOfSubtasks() {
-		return numberOfSubtasks;
+	public int getSubtaskIndex() {
+		return subtaskIndex;
 	}
 
 	/**
@@ -251,13 +128,6 @@ public final class TaskDeploymentDescriptor implements Serializable {
 	 */
 	public int getAttemptNumber() {
 		return attemptNumber;
-	}
-
-	/**
-	 * Returns the {@link TaskInfo} object for the subtask
-	 */
-	public TaskInfo getTaskInfo() {
-		return new TaskInfo(taskName, numberOfKeyGroups, indexInSubtaskGroup, numberOfSubtasks, attemptNumber);
 	}
 
 	/**
@@ -269,68 +139,39 @@ public final class TaskDeploymentDescriptor implements Serializable {
 		return targetSlotNumber;
 	}
 
-	/**
-	 * Returns the configuration of the job the task belongs to.
-	 */
-	public Configuration getJobConfiguration() {
-		return jobConfiguration;
-	}
-
-	/**
-	 * Returns the task's configuration object.
-	 */
-	public Configuration getTaskConfiguration() {
-		return taskConfiguration;
-	}
-
-	/**
-	 * Returns the name of the class containing the task code to be executed.
-	 */
-	public String getInvokableClassName() {
-		return invokableClassName;
-	}
-
-	public List<ResultPartitionDeploymentDescriptor> getProducedPartitions() {
+	public Collection<ResultPartitionDeploymentDescriptor> getProducedPartitions() {
 		return producedPartitions;
 	}
 
-	public List<InputGateDeploymentDescriptor> getInputGates() {
+	public Collection<InputGateDeploymentDescriptor> getInputGates() {
 		return inputGates;
 	}
 
-	public List<BlobKey> getRequiredJarFiles() {
-		return requiredJarFiles;
-	}
-
-	public List<URL> getRequiredClasspaths() {
-		return requiredClasspaths;
+	public TaskStateHandles getTaskStateHandles() {
+		return taskStateHandles;
 	}
 
 	@Override
 	public String toString() {
-		return String.format("TaskDeploymentDescriptor [job id: %s, job vertex id: %s, " +
-						"execution id: %s, task name: %s (%d/%d), attempt: %d, invokable: %s, " +
-						"produced partitions: %s, input gates: %s]",
-				jobID, vertexID, executionId, taskName, indexInSubtaskGroup, numberOfSubtasks,
-				attemptNumber, invokableClassName, collectionToString(producedPartitions),
-				collectionToString(inputGates));
+		return String.format("TaskDeploymentDescriptor [execution id: %s, attempt: %d, " +
+				"produced partitions: %s, input gates: %s]",
+			executionId,
+			attemptNumber,
+			collectionToString(producedPartitions),
+			collectionToString(inputGates));
 	}
 
-	private String collectionToString(Collection<?> collection) {
+	private static String collectionToString(Iterable<?> collection) {
 		final StringBuilder strBuilder = new StringBuilder();
 
 		strBuilder.append("[");
 
 		for (Object elem : collection) {
-			strBuilder.append(elem.toString());
+			strBuilder.append(elem);
 		}
 
 		strBuilder.append("]");
 
 		return strBuilder.toString();
-	}
-
-	public TaskStateHandles getTaskStateHandles() {
-		return taskStateHandles;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -372,7 +372,9 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 				@Override
 				public Void apply(Throwable failure) {
 					if (failure instanceof TimeoutException) {
-						String taskname = deployment.getTaskInfo().getTaskNameWithSubtasks() + " (" + attemptId + ')';
+						String taskname = vertex.getTaskName() + '(' +
+							(getParallelSubtaskIndex() + 1) + '/' +
+							vertex.getTotalNumberOfParallelSubtasks() + ") (" + attemptId + ')';
 
 						markFailed(new Exception(
 							"Cannot deploy task " + taskname + " - TaskManager (" + assignedResourceLocation

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -122,14 +122,13 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	 * within the job. */
 	private final SerializableObject progressLock = new SerializableObject();
 
-	/** The ID of the job this graph has been built for. */
-	private final JobID jobID;
+	/** Job specific information like the job id, job name, job configuration, etc. */
+	private final JobInformation jobInformation;
 
-	/** The name of the original job graph. */
-	private final String jobName;
-
-	/** The job configuration that was originally attached to the JobGraph. */
-	private final Configuration jobConfiguration;
+	/** Serialized version of the job specific information. This is done to avoid multiple
+	 * serializations of the same data when creating a TaskDeploymentDescriptor.
+	 */
+	private final SerializedValue<JobInformation> serializedJobInformation;
 
 	/** {@code true} if all source tasks are stoppable. */
 	private boolean isStoppable = true;
@@ -145,14 +144,6 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 
 	/** The currently executed tasks, for callbacks */
 	private final ConcurrentHashMap<ExecutionAttemptID, Execution> currentExecutions;
-
-	/** A list of all libraries required during the job execution. Libraries have to be stored
-	 * inside the BlobService and are referenced via the BLOB keys. */
-	private final List<BlobKey> requiredJarFiles;
-
-	/** A list of all classpaths required during the job execution. Classpaths have to be
-	 * accessible on all nodes in the cluster. */
-	private final List<URL> requiredClasspaths;
 
 	/** Listeners that receive messages when the entire job switches it status
 	 * (such as from RUNNING to FINISHED) */
@@ -171,9 +162,6 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	private final Time timeout;
 
 	// ------ Configuration of the Execution -------
-
-	/** The execution configuration (see {@link ExecutionConfig}) related to this specific job. */
-	private final SerializedValue<ExecutionConfig> serializedExecutionConfig;
 
 	/** Flag to indicate whether the scheduler may queue tasks for execution, or needs to be able
 	 * to deploy them immediately. */
@@ -237,7 +225,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 			Configuration jobConfig,
 			SerializedValue<ExecutionConfig> serializedConfig,
 			Time timeout,
-			RestartStrategy restartStrategy) {
+			RestartStrategy restartStrategy) throws IOException {
 		this(
 			executor,
 			jobId,
@@ -264,7 +252,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 			List<BlobKey> requiredJarFiles,
 			List<URL> requiredClasspaths,
 			ClassLoader userClassLoader,
-			MetricGroup metricGroup) {
+			MetricGroup metricGroup) throws IOException {
 
 		checkNotNull(executor);
 		checkNotNull(jobId);
@@ -272,11 +260,19 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 		checkNotNull(jobConfig);
 		checkNotNull(userClassLoader);
 
+		this.jobInformation = new JobInformation(
+			jobId,
+			jobName,
+			serializedConfig,
+			jobConfig,
+			requiredJarFiles,
+			requiredClasspaths);
+
+		// serialize the job information to do the serialisation work only once
+		this.serializedJobInformation = new SerializedValue<>(jobInformation);
+
 		this.executor = executor;
 
-		this.jobID = jobId;
-		this.jobName = jobName;
-		this.jobConfiguration = jobConfig;
 		this.userClassLoader = userClassLoader;
 
 		this.tasks = new ConcurrentHashMap<JobVertexID, ExecutionJobVertex>();
@@ -289,11 +285,6 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 
 		this.stateTimestamps = new long[JobStatus.values().length];
 		this.stateTimestamps[JobStatus.CREATED.ordinal()] = System.currentTimeMillis();
-
-		this.requiredJarFiles = requiredJarFiles;
-		this.requiredClasspaths = requiredClasspaths;
-
-		this.serializedExecutionConfig = checkNotNull(serializedConfig);
 
 		this.timeout = timeout;
 
@@ -374,7 +365,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 
 		// create the coordinator that triggers and commits checkpoints and holds the state
 		checkpointCoordinator = new CheckpointCoordinator(
-				jobID,
+				jobInformation.getJobId(),
 				interval,
 				checkpointTimeout,
 				minPauseBetweenCheckpoints,
@@ -461,16 +452,16 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	 * Returns a list of BLOB keys referring to the JAR files required to run this job
 	 * @return list of BLOB keys referring to the JAR files required to run this job
 	 */
-	public List<BlobKey> getRequiredJarFiles() {
-		return this.requiredJarFiles;
+	public Collection<BlobKey> getRequiredJarFiles() {
+		return jobInformation.getRequiredJarFileBlobKeys();
 	}
 
 	/**
 	 * Returns a list of classpaths referring to the directories/JAR files required to run this job
 	 * @return list of classpaths referring to the directories/JAR files required to run this job
 	 */
-	public List<URL> getRequiredClasspaths() {
-		return this.requiredClasspaths;
+	public Collection<URL> getRequiredClasspaths() {
+		return jobInformation.getRequiredClasspathURLs();
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -488,14 +479,18 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 		return slotProvider;
 	}
 
+	public SerializedValue<JobInformation> getSerializedJobInformation() {
+		return serializedJobInformation;
+	}
+
 	@Override
 	public JobID getJobID() {
-		return jobID;
+		return jobInformation.getJobId();
 	}
 
 	@Override
 	public String getJobName() {
-		return jobName;
+		return jobInformation.getJobName();
 	}
 
 	@Override
@@ -504,7 +499,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	}
 
 	public Configuration getJobConfiguration() {
-		return jobConfiguration;
+		return jobInformation.getJobConfiguration();
 	}
 
 	public ClassLoader getUserClassLoader() {
@@ -663,7 +658,12 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 			}
 
 			// create the execution job vertex and attach it to the graph
-			ExecutionJobVertex ejv = new ExecutionJobVertex(this, jobVertex, 1, timeout, createTimestamp);
+			ExecutionJobVertex ejv = null;
+			try {
+				ejv = new ExecutionJobVertex(this, jobVertex, 1, timeout, createTimestamp);
+			} catch (IOException e) {
+				throw new JobException("Could not create a execution job vertex for " + jobVertex.getID() + '.', e);
+			}
 			ejv.connectToPredecessors(this.intermediateResults);
 
 			ExecutionJobVertex previousTask = this.tasks.putIfAbsent(jobVertex.getID(), ejv);
@@ -933,23 +933,14 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	public ArchivedExecutionConfig getArchivedExecutionConfig() {
 		// create a summary of all relevant data accessed in the web interface's JobConfigHandler
 		try {
-			ExecutionConfig executionConfig = getSerializedExecutionConfig().deserializeValue(userClassLoader);
+			ExecutionConfig executionConfig = jobInformation.getSerializedExecutionConfig().deserializeValue(userClassLoader);
 			if (executionConfig != null) {
 				return executionConfig.archive();
 			}
 		} catch (IOException | ClassNotFoundException e) {
-			LOG.error("Couldn't create ArchivedExecutionConfig for job {} ", jobID, e);
+			LOG.error("Couldn't create ArchivedExecutionConfig for job {} ", getJobID(), e);
 		};
 		return null;
-	}
-
-	/**
-	 * Returns the serialized {@link ExecutionConfig}.
-	 *
-	 * @return ExecutionConfig
-	 */
-	public SerializedValue<ExecutionConfig> getSerializedExecutionConfig() {
-		return serializedExecutionConfig;
 	}
 
 	/**
@@ -1198,7 +1189,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 				LOG.warn("Received accumulator result for unknown execution {}.", execID);
 			}
 		} catch (Exception e) {
-			LOG.error("Cannot update accumulators for job {}.", jobID, e);
+			LOG.error("Cannot update accumulators for job {}.", getJobID(), e);
 		}
 	}
 
@@ -1225,7 +1216,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 
 			for (JobStatusListener listener : jobStatusListeners) {
 				try {
-					listener.jobStatusChanges(jobID, newState, timestamp, serializedError);
+					listener.jobStatusChanges(getJobID(), newState, timestamp, serializedError);
 				} catch (Throwable t) {
 					LOG.warn("Error while notifying JobStatusListener", t);
 				}
@@ -1246,7 +1237,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 			for (ExecutionStatusListener listener : executionListeners) {
 				try {
 					listener.executionStatusChanged(
-							jobID, vertexId, vertex.getJobVertex().getName(),
+							getJobID(), vertexId, vertex.getJobVertex().getName(),
 							vertex.getParallelism(), subtask, executionID, newExecutionState,
 							timestamp, message);
 				} catch (Throwable t) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
 import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -77,19 +78,25 @@ public class ExecutionGraphBuilder {
 		final JobID jobId = jobGraph.getJobID();
 
 		// create a new execution graph, if none exists so far
-		final ExecutionGraph executionGraph = (prior != null) ? prior :
-				new ExecutionGraph(
-						executor,
-						jobId,
-						jobName,
-						jobGraph.getJobConfiguration(),
-						jobGraph.getSerializedExecutionConfig(),
-						timeout,
-						restartStrategy,
-						jobGraph.getUserJarBlobKeys(),
-						jobGraph.getClasspaths(),
-						classLoader,
-						metrics);
+		final ExecutionGraph executionGraph;
+
+		try {
+			executionGraph = (prior != null) ? prior :
+					new ExecutionGraph(
+							executor,
+							jobId,
+							jobName,
+							jobGraph.getJobConfiguration(),
+							jobGraph.getSerializedExecutionConfig(),
+							timeout,
+							restartStrategy,
+							jobGraph.getUserJarBlobKeys(),
+							jobGraph.getClasspaths(),
+							classLoader,
+							metrics);
+		} catch (IOException e) {
+			throw new JobException("Could not create the execution graph.", e);
+		}
 
 		// set the basic properties
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -19,11 +19,9 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.Archiveable;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.JobException;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.PartialInputChannelDeploymentDescriptor;
@@ -47,7 +45,6 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.SerializedValue;
 import org.slf4j.Logger;
 
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -599,30 +596,19 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 			consumedPartitions.add(new InputGateDeploymentDescriptor(resultId, queueToRequest, partitions));
 		}
 
-		SerializedValue<ExecutionConfig> serializedConfig = getExecutionGraph().getSerializedExecutionConfig();
-		List<BlobKey> jarFiles = getExecutionGraph().getRequiredJarFiles();
-		List<URL> classpaths = getExecutionGraph().getRequiredClasspaths();
+		SerializedValue<JobInformation> serializedJobInformation = getExecutionGraph().getSerializedJobInformation();
+		SerializedValue<TaskInformation> serializedJobVertexInformation = jobVertex.getSerializedTaskInformation();
 
 		return new TaskDeploymentDescriptor(
-			getJobId(),
-			getExecutionGraph().getJobName(),
-			getJobvertexId(),
+			serializedJobInformation,
+			serializedJobVertexInformation,
 			executionId,
-			serializedConfig,
-			getTaskName(),
-			getMaxParallelism(),
 			subTaskIndex,
-			getTotalNumberOfParallelSubtasks(),
 			attemptNumber,
-			getExecutionGraph().getJobConfiguration(),
-			jobVertex.getJobVertex().getConfiguration(),
-			jobVertex.getJobVertex().getInvokableClassName(),
-			producedPartitions,
-			consumedPartitions,
-			jarFiles,
-			classpaths,
 			targetSlot.getRoot().getSlotNumber(),
-			taskStateHandles);
+			taskStateHandles,
+			producedPartitions,
+			consumedPartitions);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobInformation.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.SerializedValue;
+
+import java.io.Serializable;
+import java.net.URL;
+import java.util.Collection;
+
+/**
+ * Container class for job information which is stored in the {@link ExecutionGraph}.
+ */
+public class JobInformation implements Serializable {
+
+	private static final long serialVersionUID = 8367087049937822140L;
+
+	/** Id of the job */
+	private final JobID jobId;
+
+	/** Job name */
+	private final String jobName;
+
+	/** Serialized execution config because it can contain user code classes */
+	private final SerializedValue<ExecutionConfig> serializedExecutionConfig;
+
+	/** Configuration of the job */
+	private final Configuration jobConfiguration;
+
+	/** Blob keys for the required jar files */
+	private final Collection<BlobKey> requiredJarFileBlobKeys;
+
+	/** URLs specifying the classpath to add to the class loader */
+	private final Collection<URL> requiredClasspathURLs;
+
+
+	public JobInformation(
+			JobID jobId,
+			String jobName,
+			SerializedValue<ExecutionConfig> serializedExecutionConfig,
+			Configuration jobConfiguration,
+			Collection<BlobKey> requiredJarFileBlobKeys,
+			Collection<URL> requiredClasspathURLs) {
+		this.jobId = Preconditions.checkNotNull(jobId);
+		this.jobName = Preconditions.checkNotNull(jobName);
+		this.serializedExecutionConfig = Preconditions.checkNotNull(serializedExecutionConfig);
+		this.jobConfiguration = Preconditions.checkNotNull(jobConfiguration);
+		this.requiredJarFileBlobKeys = Preconditions.checkNotNull(requiredJarFileBlobKeys);
+		this.requiredClasspathURLs = Preconditions.checkNotNull(requiredClasspathURLs);
+	}
+
+	public JobID getJobId() {
+		return jobId;
+	}
+
+	public String getJobName() {
+		return jobName;
+	}
+
+	public SerializedValue<ExecutionConfig> getSerializedExecutionConfig() {
+		return serializedExecutionConfig;
+	}
+
+	public Configuration getJobConfiguration() {
+		return jobConfiguration;
+	}
+
+	public Collection<BlobKey> getRequiredJarFileBlobKeys() {
+		return requiredJarFileBlobKeys;
+	}
+
+	public Collection<URL> getRequiredClasspathURLs() {
+		return requiredClasspathURLs;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/TaskInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/TaskInformation.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+
+/**
+ * Container class for operator/task specific information which are stored at the
+ * {@link ExecutionJobVertex}. This information is shared by all sub tasks of this operator.
+ */
+public class TaskInformation implements Serializable {
+
+	private static final long serialVersionUID = -9006218793155953789L;
+
+	/** Job vertex id of the associated job vertex */
+	private final JobVertexID jobVertexId;
+
+	/** Name of the task */
+	private final String taskName;
+
+	/** The number of subtasks for this operator */
+	private final int numberOfSubtasks;
+
+	/** The maximum parallelism == number of key groups */
+	private final int numberOfKeyGroups;
+
+	/** Class name of the invokable to run */
+	private final String invokableClassName;
+
+	/** Configuration for the task */
+	private final Configuration taskConfiguration;
+
+	public TaskInformation(
+			JobVertexID jobVertexId,
+			String taskName,
+			int numberOfSubtasks,
+			int numberOfKeyGroups,
+			String invokableClassName,
+			Configuration taskConfiguration) {
+		this.jobVertexId = Preconditions.checkNotNull(jobVertexId);
+		this.taskName = Preconditions.checkNotNull(taskName);
+		this.numberOfSubtasks = Preconditions.checkNotNull(numberOfSubtasks);
+		this.numberOfKeyGroups = Preconditions.checkNotNull(numberOfKeyGroups);
+		this.invokableClassName = Preconditions.checkNotNull(invokableClassName);
+		this.taskConfiguration = Preconditions.checkNotNull(taskConfiguration);
+	}
+
+	public JobVertexID getJobVertexId() {
+		return jobVertexId;
+	}
+
+	public String getTaskName() {
+		return taskName;
+	}
+
+	public int getNumberOfSubtasks() {
+		return numberOfSubtasks;
+	}
+
+	public int getNumberOfKeyGroups() {
+		return numberOfKeyGroups;
+	}
+
+	public String getInvokableClassName() {
+		return invokableClassName;
+	}
+
+	public Configuration getTaskConfiguration() {
+		return taskConfiguration;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
@@ -19,7 +19,8 @@ package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.util.AbstractID;
 
@@ -59,20 +60,27 @@ public class TaskManagerJobMetricGroup extends JobMetricGroup<TaskManagerMetricG
 	//  adding / removing tasks
 	// ------------------------------------------------------------------------
 
-	public TaskMetricGroup addTask(TaskDeploymentDescriptor tdd) {
-		AbstractID vertexId = tdd.getVertexID();
-		AbstractID executionId = tdd.getExecutionId();
-		String taskName = tdd.getTaskName();
-		int subtaskIndex = tdd.getIndexInSubtaskGroup();
-		int attemptNumber = tdd.getAttemptNumber();
-
-		checkNotNull(executionId);
+	public TaskMetricGroup addTask(
+			final JobVertexID jobVertexId,
+			final ExecutionAttemptID executionAttemptID,
+			final String taskName,
+			final int subtaskIndex,
+			final int attemptNumber) {
+		checkNotNull(jobVertexId);
+		checkNotNull(executionAttemptID);
+		checkNotNull(taskName);
 
 		synchronized (this) {
 			if (!isClosed()) {
-				TaskMetricGroup task = new TaskMetricGroup(registry, this,
-					vertexId, executionId, taskName, subtaskIndex, attemptNumber);
-				tasks.put(executionId, task);
+				TaskMetricGroup task = new TaskMetricGroup(
+					registry,
+					this,
+					jobVertexId,
+					executionAttemptID,
+					taskName,
+					subtaskIndex,
+					attemptNumber);
+				tasks.put(executionAttemptID, task);
 				return task;
 			} else {
 				return null;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -35,12 +35,13 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.concurrent.BiFunction;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
@@ -70,6 +71,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,8 +85,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * The Task represents one execution of a parallel subtask on a TaskManager.
@@ -144,10 +144,10 @@ public class Task implements Runnable, TaskActions {
 	private final Configuration taskConfiguration;
 
 	/** The jar files used by this task */
-	private final List<BlobKey> requiredJarFiles;
+	private final Collection<BlobKey> requiredJarFiles;
 
 	/** The classpaths used by this task */
-	private final List<URL> requiredClasspaths;
+	private final Collection<URL> requiredClasspaths;
 
 	/** The name of the class that holds the invokable code */
 	private final String nameOfInvokableClass;
@@ -249,7 +249,15 @@ public class Task implements Runnable, TaskActions {
 	 * be undone in the case of a failing task deployment.</p>
 	 */
 	public Task(
-		TaskDeploymentDescriptor tdd,
+		JobInformation jobInformation,
+		TaskInformation taskInformation,
+		ExecutionAttemptID executionAttemptID,
+		int subtaskIndex,
+		int attemptNumber,
+		Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
+		Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors,
+		int targetSlotNumber,
+		TaskStateHandles taskStateHandles,
 		MemoryManager memManager,
 		IOManager ioManager,
 		NetworkEnvironment networkEnvironment,
@@ -265,36 +273,48 @@ public class Task implements Runnable, TaskActions {
 		PartitionStateChecker partitionStateChecker,
 		Executor executor) {
 
-		this.taskInfo = checkNotNull(tdd.getTaskInfo());
-		this.jobId = checkNotNull(tdd.getJobID());
-		this.vertexId = checkNotNull(tdd.getVertexID());
-		this.executionId  = checkNotNull(tdd.getExecutionId());
+		Preconditions.checkNotNull(jobInformation);
+		Preconditions.checkNotNull(taskInformation);
+
+		Preconditions.checkArgument(0 <= subtaskIndex, "The subtask index must be positive.");
+		Preconditions.checkArgument(0 <= attemptNumber, "The attempt number must be positive.");
+		Preconditions.checkArgument(0 <= targetSlotNumber, "The target slot number must be positive.");
+
+		this.taskInfo = new TaskInfo(
+			taskInformation.getTaskName(),
+			taskInformation.getNumberOfKeyGroups(),
+			subtaskIndex,
+			taskInformation.getNumberOfSubtasks(),
+			attemptNumber);
+
+		this.jobId = jobInformation.getJobId();
+		this.vertexId = taskInformation.getJobVertexId();
+		this.executionId  = Preconditions.checkNotNull(executionAttemptID);
 		this.taskNameWithSubtask = taskInfo.getTaskNameWithSubtasks();
-		this.jobConfiguration = checkNotNull(tdd.getJobConfiguration());
-		this.taskConfiguration = checkNotNull(tdd.getTaskConfiguration());
-		this.requiredJarFiles = checkNotNull(tdd.getRequiredJarFiles());
-		this.requiredClasspaths = checkNotNull(tdd.getRequiredClasspaths());
-		this.nameOfInvokableClass = checkNotNull(tdd.getInvokableClassName());
-		this.serializedExecutionConfig = checkNotNull(tdd.getSerializedExecutionConfig());
-		this.taskStateHandles = tdd.getTaskStateHandles();
+		this.jobConfiguration = jobInformation.getJobConfiguration();
+		this.taskConfiguration = taskInformation.getTaskConfiguration();
+		this.requiredJarFiles = jobInformation.getRequiredJarFileBlobKeys();
+		this.requiredClasspaths = jobInformation.getRequiredClasspathURLs();
+		this.nameOfInvokableClass = taskInformation.getInvokableClassName();
+		this.serializedExecutionConfig = jobInformation.getSerializedExecutionConfig();
+		this.taskStateHandles = taskStateHandles;
 
-		Configuration taskConfig = tdd.getTaskConfiguration();
-		this.taskCancellationInterval = taskConfig.getLong(TaskManagerOptions.TASK_CANCELLATION_INTERVAL);
-		this.taskCancellationTimeout = taskConfig.getLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT);
+		this.taskCancellationInterval = taskConfiguration.getLong(TaskManagerOptions.TASK_CANCELLATION_INTERVAL);
+		this.taskCancellationTimeout = taskConfiguration.getLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT);
 
-		this.memoryManager = checkNotNull(memManager);
-		this.ioManager = checkNotNull(ioManager);
-		this.broadcastVariableManager = checkNotNull(bcVarManager);
+		this.memoryManager = Preconditions.checkNotNull(memManager);
+		this.ioManager = Preconditions.checkNotNull(ioManager);
+		this.broadcastVariableManager = Preconditions.checkNotNull(bcVarManager);
 		this.accumulatorRegistry = new AccumulatorRegistry(jobId, executionId);
 
-		this.inputSplitProvider = checkNotNull(inputSplitProvider);
-		this.checkpointResponder = checkNotNull(checkpointResponder);
-		this.taskManagerConnection = checkNotNull(taskManagerConnection);
+		this.inputSplitProvider = Preconditions.checkNotNull(inputSplitProvider);
+		this.checkpointResponder = Preconditions.checkNotNull(checkpointResponder);
+		this.taskManagerConnection = Preconditions.checkNotNull(taskManagerConnection);
 
-		this.libraryCache = checkNotNull(libraryCache);
-		this.fileCache = checkNotNull(fileCache);
-		this.network = checkNotNull(networkEnvironment);
-		this.taskManagerConfig = checkNotNull(taskManagerConfig);
+		this.libraryCache = Preconditions.checkNotNull(libraryCache);
+		this.fileCache = Preconditions.checkNotNull(fileCache);
+		this.network = Preconditions.checkNotNull(networkEnvironment);
+		this.taskManagerConfig = Preconditions.checkNotNull(taskManagerConfig);
 
 		this.taskExecutionStateListeners = new CopyOnWriteArrayList<>();
 		this.metrics = metricGroup;
@@ -306,18 +326,16 @@ public class Task implements Runnable, TaskActions {
 
 		final String taskNameWithSubtaskAndId = taskNameWithSubtask + " (" + executionId + ')';
 
-		List<ResultPartitionDeploymentDescriptor> partitions = tdd.getProducedPartitions();
-		List<InputGateDeploymentDescriptor> consumedPartitions = tdd.getInputGates();
-
 		// Produced intermediate result partitions
-		this.producedPartitions = new ResultPartition[partitions.size()];
-		this.writers = new ResultPartitionWriter[partitions.size()];
+		this.producedPartitions = new ResultPartition[resultPartitionDeploymentDescriptors.size()];
+		this.writers = new ResultPartitionWriter[resultPartitionDeploymentDescriptors.size()];
 
-		for (int i = 0; i < this.producedPartitions.length; i++) {
-			ResultPartitionDeploymentDescriptor desc = partitions.get(i);
+		int counter = 0;
+
+		for (ResultPartitionDeploymentDescriptor desc: resultPartitionDeploymentDescriptors) {
 			ResultPartitionID partitionId = new ResultPartitionID(desc.getPartitionId(), executionId);
 
-			this.producedPartitions[i] = new ResultPartition(
+			this.producedPartitions[counter] = new ResultPartition(
 				taskNameWithSubtaskAndId,
 				this,
 				jobId,
@@ -330,25 +348,31 @@ public class Task implements Runnable, TaskActions {
 				ioManager,
 				networkEnvironment.getDefaultIOMode());
 
-			this.writers[i] = new ResultPartitionWriter(this.producedPartitions[i]);
+			writers[counter] = new ResultPartitionWriter(producedPartitions[counter]);
+
+			++counter;
 		}
 
 		// Consumed intermediate result partitions
-		this.inputGates = new SingleInputGate[consumedPartitions.size()];
+		this.inputGates = new SingleInputGate[inputGateDeploymentDescriptors.size()];
 		this.inputGatesById = new HashMap<>();
 
-		for (int i = 0; i < this.inputGates.length; i++) {
+		counter = 0;
+
+		for (InputGateDeploymentDescriptor inputGateDeploymentDescriptor: inputGateDeploymentDescriptors) {
 			SingleInputGate gate = SingleInputGate.create(
 				taskNameWithSubtaskAndId,
 				jobId,
 				executionId,
-				consumedPartitions.get(i),
+				inputGateDeploymentDescriptor,
 				networkEnvironment,
 				this,
 				metricGroup.getIOMetricGroup());
 
-			this.inputGates[i] = gate;
+			inputGates[counter] = gate;
 			inputGatesById.put(gate.getConsumedResultId(), gate);
+
+			++counter;
 		}
 
 		invokableHasBeenCanceled = new AtomicBoolean(false);

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
@@ -237,8 +237,8 @@ object JobManagerMessages {
     * @param requiredClasspaths The urls of the required classpaths
     */
   case class ClassloadingProps(blobManagerPort: Integer,
-                               requiredJarFiles: java.util.List[BlobKey],
-                               requiredClasspaths: java.util.List[URL])
+                               requiredJarFiles: java.util.Collection[BlobKey],
+                               requiredClasspaths: java.util.Collection[URL])
 
   /**
    * Requests the port of the blob manager from the job manager. The result is sent back to the

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -75,7 +75,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.language.postfixOps
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 /**
  * The TaskManager is responsible for executing the individual tasks of a Flink job. It is
@@ -1120,24 +1120,46 @@ class TaskManager(
 
       val jobManagerGateway = new AkkaActorGateway(jobManagerActor, leaderSessionID.orNull)
 
-      var jobName = tdd.getJobName
-      if (tdd.getJobName.length == 0) {
-        jobName = tdd.getJobID.toString()
-      } else {
-        jobName = tdd.getJobName
+      val jobInformation = try {
+        tdd.getSerializedJobInformation.deserializeValue(getClass.getClassLoader)
+      } catch {
+        case e @ (_: IOException | _: ClassNotFoundException) =>
+          throw new IOException("Could not deserialize the job information.", e)
       }
-      
-      val taskMetricGroup = taskManagerMetricGroup.addTaskForJob(tdd)
+
+      val taskInformation = try {
+        tdd.getSerializedTaskInformation.deserializeValue(getClass.getClassLoader)
+      } catch {
+        case e@(_: IOException | _: ClassNotFoundException) =>
+          throw new IOException("Could not deserialize the job vertex information.", e)
+      }
+
+      val taskMetricGroup = taskManagerMetricGroup.addTaskForJob(
+        jobInformation.getJobId,
+        jobInformation.getJobName,
+        taskInformation.getJobVertexId,
+        tdd.getExecutionAttemptId,
+        taskInformation.getTaskName,
+        tdd.getSubtaskIndex,
+        tdd.getAttemptNumber)
 
       val inputSplitProvider = new TaskInputSplitProvider(
         jobManagerGateway,
-        tdd.getJobID,
-        tdd.getVertexID,
-        tdd.getExecutionId,
+        jobInformation.getJobId,
+        taskInformation.getJobVertexId,
+        tdd.getExecutionAttemptId,
         config.timeout)
 
       val task = new Task(
-        tdd,
+        jobInformation,
+        taskInformation,
+        tdd.getExecutionAttemptId,
+        tdd.getSubtaskIndex,
+        tdd.getAttemptNumber,
+        tdd.getProducedPartitions,
+        tdd.getInputGates,
+        tdd.getTargetSlotNumber,
+        tdd.getTaskStateHandles,
         memoryManager,
         ioManager,
         network,
@@ -1155,7 +1177,7 @@ class TaskManager(
 
       log.info(s"Received task ${task.getTaskInfo.getTaskNameWithSubtasks()}")
 
-      val execId = tdd.getExecutionId
+      val execId = tdd.getExecutionAttemptId
       // add the task to the map
       val prevTask = runningTasks.put(execId, task)
       if (prevTask != null) {
@@ -1163,11 +1185,12 @@ class TaskManager(
         runningTasks.put(execId, prevTask)
         throw new IllegalStateException("TaskManager already contains a task for id " + execId)
       }
-      
+
       // all good, we kick off the task, which performs its own initialization
       task.startTaskThread()
 
       sender ! decorateMessage(Acknowledge.get())
+
     }
     catch {
       case t: Throwable =>

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.ExternalizedCheckpointSettings;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
@@ -122,6 +123,7 @@ public class ExecutionGraphCheckpointCoordinatorTest {
 				new DisabledCheckpointStatsTracker());
 
 		JobVertex jobVertex = new JobVertex("MockVertex");
+		jobVertex.setInvokableClass(AbstractInvokable.class);
 		executionGraph.attachJobGraph(Collections.singletonList(jobVertex));
 
 		return executionGraph;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -31,10 +31,13 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.BatchTask;
 import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.runtime.state.TaskStateHandles;
 import org.apache.flink.util.SerializedValue;
 
 import org.junit.Test;
@@ -60,33 +63,42 @@ public class TaskDeploymentDescriptorTest {
 			final List<BlobKey> requiredJars = new ArrayList<BlobKey>(0);
 			final List<URL> requiredClasspaths = new ArrayList<URL>(0);
 			final SerializedValue<ExecutionConfig> executionConfig = new SerializedValue<>(new ExecutionConfig());
+			final SerializedValue<JobInformation> serializedJobInformation = new SerializedValue<>(new JobInformation(
+				jobID, jobName, executionConfig, jobConfiguration, requiredJars, requiredClasspaths));
+			final SerializedValue<TaskInformation> serializedJobVertexInformation = new SerializedValue<>(new TaskInformation(
+				vertexID, taskName, currentNumberOfSubtasks, numberOfKeyGroups, invokableClass.getName(), taskConfiguration));
+			final int targetSlotNumber = 47;
+			final TaskStateHandles taskStateHandles = new TaskStateHandles();
 
-			final TaskDeploymentDescriptor orig = new TaskDeploymentDescriptor(jobID, jobName, vertexID, execId,
-				executionConfig, taskName, numberOfKeyGroups, indexInSubtaskGroup, currentNumberOfSubtasks, attemptNumber,
-				jobConfiguration, taskConfiguration, invokableClass.getName(), producedResults, inputGates,
-				requiredJars, requiredClasspaths, 47);
+			final TaskDeploymentDescriptor orig = new TaskDeploymentDescriptor(
+				serializedJobInformation,
+				serializedJobVertexInformation,
+				execId,
+				indexInSubtaskGroup,
+				attemptNumber,
+				targetSlotNumber,
+				taskStateHandles,
+				producedResults,
+				inputGates);
 	
 			final TaskDeploymentDescriptor copy = CommonTestUtils.createCopySerializable(orig);
 	
-			assertFalse(orig.getJobID() == copy.getJobID());
-			assertFalse(orig.getVertexID() == copy.getVertexID());
-			assertFalse(orig.getTaskName() == copy.getTaskName());
-			assertFalse(orig.getJobConfiguration() == copy.getJobConfiguration());
-			assertFalse(orig.getTaskConfiguration() == copy.getTaskConfiguration());
+			assertFalse(orig.getSerializedJobInformation() == copy.getSerializedJobInformation());
+			assertFalse(orig.getSerializedTaskInformation() == copy.getSerializedTaskInformation());
+			assertFalse(orig.getExecutionAttemptId() == copy.getExecutionAttemptId());
+			assertFalse(orig.getTaskStateHandles() == copy.getTaskStateHandles());
+			assertFalse(orig.getProducedPartitions() == copy.getProducedPartitions());
+			assertFalse(orig.getInputGates() == copy.getInputGates());
 
-			assertEquals(orig.getJobID(), copy.getJobID());
-			assertEquals(orig.getVertexID(), copy.getVertexID());
-			assertEquals(orig.getTaskName(), copy.getTaskName());
-			assertEquals(orig.getNumberOfKeyGroups(), copy.getNumberOfKeyGroups());
-			assertEquals(orig.getIndexInSubtaskGroup(), copy.getIndexInSubtaskGroup());
-			assertEquals(orig.getNumberOfSubtasks(), copy.getNumberOfSubtasks());
+			assertEquals(orig.getSerializedJobInformation(), copy.getSerializedJobInformation());
+			assertEquals(orig.getSerializedTaskInformation(), copy.getSerializedTaskInformation());
+			assertEquals(orig.getExecutionAttemptId(), copy.getExecutionAttemptId());
+			assertEquals(orig.getSubtaskIndex(), copy.getSubtaskIndex());
 			assertEquals(orig.getAttemptNumber(), copy.getAttemptNumber());
+			assertEquals(orig.getTargetSlotNumber(), copy.getTargetSlotNumber());
+			assertEquals(orig.getTaskStateHandles(), copy.getTaskStateHandles());
 			assertEquals(orig.getProducedPartitions(), copy.getProducedPartitions());
 			assertEquals(orig.getInputGates(), copy.getInputGates());
-			assertEquals(orig.getSerializedExecutionConfig(), copy.getSerializedExecutionConfig());
-
-			assertEquals(orig.getRequiredJarFiles(), copy.getRequiredJarFiles());
-			assertEquals(orig.getRequiredClasspaths(), copy.getRequiredClasspaths());
 		}
 		catch (Exception e) {
 			e.printStackTrace();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AllVerticesIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AllVerticesIteratorTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -37,7 +38,12 @@ public class AllVerticesIteratorTest {
 			JobVertex v2 = new JobVertex("v2");
 			JobVertex v3 = new JobVertex("v3");
 			JobVertex v4 = new JobVertex("v4");
-			
+
+			v1.setInvokableClass(AbstractInvokable.class);
+			v2.setInvokableClass(AbstractInvokable.class);
+			v3.setInvokableClass(AbstractInvokable.class);
+			v4.setInvokableClass(AbstractInvokable.class);
+
 			v1.setParallelism(1);
 			v2.setParallelism(7);
 			v3.setParallelism(3);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.ExternalizedCheckpointSettings;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
@@ -81,6 +82,9 @@ public class ArchivedExecutionGraphTest {
 
 		v1.setParallelism(1);
 		v2.setParallelism(2);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
 
 		List<JobVertex> vertices = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
 
@@ -95,7 +96,13 @@ public class ExecutionGraphConstructionTest {
 		v3.setParallelism(2);
 		v4.setParallelism(11);
 		v5.setParallelism(4);
-		
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
+		v3.setInvokableClass(AbstractInvokable.class);
+		v4.setInvokableClass(AbstractInvokable.class);
+		v5.setInvokableClass(AbstractInvokable.class);
+
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.ALL_TO_ALL);
 		v4.connectNewDataSetAsInput(v2, DistributionPattern.ALL_TO_ALL);
 		v4.connectNewDataSetAsInput(v3, DistributionPattern.ALL_TO_ALL);
@@ -137,7 +144,11 @@ public class ExecutionGraphConstructionTest {
 		v1.setParallelism(5);
 		v2.setParallelism(7);
 		v3.setParallelism(2);
-		
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
+		v3.setInvokableClass(AbstractInvokable.class);
+
 		// this creates an intermediate result for v1
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.ALL_TO_ALL);
 		
@@ -171,7 +182,10 @@ public class ExecutionGraphConstructionTest {
 		JobVertex v5 = new JobVertex("vertex5");
 		v4.setParallelism(11);
 		v5.setParallelism(4);
-		
+
+		v4.setInvokableClass(AbstractInvokable.class);
+		v5.setInvokableClass(AbstractInvokable.class);
+
 		v4.connectDataSetAsInput(v2result, DistributionPattern.ALL_TO_ALL);
 		v4.connectDataSetAsInput(v3result_1, DistributionPattern.ALL_TO_ALL);
 		v5.connectNewDataSetAsInput(v4, DistributionPattern.ALL_TO_ALL);
@@ -205,6 +219,10 @@ public class ExecutionGraphConstructionTest {
 		v1.setParallelism(5);
 		v2.setParallelism(7);
 		v3.setParallelism(2);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
+		v3.setInvokableClass(AbstractInvokable.class);
 		
 		// this creates an intermediate result for v1
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.ALL_TO_ALL);
@@ -213,8 +231,7 @@ public class ExecutionGraphConstructionTest {
 		IntermediateDataSet v2result = v2.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
 		IntermediateDataSet v3result_1 = v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
 		IntermediateDataSet v3result_2 = v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
-		
-		
+
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3));
 
 		ExecutionGraph eg = new ExecutionGraph(
@@ -239,7 +256,10 @@ public class ExecutionGraphConstructionTest {
 		JobVertex v5 = new JobVertex("vertex5");
 		v4.setParallelism(11);
 		v5.setParallelism(4);
-		
+
+		v4.setInvokableClass(AbstractInvokable.class);
+		v5.setInvokableClass(AbstractInvokable.class);
+
 		v4.connectIdInput(v2result.getId(), DistributionPattern.ALL_TO_ALL);
 		v4.connectIdInput(v3result_1.getId(), DistributionPattern.ALL_TO_ALL);
 		v5.connectNewDataSetAsInput(v4, DistributionPattern.ALL_TO_ALL);
@@ -469,7 +489,8 @@ public class ExecutionGraphConstructionTest {
 		// construct part one of the execution graph
 		JobVertex v1 = new JobVertex("vertex1");
 		v1.setParallelism(7);
-		
+		v1.setInvokableClass(AbstractInvokable.class);
+
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1));
 
 		ExecutionGraph eg = new ExecutionGraph(
@@ -490,6 +511,7 @@ public class ExecutionGraphConstructionTest {
 		
 		// attach the second part of the graph
 		JobVertex v2 = new JobVertex("vertex2");
+		v2.setInvokableClass(AbstractInvokable.class);
 		v2.connectIdInput(new IntermediateDataSetID(), DistributionPattern.ALL_TO_ALL);
 		
 		List<JobVertex> ordered2 = new ArrayList<JobVertex>(Arrays.asList(v2));
@@ -520,7 +542,13 @@ public class ExecutionGraphConstructionTest {
 		v3.setParallelism(2);
 		v4.setParallelism(11);
 		v5.setParallelism(4);
-		
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
+		v3.setInvokableClass(AbstractInvokable.class);
+		v4.setInvokableClass(AbstractInvokable.class);
+		v5.setInvokableClass(AbstractInvokable.class);
+
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.ALL_TO_ALL);
 		v4.connectNewDataSetAsInput(v2, DistributionPattern.ALL_TO_ALL);
 		v4.connectNewDataSetAsInput(v3, DistributionPattern.ALL_TO_ALL);
@@ -579,6 +607,12 @@ public class ExecutionGraphConstructionTest {
 			v3.setParallelism(2);
 			v4.setParallelism(11);
 			v5.setParallelism(4);
+
+			v1.setInvokableClass(AbstractInvokable.class);
+			v2.setInvokableClass(AbstractInvokable.class);
+			v3.setInvokableClass(AbstractInvokable.class);
+			v4.setInvokableClass(AbstractInvokable.class);
+			v5.setInvokableClass(AbstractInvokable.class);
 			
 			v2.connectNewDataSetAsInput(v1, DistributionPattern.ALL_TO_ALL);
 			v4.connectNewDataSetAsInput(v2, DistributionPattern.ALL_TO_ALL);
@@ -672,6 +706,8 @@ public class ExecutionGraphConstructionTest {
 			JobVertex v2 = new JobVertex("vertex2");
 			v1.setParallelism(6);
 			v2.setParallelism(4);
+			v1.setInvokableClass(AbstractInvokable.class);
+			v2.setInvokableClass(AbstractInvokable.class);
 			
 			SlotSharingGroup sl1 = new SlotSharingGroup();
 			v1.setSlotSharingGroup(sl1);
@@ -690,6 +726,12 @@ public class ExecutionGraphConstructionTest {
 			v5.setParallelism(3);
 			v6.setParallelism(3);
 			v7.setParallelism(3);
+
+			v3.setInvokableClass(AbstractInvokable.class);
+			v4.setInvokableClass(AbstractInvokable.class);
+			v5.setInvokableClass(AbstractInvokable.class);
+			v6.setInvokableClass(AbstractInvokable.class);
+			v7.setInvokableClass(AbstractInvokable.class);
 			
 			SlotSharingGroup sl2 = new SlotSharingGroup();
 			v3.setSlotSharingGroup(sl2);
@@ -706,6 +748,7 @@ public class ExecutionGraphConstructionTest {
 			// isolated vertex
 			JobVertex v8 = new JobVertex("vertex8");
 			v8.setParallelism(2);
+			v8.setInvokableClass(AbstractInvokable.class);
 
 			JobGraph jg = new JobGraph(jobId, jobName, v1, v2, v3, v4, v5, v6, v7, v8);
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -25,8 +25,10 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -117,22 +119,28 @@ public class ExecutionGraphDeploymentTest {
 			TaskDeploymentDescriptor descr = instanceGateway.lastTDD;
 			assertNotNull(descr);
 
-			assertEquals(jobId, descr.getJobID());
-			assertEquals(jid2, descr.getVertexID());
-			assertEquals(3, descr.getIndexInSubtaskGroup());
-			assertEquals(10, descr.getNumberOfSubtasks());
-			assertEquals(BatchTask.class.getName(), descr.getInvokableClassName());
-			assertEquals("v2", descr.getTaskName());
+			JobInformation jobInformation = descr.getSerializedJobInformation().deserializeValue(getClass().getClassLoader());
+			TaskInformation taskInformation = descr.getSerializedTaskInformation().deserializeValue(getClass().getClassLoader());
 
-			List<ResultPartitionDeploymentDescriptor> producedPartitions = descr.getProducedPartitions();
-			List<InputGateDeploymentDescriptor> consumedPartitions = descr.getInputGates();
+			assertEquals(jobId, jobInformation.getJobId());
+			assertEquals(jid2, taskInformation.getJobVertexId());
+			assertEquals(3, descr.getSubtaskIndex());
+			assertEquals(10, taskInformation.getNumberOfSubtasks());
+			assertEquals(BatchTask.class.getName(), taskInformation.getInvokableClassName());
+			assertEquals("v2", taskInformation.getTaskName());
+
+			Collection<ResultPartitionDeploymentDescriptor> producedPartitions = descr.getProducedPartitions();
+			Collection<InputGateDeploymentDescriptor> consumedPartitions = descr.getInputGates();
 
 			assertEquals(2, producedPartitions.size());
 			assertEquals(1, consumedPartitions.size());
 
-			assertEquals(10, producedPartitions.get(0).getNumberOfSubpartitions());
-			assertEquals(10, producedPartitions.get(1).getNumberOfSubpartitions());
-			assertEquals(10, consumedPartitions.get(0).getInputChannelDeploymentDescriptors().length);
+			Iterator<ResultPartitionDeploymentDescriptor> iteratorProducedPartitions = producedPartitions.iterator();
+			Iterator<InputGateDeploymentDescriptor> iteratorConsumedPartitions = consumedPartitions.iterator();
+
+			assertEquals(10, iteratorProducedPartitions.next().getNumberOfSubpartitions());
+			assertEquals(10, iteratorProducedPartitions.next().getNumberOfSubpartitions());
+			assertEquals(10, iteratorConsumedPartitions.next().getInputChannelDeploymentDescriptors().length);
 		}
 		catch (Exception e) {
 			e.printStackTrace();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
 
@@ -56,6 +57,9 @@ public class PointwisePatternTest {
 	
 		v1.setParallelism(N);
 		v2.setParallelism(N);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
 	
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 	
@@ -98,6 +102,9 @@ public class PointwisePatternTest {
 	
 		v1.setParallelism(2 * N);
 		v2.setParallelism(N);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
 	
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 	
@@ -141,6 +148,9 @@ public class PointwisePatternTest {
 	
 		v1.setParallelism(3 * N);
 		v2.setParallelism(N);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
 	
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 	
@@ -185,6 +195,9 @@ public class PointwisePatternTest {
 	
 		v1.setParallelism(N);
 		v2.setParallelism(2 * N);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
 	
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 	
@@ -227,6 +240,9 @@ public class PointwisePatternTest {
 	
 		v1.setParallelism(N);
 		v2.setParallelism(7 * N);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
 	
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 	
@@ -289,6 +305,9 @@ public class PointwisePatternTest {
 	
 		v1.setParallelism(lowDop);
 		v2.setParallelism(highDop);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
 	
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 	
@@ -342,6 +361,9 @@ public class PointwisePatternTest {
 	
 		v1.setParallelism(highDop);
 		v2.setParallelism(lowDop);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
 	
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
@@ -58,7 +59,13 @@ public class VertexSlotSharingTest {
 			v3.setParallelism(7);
 			v4.setParallelism(1);
 			v5.setParallelism(11);
-			
+
+			v1.setInvokableClass(AbstractInvokable.class);
+			v2.setInvokableClass(AbstractInvokable.class);
+			v3.setInvokableClass(AbstractInvokable.class);
+			v4.setInvokableClass(AbstractInvokable.class);
+			v5.setInvokableClass(AbstractInvokable.class);
+
 			v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 			v5.connectNewDataSetAsInput(v4, DistributionPattern.POINTWISE);
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerGroupTest.java
@@ -27,11 +27,14 @@ import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.util.DummyCharacterFilter;
+import org.apache.flink.runtime.state.TaskStateHandles;
 import org.apache.flink.util.AbstractID;
 
 import org.apache.flink.util.SerializedValue;
@@ -41,6 +44,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collection;
 
 import static org.junit.Assert.*;
 
@@ -74,7 +78,7 @@ public class TaskManagerGroupTest extends TestLogger {
 		final ExecutionAttemptID execution13 = new ExecutionAttemptID();
 		final ExecutionAttemptID execution21 = new ExecutionAttemptID();
 
-		TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(
+		TaskDeploymentDescriptor tdd1 = createTaskDeploymentDescriptor(
 			jid1, 
 			jobName1, 
 			vertex11, 
@@ -89,7 +93,7 @@ public class TaskManagerGroupTest extends TestLogger {
 			new ArrayList<BlobKey>(), 
 			new ArrayList<URL>(), 0);
 
-		TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(
+		TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 			jid1,
 			jobName1,
 			vertex12,
@@ -104,7 +108,7 @@ public class TaskManagerGroupTest extends TestLogger {
 			new ArrayList<BlobKey>(),
 			new ArrayList<URL>(), 0);
 
-		TaskDeploymentDescriptor tdd3 = new TaskDeploymentDescriptor(
+		TaskDeploymentDescriptor tdd3 = createTaskDeploymentDescriptor(
 			jid2,
 			jobName2,
 			vertex21,
@@ -119,7 +123,7 @@ public class TaskManagerGroupTest extends TestLogger {
 			new ArrayList<BlobKey>(),
 			new ArrayList<URL>(), 0);
 
-		TaskDeploymentDescriptor tdd4 = new TaskDeploymentDescriptor(
+		TaskDeploymentDescriptor tdd4 = createTaskDeploymentDescriptor(
 			jid1,
 			jobName1,
 			vertex13,
@@ -134,9 +138,12 @@ public class TaskManagerGroupTest extends TestLogger {
 			new ArrayList<BlobKey>(),
 			new ArrayList<URL>(), 0);
 		
-		TaskMetricGroup tmGroup11 = group.addTaskForJob(tdd1);
-		TaskMetricGroup tmGroup12 = group.addTaskForJob(tdd2);
-		TaskMetricGroup tmGroup21 = group.addTaskForJob(tdd3);
+		TaskMetricGroup tmGroup11 = group.addTaskForJob(
+			jid1, jobName1, vertex11, execution11, "test", 17, 0);
+		TaskMetricGroup tmGroup12 = group.addTaskForJob(
+			jid1, jobName1, vertex12, execution12, "test", 13, 1);
+		TaskMetricGroup tmGroup21 = group.addTaskForJob(
+			jid2, jobName2, vertex21, execution21, "test", 7, 2);
 		
 		assertEquals(2, group.numRegisteredJobMetricGroups());
 		assertFalse(tmGroup11.parent().isClosed());
@@ -156,7 +163,8 @@ public class TaskManagerGroupTest extends TestLogger {
 		assertEquals(1, group.numRegisteredJobMetricGroups());
 		
 		// add one more to job one
-		TaskMetricGroup tmGroup13 = group.addTaskForJob(tdd4);
+		TaskMetricGroup tmGroup13 = group.addTaskForJob(
+			jid1, jobName1, vertex13, execution13, "test", 0, 0);
 		tmGroup12.close();
 		tmGroup13.close();
 
@@ -190,7 +198,7 @@ public class TaskManagerGroupTest extends TestLogger {
 		final ExecutionAttemptID execution12 = new ExecutionAttemptID();
 		final ExecutionAttemptID execution21 = new ExecutionAttemptID();
 
-		TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(
+		TaskDeploymentDescriptor tdd1 = createTaskDeploymentDescriptor(
 			jid1,
 			jobName1,
 			vertex11,
@@ -205,7 +213,7 @@ public class TaskManagerGroupTest extends TestLogger {
 			new ArrayList<BlobKey>(),
 			new ArrayList<URL>(), 0);
 
-		TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(
+		TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 			jid1,
 			jobName1,
 			vertex12,
@@ -220,7 +228,7 @@ public class TaskManagerGroupTest extends TestLogger {
 			new ArrayList<BlobKey>(),
 			new ArrayList<URL>(), 0);
 
-		TaskDeploymentDescriptor tdd3 = new TaskDeploymentDescriptor(
+		TaskDeploymentDescriptor tdd3 = createTaskDeploymentDescriptor(
 			jid2,
 			jobName2,
 			vertex21,
@@ -235,9 +243,12 @@ public class TaskManagerGroupTest extends TestLogger {
 			new ArrayList<BlobKey>(),
 			new ArrayList<URL>(), 0);
 
-		TaskMetricGroup tmGroup11 = group.addTaskForJob(tdd1);
-		TaskMetricGroup tmGroup12 = group.addTaskForJob(tdd2);
-		TaskMetricGroup tmGroup21 = group.addTaskForJob(tdd3);
+		TaskMetricGroup tmGroup11 = group.addTaskForJob(
+			jid1, jobName1, vertex11, execution11, "test", 17, 0);
+		TaskMetricGroup tmGroup12 = group.addTaskForJob(
+			jid1, jobName1, vertex12, execution12, "test", 13, 1);
+		TaskMetricGroup tmGroup21 = group.addTaskForJob(
+			jid2, jobName2, vertex21, execution21, "test", 7, 1);
 		
 		group.close();
 		
@@ -282,5 +293,57 @@ public class TaskManagerGroupTest extends TestLogger {
 		QueryScopeInfo.TaskManagerQueryScopeInfo info = tm.createQueryServiceMetricInfo(new DummyCharacterFilter());
 		assertEquals("", info.scope);
 		assertEquals("id", info.taskManagerID);
+	}
+
+	private static TaskDeploymentDescriptor createTaskDeploymentDescriptor(
+		JobID jobId,
+		String jobName,
+		JobVertexID jobVertexId,
+		ExecutionAttemptID executionAttemptId,
+		SerializedValue<ExecutionConfig> serializedExecutionConfig,
+		String taskName,
+		int numberOfKeyGroups,
+		int subtaskIndex,
+		int parallelism,
+		int attemptNumber,
+		Configuration jobConfiguration,
+		Configuration taskConfiguration,
+		String invokableClassName,
+		Collection<ResultPartitionDeploymentDescriptor> producedPartitions,
+		Collection<InputGateDeploymentDescriptor> inputGates,
+		Collection<BlobKey> requiredJarFiles,
+		Collection<URL> requiredClasspaths,
+		int targetSlotNumber) throws IOException {
+
+		JobInformation jobInformation = new JobInformation(
+			jobId,
+			jobName,
+			serializedExecutionConfig,
+			jobConfiguration,
+			requiredJarFiles,
+			requiredClasspaths);
+
+		TaskInformation taskInformation = new TaskInformation(
+			jobVertexId,
+			taskName,
+			parallelism,
+			numberOfKeyGroups,
+			invokableClassName,
+			taskConfiguration);
+
+		SerializedValue<JobInformation> serializedJobInformation = new SerializedValue<>(jobInformation);
+		SerializedValue<TaskInformation> serializedJobVertexInformation = new SerializedValue<>(taskInformation);
+
+		return new TaskDeploymentDescriptor(
+			serializedJobInformation,
+			serializedJobVertexInformation,
+			executionAttemptId,
+			subtaskIndex,
+			attemptNumber,
+			targetSlotNumber,
+			new TaskStateHandles(),
+			producedPartitions,
+			inputGates);
+
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -27,10 +27,11 @@ import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
@@ -152,19 +153,32 @@ public class TaskAsyncCallTest {
 		when(networkEnvironment.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class)))
 				.thenReturn(mock(TaskKvStateRegistry.class));
 
-		TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
-				new JobID(), "Job Name", new JobVertexID(), new ExecutionAttemptID(),
-				new SerializedValue<>(new ExecutionConfig()),
-				"Test Task", 1, 0, 1, 0,
-				new Configuration(), new Configuration(),
-				CheckpointsInOrderInvokable.class.getName(),
-				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-				Collections.<InputGateDeploymentDescriptor>emptyList(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
-				0);
+		JobInformation jobInformation = new JobInformation(
+			new JobID(),
+			"Job Name",
+			new SerializedValue<>(new ExecutionConfig()),
+			new Configuration(),
+			Collections.<BlobKey>emptyList(),
+			Collections.<URL>emptyList());
 
-		return new Task(tdd,
+		TaskInformation taskInformation = new TaskInformation(
+			new JobVertexID(),
+			"Test Task",
+			1,
+			1,
+			CheckpointsInOrderInvokable.class.getName(),
+			new Configuration());
+
+		return new Task(
+			jobInformation,
+			taskInformation,
+			new ExecutionAttemptID(),
+			0,
+			0,
+			Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
+			Collections.<InputGateDeploymentDescriptor>emptyList(),
+			0,
+			new TaskStateHandles(),
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			networkEnvironment,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -42,6 +42,8 @@ import org.apache.flink.runtime.deployment.ResultPartitionLocation;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.instance.InstanceID;
@@ -90,6 +92,7 @@ import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -170,12 +173,13 @@ public class TaskManagerTest extends TestLogger {
 				final ExecutionAttemptID eid = new ExecutionAttemptID();
 				final SerializedValue<ExecutionConfig> executionConfig = new SerializedValue<>(new ExecutionConfig());
 
-				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(jid, "TestJob", vid, eid, executionConfig,
-						"TestTask", 7, 2, 7, 0, new Configuration(), new Configuration(),
-						TestInvokableCorrect.class.getName(),
-						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+				final TaskDeploymentDescriptor tdd = createTaskDeploymentDescriptor(
+					jid, "TestJob", vid, eid, executionConfig,
+					"TestTask", 7, 2, 7, 0, new Configuration(), new Configuration(),
+					TestInvokableCorrect.class.getName(),
+					Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
+					Collections.<InputGateDeploymentDescriptor>emptyList(),
+					new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
 
 
 				new Within(d) {
@@ -267,7 +271,7 @@ public class TaskManagerTest extends TestLogger {
 				final ExecutionAttemptID eid1 = new ExecutionAttemptID();
 				final ExecutionAttemptID eid2 = new ExecutionAttemptID();
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd1 = createTaskDeploymentDescriptor(
 						jid1, "TestJob1", vid1, eid1,
 						new SerializedValue<>(new ExecutionConfig()),
 						"TestTask1", 5, 1, 5, 0,
@@ -276,7 +280,7 @@ public class TaskManagerTest extends TestLogger {
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
 						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid2, "TestJob2", vid2, eid2,
 						new SerializedValue<>(new ExecutionConfig()),
 						"TestTask2", 7, 2, 7, 0,
@@ -406,13 +410,13 @@ public class TaskManagerTest extends TestLogger {
 
 				final SerializedValue<ExecutionConfig> executionConfig = new SerializedValue<>(new ExecutionConfig());
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid1, "TestJob", vid1, eid1, executionConfig,
+				final TaskDeploymentDescriptor tdd1 = createTaskDeploymentDescriptor(jid1, "TestJob", vid1, eid1, executionConfig,
 						"TestTask1", 5, 1, 5, 0, new Configuration(), new Configuration(), StoppableInvokable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
 						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid2, "TestJob", vid2, eid2, executionConfig,
+				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(jid2, "TestJob", vid2, eid2, executionConfig,
 						"TestTask2", 7, 2, 7, 0, new Configuration(), new Configuration(), TestInvokableBlockingCancelable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
@@ -531,7 +535,7 @@ public class TaskManagerTest extends TestLogger {
 				final ExecutionAttemptID eid1 = new ExecutionAttemptID();
 				final ExecutionAttemptID eid2 = new ExecutionAttemptID();
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd1 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid1, eid1,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Sender", 1, 0, 1, 0,
@@ -540,7 +544,7 @@ public class TaskManagerTest extends TestLogger {
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
 						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid2, eid2,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Receiver", 7, 2, 7, 0,
@@ -636,7 +640,7 @@ public class TaskManagerTest extends TestLogger {
 								}
 						);
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd1 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid1, eid1,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Sender", 1, 0, 1, 0,
@@ -644,7 +648,7 @@ public class TaskManagerTest extends TestLogger {
 						irpdd, Collections.<InputGateDeploymentDescriptor>emptyList(), new ArrayList<BlobKey>(),
 						Collections.<URL>emptyList(), 0);
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid2, eid2,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Receiver", 7, 2, 7, 0,
@@ -781,7 +785,7 @@ public class TaskManagerTest extends TestLogger {
 								}
 						);
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd1 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid1, eid1,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Sender", 1, 0, 1, 0,
@@ -789,7 +793,7 @@ public class TaskManagerTest extends TestLogger {
 						irpdd, Collections.<InputGateDeploymentDescriptor>emptyList(),
 						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid2, eid2,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Receiver", 7, 2, 7, 0,
@@ -929,7 +933,7 @@ public class TaskManagerTest extends TestLogger {
 				final InputGateDeploymentDescriptor igdd =
 						new InputGateDeploymentDescriptor(resultId, 0, icdd);
 
-				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid, eid,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Receiver", 1, 0, 1, 0,
@@ -1022,7 +1026,7 @@ public class TaskManagerTest extends TestLogger {
 				final InputGateDeploymentDescriptor igdd =
 						new InputGateDeploymentDescriptor(resultId, 0, icdd);
 
-				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid, eid,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Receiver", 1, 0, 1, 0,
@@ -1096,9 +1100,11 @@ public class TaskManagerTest extends TestLogger {
 						true,
 						false);
 
+				final JobID jobId = new JobID();
+
 				// Single blocking task
-				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
-						new JobID(),
+				final TaskDeploymentDescriptor tdd = createTaskDeploymentDescriptor(
+						jobId,
 						"Job",
 						new JobVertexID(),
 						new ExecutionAttemptID(),
@@ -1130,7 +1136,7 @@ public class TaskManagerTest extends TestLogger {
 
 							Future<Object> taskRunningFuture = taskManager.ask(
 									new TestingTaskManagerMessages.NotifyWhenTaskIsRunning(
-											tdd.getExecutionId()), timeout);
+											tdd.getExecutionAttemptId()), timeout);
 
 							taskManager.tell(new SubmitTask(tdd));
 
@@ -1190,7 +1196,7 @@ public class TaskManagerTest extends TestLogger {
 
 								taskManager.tell(new TriggerStackTraceSample(
 												19230,
-												tdd.getExecutionId(),
+												tdd.getExecutionAttemptId(),
 												numSamples,
 												Time.milliseconds(100L),
 												0),
@@ -1206,7 +1212,7 @@ public class TaskManagerTest extends TestLogger {
 
 								// ---- Verify response ----
 								assertEquals(19230, response.getSampleId());
-								assertEquals(tdd.getExecutionId(), response.getExecutionAttemptID());
+								assertEquals(tdd.getExecutionAttemptId(), response.getExecutionAttemptID());
 
 								List<StackTraceElement[]> traces = response.getSamples();
 
@@ -1262,7 +1268,7 @@ public class TaskManagerTest extends TestLogger {
 
 							taskManager.tell(new TriggerStackTraceSample(
 											1337,
-											tdd.getExecutionId(),
+											tdd.getExecutionAttemptId(),
 											numSamples,
 											Time.milliseconds(100L),
 											maxDepth),
@@ -1278,7 +1284,7 @@ public class TaskManagerTest extends TestLogger {
 
 							// ---- Verify response ----
 							assertEquals(1337, response.getSampleId());
-							assertEquals(tdd.getExecutionId(), response.getExecutionAttemptID());
+							assertEquals(tdd.getExecutionAttemptId(), response.getExecutionAttemptID());
 
 							List<StackTraceElement[]> traces = response.getSamples();
 
@@ -1309,7 +1315,7 @@ public class TaskManagerTest extends TestLogger {
 								taskManager.tell(
 									new TriggerStackTraceSample(
 										44,
-										tdd.getExecutionId(),
+										tdd.getExecutionAttemptId(),
 										Integer.MAX_VALUE,
 										Time.milliseconds(10L),
 										0),
@@ -1318,11 +1324,11 @@ public class TaskManagerTest extends TestLogger {
 								Thread.sleep(sleepTime);
 
 								Future<?> removeFuture = taskManager.ask(
-										new TestingJobManagerMessages.NotifyWhenJobRemoved(tdd.getJobID()),
+										new TestingJobManagerMessages.NotifyWhenJobRemoved(jobId),
 										remaining());
 
 								// Cancel the task
-								taskManager.tell(new CancelTask(tdd.getExecutionId()));
+								taskManager.tell(new CancelTask(tdd.getExecutionAttemptId()));
 
 								// Receive the expected message (heartbeat races possible)
 								while (true) {
@@ -1330,7 +1336,7 @@ public class TaskManagerTest extends TestLogger {
 									if (msg[0] instanceof StackTraceSampleResponse) {
 										StackTraceSampleResponse response = (StackTraceSampleResponse) msg[0];
 
-										assertEquals(tdd.getExecutionId(), response.getExecutionAttemptID());
+										assertEquals(tdd.getExecutionAttemptId(), response.getExecutionAttemptID());
 										assertEquals(44, response.getSampleId());
 
 										// Done
@@ -1341,7 +1347,7 @@ public class TaskManagerTest extends TestLogger {
 
 										Future<?> taskRunningFuture = taskManager.ask(
 												new TestingTaskManagerMessages.NotifyWhenTaskIsRunning(
-														tdd.getExecutionId()), timeout);
+														tdd.getExecutionAttemptId()), timeout);
 
 										// Resubmit
 										taskManager.tell(new SubmitTask(tdd));
@@ -1425,7 +1431,7 @@ public class TaskManagerTest extends TestLogger {
 				false // don't deploy eagerly but with the first completed memory buffer
 			);
 
-			final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(jid, "TestJob", vid, eid, executionConfig,
+			final TaskDeploymentDescriptor tdd = createTaskDeploymentDescriptor(jid, "TestJob", vid, eid, executionConfig,
 				"TestTask", 1, 0, 1, 0, new Configuration(), new Configuration(),
 				TestInvokableRecordCancel.class.getName(),
 				Collections.singletonList(resultPartitionDeploymentDescriptor),
@@ -1710,5 +1716,57 @@ public class TaskManagerTest extends TestLogger {
 				return gotCanceledFuture;
 			}
 		}
+	}
+
+	private static TaskDeploymentDescriptor createTaskDeploymentDescriptor(
+		JobID jobId,
+		String jobName,
+		JobVertexID jobVertexId,
+		ExecutionAttemptID executionAttemptId,
+		SerializedValue<ExecutionConfig> serializedExecutionConfig,
+		String taskName,
+		int numberOfKeyGroups,
+		int subtaskIndex,
+		int parallelism,
+		int attemptNumber,
+		Configuration jobConfiguration,
+		Configuration taskConfiguration,
+		String invokableClassName,
+		Collection<ResultPartitionDeploymentDescriptor> producedPartitions,
+		Collection<InputGateDeploymentDescriptor> inputGates,
+		Collection<BlobKey> requiredJarFiles,
+		Collection<URL> requiredClasspaths,
+		int targetSlotNumber) throws IOException {
+
+		JobInformation jobInformation = new JobInformation(
+			jobId,
+			jobName,
+			serializedExecutionConfig,
+			jobConfiguration,
+			requiredJarFiles,
+			requiredClasspaths);
+
+		TaskInformation taskInformation = new TaskInformation(
+			jobVertexId,
+			taskName,
+			parallelism,
+			numberOfKeyGroups,
+			invokableClassName,
+			taskConfiguration);
+
+		SerializedValue<JobInformation> serializedJobInformation = new SerializedValue<>(jobInformation);
+		SerializedValue<TaskInformation> serializedJobVertexInformation = new SerializedValue<>(taskInformation);
+
+		return new TaskDeploymentDescriptor(
+			serializedJobInformation,
+			serializedJobVertexInformation,
+			executionAttemptId,
+			subtaskIndex,
+			attemptNumber,
+			targetSlotNumber,
+			null,
+			producedPartitions,
+			inputGates);
+
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
@@ -20,8 +20,13 @@ package org.apache.flink.runtime.taskmanager;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.io.network.netty.PartitionStateChecker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
@@ -32,11 +37,10 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.StoppableTask;
 import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.util.SerializedValue;
+import org.apache.flink.runtime.state.TaskStateHandles;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -44,6 +48,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.concurrent.Executor;
 
 import static org.mockito.Mockito.mock;
@@ -59,18 +64,22 @@ public class TaskStopTest {
 		TaskInfo taskInfoMock = mock(TaskInfo.class);
 		when(taskInfoMock.getTaskNameWithSubtasks()).thenReturn("dummyName");
 
-		TaskDeploymentDescriptor tddMock = mock(TaskDeploymentDescriptor.class);
-		when(tddMock.getTaskInfo()).thenReturn(taskInfoMock);
-		when(tddMock.getJobID()).thenReturn(mock(JobID.class));
-		when(tddMock.getVertexID()).thenReturn(mock(JobVertexID.class));
-		when(tddMock.getExecutionId()).thenReturn(mock(ExecutionAttemptID.class));
-		when(tddMock.getJobConfiguration()).thenReturn(mock(Configuration.class));
-		when(tddMock.getTaskConfiguration()).thenReturn(mock(Configuration.class));
-		when(tddMock.getSerializedExecutionConfig()).thenReturn(mock(SerializedValue.class));
-		when(tddMock.getInvokableClassName()).thenReturn("className");
-
 		task = new Task(
-			tddMock,
+			mock(JobInformation.class),
+			new TaskInformation(
+				new JobVertexID(),
+				"test task name",
+				1,
+				1,
+				"foobar",
+				new Configuration()),
+			mock(ExecutionAttemptID.class),
+			0,
+			0,
+			Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
+			Collections.<InputGateDeploymentDescriptor>emptyList(),
+			0,
+			mock(TaskStateHandles.class),
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			mock(NetworkEnvironment.class),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -30,10 +30,11 @@ import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
@@ -48,6 +49,7 @@ import org.apache.flink.runtime.operators.testutils.UnregisteredTaskMetricsGroup
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.StateBackendFactory;
+import org.apache.flink.runtime.state.TaskStateHandles;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
@@ -242,35 +244,46 @@ public class StreamTaskTest {
 		when(network.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class)))
 				.thenReturn(mock(TaskKvStateRegistry.class));
 
-		TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
-				new JobID(), "Job Name", new JobVertexID(), new ExecutionAttemptID(),
-				new SerializedValue<>(new ExecutionConfig()),
-				"Test Task", 1, 0, 1, 0,
-				new Configuration(),
-				taskConfig.getConfiguration(),
-				invokable.getName(),
-				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-				Collections.<InputGateDeploymentDescriptor>emptyList(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
-				0);
+		JobInformation jobInformation = new JobInformation(
+			new JobID(),
+			"Job Name",
+			new SerializedValue<>(new ExecutionConfig()),
+			new Configuration(),
+			Collections.<BlobKey>emptyList(),
+			Collections.<URL>emptyList());
+
+		TaskInformation taskInformation = new TaskInformation(
+			new JobVertexID(),
+			"Test Task",
+			1,
+			1,
+			invokable.getName(),
+			taskConfig.getConfiguration());
 
 		return new Task(
-				tdd,
-				mock(MemoryManager.class),
-				mock(IOManager.class),
-				network,
-				mock(BroadcastVariableManager.class),
-				mock(TaskManagerConnection.class),
-				mock(InputSplitProvider.class),
-				mock(CheckpointResponder.class),
-				libCache,
-				mock(FileCache.class),
-				new TaskManagerRuntimeInfo("localhost", taskManagerConfig, System.getProperty("java.io.tmpdir")),
-				new UnregisteredTaskMetricsGroup(),
-				consumableNotifier,
-				partitionStateChecker,
-				executor);
+			jobInformation,
+			taskInformation,
+			new ExecutionAttemptID(),
+			0,
+			0,
+			Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
+			Collections.<InputGateDeploymentDescriptor>emptyList(),
+			0,
+			new TaskStateHandles(),
+			mock(MemoryManager.class),
+			mock(IOManager.class),
+			network,
+			mock(BroadcastVariableManager.class),
+			mock(TaskManagerConnection.class),
+			mock(InputSplitProvider.class),
+			mock(CheckpointResponder.class),
+			libCache,
+			mock(FileCache.class),
+			new TaskManagerRuntimeInfo("localhost", taskManagerConfig, System.getProperty("java.io.tmpdir")),
+			new UnregisteredTaskMetricsGroup(),
+			consumableNotifier,
+			partitionStateChecker,
+			executor);
 	}
 	
 	// ------------------------------------------------------------------------

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.checkpoint.TaskState;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointV1;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -310,7 +311,11 @@ public class SavepointITCase extends TestLogger {
 
 								LOG.info("Received: " + tdd.toString() + ".");
 
-								tdds.put(tdd.getVertexID(), tdd);
+								TaskInformation taskInformation = tdd
+									.getSerializedTaskInformation()
+									.deserializeValue(getClass().getClassLoader());
+
+								tdds.put(taskInformation.getJobVertexId(), tdd);
 							}
 						}
 						catch (Throwable t) {
@@ -337,7 +342,7 @@ public class SavepointITCase extends TestLogger {
 				assertEquals(taskState.getNumberCollectedStates(), taskTdds.size());
 
 				for (TaskDeploymentDescriptor tdd : taskTdds) {
-					SubtaskState subtaskState = taskState.getState(tdd.getIndexInSubtaskGroup());
+					SubtaskState subtaskState = taskState.getState(tdd.getSubtaskIndex());
 
 					assertNotNull(subtaskState);
 


### PR DESCRIPTION
In order to speed up the serialization of the `TaskDeploymentDescriptor` we can pre serialize
all information which stays the same for all `TaskDeploymentDescriptors`. The information which
is static for a TDD is the job related information contained in the `ExecutionGraph` and the
operator/task related information stored in the `ExecutionJobVertex`.

In order to pre serialize this information, this PR introduces the `JobInformation` class
and the `TaskInformation` class which are stored in serialized form in the `ExecutionGraph`
and the `ExecutionJobVertex`, respectively.

The `TaskDeploymentDescriptor` is initialized with the serialized `JobInformation` and `TaskInformation` before it is sent to the `TaskManager`. On the `TaskManager` side the serialized `JobInformation` and `TaskInformation` are deserialized using the system class loader.