### PR TITLE
[FLINK-5112] [ExecutionGraph] Remove unused accumulator aggregation code from ArchivedExecutionJobVertex

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionJobVertex.java
@@ -17,8 +17,6 @@
  */
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.api.common.accumulators.Accumulator;
-import org.apache.flink.api.common.accumulators.AccumulatorHelper;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.checkpoint.stats.CheckpointStatsTracker;
 import org.apache.flink.runtime.checkpoint.stats.OperatorCheckpointStats;
@@ -27,8 +25,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import scala.Option;
 
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionJobVertex.getAggregateJobVertexState;
 
@@ -54,13 +50,6 @@ public class ArchivedExecutionJobVertex implements AccessExecutionJobVertex, Ser
 			taskVertices[x] = jobVertex.getTaskVertices()[x].archive();
 		}
 
-		Map<String, Accumulator<?, ?>> tmpArchivedUserAccumulators = new HashMap<>();
-		for (ExecutionVertex vertex : jobVertex.getTaskVertices()) {
-			Map<String, Accumulator<?, ?>> next = vertex.getCurrentExecutionAttempt().getUserAccumulators();
-			if (next != null) {
-				AccumulatorHelper.mergeInto(tmpArchivedUserAccumulators, next);
-			}
-		}
 		archivedUserAccumulators = jobVertex.getAggregatedUserAccumulatorsStringified();
 
 		this.id = jobVertex.getJobVertexId();


### PR DESCRIPTION
The ArchivedExecutionJobVertex calculated for its ExecutionVertices the aggregated accumulator
value. However, the result was nowhere stored. This indicates that this code is no longer used
and can be removed.

Review @zentol.