### PR TITLE
[FLINK-4565] Support for SQL IN operator

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/expressionDsl.scala
@@ -102,6 +102,9 @@ trait ImplicitExpressionOperations {
   def asc = Asc(expr)
   def desc = Desc(expr)
 
+
+  def in(subquery: Expression*) = In(expr +: subquery)
+
   /**
     * Returns the start time of a window when applied on a window reference.
     */

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenerator.scala
@@ -840,6 +840,16 @@ class CodeGenerator(
         requireTimeInterval(operand)
         generateUnaryIntervalPlusMinus(plus = true, nullCheck, operand)
 
+      case IN =>
+        val left = operands.head
+        val right = operands.tail
+        val addReusableCodeCallback = (declaration: String, initialization: String) => {
+          reusableMemberStatements.add(declaration)
+          reusableInitStatements.add(initialization)
+        }
+        generateIn(nullCheck, left, right, addReusableCodeCallback)
+
+
       // comparison
       case EQUALS =>
         val left = operands.head

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/In.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/In.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.expressions
+
+import org.apache.calcite.rex.RexNode
+import org.apache.calcite.sql.SqlOperator
+import org.apache.calcite.sql.fun.SqlStdOperatorTable
+import org.apache.calcite.tools.RelBuilder
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.table.typeutils.TypeCheckUtils._
+import org.apache.flink.api.table.validate.{ExprValidationResult, ValidationFailure, ValidationSuccess}
+
+case class In(expressions: Seq[Expression]) extends Expression {
+  override def toString = s"${expressions.head}.in(${expressions.tail.mkString(", ")})"
+
+  /**
+    * List of child nodes that should be considered when doing transformations. Other values
+    * in the Product will not be transformed, only handed through.
+    */
+  override private[flink] def children: Seq[Expression] = expressions
+
+  private[flink] val sqlOperator: SqlOperator = SqlStdOperatorTable.IN
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(SqlStdOperatorTable.IN, children.map(_.toRexNode): _*)
+  }
+
+  override private[flink] def validateInput(): ExprValidationResult = {
+    if (children.tail.contains(null)) {
+      ValidationFailure("Operands on right side of IN operator must be not null")
+    } else {
+      val types = children.tail.map(_.resultType)
+      if (types.distinct.length != 1) {
+        ValidationFailure(
+          s"Types on the right side of IN operator must be the same, got ${types.mkString(", ")}."
+        )
+      } else {
+        (children.head.resultType, children.tail.head.resultType) match {
+          case (lType, rType) if isNumeric(lType) && isNumeric(rType) => ValidationSuccess
+          case (lType, rType) if isComparable(lType) && lType == rType => ValidationSuccess
+          case (lType, rType) =>
+            ValidationFailure(
+              s"Types on the both side of IN operator must be the same, got $lType and $rType"
+            )
+        }
+      }
+
+    }
+  }
+
+  /**
+    * Returns the [[TypeInformation]] for evaluating this expression.
+    * It is sometimes not available until the expression is valid.
+    */
+  override private[flink] def resultType: TypeInformation[_] = BOOLEAN_TYPE_INFO
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/validate/FunctionCatalog.scala
@@ -118,6 +118,7 @@ class FunctionCatalog {
 object FunctionCatalog {
 
   val builtInFunctions: Map[String, Class[_]] = Map(
+    "in" -> classOf[In],
     // logic
     "isNull" -> classOf[IsNull],
     "isNotNull" -> classOf[IsNotNull],
@@ -252,6 +253,7 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     SqlStdOperatorTable.CASE,
     SqlStdOperatorTable.REINTERPRET,
     SqlStdOperatorTable.EXTRACT_DATE,
+    SqlStdOperatorTable.IN,
     // FUNCTIONS
     SqlStdOperatorTable.SUBSTRING,
     SqlStdOperatorTable.OVERLAY,

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/batch/table/InITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/api/java/batch/table/InITCase.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.batch.table;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.table.BatchTableEnvironment;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.scala.batch.utils.TableProgramsTestBase;
+import org.apache.flink.api.table.Row;
+import org.apache.flink.api.table.Table;
+import org.apache.flink.api.table.TableEnvironment;
+import org.apache.flink.api.table.ValidationException;
+import org.apache.flink.test.javaApiOperators.util.CollectionDataSets;
+import org.apache.flink.test.util.TestBaseUtils;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class InITCase extends TableProgramsTestBase {
+
+	public InITCase(TestExecutionMode mode, TableConfigMode configMode) {
+		super(mode, configMode);
+	}
+
+	@Test
+	public void testInWithNumericLiterals() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+
+		DataSet<Tuple3<Integer, Long, String>> in1 = CollectionDataSets.get3TupleDataSet(env);
+		Table ds1 = tableEnv.fromDataSet(in1, "a, b, c");
+		Table simpleIn = ds1.select("a, b, c").where("a.in(1, 3, 7)");
+		DataSet<Row> ds = tableEnv.toDataSet(simpleIn, Row.class);
+		List<Row> results = ds.collect();
+		String expected = "1,1,Hi\n" + "3,2,Hello world\n" + "7,4,Comment#1\n";
+		TestBaseUtils.compareResultAsText(results, expected);
+	}
+
+	@Test
+	public void testInWithManyLiterals() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+
+		DataSet<Tuple3<Integer, Long, String>> in1 = CollectionDataSets.get3TupleDataSet(env);
+		Table ds1 = tableEnv.fromDataSet(in1, "a, b, c");
+		Table simpleIn = ds1.select("a, b, c").where("c.in(\"Hi\", \"Hello\", \"Hello world\", \"Hello world, how are you?\", \"I am fine.\", \"Luke Skywalker\", \"Comment#1\", \"Comment#2\", \"Comment#3\", \"Comment#4\", \"Comment#5\", \"Comment#6\", \"Comment#7\", \"Comment#8\", \"Comment#9\", \"Comment#10\", \"Comment#11\", \"Comment#12\", \"Comment#13\", \"Comment#14\")");
+		DataSet<Row> ds = tableEnv.toDataSet(simpleIn, Row.class);
+		List<Row> results = ds.collect();
+		String expected = "1,1,Hi\n" +
+			"2,2,Hello\n" +
+			"3,2,Hello world\n" +
+			"4,3,Hello world, how are you?\n" +
+			"5,3,I am fine.\n" +
+			"6,3,Luke Skywalker\n" +
+			"7,4,Comment#1\n" +
+			"8,4,Comment#2\n" +
+			"9,4,Comment#3\n" +
+			"10,4,Comment#4\n" +
+			"11,5,Comment#5\n" +
+			"12,5,Comment#6\n" +
+			"13,5,Comment#7\n" +
+			"14,5,Comment#8\n" +
+			"15,5,Comment#9\n" +
+			"16,6,Comment#10\n" +
+			"17,6,Comment#11\n" +
+			"18,6,Comment#12\n" +
+			"19,6,Comment#13\n" +
+			"20,6,Comment#14\n";
+		TestBaseUtils.compareResultAsText(results, expected);
+	}
+
+	@Test
+	public void testInWithStringLiterals() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+		DataSet<Tuple3<Integer, Long, String>> in1 = CollectionDataSets.get3TupleDataSet(env);
+
+		Table ds1 = tableEnv.fromDataSet(in1, "a, b, c");
+
+		Table simpleIn = ds1.select("a, b, c").where("c.in(\"Hi\", \"Hello world\", \"Comment#1\")");
+		DataSet<Row> ds = tableEnv.toDataSet(simpleIn, Row.class);
+		List<Row> results = ds.collect();
+		String expected = "1,1,Hi\n" + "3,2,Hello world\n" + "7,4,Comment#1\n";
+		TestBaseUtils.compareResultAsText(results, expected);
+	}
+
+	@Ignore
+	@Test
+	public void testInWithBigDecimalLiterals() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+		DataSet<Tuple3<Integer, Long, String>> in1 = CollectionDataSets.get3TupleDataSet(env);
+
+		Table ds1 = tableEnv.fromDataSet(in1, "a, b, c");
+
+		Table simpleIn = ds1.select("a, b, c").where("a.in(BigDecimal(1), BigDecimal(2), BigDecimal(3.01))");
+		DataSet<Row> ds = tableEnv.toDataSet(simpleIn, Row.class);
+		List<Row> results = ds.collect();
+		String expected = "1,1,Hi\n" + "2,2,Hello\n";
+		TestBaseUtils.compareResultAsText(results, expected);
+  	}
+	
+	@Ignore
+	@Test(expected = ValidationException.class)
+	public void testInWithNullOperand() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+		DataSet<Tuple3<Integer, Long, String>> in1 = CollectionDataSets.get3TupleDataSet(env);
+		Table ds1 = tableEnv.fromDataSet(in1, "a, b, c");
+
+		Table simpleIn = ds1.select("a, b, c").where("c.in(\"Hi\", \"Hello world\", \"Comment#1\", \"null\")");
+		DataSet<Row> ds = tableEnv.toDataSet(simpleIn, Row.class);
+		ds.collect();
+  	}
+
+	@Test(expected = ValidationException.class)
+	public void testInWithDifferentTypeRightOperands() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+		DataSet<Tuple3<Integer, Long, String>> in1 = CollectionDataSets.get3TupleDataSet(env);
+		Table ds1 = tableEnv.fromDataSet(in1, "a, b, c");
+
+		Table simpleIn = ds1.select("a, b, c").where("c.in(\"Hi\", \"Hello world\", \"Comment#1\", 1)");
+		DataSet<Row> ds = tableEnv.toDataSet(simpleIn, Row.class);
+		ds.collect();
+  	}
+
+	@Test(expected = ValidationException.class)
+	public void testInWithDifferentTypeOperands() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+		DataSet<Tuple3<Integer, Long, String>> in1 = CollectionDataSets.get3TupleDataSet(env);
+		Table ds1 = tableEnv.fromDataSet(in1, "a, b, c");
+
+		Table simpleIn = ds1.select("a, b, c").where("a.in(\"Hi\", \"Hello world\", \"Comment#1\")");
+		DataSet<Row> ds = tableEnv.toDataSet(simpleIn, Row.class);
+		ds.collect();
+  	}
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/table/InITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/table/InITCase.scala
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.scala.batch.table
+
+
+import org.apache.flink.api.scala._
+import org.apache.flink.api.scala.batch.utils.TableProgramsTestBase
+import org.apache.flink.api.scala.batch.utils.TableProgramsTestBase.TableConfigMode
+import org.apache.flink.api.scala.table._
+import org.apache.flink.api.scala.util.CollectionDataSets
+import org.apache.flink.api.table.{Row, TableEnvironment, ValidationException}
+import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
+import org.apache.flink.test.util.TestBaseUtils
+import org.junit._
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import scala.collection.JavaConverters._
+
+@RunWith(classOf[Parameterized])
+class InITCase(
+                mode: TestExecutionMode,
+                configMode: TableConfigMode)
+  extends TableProgramsTestBase(mode, configMode) {
+
+  @Test
+  def testInWithManyLiterals(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    val simpleIn = ds1.select('a, 'b, 'c).where('c.in("Hi",
+      "Hello",
+      "Hello world",
+      "Hello world, how are you?",
+      "I am fine.",
+      "Luke Skywalker",
+      "Comment#1",
+      "Comment#2",
+      "Comment#3",
+      "Comment#4",
+      "Comment#5",
+      "Comment#6",
+      "Comment#7",
+      "Comment#8",
+      "Comment#9",
+      "Comment#10",
+      "Comment#11",
+      "Comment#12",
+      "Comment#13",
+      "Comment#14"))
+    val resultsSimple = simpleIn.toDataSet[Row].collect()
+    val expected = "1,1,Hi\n" +
+      "2,2,Hello\n" +
+      "3,2,Hello world\n" +
+      "4,3,Hello world, how are you?\n" +
+      "5,3,I am fine.\n" +
+      "6,3,Luke Skywalker\n" +
+      "7,4,Comment#1\n" +
+      "8,4,Comment#2\n" +
+      "9,4,Comment#3\n" +
+      "10,4,Comment#4\n" +
+      "11,5,Comment#5\n" +
+      "12,5,Comment#6\n" +
+      "13,5,Comment#7\n" +
+      "14,5,Comment#8\n" +
+      "15,5,Comment#9\n" +
+      "16,6,Comment#10\n" +
+      "17,6,Comment#11\n" +
+      "18,6,Comment#12\n" +
+      "19,6,Comment#13\n" +
+      "20,6,Comment#14\n"
+    TestBaseUtils.compareResultAsText(resultsSimple.asJava, expected)
+
+  }
+
+  @Test
+  def testInWithNumericLiterals(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    val simpleIn = ds1.select('a, 'b, 'c).where('a.in(1, 3, 7))
+    val resultsSimple = simpleIn.toDataSet[Row].collect()
+    val expected = "1,1,Hi\n" + "3,2,Hello world\n" + "7,4,Comment#1\n"
+    TestBaseUtils.compareResultAsText(resultsSimple.asJava, expected)
+  }
+
+  @Test
+  def testInWithDifferentNumericTypeOperands(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    val simpleIn = ds1
+      .select('a, 'b, 'c)
+      .where('a.in(BigDecimal(1.0), BigDecimal(2.00), BigDecimal(3.01)))
+    val resultsSimple = simpleIn.toDataSet[Row].collect()
+    val expected = "1,1,Hi\n" + "2,2,Hello\n"
+    TestBaseUtils.compareResultAsText(resultsSimple.asJava, expected)
+  }
+
+  @Test
+  def testInWithStringLiterals(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    val simpleIn = ds1.select('a, 'b, 'c).where('c.in("Hi", "Hello world", "Comment#1"))
+    val resultsSimple = simpleIn.toDataSet[Row].collect()
+    val expected = "1,1,Hi\n" + "3,2,Hello world\n" + "7,4,Comment#1\n"
+    TestBaseUtils.compareResultAsText(resultsSimple.asJava, expected)
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testInWithNullOperand(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    ds1
+      .select('a, 'b, 'c)
+      .where('c.in("Hi", "Hello world", "Comment#1", null))
+      .toDataSet[Row]
+      .collect()
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testInWithDifferentTypeRightOperands(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    ds1
+      .select('a, 'b, 'c)
+      .where('c.in("Hi", "Hello world", "Comment#1", 1))
+      .toDataSet[Row]
+      .collect()
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testInWithDifferentTypeOperands(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    ds1.select('a, 'b, 'c)
+      .where('a.in("Hi", "Hello world", "Comment#1")).toDataSet[Row].collect()
+  }
+
+}


### PR DESCRIPTION
This PR is a part of work on SQL IN operator in Table API, which implements IN for literals.
Two cases are covered: less and great then 20 literals.

Also I have some questions:
- converting all numeric types to BigDecimal isn't ok? I decided to make so to simplify use of hashset.
- validation isn't really good. It forces to use operator with same type literals. Should I rework it or maybe just add more cases?

expressionDsl.scala:
	entry point for IN operator in scala API
ScalarOperators.scala:
	1) All numeric types are upcasting to BigDecimal for using in hashset, other types are unchanged in 	castNumeric
	2) valuesInitialization used for 2 cases: when we have more then 20 operands (then we use hashset, 	initialized in constructor, descibed below) and less then 20 operands (then we initialize operands in 	method's body and use them in conjunction)
	3) comparison also covers described above cases. In first case we use callback to declare and initialize 	hashset with all operands. Otherwise we just put all operands in conjunction.
	4) Final code is built up with these code snippets.
CodeGenerator.scala:
	passes arguments and callback to declare and init hashet
FunctionCatalog.scala:
	registers "in" as method
InITCase:
	some use cases