### PR TITLE
[backport] [FLINK-5057] [task] Pick cancellation timeout from task manager config

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -287,11 +287,12 @@ public class Task implements Runnable {
 		this.nameOfInvokableClass = taskInformation.getInvokableClassName();
 		this.operatorState = operatorState;
 
-		this.taskCancellationInterval = taskConfiguration.getLong(
+		Configuration tmConfig = taskManagerConfig.getConfiguration();
+		this.taskCancellationInterval = tmConfig.getLong(
 				ConfigConstants.TASK_CANCELLATION_INTERVAL_MILLIS,
 				ConfigConstants.DEFAULT_TASK_CANCELLATION_INTERVAL_MILLIS);
 
-		this.taskCancellationTimeout = taskConfiguration.getLong(
+		this.taskCancellationTimeout = tmConfig.getLong(
 				ConfigConstants.TASK_CANCELLATION_TIMEOUT_MILLIS,
 				ConfigConstants.DEFAULT_TASK_CANCELLATION_TIMEOUT_MILLIS);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
@@ -47,6 +47,7 @@ import java.lang.reflect.Field;
 import java.util.Collections;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ TaskDeploymentDescriptor.class, JobID.class, FiniteDuration.class })
@@ -54,6 +55,8 @@ public class TaskStopTest {
 	private Task task;
 
 	public void doMocking(AbstractInvokable taskMock) throws Exception {
+		TaskManagerRuntimeInfo tmRuntimeInfo = mock(TaskManagerRuntimeInfo.class);
+			when(tmRuntimeInfo.getConfiguration()).thenReturn(new Configuration());
 
 		task = new Task(
 			mock(JobInformation.class),
@@ -79,7 +82,7 @@ public class TaskStopTest {
 			mock(FiniteDuration.class),
 			mock(LibraryCacheManager.class),
 			mock(FileCache.class),
-			mock(TaskManagerRuntimeInfo.class),
+			tmRuntimeInfo,
 			mock(TaskMetricGroup.class));
 
 		Field f = task.getClass().getDeclaredField("invokable");
@@ -91,7 +94,7 @@ public class TaskStopTest {
 		f2.set(task, ExecutionState.RUNNING);
 	}
 
-	@Test(timeout = 10000)
+	@Test(timeout = 20000)
 	public void testStopExecution() throws Exception {
 		StoppableTestTask taskMock = new StoppableTestTask();
 		doMocking(taskMock);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -752,10 +752,11 @@ public class TaskTest extends TestLogger {
 		return createTask(invokable, libCache, networkEnvironment, new Configuration(), new ExecutionConfig());
 	}
 
-	private Task createTask(Class<? extends AbstractInvokable> invokable,
-							LibraryCacheManager libCache,
-							NetworkEnvironment networkEnvironment,
-		Configuration taskConfig,
+	private Task createTask(
+		Class<? extends AbstractInvokable> invokable,
+		LibraryCacheManager libCache,
+		NetworkEnvironment networkEnvironment,
+		Configuration taskManagerConfig,
 		ExecutionConfig execConfig) throws IOException {
 		
 		JobID jobId = new JobID();
@@ -777,7 +778,7 @@ public class TaskTest extends TestLogger {
 			"Test Task",
 			1,
 			invokable.getName(),
-			taskConfig);
+			new Configuration());
 		
 		return new Task(
 			jobInformation,
@@ -798,7 +799,7 @@ public class TaskTest extends TestLogger {
 				new FiniteDuration(60, TimeUnit.SECONDS),
 				libCache,
 				mock(FileCache.class),
-				new TaskManagerRuntimeInfo("localhost", new Configuration(), System.getProperty("java.io.tmpdir")),
+				new TaskManagerRuntimeInfo("localhost", taskManagerConfig, System.getProperty("java.io.tmpdir")),
 				mock(TaskMetricGroup.class));
 	}
 


### PR DESCRIPTION
Backport of #2793 with no major changes. This should be merged for 1.1.4 (requiring a new RC).