### PR TITLE
[FLINK-4712] [FLINK-4713] [ml] Ranking recommendation & evaluation (WIP)

### DIFF
--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/classification/Classifier.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/classification/Classifier.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.classification
+
+import org.apache.flink.ml.pipeline.Predictor
+
+/** Trait that classification algorithms should implement
+  *
+  * @tparam Self Type of the implementing class
+  */
+trait Classifier[Self] extends Predictor[Self]{
+  that: Self =>
+
+}

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/classification/SVM.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/classification/SVM.scala
@@ -130,7 +130,7 @@ import breeze.linalg.{DenseVector => BreezeDenseVector, Vector => BreezeVector}
   *  distance to the hyperplane for each example. Setting it to false will return the binary
   *  class label (+1.0, -1.0) (Default value: '''false''')
   */
-class SVM extends Predictor[SVM] {
+class SVM extends Classifier[SVM] {
 
   import SVM._
 

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/evaluation/Score.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/evaluation/Score.scala
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.evaluation
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.scala._
+import org.apache.flink.ml._
+
+import scala.reflect.ClassTag
+
+/**
+ * Evaluation score
+ *
+ * Can be used to calculate a performance score for an algorithm, when provided with a DataSet
+ * of (truth, prediction) tuples
+ *
+ * @tparam PredictionType output type
+ */
+trait Score[PredictionType] {
+  def evaluate(trueAndPredicted: DataSet[(PredictionType, PredictionType)]): DataSet[Double]
+}
+
+/** Traits to allow us to determine at runtime if a Score is a loss (lower is better) or a
+  * performance score (higher is better)
+  */
+trait Loss
+
+trait PerformanceScore
+
+/**
+ * Metrics expressible as a mean of a function taking output pairs as input
+ *
+ * @param scoringFct function to apply to all elements
+ * @tparam PredictionType output type
+ */
+abstract class MeanScore[PredictionType: TypeInformation: ClassTag](
+    scoringFct: (PredictionType, PredictionType) => Double)
+    (implicit yyt: TypeInformation[(PredictionType, PredictionType)])
+  extends Score[PredictionType] with Serializable {
+
+  def evaluate(trueAndPredicted: DataSet[(PredictionType, PredictionType)]): DataSet[Double] = {
+    trueAndPredicted.map(yy => scoringFct(yy._1, yy._2)).mean()
+  }
+}
+
+/** Scores aimed at evaluating the performance of regression algorithms
+  *
+  */
+object RegressionScores {
+  /**
+   * Mean Squared loss function
+   *
+   * Calculates (y1 - y2)^2^ and returns the mean.
+   *
+   * @return a Loss object
+   */
+  def squaredLoss = new MeanScore[Double]((y1,y2) => (y1 - y2) * (y1 - y2)) with Loss
+
+  /**
+   * Mean Zero One Loss Function also usable for score information
+   *
+   * Assigns 1 if sign of outputs differ and 0 if the signs are equal, and returns the mean
+   *
+   * @return a Loss object
+   */
+  def zeroOneSignumLoss = new MeanScore[Double]({ (y1, y2) =>
+    val sy1 = y1.signum
+    val sy2 = y2.signum
+    if (sy1 == sy2) 0 else 1
+  }) with Loss
+
+  /** Calculates the coefficient of determination, $R^2^$
+    *
+    * $R^2^$ indicates how well the data fit the a calculated model
+    * Reference: [[http://en.wikipedia.org/wiki/Coefficient_of_determination]]
+    */
+  def r2Score = new Score[Double] with PerformanceScore {
+    override def evaluate(trueAndPredicted: DataSet[(Double, Double)]): DataSet[Double] = {
+      val onlyTrue = trueAndPredicted.map(truthPrediction => truthPrediction._1)
+      val meanTruth = onlyTrue.mean()
+
+      val ssRes = trueAndPredicted
+        .map(tp => (tp._1 - tp._2) * (tp._1 - tp._2)).reduce(_ + _)
+      val ssTot = onlyTrue
+        .mapWithBcVariable(meanTruth) {
+          case (truth: Double, meanTruth: Double) => (truth - meanTruth) * (truth - meanTruth)
+        }.reduce(_ + _)
+
+      val r2 = ssRes
+        .mapWithBcVariable(ssTot) {
+          case (ssRes: Double, ssTot: Double) =>
+          // We avoid dividing by 0 and just assign 0.0
+          if (ssTot == 0.0) {
+            0.0
+          }
+          else {
+            1 - (ssRes / ssTot)
+          }
+      }
+      r2
+    }
+  }
+}
+
+/** Scores aimed at evaluating the performance of classification algorithms
+  *
+  */
+object ClassificationScores {
+  /** Calculates the fraction of correct predictions
+    *
+    */
+  def accuracyScore = {
+    new MeanScore[Double]((y1, y2) => if (y1.approximatelyEquals(y2)) 1 else 0)
+      with PerformanceScore
+  }
+
+  /**
+   * Mean Zero One Loss Function
+   *
+   * Assigns 1 if outputs differ and 0 if they are equal, and returns the mean.
+   *
+   * @return a Loss object
+   */
+  def zeroOneLoss = {
+    new MeanScore[Double]((y1, y2) => if (y1.approximatelyEquals(y2)) 0 else 1) with Loss
+  }
+}
+
+

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/evaluation/Score.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/evaluation/Score.scala
@@ -18,11 +18,36 @@
 
 package org.apache.flink.ml.evaluation
 
+import org.apache.flink.api.common.operators.Order
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala._
 import org.apache.flink.ml._
+import org.apache.flink.ml.pipeline._
+import org.apache.flink.ml.RichNumericDataSet
+import org.apache.flink.util.Collector
 
 import scala.reflect.ClassTag
+
+trait Score[
+  PredictorType[PredictorInstanceType],
+  PreparedTesting
+] {
+  def evaluate(test: PreparedTesting): DataSet[Double]
+}
+
+abstract class RankingScore extends Score[
+  RankingPredictor,
+  (DataSet[(Int, Int, Double)], DataSet[(Int,Int,Int)])
+  ] with Serializable{
+  // We will either have to add a k:Int parameter into the test tuple,
+  // count the predictions in the DataSet[Int,Int,Int], or add
+  // scoreParameters to the Score trait, and there are reasons to do
+  // both. Let's discuss this later.
+  // todo: revisit this
+
+  override def evaluate(testAndPredictions: (DataSet[(Int, Int, Double)], DataSet[(Int, Int, Int)]))
+  : DataSet[Double]
+}
 
 /**
  * Evaluation score
@@ -32,7 +57,10 @@ import scala.reflect.ClassTag
  *
  * @tparam PredictionType output type
  */
-trait Score[PredictionType] {
+trait PairwiseScore[PredictionType] extends Score[
+  Predictor,
+  DataSet[(PredictionType, PredictionType)]
+] {
   def evaluate(trueAndPredicted: DataSet[(PredictionType, PredictionType)]): DataSet[Double]
 }
 
@@ -52,9 +80,9 @@ trait PerformanceScore
 abstract class MeanScore[PredictionType: TypeInformation: ClassTag](
     scoringFct: (PredictionType, PredictionType) => Double)
     (implicit yyt: TypeInformation[(PredictionType, PredictionType)])
-  extends Score[PredictionType] with Serializable {
+  extends PairwiseScore[PredictionType] with Serializable {
 
-  def evaluate(trueAndPredicted: DataSet[(PredictionType, PredictionType)]): DataSet[Double] = {
+  override def evaluate(trueAndPredicted: DataSet[(PredictionType, PredictionType)]): DataSet[Double] = {
     trueAndPredicted.map(yy => scoringFct(yy._1, yy._2)).mean()
   }
 }
@@ -90,7 +118,7 @@ object RegressionScores {
     * $R^2^$ indicates how well the data fit the a calculated model
     * Reference: [[http://en.wikipedia.org/wiki/Coefficient_of_determination]]
     */
-  def r2Score = new Score[Double] with PerformanceScore {
+  def r2Score = new PairwiseScore[Double] with PerformanceScore {
     override def evaluate(trueAndPredicted: DataSet[(Double, Double)]): DataSet[Double] = {
       val onlyTrue = trueAndPredicted.map(truthPrediction => truthPrediction._1)
       val meanTruth = onlyTrue.mean()
@@ -142,4 +170,228 @@ object ClassificationScores {
   }
 }
 
+object RankingScores extends Serializable {
+  def ndcgScore(topK: Int) =
+    new RankingScore {
+      // These could be private, however it makes sense to make them
+      // user facing, too.
+      // todo: revisit this
+      def calculateIdcgs(test: DataSet[(Int, Int, Double)])
+      : DataSet[(Int, Double)] = {
+        test
+          .groupBy(0)
+          .sortGroup(2, Order.DESCENDING)
+          .reduceGroup(elements => {
+            val bufferedElements = elements.buffered
+            val user = bufferedElements.head._1
+            val idcg = bufferedElements
+              .map(_._3)
+              .zip((1 to topK).toIterator)
+              .map { case (rel, rank) => rel / (scala.math.log(rank + 1) / scala.math.log(2)) }
+              .sum
+            (user, idcg)
+          })
+      }
 
+      def calculateDcgs(predictions: DataSet[(Int, Int, Int)], test: DataSet[(Int, Int, Double)])
+      : DataSet[(Int, Double)] =
+        predictions
+          .leftOuterJoin(test)
+          .where(0, 1)
+          .equalTo(0, 1)
+          .apply((l, r) => (l, Option(r)))
+          .groupBy(_._1._1)
+          .reduceGroup(elements => {
+            val bufferedElements = elements.toList
+            val user = bufferedElements.head._1._1
+            val dcg: Double = bufferedElements
+              .map {
+                case ((u1, i1, rank), Some((u2, i2, rel))) =>
+                  rel / (scala.math.log(rank + 1) / scala.math.log(2))
+                case (l, None) =>
+                  0.0
+              }
+              .sum
+            (user, dcg)
+          })
+
+      def calculateNdcgs(dcgs: DataSet[(Int, Double)], idcgs: DataSet[(Int, Double)])
+      : DataSet[(Int, Double)] =
+        idcgs
+          .join(dcgs)
+          .where(0)
+          .equalTo(0)
+          .apply((idcg, dcg) => (idcg._1, dcg._2 / idcg._2))
+
+      def averageNdcg(test: DataSet[(Int, Int, Double)], rankingPredictions: DataSet[(Int, Int, Int)])
+      : DataSet[Double] = {
+        val idcgs = calculateIdcgs(test)
+        val dcgs = calculateDcgs(rankingPredictions, test)
+        val ndcgs = calculateNdcgs(dcgs, idcgs)
+        ndcgs.map(_._2).mean()
+      }
+
+      override def evaluate(testAndPredictions: (DataSet[(Int, Int, Double)], DataSet[(Int, Int, Int)]))
+      : DataSet[Double] = {
+        val (test, predictions) = testAndPredictions
+        averageNdcg(test, predictions)
+      }
+    }
+
+  object PrecisionAndRecallScoresUtilities extends Serializable {
+    // The reason that these are public facing functions is that if
+    // one tries to calculate precision and also recall, the
+    // heavy lifting has to be done twice, while the two metrics
+    // calculate basically the same think, up to a certain .map()
+    // at the end of the calculation. This way the users can
+    // efficiently calculate these two metrics themselves without
+    // calculating things twice. Flink calculates them at the same
+    // time and returns a tuple - we cant do this, since the eval
+    // api expects single double as return type.
+    // todo: revisit this
+
+    def joinWithTest(rankingPredictions: DataSet[(Int, Int, Int)], test: DataSet[(Int, Int, Double)])
+    : DataSet[(Int, Int, Option[Int], String)] = {
+      rankingPredictions
+        .fullOuterJoin(test)
+        .where(0, 1)
+        .equalTo(0, 1)
+        .apply((l, r, o: Collector[(Int, Int, Option[Int], String)]) => {
+          (Option(l), Option(r)) match {
+            // todo: use sealed trait instead of strings
+            case (None, Some(rr)) => o.collect((rr._1, rr._2, None, "false_negative"))
+            case (Some(ll), None) => o.collect((ll._1, ll._2, Some(ll._3), "false_positive"))
+            case (Some(ll), Some(rr)) => o.collect((ll._1, ll._2, Some(ll._3), "true_positive"))
+            case default => ()
+          }
+        })
+    }
+
+    def countTypes(joined: DataSet[(Int, Int, Option[Int], String)])
+    : DataSet[(Int, Int, Int, Int)] = {
+      joined
+        .groupBy(0)
+        .reduceGroup(elements => {
+          val bufferedElements = elements.toList
+          val user = bufferedElements.head._1
+          var truePositive, falsePositive, falseNegative = 0
+          for ((_, _, _, t) <- bufferedElements) {
+            t match {
+              case "true_positive" => truePositive += 1
+              case "false_positive" => falsePositive += 1
+              case "false_negative" => falseNegative += 1
+            }
+          }
+          (user, truePositive, falsePositive, falseNegative)
+        })
+    }
+
+
+    def countTypesUpToK(joined: DataSet[(Int, Int, Option[Int], String)])
+    : DataSet[(Int, Int, Int, Int, Int)] =
+      joined
+        .map(x => x match {
+          case (user, item, Some(rank), t) => (user, item, rank, t)
+          case (user, item, None, t) => (user, item, 0, t)
+        })
+        .groupBy(0)
+        .sortGroup(2, Order.ASCENDING)
+        // todo: something else instead of strings and case classes instead of (long) tuples
+        .reduceGroup((elements, collector: Collector[(Int, Int, Int, Int, Int)]) => {
+        val bufferedElements = elements.toList
+        val user = bufferedElements.head._1
+        var truePositive, falsePositive, falseNegative = 0
+        val allTruePositive = bufferedElements.count(_._4 == "true_positive")
+        for ((_, _, rank, t) <- bufferedElements) {
+          t match {
+            case "true_positive" => truePositive += 1
+            case "false_positive" => falsePositive += 1
+            case "false_negative" => falseNegative += 1
+          }
+          if (rank != 0) {
+            collector.collect((user, rank, truePositive, falsePositive, falseNegative + (allTruePositive - truePositive)))
+          }
+        }
+      })
+
+    def precisions(rankingPredictions: DataSet[(Int, Int, Int)], test: DataSet[(Int, Int, Double)])
+    : DataSet[(Int, Double)] = {
+      val countedPerUser = countTypes(joinWithTest(rankingPredictions, test))
+
+      val calculatePrecision = (user: Int, truePositive: Int, falsePositive: Int, falseNegative: Int) =>
+        truePositive.toDouble / (truePositive.toDouble + falsePositive.toDouble)
+
+      countedPerUser.map(x => (x._1, calculatePrecision.tupled(x)))
+    }
+
+    def recalls(rankingPredictions: DataSet[(Int, Int, Int)], test: DataSet[(Int, Int, Double)])
+    : DataSet[(Int, Double)] = {
+      val countedPerUser = countTypes(joinWithTest(rankingPredictions, test))
+
+      val calculateRecall = (user: Int, truePositive: Int, falsePositive: Int, falseNegative: Int) =>
+        truePositive.toDouble / (truePositive.toDouble + falseNegative.toDouble)
+
+      countedPerUser.map(x => (x._1, calculateRecall.tupled(x)))
+    }
+
+    def meanAveragePrecisionAndRecall(rankingPredictions: DataSet[(Int, Int, Int)], test: DataSet[(Int, Int, Double)])
+    : DataSet[(Int, Double, Double)] = {
+      val counted = countTypesUpToK(joinWithTest(rankingPredictions, test))
+
+      val calculatePrecision = (user: Int, truePositive: Int, falsePositive: Int, falseNegative: Int) =>
+        truePositive.toDouble / (truePositive.toDouble + falsePositive.toDouble)
+
+      val calculateRecall = (user: Int, truePositive: Int, falsePositive: Int, falseNegative: Int) =>
+        truePositive.toDouble / (truePositive.toDouble + falseNegative.toDouble)
+
+      counted
+        .map(x => (x._1, x._3, x._4, x._5))
+        .map(x => (x._1, calculatePrecision.tupled(x), calculateRecall.tupled(x)))
+        .groupBy(0)
+        .reduceGroup(elements => {
+          val bufferedElements = elements.toList
+          (bufferedElements.head._1,
+            bufferedElements.map(_._2).sum / bufferedElements.length,
+            bufferedElements.map(_._3).sum / bufferedElements.length)
+        })
+    }
+  }
+
+  def precisionScore(topK: Int) = new RankingScore {
+    override def evaluate(testAndPredictions: (DataSet[(Int, Int, Double)], DataSet[(Int, Int, Int)]))
+    : DataSet[Double] = {
+      val (test, predictions) = testAndPredictions
+      val precs = PrecisionAndRecallScoresUtilities.precisions(predictions, test)
+      precs.map(_._2).mean()
+    }
+  }
+
+  def recallScore(topK: Int) = new RankingScore {
+    override def evaluate(testAndPredictions: (DataSet[(Int, Int, Double)], DataSet[(Int, Int, Int)]))
+    : DataSet[Double] = {
+      val (test, predictions) = testAndPredictions
+      val recs = PrecisionAndRecallScoresUtilities.recalls(predictions, test)
+      recs.map(_._2).mean()
+    }
+  }
+
+  def meanPrecisionScore(topK: Int) = new RankingScore {
+    override def evaluate(testAndPredictions: (DataSet[(Int, Int, Double)], DataSet[(Int, Int, Int)]))
+    : DataSet[Double] = {
+      val (test, predictions) = testAndPredictions
+      val meanAvgPrecAndRecall = PrecisionAndRecallScoresUtilities
+        .meanAveragePrecisionAndRecall(predictions, test)
+      meanAvgPrecAndRecall.map(_._2).mean()
+    }
+  }
+
+  def meanRecallScore(topK: Int) = new RankingScore {
+    override def evaluate(testAndPredictions: (DataSet[(Int, Int, Double)], DataSet[(Int, Int, Int)]))
+    : DataSet[Double] = {
+      val (test, predictions) = testAndPredictions
+      val meanAvgPrecAndRecall = PrecisionAndRecallScoresUtilities
+        .meanAveragePrecisionAndRecall(predictions, test)
+      meanAvgPrecAndRecall.map(_._3).mean()
+    }
+  }
+}

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/evaluation/Scorer.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/evaluation/Scorer.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.ml.evaluation
+
+import org.apache.flink.api.scala._
+import org.apache.flink.ml.common.{ParameterMap, WithParameters}
+import org.apache.flink.ml.pipeline.{EvaluateDataSetOperation, Predictor}
+
+//TODO: Need to generalize type of Score (and evaluateOperation)
+class Scorer(val score: Score[Double]) extends WithParameters {
+
+  def evaluate[Testing, PredictorInstance <: Predictor[PredictorInstance]](
+      testing: DataSet[Testing],
+      predictorInstance: PredictorInstance,
+      evaluateParameters: ParameterMap = ParameterMap.Empty)
+      (implicit evaluateOperation: EvaluateDataSetOperation[PredictorInstance, Testing, Double]):
+    DataSet[Double] = {
+
+    val resultingParameters = predictorInstance.parameters ++ evaluateParameters
+    val predictions = predictorInstance.evaluate[Testing, Double](testing, resultingParameters)
+    score.evaluate(predictions)
+  }
+
+}

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Predictor.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Predictor.scala
@@ -19,10 +19,15 @@
 package org.apache.flink.ml.pipeline
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.scala._
+import org.apache.flink.api.scala.{DataSet, _}
 import org.apache.flink.ml._
-import org.apache.flink.ml.common.{FlinkMLTools, LabeledVector, ParameterMap, WithParameters}
+import org.apache.flink.ml.common._
 import org.apache.flink.ml.math.{Vector => FlinkVector}
+import org.apache.flink.ml.recommendation.ALS
+import org.apache.flink.ml.recommendation.ALS.Factors
+import org.apache.flink.util.Collector
+
+import scala.collection.mutable
 
 /** Predictor trait for Flink's pipeline operators.
   *
@@ -78,6 +83,134 @@ trait Predictor[Self] extends Estimator[Self] with WithParameters {
     FlinkMLTools.registerFlinkMLTypes(testing.getExecutionEnvironment)
     evaluator.evaluateDataSet(this, evaluateParameters, testing)
   }
+}
+
+trait RankingPredictor[Self] extends Estimator[Self] with WithParameters {
+  that: Self =>
+
+  def predictRankings(
+    k: Int,
+    users: DataSet[Int],
+    predictParameters: ParameterMap = ParameterMap.Empty)(implicit
+    rankingPredictOperation : RankingPredictOperation[Self])
+  : DataSet[(Int,Int,Int)] =
+    rankingPredictOperation.predictRankings(this, k, users, predictParameters)
+
+  def evaluateRankings(
+    testing: DataSet[(Int,Int,Double)],
+    evaluateParameters: ParameterMap = ParameterMap.Empty)(implicit
+    rankingPredictOperation : RankingPredictOperation[Self])
+  : DataSet[(Int,Int,Int)] = {
+    // todo: do not burn 100 topK into code
+    predictRankings(100, testing.map(_._1).distinct(), evaluateParameters)
+  }
+}
+
+trait RankingPredictOperation[Instance] {
+  def predictRankings(
+    instance: Instance,
+    k: Int,
+    users: DataSet[Int],
+    predictParameters: ParameterMap = ParameterMap.Empty)
+  : DataSet[(Int, Int, Int)]
+}
+
+/**
+  * Trait for providing auxiliary data for ranking evaluations.
+  *
+  * They are useful e.g. for excluding items found in the training [[DataSet]]
+  * from the recommended top K items.
+  */
+trait TrainingRatingsProvider {
+
+  def getTrainingData: DataSet[(Int, Int, Double)]
+
+  /**
+    * Retrieving the training items.
+    * Although this can be calculated from the training data, it requires a costly
+    * [[DataSet.distinct]] operation, while in matrix factor models the set items could be
+    * given more efficiently from the item factors.
+    */
+  def getTrainingItems: DataSet[Int] = {
+    getTrainingData.map(_._2).distinct()
+  }
+}
+
+/**
+  * Ranking predictions for the most common case.
+  * If we can predict ratings, we can compute top K lists by sorting the predicted ratings.
+  */
+class RankingFromRatingPredictOperation[Instance <: TrainingRatingsProvider]
+(val ratingPredictor: PredictDataSetOperation[Instance, (Int, Int), (Int, Int, Double)])
+  extends RankingPredictOperation[Instance] {
+
+  private def getUserItemPairs(users: DataSet[Int], items: DataSet[Int], exclude: DataSet[(Int, Int)])
+  : DataSet[(Int, Int)] = {
+    users.cross(items)
+      .leftOuterJoin(exclude).where(0, 1).equalTo(0, 1)
+      .apply((l, r, o: Collector[(Int, Int)]) => {
+        Option(r) match {
+          case Some(_) => ()
+          case None => o.collect(l)
+        }
+      })
+  }
+
+  private def rankingsFromRatings(
+                   topK: Int,
+                   scores: DataSet[(Int, Int, Double)])
+  : DataSet[(Int, Int, Int)] = {
+    scores
+      .groupBy(0)
+      .combineGroup((elements, collector: Collector[(Int, Array[(Int, Double)])]) => {
+        val bufferedElements = elements.buffered
+        val head = bufferedElements.head
+        var topKitems = mutable.SortedSet[(Int, Int, Double)]()(
+          Ordering[(Double, Int)].reverse.on(x => (x._3, x._2)))
+        for (e <- bufferedElements) {
+          topKitems += e
+          if (topKitems.size > topK) {
+            topKitems = topKitems.dropRight(1)
+          }
+        }
+        collector.collect((head._1, topKitems.toArray.map(x => (x._2, x._3))))
+      })
+      .withForwardedFields("0")
+      .groupBy(0)
+      .reduce((l, r) => {
+        var topKitems = mutable.SortedSet[(Int, Double)]()(
+          Ordering[(Double, Int)].reverse.on(x => (x._2, x._1)))
+        topKitems ++= l._2 ++= r._2
+        (l._1, topKitems.take(topK).toArray)
+      })
+      .flatMap(x => for (e <- x._2.zip(1 to topK)) yield (x._1, e._1._1, e._2))
+  }
+
+  override def predictRankings(
+                                instance: Instance,
+                                k: Int,
+                                users: DataSet[Int],
+                                predictParameters: ParameterMap = ParameterMap.Empty)
+  : DataSet[(Int, Int, Int)] = {
+    val trainData = instance.getTrainingData
+    val items = instance.getTrainingItems
+    val exclude: DataSet[(Int, Int)] =
+      if (predictParameters.get(RankingPredictor.ExcludeKnown).getOrElse(false))
+        trainData.map(x => (x._1, x._2))
+      else
+        trainData.getExecutionEnvironment.fromCollection(Seq())
+    val userItemPairs = getUserItemPairs(users, items, exclude)
+    val scores = ratingPredictor.predictDataSet(instance, predictParameters, userItemPairs)
+    this.rankingsFromRatings(k, scores)
+  }
+}
+
+object RankingPredictor {
+
+  case object ExcludeKnown extends Parameter[Boolean] {
+    val defaultValue: Option[Boolean] = Some(true)
+  }
+
 }
 
 object Predictor {
@@ -203,6 +336,7 @@ object Predictor {
       }
     }
   }
+
 }
 
 /** Type class for the predict operation of [[Predictor]]. This predict operation works on DataSets.
@@ -267,6 +401,21 @@ trait PredictOperation[Instance, Model, Testing, Prediction] extends Serializabl
   def predict(value: Testing, model: Model): Prediction
 }
 
+/**
+  * Operation for preparing a testing [[DataSet]] for evaluation.
+  *
+  * The most commonly [[EvaluateDataSetOperation]] is used, but evaluation of
+  * ranking recommendations need input in a different form.
+  */
+trait PrepareOperation[Instance, Testing, Prepared] extends Serializable {
+
+  def prepare(
+               als: Instance,
+               test : DataSet[Testing],
+               parameters : ParameterMap)
+  : Prepared
+}
+
 /** Type class for the evaluate operation of [[Predictor]]. This evaluate operation works on
   * DataSets.
   *
@@ -279,7 +428,15 @@ trait PredictOperation[Instance, Model, Testing, Prediction] extends Serializabl
   * @tparam Prediction The type of the label that the prediction operation will produce (output)
   *
   */
-trait EvaluateDataSetOperation[Instance, Testing, Prediction] extends Serializable{
+trait EvaluateDataSetOperation[Instance, Testing, Prediction] extends
+  PrepareOperation[Instance, Testing, DataSet[(Prediction,Prediction)]] {
+
+  override def prepare(als: Instance,
+                       test: DataSet[Testing],
+                       parameters: ParameterMap)
+  : DataSet[(Prediction, Prediction)] =
+    evaluateDataSet(als, parameters, test)
+
   def evaluateDataSet(
       instance: Instance,
       evaluateParameters: ParameterMap,

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/regression/MultipleLinearRegression.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/regression/MultipleLinearRegression.scala
@@ -90,7 +90,7 @@ import org.apache.flink.ml.pipeline.{PredictOperation, FitOperation, Predictor}
   *  [[LearningRateMethod]] for all supported methods.
   *
   */
-class MultipleLinearRegression extends Predictor[MultipleLinearRegression] {
+class MultipleLinearRegression extends Regressor[MultipleLinearRegression]  {
   import org.apache.flink.ml._
   import MultipleLinearRegression._
 

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/regression/Regressor.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/regression/Regressor.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.regression
+
+import org.apache.flink.ml.pipeline.Predictor
+
+/** Trait that regression algorithms should implement
+  *
+  * @tparam Self Type of the implementing class
+  */
+trait Regressor[Self] extends Predictor[Self]{
+  that: Self =>
+
+}

--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/MLUtilsSuite.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/MLUtilsSuite.scala
@@ -105,4 +105,14 @@ class MLUtilsSuite extends FlatSpec with Matchers with FlinkTestBase {
 
     tempFile.delete()
   }
+
+  it should "correctly find the mean of a DataSet" in  {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val ds = env.fromCollection(List(5.0, -5.0, 0.0))
+
+    val mean = ds.mean().collect().head
+
+    mean should be (0.0 +- 1e-9)
+  }
 }

--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/classification/SVMITSuite.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/classification/SVMITSuite.scala
@@ -20,7 +20,7 @@ package org.apache.flink.ml.classification
 
 import org.apache.flink.ml.util.FlinkTestBase
 import org.scalatest.{FlatSpec, Matchers}
-import org.apache.flink.ml.math.DenseVector
+import org.apache.flink.ml.math.{Vector => FlinkVector, DenseVector}
 
 import org.apache.flink.api.scala._
 
@@ -28,30 +28,7 @@ class SVMITSuite extends FlatSpec with Matchers with FlinkTestBase {
 
   behavior of "The SVM using CoCoA implementation"
 
-  it should "train a SVM" in {
-    val env = ExecutionEnvironment.getExecutionEnvironment
-
-    val svm = SVM().
-    setBlocks(env.getParallelism).
-    setIterations(100).
-    setLocalIterations(100).
-    setRegularization(0.002).
-    setStepsize(0.1).
-    setSeed(0)
-
-    val trainingDS = env.fromCollection(Classification.trainingData)
-
-    svm.fit(trainingDS)
-
-    val weightVector = svm.weightsOption.get.collect().head
-
-    weightVector.valueIterator.zip(Classification.expectedWeightVector.valueIterator).foreach {
-      case (weight, expectedWeight) =>
-        weight should be(expectedWeight +- 0.1)
-    }
-  }
-
-  it should "make (mostly) correct predictions" in {
+  def fixture = new {
     val env = ExecutionEnvironment.getExecutionEnvironment
 
     val svm = SVM().
@@ -62,13 +39,33 @@ class SVMITSuite extends FlatSpec with Matchers with FlinkTestBase {
       setStepsize(0.1).
       setSeed(0)
 
+
     val trainingDS = env.fromCollection(Classification.trainingData)
 
-    val test = trainingDS.map(x => (x.vector, x.label))
+    val test = trainingDS.map(x => x.vector)
 
     svm.fit(trainingDS)
+  }
 
-    val predictionPairs = svm.evaluate(test)
+  it should "train a SVM" in {
+
+    val f = fixture
+
+    val weightVector = f.svm.weightsOption.get.collect().head
+
+    weightVector.valueIterator.zip(Classification.expectedWeightVector.valueIterator).foreach {
+      case (weight, expectedWeight) =>
+        weight should be(expectedWeight +- 0.1)
+    }
+  }
+
+  it should "make (mostly) correct predictions" in {
+
+    val f = fixture
+
+    val test = f.trainingDS
+
+    val predictionPairs = f.svm.evaluate(test)
 
     val absoluteErrorSum = predictionPairs.collect().map{
       case (truth, prediction) => Math.abs(truth - prediction)}.sum
@@ -98,7 +95,5 @@ class SVMITSuite extends FlatSpec with Matchers with FlinkTestBase {
     val rawPrediction = svm.predict(test).map(vectorLabel => vectorLabel._2).collect().head
 
     rawPrediction should be (15.0 +- 1e-9)
-
-
   }
 }

--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/evaluation/RankingScoreITSuite.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/evaluation/RankingScoreITSuite.scala
@@ -1,0 +1,352 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.ml.evaluation
+
+import org.apache.flink.api.scala._
+import org.apache.flink.ml.common.ParameterMap
+import org.apache.flink.ml.pipeline.{PredictDataSetOperation, RankingFromRatingPredictOperation,
+RankingPredictor, TrainingRatingsProvider}
+import org.apache.flink.ml.util.FlinkTestBase
+import org.scalatest.{FlatSpec, Matchers}
+
+class RankingScoreITSuite extends FlatSpec with Matchers with FlinkTestBase {
+
+  def log2(d : Double) = scala.math.log(d)/scala.math.log(2)
+
+  behavior of "ndcgScore"
+
+  it should "calculate idcgs correctly" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val test = env.fromCollection(Seq(
+      (1,1,0.7),
+      (1,2,0.9),
+      (1,3,0.8),
+      (1,4,1.0),
+      (2,1,0.9),
+      (2,2,0.6)
+    ))
+    val idcgs = RankingScores.ndcgScore(3).calculateIdcgs(test).collect()
+    idcgs.toSet shouldEqual Set(
+      (1, 1/log2(2) + 0.9/log2(3) + 0.8/log2(4) ),
+      (2, 0.9/log2(2) + 0.6/log2(3))
+    )
+  }
+  it should "calculate dcgs correctly" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val test = env.fromCollection(Seq(
+      (1,1,0.7),
+      (1,2,0.9),
+      (1,3,0.8),
+      (1,4,1.0),
+      (2,1,0.9),
+      (2,2,0.6),
+      (3,1,0.9)
+    ))
+    val predictions = env.fromCollection(Seq(
+      (1,10,1),
+      (1,3,2),
+      (2,5,1),
+      (2,6,2),
+      (3,1,1),
+      (3,2,2)
+    ))
+    val dcgs = RankingScores.ndcgScore(4).calculateDcgs(predictions, test).collect()
+    dcgs.toSet shouldEqual Set(
+      (1, 0.8/log2(3) ),
+      (2, 0.0),
+      (3, 0.9/log2(2) )
+    )
+  }
+  it should "calculate ndcgs correctly" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val idcgs = env.fromCollection(Seq(
+      (1,2.0),
+      (2,4.0),
+      (3,1.0),
+      (4,2.5),
+      (5,3.0)
+    ))
+    val dcgs = env.fromCollection(Seq(
+      (1,1.0),
+      (2,0.0),
+      (3,1.0)
+    ))
+    val ndcgs = RankingScores.ndcgScore(4).calculateNdcgs(dcgs, idcgs).collect()
+    ndcgs.toSet shouldEqual Set(
+      (1,0.5),
+      (2,0.0),
+      (3,1.0)
+    )
+  }
+  it should "calculate ndcg correctly" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val test = env.fromCollection(Seq(
+      (1,1,0.7),
+      (1,2,0.9),
+      (1,3,0.8),
+      (1,4,1.0),
+      (2,1,0.9),
+      (2,2,0.6),
+      (3,1,0.9)
+    ))
+    val predictions = env.fromCollection(Seq(
+      (1,10,1),
+      (1,3,2),
+      (2,5,1),
+      (2,6,2),
+      (3,1,1),
+      (3,2,2)
+    ))
+    val ndcgs = RankingScores.ndcgScore(4).evaluate((test, predictions)).collect()
+    ndcgs.toSet shouldEqual Set(
+      (
+        (0.8/log2(3))/(1.0/log2(2) + 0.9/log2(3) + 0.8/log2(4) + 0.7/log2(5)) + //item 1 dcg/idcg
+        0 + //item 2 dcg/idcg
+        (0.9/log2(2))/(0.9/log2(2)) //item 3 dcg/idcg
+      ) / 3
+    )
+  }
+
+  behavior of "precision and recall scores"
+
+  it should "join recommendations with test correctly" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val recommendations = env.fromCollection(Seq(
+      (1,1,1),
+      (1,2,2),
+      (1,3,3),
+      (2,4,1),
+      (2,5,2),
+      (2,1,3)
+    ))
+    val test = env.fromCollection(Seq(
+      (1,1,1.0),
+      (1,10,2.0),
+      (2,1,1.0),
+      (2,3,1.0),
+      (2,12,1.0),
+      (2,5,1.0),
+      (2,13,1.0),
+      (2,7,1.0)
+    ))
+    val joined = RankingScores.PrecisionAndRecallScoresUtilities.joinWithTest(recommendations, test)
+      .collect()
+    joined.toSet shouldEqual Set(
+      (1,1,Some(1),"true_positive"),
+      (1,2,Some(2),"false_positive"),
+      (1,3,Some(3),"false_positive"),
+      (1,10,None,"false_negative"),
+      (2,1,Some(3),"true_positive"),
+      (2,3,None,"false_negative"),
+      (2,4,Some(1),"false_positive"),
+      (2,5,Some(2),"true_positive"),
+      (2,7,None,"false_negative"),
+      (2,12,None,"false_negative"),
+      (2,13,None,"false_negative")
+    )
+  }
+  it should "count the types per user correctly" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val setToCount = env.fromCollection(Seq(
+      (1,1,Some(1),"true_positive"),
+      (1,2,Some(2),"false_positive"),
+      (1,3,Some(3),"false_positive"),
+      (1,10,None,"false_negative"),
+      (2,1,Some(3),"true_positive"),
+      (2,3,None,"false_negative"),
+      (2,4,Some(1),"false_positive"),
+      (2,5,Some(2),"true_positive"),
+      (2,7,None,"false_negative"),
+      (2,12,None,"false_negative"),
+      (2,13,None,"false_negative")
+    ))
+    val counted = RankingScores.PrecisionAndRecallScoresUtilities.countTypes(setToCount).collect()
+    counted.toSet shouldEqual Set(
+      (1,1,2,1),
+      (2,2,1,4)
+    )
+  }
+  it should "calculate precisions correctly" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val recommendations = env.fromCollection(Seq(
+      (1,1,1),
+      (1,2,2),
+      (1,3,3),
+      (2,4,1),
+      (2,5,2),
+      (2,1,3)
+    ))
+    val test = env.fromCollection(Seq(
+      (1,1,1.0),
+      (1,10,2.0),
+      (2,1,1.0),
+      (2,3,1.0),
+      (2,12,1.0),
+      (2,5,1.0),
+      (2,13,1.0),
+      (2,7,1.0)
+    ))
+    val precisions = RankingScores.PrecisionAndRecallScoresUtilities
+      .precisions(recommendations, test).collect()
+    precisions.toSet shouldEqual Set(
+      (1,1.0/3.0),
+      (2,2.0/3.0)
+    )
+  }
+  it should "calculate recalls correctly" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val recommendations = env.fromCollection(Seq(
+      (1,1,1),
+      (1,2,2),
+      (1,3,3),
+      (2,4,1),
+      (2,5,2),
+      (2,1,3)
+    ))
+    val test = env.fromCollection(Seq(
+      (1,1,1.0),
+      (1,10,2.0),
+      (2,1,1.0),
+      (2,3,1.0),
+      (2,12,1.0),
+      (2,5,1.0),
+      (2,13,1.0),
+      (2,7,1.0)
+    ))
+    val recalls = RankingScores.PrecisionAndRecallScoresUtilities.recalls(recommendations, test)
+      .collect()
+    recalls.toSet shouldEqual Set(
+      (1,1.0/2.0),
+      (2,2.0/6.0)
+    )
+  }
+  it should "count the types per user up to k correctly" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val setToCount = env.fromCollection(Seq(
+      (1,1,Some(1),"true_positive"),
+      (1,2,None,"false_negative"),
+      (1,3,Some(3),"true_positive"),
+      (1,10,Some(2),"false_positive"),
+      (2,1,Some(3),"true_positive"),
+      (2,3,None,"false_negative"),
+      (2,4,Some(1),"false_positive"),
+      (2,5,Some(2),"true_positive"),
+      (2,7,None,"false_negative"),
+      (2,12,None,"false_negative"),
+      (2,13,None,"false_negative")
+    ))
+    val counted = RankingScores.PrecisionAndRecallScoresUtilities.countTypesUpToK(setToCount)
+      .collect()
+    counted.toSet shouldEqual Set(
+      (1,1,1,0,2),
+      (1,2,1,1,2),
+      (1,3,2,1,1),
+      (2,1,0,1,6),
+      (2,2,1,1,5),
+      (2,3,2,1,4)
+    )
+  }
+  it should "calculate mean average precision per user correctly" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val recommendations = env.fromCollection(Seq(
+      (1,1,1),
+      (1,2,2),
+      (1,3,3),
+      (2,4,1),
+      (2,5,2),
+      (2,1,3)
+    ))
+    val test = env.fromCollection(Seq(
+      (1,1,1.0),
+      (1,10,2.0),
+      (2,1,1.0),
+      (2,3,1.0),
+      (2,12,1.0),
+      (2,5,1.0),
+      (2,13,1.0),
+      (2,7,1.0)
+    ))
+    val precisionAndRecall = RankingScores
+      .PrecisionAndRecallScoresUtilities
+      .meanAveragePrecisionAndRecall(recommendations, test).collect()
+
+    //    (1,1,1,0,1)
+    //    (1,2,1,1,1)
+    //    (1,3,1,2,1)
+    //    (2,1,0,1,6)
+    //    (2,2,1,1,5)
+    //    (2,3,2,1,4)
+
+    precisionAndRecall.toSet shouldEqual Set(
+      (1, (1.0/1.0+1.0/2.0+1.0/3.0)/3, (1.0/2.0 + 1.0/2.0 + 1.0/2.0)/3),
+      (2, (0.0/1.0+1.0/2.0+2.0/3.0)/3, (0.0/6.0 + 1.0/6.0 + 2.0/6.0)/3)
+    )
+  }
+
+  behavior of "ranking scores and scorer"
+  it should "be possible to evaluate a RankingPredictor using a scorer" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    class MockFromRatingPredictor extends RankingPredictor[MockFromRatingPredictor]
+      with TrainingRatingsProvider {
+      override def getTrainingItems: DataSet[Int] =
+        env.fromCollection(Seq(1,2,3))
+      override def getTrainingData: DataSet[(Int, Int, Double)] =
+        env.fromCollection(Seq((3,1,1.0),(3,2,1.0),(3,3,1.0),(3,4,1.0), (3,5,1.0)))
+    }
+
+    val mockedPredictor = new PredictDataSetOperation[
+      MockFromRatingPredictor, (Int, Int), (Int ,Int, Double)] {
+      override def predictDataSet(
+        instance: MockFromRatingPredictor,
+        predictParameters: ParameterMap,
+        input: DataSet[(Int, Int)])
+      : DataSet[(Int, Int, Double)] = env.fromCollection(Seq(
+        (1,1,0.7),
+        (1,2,0.9),
+        (1,3,0.8),
+        (1,4,1.0),
+        (2,2,0.8),
+        (2,3,1.0)
+      ))
+    }
+
+    implicit val rankingFromRatingPredictOperation =
+      new RankingFromRatingPredictOperation(mockedPredictor)
+
+    val predictor = new MockFromRatingPredictor
+
+    val test = env.fromCollection(Seq(
+      (1,1,1.0),
+      (1,10,2.0),
+      (2,1,1.0),
+      (2,2,1.0)
+    ))
+
+    val scorer = new Scorer(RankingScores.ndcgScore(100))
+    // todo: fix implicit scoping
+    val result = scorer.evaluate(test, predictor, new ParameterMap)(
+      Scorer.defaultRankingEvalPrepare)
+    result.collect().toSet shouldEqual Set(
+      (
+        (1.0/log2(5))/(2.0/log2(2)+1.0/log2(3)) +
+        (1.0/log2(3))/(1.0/log2(2)+1.0/log2(3))
+      ) / 2
+    )
+  }
+}

--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/evaluation/ScoreITSuite.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/evaluation/ScoreITSuite.scala
@@ -16,11 +16,13 @@
  * limitations under the License.
  */
 
+
 package org.apache.flink.ml.evaluation
 
 import org.apache.flink.api.scala._
 import org.apache.flink.ml.util.FlinkTestBase
 import org.scalatest.{FlatSpec, Matchers}
+
 
 class ScoreITSuite extends FlatSpec with Matchers with FlinkTestBase {
 

--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/evaluation/ScoreITSuite.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/evaluation/ScoreITSuite.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.evaluation
+
+import org.apache.flink.api.scala._
+import org.apache.flink.ml.util.FlinkTestBase
+import org.scalatest.{FlatSpec, Matchers}
+
+class ScoreITSuite extends FlatSpec with Matchers with FlinkTestBase {
+
+  behavior of "Evaluation Score functions"
+
+  it should "work for squared loss" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val yy = env.fromCollection(Seq((0.0, 1.0), (0.0, 0.0), (3.0, 5.0)))
+
+    val loss = RegressionScores.squaredLoss
+
+    val result = loss.evaluate(yy).collect()
+
+    result.length shouldBe 1
+    result.head shouldBe (1.6666666666 +- 1e-4)
+  }
+
+  it should "work for zero one loss" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val yy = env.fromCollection(Seq(1.0 -> 1.0, 2.0 -> 2.0, 3.0 -> 4.0, 4.0 -> 5.0))
+
+    val loss = ClassificationScores.zeroOneLoss
+
+    val result = loss.evaluate(yy).collect()
+
+    result.length shouldBe 1
+    result.head shouldBe (0.5 +- 1e9)
+  }
+
+  it should "work for zero one loss applied to signs" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val yy = env.fromCollection(Seq[(Double,Double)](
+      -2.3 -> 2.3, -1.0 -> -10.5, 2.0 -> 3.0, 4.0 -> -5.0))
+
+    val loss = RegressionScores.zeroOneSignumLoss
+
+    val result = loss.evaluate(yy).collect()
+
+    result.length shouldBe 1
+    result.head shouldBe (0.5 +- 1e9)
+  }
+
+  it should "work for accuracy score" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val yy = env.fromCollection(Seq(0.0 -> 0.0, 1.0 -> 1.0, 2.0 -> 2.0, 3.0 -> 2.0))
+
+    val accuracyScore = ClassificationScores.accuracyScore
+
+    val result = accuracyScore.evaluate(yy).collect()
+
+    result.length shouldBe 1
+    result.head shouldBe (0.75 +- 1e9)
+  }
+
+  it should "calculate the R2 score correctly" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    // List of 50 (i, i + 1.0) tuples, where i the index
+    val valueList = Range.Double(0.0, 50.0, 1.0) zip Range.Double(0.0, 50.0, 1.0).map(_ + 1)
+
+    val yy = env.fromCollection(valueList)
+
+    val r2 = RegressionScores.r2Score
+
+    val result = r2.evaluate(yy).collect()
+
+    result.length shouldBe 1
+    result.head shouldBe (0.99519807923169268 +- 1e9)
+  }
+
+  it should "calculate the R2 score correctly for edge cases" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    // List of 50 (0.0, 1.0) tuples
+    val valueList = Array.ofDim[Double](50) zip Array.ofDim[Double](50).map(_ + 1.0)
+
+    val yy = env.fromCollection(valueList)
+
+    val r2 = RegressionScores.r2Score
+
+    val result = r2.evaluate(yy).collect()
+
+    result.length shouldBe 1
+    result.head shouldBe (0.0 +- 1e9)
+  }
+}

