### PR TITLE
[FLINK-5146] Improved resource cleanup in RocksDB keyed state backend

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/pom.xml
+++ b/flink-contrib/flink-statebackend-rocksdb/pom.xml
@@ -57,7 +57,7 @@ under the License.
 		<dependency>
 			<groupId>org.rocksdb</groupId>
 			<artifactId>rocksdbjni</artifactId>
-			<version>4.5.1</version>
+			<version>4.11.2</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -322,9 +322,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 					private void releaseSnapshotOperationResources(boolean canceled) {
 						// hold the db lock while operation on the db to guard us against async db disposal
 						synchronized (asyncSnapshotLock) {
-							//if (db != null) {
-								snapshotOperation.releaseSnapshotResources(canceled);
-							//}
+							snapshotOperation.releaseSnapshotResources(canceled);
 						}
 					}
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -230,9 +230,9 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		// Dispose decoupled db
 		if (cleanupRockDBReference != null) {
 			for (Tuple2<ColumnFamilyHandle, StateDescriptor<?, ?>> column : kvStateInformation.values()) {
-				column.f0.dispose();
+				column.f0.close();
 			}
-			cleanupRockDBReference.dispose();
+			cleanupRockDBReference.close();
 		}
 
 		try {
@@ -427,19 +427,19 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 			if (null != kvStateIterators) {
 				for (Tuple2<RocksIterator, Integer> kvStateIterator : kvStateIterators) {
-					kvStateIterator.f0.dispose();
+					kvStateIterator.f0.close();
 				}
 				kvStateIterators = null;
 			}
 
 			if (null != snapshot) {
 				stateBackend.db.releaseSnapshot(snapshot);
-				snapshot.dispose();
+				snapshot.close();
 				snapshot = null;
 			}
 
 			if (null != readOptions) {
-				readOptions.dispose();
+				readOptions.close();
 				readOptions = null;
 			}
 
@@ -562,7 +562,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 					mergeIterator.next();
 				}
 			} finally {
-				mergeIterator.dispose();
+				mergeIterator.close();
 			}
 
 			//epilogue: write last key-group
@@ -864,8 +864,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			return kvStateId;
 		}
 
-		public void dispose() {
-			this.iterator.dispose();
+		public void close() {
+			this.iterator.close();
 		}
 	}
 
@@ -906,7 +906,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 					if (rocksIterator.isValid()) {
 						heap.offer(new MergeIterator(rocksIterator, rocksIteratorWithKVStateId.f1));
 					} else {
-						rocksIterator.dispose();
+						rocksIterator.close();
 					}
 				}
 
