### PR TITLE
[FLINK-4491] Handle index.number_of_shards in the ES connector

### DIFF
--- a/flink-streaming-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/ElasticsearchSink.java
+++ b/flink-streaming-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/ElasticsearchSink.java
@@ -204,7 +204,7 @@ public class ElasticsearchSink<T> extends RichSinkFunction<T> {
 				if (response.hasFailures()) {
 					for (BulkItemResponse itemResp : response.getItems()) {
 						if (itemResp.isFailed()) {
-							LOG.error("Failed to index document in Elasticsearch: " + itemResp.getFailureMessage()+" "+request.requests().size());
+							LOG.error("Failed to index document in Elasticsearch: " + itemResp.getFailureMessage());
 							failureThrowable.compareAndSet(null, new RuntimeException(itemResp.getFailureMessage()));
 						}
 					}
@@ -245,11 +245,7 @@ public class ElasticsearchSink<T> extends RichSinkFunction<T> {
 
 	@Override
 	public void invoke(T element) {
-		try {
-			elasticsearchSinkFunction.process(element, getRuntimeContext(), requestIndexer);
-		} catch (Exception ex) {
-			ex.printStackTrace();
-		}
+		elasticsearchSinkFunction.process(element, getRuntimeContext(), requestIndexer);
 	}
 
 	@Override

--- a/flink-streaming-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/helper/ElasticSearchHelper.java
+++ b/flink-streaming-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/helper/ElasticSearchHelper.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.flink.streaming.connectors.elasticsearch2.helper;
+
+import com.google.common.collect.ImmutableList;
+
+import org.apache.flink.streaming.connectors.elasticsearch2.ElasticsearchSink;
+import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ElasticSearchHelper {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchSink.class);
+
+	private Client client;
+
+	/**
+	 * Creates a new ElasticSearchHelper that connects to the cluster using a
+	 * TransportClient.
+	 *
+	 * @param userConfig
+	 *            The map of user settings that are passed when constructing the
+	 *            TransportClients
+	 * @param transportAddresses
+	 *            The Elasticsearch Nodes to which to connect using a
+	 *            {@code TransportClient}
+	 */
+	public ElasticSearchHelper(Map<String, String> userConfig, List<InetSocketAddress> transportAddresses) {
+		client = buildElasticsearchClient(userConfig, transportAddresses);
+	}
+
+	/**
+	 * Build a TransportClient to connect to the cluster.
+	 * 
+	 * @param userConfig
+	 *            The map of user settings that are passed when constructing the
+	 *            TransportClients
+	 * @param transportAddresses
+	 *            The Elasticsearch Nodes to which to connect using a
+	 *            {@code TransportClient}
+	 * @return Initialized TransportClient
+	 */
+	public static Client buildElasticsearchClient(Map<String, String> userConfig,
+			List<InetSocketAddress> transportAddresses) {
+		List<TransportAddress> transportNodes;
+		transportNodes = new ArrayList<>(transportAddresses.size());
+		for (InetSocketAddress address : transportAddresses) {
+			transportNodes.add(new InetSocketTransportAddress(address));
+		}
+
+		Settings settings = Settings.settingsBuilder().put(userConfig).build();
+
+		TransportClient transportClient = TransportClient.builder().settings(settings).build();
+		for (TransportAddress transport : transportNodes) {
+			transportClient.addTransportAddress(transport);
+		}
+
+		// verify that we actually are connected to a cluster
+		ImmutableList<DiscoveryNode> nodes = ImmutableList.copyOf(transportClient.connectedNodes());
+		if (nodes.isEmpty()) {
+			throw new RuntimeException("Client is not connected to any Elasticsearch nodes!");
+		}
+		return transportClient;
+	}
+
+	/**
+	 * Create a new index template.
+	 * 
+	 * @param templateName
+	 *            Name of the template to create
+	 * @param templateReq
+	 *            Json defining the index template
+	 */
+	public void initTemplate(String templateName, String templateReq) throws Exception {
+		// Check if the template is set
+		if (templateReq != null && !templateReq.equals("")) {
+			// Json deserialization
+			PutIndexTemplateRequest request = new PutIndexTemplateRequest(templateName).source(templateReq);
+			// Sending the request to elastic search
+			client.admin().indices().putTemplate(request).get();
+		}
+	}
+
+	/**
+	 * Create a new mapping for a document type for an index.
+	 * 
+	 * @param indexName
+	 *            Index name where add the mapping
+	 * @param docType
+	 *            Document type of the mapping
+	 * @param mappingReq
+	 *            Json defining the index mapping
+	 */
+	public void initIndexMapping(String indexName, String docType, String mappingReq) {
+		try {
+			// Check if the index exists
+			SearchResponse response = client.prepareSearch(indexName).setTypes(docType).get();
+			if (response != null) {
+				LOG.debug("Index found, no need to create it...");
+			}
+		} catch (IndexNotFoundException infe) {
+			// If the index does not exist, create it
+			client.admin().indices().prepareCreate(indexName)
+					.setSettings(Settings.builder().put("index.number_of_shards", 3).put("index.number_of_replicas", 2))
+					.execute().actionGet();
+			LOG.info("Index not found, creating it...");
+		}
+		// Put the mapping to the index
+		client.admin().indices().preparePutMapping(indexName).setType(docType).setSource(mappingReq).get();
+		LOG.debug("Updating mappings...");
+	}
+
+}

--- a/flink-streaming-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/helper/ElasticSearchHelper.java
+++ b/flink-streaming-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/helper/ElasticSearchHelper.java
@@ -22,6 +22,7 @@ import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateReque
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
@@ -46,10 +47,10 @@ import java.util.Map;
  *				ElasticSearchHelper esHelper = new ElasticSearchHelper(config, transports);
  *
  *				//Create an Index Template given a name and the json structure
- * 				esHelper.initTemplate(templateName, templateRequest);
+ *				esHelper.initTemplate(templateName, templateRequest);
  * 
- * 				//Create an Index Mapping given the Index Name, DocType and the json structure
- * 				esHelper.initIndexMapping(indexName, docType, mappingsRequest);
+ *				//Create an Index Mapping given the Index Name, DocType and the json structure
+ *				esHelper.initIndexMapping(indexName, docType, mappingsRequest);
  *
  * }</pre>
  * 
@@ -172,8 +173,8 @@ public class ElasticSearchHelper {
 				for (String indexName:mappingRequest.indices()){
 					// If the index does not exist, create it
 					client.admin().indices().prepareCreate(indexName)
-							.setSettings(Settings.builder().put("index.number_of_shards", DEFAULT_INDEX_SHARDS)
-							.put("index.number_of_replicas", DEFAULT_INDEX_REPLICAS)).execute().actionGet();
+							.setSettings(Settings.builder().put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, DEFAULT_INDEX_SHARDS)
+							.put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, DEFAULT_INDEX_REPLICAS)).execute().actionGet();
 					LOG.info("Index "+indexName+" not found, creating it...");
 				}
 			}

