### PR TITLE
[FLINK-5122] Index requests will be retried if the error is only temp…

### DIFF
--- a/docs/dev/connectors/elasticsearch2.md
+++ b/docs/dev/connectors/elasticsearch2.md
@@ -138,6 +138,8 @@ This will buffer elements and Action Requests before sending to the cluster. The
 This now provides a list of Elasticsearch Nodes
 to which the sink should connect via a `TransportClient`.
 
+Optionally, the sink can try to re-execute the bulk request when the error message matches certain patterns indicating a timeout or a overloaded cluster. This behaviour is disabled by default and can be enabled by setting `checkErrorAndRetryBulk(true)`.
+
 More information about Elasticsearch can be found [here](https://elastic.co).
 
 

--- a/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/ElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/ElasticsearchSink.java
@@ -198,8 +198,8 @@ public class ElasticsearchSink<T> extends RichSinkFunction<T>  {
 
 			@Override
 			public void afterBulk(long executionId, BulkRequest request, BulkResponse response) {
-				boolean allRequestsRepeatable = true;
 				if (response.hasFailures()) {
+					boolean allRequestsRepeatable = true;
 					for (BulkItemResponse itemResp : response.getItems()) {
 						if (itemResp.isFailed()) {
 							// Check if index request can be retried
@@ -211,7 +211,6 @@ public class ElasticsearchSink<T> extends RichSinkFunction<T>  {
 									)
 								) {
 								LOG.debug("Retry bulk: {}", itemResp.getFailureMessage());
-								reAddBulkRequest(request);
 							} else { // Cannot retry action
 								allRequestsRepeatable = false;
 								LOG.error("Failed to index document in Elasticsearch: {}", itemResp.getFailureMessage());
@@ -219,7 +218,9 @@ public class ElasticsearchSink<T> extends RichSinkFunction<T>  {
 							}
 						}
 					}
-					if (!allRequestsRepeatable) {
+					if (allRequestsRepeatable) {
+						reAddBulkRequest(request);
+					} else {
 						hasFailure.set(true);
 					}
 				}


### PR DESCRIPTION
This PR will re-add index requests to the BulkProcessor if the error is temporary, like
* Timeout errors
* No master (node down, network problems)
* UnavailableShardsException (Rebalancing, node down, network problems)
* Bulk queue on node full (too many index requests, load to high on cluster)