### PR TITLE
[FLINK-5013] [kinesis] Shade AWS dependencies to work with older EMR versions

### DIFF
--- a/flink-streaming-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-streaming-connectors/flink-connector-kinesis/pom.xml
@@ -150,6 +150,10 @@ under the License.
 									<pattern>com.google.protobuf</pattern>
 									<shadedPattern>org.apache.flink.kinesis.shaded.com.google.protobuf</shadedPattern>
 								</relocation>
+								<relocation>
+									<pattern>com.amazonaws</pattern>
+									<shadedPattern>org.apache.flink.kinesis.shaded.com.amazonaws</shadedPattern>
+								</relocation>
 							</relocations>
 						</configuration>
 					</execution>


### PR DESCRIPTION
This PR adds shading to fix the reported dependency issues on older EMR versions.
Randomly tested for 4.x EMR on versions 4.3.0, 4.4.0, 4.7.2, and 4.8.0, as well as 5.0.3. Works without issues.

However, for the native Flink support in EMR 5.1.0, the `NoSuchMethodError` for `HttpConnectionParams.setSoKeepalive` still remains, even with the shading. I'm suspecting that its a different problem.