--- a/flink-streaming-connectors/flink-connector-elasticsearch2/src/test/java/org/apache/flink/streaming/connectors/elasticsearch2/ElasticsearchSinkITCase.java
+++ b/flink-streaming-connectors/flink-connector-elasticsearch2/src/test/java/org/apache/flink/streaming/connectors/elasticsearch2/ElasticsearchSinkITCase.java
@@ -23,13 +23,19 @@ import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.connectors.elasticsearch2.helper.ElasticSearchHelper;
 import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesRequest;
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 import org.junit.Assert;
@@ -209,6 +215,122 @@ public class ElasticsearchSinkITCase extends StreamingMultipleProgramsTestBase {
 		public void cancel() {
 			running = false;
 		}
+	}
+	
+	@Test
+	public void testTemplateCreation() throws Exception {
+		// Settings.Builder settings=Settings.settingsBuilder().put("","");
+
+		Map<String, String> config = new HashMap<>();
+		// This instructs the sink to emit after every element, otherwise they
+		// would be buffered
+		config.put(ElasticsearchSink.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
+		config.put("cluster.name", "my-transport-client-cluster");
+
+		File dataDir = tempFolder.newFolder();
+		Node node = NodeBuilder.nodeBuilder()
+				.settings(Settings.settingsBuilder().put("path.home", dataDir.getParent()).put("http.enabled", false)
+						.put("path.data", dataDir.getAbsolutePath()))
+				// set a custom cluster name to verify that user config works
+				// correctly
+				.clusterName("my-transport-client-cluster").node();
+
+		// Can't use {@link TransportAddress} as its not Serializable in
+		// Elasticsearch 2.x
+		List<InetSocketAddress> transports = new ArrayList<>();
+		transports.add(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 9300));
+
+		String templateName = "my-template";
+		String templateReq = "{\"template\":\"te*\",\"settings\":{\"number_of_shards\":1},"
+				+ "\"mappings\":{\"type1\":{\"_source\":{\"enabled\":false},"
+				+ "\"properties\":{\"host_name\":{\"type\":\"keyword\"},"
+				+ "\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z YYYY\"}}}}}";
+		ElasticSearchHelper esHelper = new ElasticSearchHelper(config, transports);
+		esHelper.initTemplate(templateName, templateReq);
+
+		// verify the results
+		Client client = node.client();
+		GetIndexTemplatesResponse response = client.admin().indices()
+				.getTemplates(new GetIndexTemplatesRequest(templateName)).get();
+		Assert.assertTrue(response.getIndexTemplates().size() == 1);
+
+		node.close();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testTemplateCreationFailed() throws Exception {
+		// Settings.Builder settings=Settings.settingsBuilder().put("","");
+
+		Map<String, String> config = new HashMap<>();
+		// This instructs the sink to emit after every element, otherwise they
+		// would be buffered
+		config.put(ElasticsearchSink.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
+		config.put("cluster.name", "my-transport-client-cluster");
+
+		File dataDir = tempFolder.newFolder();
+		Node node = NodeBuilder.nodeBuilder()
+				.settings(Settings.settingsBuilder().put("path.home", dataDir.getParent()).put("http.enabled", false)
+						.put("path.data", dataDir.getAbsolutePath()))
+				// set a custom cluster name to verify that user config works
+				// correctly
+				.clusterName("my-transport-client-cluster").node();
+
+		// Can't use {@link TransportAddress} as its not Serializable in
+		// Elasticsearch 2.x
+		List<InetSocketAddress> transports = new ArrayList<>();
+		transports.add(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 9300));
+
+		String templateName = "my-template";
+		// Wrong template syntax
+		String templateReq = "*this is wrong*";
+		
+		ElasticSearchHelper esHelper = new ElasticSearchHelper(config, transports);
+		esHelper.initTemplate(templateName, templateReq);
+
+		// verify the results
+		Client client = node.client();
+		GetIndexTemplatesResponse response = client.admin().indices()
+				.getTemplates(new GetIndexTemplatesRequest(templateName)).get();
+		Assert.assertTrue(response.getIndexTemplates().size() == 0);
+
+		node.close();
+	}
+
+	@Test
+	public void testMappingsCreation() throws Exception {
+
+		Map<String, String> config = new HashMap<>();
+		// This instructs the sink to emit after every element, otherwise they
+		// would be buffered
+		config.put(ElasticsearchSink.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
+		config.put("cluster.name", "my-transport-client-cluster");
+		
+		File dataDir = tempFolder.newFolder();
+		Node node = NodeBuilder.nodeBuilder()
+				.settings(Settings.settingsBuilder().put("path.home", dataDir.getParent()).put("http.enabled", false)
+						.put("path.data", dataDir.getAbsolutePath()))
+				// set a custom cluster name to verify that user config works
+				// correctly
+				.clusterName("my-transport-client-cluster").node();
+
+		// Can't use {@link TransportAddress} as its not Serializable in
+		// Elasticsearch 2.x
+		List<InetSocketAddress> transports = new ArrayList<>();
+		transports.add(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 9300));
+
+		String indexName = "twitter";
+		String docType = "tweet";
+		String mappingsReq = "{\"tweet\":{\"properties\":{\"message\":{\"type\":\"string\"}}}}";
+
+		ElasticSearchHelper esHelper = new ElasticSearchHelper(config, transports);
+		esHelper.initIndexMapping(indexName, docType, mappingsReq);
+
+		// verify the results
+		Client client = node.client();
+		GetMappingsResponse response = client.admin().indices().getMappings(new GetMappingsRequest()).actionGet();
+		Assert.assertTrue(response.getMappings().size() > 0);
+
+		node.close();
 	}
 
 	private static class TestElasticsearchSinkFunction implements ElasticsearchSinkFunction<Tuple2<Integer, String>> {

--- a/flink-streaming-connectors/flink-connector-elasticsearch2/src/test/java/org/apache/flink/streaming/connectors/elasticsearch2/ElasticsearchSinkITCase.java
+++ b/flink-streaming-connectors/flink-connector-elasticsearch2/src/test/java/org/apache/flink/streaming/connectors/elasticsearch2/ElasticsearchSinkITCase.java
@@ -34,8 +34,8 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
+import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 import org.junit.Assert;
@@ -79,7 +79,7 @@ public class ElasticsearchSinkITCase extends StreamingMultipleProgramsTestBase {
 		Map<String, String> config = new HashMap<>();
 		// This instructs the sink to emit after every element, otherwise they would be buffered
 		config.put(ElasticsearchSink.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
-		config.put("cluster.name", "my-transport-client-cluster");
+		config.put(ClusterName.SETTING, "my-transport-client-cluster");
 
 		// Can't use {@link TransportAddress} as its not Serializable in Elasticsearch 2.x
 		List<InetSocketAddress> transports = new ArrayList<>();
@@ -121,7 +121,7 @@ public class ElasticsearchSinkITCase extends StreamingMultipleProgramsTestBase {
 	Map<String, String> config = new HashMap<>();
 	// This instructs the sink to emit after every element, otherwise they would be buffered
 	config.put(ElasticsearchSink.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
-	config.put("cluster.name", "my-transport-client-cluster");
+	config.put(ClusterName.SETTING, "my-transport-client-cluster");
 
 	source.addSink(new ElasticsearchSink<>(config, null, new TestElasticsearchSinkFunction()));
 
@@ -159,7 +159,7 @@ public class ElasticsearchSinkITCase extends StreamingMultipleProgramsTestBase {
 	Map<String, String> config = new HashMap<>();
 	// This instructs the sink to emit after every element, otherwise they would be buffered
 	config.put(ElasticsearchSink.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
-	config.put("cluster.name", "my-transport-client-cluster");
+	config.put(ClusterName.SETTING, "my-transport-client-cluster");
 
 	source.addSink(new ElasticsearchSink<>(config, new ArrayList<InetSocketAddress>(), new TestElasticsearchSinkFunction()));
 
@@ -189,7 +189,7 @@ public class ElasticsearchSinkITCase extends StreamingMultipleProgramsTestBase {
 		Map<String, String> config = new HashMap<>();
 		// This instructs the sink to emit after every element, otherwise they would be buffered
 		config.put(ElasticsearchSink.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
-		config.put("cluster.name", "my-node-client-cluster");
+		config.put(ClusterName.SETTING, "my-node-client-cluster");
 
 		List<InetSocketAddress> transports = new ArrayList<>();
 		transports.add(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 9300));
@@ -225,7 +225,7 @@ public class ElasticsearchSinkITCase extends StreamingMultipleProgramsTestBase {
 		// This instructs the sink to emit after every element, otherwise they
 		// would be buffered
 		config.put(ElasticsearchSink.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
-		config.put("cluster.name", "my-transport-client-cluster");
+		config.put(ClusterName.SETTING, "my-transport-client-cluster");
 
 		File dataDir = tempFolder.newFolder();
 		Node node = NodeBuilder.nodeBuilder()
@@ -265,7 +265,7 @@ public class ElasticsearchSinkITCase extends StreamingMultipleProgramsTestBase {
 		// This instructs the sink to emit after every element, otherwise they
 		// would be buffered
 		config.put(ElasticsearchSink.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
-		config.put("cluster.name", "my-transport-client-cluster");
+		config.put(ClusterName.SETTING, "my-transport-client-cluster");
 
 		File dataDir = tempFolder.newFolder();
 		Node node = NodeBuilder.nodeBuilder()
@@ -303,7 +303,7 @@ public class ElasticsearchSinkITCase extends StreamingMultipleProgramsTestBase {
 		// This instructs the sink to emit after every element, otherwise they
 		// would be buffered
 		config.put(ElasticsearchSink.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
-		config.put("cluster.name", "my-transport-client-cluster");
+		config.put(ClusterName.SETTING, "my-transport-client-cluster");
 		
 		File dataDir = tempFolder.newFolder();
 		Node node = NodeBuilder.nodeBuilder()


### PR DESCRIPTION
Implemented the Index Template and Index Mapping creation. 
Number of shards and many other properties can be defined in the Index Template.

### Usage
Before calling ElasticasearchSink instantiate ElasticSearchHelper

```java
ElasticSearchHelper esHelper = new ElasticSearchHelper(config, transports);
//Create an Index Template given a name and the json structure
esHelper.initTemplate(templateName, templateRequest);
//Create an Index Mapping given the Index Name, DocType and the json structure
esHelper.initIndexMapping(indexName, docType, mappingsRequest);
```

### TemplateRequest example
```json
{
  "template": "te*",
  "settings": {
    "number_of_shards": 1
  },
  "mappings": {
    "type1": {
      "_source": {
        "enabled": false
      },
      "properties": {
        "host_name": {
          "type": "keyword"
        },
        "created_at": {
          "type": "date",
          "format": "EEE MMM dd HH:mm:ss Z YYYY"
        }
      }
    }
  }
}
```
### MappingRequest example
```json
{
  "mappings": {
    "user": {
      "_all": {
        "enabled": false
      },
      "properties": {
        "title": {
          "type": "string"
        },
        "name": {
          "type": "string"
        },
        "age": {
          "type": "integer"
        }
      }
    }
  }
}
```



