### PR TITLE
[FLINK-4631] Fixed stream task that was interrupted before it was initialized.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -67,9 +67,7 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 
 	@Override
 	protected void cleanup() throws Exception {
-		if (inputProcessor != null) {
-			inputProcessor.cleanup();
-		}
+		inputProcessor.cleanup();
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -167,6 +167,9 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	 * needs to be initialized to true, so that early cancel() before invoke() behaves correctly */
 	private volatile boolean isRunning;
 
+	/** Flag to mark that the task was initialized. */
+	private volatile boolean initialized;
+
 	/** Flag to mark this task as canceled */
 	private volatile boolean canceled;
 
@@ -241,6 +244,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 			// task specific initialization
 			init();
+			initialized = true;
 
 			// save the work of reloading state, etc, if the task is already canceled
 			if (canceled) {
@@ -333,7 +337,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 			// we must! perform this cleanup
 			try {
-				cleanup();
+				if (initialized) {
+					cleanup();
+				} else {
+					LOG.warn("Task was interrupted before it was initialized");
+				}
 			}
 			catch (Throwable t) {
 				// catch and log the exception to not replace the original exception


### PR DESCRIPTION
I think this is the best solution for this issue - to check that initialization was finished before call `cleanup` method. May be some tests is needed to check this piece of code.