### PR TITLE
[backport] [FLINK-5046] [tdd] Preserialize TaskDeploymentDescriptor information

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
@@ -18,23 +18,15 @@
 
 package org.apache.flink.runtime.deployment;
 
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.TaskInfo;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.state.StateHandle;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
 
 import java.io.Serializable;
-import java.net.URL;
 import java.util.Collection;
-import java.util.List;
-
-import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A task deployment descriptor contains all the information necessary to deploy a task on a task manager.
@@ -43,177 +35,83 @@ public final class TaskDeploymentDescriptor implements Serializable {
 
 	private static final long serialVersionUID = -3233562176034358530L;
 
-	/** The ID of the job the tasks belongs to. */
-	private final JobID jobID;
-	private final String jobName;
+	/** Serialized job information */
+	private final SerializedValue<JobInformation> serializedJobInformation;
 
-	/** The task's job vertex ID. */
-	private final JobVertexID vertexID;
+	/** Serialized task information */
+	private final SerializedValue<TaskInformation> serializedTaskInformation;
 
 	/** The ID referencing the attempt to execute the task. */
 	private final ExecutionAttemptID executionId;
 
-	/** The task's name. */
-	private final String taskName;
-
 	/** The task's index in the subtask group. */
-	private final int indexInSubtaskGroup;
-
-	/** The number of sub tasks. */
-	private final int numberOfSubtasks;
+	private final int subtaskIndex;
 
 	/** Attempt number the task */
 	private final int attemptNumber;
 
-	/** The configuration of the job the task belongs to. */
-	private final Configuration jobConfiguration;
-
-	/** The task's configuration object. */
-	private final Configuration taskConfiguration;
-
-	/** The name of the class containing the task code to be executed. */
-	private final String invokableClassName;
-
 	/** The list of produced intermediate result partition deployment descriptors. */
-	private final List<ResultPartitionDeploymentDescriptor> producedPartitions;
+	private final Collection<ResultPartitionDeploymentDescriptor> producedPartitions;
 
 	/** The list of consumed intermediate result partitions. */
-	private final List<InputGateDeploymentDescriptor> inputGates;
+	private final Collection<InputGateDeploymentDescriptor> inputGates;
 
+	/** Slot number to run the sub task in on the target machine */
 	private final int targetSlotNumber;
 
-	/** The list of JAR files required to run this task. */
-	private final List<BlobKey> requiredJarFiles;
-	
-	/** The list of classpaths required to run this task. */
-	private final List<URL> requiredClasspaths;
-
+	/** State handles for the sub task */
 	private final SerializedValue<StateHandle<?>> operatorState;
 
-	/** The execution configuration (see {@link ExecutionConfig}) related to the specific job. */
-	private final SerializedValue<ExecutionConfig> serializedExecutionConfig;
-
-	/**
-	 * Constructs a task deployment descriptor.
-	 */
 	public TaskDeploymentDescriptor(
-			JobID jobID,
-			String jobName,
-			JobVertexID vertexID,
-			ExecutionAttemptID executionId,
-			SerializedValue<ExecutionConfig> serializedExecutionConfig,
-			String taskName,
-			int indexInSubtaskGroup,
-			int numberOfSubtasks,
+			SerializedValue<JobInformation> serializedJobInformation,
+			SerializedValue<TaskInformation> serializedTaskInformation,
+			ExecutionAttemptID executionAttemptId,
+			int subtaskIndex,
 			int attemptNumber,
-			Configuration jobConfiguration,
-			Configuration taskConfiguration,
-			String invokableClassName,
-			List<ResultPartitionDeploymentDescriptor> producedPartitions,
-			List<InputGateDeploymentDescriptor> inputGates,
-			List<BlobKey> requiredJarFiles,
-			List<URL> requiredClasspaths,
 			int targetSlotNumber,
-			SerializedValue<StateHandle<?>> operatorState) {
+			SerializedValue<StateHandle<?>> operatorState,
+			Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
+			Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors) {
 
-		checkArgument(indexInSubtaskGroup >= 0);
-		checkArgument(numberOfSubtasks > indexInSubtaskGroup);
-		checkArgument(targetSlotNumber >= 0);
-		checkArgument(attemptNumber >= 0);
+		this.serializedJobInformation = Preconditions.checkNotNull(serializedJobInformation);
+		this.serializedTaskInformation = Preconditions.checkNotNull(serializedTaskInformation);
+		this.executionId = Preconditions.checkNotNull(executionAttemptId);
 
-		this.jobID = checkNotNull(jobID);
-		this.jobName = checkNotNull(jobName);
-		this.vertexID = checkNotNull(vertexID);
-		this.executionId = checkNotNull(executionId);
-		this.serializedExecutionConfig = checkNotNull(serializedExecutionConfig);
-		this.taskName = checkNotNull(taskName);
-		this.indexInSubtaskGroup = indexInSubtaskGroup;
-		this.numberOfSubtasks = numberOfSubtasks;
+		Preconditions.checkArgument(0 <= subtaskIndex, "The subtask index must be positive.");
+		this.subtaskIndex = subtaskIndex;
+
+		Preconditions.checkArgument(0 <= attemptNumber, "The attempt number must be positive.");
 		this.attemptNumber = attemptNumber;
-		this.jobConfiguration = checkNotNull(jobConfiguration);
-		this.taskConfiguration = checkNotNull(taskConfiguration);
-		this.invokableClassName = checkNotNull(invokableClassName);
-		this.producedPartitions = checkNotNull(producedPartitions);
-		this.inputGates = checkNotNull(inputGates);
-		this.requiredJarFiles = checkNotNull(requiredJarFiles);
-		this.requiredClasspaths = checkNotNull(requiredClasspaths);
+
+		Preconditions.checkArgument(0 <= targetSlotNumber, "The target slot number must be positive.");
 		this.targetSlotNumber = targetSlotNumber;
+
 		this.operatorState = operatorState;
-	}
 
-	public TaskDeploymentDescriptor(
-		JobID jobID,
-		String jobName,
-		JobVertexID vertexID,
-		ExecutionAttemptID executionId,
-		SerializedValue<ExecutionConfig> serializedExecutionConfig,
-		String taskName,
-		int indexInSubtaskGroup,
-		int numberOfSubtasks,
-		int attemptNumber,
-		Configuration jobConfiguration,
-		Configuration taskConfiguration,
-		String invokableClassName,
-		List<ResultPartitionDeploymentDescriptor> producedPartitions,
-		List<InputGateDeploymentDescriptor> inputGates,
-		List<BlobKey> requiredJarFiles,
-		List<URL> requiredClasspaths,
-		int targetSlotNumber) {
-
-		this(
-			jobID,
-			jobName,
-			vertexID,
-			executionId,
-			serializedExecutionConfig,
-			taskName,
-			indexInSubtaskGroup,
-			numberOfSubtasks,
-			attemptNumber,
-			jobConfiguration,
-			taskConfiguration,
-			invokableClassName,
-			producedPartitions,
-			inputGates,
-			requiredJarFiles,
-			requiredClasspaths,
-			targetSlotNumber,
-			null);
+		this.producedPartitions = Preconditions.checkNotNull(resultPartitionDeploymentDescriptors);
+		this.inputGates = Preconditions.checkNotNull(inputGateDeploymentDescriptors);
 	}
 
 	/**
-	 * Returns the execution configuration (see {@link ExecutionConfig}) related to the
-	 * specific job.
+	 * Return the sub task's serialized job information.
+	 *
+	 * @return serialized job information
 	 */
-	public SerializedValue<ExecutionConfig> getSerializedExecutionConfig() {
-		return serializedExecutionConfig;
+	public SerializedValue<JobInformation> getSerializedJobInformation() {
+		return serializedJobInformation;
 	}
 
 	/**
-	 * Returns the ID of the job the tasks belongs to.
+	 * Return the sub task's serialized task information.
+	 *
+	 * @return serialized task information
 	 */
-	public JobID getJobID() {
-		return jobID;
-	}
-	
-	public String getJobName() { return jobName; }
-
-	/**
-	 * Returns the task's execution vertex ID.
-	 */
-	public JobVertexID getVertexID() {
-		return vertexID;
+	public SerializedValue<TaskInformation> getSerializedTaskInformation() {
+		return serializedTaskInformation;
 	}
 
-	public ExecutionAttemptID getExecutionId() {
+	public ExecutionAttemptID getExecutionAttemptId() {
 		return executionId;
-	}
-
-	/**
-	 * Returns the task's name.
-	 */
-	public String getTaskName() {
-		return taskName;
 	}
 
 	/**
@@ -221,15 +119,8 @@ public final class TaskDeploymentDescriptor implements Serializable {
 	 *
 	 * @return the task's index in the subtask group
 	 */
-	public int getIndexInSubtaskGroup() {
-		return indexInSubtaskGroup;
-	}
-
-	/**
-	 * Returns the current number of subtasks.
-	 */
-	public int getNumberOfSubtasks() {
-		return numberOfSubtasks;
+	public int getSubtaskIndex() {
+		return subtaskIndex;
 	}
 
 	/**
@@ -237,13 +128,6 @@ public final class TaskDeploymentDescriptor implements Serializable {
 	 */
 	public int getAttemptNumber() {
 		return attemptNumber;
-	}
-
-	/**
-	 * Returns the {@link TaskInfo} object for the subtask
-	 */
-	public TaskInfo getTaskInfo() {
-		return new TaskInfo(taskName, indexInSubtaskGroup, numberOfSubtasks, attemptNumber);
 	}
 
 	/**
@@ -255,68 +139,39 @@ public final class TaskDeploymentDescriptor implements Serializable {
 		return targetSlotNumber;
 	}
 
-	/**
-	 * Returns the configuration of the job the task belongs to.
-	 */
-	public Configuration getJobConfiguration() {
-		return jobConfiguration;
-	}
-
-	/**
-	 * Returns the task's configuration object.
-	 */
-	public Configuration getTaskConfiguration() {
-		return taskConfiguration;
-	}
-
-	/**
-	 * Returns the name of the class containing the task code to be executed.
-	 */
-	public String getInvokableClassName() {
-		return invokableClassName;
-	}
-
-	public List<ResultPartitionDeploymentDescriptor> getProducedPartitions() {
+	public Collection<ResultPartitionDeploymentDescriptor> getProducedPartitions() {
 		return producedPartitions;
 	}
 
-	public List<InputGateDeploymentDescriptor> getInputGates() {
+	public Collection<InputGateDeploymentDescriptor> getInputGates() {
 		return inputGates;
 	}
 
-	public List<BlobKey> getRequiredJarFiles() {
-		return requiredJarFiles;
-	}
-
-	public List<URL> getRequiredClasspaths() {
-		return requiredClasspaths;
+	public SerializedValue<StateHandle<?>> getOperatorState() {
+		return operatorState;
 	}
 
 	@Override
 	public String toString() {
-		return String.format("TaskDeploymentDescriptor [job id: %s, job vertex id: %s, " +
-						"execution id: %s, task name: %s (%d/%d), attempt: %d, invokable: %s, " +
-						"produced partitions: %s, input gates: %s]",
-				jobID, vertexID, executionId, taskName, indexInSubtaskGroup, numberOfSubtasks,
-				attemptNumber, invokableClassName, collectionToString(producedPartitions),
-				collectionToString(inputGates));
+		return String.format("TaskDeploymentDescriptor [execution id: %s, attempt: %d, " +
+				"produced partitions: %s, input gates: %s]",
+			executionId,
+			attemptNumber,
+			collectionToString(producedPartitions),
+			collectionToString(inputGates));
 	}
 
-	private String collectionToString(Collection<?> collection) {
+	private static String collectionToString(Iterable<?> collection) {
 		final StringBuilder strBuilder = new StringBuilder();
 
 		strBuilder.append("[");
 
 		for (Object elem : collection) {
-			strBuilder.append(elem.toString());
+			strBuilder.append(elem);
 		}
 
 		strBuilder.append("]");
 
 		return strBuilder.toString();
-	}
-
-	public SerializedValue<StateHandle<?>> getOperatorState() {
-		return operatorState;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -388,7 +388,9 @@ public class Execution implements Serializable {
 				public void onComplete(Throwable failure, Object success) throws Throwable {
 					if (failure != null) {
 						if (failure instanceof TimeoutException) {
-							String taskname = deployment.getTaskInfo().getTaskNameWithSubtasks() + " (" + attemptId + ')';
+						String taskname = vertex.getTaskName() + '(' +
+							(vertex.getParallelSubtaskIndex() + 1) + '/' +
+							vertex.getTotalNumberOfParallelSubtasks() + ") (" + attemptId + ')';
 
 							markFailed(new Exception(
 									"Cannot deploy task " + taskname + " - TaskManager (" + instance

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.JobException;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.PartialInputChannelDeploymentDescriptor;
@@ -50,7 +48,6 @@ import org.slf4j.Logger;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.io.Serializable;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -666,29 +663,19 @@ public class ExecutionVertex implements Serializable {
 			consumedPartitions.add(new InputGateDeploymentDescriptor(resultId, queueToRequest, partitions));
 		}
 
-		SerializedValue<ExecutionConfig> serializedConfig = getExecutionGraph().getSerializedExecutionConfig();
-		List<BlobKey> jarFiles = getExecutionGraph().getRequiredJarFiles();
-		List<URL> classpaths = getExecutionGraph().getRequiredClasspaths();
+		SerializedValue<JobInformation> serializedJobInformation = getExecutionGraph().getSerializedJobInformation();
+		SerializedValue<TaskInformation> serializedJobVertexInformation = jobVertex.getSerializedTaskInformation();
 
 		return new TaskDeploymentDescriptor(
-			getJobId(),
-			getExecutionGraph().getJobName(),
-			getJobvertexId(),
+			serializedJobInformation,
+			serializedJobVertexInformation,
 			executionId,
-			serializedConfig,
-			getTaskName(),
 			subTaskIndex,
-			getTotalNumberOfParallelSubtasks(),
 			attemptNumber,
-			getExecutionGraph().getJobConfiguration(),
-			jobVertex.getJobVertex().getConfiguration(),
-			jobVertex.getJobVertex().getInvokableClassName(),
-			producedPartitions,
-			consumedPartitions,
-			jarFiles,
-			classpaths,
 			targetSlot.getRoot().getSlotNumber(),
-			operatorState);
+			operatorState,
+			producedPartitions,
+			consumedPartitions);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobInformation.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.SerializedValue;
+
+import java.io.Serializable;
+import java.net.URL;
+import java.util.Collection;
+
+/**
+ * Container class for job information which is stored in the {@link ExecutionGraph}.
+ */
+public class JobInformation implements Serializable {
+
+	private static final long serialVersionUID = 8367087049937822140L;
+
+	/** Id of the job */
+	private final JobID jobId;
+
+	/** Job name */
+	private final String jobName;
+
+	/** Serialized execution config because it can contain user code classes */
+	private final SerializedValue<ExecutionConfig> serializedExecutionConfig;
+
+	/** Configuration of the job */
+	private final Configuration jobConfiguration;
+
+	/** Blob keys for the required jar files */
+	private final Collection<BlobKey> requiredJarFileBlobKeys;
+
+	/** URLs specifying the classpath to add to the class loader */
+	private final Collection<URL> requiredClasspathURLs;
+
+
+	public JobInformation(
+			JobID jobId,
+			String jobName,
+			SerializedValue<ExecutionConfig> serializedExecutionConfig,
+			Configuration jobConfiguration,
+			Collection<BlobKey> requiredJarFileBlobKeys,
+			Collection<URL> requiredClasspathURLs) {
+		this.jobId = Preconditions.checkNotNull(jobId);
+		this.jobName = Preconditions.checkNotNull(jobName);
+		this.serializedExecutionConfig = Preconditions.checkNotNull(serializedExecutionConfig);
+		this.jobConfiguration = Preconditions.checkNotNull(jobConfiguration);
+		this.requiredJarFileBlobKeys = Preconditions.checkNotNull(requiredJarFileBlobKeys);
+		this.requiredClasspathURLs = Preconditions.checkNotNull(requiredClasspathURLs);
+	}
+
+	public JobID getJobId() {
+		return jobId;
+	}
+
+	public String getJobName() {
+		return jobName;
+	}
+
+	public SerializedValue<ExecutionConfig> getSerializedExecutionConfig() {
+		return serializedExecutionConfig;
+	}
+
+	public Configuration getJobConfiguration() {
+		return jobConfiguration;
+	}
+
+	public Collection<BlobKey> getRequiredJarFileBlobKeys() {
+		return requiredJarFileBlobKeys;
+	}
+
+	public Collection<URL> getRequiredClasspathURLs() {
+		return requiredClasspathURLs;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/TaskInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/TaskInformation.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+
+/**
+ * Container class for operator/task specific information which are stored at the
+ * {@link ExecutionJobVertex}. This information is shared by all sub tasks of this operator.
+ */
+public class TaskInformation implements Serializable {
+
+	private static final long serialVersionUID = -9006218793155953789L;
+
+	/** Job vertex id of the associated job vertex */
+	private final JobVertexID jobVertexId;
+
+	/** Name of the task */
+	private final String taskName;
+
+	/** The number of subtasks for this operator */
+	private final int parallelism;
+
+	/** Class name of the invokable to run */
+	private final String invokableClassName;
+
+	/** Configuration for the task */
+	private final Configuration taskConfiguration;
+
+	public TaskInformation(
+			JobVertexID jobVertexId,
+			String taskName,
+			int parallelism,
+			String invokableClassName,
+			Configuration taskConfiguration) {
+		this.jobVertexId = Preconditions.checkNotNull(jobVertexId);
+		this.taskName = Preconditions.checkNotNull(taskName);
+		this.parallelism = Preconditions.checkNotNull(parallelism);
+		this.invokableClassName = Preconditions.checkNotNull(invokableClassName);
+		this.taskConfiguration = Preconditions.checkNotNull(taskConfiguration);
+	}
+
+	public JobVertexID getJobVertexId() {
+		return jobVertexId;
+	}
+
+	public String getTaskName() {
+		return taskName;
+	}
+
+	public int getParallelism() {
+		return parallelism;
+	}
+
+	public String getInvokableClassName() {
+		return invokableClassName;
+	}
+
+	public Configuration getTaskConfiguration() {
+		return taskConfiguration;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
@@ -18,7 +18,8 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.scope.TaskManagerJobScopeFormat;
 import org.apache.flink.util.AbstractID;
@@ -74,20 +75,27 @@ public class TaskManagerJobMetricGroup extends JobMetricGroup {
 	//  adding / removing tasks
 	// ------------------------------------------------------------------------
 
-	public TaskMetricGroup addTask(TaskDeploymentDescriptor tdd) {
-		AbstractID vertexId = tdd.getVertexID();
-		AbstractID executionId = tdd.getExecutionId();
-		String taskName = tdd.getTaskName();
-		int subtaskIndex = tdd.getIndexInSubtaskGroup();
-		int attemptNumber = tdd.getAttemptNumber();
-
-		checkNotNull(executionId);
+	public TaskMetricGroup addTask(
+			final JobVertexID jobVertexId,
+			final ExecutionAttemptID executionAttemptID,
+			final String taskName,
+			final int subtaskIndex,
+			final int attemptNumber) {
+		checkNotNull(jobVertexId);
+		checkNotNull(executionAttemptID);
+		checkNotNull(taskName);
 
 		synchronized (this) {
 			if (!isClosed()) {
-				TaskMetricGroup task = new TaskMetricGroup(registry, this,
-					vertexId, executionId, taskName, subtaskIndex, attemptNumber);
-				tasks.put(executionId, task);
+				TaskMetricGroup task = new TaskMetricGroup(
+					registry,
+					this,
+					jobVertexId,
+					executionAttemptID,
+					taskName,
+					subtaskIndex,
+					attemptNumber);
+				tasks.put(executionAttemptID, task);
 				return task;
 			} else {
 				return null;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
@@ -19,9 +19,11 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.scope.TaskManagerScopeFormat;
+import org.apache.flink.util.Preconditions;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -67,11 +69,19 @@ public class TaskManagerMetricGroup extends ComponentMetricGroup {
 	//  job groups
 	// ------------------------------------------------------------------------
 
-	public TaskMetricGroup addTaskForJob(TaskDeploymentDescriptor tdd) {
-		JobID jobId = tdd.getJobID();
-		String jobName = tdd.getJobName().length() == 0 
-			? tdd.getJobID().toString()
-			: tdd.getJobName();
+	public TaskMetricGroup addTaskForJob(
+			final JobID jobId,
+			final String jobName,
+			final JobVertexID jobVertexId,
+			final ExecutionAttemptID executionAttemptId,
+			final String taskName,
+			final int subtaskIndex,
+			final int attemptNumber) {
+		Preconditions.checkNotNull(jobId);
+
+		String resolvedJobName = jobName == null || jobName.isEmpty()
+			? jobId.toString()
+			: jobName;
 
 		// we cannot strictly lock both our map modification and the job group modification
 		// because it might lead to a deadlock
@@ -82,14 +92,19 @@ public class TaskManagerMetricGroup extends ComponentMetricGroup {
 				currentJobGroup = jobs.get(jobId);
 
 				if (currentJobGroup == null || currentJobGroup.isClosed()) {
-					currentJobGroup = new TaskManagerJobMetricGroup(registry, this, jobId, jobName);
+					currentJobGroup = new TaskManagerJobMetricGroup(registry, this, jobId, resolvedJobName);
 					jobs.put(jobId, currentJobGroup);
 				}
 			}
 
 			// try to add another task. this may fail if we found a pre-existing job metrics
 			// group and it is closed concurrently
-			TaskMetricGroup taskGroup = currentJobGroup.addTask(tdd);
+			TaskMetricGroup taskGroup = currentJobGroup.addTask(
+				jobVertexId,
+				executionAttemptId,
+				taskName,
+				subtaskIndex,
+				attemptNumber);
 
 			if (taskGroup != null) {
 				// successfully added the next task

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/testingUtils/TestingTaskManagerLike.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/testingUtils/TestingTaskManagerLike.scala
@@ -149,11 +149,19 @@ trait TestingTaskManagerLike extends FlinkActor {
       registeredSubmitTaskListeners.put(jobId, sender())
 
     case msg@SubmitTask(tdd) =>
-      registeredSubmitTaskListeners.get(tdd.getJobID) match {
-        case Some(listenerRef) =>
-          listenerRef ! ResponseSubmitTaskListener(tdd)
-        case None =>
-        // Nothing to do
+      try {
+        val jobId = tdd.getSerializedJobInformation.deserializeValue(getClass.getClassLoader)
+          .getJobId
+
+        registeredSubmitTaskListeners.get(jobId) match {
+          case Some(listenerRef) =>
+            listenerRef ! ResponseSubmitTaskListener(tdd)
+          case None =>
+          // Nothing to do
+        }
+      } catch {
+        case e: Exception =>
+          log.error("Could not deserialize the job information.", e)
       }
 
       super.handleMessage(msg)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.RecoveryMode;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
@@ -154,6 +155,7 @@ public class ExecutionGraphCheckpointCoordinatorTest {
 				new DisabledCheckpointStatsTracker());
 
 		JobVertex jobVertex = new JobVertex("MockVertex");
+		jobVertex.setInvokableClass(AbstractInvokable.class);
 		executionGraph.attachJobGraph(Collections.singletonList(jobVertex));
 
 		return executionGraph;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -31,6 +31,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.BatchTask;
@@ -59,32 +61,39 @@ public class TaskDeploymentDescriptorTest {
 			final List<BlobKey> requiredJars = new ArrayList<BlobKey>(0);
 			final List<URL> requiredClasspaths = new ArrayList<URL>(0);
 			final SerializedValue<ExecutionConfig> executionConfig = new SerializedValue<>(new ExecutionConfig());
+			final SerializedValue<JobInformation> serializedJobInformation = new SerializedValue<>(new JobInformation(
+				jobID, jobName, executionConfig, jobConfiguration, requiredJars, requiredClasspaths));
+			final SerializedValue<TaskInformation> serializedJobVertexInformation = new SerializedValue<>(new TaskInformation(
+				vertexID, taskName, currentNumberOfSubtasks, invokableClass.getName(), taskConfiguration));
+			final int targetSlotNumber = 47;
 
-			final TaskDeploymentDescriptor orig = new TaskDeploymentDescriptor(jobID, jobName, vertexID, execId,
-				executionConfig, taskName, indexInSubtaskGroup, currentNumberOfSubtasks, attemptNumber,
-				jobConfiguration, taskConfiguration, invokableClass.getName(), producedResults, inputGates,
-				requiredJars, requiredClasspaths, 47);
+			final TaskDeploymentDescriptor orig = new TaskDeploymentDescriptor(
+				serializedJobInformation,
+				serializedJobVertexInformation,
+				execId,
+				indexInSubtaskGroup,
+				attemptNumber,
+				targetSlotNumber,
+				null,
+				producedResults,
+				inputGates);
 	
 			final TaskDeploymentDescriptor copy = CommonTestUtils.createCopySerializable(orig);
 	
-			assertFalse(orig.getJobID() == copy.getJobID());
-			assertFalse(orig.getVertexID() == copy.getVertexID());
-			assertFalse(orig.getTaskName() == copy.getTaskName());
-			assertFalse(orig.getJobConfiguration() == copy.getJobConfiguration());
-			assertFalse(orig.getTaskConfiguration() == copy.getTaskConfiguration());
+			assertFalse(orig.getSerializedJobInformation() == copy.getSerializedJobInformation());
+			assertFalse(orig.getSerializedTaskInformation() == copy.getSerializedTaskInformation());
+			assertFalse(orig.getExecutionAttemptId() == copy.getExecutionAttemptId());
+			assertFalse(orig.getProducedPartitions() == copy.getProducedPartitions());
+			assertFalse(orig.getInputGates() == copy.getInputGates());
 
-			assertEquals(orig.getJobID(), copy.getJobID());
-			assertEquals(orig.getVertexID(), copy.getVertexID());
-			assertEquals(orig.getTaskName(), copy.getTaskName());
-			assertEquals(orig.getIndexInSubtaskGroup(), copy.getIndexInSubtaskGroup());
-			assertEquals(orig.getNumberOfSubtasks(), copy.getNumberOfSubtasks());
+			assertEquals(orig.getSerializedJobInformation(), copy.getSerializedJobInformation());
+			assertEquals(orig.getSerializedTaskInformation(), copy.getSerializedTaskInformation());
+			assertEquals(orig.getExecutionAttemptId(), copy.getExecutionAttemptId());
+			assertEquals(orig.getSubtaskIndex(), copy.getSubtaskIndex());
 			assertEquals(orig.getAttemptNumber(), copy.getAttemptNumber());
+			assertEquals(orig.getTargetSlotNumber(), copy.getTargetSlotNumber());
 			assertEquals(orig.getProducedPartitions(), copy.getProducedPartitions());
 			assertEquals(orig.getInputGates(), copy.getInputGates());
-			assertEquals(orig.getSerializedExecutionConfig(), copy.getSerializedExecutionConfig());
-
-			assertEquals(orig.getRequiredJarFiles(), copy.getRequiredJarFiles());
-			assertEquals(orig.getRequiredClasspaths(), copy.getRequiredClasspaths());
 		}
 		catch (Exception e) {
 			e.printStackTrace();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AllVerticesIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AllVerticesIteratorTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -37,7 +38,12 @@ public class AllVerticesIteratorTest {
 			JobVertex v2 = new JobVertex("v2");
 			JobVertex v3 = new JobVertex("v3");
 			JobVertex v4 = new JobVertex("v4");
-			
+
+			v1.setInvokableClass(AbstractInvokable.class);
+			v2.setInvokableClass(AbstractInvokable.class);
+			v3.setInvokableClass(AbstractInvokable.class);
+			v4.setInvokableClass(AbstractInvokable.class);
+
 			v1.setParallelism(1);
 			v2.setParallelism(7);
 			v3.setParallelism(3);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
 
@@ -95,7 +96,13 @@ public class ExecutionGraphConstructionTest {
 		v3.setParallelism(2);
 		v4.setParallelism(11);
 		v5.setParallelism(4);
-		
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
+		v3.setInvokableClass(AbstractInvokable.class);
+		v4.setInvokableClass(AbstractInvokable.class);
+		v5.setInvokableClass(AbstractInvokable.class);
+
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.ALL_TO_ALL);
 		v4.connectNewDataSetAsInput(v2, DistributionPattern.ALL_TO_ALL);
 		v4.connectNewDataSetAsInput(v3, DistributionPattern.ALL_TO_ALL);
@@ -137,7 +144,11 @@ public class ExecutionGraphConstructionTest {
 		v1.setParallelism(5);
 		v2.setParallelism(7);
 		v3.setParallelism(2);
-		
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
+		v3.setInvokableClass(AbstractInvokable.class);
+
 		// this creates an intermediate result for v1
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.ALL_TO_ALL);
 		
@@ -171,7 +182,10 @@ public class ExecutionGraphConstructionTest {
 		JobVertex v5 = new JobVertex("vertex5");
 		v4.setParallelism(11);
 		v5.setParallelism(4);
-		
+
+		v4.setInvokableClass(AbstractInvokable.class);
+		v5.setInvokableClass(AbstractInvokable.class);
+
 		v4.connectDataSetAsInput(v2result, DistributionPattern.ALL_TO_ALL);
 		v4.connectDataSetAsInput(v3result_1, DistributionPattern.ALL_TO_ALL);
 		v5.connectNewDataSetAsInput(v4, DistributionPattern.ALL_TO_ALL);
@@ -205,6 +219,10 @@ public class ExecutionGraphConstructionTest {
 		v1.setParallelism(5);
 		v2.setParallelism(7);
 		v3.setParallelism(2);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
+		v3.setInvokableClass(AbstractInvokable.class);
 		
 		// this creates an intermediate result for v1
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.ALL_TO_ALL);
@@ -213,8 +231,7 @@ public class ExecutionGraphConstructionTest {
 		IntermediateDataSet v2result = v2.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
 		IntermediateDataSet v3result_1 = v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
 		IntermediateDataSet v3result_2 = v3.createAndAddResultDataSet(ResultPartitionType.PIPELINED);
-		
-		
+
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3));
 
 		ExecutionGraph eg = new ExecutionGraph(
@@ -239,7 +256,10 @@ public class ExecutionGraphConstructionTest {
 		JobVertex v5 = new JobVertex("vertex5");
 		v4.setParallelism(11);
 		v5.setParallelism(4);
-		
+
+		v4.setInvokableClass(AbstractInvokable.class);
+		v5.setInvokableClass(AbstractInvokable.class);
+
 		v4.connectIdInput(v2result.getId(), DistributionPattern.ALL_TO_ALL);
 		v4.connectIdInput(v3result_1.getId(), DistributionPattern.ALL_TO_ALL);
 		v5.connectNewDataSetAsInput(v4, DistributionPattern.ALL_TO_ALL);
@@ -469,7 +489,8 @@ public class ExecutionGraphConstructionTest {
 		// construct part one of the execution graph
 		JobVertex v1 = new JobVertex("vertex1");
 		v1.setParallelism(7);
-		
+		v1.setInvokableClass(AbstractInvokable.class);
+
 		List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1));
 
 		ExecutionGraph eg = new ExecutionGraph(
@@ -490,6 +511,7 @@ public class ExecutionGraphConstructionTest {
 		
 		// attach the second part of the graph
 		JobVertex v2 = new JobVertex("vertex2");
+		v2.setInvokableClass(AbstractInvokable.class);
 		v2.connectIdInput(new IntermediateDataSetID(), DistributionPattern.ALL_TO_ALL);
 		
 		List<JobVertex> ordered2 = new ArrayList<JobVertex>(Arrays.asList(v2));
@@ -520,7 +542,13 @@ public class ExecutionGraphConstructionTest {
 		v3.setParallelism(2);
 		v4.setParallelism(11);
 		v5.setParallelism(4);
-		
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
+		v3.setInvokableClass(AbstractInvokable.class);
+		v4.setInvokableClass(AbstractInvokable.class);
+		v5.setInvokableClass(AbstractInvokable.class);
+
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.ALL_TO_ALL);
 		v4.connectNewDataSetAsInput(v2, DistributionPattern.ALL_TO_ALL);
 		v4.connectNewDataSetAsInput(v3, DistributionPattern.ALL_TO_ALL);
@@ -579,6 +607,12 @@ public class ExecutionGraphConstructionTest {
 			v3.setParallelism(2);
 			v4.setParallelism(11);
 			v5.setParallelism(4);
+
+			v1.setInvokableClass(AbstractInvokable.class);
+			v2.setInvokableClass(AbstractInvokable.class);
+			v3.setInvokableClass(AbstractInvokable.class);
+			v4.setInvokableClass(AbstractInvokable.class);
+			v5.setInvokableClass(AbstractInvokable.class);
 			
 			v2.connectNewDataSetAsInput(v1, DistributionPattern.ALL_TO_ALL);
 			v4.connectNewDataSetAsInput(v2, DistributionPattern.ALL_TO_ALL);
@@ -672,6 +706,8 @@ public class ExecutionGraphConstructionTest {
 			JobVertex v2 = new JobVertex("vertex2");
 			v1.setParallelism(6);
 			v2.setParallelism(4);
+			v1.setInvokableClass(AbstractInvokable.class);
+			v2.setInvokableClass(AbstractInvokable.class);
 			
 			SlotSharingGroup sl1 = new SlotSharingGroup();
 			v1.setSlotSharingGroup(sl1);
@@ -690,6 +726,12 @@ public class ExecutionGraphConstructionTest {
 			v5.setParallelism(3);
 			v6.setParallelism(3);
 			v7.setParallelism(3);
+
+			v3.setInvokableClass(AbstractInvokable.class);
+			v4.setInvokableClass(AbstractInvokable.class);
+			v5.setInvokableClass(AbstractInvokable.class);
+			v6.setInvokableClass(AbstractInvokable.class);
+			v7.setInvokableClass(AbstractInvokable.class);
 			
 			SlotSharingGroup sl2 = new SlotSharingGroup();
 			v3.setSlotSharingGroup(sl2);
@@ -706,6 +748,7 @@ public class ExecutionGraphConstructionTest {
 			// isolated vertex
 			JobVertex v8 = new JobVertex("vertex8");
 			v8.setParallelism(2);
+			v8.setInvokableClass(AbstractInvokable.class);
 
 			JobGraph jg = new JobGraph(jobId, jobName, v1, v2, v3, v4, v5, v6, v7, v8);
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -25,9 +25,11 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -121,22 +123,28 @@ public class ExecutionGraphDeploymentTest {
 			TaskDeploymentDescriptor descr = instanceGateway.lastTDD;
 			assertNotNull(descr);
 
-			assertEquals(jobId, descr.getJobID());
-			assertEquals(jid2, descr.getVertexID());
-			assertEquals(3, descr.getIndexInSubtaskGroup());
-			assertEquals(10, descr.getNumberOfSubtasks());
-			assertEquals(BatchTask.class.getName(), descr.getInvokableClassName());
-			assertEquals("v2", descr.getTaskName());
+			JobInformation jobInformation = descr.getSerializedJobInformation().deserializeValue(getClass().getClassLoader());
+			TaskInformation taskInformation = descr.getSerializedTaskInformation().deserializeValue(getClass().getClassLoader());
 
-			List<ResultPartitionDeploymentDescriptor> producedPartitions = descr.getProducedPartitions();
-			List<InputGateDeploymentDescriptor> consumedPartitions = descr.getInputGates();
+			assertEquals(jobId, jobInformation.getJobId());
+			assertEquals(jid2, taskInformation.getJobVertexId());
+			assertEquals(3, descr.getSubtaskIndex());
+			assertEquals(10, taskInformation.getParallelism());
+			assertEquals(BatchTask.class.getName(), taskInformation.getInvokableClassName());
+			assertEquals("v2", taskInformation.getTaskName());
+
+			Collection<ResultPartitionDeploymentDescriptor> producedPartitions = descr.getProducedPartitions();
+			Collection<InputGateDeploymentDescriptor> consumedPartitions = descr.getInputGates();
 
 			assertEquals(2, producedPartitions.size());
 			assertEquals(1, consumedPartitions.size());
 
-			assertEquals(10, producedPartitions.get(0).getNumberOfSubpartitions());
-			assertEquals(10, producedPartitions.get(1).getNumberOfSubpartitions());
-			assertEquals(10, consumedPartitions.get(0).getInputChannelDeploymentDescriptors().length);
+			Iterator<ResultPartitionDeploymentDescriptor> iteratorProducedPartitions = producedPartitions.iterator();
+			Iterator<InputGateDeploymentDescriptor> iteratorConsumedPartitions = consumedPartitions.iterator();
+
+			assertEquals(10, iteratorProducedPartitions.next().getNumberOfSubpartitions());
+			assertEquals(10, iteratorProducedPartitions.next().getNumberOfSubpartitions());
+			assertEquals(10, iteratorConsumedPartitions.next().getInputChannelDeploymentDescriptors().length);
 		}
 		catch (Exception e) {
 			e.printStackTrace();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
 
@@ -56,6 +57,9 @@ public class PointwisePatternTest {
 	
 		v1.setParallelism(N);
 		v2.setParallelism(N);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
 	
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 	
@@ -98,6 +102,9 @@ public class PointwisePatternTest {
 	
 		v1.setParallelism(2 * N);
 		v2.setParallelism(N);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
 	
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 	
@@ -141,6 +148,9 @@ public class PointwisePatternTest {
 	
 		v1.setParallelism(3 * N);
 		v2.setParallelism(N);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
 	
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 	
@@ -185,6 +195,9 @@ public class PointwisePatternTest {
 	
 		v1.setParallelism(N);
 		v2.setParallelism(2 * N);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
 	
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 	
@@ -227,6 +240,9 @@ public class PointwisePatternTest {
 	
 		v1.setParallelism(N);
 		v2.setParallelism(7 * N);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
 	
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 	
@@ -289,6 +305,9 @@ public class PointwisePatternTest {
 	
 		v1.setParallelism(lowDop);
 		v2.setParallelism(highDop);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
 	
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 	
@@ -342,6 +361,9 @@ public class PointwisePatternTest {
 	
 		v1.setParallelism(highDop);
 		v2.setParallelism(lowDop);
+
+		v1.setInvokableClass(AbstractInvokable.class);
+		v2.setInvokableClass(AbstractInvokable.class);
 	
 		v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexLocationConstraintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexLocationConstraintTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
@@ -405,6 +406,7 @@ public class VertexLocationConstraintTest {
 	public void testArchivingClearsFields() {
 		try {
 			JobVertex vertex = new JobVertex("test vertex", new JobVertexID());
+			vertex.setInvokableClass(AbstractInvokable.class);
 			JobGraph jg = new JobGraph("test job", vertex);
 			
 			ExecutionGraph eg = new ExecutionGraph(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
@@ -58,7 +59,13 @@ public class VertexSlotSharingTest {
 			v3.setParallelism(7);
 			v4.setParallelism(1);
 			v5.setParallelism(11);
-			
+
+			v1.setInvokableClass(AbstractInvokable.class);
+			v2.setInvokableClass(AbstractInvokable.class);
+			v3.setInvokableClass(AbstractInvokable.class);
+			v4.setInvokableClass(AbstractInvokable.class);
+			v5.setInvokableClass(AbstractInvokable.class);
+
 			v2.connectNewDataSetAsInput(v1, DistributionPattern.POINTWISE);
 			v5.connectNewDataSetAsInput(v4, DistributionPattern.POINTWISE);
 			

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.network.api.reader.BufferReader;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -27,10 +27,11 @@ import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.DummyActorGateway;
@@ -150,31 +151,44 @@ public class TaskAsyncCallTest {
 		when(networkEnvironment.getPartitionConsumableNotifier()).thenReturn(consumableNotifier);
 		when(networkEnvironment.getDefaultIOMode()).thenReturn(IOManager.IOMode.SYNC);
 
-		TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
-				new JobID(), "Job Name", new JobVertexID(), new ExecutionAttemptID(),
-				new SerializedValue<>(new ExecutionConfig()),
-				"Test Task", 0, 1, 0,
-				new Configuration(), new Configuration(),
-				CheckpointsInOrderInvokable.class.getName(),
-				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-				Collections.<InputGateDeploymentDescriptor>emptyList(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
-				0);
+		JobInformation jobInformation = new JobInformation(
+			new JobID(),
+			"Job Name",
+			new SerializedValue<>(new ExecutionConfig()),
+			new Configuration(),
+			Collections.<BlobKey>emptyList(),
+			Collections.<URL>emptyList());
+
+		TaskInformation taskInformation = new TaskInformation(
+			new JobVertexID(),
+			"Test Task",
+			1,
+			CheckpointsInOrderInvokable.class.getName(),
+			new Configuration());
 
 		ActorGateway taskManagerGateway = DummyActorGateway.INSTANCE;
-		return new Task(tdd,
-				mock(MemoryManager.class),
-				mock(IOManager.class),
-				networkEnvironment,
-				mock(BroadcastVariableManager.class),
-				taskManagerGateway,
-				DummyActorGateway.INSTANCE,
-				new FiniteDuration(60, TimeUnit.SECONDS),
-				libCache,
-				mock(FileCache.class),
-				new TaskManagerRuntimeInfo("localhost", new Configuration(), System.getProperty("java.io.tmpdir")),
-				mock(TaskMetricGroup.class));
+
+		return new Task(
+			jobInformation,
+			taskInformation,
+			new ExecutionAttemptID(),
+			0,
+			0,
+			Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
+			Collections.<InputGateDeploymentDescriptor>emptyList(),
+			0,
+			null,
+			mock(MemoryManager.class),
+			mock(IOManager.class),
+			networkEnvironment,
+			mock(BroadcastVariableManager.class),
+			taskManagerGateway,
+			DummyActorGateway.INSTANCE,
+			new FiniteDuration(60, TimeUnit.SECONDS),
+			libCache,
+			mock(FileCache.class),
+			new TaskManagerRuntimeInfo("localhost", new Configuration(), System.getProperty("java.io.tmpdir")),
+			mock(TaskMetricGroup.class));
 	}
 	
 	public static class CheckpointsInOrderInvokable extends AbstractInvokable implements StatefulTask<StateHandle<Serializable>> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -39,6 +39,8 @@ import org.apache.flink.runtime.deployment.ResultPartitionLocation;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.instance.InstanceID;
@@ -89,6 +91,7 @@ import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -168,12 +171,13 @@ public class TaskManagerTest extends TestLogger {
 				final ExecutionAttemptID eid = new ExecutionAttemptID();
 				final SerializedValue<ExecutionConfig> executionConfig = new SerializedValue<>(new ExecutionConfig());
 
-				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(jid, "TestJob", vid, eid, executionConfig,
-						"TestTask", 2, 7, 0, new Configuration(), new Configuration(),
-						TestInvokableCorrect.class.getName(),
-						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+				final TaskDeploymentDescriptor tdd = createTaskDeploymentDescriptor(
+					jid, "TestJob", vid, eid, executionConfig,
+					"TestTask", 2, 7, 0, new Configuration(), new Configuration(),
+					TestInvokableCorrect.class.getName(),
+					Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
+					Collections.<InputGateDeploymentDescriptor>emptyList(),
+					new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
 
 
 				new Within(d) {
@@ -265,7 +269,7 @@ public class TaskManagerTest extends TestLogger {
 				final ExecutionAttemptID eid1 = new ExecutionAttemptID();
 				final ExecutionAttemptID eid2 = new ExecutionAttemptID();
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd1 = createTaskDeploymentDescriptor(
 						jid1, "TestJob1", vid1, eid1,
 						new SerializedValue<>(new ExecutionConfig()),
 						"TestTask1", 1, 5, 0,
@@ -274,7 +278,7 @@ public class TaskManagerTest extends TestLogger {
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
 						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid2, "TestJob2", vid2, eid2,
 						new SerializedValue<>(new ExecutionConfig()),
 						"TestTask2", 2, 7, 0,
@@ -405,13 +409,13 @@ public class TaskManagerTest extends TestLogger {
 
 				final SerializedValue<ExecutionConfig> executionConfig = new SerializedValue<>(new ExecutionConfig());
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(jid1, "TestJob", vid1, eid1, executionConfig,
+				final TaskDeploymentDescriptor tdd1 = createTaskDeploymentDescriptor(jid1, "TestJob", vid1, eid1, executionConfig,
 						"TestTask1", 1, 5, 0, new Configuration(), new Configuration(), StoppableInvokable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
 						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(jid2, "TestJob", vid2, eid2, executionConfig,
+				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(jid2, "TestJob", vid2, eid2, executionConfig,
 						"TestTask2", 2, 7, 0, new Configuration(), new Configuration(), TestInvokableBlockingCancelable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
@@ -531,7 +535,7 @@ public class TaskManagerTest extends TestLogger {
 				final ExecutionAttemptID eid1 = new ExecutionAttemptID();
 				final ExecutionAttemptID eid2 = new ExecutionAttemptID();
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd1 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid1, eid1,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Sender", 0, 1, 0,
@@ -540,7 +544,7 @@ public class TaskManagerTest extends TestLogger {
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
 						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid2, eid2,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Receiver", 2, 7, 0,
@@ -636,7 +640,7 @@ public class TaskManagerTest extends TestLogger {
 								}
 						);
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd1 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid1, eid1,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Sender", 0, 1, 0,
@@ -644,7 +648,7 @@ public class TaskManagerTest extends TestLogger {
 						irpdd, Collections.<InputGateDeploymentDescriptor>emptyList(), new ArrayList<BlobKey>(),
 						Collections.<URL>emptyList(), 0);
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid2, eid2,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Receiver", 2, 7, 0,
@@ -781,7 +785,7 @@ public class TaskManagerTest extends TestLogger {
 								}
 						);
 
-				final TaskDeploymentDescriptor tdd1 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd1 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid1, eid1,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Sender", 0, 1, 0,
@@ -789,7 +793,7 @@ public class TaskManagerTest extends TestLogger {
 						irpdd, Collections.<InputGateDeploymentDescriptor>emptyList(),
 						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
 
-				final TaskDeploymentDescriptor tdd2 = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid2, eid2,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Receiver", 2, 7, 0,
@@ -929,7 +933,7 @@ public class TaskManagerTest extends TestLogger {
 				final InputGateDeploymentDescriptor igdd =
 						new InputGateDeploymentDescriptor(resultId, 0, icdd);
 
-				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid, eid,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Receiver", 0, 1, 0,
@@ -1025,7 +1029,7 @@ public class TaskManagerTest extends TestLogger {
 				final InputGateDeploymentDescriptor igdd =
 						new InputGateDeploymentDescriptor(resultId, 0, icdd);
 
-				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
+				final TaskDeploymentDescriptor tdd = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid, eid,
 						new SerializedValue<>(new ExecutionConfig()),
 						"Receiver", 0, 1, 0,
@@ -1099,9 +1103,11 @@ public class TaskManagerTest extends TestLogger {
 						true,
 						false);
 
+				final JobID jobId = new JobID();
+
 				// Single blocking task
-				final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
-						new JobID(),
+				final TaskDeploymentDescriptor tdd = createTaskDeploymentDescriptor(
+						jobId,
 						"Job",
 						new JobVertexID(),
 						new ExecutionAttemptID(),
@@ -1132,7 +1138,7 @@ public class TaskManagerTest extends TestLogger {
 
 							Future<Object> taskRunningFuture = taskManager.ask(
 									new TestingTaskManagerMessages.NotifyWhenTaskIsRunning(
-											tdd.getExecutionId()), timeout);
+											tdd.getExecutionAttemptId()), timeout);
 
 							taskManager.tell(new SubmitTask(tdd));
 
@@ -1194,7 +1200,7 @@ public class TaskManagerTest extends TestLogger {
 
 								taskManager.tell(new TriggerStackTraceSample(
 												19230,
-												tdd.getExecutionId(),
+												tdd.getExecutionAttemptId(),
 												numSamples,
 												new FiniteDuration(100, TimeUnit.MILLISECONDS),
 												0),
@@ -1210,7 +1216,7 @@ public class TaskManagerTest extends TestLogger {
 
 								// ---- Verify response ----
 								assertEquals(19230, response.sampleId());
-								assertEquals(tdd.getExecutionId(), response.executionId());
+								assertEquals(tdd.getExecutionAttemptId(), response.executionId());
 
 								List<StackTraceElement[]> traces = response.samples();
 
@@ -1266,7 +1272,7 @@ public class TaskManagerTest extends TestLogger {
 
 							taskManager.tell(new TriggerStackTraceSample(
 											1337,
-											tdd.getExecutionId(),
+											tdd.getExecutionAttemptId(),
 											numSamples,
 											new FiniteDuration(100, TimeUnit.MILLISECONDS),
 											maxDepth),
@@ -1282,7 +1288,7 @@ public class TaskManagerTest extends TestLogger {
 
 							// ---- Verify response ----
 							assertEquals(1337, response.sampleId());
-							assertEquals(tdd.getExecutionId(), response.executionId());
+							assertEquals(tdd.getExecutionAttemptId(), response.executionId());
 
 							List<StackTraceElement[]> traces = response.samples();
 
@@ -1312,7 +1318,7 @@ public class TaskManagerTest extends TestLogger {
 								// during a sample
 								taskManager.tell(new TriggerStackTraceSample(
 												44,
-												tdd.getExecutionId(),
+										tdd.getExecutionAttemptId(),
 												Integer.MAX_VALUE,
 												new FiniteDuration(10, TimeUnit.MILLISECONDS),
 												0),
@@ -1321,11 +1327,11 @@ public class TaskManagerTest extends TestLogger {
 								Thread.sleep(sleepTime);
 
 								Future<?> removeFuture = taskManager.ask(
-										new TestingJobManagerMessages.NotifyWhenJobRemoved(tdd.getJobID()),
+										new TestingJobManagerMessages.NotifyWhenJobRemoved(jobId),
 										remaining());
 
 								// Cancel the task
-								taskManager.tell(new CancelTask(tdd.getExecutionId()));
+								taskManager.tell(new CancelTask(tdd.getExecutionAttemptId()));
 
 								// Receive the expected message (heartbeat races possible)
 								while (true) {
@@ -1333,7 +1339,7 @@ public class TaskManagerTest extends TestLogger {
 									if (msg[0] instanceof ResponseStackTraceSampleSuccess) {
 										ResponseStackTraceSampleSuccess response = (ResponseStackTraceSampleSuccess) msg[0];
 
-										assertEquals(tdd.getExecutionId(), response.executionId());
+										assertEquals(tdd.getExecutionAttemptId(), response.executionId());
 										assertEquals(44, response.sampleId());
 
 										// Done
@@ -1344,7 +1350,7 @@ public class TaskManagerTest extends TestLogger {
 
 										Future<?> taskRunningFuture = taskManager.ask(
 												new TestingTaskManagerMessages.NotifyWhenTaskIsRunning(
-														tdd.getExecutionId()), timeout);
+														tdd.getExecutionAttemptId()), timeout);
 
 										// Resubmit
 										taskManager.tell(new SubmitTask(tdd));
@@ -1428,7 +1434,7 @@ public class TaskManagerTest extends TestLogger {
 				false // don't deploy eagerly but with the first completed memory buffer
 			);
 
-			final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(jid, "TestJob", vid, eid, executionConfig,
+			final TaskDeploymentDescriptor tdd = createTaskDeploymentDescriptor(jid, "TestJob", vid, eid, executionConfig,
 				"TestTask", 0, 1, 0, new Configuration(), new Configuration(),
 				TestInvokableRecordCancel.class.getName(),
 				Collections.singletonList(resultPartitionDeploymentDescriptor),
@@ -1716,5 +1722,55 @@ public class TaskManagerTest extends TestLogger {
 				return gotCanceledFuture.future();
 			}
 		}
+	}
+
+	private static TaskDeploymentDescriptor createTaskDeploymentDescriptor(
+		JobID jobId,
+		String jobName,
+		JobVertexID jobVertexId,
+		ExecutionAttemptID executionAttemptId,
+		SerializedValue<ExecutionConfig> serializedExecutionConfig,
+		String taskName,
+		int subtaskIndex,
+		int parallelism,
+		int attemptNumber,
+		Configuration jobConfiguration,
+		Configuration taskConfiguration,
+		String invokableClassName,
+		Collection<ResultPartitionDeploymentDescriptor> producedPartitions,
+		Collection<InputGateDeploymentDescriptor> inputGates,
+		Collection<BlobKey> requiredJarFiles,
+		Collection<URL> requiredClasspaths,
+		int targetSlotNumber) throws IOException {
+
+		JobInformation jobInformation = new JobInformation(
+			jobId,
+			jobName,
+			serializedExecutionConfig,
+			jobConfiguration,
+			requiredJarFiles,
+			requiredClasspaths);
+
+		TaskInformation taskInformation = new TaskInformation(
+			jobVertexId,
+			taskName,
+			parallelism,
+			invokableClassName,
+			taskConfiguration);
+
+		SerializedValue<JobInformation> serializedJobInformation = new SerializedValue<>(jobInformation);
+		SerializedValue<TaskInformation> serializedJobVertexInformation = new SerializedValue<>(taskInformation);
+
+		return new TaskDeploymentDescriptor(
+			serializedJobInformation,
+			serializedJobVertexInformation,
+			executionAttemptId,
+			subtaskIndex,
+			attemptNumber,
+			targetSlotNumber,
+			null,
+			producedPartitions,
+			inputGates);
+
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
@@ -18,8 +18,12 @@
 package org.apache.flink.runtime.taskmanager;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
@@ -30,11 +34,9 @@ import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.StoppableTask;
 import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.util.SerializedValue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -42,9 +44,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ TaskDeploymentDescriptor.class, JobID.class, FiniteDuration.class })
@@ -53,23 +55,33 @@ public class TaskStopTest {
 
 	public void doMocking(AbstractInvokable taskMock) throws Exception {
 
-		TaskInfo taskInfoMock = mock(TaskInfo.class);
-		when(taskInfoMock.getTaskNameWithSubtasks()).thenReturn("dummyName");
+		task = new Task(
+			mock(JobInformation.class),
+			new TaskInformation(
+				new JobVertexID(),
+				"test task name",
+				1,
+				"foobar",
+				new Configuration()),
+			mock(ExecutionAttemptID.class),
+			0,
+			0,
+			Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
+			Collections.<InputGateDeploymentDescriptor>emptyList(),
+			0,
+			null,
+			mock(MemoryManager.class),
+			mock(IOManager.class),
+			mock(NetworkEnvironment.class),
+			mock(BroadcastVariableManager.class),
+			mock(ActorGateway.class),
+			mock(ActorGateway.class),
+			mock(FiniteDuration.class),
+			mock(LibraryCacheManager.class),
+			mock(FileCache.class),
+			mock(TaskManagerRuntimeInfo.class),
+			mock(TaskMetricGroup.class));
 
-		TaskDeploymentDescriptor tddMock = mock(TaskDeploymentDescriptor.class);
-		when(tddMock.getTaskInfo()).thenReturn(taskInfoMock);
-		when(tddMock.getJobID()).thenReturn(mock(JobID.class));
-		when(tddMock.getVertexID()).thenReturn(mock(JobVertexID.class));
-		when(tddMock.getExecutionId()).thenReturn(mock(ExecutionAttemptID.class));
-		when(tddMock.getJobConfiguration()).thenReturn(mock(Configuration.class));
-		when(tddMock.getTaskConfiguration()).thenReturn(mock(Configuration.class));
-		when(tddMock.getSerializedExecutionConfig()).thenReturn(mock(SerializedValue.class));
-		when(tddMock.getInvokableClassName()).thenReturn("className");
-
-		task = new Task(tddMock, mock(MemoryManager.class), mock(IOManager.class), mock(NetworkEnvironment.class),
-				mock(BroadcastVariableManager.class), mock(ActorGateway.class), mock(ActorGateway.class),
-				mock(FiniteDuration.class), mock(LibraryCacheManager.class), mock(FileCache.class),
-				mock(TaskManagerRuntimeInfo.class), mock(TaskMetricGroup.class));
 		Field f = task.getClass().getDeclaredField("invokable");
 		f.setAccessible(true);
 		f.set(task, taskMock);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -27,11 +27,12 @@ import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -707,29 +708,29 @@ public class TaskTest extends TestLogger {
 		}
 	}
 
-	private Task createTask(Class<? extends AbstractInvokable> invokable) {
+	private Task createTask(Class<? extends AbstractInvokable> invokable) throws IOException {
 		return createTask(invokable, new Configuration(), new ExecutionConfig());
 	}
 
-	private Task createTask(Class<? extends AbstractInvokable> invokable, Configuration config) {
+	private Task createTask(Class<? extends AbstractInvokable> invokable, Configuration config) throws IOException {
 		return createTask(invokable, config, new ExecutionConfig());
 	}
 
-	private Task createTask(Class<? extends AbstractInvokable> invokable, Configuration config, ExecutionConfig execConfig) {
+	private Task createTask(Class<? extends AbstractInvokable> invokable, Configuration config, ExecutionConfig execConfig) throws IOException {
 		LibraryCacheManager libCache = mock(LibraryCacheManager.class);
 		when(libCache.getClassLoader(any(JobID.class))).thenReturn(getClass().getClassLoader());
 		return createTask(invokable, libCache, config, execConfig);
 	}
 
 	private Task createTask(Class<? extends AbstractInvokable> invokable,
-							LibraryCacheManager libCache) {
+			LibraryCacheManager libCache) throws IOException {
 		return createTask(invokable, libCache, new Configuration(), new ExecutionConfig());
 	}
 
 	private Task createTask(Class<? extends AbstractInvokable> invokable,
 							LibraryCacheManager libCache,
 							Configuration config,
-							ExecutionConfig execConfig) {
+			ExecutionConfig execConfig) throws IOException {
 
 		ResultPartitionManager partitionManager = mock(ResultPartitionManager.class);
 		ResultPartitionConsumableNotifier consumableNotifier = mock(ResultPartitionConsumableNotifier.class);
@@ -743,7 +744,7 @@ public class TaskTest extends TestLogger {
 	
 	private Task createTask(Class<? extends AbstractInvokable> invokable,
 							LibraryCacheManager libCache,
-							NetworkEnvironment networkEnvironment) {
+							NetworkEnvironment networkEnvironment) throws IOException {
 
 		return createTask(invokable, libCache, networkEnvironment, new Configuration(), new ExecutionConfig());
 	}
@@ -751,13 +752,40 @@ public class TaskTest extends TestLogger {
 	private Task createTask(Class<? extends AbstractInvokable> invokable,
 							LibraryCacheManager libCache,
 							NetworkEnvironment networkEnvironment,
-							Configuration config,
-							ExecutionConfig execConfig) {
+		Configuration taskConfig,
+		ExecutionConfig execConfig) throws IOException {
 		
-		TaskDeploymentDescriptor tdd = createTaskDeploymentDescriptor(invokable, config, execConfig);
+		JobID jobId = new JobID();
+		JobVertexID jobVertexId = new JobVertexID();
+		ExecutionAttemptID executionAttemptId = new ExecutionAttemptID();
+		
+		SerializedValue<ExecutionConfig> serializedExecutionConfig = new SerializedValue<>(execConfig);
+
+		JobInformation jobInformation = new JobInformation(
+			jobId,
+			"Test Job",
+			serializedExecutionConfig,
+			new Configuration(),
+			Collections.<BlobKey>emptyList(),
+			Collections.<URL>emptyList());
+
+		TaskInformation taskInformation = new TaskInformation(
+			jobVertexId,
+			"Test Task",
+			1,
+			invokable.getName(),
+			taskConfig);
 		
 		return new Task(
-				tdd,
+			jobInformation,
+			taskInformation,
+			executionAttemptId,
+			0,
+			0,
+			Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
+			Collections.<InputGateDeploymentDescriptor>emptyList(),
+			0,
+			null,
 				mock(MemoryManager.class),
 				mock(IOManager.class),
 				networkEnvironment,
@@ -771,34 +799,7 @@ public class TaskTest extends TestLogger {
 				mock(TaskMetricGroup.class));
 	}
 
-	private TaskDeploymentDescriptor createTaskDeploymentDescriptor(Class<? extends AbstractInvokable> invokable) {
-		return createTaskDeploymentDescriptor(invokable, new Configuration(), new ExecutionConfig());
-	}
 
-	private TaskDeploymentDescriptor createTaskDeploymentDescriptor(
-			Class<? extends AbstractInvokable> invokable,
-			Configuration taskConfig,
-			ExecutionConfig execConfig) {
-
-		SerializedValue<ExecutionConfig> serializedExecConfig;
-		try {
-			serializedExecConfig = new SerializedValue<>(execConfig);
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-		
-		return new TaskDeploymentDescriptor(
-				new JobID(), "Test Job", new JobVertexID(), new ExecutionAttemptID(),
-				serializedExecConfig,
-				"Test Task", 0, 1, 0,
-				new Configuration(), taskConfig,
-				invokable.getName(),
-				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-				Collections.<InputGateDeploymentDescriptor>emptyList(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
-				0);
-	}
 
 	// ------------------------------------------------------------------------
 	// Validation Methods

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -29,10 +29,11 @@ import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -209,31 +210,41 @@ public class StreamTaskTest {
 		when(network.getPartitionConsumableNotifier()).thenReturn(consumableNotifier);
 		when(network.getDefaultIOMode()).thenReturn(IOManager.IOMode.SYNC);
 
-		TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
-				new JobID(), "Job Name", new JobVertexID(), new ExecutionAttemptID(),
-				new SerializedValue<>(new ExecutionConfig()),
-				"Test Task", 0, 1, 0,
-				new Configuration(),
-				taskConfig.getConfiguration(),
-				invokable.getName(),
-				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-				Collections.<InputGateDeploymentDescriptor>emptyList(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
-				0);
+		JobInformation jobInformation = new JobInformation(
+			new JobID(),
+			"Job Name",
+			new SerializedValue<>(new ExecutionConfig()),
+			new Configuration(),
+			Collections.<BlobKey>emptyList(),
+			Collections.<URL>emptyList());
+
+		TaskInformation taskInformation = new TaskInformation(
+			new JobVertexID(),
+			"Test Task",
+			1,
+			invokable.getName(),
+			taskConfig.getConfiguration());
 
 		return new Task(
-				tdd,
-				mock(MemoryManager.class),
-				mock(IOManager.class),
-				network,
-				mock(BroadcastVariableManager.class),
+			jobInformation,
+			taskInformation,
+			new ExecutionAttemptID(),
+			0,
+			0,
+			Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
+			Collections.<InputGateDeploymentDescriptor>emptyList(),
+			0,
+			null,
+			mock(MemoryManager.class),
+			mock(IOManager.class),
+			network,
+			mock(BroadcastVariableManager.class),
 				new DummyGateway(),
 				new DummyGateway(),
 				new FiniteDuration(60, TimeUnit.SECONDS),
-				libCache,
-				mock(FileCache.class),
-				new TaskManagerRuntimeInfo("localhost", taskManagerConfig, System.getProperty("java.io.tmpdir")),
+			libCache,
+			mock(FileCache.class),
+			new TaskManagerRuntimeInfo("localhost", taskManagerConfig, System.getProperty("java.io.tmpdir")),
 				new UnregisteredTaskMetricsGroup());
 	}
 	

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.checkpoint.savepoint.SavepointStoreFactory;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointV0;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -304,7 +305,11 @@ public class SavepointITCase extends TestLogger {
 
 								LOG.info("Received: " + tdd.toString() + ".");
 
-								tdds.put(tdd.getVertexID(), tdd);
+								TaskInformation taskInformation = tdd
+									.getSerializedTaskInformation()
+									.deserializeValue(getClass().getClassLoader());
+
+								tdds.put(taskInformation.getJobVertexId(), tdd);
 							}
 						}
 						catch (Throwable t) {
@@ -331,7 +336,7 @@ public class SavepointITCase extends TestLogger {
 				assertEquals(taskState.getNumberCollectedStates(), taskTdds.size());
 
 				for (TaskDeploymentDescriptor tdd : taskTdds) {
-					SubtaskState subtaskState = taskState.getState(tdd.getIndexInSubtaskGroup());
+					SubtaskState subtaskState = taskState.getState(tdd.getSubtaskIndex());
 
 					assertNotNull(subtaskState);
 					errMsg = "Initial operator state mismatch.";


### PR DESCRIPTION
This is a backport of #2779 for the release 1.1 branch.

In order to speed up the serialization of the TaskDeploymentDescriptor we can pre serialize
all information which stays the same for all TaskDeploymentDescriptors. The information which
is static for a TDD is the job related information contained in the ExecutionGraph and the
operator/task related information stored in the ExecutionJobVertex.

In order to pre serialize this information, this PR introduces the JobInformation class
and the TaskInformration class which are stored in serialized form in the ExecutionGraph
and the ExecutionJobVertex, respectively.

Fix for release-1.1