### PR TITLE
[FLINK-4921] Upgrade to Mesos 1.0.1

### DIFF
--- a/flink-mesos/pom.xml
+++ b/flink-mesos/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	<packaging>jar</packaging>
 
     <properties>
-        <mesos.version>0.27.1</mesos.version>
+        <mesos.version>1.0.1</mesos.version>
     </properties>
 	
     <dependencies>
@@ -68,6 +68,13 @@ under the License.
 		<dependency>
 			<groupId>com.typesafe.akka</groupId>
 			<artifactId>akka-remote_${scala.binary.version}</artifactId>
+			<exclusions>
+				<!-- exclude protobuf here to allow the mesos library to provide it -->
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -253,15 +260,21 @@ under the License.
 							<goal>shade</goal>
 						</goals>
 						<configuration>
+							<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
 							<artifactSet>
 								<includes combine.children="append">
 									<include>org.apache.flink:flink-shaded-curator-recipes</include>
+									<include>com.google.protobuf:*</include>
 								</includes>
 							</artifactSet>
-							<relocations combine.children="append">
+							<relocations combine.children="override">
 								<relocation>
 									<pattern>org.apache.curator</pattern>
-									<shadedPattern>org.apache.flink.shaded.org.apache.curator</shadedPattern>
+									<shadedPattern>org.apache.flink.mesos.shaded.org.apache.curator</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.google.protobuf</pattern>
+									<shadedPattern>org.apache.flink.mesos.shaded.com.google.protobuf</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>


### PR DESCRIPTION
Updated the Mesos dependency, to unlock some new features (notably the
ability to fetch into sandbox sub-directories).

Shaded the protobuf dependency because the new Mesos library depends on
a newer version than does akka-remoting.