### PR TITLE
[FLINK-4741] Fix for the proper shutdown the ServerBootstrap in the process of stopping the WebRuntumeMonitor

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -458,6 +458,9 @@ public class WebRuntimeMonitor implements WebMonitor {
 				if (bootstrap.group() != null) {
 					bootstrap.group().shutdownGracefully();
 				}
+				if (bootstrap.childGroup() != null) {
+					bootstrap.childGroup().shutdownGracefully();
+				}
 			}
 
 			stackTraceSamples.shutDown();


### PR DESCRIPTION
[FLINK-4741] WebRuntimeMonitor does not shut down all of it's threads (EventLoopGroups) on exit.

bootstrap.childGroup().shutdownGracefully() method has been added to the correct shutdown WebRuntimeMonitor.

More detailed explanation:

bootrstrap - it is io.netty.bootstrap.ServerBootstrap - a helper class that sets up a netty-server.

In its work netty-server uses two EventLoopGroups: 
The first one, often called 'boss', accepts an incoming connection. 
The second one, often called 'worker', handles the traffic of the accepted connection once the boss accepts the connection and registers the accepted connection to the worker.

At the end of netty-server work should be shut down all the threads in each of the two EventLoopGroups.

First EventLoopGroups stops when called bootstrap.group().shutdownGracefully().
To stop the second EventLoopGroups this request adds call of bootstrap.chiledGroup().shutdownGracefully() method.


This proposal corresponds to netty user guide:
http://netty.io/wiki/user-guide-for-4.x.html