@@ -946,7 +946,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 					detectNewKeyGroup(oldKey);
 				}
 			} else {
-				currentSubIterator.dispose();
+				currentSubIterator.close();
 				if (heap.isEmpty()) {
 					currentSubIterator = null;
 					valid = false;
@@ -1034,15 +1034,15 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			return 0;
 		}
 
-		public void dispose() {
+		public void close() {
 
 			if (null != currentSubIterator) {
-				currentSubIterator.dispose();
+				currentSubIterator.close();
 				currentSubIterator = null;
 			}
 
 			for (MergeIterator iterator : heap) {
-				iterator.dispose();
+				iterator.close();
 			}
 			heap.clear();
 		}

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -18,15 +18,51 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.StateBackendTestBase;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
 import org.apache.flink.util.OperatingSystem;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ReadOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksIterator;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.RunnableFuture;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.spy;
 
 /**
  * Tests for the partitioned state part of {@link RocksDBStateBackend}.
@@ -48,5 +84,178 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 		RocksDBStateBackend backend = new RocksDBStateBackend(new FsStateBackend(checkpointPath));
 		backend.setDbStoragePath(dbPath);
 		return backend;
+	}
+
+	@Test
+	public void testSnap() throws Exception {
+		OneShotLatch blocker = new OneShotLatch();
+		OneShotLatch waiter = new OneShotLatch();
+		BlockerCheckpointStreamFactory testStreamFactory = new BlockerCheckpointStreamFactory(1024 * 1024);
+		testStreamFactory.setBlockerLatch(blocker);
+		testStreamFactory.setWaiterLatch(waiter);
+		testStreamFactory.setAfterNumberInvocations(100);
+
+		RocksDBStateBackend backend = getStateBackend();
+		Environment env = new DummyEnvironment("TestTask", 1, 0);
+
+		final RocksDBKeyedStateBackend<Integer> keyedStateBackend = (RocksDBKeyedStateBackend<Integer>) backend.createKeyedStateBackend(
+				env,
+				new JobID(),
+				"Test",
+				IntSerializer.INSTANCE,
+				2,
+				new KeyGroupRange(0, 1),
+				mock(TaskKvStateRegistry.class));
+
+		ValueState<Integer> testState1 = keyedStateBackend.getPartitionedState(
+				VoidNamespace.INSTANCE,
+				VoidNamespaceSerializer.INSTANCE,
+				new ValueStateDescriptor<>("TestState-1", Integer.class, 0));
+
+		ValueState<String> testState2 = keyedStateBackend.getPartitionedState(
+				VoidNamespace.INSTANCE,
+				VoidNamespaceSerializer.INSTANCE,
+				new ValueStateDescriptor<>("TestState-2", String.class, ""));
+
+		final List<RocksIterator> allCreatedIterators = new ArrayList<>();
+		final RocksDB realDB = keyedStateBackend.db;
+		keyedStateBackend.db = spy(realDB);
+		doAnswer(new Answer<Object>() {
+
+			@Override
+			public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+				Object[] args = invocationOnMock.getArguments();
+				RocksIterator rocksIterator = spy((RocksIterator) invocationOnMock.getMethod().invoke(realDB, args));
+				allCreatedIterators.add(rocksIterator);
+				return rocksIterator;
+			}
+		}).when(keyedStateBackend.db).newIterator(any(ColumnFamilyHandle.class), any(ReadOptions.class));
+
+		for (int i = 0; i < 100; ++i) {
+			keyedStateBackend.setCurrentKey(i);
+			testState1.update(4200 + i);
+			testState2.update("S-" + (4200 + i));
+		}
+
+		RunnableFuture<KeyGroupsStateHandle> snapshot = keyedStateBackend.snapshot(0L, 0L, testStreamFactory);
+		Thread asyncSnapshotThread = new Thread(snapshot);
+		asyncSnapshotThread.start();
+		//TODO replace with reset-latch wait!!!!
+		Thread.sleep(100);
+		for (int i = 50; i < 150; ++i) {
+			if (i % 10 == 0) {
+				Thread.sleep(1);
+			}
+			keyedStateBackend.setCurrentKey(i);
+			testState1.update(4200 + i);
+			testState2.update("S-" + (4200 + i));
+		}
+		blocker.trigger();
+		snapshot.cancel(true);
+		assertTrue(testStreamFactory.getLastCreatedStream().isClosed());
+		waiter.await();
+		KeyGroupsStateHandle keyGroupsStateHandle = null;
+		try {
+			keyGroupsStateHandle = snapshot.get();
+			fail();
+		} catch (Exception expected) {
+			//expected.printStackTrace();
+			//assertTrue(expected.getCause() instanceof IOException);
+		}
+		for (RocksIterator iterator : allCreatedIterators) {
+			verify(iterator, times(1)).dispose();
+		}
+
+		assertNotNull(null, keyedStateBackend.db);
+		RocksDB spyDB = keyedStateBackend.db;
+		keyedStateBackend.dispose();
+
+		verify(spyDB, atLeastOnce()).dispose();
+		assertEquals(null, keyedStateBackend.db);
+
+		//System.out.println(keyGroupsStateHandle.getStateSize());
+		//System.out.println(keyGroupsStateHandle.getGroupRangeOffsets());
+		asyncSnapshotThread.join();
+	}
+
+	static class BlockerCheckpointStreamFactory implements CheckpointStreamFactory {
+
+		private final int maxSize;
+		private int afterNumberInvocations;
+		private OneShotLatch blocker;
+		private OneShotLatch waiter;
+
+		MemCheckpointStreamFactory.MemoryCheckpointOutputStream lastCreatedStream;
+
+		public MemCheckpointStreamFactory.MemoryCheckpointOutputStream getLastCreatedStream() {
+			return lastCreatedStream;
+		}
+
+		public BlockerCheckpointStreamFactory(int maxSize) {
+			this.maxSize = maxSize;
+		}
+
+		public void setAfterNumberInvocations(int afterNumberInvocations) {
+			this.afterNumberInvocations = afterNumberInvocations;
+		}
+
+		public void setBlockerLatch(OneShotLatch latch) {
+			this.blocker = latch;
+		}
+
+		public void setWaiterLatch(OneShotLatch latch) {
+			this.waiter = latch;
+		}
+
+		@Override
+		public MemCheckpointStreamFactory.MemoryCheckpointOutputStream createCheckpointStateOutputStream(long checkpointID, long timestamp) throws Exception {
+			this.lastCreatedStream = new MemCheckpointStreamFactory.MemoryCheckpointOutputStream(maxSize) {
+
+				private int afterNInvocations = afterNumberInvocations;
+				private final OneShotLatch streamBlocker = blocker;
+				private final OneShotLatch streamWaiter = waiter;
+
+				@Override
+				public void write(int b) throws IOException {
+
+					if (afterNInvocations > 0) {
+						--afterNInvocations;
+					}
+
+					if (0 == afterNInvocations && null != streamBlocker) {
+						try {
+							streamBlocker.await();
+						} catch (InterruptedException ignored) {
+						}
+					}
+					try {
+						super.write(b);
+					} catch (IOException ex) {
+						if (null != streamWaiter) {
+							streamWaiter.trigger();
+						}
+						throw ex;
+					}
+
+					if (0 == afterNInvocations && null != streamWaiter) {
+						streamWaiter.trigger();
+					}
+				}
+
+				@Override
+				public void close() {
+					super.close();
+					if (null != streamWaiter) {
+						streamWaiter.trigger();
+					}
+				}
+			};
+			return lastCreatedStream;
+		}
+
+		@Override
+		public void close() throws Exception {
+
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/async/AbstractAsyncIOCallable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/async/AbstractAsyncIOCallable.java
@@ -131,7 +131,7 @@ public abstract class AbstractAsyncIOCallable<V, D extends Closeable> implements
 	 * it finished or was stopped.
 	 */
 	@Override
-	public void done() {
+	public void done(boolean canceled) {
 		//optional callback hook
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/async/AsyncDoneCallback.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/async/AsyncDoneCallback.java
@@ -25,7 +25,9 @@ public interface AsyncDoneCallback {
 
 	/**
 	 * the callback
+	 *
+	 * @param canceled true if the callback is done, but was canceled
 	 */
-	void done();
+	void done(boolean canceled);
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/async/AsyncStoppableTaskWithCallback.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/async/AsyncStoppableTaskWithCallback.java
@@ -36,17 +36,13 @@ public class AsyncStoppableTaskWithCallback<V> extends FutureTask<V> {
 
 	@Override
 	public boolean cancel(boolean mayInterruptIfRunning) {
-		
-		if (mayInterruptIfRunning) {
-			stoppableCallbackCallable.stop();
-		}
-
+		stoppableCallbackCallable.stop();
 		return super.cancel(mayInterruptIfRunning);
 	}
 
 	@Override
 	protected void done() {
-		stoppableCallbackCallable.done();
+		stoppableCallbackCallable.done(isCancelled());
 	}
 
 	public static <V> AsyncStoppableTaskWithCallback<V> from(StoppableCallbackCallable<V> callable) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemCheckpointStreamFactory.java
@@ -144,7 +144,7 @@ public class MemCheckpointStreamFactory implements CheckpointStreamFactory {
 				return bytes;
 			}
 			else {
-				throw new IllegalStateException("stream has already been closed");
+				throw new IOException("stream has already been closed");
 			}
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorSnapshotResult.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorSnapshotResult.java
@@ -78,4 +78,11 @@ public class OperatorSnapshotResult {
 	public void setOperatorStateRawFuture(RunnableFuture<OperatorStateHandle> operatorStateRawFuture) {
 		this.operatorStateRawFuture = operatorStateRawFuture;
 	}
+
+	public void cancel() {
+		getKeyedStateManagedFuture().cancel(true);
+		getOperatorStateManagedFuture().cancel(true);
+		getKeyedStateRawFuture().cancel(true);
+		getOperatorStateRawFuture().cancel(true);
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -217,7 +217,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 			configuration = new StreamConfig(getTaskConfiguration());
 
-			stateBackend = createStateBackend();
+			stateBackend = createStateBackend(); //TODO close/cleanup!
 
 			accumulatorMap = getEnvironment().getAccumulatorRegistry().getUserMap();
 

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/OneShotLatch.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/OneShotLatch.java
@@ -107,4 +107,13 @@ public final class OneShotLatch {
 	public boolean isTriggered() {
 		return triggered;
 	}
+
+	/**
+	 * resets the latch to triggered = false
+	 */
+	public void reset() {
+		synchronized (lock) {
+			triggered = false;
+		}
+	}
 }


### PR DESCRIPTION
Currently, the resources such as taken snapshots or iterators are not always cleaned up in the RocksDB state backend. In particular, not starting the runnable future will leave taken snapshots unreleased.

This preliminary PR improves the behaviour of releasing resources obtained through the RocksDB JNI bridge.

IMPORTANT NOTICE: This PR also upticks the current version of RocksDB to 4.11.2, as I found some instabilities in the old version that could lead to segfaults, in particular at GC time.