--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/evaluation/ScorerITSuite.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/evaluation/ScorerITSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.ml.evaluation
+
+import org.apache.flink.api.scala._
+import org.apache.flink.ml.common.ParameterMap
+import org.apache.flink.ml.preprocessing.StandardScaler
+import org.apache.flink.ml.regression.MultipleLinearRegression
+import org.apache.flink.ml.regression.RegressionData._
+import org.apache.flink.ml.util.FlinkTestBase
+import org.scalatest.{FlatSpec, Matchers}
+
+class ScorerITSuite  extends FlatSpec with Matchers with FlinkTestBase {
+
+  behavior of "the Scorer class"
+
+  def fixture =  new {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val loss = RegressionScores.squaredLoss
+
+    val scorer = new Scorer(loss)
+
+    val mlr = MultipleLinearRegression()
+
+    val parameters = ParameterMap()
+
+    parameters.add(MultipleLinearRegression.Stepsize, 1.0)
+    parameters.add(MultipleLinearRegression.Iterations, 10)
+    parameters.add(MultipleLinearRegression.ConvergenceThreshold, 0.001)
+
+    val inputDS = env.fromCollection(data)
+  }
+
+  it should "work for squared loss" in {
+
+    val f =  fixture
+
+    f.mlr.fit(f.inputDS, f.parameters)
+
+    val evaluationDS = f.inputDS.map(x => (x.vector, x.label))
+
+    val mse = f.scorer.evaluate(evaluationDS, f.mlr).collect().head
+
+    mse should be < 2.0
+  }
+
+  it should "be possible to obtain scores for a chained predictor" in {
+    val f = fixture
+
+    val scaler = StandardScaler()
+
+    val chainedMLR = scaler.chainPredictor(f.mlr)
+
+    chainedMLR.fit(f.inputDS, f.parameters)
+
+    val evaluationDS = f.inputDS.map(x => (x.vector, x.label))
+
+    val mse = f.scorer.evaluate(evaluationDS, chainedMLR).collect().head
+
+    mse should be < 2.0
+  }
+}

