### PR TITLE
[FLINK-5076] Shutting down TM when shutting down mini cluster.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -312,6 +312,19 @@ public class MiniCluster {
 			resourceManagerRunners = null;
 		}
 
+		if (taskManagerRunners != null) {
+			for (TaskManagerRunner tm : taskManagerRunners) {
+				if (tm != null) {
+					try {
+						tm.shutDown(null);
+					} catch (Throwable t) {
+						exception = firstOrSuppressed(t, exception);
+					}
+				}
+			}
+			taskManagerRunners = null;
+		}
+
 		// shut down the RpcServices
 		exception = shutDownRpc(commonRpcService, exception);
 		exception = shutDownRpcs(jobManagerRpcServices, exception);


### PR DESCRIPTION
This PR [#5076](https://issues.apache.org/jira/browse/FLINK-5076) adds shutting down task manager when shutting down new mini cluster.