### PR TITLE
[FLINK-5016] [ci] Increase no output timeout to 10 mins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ env:
 before_script:
    - "gem install --no-document --version 0.8.9 faraday "
 
-# We run mvn and monitor its output. If there is no output for the specified number of seconds, we
-# print the stack traces of all running Java processes.
-script: "./tools/travis_mvn_watchdog.sh 300"
+# We run mvn and monitor its output to stdout. If there is no output for the
+# specified number of seconds, we print the stack traces of all running Java
+# processes.
+script: "./tools/travis_mvn_watchdog.sh 600"

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -36,7 +36,7 @@ echo "Build for commit ${TRAVIS_COMMIT} of ${TRAVIS_REPO_SLUG} [build ID: ${TRAV
 # =============================================================================
 
 # Number of seconds w/o output before printing a stack trace and killing $MVN
-MAX_NO_OUTPUT=${1:-300}
+MAX_NO_OUTPUT=${1:-600}
 
 # Number of seconds to sleep before checking the output again
 SLEEP_TIME=20


### PR DESCRIPTION
Some heavy test suites occasionally have quite long running times on Travis, in which cases the no output timeout of 5 mins is too aggressive and incorrectly fails the build. This behaviour is meant to help debugging any deadlock situations we encounter on Travis.

This PR increases the no output timeout to 10 minutes. Since we're quite close to the maximum build times this will not detect anything that deadlocks in the last 10 minutes of the build after which Travis errors the build. I think that's OK.

Do you think increasing the timeout is OK or should we instead add some output to the heavy test suites or split them up?

/cc @tillrohrmann @aljoscha 