### PR TITLE
[FLINK-4449] [cluster management] add Heartbeat manager in ResourceManager with TaskExecutor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.concurrent.AcceptFunction;
 import org.apache.flink.runtime.concurrent.Future;
 import org.slf4j.Logger;
 
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -43,10 +43,10 @@ public class HeartbeatManagerSenderImpl<I, O> extends HeartbeatManagerImpl<I, O>
 		long heartbeatPeriod,
 		long heartbeatTimeout,
 		ResourceID ownResourceID,
-		ExecutorService executorService,
+		Executor executor,
 		ScheduledExecutorService scheduledExecutorService,
 		Logger log) {
-		super(heartbeatTimeout, ownResourceID, executorService, scheduledExecutorService, log);
+		super(heartbeatTimeout, ownResourceID, executor, scheduledExecutorService, log);
 
 		triggerFuture = scheduledExecutorService.scheduleAtFixedRate(this, 0L, heartbeatPeriod, TimeUnit.MILLISECONDS);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/HeartbeatService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/HeartbeatService.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.AcceptFunction;
+import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.heartbeat.HeartbeatListener;
+import org.apache.flink.runtime.heartbeat.HeartbeatManagerSenderImpl;
+import org.apache.flink.runtime.heartbeat.HeartbeatTarget;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Service which is responsible for heartbeat communication with TaskExecutor.
+ */
+public class HeartbeatService {
+
+	private static final Logger LOG = LoggerFactory.getLogger(HeartbeatService.class);
+
+	private final HeartbeatManagerSenderImpl<Void, UUID> taskExecutorHeartbeatManager;
+
+	/** Resource ID of the ResourceManager */
+	private final ResourceID resourceManagerIdentify;
+
+	private final ScheduledExecutorService scheduledExecutorService;
+
+	private final Executor executor;
+
+	private HeartbeatListener<Void, UUID> heartbeatListener;
+
+	public HeartbeatService(ResourceManagerConfiguration resourceManagerConfiguration, Executor executor) {
+		this.resourceManagerIdentify = ResourceID.generate();
+		this.scheduledExecutorService = Executors.newScheduledThreadPool(16);
+		this.executor = executor;
+		this.taskExecutorHeartbeatManager = new HeartbeatManagerSenderImpl<>(resourceManagerConfiguration.getHeartbeatInterval().toMilliseconds(),
+			resourceManagerConfiguration.getTimeout().toMilliseconds(), resourceManagerIdentify, executor, scheduledExecutorService, LOG);
+	}
+
+	/**
+	 * Starts the service with the given heartbeat listener
+	 *
+	 * @param heartbeatListener heartbeat listener to listener for heartbeat actions with TaskExecutor
+	 */
+	public void start(HeartbeatListener<Void, UUID> heartbeatListener) {
+		this.heartbeatListener = heartbeatListener;
+		this.taskExecutorHeartbeatManager.start(heartbeatListener);
+	}
+
+	/**
+	 * Stops the service
+	 *
+	 * @throws Exception
+	 */
+	public void stop() throws Exception {
+		try {
+			scheduledExecutorService.shutdown();
+			while (!scheduledExecutorService.awaitTermination(5000L, TimeUnit.MILLISECONDS)) {
+				// break util scheduleExecutorService terminates
+			}
+		} finally {
+			this.taskExecutorHeartbeatManager.stop();
+		}
+	}
+
+	/**
+	 * Adds a TaskExecutor to monitor
+	 *
+	 * @param resourceID          ResourceId of the taskExecutor to monitor
+	 * @param taskExecutorGateway the taskExecutor to monitor
+	 */
+	public void monitorTaskExecutor(ResourceID resourceID, final TaskExecutorGateway taskExecutorGateway) {
+
+		this.taskExecutorHeartbeatManager.monitorTarget(resourceID, new HeartbeatTarget<UUID>() {
+
+				@Override
+				public void sendHeartbeat(ResourceID resourceID, UUID payload) {
+					throw new UnsupportedOperationException("the method is not supported now!");
+				}
+
+				@Override
+				public void requestHeartbeat(ResourceID resourceID, UUID payload) {
+					Future<UUID> futurePayload = heartbeatListener.retrievePayload();
+
+					futurePayload.thenAcceptAsync(new AcceptFunction<UUID>() {
+						@Override
+						public void accept(UUID retrievedPayload) {
+							taskExecutorGateway.requestHeartbeatResponseToResourceManager(resourceManagerIdentify, retrievedPayload);
+						}
+					}, executor);
+				}
+			}
+
+		);
+	}
+
+	/**
+	 * Removes a taskExecutor to monitor
+	 *
+	 * @param resourceID ResourceId of the taskExecutor to unmonitor
+	 */
+	public void unmonitor(ResourceID resourceID) {
+		this.taskExecutorHeartbeatManager.unmonitorTarget(resourceID);
+	}
+
+	/**
+	 * Receives heartbeat response from taskExecutor
+	 *
+	 * @param resourceID ResourceId of the taskExecutor which send the heartbeat response
+	 */
+	public void heartbeatResponseFromTaskExecutor(ResourceID resourceID) {
+		this.taskExecutorHeartbeatManager.sendHeartbeat(resourceID, null);
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/HeartbeatService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/HeartbeatService.java
@@ -40,6 +40,8 @@ public class HeartbeatService {
 
 	private final HeartbeatManagerSenderImpl<Void, Void> taskExecutorHeartbeatManager;
 
+	private HeartbeatListener<Void, Void> taskExecutorHeartbeatListener;
+
 	/** Resource ID of the ResourceManager */
 	private final ResourceID resourceManagerIdentify;
 
@@ -55,10 +57,10 @@ public class HeartbeatService {
 	/**
 	 * Starts the service with the given heartbeat listener
 	 *
-	 * @param heartbeatListener heartbeat listener to listener for heartbeat actions with TaskExecutor
+	 * @param taskExecutorHeartbeatListener heartbeat listener to listener for heartbeat actions with TaskExecutor
 	 */
-	public void start(HeartbeatListener<Void, Void> heartbeatListener) {
-		this.taskExecutorHeartbeatManager.start(heartbeatListener);
+	public void start(HeartbeatListener<Void, Void> taskExecutorHeartbeatListener) {
+		this.taskExecutorHeartbeatManager.start(taskExecutorHeartbeatListener);
 	}
 
 	/**
@@ -106,7 +108,7 @@ public class HeartbeatService {
 	 *
 	 * @param resourceID ResourceId of the taskExecutor to unmonitor
 	 */
-	public void unmonitor(ResourceID resourceID) {
+	public void unmonitorTaskExecutor(ResourceID resourceID) {
 		this.taskExecutorHeartbeatManager.unmonitorTarget(resourceID);
 	}
 
@@ -115,7 +117,7 @@ public class HeartbeatService {
 	 *
 	 * @param resourceID ResourceId of the taskExecutor which send the heartbeat response
 	 */
-	public void heartbeatResponseFromTaskExecutor(ResourceID resourceID) {
+	public void sendHeartbeatFromTaskManager(ResourceID resourceID) {
 		this.taskExecutorHeartbeatManager.sendHeartbeat(resourceID, null);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -43,7 +43,7 @@ public interface ResourceManagerGateway extends RpcGateway {
 	 * Register a {@link JobMaster} at the resource manager.
 	 *
 	 * @param resourceManagerLeaderId The fencing token for the ResourceManager leader
-	 * @param jobMasterLeaderId The fencing token for the JobMaster leader
+	 * @param jobMasterLeaderId       The fencing token for the JobMaster leader
 	 * @param jobMasterAddress        The address of the JobMaster that registers
 	 * @param jobID                   The Job ID of the JobMaster that registers
 	 * @param timeout                 Timeout for the future to complete
@@ -61,8 +61,8 @@ public interface ResourceManagerGateway extends RpcGateway {
 	 * Requests a slot from the resource manager.
 	 *
 	 * @param resourceManagerLeaderID leader if of the ResourceMaster
-	 * @param jobMasterLeaderID leader if of the JobMaster
-	 * @param slotRequest The slot to request
+	 * @param jobMasterLeaderID       leader if of the JobMaster
+	 * @param slotRequest             The slot to request
 	 * @return The confirmation that the slot gets allocated
 	 */
 	Future<RMSlotRequestReply> requestSlot(
@@ -74,12 +74,11 @@ public interface ResourceManagerGateway extends RpcGateway {
 	/**
 	 * Register a {@link org.apache.flink.runtime.taskexecutor.TaskExecutor} at the resource manager.
 	 *
-	 * @param resourceManagerLeaderId  The fencing token for the ResourceManager leader
+	 * @param resourceManagerLeaderId The fencing token for the ResourceManager leader
 	 * @param taskExecutorAddress     The address of the TaskExecutor that registers
 	 * @param resourceID              The resource ID of the TaskExecutor that registers
 	 * @param slotReport              The slot report containing free and allocated task slots
 	 * @param timeout                 The timeout for the response.
-	 *
 	 * @return The future to the response by the ResourceManager.
 	 */
 	Future<RegistrationResponse> registerTaskExecutor(
@@ -93,8 +92,8 @@ public interface ResourceManagerGateway extends RpcGateway {
 	 * Sent by the TaskExecutor to notify the ResourceManager that a slot has become available.
 	 *
 	 * @param resourceManagerLeaderId The ResourceManager leader id
-	 * @param instanceId TaskExecutor's instance id
-	 * @param slotID The SlotID of the freed slot
+	 * @param instanceId              TaskExecutor's instance id
+	 * @param slotID                  The SlotID of the freed slot
 	 */
 	void notifySlotAvailable(
 		UUID resourceManagerLeaderId,
@@ -112,12 +111,12 @@ public interface ResourceManagerGateway extends RpcGateway {
 	 * Unregisters an infoMessage listener
 	 *
 	 * @param infoMessageListenerAddress address of infoMessage listener to unregister from this resource manager
-	 *
 	 */
 	void unRegisterInfoMessageListener(String infoMessageListenerAddress);
 
 	/**
 	 * shutdown cluster
+	 *
 	 * @param finalStatus
 	 * @param optionalDiagnostics
 	 */
@@ -125,15 +124,16 @@ public interface ResourceManagerGateway extends RpcGateway {
 
 	/**
 	 * Gets the currently registered number of TaskManagers.
-	 * 
+	 *
 	 * @param leaderSessionId The leader session ID with which to address the ResourceManager.
 	 * @return The future to the number of registered TaskManagers.
 	 */
 	Future<Integer> getNumberOfRegisteredTaskManagers(UUID leaderSessionId);
 
-	/* Receives heartbeat response from taskExecutor
+	/*
+	 * Sends the heartbeat to resource manager from task manager
 	 *
-	 * @param resourceID the resource id of the TaskExecutor
+	 * @param resourceID unique id of the task manager
 	 */
-	void heartbeatResponseFromTaskExecutor(ResourceID resourceID);
+	void sendHeartbeatFromTaskManager(final ResourceID resourceID);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -130,4 +130,10 @@ public interface ResourceManagerGateway extends RpcGateway {
 	 * @return The future to the number of registered TaskManagers.
 	 */
 	Future<Integer> getNumberOfRegisteredTaskManagers(UUID leaderSessionId);
+
+	/* Receives heartbeat response from taskExecutor
+	 *
+	 * @param resourceID the resource id of the TaskExecutor
+	 */
+	void heartbeatResponseFromTaskExecutor(ResourceID resourceID);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRunner.java
@@ -55,6 +55,7 @@ public class ResourceManagerRunner implements FatalErrorHandler {
 		final ResourceManagerConfiguration resourceManagerConfiguration = ResourceManagerConfiguration.fromConfiguration(configuration);
 		final SlotManagerFactory slotManagerFactory = new DefaultSlotManager.Factory();
 		final JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(highAvailabilityServices);
+		final HeartbeatService heartbeatService = new HeartbeatService(resourceManagerConfiguration, rpcService.getExecutor());
 
 		this.resourceManager = new StandaloneResourceManager(
 			rpcService,
@@ -63,6 +64,7 @@ public class ResourceManagerRunner implements FatalErrorHandler {
 			slotManagerFactory,
 			metricRegistry,
 			jobLeaderIdService,
+			heartbeatService,
 			this);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
@@ -43,6 +43,7 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
 			SlotManagerFactory slotManagerFactory,
 			MetricRegistry metricRegistry,
 			JobLeaderIdService jobLeaderIdService,
+			HeartbeatService heartbeatService,
 			FatalErrorHandler fatalErrorHandler) {
 		super(
 			rpcService,
@@ -51,6 +52,7 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
 			slotManagerFactory,
 			metricRegistry,
 			jobLeaderIdService,
+			heartbeatService,
 			fatalErrorHandler);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -441,6 +441,15 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 	}
 
 	// ----------------------------------------------------------------------
+	// Heartbeat RPC
+	// ----------------------------------------------------------------------
+
+	@RpcMethod
+	public void requestHeartbeatFromResourceManager(ResourceID resourceID) {
+		// TODO
+	}
+
+	// ----------------------------------------------------------------------
 	// Checkpointing RPCs
 	// ----------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestReply;
@@ -129,4 +130,12 @@ public interface TaskExecutorGateway extends RpcGateway {
 	 * @return Future acknowledge if the task is successfully canceled
 	 */
 	Future<Acknowledge> cancelTask(ExecutionAttemptID executionAttemptID, @RpcTimeout Time timeout);
+
+	/**
+	 *  Request a heartbeat response from TaskExecutor to ResourceManager
+	 *
+	 * @param resourceManagerId Resource ID of the ResourceManager
+	 * @param resourceManagerLeaderId current leader id of the ResourceManager
+	 */
+	void requestHeartbeatResponseToResourceManager(ResourceID resourceManagerId, UUID resourceManagerLeaderId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -132,10 +132,9 @@ public interface TaskExecutorGateway extends RpcGateway {
 	Future<Acknowledge> cancelTask(ExecutionAttemptID executionAttemptID, @RpcTimeout Time timeout);
 
 	/**
-	 *  Request a heartbeat response from TaskExecutor to ResourceManager
+	 *  request heartbeat from the resource manager
 	 *
-	 * @param resourceManagerId Resource ID of the ResourceManager
-	 * @param resourceManagerLeaderId current leader id of the ResourceManager
+	 * @param resourceID unique id of the resource manager
 	 */
-	void requestHeartbeatResponseToResourceManager(ResourceID resourceManagerId, UUID resourceManagerLeaderId);
+	void requestHeartbeatFromResourceManager(ResourceID resourceID);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorRegistrationSuccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorRegistrationSuccess.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 
@@ -33,16 +34,21 @@ public final class TaskExecutorRegistrationSuccess extends RegistrationResponse.
 
 	private final InstanceID registrationId;
 
+	private final ResourceID resourceManagerIdentify;
+
 	private final long heartbeatInterval;
 
 	/**
 	 * Create a new {@code TaskExecutorRegistrationSuccess} message.
-	 * 
-	 * @param registrationId     The ID that the ResourceManager assigned the registration.
-	 * @param heartbeatInterval  The interval in which the ResourceManager will heartbeat the TaskExecutor.
+	 *
+	 * @param registrationId          The ID that the ResourceManager assigned the registration.
+	 * @param resourceManagerIdentify The identify of the ResourceManager, for heartbeat
+	 * @param heartbeatInterval       The interval in which the ResourceManager will heartbeat the TaskExecutor.
 	 */
-	public TaskExecutorRegistrationSuccess(InstanceID registrationId, long heartbeatInterval) {
+	public TaskExecutorRegistrationSuccess(InstanceID registrationId, ResourceID resourceManagerIdentify,
+		long heartbeatInterval) {
 		this.registrationId = registrationId;
+		this.resourceManagerIdentify = resourceManagerIdentify;
 		this.heartbeatInterval = heartbeatInterval;
 	}
 
@@ -60,9 +66,16 @@ public final class TaskExecutorRegistrationSuccess extends RegistrationResponse.
 		return heartbeatInterval;
 	}
 
+	/**
+	 * Get the identify of ResourceManager
+	 */
+	public ResourceID getResourceManagerIdentify() {
+		return resourceManagerIdentify;
+	}
+
 	@Override
 	public String toString() {
-		return "TaskExecutorRegistrationSuccess (" + registrationId + " / " + heartbeatInterval + ')';
+		return "TaskExecutorRegistrationSuccess (" + registrationId + " / " + resourceManagerIdentify + " / " + heartbeatInterval + ')';
 	}
 
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -50,6 +50,7 @@ public class ResourceManagerHATest {
 		SlotManagerFactory slotManagerFactory = new TestingSlotManagerFactory();
 		MetricRegistry metricRegistry = mock(MetricRegistry.class);
 		JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(highAvailabilityServices);
+		HeartbeatService heartbeatService = new HeartbeatService(resourceManagerConfiguration, rpcService.getExecutor());
 		TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
 
 		final ResourceManager resourceManager =
@@ -60,6 +61,7 @@ public class ResourceManagerHATest {
 				slotManagerFactory,
 				metricRegistry,
 				jobLeaderIdService,
+				heartbeatService,
 				testingFatalErrorHandler);
 		resourceManager.start();
 		// before grant leadership, resourceManager's leaderId is null

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -197,6 +197,7 @@ public class ResourceManagerJobMasterTest {
 		SlotManagerFactory slotManagerFactory = new TestingSlotManagerFactory();
 		MetricRegistry metricRegistry = mock(MetricRegistry.class);
 		JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(highAvailabilityServices);
+		HeartbeatService heartbeatService = new HeartbeatService(resourceManagerConfiguration, rpcService.getExecutor());
 
 		ResourceManager resourceManager = new StandaloneResourceManager(
 			rpcService,
@@ -205,6 +206,7 @@ public class ResourceManagerJobMasterTest {
 			slotManagerFactory,
 			metricRegistry,
 			jobLeaderIdService,
+			heartbeatService,
 			fatalErrorHandler);
 		resourceManager.start();
 		return resourceManager;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
@@ -149,7 +149,7 @@ public class ResourceManagerTaskExecutorTest {
 		ResourceManagerConfiguration resourceManagerConfiguration = new ResourceManagerConfiguration(Time.seconds(5L), Time.seconds(5L));
 		MetricRegistry metricRegistry = mock(MetricRegistry.class);
 		JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(highAvailabilityServices);
-
+		HeartbeatService heartbeatService = new HeartbeatService(resourceManagerConfiguration, rpcService.getExecutor());
 
 		StandaloneResourceManager resourceManager =
 			new StandaloneResourceManager(
@@ -159,6 +159,7 @@ public class ResourceManagerTaskExecutorTest {
 				slotManagerFactory,
 				metricRegistry,
 				jobLeaderIdService,
+				heartbeatService,
 				fatalErrorHandler);
 		resourceManager.start();
 		return resourceManager;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingLeaderRetrievalService;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.registration.RegistrationResponse;
+import org.apache.flink.runtime.resourcemanager.HeartbeatService;
 import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerConfiguration;
@@ -109,6 +110,7 @@ public class SlotProtocolTest extends TestLogger {
 
 		ResourceManagerConfiguration resourceManagerConfiguration = new ResourceManagerConfiguration(Time.seconds(5L), Time.seconds(5L));
 		JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(testingHaServices);
+		HeartbeatService heartbeatService = new HeartbeatService(resourceManagerConfiguration, testRpcService.getExecutor());
 
 		final TestingSlotManagerFactory slotManagerFactory = new TestingSlotManagerFactory();
 		SpiedResourceManager resourceManager =
@@ -119,6 +121,7 @@ public class SlotProtocolTest extends TestLogger {
 				slotManagerFactory,
 				mock(MetricRegistry.class),
 				jobLeaderIdService,
+				heartbeatService,
 				mock(FatalErrorHandler.class));
 		resourceManager.start();
 		rmLeaderElectionService.isLeader(rmLeaderID);
@@ -211,6 +214,7 @@ public class SlotProtocolTest extends TestLogger {
 		ResourceManagerConfiguration resourceManagerConfiguration = new ResourceManagerConfiguration(Time.seconds(5L), Time.seconds(5L));
 
 		JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(testingHaServices);
+		HeartbeatService heartbeatService = new HeartbeatService(resourceManagerConfiguration, testRpcService.getExecutor());
 
 		TestingSlotManagerFactory slotManagerFactory = new TestingSlotManagerFactory();
 		ResourceManager<ResourceID> resourceManager =
@@ -221,6 +225,7 @@ public class SlotProtocolTest extends TestLogger {
 				slotManagerFactory,
 				mock(MetricRegistry.class),
 				jobLeaderIdService,
+				heartbeatService,
 				mock(FatalErrorHandler.class)));
 		resourceManager.start();
 		rmLeaderElectionService.isLeader(rmLeaderID);
@@ -297,6 +302,7 @@ public class SlotProtocolTest extends TestLogger {
 				SlotManagerFactory slotManagerFactory,
 				MetricRegistry metricRegistry,
 				JobLeaderIdService jobLeaderIdService,
+				HeartbeatService heartbeatService,
 				FatalErrorHandler fatalErrorHandler) {
 			super(
 				rpcService,
@@ -305,6 +311,7 @@ public class SlotProtocolTest extends TestLogger {
 				slotManagerFactory,
 				metricRegistry,
 				jobLeaderIdService,
+				heartbeatService,
 				fatalErrorHandler);
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.registration.RegistrationResponse;
+import org.apache.flink.runtime.resourcemanager.HeartbeatService;
 import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerConfiguration;
@@ -109,6 +110,7 @@ public class TaskExecutorITCase {
 		final TaskSlotTable taskSlotTable = new TaskSlotTable(Arrays.asList(resourceProfile), new TimerService<AllocationID>(scheduledExecutorService, 100L));
 		final JobManagerTable jobManagerTable = new JobManagerTable();
 		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation);
+		HeartbeatService heartbeatService = new HeartbeatService(resourceManagerConfiguration, rpcService.getExecutor());
 
 		ResourceManager<ResourceID> resourceManager = new StandaloneResourceManager(
 			rpcService,
@@ -117,6 +119,7 @@ public class TaskExecutorITCase {
 			slotManagerFactory,
 			metricRegistry,
 			jobLeaderIdService,
+			heartbeatService,
 			testingFatalErrorHandler);
 
 		TaskExecutor taskExecutor = new TaskExecutor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -369,13 +369,14 @@ public class TaskExecutorTest extends TestLogger {
 
 		final ResourceManagerGateway resourceManagerGateway = mock(ResourceManagerGateway.class);
 		final InstanceID registrationId = new InstanceID();
+		final ResourceID resourceID = ResourceID.generate();
 
 		when(resourceManagerGateway.registerTaskExecutor(
 			eq(resourceManagerLeaderId),
 			any(String.class),
 			eq(resourceId),
 			any(SlotReport.class),
-			any(Time.class))).thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(new TaskExecutorRegistrationSuccess(registrationId, 1000L)));
+			any(Time.class))).thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(new TaskExecutorRegistrationSuccess(registrationId, resourceID, 1000L)));
 
 		final String jobManagerAddress = "jm";
 		final UUID jobManagerLeaderId = UUID.randomUUID();
@@ -478,13 +479,14 @@ public class TaskExecutorTest extends TestLogger {
 
 		final ResourceManagerGateway resourceManagerGateway = mock(ResourceManagerGateway.class);
 		final InstanceID registrationId = new InstanceID();
+		final ResourceID resourceID = ResourceID.generate();
 
 		when(resourceManagerGateway.registerTaskExecutor(
 			eq(resourceManagerLeaderId),
 			any(String.class),
 			eq(resourceId),
 			any(SlotReport.class),
-			any(Time.class))).thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(new TaskExecutorRegistrationSuccess(registrationId, 1000L)));
+			any(Time.class))).thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(new TaskExecutorRegistrationSuccess(registrationId, resourceID, 1000L)));
 
 		final ResourceID jmResourceId = new ResourceID(jobManagerAddress);
 		final int blobPort = 42;


### PR DESCRIPTION
This pr aims to add Heartbeat manager in ResourceManager with TaskExecutor. This pr focused on  ResourceManager side, while #2770 focused on the TaskExecutor side. The main difference in this pr including:
1. Add heartbeatService which is responsible for heartbeat communication with TaskExecutor
2. Register heartbeatService to ResourceManager as a service when ResourceManagerRunner constructor a new  ResourceManager instance
3. Add heartbeat RPC method in ResourceManagerGateway and TaskExecutorGateway, and implement the logic in the ResourceManager.
4. Change the TaskExecutorRegistrationSuccess because RM should tell TM its heart identifier.
5. Change some testcase in order to adapt to the modification.