### PR TITLE
[FLINK-4832] Count/Sum 0 elements

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetAggregate.scala
@@ -18,14 +18,18 @@
 
 package org.apache.flink.api.table.plan.nodes.dataset
 
+import com.google.common.collect.ImmutableList
+import org.apache.calcite.rex.RexLiteral
 import org.apache.calcite.plan.{RelOptCluster, RelOptCost, RelOptPlanner, RelTraitSet}
-import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rel.`type`.{RelDataTypeFactory, RelDataType}
+import org.apache.calcite.rel.core.{RelFactories, AggregateCall}
 import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.DataSet
+import org.apache.flink.api.java.operators.MapOperator
 import org.apache.flink.api.table.plan.nodes.FlinkAggregate
+import org.apache.flink.api.table.plan.rules.dataSet.DataSetValuesRule
 import org.apache.flink.api.table.runtime.aggregate.AggregateUtil
 import org.apache.flink.api.table.runtime.aggregate.AggregateUtil.CalcitePair
 import org.apache.flink.api.table.typeutils.{RowTypeInfo, TypeConverter}
@@ -133,7 +137,7 @@ class DataSetAggregate(
       else {
         // global aggregation
         val aggOpName = s"select:($aggString)"
-        mappedInput.asInstanceOf[DataSet[Row]]
+        mappedInput.asInstanceOf[DataSet[Row]].union(dummyRow(mappedInput,tableEnv))
           .reduceGroup(groupReduceFunction)
           .returns(rowTypeInfo)
           .name(aggOpName)
@@ -156,5 +160,42 @@ class DataSetAggregate(
         .name(mapName)
       case _ => result
     }
+  }
+
+  /**
+    * Dummy [[Row]] into a [[DataSet]] for result after map operations.
+    * @param mapOperator after which insert dummy records
+    * @param tableEnv [[BatchTableEnvironment]] for getting rel builder and type factory
+    * @tparam IN mapOperator input type
+    * @tparam OUT mapOperator output type
+    * @return DataSet of type Row is contains null literals for columns
+    */
+  private def dummyRow[IN,OUT](
+      mapOperator: MapOperator[IN,OUT],
+      tableEnv: BatchTableEnvironment): DataSet[Row] = {
+
+    val builder: RelDataTypeFactory.FieldInfoBuilder = getCluster.getTypeFactory.builder
+    val rowInfo = mapOperator.getResultType.asInstanceOf[RowTypeInfo]
+
+    val nullLiterals :ImmutableList[ImmutableList[RexLiteral]] =
+      ImmutableList.of(ImmutableList.copyOf[RexLiteral](
+        for (fieldName <- rowInfo.getFieldNames)
+          yield {
+            val columnType = tableEnv.getTypeFactory
+              .createTypeFromTypeInfo(rowInfo.getTypeAt(fieldName))
+            builder.add(fieldName, columnType)
+            tableEnv.getRelBuilder.getRexBuilder
+              .makeLiteral(null,columnType,false).asInstanceOf[RexLiteral]
+          }))
+
+    val dataType = builder.build()
+
+    val relNode = RelFactories.DEFAULT_VALUES_FACTORY
+      .createValues(getCluster, dataType, nullLiterals)
+
+    DataSetValuesRule.INSTANCE.asInstanceOf[DataSetValuesRule]
+      .convert(relNode).asInstanceOf[DataSetValues]
+      .translateToPlan(tableEnv, Some(TypeConverter.DEFAULT_ROW_TYPE))
+      .asInstanceOf[DataSet[Row]]
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/FlinkRuleSets.scala
@@ -99,6 +99,7 @@ object FlinkRuleSets {
 
     // translate to Flink DataSet nodes
     DataSetAggregateRule.INSTANCE,
+    DataSetAggregateWithNullValuesRule.INSTANCE,
     DataSetCalcRule.INSTANCE,
     DataSetJoinRule.INSTANCE,
     DataSetScanRule.INSTANCE,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetAggregateWithNullValuesRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetAggregateWithNullValuesRule.scala
@@ -48,7 +48,6 @@ class DataSetAggregateWithNullValuesRule
       return false
     }
 
-    // TODO code duplicates DataSetAggregateRule#matches
     // check if we have distinct aggregates
     val distinctAggs = agg.getAggCallList.exists(_.isDistinct)
     if (distinctAggs) {
@@ -79,19 +78,11 @@ class DataSetAggregateWithNullValuesRule
 
     val logicalValues = LogicalValues.create(cluster, agg.getInput.getRowType, nullLiterals)
     val logicalUnion = LogicalUnion.create(List(logicalValues, agg.getInput), true)
-    val logicalAggregate = new LogicalAggregate(
-      cluster,
-      traitSet,
-      logicalUnion,
-      true,
-      agg.getGroupSet,
-      agg.getGroupSets,
-      agg.getAggCallList)
 
     new DataSetAggregate(
       cluster,
       traitSet,
-      RelOptRule.convert(logicalAggregate.getInput, DataSetConvention.INSTANCE),
+      RelOptRule.convert(logicalUnion, DataSetConvention.INSTANCE),
       agg.getNamedAggCalls,
       rel.getRowType,
       agg.getInput.getRowType,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetAggregateWithNullValuesRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/rules/dataSet/DataSetAggregateWithNullValuesRule.scala
@@ -15,34 +15,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.api.table.plan.rules.dataSet
 
-import org.apache.calcite.plan.{RelOptRuleCall, Convention, RelOptRule, RelTraitSet}
+import org.apache.calcite.plan._
+import scala.collection.JavaConversions._
+import com.google.common.collect.ImmutableList
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
-import org.apache.calcite.rel.logical.LogicalAggregate
-import org.apache.flink.api.table.TableException
+import org.apache.calcite.rel.logical.{LogicalValues, LogicalUnion, LogicalAggregate}
+import org.apache.calcite.rex.RexLiteral
+import org.apache.flink.api.table._
 import org.apache.flink.api.table.plan.nodes.dataset.{DataSetAggregate, DataSetConvention}
-import scala.collection.JavaConversions._
 
-class DataSetAggregateRule
+/**
+  * Rule for insert [[Row]] with null records into a [[DataSetAggregate]]
+  * Rule apply for non grouped aggregate query
+  */
+class DataSetAggregateWithNullValuesRule
   extends ConverterRule(
-      classOf[LogicalAggregate],
-      Convention.NONE,
-      DataSetConvention.INSTANCE,
-      "DataSetAggregateRule")
-  {
+    classOf[LogicalAggregate],
+    Convention.NONE,
+    DataSetConvention.INSTANCE,
+    "DataSetAggregateWithNullValuesRule")
+{
 
   override def matches(call: RelOptRuleCall): Boolean = {
     val agg: LogicalAggregate = call.rel(0).asInstanceOf[LogicalAggregate]
 
-    //for non grouped agg sets should attach null row to source data
-    //need apply DataSetAggregateWithNullValuesRule
-    if (agg.getGroupSet.isEmpty) {
+    //for grouped agg sets shouldn't attach of null row
+    //need apply other rules. e.g. [[DataSetAggregateRule]]
+    if (!agg.getGroupSet.isEmpty) {
       return false
     }
 
+    // TODO code duplicates DataSetAggregateRule#matches
     // check if we have distinct aggregates
     val distinctAggs = agg.getAggCallList.exists(_.isDistinct)
     if (distinctAggs) {
@@ -50,30 +56,50 @@ class DataSetAggregateRule
     }
 
     // check if we have grouping sets
-    val groupSets = agg.getGroupSets.size() != 1 || agg.getGroupSets.get(0) != agg.getGroupSet
+    val groupSets = agg.getGroupSets.size() == 0 || agg.getGroupSets.get(0) != agg.getGroupSet
     if (groupSets || agg.indicator) {
       throw TableException("GROUPING SETS are currently not supported.")
     }
-
     !distinctAggs && !groupSets && !agg.indicator
   }
 
   override def convert(rel: RelNode): RelNode = {
     val agg: LogicalAggregate = rel.asInstanceOf[LogicalAggregate]
     val traitSet: RelTraitSet = rel.getTraitSet.replace(DataSetConvention.INSTANCE)
-    val convInput: RelNode = RelOptRule.convert(agg.getInput, DataSetConvention.INSTANCE)
+    val cluster: RelOptCluster = rel.getCluster
+
+    val fieldTypes = agg.getInput.getRowType.getFieldList.map(_.getType)
+    val nullLiterals :ImmutableList[ImmutableList[RexLiteral]] =
+      ImmutableList.of(ImmutableList.copyOf[RexLiteral](
+        for (fieldType <- fieldTypes)
+          yield {
+            cluster.getRexBuilder.
+              makeLiteral(null, fieldType, false).asInstanceOf[RexLiteral]
+          }))
+
+    val logicalValues = LogicalValues.create(cluster, agg.getInput.getRowType, nullLiterals)
+    val logicalUnion = LogicalUnion.create(List(logicalValues, agg.getInput), true)
+    val logicalAggregate = new LogicalAggregate(
+      cluster,
+      traitSet,
+      logicalUnion,
+      true,
+      agg.getGroupSet,
+      agg.getGroupSets,
+      agg.getAggCallList)
 
     new DataSetAggregate(
-      rel.getCluster,
+      cluster,
       traitSet,
-      convInput,
+      RelOptRule.convert(logicalAggregate.getInput, DataSetConvention.INSTANCE),
       agg.getNamedAggCalls,
       rel.getRowType,
       agg.getInput.getRowType,
-      agg.getGroupSet.toArray)
-    }
+      agg.getGroupSet.toArray
+    )
   }
+}
 
-object DataSetAggregateRule {
-  val INSTANCE: RelOptRule = new DataSetAggregateRule
+object DataSetAggregateWithNullValuesRule {
+  val INSTANCE: RelOptRule = new DataSetAggregateWithNullValuesRule
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/sql/AggregationsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/sql/AggregationsITCase.scala
@@ -258,4 +258,42 @@ class AggregationsITCase(
     // must fail. grouping sets are not supported
     tEnv.sql(sqlQuery).toDataSet[Row]
   }
+
+  @Test
+  def testDummyRecords(): Unit = {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val sqlQuery = "SELECT avg(a),sum(a),count(b) " +
+      "FROM MyTable where a = 4 group by a"
+
+    val sqlQuery2 = "SELECT avg(a),sum(a),count(b) " +
+      "FROM MyTable where a = 4"
+
+    val sqlQuery3 = "SELECT avg(a),sum(a),count(b) " +
+      "FROM MyTable"
+
+    val ds = env.fromElements(
+      (1: Byte, 1: Short),
+      (2: Byte, 2: Short))
+      .toTable(tEnv, 'a, 'b)
+
+    tEnv.registerTable("MyTable", ds)
+
+    val result = tEnv.sql(sqlQuery)
+    val result2 = tEnv.sql(sqlQuery2)
+    val result3 = tEnv.sql(sqlQuery3)
+
+    val results = result.toDataSet[Row].collect()
+    val expected = Seq.empty
+    val results2 = result2.toDataSet[Row].collect()
+    val expected2 = "null,null,0"
+    val results3 = result3.toDataSet[Row].collect()
+    val expected3 = "1,3,2"
+
+    assert(results.equals(expected), "Empty result is expected for grouped set, but actual: "+results)
+    TestBaseUtils.compareResultAsText(results2.asJava, expected2)
+    TestBaseUtils.compareResultAsText(results3.asJava, expected3)
+  }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/sql/AggregationsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/sql/AggregationsITCase.scala
@@ -260,7 +260,7 @@ class AggregationsITCase(
   }
 
   @Test
-  def testDummyRecords(): Unit = {
+  def testAggregateEmptyDataSets(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
@@ -287,12 +287,13 @@ class AggregationsITCase(
 
     val results = result.toDataSet[Row].collect()
     val expected = Seq.empty
-    val results2 = result2.toDataSet[Row].collect()
+    val results2 =  result2.toDataSet[Row].collect()
     val expected2 = "null,null,0"
     val results3 = result3.toDataSet[Row].collect()
     val expected3 = "1,3,2"
 
-    assert(results.equals(expected), "Empty result is expected for grouped set, but actual: "+results)
+    assert(results.equals(expected),
+      "Empty result is expected for grouped set, but actual: " + results)
     TestBaseUtils.compareResultAsText(results2.asJava, expected2)
     TestBaseUtils.compareResultAsText(results3.asJava, expected3)
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/table/AggregationsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/table/AggregationsITCase.scala
@@ -400,5 +400,36 @@ class AggregationsITCase(
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
+  @Test
+  def testDummyRecords(): Unit = {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val t =  env.fromElements(
+      (1: Byte, 1: Short),
+      (2: Byte, 2: Short))
+      .toTable(tEnv, 'a, 'b)
+
+    val result = t.groupBy('a)
+      .select('a, 'a.avg, 'a.sum, 'b.count)
+      .where('a === 4)
+
+    val result2 = t.select('a,'b).where('a === 4)
+      .select('a.avg,'a.sum,'b.count)
+    val result3 = t.select('a.avg,'a.sum,'b.count)
+
+    val results = result.toDataSet[Row].collect()
+    val expected = Seq.empty
+    val results2 = result2.toDataSet[Row].collect()
+    val expected2 = "null,null,0"
+    val results3 = result3.toDataSet[Row].collect()
+    val expected3 = "1,3,2"
+
+    assert(results.equals(expected),"Empty result is expected for grouped set, but actual: "+results)
+    TestBaseUtils.compareResultAsText(results2.asJava, expected2)
+    TestBaseUtils.compareResultAsText(results3.asJava, expected3)
+  }
+
 }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/table/AggregationsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/table/AggregationsITCase.scala
@@ -401,7 +401,7 @@ class AggregationsITCase(
   }
 
   @Test
-  def testDummyRecords(): Unit = {
+  def testAggregateEmptyDataSets(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
@@ -426,7 +426,8 @@ class AggregationsITCase(
     val results3 = result3.toDataSet[Row].collect()
     val expected3 = "1,3,2"
 
-    assert(results.equals(expected),"Empty result is expected for grouped set, but actual: "+results)
+    assert(results.equals(expected),
+      "Empty result is expected for grouped set, but actual: " + results)
     TestBaseUtils.compareResultAsText(results2.asJava, expected2)
     TestBaseUtils.compareResultAsText(results3.asJava, expected3)
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/table/AggregationsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/table/AggregationsITCase.scala
@@ -399,38 +399,5 @@ class AggregationsITCase(
     val results = t.toDataSet[Row].collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
-
-  @Test
-  def testAggregateEmptyDataSets(): Unit = {
-
-    val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
-
-    val t =  env.fromElements(
-      (1: Byte, 1: Short),
-      (2: Byte, 2: Short))
-      .toTable(tEnv, 'a, 'b)
-
-    val result = t.groupBy('a)
-      .select('a, 'a.avg, 'a.sum, 'b.count)
-      .where('a === 4)
-
-    val result2 = t.select('a,'b).where('a === 4)
-      .select('a.avg,'a.sum,'b.count)
-    val result3 = t.select('a.avg,'a.sum,'b.count)
-
-    val results = result.toDataSet[Row].collect()
-    val expected = Seq.empty
-    val results2 = result2.toDataSet[Row].collect()
-    val expected2 = "null,null,0"
-    val results3 = result3.toDataSet[Row].collect()
-    val expected3 = "1,3,2"
-
-    assert(results.equals(expected),
-      "Empty result is expected for grouped set, but actual: " + results)
-    TestBaseUtils.compareResultAsText(results2.asJava, expected2)
-    TestBaseUtils.compareResultAsText(results3.asJava, expected3)
-  }
-
 }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/AggregationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/AggregationTest.scala
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.table
+
+import org.apache.flink.api.scala._
+import org.apache.flink.api.scala.table._
+import org.apache.flink.api.table.utils.TableTestBase
+import org.apache.flink.api.table.utils.TableTestUtil._
+import org.junit.Test
+
+/**
+  * Test for testing aggregate plans.
+  */
+class AggregationTest extends TableTestBase {
+
+  @Test
+  def testAggregateQueryBatchSQL(): Unit = {
+    val util = batchTestUtil()
+    util.addTable[(Int, Long, Int)]("MyTable", 'a, 'b, 'c)
+
+    val sqlQuery = (
+      "SELECT avg(a),sum(b),count(c) FROM MyTable",
+      "SELECT avg(a),sum(b),count(c) FROM MyTable WHERE a = 1"
+    )
+
+    val calcNode = unaryNode(
+      "DataSetCalc",
+      batchTableNode(0),
+      term("select", "a", "b", "c"),
+      term("where", "=(a, 1)")
+    )
+
+    val setValues = (
+      unaryNode(
+        "DataSetValues",
+        batchTableNode(0),
+        tuples(List(null,null,null)),
+        term("values","a","b","c")
+      ),
+      unaryNode(
+        "DataSetValues",
+        calcNode,
+        tuples(List(null,null,null)),
+        term("values","a","b","c")
+      )
+    )
+    val union = (
+      unaryNode(
+      "DataSetUnion",
+      setValues._1,
+      term("union","a","b","c")
+    ),
+      unaryNode(
+      "DataSetUnion",
+      setValues._2,
+      term("union","a","b","c")
+      )
+    )
+
+    val aggregate = (
+      unaryNode(
+        "DataSetAggregate",
+        union._1,
+        term("select",
+          "AVG(a) AS EXPR$0",
+          "SUM(b) AS EXPR$1",
+          "COUNT(c) AS EXPR$2")
+      ),
+      unaryNode(
+        "DataSetAggregate",
+        union._2,
+        term("select",
+          "AVG(a) AS EXPR$0",
+          "SUM(b) AS EXPR$1",
+          "COUNT(c) AS EXPR$2")
+      )
+    )
+    util.verifySql(sqlQuery._1, aggregate._1)
+    util.verifySql(sqlQuery._2, aggregate._2)
+  }
+
+  @Test
+  def testAggregateGroupQueryBatchSQL(): Unit = {
+    val util = batchTestUtil()
+    util.addTable[(Int, Long, Int)]("MyTable", 'a, 'b, 'c)
+
+    val sqlQuery = (
+      "SELECT avg(a),sum(b),count(c) FROM MyTable GROUP BY a",
+      "SELECT avg(a),sum(b),count(c) FROM MyTable WHERE a = 1 GROUP BY a"
+      )
+
+    val calcNode = unaryNode(
+      "DataSetCalc",
+      batchTableNode(0),
+      term("select","a", "b", "c") ,
+      term("where","=(a, 1)")
+    )
+
+    val aggregate = (
+      unaryNode(
+        "DataSetAggregate",
+        batchTableNode(0),
+        term("groupBy", "a"),
+        term("select",
+          "a",
+          "AVG(a) AS EXPR$0",
+          "SUM(b) AS EXPR$1",
+          "COUNT(c) AS EXPR$2")
+      ),
+      unaryNode(
+        "DataSetAggregate",
+        calcNode,
+        term("groupBy", "a"),
+        term("select",
+          "a",
+          "AVG(a) AS EXPR$0",
+          "SUM(b) AS EXPR$1",
+          "COUNT(c) AS EXPR$2")
+      )
+    )
+    val expected = (
+      unaryNode(
+        "DataSetCalc",
+        aggregate._1,
+        term("select",
+          "EXPR$0",
+          "EXPR$1",
+          "EXPR$2")
+      ),
+      unaryNode(
+        "DataSetCalc",
+        aggregate._2,
+        term("select",
+          "EXPR$0",
+          "EXPR$1",
+          "EXPR$2")
+      )
+    )
+    util.verifySql(sqlQuery._1, expected._1)
+    util.verifySql(sqlQuery._2, expected._2)
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/utils/TableTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/utils/TableTestBase.scala
@@ -66,18 +66,23 @@ object TableTestUtil {
   def unaryNode(node: String, input: String, term: String*): String = {
     s"""$node(${term.mkString(", ")})
        |$input
-       |""".stripMargin
+       |""".stripMargin.stripLineEnd
   }
 
   def binaryNode(node: String, left: String, right: String, term: String*): String = {
     s"""$node(${term.mkString(", ")})
        |$left
        |$right
-       |""".stripMargin
+       |""".stripMargin.stripLineEnd
   }
 
   def term(term: AnyRef, value: AnyRef*): String = {
     s"$term=[${value.mkString(", ")}]"
+  }
+
+  def tuples(value:List[AnyRef]*): String={
+    val listValues = value.map( listValue => s"{ ${listValue.mkString(", ")} }")
+    term("tuples","[" + listValues.mkString(", ") + "]")
   }
 
   def batchTableNode(idx: Int): String = {


### PR DESCRIPTION
Hello.
Currently, if `AggregateDataSet` is empty then we unable to count or sum up 0 elements. 
These changes allows to get correct result of aggregate function through dummy row union with the  `AggregateDataSet`.