### PR TITLE
[FLINK-5147] Prevent NPE in LocalFS#delete()

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -184,8 +184,13 @@ public class LocalFileSystem extends FileSystem {
 		final File file = pathToFile(f);
 		if (file.isFile()) {
 			return file.delete();
-		} else if ((!recursive) && file.isDirectory() && (file.listFiles().length != 0)) {
-			throw new IOException("Directory " + file.toString() + " is not empty");
+		} else if ((!recursive) && file.isDirectory()) {
+			File[] containedFiles = file.listFiles();
+			if (containedFiles == null) {
+				throw new IOException("Directory " + file.toString() + " does not exist or an I/O error occurred");
+			} else if (containedFiles.length != 0) {
+				throw new IOException("Directory " + file.toString() + " is not empty");
+			}
 		}
 
 		return delete(file);


### PR DESCRIPTION
This PR prevents an NullPointerException in `LocalFileSystem#delete()`. `File#listFiles()` can return null if either the file does not exist or some I/O error occurred. Since we can't differentiate between the cases we always throw an IOException.

This means that this PR only replaces the thrown NPE with an IOE. This should however harden the failing test case, since `delete()` is called from `FileSystem#initOutPathLocalFS()` which is aware of possible race-conditions. It just did not account for the possibility of an NPE.