--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/pipeline/RankingPredictorTest.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/pipeline/RankingPredictorTest.scala
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.ml.pipeline
+
+import org.apache.flink.api.scala._
+import org.apache.flink.ml.common.ParameterMap
+import org.apache.flink.ml.util.FlinkTestBase
+import org.scalatest.{FlatSpec, Matchers}
+
+class RankingPredictorTest extends FlatSpec with Matchers with FlinkTestBase {
+
+  behavior of "Evaluation of ranking prediction"
+  it should "make ranking predictions correctly based on rating predictions" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val mockedPredictor = new PredictDataSetOperation[
+      MockFromRatingPredictor, (Int, Int), (Int ,Int, Double)] {
+      override def predictDataSet(
+        instance: MockFromRatingPredictor,
+        predictParameters: ParameterMap,
+        input: DataSet[(Int, Int)])
+      : DataSet[(Int, Int, Double)] = env.fromCollection(Seq(
+        (1,1,0.7),
+        (1,2,0.9),
+        (1,3,0.8),
+        (1,4,1.0),
+        (2,1,0.9),
+        (2,2,0.8),
+        (2,3,1.0),
+        (2,4,0.1),
+        (2,5,0.9)
+      ))
+    }
+    val rankingFromRatingPredictOperation = new RankingFromRatingPredictOperation(mockedPredictor)
+    class MockFromRatingPredictor extends RankingPredictor[MockFromRatingPredictor]
+      with TrainingRatingsProvider {
+      override def getTrainingItems: DataSet[Int] =
+        env.fromCollection(Seq(1,2,3))
+      override def getTrainingData: DataSet[(Int, Int, Double)] =
+        env.fromCollection(Seq((3,1,1.0),(3,2,1.0),(3,3,1.0),(3,4,1.0), (3,5,1.0)))
+    }
+
+    val mockPredictor = new MockFromRatingPredictor()
+    val users = env.fromCollection(Seq(1,2))
+    val rankings = mockPredictor.predictRankings(3,users,new ParameterMap)(
+      rankingFromRatingPredictOperation).collect()
+    rankings.toSet shouldBe Set(
+      (1,4,1),
+      (1,2,2),
+      (1,3,3),
+      (2,3,1),
+      (2,5,2),
+      (2,1,3)
+    )
+  }
+  it should "use default itemsgetter if necessary" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val mockedPredictor = new PredictDataSetOperation[
+      MockFromRatingPredictor, (Int, Int), (Int ,Int, Double)] {
+      override def predictDataSet(
+        instance: MockFromRatingPredictor,
+        predictParameters: ParameterMap,
+        input: DataSet[(Int, Int)])
+      : DataSet[(Int, Int, Double)] = env.fromCollection(Seq(
+        (1,1,0.7),
+        (1,2,0.9),
+        (1,3,0.8),
+        (1,4,1.0),
+        (2,1,0.9),
+        (2,2,0.8),
+        (2,3,1.0),
+        (2,4,0.1),
+        (2,5,0.9)
+      ))
+    }
+    val rankingFromRatingPredictOperation = new RankingFromRatingPredictOperation(mockedPredictor)
+    class MockFromRatingPredictor extends RankingPredictor[MockFromRatingPredictor]
+      with TrainingRatingsProvider {
+      override def getTrainingData: DataSet[(Int, Int, Double)] =
+        env.fromCollection(Seq((3,1,1.0),(3,2,1.0),(3,3,1.0),(3,4,1.0), (3,5,1.0)))
+    }
+
+    val mockPredictor = new MockFromRatingPredictor()
+    val users = env.fromCollection(Seq(1,2))
+    val rankings = mockPredictor.predictRankings(3,users,new ParameterMap)(
+      rankingFromRatingPredictOperation).collect()
+    rankings.toSet shouldBe Set(
+      (1,4,1),
+      (1,2,2),
+      (1,3,3),
+      (2,3,1),
+      (2,5,2),
+      (2,1,3)
+    )
+  }
+  it should "exclude pairs from ranking predictions if asked to" in {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    var calledArguments :DataSet[(Int,Int)] = null
+    val mockedPredictor = new PredictDataSetOperation[
+      MockPredictor, (Int, Int), (Int ,Int, Double)] {
+      override def predictDataSet(
+        instance: MockPredictor,
+        predictParameters: ParameterMap,
+        input: DataSet[(Int, Int)])
+      : DataSet[(Int, Int, Double)] = {
+        calledArguments = input
+        env.fromCollection(Seq(
+          (1,1,0.7),
+          (1,2,0.9),
+          (1,3,0.8),
+          (1,4,1.0),
+          (2,1,0.9),
+          (2,2,0.8),
+          (2,3,1.0),
+          (2,4,0.1),
+          (2,5,0.9)
+        ))
+      }
+    }
+    val rankingFromRatingPredictOperation = new RankingFromRatingPredictOperation(mockedPredictor)
+    class MockPredictor extends RankingPredictor[MockPredictor] with TrainingRatingsProvider{
+      override def getTrainingData: DataSet[(Int, Int, Double)] =
+        env.fromCollection(Seq((3,1,1.0),(3,2,1.0),(2,3,1.0)))
+      override def getTrainingItems: DataSet[Int] =
+        env.fromCollection(Seq(1,2,3,4,5))
+    }
+    val mockPredictor = new MockPredictor()
+    val users = env.fromCollection(Seq(1,2))
+    val par = new ParameterMap
+    mockPredictor.predictRankings(3,users,par)(rankingFromRatingPredictOperation).collect()
+    calledArguments.collect().toSet shouldBe Set(
+      (1,1),
+      (1,2),
+      (1,3),
+      (1,4),
+      (1,5),
+      (2,1),
+      (2,2),
+      (2,4),
+      (2,5)
+    )
+    par.add(RankingPredictor.ExcludeKnown, false)
+    mockPredictor.predictRankings(3,users,par)(rankingFromRatingPredictOperation).collect()
+    calledArguments.collect().toSet shouldBe Set(
+      (1,1),
+      (1,2),
+      (1,3),
+      (1,4),
+      (1,5),
+      (2,1),
+      (2,2),
+      (2,3),
+      (2,4),
+      (2,5)
+    )
+  }
+}

