### PR TITLE
[FLINK-5067] Make Flink compile with 1.8 Java compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,12 @@ matrix:
     - jdk: "oraclejdk8"
       env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis -Dmaven.javadoc.skip=true"
 
+    # Let's assume that people who want to run Java 8 also have recent version of Hadoop and will use Scala 2.11
+    - jdk: "oraclejdk8"
+      env: PROFILE="-Dhadoop.version=2.7.3 -Djava.minor.version=1.8 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis -Dmaven.javadoc.skip=true"
+    - jdk: "oraclejdk8"
+      env: PROFILE="-Dhadoop.version=2.7.3 -Djava.minor.version=1.8 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis -Dmaven.javadoc.skip=true"
+
     - jdk: "oraclejdk8"
       env: PROFILE="-Dhadoop.version=2.6.3 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis -Dmaven.javadoc.skip=true"
     - jdk: "oraclejdk8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,9 @@ matrix:
   include:
   # Always run test groups A and B together
     - jdk: "oraclejdk8"
-      env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis -Dmaven.javadoc.skip=true"
+      env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis,jdk8 -Dmaven.javadoc.skip=true"
     - jdk: "oraclejdk8"
-      env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis -Dmaven.javadoc.skip=true"
-
-    # Let's assume that people who want to run Java 8 also have recent version of Hadoop and will use Scala 2.11
-    - jdk: "oraclejdk8"
-      env: PROFILE="-Dhadoop.version=2.7.3 -Djava.minor.version=1.8 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis -Dmaven.javadoc.skip=true"
-    - jdk: "oraclejdk8"
-      env: PROFILE="-Dhadoop.version=2.7.3 -Djava.minor.version=1.8 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis -Dmaven.javadoc.skip=true"
+      env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis,jdk8 -Dmaven.javadoc.skip=true"
 
     - jdk: "oraclejdk8"
       env: PROFILE="-Dhadoop.version=2.6.3 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis -Dmaven.javadoc.skip=true"

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializer.java
@@ -109,7 +109,7 @@ public class TupleSerializer<T extends Tuple> extends TupleSerializerBase<T> {
 	@Override
 	public T copy(T from, T reuse) {
 		for (int i = 0; i < arity; i++) {
-			Object copy = fieldSerializers[i].copy(from.getField(i), reuse.getField(i));
+			Object copy = fieldSerializers[i].copy((Object)from.getField(i), reuse.getField(i));
 			reuse.setField(copy, i);
 		}
 		

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorTTT1Test.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorTTT1Test.java
@@ -132,7 +132,7 @@ public class TupleComparatorTTT1Test extends TupleComparatorTestBase<Tuple3<Tupl
 	
 	protected void deepEquals(String message, Tuple2<?,?> should, Tuple2<?,?> is) {
 		for (int x = 0; x < should.getArity(); x++) {
-			assertEquals(message, should.getField(x), is.getField(x));
+			assertEquals(message, (Object)should.getField(x), is.getField(x));
 		}
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorTTT2Test.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorTTT2Test.java
@@ -139,7 +139,7 @@ public class TupleComparatorTTT2Test extends TupleComparatorTestBase<Tuple3<Tupl
 	
 	protected void deepEquals(String message, Tuple2<?,?> should, Tuple2<?,?> is) {
 		for (int x = 0; x < should.getArity(); x++) {
-			assertEquals(message, should.getField(x), is.getField(x));
+			assertEquals(message, (Object)should.getField(x), is.getField(x));
 		}
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorTTT3Test.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TupleComparatorTTT3Test.java
@@ -148,7 +148,7 @@ public class TupleComparatorTTT3Test extends TupleComparatorTestBase<Tuple3<Tupl
 	
 	protected void deepEquals(String message, Tuple2<?,?> should, Tuple2<?,?> is) {
 		for (int x = 0; x < should.getArity(); x++) {
-			assertEquals(message, should.getField(x), is.getField(x));
+			assertEquals(message, (Object)should.getField(x), is.getField(x));
 		}
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/tuple/base/TupleComparatorTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/tuple/base/TupleComparatorTestBase.java
@@ -30,7 +30,7 @@ public abstract class TupleComparatorTestBase<T extends Tuple> extends Comparato
 	@Override
 	protected void deepEquals(String message, T should, T is) {
 		for (int x = 0; x < should.getArity(); x++) {
-			assertEquals(should.getField(x), is.getField(x));
+			assertEquals((Object)should.getField(x), is.getField(x));
 		}
 	}
 

--- a/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionAccumulatorsTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionAccumulatorsTest.java
@@ -35,7 +35,7 @@ public class CollectionExecutionAccumulatorsTest {
 	@Test
 	public void testAccumulator() {
 		try {
-			final int NUM_ELEMENTS = 100;
+			final Integer NUM_ELEMENTS = 100;
 			
 			ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
 			

--- a/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionAccumulatorsTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionAccumulatorsTest.java
@@ -35,7 +35,7 @@ public class CollectionExecutionAccumulatorsTest {
 	@Test
 	public void testAccumulator() {
 		try {
-			final Integer NUM_ELEMENTS = 100;
+			final int NUM_ELEMENTS = 100;
 			
 			ExecutionEnvironment env = ExecutionEnvironment.createCollectionsEnvironment();
 			
@@ -46,8 +46,8 @@ public class CollectionExecutionAccumulatorsTest {
 			JobExecutionResult result = env.execute();
 			
 			assertTrue(result.getNetRuntime() >= 0);
-			
-			assertEquals(NUM_ELEMENTS, result.getAccumulatorResult(ACCUMULATOR_NAME));
+
+			assertEquals(NUM_ELEMENTS, (int) result.getAccumulatorResult(ACCUMULATOR_NAME));
 		}
 		catch (Exception e) {
 			e.printStackTrace();

--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorIterativeITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorIterativeITCase.java
@@ -48,7 +48,7 @@ public class AccumulatorIterativeITCase extends JavaProgramTestBase {
 		
 		iteration.closeWith(iteration.reduceGroup(new SumReducer())).output(new DiscardingOutputFormat<Integer>());
 		
-		Assert.assertEquals(NUM_ITERATIONS * 6, env.execute().getAccumulatorResult(ACC_NAME));
+		Assert.assertEquals(Integer.valueOf(NUM_ITERATIONS * 6), env.execute().getAccumulatorResult(ACC_NAME));
 	}
 	
 	static final class SumReducer extends RichGroupReduceFunction<Integer, Integer> {

--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorIterativeITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorIterativeITCase.java
@@ -47,8 +47,8 @@ public class AccumulatorIterativeITCase extends JavaProgramTestBase {
 		IterativeDataSet<Integer> iteration = env.fromElements(1, 2, 3).iterate(NUM_ITERATIONS);
 		
 		iteration.closeWith(iteration.reduceGroup(new SumReducer())).output(new DiscardingOutputFormat<Integer>());
-		
-		Assert.assertEquals(Integer.valueOf(NUM_ITERATIONS * 6), env.execute().getAccumulatorResult(ACC_NAME));
+
+		Assert.assertEquals(NUM_ITERATIONS * 6, (int) env.execute().getAccumulatorResult(ACC_NAME));
 	}
 	
 	static final class SumReducer extends RichGroupReduceFunction<Integer, Integer> {

--- a/flink-tests/src/test/java/org/apache/flink/test/windowing/sessionwindows/SessionWindowITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/windowing/sessionwindows/SessionWindowITCase.java
@@ -122,11 +122,11 @@ public class SessionWindowITCase extends StreamingMultipleProgramsTestBase {
 
 		// check that overall event counts match with our expectations. remember that late events within lateness will
 		// each trigger a window!
-		Assert.assertEquals(
-				(LATE_EVENTS_PER_SESSION + 1) * NUMBER_OF_SESSIONS * EVENTS_PER_SESSION,
+		Assert.assertEquals(Long.valueOf(
+				(LATE_EVENTS_PER_SESSION + 1) * NUMBER_OF_SESSIONS * EVENTS_PER_SESSION),
 				result.getAccumulatorResult(SESSION_COUNTER_ON_TIME_KEY));
-		Assert.assertEquals(
-				NUMBER_OF_SESSIONS * (LATE_EVENTS_PER_SESSION * (LATE_EVENTS_PER_SESSION + 1) / 2),
+		Assert.assertEquals(Long.valueOf(
+				NUMBER_OF_SESSIONS * (LATE_EVENTS_PER_SESSION * (LATE_EVENTS_PER_SESSION + 1) / 2)),
 				result.getAccumulatorResult(SESSION_COUNTER_LATE_KEY));
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/windowing/sessionwindows/SessionWindowITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/windowing/sessionwindows/SessionWindowITCase.java
@@ -31,8 +31,6 @@ import org.apache.flink.streaming.api.windowing.assigners.EventTimeSessionWindow
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.EventTimeTrigger;
 import org.apache.flink.streaming.api.windowing.triggers.PurgingTrigger;
-import org.apache.flink.streaming.api.windowing.triggers.Trigger;
-import org.apache.flink.streaming.api.windowing.triggers.TriggerResult;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
 import org.apache.flink.util.Collector;
@@ -122,12 +120,12 @@ public class SessionWindowITCase extends StreamingMultipleProgramsTestBase {
 
 		// check that overall event counts match with our expectations. remember that late events within lateness will
 		// each trigger a window!
-		Assert.assertEquals(Long.valueOf(
-				(LATE_EVENTS_PER_SESSION + 1) * NUMBER_OF_SESSIONS * EVENTS_PER_SESSION),
-				result.getAccumulatorResult(SESSION_COUNTER_ON_TIME_KEY));
-		Assert.assertEquals(Long.valueOf(
-				NUMBER_OF_SESSIONS * (LATE_EVENTS_PER_SESSION * (LATE_EVENTS_PER_SESSION + 1) / 2)),
-				result.getAccumulatorResult(SESSION_COUNTER_LATE_KEY));
+		Assert.assertEquals(
+			(LATE_EVENTS_PER_SESSION + 1) * NUMBER_OF_SESSIONS * EVENTS_PER_SESSION,
+			(long) result.getAccumulatorResult(SESSION_COUNTER_ON_TIME_KEY));
+		Assert.assertEquals(
+			NUMBER_OF_SESSIONS * (LATE_EVENTS_PER_SESSION * (LATE_EVENTS_PER_SESSION + 1) / 2),
+			(long) result.getAccumulatorResult(SESSION_COUNTER_LATE_KEY));
 	}
 
 	/**

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@ under the License.
 		<slf4j.version>1.7.7</slf4j.version>
 		<guava.version>18.0</guava.version>
 		<akka.version>2.3.7</akka.version>
-		<java.version>1.7</java.version>
+		<java.minor.version>1.7</java.minor.version>
 		<scala.macros.version>2.0.1</scala.macros.version>
 		<!-- Default scala versions, may be overwritten by build profiles -->
 		<scala.version>2.10.4</scala.version>
@@ -938,8 +938,8 @@ under the License.
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version><!--$NO-MVN-MAN-VER$-->
 				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
+					<source>${java.minor.version}</source>
+					<target>${java.minor.version}</target>
 					<!-- The output of Xlint is not shown by default, but we activate it for the QA bot
 					to be able to get more warnings -->
 					<compilerArgument>-Xlint:all</compilerArgument>
@@ -1022,7 +1022,7 @@ under the License.
 									<version>[3.0.3,)</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
-									<version>${java.version}</version>
+									<version>${java.minor.version}</version>
 								</requireJavaVersion>
 							</rules>
 						</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@ under the License.
 		<slf4j.version>1.7.7</slf4j.version>
 		<guava.version>18.0</guava.version>
 		<akka.version>2.3.7</akka.version>
-		<java.minor.version>1.7</java.minor.version>
+		<java.version>1.7</java.version>
 		<scala.macros.version>2.0.1</scala.macros.version>
 		<!-- Default scala versions, may be overwritten by build profiles -->
 		<scala.version>2.10.4</scala.version>
@@ -732,10 +732,10 @@ under the License.
 		</profile>
 		<profile>
 			<id>jdk8</id>
-			<activation>
-				<activeByDefault>false</activeByDefault>
-				<jdk>1.8</jdk>
-			</activation>
+			<!-- do not activate automatically to prevent 1.8 target while Java 7 is the supported -->
+			<properties>
+				<java.version>1.8</java.version>
+			</properties>
 			<modules>
 				<module>flink-java8</module>
 			</modules>
@@ -938,8 +938,8 @@ under the License.
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version><!--$NO-MVN-MAN-VER$-->
 				<configuration>
-					<source>${java.minor.version}</source>
-					<target>${java.minor.version}</target>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
 					<!-- The output of Xlint is not shown by default, but we activate it for the QA bot
 					to be able to get more warnings -->
 					<compilerArgument>-Xlint:all</compilerArgument>
@@ -1022,7 +1022,7 @@ under the License.
 									<version>[3.0.3,)</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
-									<version>${java.minor.version}</version>
+									<version>${java.version}</version>
 								</requireJavaVersion>
 							</rules>
 						</configuration>


### PR DESCRIPTION
- New type inference rules changed which overloaded methods are picked.
- Renamed java.version property in maven to java.minor.version. This is due to the fact that overriding java.version is used by some third-party classes and they expect the version to be fully qualified.
- Introduced Java 8 build for Travis CI