### PR TITLE
[FLINK-5058]taskManagerMemory attribute set wrong value

### DIFF
--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -242,7 +242,7 @@ object FlinkShell {
 
     // set configuration from user input
     yarnConfig.jobManagerMemory.foreach((jmMem) => args ++= Seq("-yjm", jmMem.toString))
-    yarnConfig.slots.foreach((tmMem) => args ++= Seq("-ytm", tmMem.toString))
+    yarnConfig.taskManagerMemory.foreach((tmMem) => args ++= Seq("-ytm", tmMem.toString))
     yarnConfig.name.foreach((name) => args ++= Seq("-ynm", name.toString))
     yarnConfig.queue.foreach((queue) => args ++= Seq("-yqu", queue.toString))
     yarnConfig.slots.foreach((slots) => args ++= Seq("-ys", slots.toString))


### PR DESCRIPTION
In FlinkShell.scala, someone mistakenly set `slots` value to `taskManagerMemory` attribute as follow:
```
// set configuration from user input
yarnConfig.jobManagerMemory.foreach((jmMem) => args ++= Seq("-yjm", jmMem.toString))
yarnConfig.slots.foreach((tmMem) => args ++= Seq("-ytm", tmMem.toString))
yarnConfig.name.foreach((name) => args ++= Seq("-ynm", name.toString))
yarnConfig.queue.foreach((queue) => args ++= Seq("-yqu", queue.toString))
yarnConfig.slots.foreach((slots) => args ++= Seq("-ys", slots.toString))
```
Note on the third line: `yarnConfig.slots.foreach((tmMem) => args ++= Seq("-ytm", tmMem.toString))` , we set `slots` value to `-ytm` attribute, the right code should be:
```
// set configuration from user input
yarnConfig.jobManagerMemory.foreach((jmMem) => args ++= Seq("-yjm", jmMem.toString))
yarnConfig.taskManagerMemory.foreach((tmMem) => args ++= Seq("-ytm", tmMem.toString))
yarnConfig.name.foreach((name) => args ++= Seq("-ynm", name.toString))
yarnConfig.queue.foreach((queue) => args ++= Seq("-yqu", queue.toString))
yarnConfig.slots.foreach((slots) => args ++= Seq("-ys", slots.toString))
```
please review tihs pull, thanks.