--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/recommendation/ALSITSuite.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/recommendation/ALSITSuite.scala
@@ -25,6 +25,8 @@ import scala.language.postfixOps
 
 import org.apache.flink.api.scala._
 
+import Recommendation._
+
 class ALSITSuite
   extends FlatSpec
   with Matchers
@@ -34,8 +36,7 @@ class ALSITSuite
 
   behavior of "The alternating least squares (ALS) implementation"
 
-  it should "properly factorize a matrix" in {
-    import Recommendation._
+  def fixture = new {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
 
@@ -49,28 +50,33 @@ class ALSITSuite
 
     als.fit(inputDS)
 
-    val testData = env.fromCollection(expectedResult.map{
-      case (userID, itemID, rating) => (userID, itemID)
-    })
+    val evaluationData = env.fromCollection(expectedResult)
 
-    val predictions = als.predict(testData).collect()
+    val testData = evaluationData.map(idsAndRating => (idsAndRating._1 , idsAndRating._2))
+  }
+
+  it should "properly factorize a matrix" in {
+
+    val f =  fixture
+
+    val predictions = f.als.predict(f.testData).collect()
 
     predictions.length should equal(expectedResult.length)
 
     val resultMap = expectedResult map {
-      case (uID, iID, value) => (uID, iID) -> value
+      case (uID, iID, rating) => (uID, iID) -> rating
     } toMap
 
     predictions foreach {
-      case (uID, iID, value) => {
-        resultMap.isDefinedAt((uID, iID)) should be(true)
+      case (uID, iID, rating) => {
+        resultMap.isDefinedAt((uID, iID)) should be (true)
 
-        value should be(resultMap((uID, iID)) +- 0.1)
+        rating should be(resultMap((uID, iID)) +- 0.1)
       }
     }
 
-    val risk = als.empiricalRisk(inputDS).collect().head
+    val risk = f.als.empiricalRisk(f.inputDS).collect().head
 
-    risk should be(expectedEmpiricalRisk +- 1)
+    risk should be (expectedEmpiricalRisk +- 1)
   }
 }


### PR DESCRIPTION
Please note that this is a work-in-progress PR for discussing API design decisions. We propose here a class hierarchy for fitting the ranking evaluations into the proposed evaluation framework (see [PR](https://github.com/apache/flink/pull/1849)).
The features are mostly working, but documentation is missing and minor refactoring is needed. The evaluations currently work with top 100 rankings (burnt-in), and we still need to fix that. We need feedback for two main solutions, so we can go on with the PR. Thanks for any comment!

### `RankingPredictor`

We have managed to rework the evaluation framework proposed by @thvasilo, so that ranking predictions would fit in. Our approach is to use separate `RankingPredictor` and `Predictor` traits. One main problem however remains: there is no common superclass for `RankingPredictor` and `Predictor` so the pipelining mechanism might not work. A `Predictor` can only be at the and of the pipeline, so this should not really be a problem, but I do not know for sure. An alternative solution would be to have different objects `ALS` and `RankingALS` that give different predictions, but both extends only a `Predictor`. There could be implicit conversions between the two. I would prefer the current solution if it does not break the pipelining. @thvasilo what do you think about this?

(This seems to be a problem similar to having a `predict_proba` function in scikit learn classification models, where the same model for the same input gives two different predictions: a `predict` for discrete predictions and `predict_proba` for giving a probability.)

### Generalizing `EvalutateDataSetOperation`

On the other hand, we seem to have solved the scoring issue. The users can evaluate a recommendation algorithm such as ALS by using a score operating on rankings (e.g. nDCG), or a score operating on ratings (e.g. RMSE). They only need to modify the `Score` they use in their code, and nothing else.

The main problem was that the evaluate method and `EvaluateDataSetOperation` were not general enough. They prepare the evaluation to `(trueValue, predictedValue)` pairs (i.e. a `DataSet[(PredictionType, PredictionType)]`), while ranking evaluations needed a more general input with the true ratings (`DataSet[(Int,Int,Double)]`) and the predicted rankings (`DataSet[(Int,Int,Int)]`).

Instead of using `EvaluateDataSetOperation` we use a more general `PrepareOperation`. We rename the `Score` in the original evaluation framework to `PairwiseScore`. `RankingScore` and `PairwiseScore` has a common trait `Score`. This way the user can use both a `RankingScore` and a `PairwiseScore` for a certain model, and only need to alter the score used in the code.

In case of pairwise scores (that only need true and predicted value pairs for evaluation) `EvaluateDataSetOperation` is used as a `PrepareOperation`. It prepares the evaluation by creating `(trueValue, predicitedValue)` pairs from the test dataset. Thus, the result of preparing and the input of `PairwiseScore`s will be `DataSet[(PredictionType,PredictionType)]`. In case of rankings the `PrepareOperation` passes the test dataset and creates the rankings. The result of preparing and the input of `RankingScore`s will be `(DataSet[Int,Int,Double], DataSet[Int,Int,Int])`. I believe this is a fairly acceptable solution that avoids breaking the API.