### PR TITLE
[FLINK-5002] Renamed getNumberOfUsedBuffers() method to bestEffortGetNumOfUsedBuffers(), add a check to ensure that it does not return a negative value

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferPool.java
@@ -71,6 +71,6 @@ public interface BufferPool extends BufferProvider, BufferRecycler {
 	/**
 	 * Returns the number of used buffers of this buffer pool.
 	 */
-	int getNumberOfUsedBuffers();
+	int bestEffortGetNumOfUsedBuffers();
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -111,7 +111,7 @@ class LocalBufferPool implements BufferPool {
 	}
 
 	@Override
-	public int getNumberOfUsedBuffers() {
+	public int bestEffortGetNumOfUsedBuffers() {
 		return numberOfRequestedMemorySegments - availableMemorySegments.size();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -112,7 +112,7 @@ class LocalBufferPool implements BufferPool {
 
 	@Override
 	public int bestEffortGetNumOfUsedBuffers() {
-		return numberOfRequestedMemorySegments - availableMemorySegments.size();
+		return Math.max(0, numberOfRequestedMemorySegments - availableMemorySegments.size());
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -182,7 +182,7 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 			int bufferPoolSize = 0;
 
 			for (SingleInputGate inputGate : task.getAllInputGates()) {
-				usedBuffers += inputGate.getBufferPool().getNumberOfUsedBuffers();
+				usedBuffers += inputGate.getBufferPool().bestEffortGetNumOfUsedBuffers();
 				bufferPoolSize += inputGate.getBufferPool().getNumBuffers();
 			}
 
@@ -211,7 +211,7 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 			int bufferPoolSize = 0;
 
 			for (ResultPartition resultPartition : task.getProducedPartitions()) {
-				usedBuffers += resultPartition.getBufferPool().getNumberOfUsedBuffers();
+				usedBuffers += resultPartition.getBufferPool().bestEffortGetNumOfUsedBuffers();
 				bufferPoolSize += resultPartition.getBufferPool().getNumBuffers();
 			}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -38,7 +38,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -329,34 +328,6 @@ public class LocalBufferPoolTest {
 		}
 	}
 
-	@Test
-	public void testBestEffortGetNumOfUsedBuffersReturnPositive() throws Exception {
-		int numBuffers = 10;
-		localBufferPool.setNumBuffers(numBuffers);
-
-		AtomicInteger errorCounter = new AtomicInteger(0);
-
-		Thread methodRequester = new Thread(new BestEffortGetNumOfUsedBuffersRequesterTask(localBufferPool, errorCounter));
-		executor.submit(methodRequester);
-
-		List<Buffer> buffers = Lists.newArrayList();
-		for (int i = 0; i < numBuffers; i++) {
-			buffers.add(localBufferPool.requestBuffer());
-		}
-
-		localBufferPool.setNumBuffers(numBuffers / 2);
-
-		for (Buffer buffer : buffers) {
-			buffer.recycle();
-		}
-
-		localBufferPool.lazyDestroy();
-
-		methodRequester.interrupt();
-
-		assertEquals("bestEffortGetNumOfUsedBuffers() returned a negative value", 0, errorCounter.get());
-	}
-
 	// ------------------------------------------------------------------------
 	// Helpers
 	// ------------------------------------------------------------------------
@@ -389,29 +360,6 @@ public class LocalBufferPoolTest {
 			}
 
 			return true;
-		}
-	}
-
-	private static class BestEffortGetNumOfUsedBuffersRequesterTask implements Runnable {
-
-		private final AtomicInteger errorCounter;
-
-		private final BufferPool localBufferPool;
-
-		private BestEffortGetNumOfUsedBuffersRequesterTask(BufferPool localBufferPool, AtomicInteger errorCounter) {
-
-			this.localBufferPool = localBufferPool;
-			this.errorCounter = errorCounter;
-		}
-
-		@Override
-		public void run() {
-
-			while (!Thread.interrupted()) {
-				if(localBufferPool.bestEffortGetNumOfUsedBuffers() < 0){
-					errorCounter.incrementAndGet();
-				}
-			}
 		}
 	}
 }


### PR DESCRIPTION
[FLINK-5002] Lack of synchronization in LocalBufferPool#getNumberOfUsedBuffers

According to Stefan proposal, I renamed the method and added test to make sure that the method does not return a negative value.