### PR TITLE
[FLINK-4872] [types] Type erasure problem exclusively on cluster execution

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -751,24 +751,9 @@ public class TypeExtractor {
 			
 			// due to a Java 6 bug, it is possible that the JVM classifies e.g. String[] or int[] as GenericArrayType instead of Class
 			if (componentType instanceof Class) {
-				
 				Class<?> componentClass = (Class<?>) componentType;
-				String className;
-				// for int[], double[] etc.
-				if(componentClass.isPrimitive()) {
-					className = encodePrimitiveClass(componentClass);
-				}
-				// for String[], Integer[] etc.
-				else {
-					className = "L" + componentClass.getName() + ";";
-				}
-				
-				Class<OUT> classArray;
-				try {
-					classArray = (Class<OUT>) Class.forName("[" + className, true, Thread.currentThread().getContextClassLoader());
-				} catch (ClassNotFoundException e) {
-					throw new InvalidTypesException("Could not convert GenericArrayType to Class.");
-				}
+
+				Class<OUT> classArray = (Class<OUT>) (java.lang.reflect.Array.newInstance(componentClass, 0).getClass());
 
 				return getForClass(classArray);
 			} else {
@@ -778,21 +763,8 @@ public class TypeExtractor {
 					in1Type,
 					in2Type);
 
-				Class<OUT> classArray;
-
-				try {
-					String componentClassName = componentInfo.getTypeClass().getName();
-					String resultingClassName;
-
-					if (componentClassName.startsWith("[")) {
-						resultingClassName = "[" + componentClassName;
-					} else {
-						resultingClassName = "[L" + componentClassName + ";";
-					}
-					classArray = (Class<OUT>) Class.forName(resultingClassName, true, Thread.currentThread().getContextClassLoader());
-				} catch (ClassNotFoundException e) {
-					throw new InvalidTypesException("Could not convert GenericArrayType to Class.");
-				}
+				Class<?> componentClass = componentInfo.getTypeClass();
+				Class<OUT> classArray = (Class<OUT>) (java.lang.reflect.Array.newInstance(componentClass, 0).getClass());
 
 				return ObjectArrayTypeInfo.getInfoFor(classArray, componentInfo);
 			}
@@ -1558,34 +1530,6 @@ public class TypeExtractor {
 					+ "Currently, only the Eclipse JDT compiler preserves the type information necessary to use the lambdas feature type-safely. \n"
 					+ "See the documentation for more information about how to compile jobs containing lambda expressions.");
 		}
-	}
-	
-	private static String encodePrimitiveClass(Class<?> primitiveClass) {
-		if (primitiveClass == boolean.class) {
-			return "Z";
-		}
-		else if (primitiveClass == byte.class) {
-			return "B";
-		}
-		else if (primitiveClass == char.class) {
-			return "C";
-		}
-		else if (primitiveClass == double.class) {
-			return "D";
-		}
-		else if (primitiveClass == float.class) {
-			return "F";
-		}
-		else if (primitiveClass == int.class) {
-			return "I";
-		}
-		else if (primitiveClass == long.class) {
-			return "J";
-		}
-		else if (primitiveClass == short.class) {
-			return "S";
-		}
-		throw new InvalidTypesException();
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -765,7 +765,7 @@ public class TypeExtractor {
 				
 				Class<OUT> classArray;
 				try {
-					classArray = (Class<OUT>) Class.forName("[" + className);
+					classArray = (Class<OUT>) Class.forName("[" + className, true, Thread.currentThread().getContextClassLoader());
 				} catch (ClassNotFoundException e) {
 					throw new InvalidTypesException("Could not convert GenericArrayType to Class.");
 				}
@@ -789,7 +789,7 @@ public class TypeExtractor {
 					} else {
 						resultingClassName = "[L" + componentClassName + ";";
 					}
-					classArray = (Class<OUT>) Class.forName(resultingClassName);
+					classArray = (Class<OUT>) Class.forName(resultingClassName, true, Thread.currentThread().getContextClassLoader());
 				} catch (ClassNotFoundException e) {
 					throw new InvalidTypesException("Could not convert GenericArrayType to Class.");
 				}


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

This PR solves a classloader issue in the TypeExtractor that only happens when using object arrays on a cluster. A test for this change would be difficult but in general this feature is already tested in the existing tests.
