### PR TITLE
[FLINK-5093] java.util.ConcurrentModificationException is thrown when stopping TimerService

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TimerService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TimerService.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.taskexecutor.slot;
 import org.apache.flink.util.Preconditions;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
@@ -60,9 +61,7 @@ public class TimerService<K> {
 	}
 
 	public void stop() {
-		for (K key: timeouts.keySet()) {
-			unregisterTimeout(key);
-		}
+		unregisterAllTimeouts();
 
 		timeoutListener = null;
 
@@ -98,6 +97,18 @@ public class TimerService<K> {
 		if (timeout != null) {
 			timeout.cancel();
 		}
+	}
+
+	/**
+	 * Unregister all timeouts.
+	 */
+	protected void unregisterAllTimeouts() {
+		for (Timeout<K> timeout : timeouts.values()) {
+			if (timeout != null) {
+				timeout.cancel();
+			}
+		}
+		timeouts.clear();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TimerService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TimerService.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.taskexecutor.slot;
 import org.apache.flink.util.Preconditions;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TimerServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TimerServiceTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.slot;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.junit.Test;
+import org.mockito.internal.util.reflection.Whitebox;
+
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TimerServiceTest {
+	/**
+	 * Test all timeouts registered can be unregistered
+	 * @throws Exception
+   */
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testUnregisterAllTimeouts() throws Exception {
+		// Prepare all instances.
+		ScheduledExecutorService scheduledExecutorService = mock(ScheduledExecutorService.class);
+		ScheduledFuture scheduledFuture = mock(ScheduledFuture.class);
+		when(scheduledExecutorService.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
+			.thenReturn(scheduledFuture);
+		TimerService<AllocationID> timerService = new TimerService<>(scheduledExecutorService);
+		TimeoutListener<AllocationID> listener = mock(TimeoutListener.class);
+
+		timerService.start(listener);
+
+		// Invoke register and unregister.
+		timerService.registerTimeout(new AllocationID(), 10, TimeUnit.SECONDS);
+		timerService.registerTimeout(new AllocationID(), 10, TimeUnit.SECONDS);
+
+		timerService.unregisterAllTimeouts();
+
+		// Verify.
+		Map<?, ?> timeouts = (Map<?, ?>) Whitebox.getInternalState(timerService, "timeouts");
+		assertTrue(timeouts.isEmpty());
+		verify(scheduledFuture, times(2)).cancel(true);
+	}
+
+}


### PR DESCRIPTION
[FLINK-5093] Fix bug about java.util.ConcurrentModificationException thrown while stopping TimerService. Add a new method "unregisterAllTimeouts" and UT for it.