### PR TITLE
[FLINK-5071][yarn] adjust vcore validation check

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -305,12 +305,17 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			throw new YarnDeploymentException("Flink configuration object has not been set");
 		}
 
+		// Check if we don't exceed YARN's maximum virtual cores.
+		// The number of cores can be configured in the config.
+		// If not configured, it is set to the number of task slots
 		int numYarnVcores = conf.getInt(YarnConfiguration.NM_VCORES, YarnConfiguration.DEFAULT_NM_VCORES);
+		int configuredVcores = flinkConfiguration.getInteger(ConfigConstants.YARN_VCORES, slots);
 		// don't configure more than the maximum configured number of vcores
-		if (slots > numYarnVcores) {
+		if (configuredVcores > numYarnVcores) {
 			throw new IllegalConfigurationException(
-				String.format("The number of task slots per node was configured with %d" +
-					" but Yarn only has %d virtual cores available.", slots, numYarnVcores));
+				String.format("The number of virtual cores per node were configured with %d" +
+					" but Yarn only has %d virtual cores available.",
+					configuredVcores, numYarnVcores));
 		}
 
 		// check if required Hadoop environment variables are set. If not, warn user

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -314,8 +314,10 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		if (configuredVcores > numYarnVcores) {
 			throw new IllegalConfigurationException(
 				String.format("The number of virtual cores per node were configured with %d" +
-					" but Yarn only has %d virtual cores available.",
-					configuredVcores, numYarnVcores));
+						" but Yarn only has %d virtual cores available. Please note that the number" +
+						" of virtual cores is set to the number of task slots by default unless configured" +
+						" in the Flink config with '%s.'",
+					configuredVcores, numYarnVcores, ConfigConstants.YARN_VCORES));
 		}
 
 		// check if required Hadoop environment variables are set. If not, warn user

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.yarn;
 
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.hadoop.fs.Path;
@@ -47,7 +48,6 @@ public class YarnClusterDescriptorTest {
 	@Test
 	public void testFailIfTaskSlotsHigherThanMaxVcores() {
 
-
 		YarnClusterDescriptor clusterDescriptor = new YarnClusterDescriptor();
 
 		clusterDescriptor.setLocalJarPath(new Path(flinkJar.getPath()));
@@ -65,5 +65,28 @@ public class YarnClusterDescriptorTest {
 		}
 	}
 
+	@Test
+	public void testConfigOverwrite() {
 
+		YarnClusterDescriptor clusterDescriptor = new YarnClusterDescriptor();
+
+		Configuration configuration = new Configuration();
+		// overwrite vcores in config
+		configuration.setInteger(ConfigConstants.YARN_VCORES, Integer.MAX_VALUE);
+
+		clusterDescriptor.setLocalJarPath(new Path(flinkJar.getPath()));
+		clusterDescriptor.setFlinkConfiguration(configuration);
+		clusterDescriptor.setConfigurationDirectory(temporaryFolder.getRoot().getAbsolutePath());
+		clusterDescriptor.setConfigurationFilePath(new Path(flinkConf.getPath()));
+
+		// configure slots
+		clusterDescriptor.setTaskManagerSlots(1);
+
+		try {
+			clusterDescriptor.deploy();
+		} catch (Exception e) {
+			e.printStackTrace();
+			Assert.assertTrue(e.getCause() instanceof IllegalConfigurationException);
+		}
+	}
 }


### PR DESCRIPTION
The check didn't take the virtual core settings configured in the Flink configuration into account.