### PR TITLE
[FLINK-5175] StreamExecutionEnvironment's set function return `this` instead of void

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -453,8 +453,11 @@ public abstract class StreamExecutionEnvironment {
 	 * @param restartStrategyConfiguration Restart strategy configuration to be set
 	 */
 	@PublicEvolving
-	public void setRestartStrategy(RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration) {
+	public StreamExecutionEnvironment setRestartStrategy(
+		RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration) {
+
 		config.setRestartStrategy(restartStrategyConfiguration);
+		return this;
 	}
 
 	/**
@@ -482,8 +485,9 @@ public abstract class StreamExecutionEnvironment {
 	 */
 	@Deprecated
 	@PublicEvolving
-	public void setNumberOfExecutionRetries(int numberOfExecutionRetries) {
+	public StreamExecutionEnvironment setNumberOfExecutionRetries(int numberOfExecutionRetries) {
 		config.setNumberOfExecutionRetries(numberOfExecutionRetries);
+		return this;
 	}
 
 	/**
@@ -531,8 +535,11 @@ public abstract class StreamExecutionEnvironment {
 	 * @param serializer
 	 * 		The serializer to use.
 	 */
-	public <T extends Serializer<?> & Serializable>void addDefaultKryoSerializer(Class<?> type, T serializer) {
+	public <T extends Serializer<?> & Serializable>StreamExecutionEnvironment addDefaultKryoSerializer(
+		Class<?> type, T serializer) {
+
 		config.addDefaultKryoSerializer(type, serializer);
+		return this;
 	}
 
 	/**
@@ -543,8 +550,11 @@ public abstract class StreamExecutionEnvironment {
 	 * @param serializerClass
 	 * 		The class of the serializer to use.
 	 */
-	public void addDefaultKryoSerializer(Class<?> type, Class<? extends Serializer<?>> serializerClass) {
+	public StreamExecutionEnvironment addDefaultKryoSerializer(
+		Class<?> type, Class<? extends Serializer<?>> serializerClass) {
+
 		config.addDefaultKryoSerializer(type, serializerClass);
+		return this;
 	}
 
 	/**
@@ -559,8 +569,11 @@ public abstract class StreamExecutionEnvironment {
 	 * @param serializer
 	 * 		The serializer to use.
 	 */
-	public <T extends Serializer<?> & Serializable>void registerTypeWithKryoSerializer(Class<?> type, T serializer) {
+	public <T extends Serializer<?> & Serializable>StreamExecutionEnvironment registerTypeWithKryoSerializer(
+		Class<?> type, T serializer) {
+
 		config.registerTypeWithKryoSerializer(type, serializer);
+		return this;
 	}
 
 	/**
@@ -573,8 +586,11 @@ public abstract class StreamExecutionEnvironment {
 	 * 		The class of the serializer to use.
 	 */
 	@SuppressWarnings("rawtypes")
-	public void registerTypeWithKryoSerializer(Class<?> type, Class<? extends Serializer> serializerClass) {
+	public StreamExecutionEnvironment registerTypeWithKryoSerializer(
+		Class<?> type, Class<? extends Serializer> serializerClass) {
+
 		config.registerTypeWithKryoSerializer(type, serializerClass);
+		return this;
 	}
 
 	/**
@@ -586,7 +602,7 @@ public abstract class StreamExecutionEnvironment {
 	 * @param type
 	 * 		The class of the type to register.
 	 */
-	public void registerType(Class<?> type) {
+	public StreamExecutionEnvironment registerType(Class<?> type) {
 		if (type == null) {
 			throw new NullPointerException("Cannot register null type class.");
 		}
@@ -598,6 +614,8 @@ public abstract class StreamExecutionEnvironment {
 		} else {
 			config.registerKryoType(type);
 		}
+
+		return this;
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -616,13 +634,15 @@ public abstract class StreamExecutionEnvironment {
 	 * @param characteristic The time characteristic.
 	 */
 	@PublicEvolving
-	public void setStreamTimeCharacteristic(TimeCharacteristic characteristic) {
+	public StreamExecutionEnvironment setStreamTimeCharacteristic(TimeCharacteristic characteristic) {
 		this.timeCharacteristic = Preconditions.checkNotNull(characteristic);
 		if (characteristic == TimeCharacteristic.ProcessingTime) {
 			getConfig().setAutoWatermarkInterval(0);
 		} else {
 			getConfig().setAutoWatermarkInterval(200);
 		}
+
+		return this;
 	}
 
 	/**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.scala
 
 import com.esotericsoftware.kryo.Serializer
 import org.apache.flink.annotation.{Internal, Public, PublicEvolving}
+import org.apache.flink.api.common.JobExecutionResult
 import org.apache.flink.api.common.io.{FileInputFormat, FilePathFilter, InputFormat}
 import org.apache.flink.api.common.restartstrategy.RestartStrategies.RestartStrategyConfiguration
 import org.apache.flink.api.common.typeinfo.TypeInformation
@@ -29,6 +30,7 @@ import org.apache.flink.runtime.state.AbstractStateBackend
 import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JavaEnv}
 import org.apache.flink.streaming.api.functions.source._
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
+import org.apache.flink.streaming.api.graph.StreamGraph
 import org.apache.flink.streaming.api.{CheckpointingMode, TimeCharacteristic}
 import org.apache.flink.util.SplittableIterator
 
@@ -278,8 +280,9 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     *            FixedDelayRestartStrategyConfiguration contains the number of execution retries.
     */
   @PublicEvolving
-  def setNumberOfExecutionRetries(numRetries: Int): Unit = {
+  def setNumberOfExecutionRetries(numRetries: Int): StreamExecutionEnvironment = {
     javaEnv.setNumberOfExecutionRetries(numRetries)
+    this
   }
 
   /**
@@ -291,7 +294,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     *            FixedDelayRestartStrategyConfiguration contains the number of execution retries.
     */
   @PublicEvolving
-  def getNumberOfExecutionRetries = javaEnv.getNumberOfExecutionRetries
+  def getNumberOfExecutionRetries: Int = javaEnv.getNumberOfExecutionRetries
 
   // --------------------------------------------------------------------------------------------
   // Registry for types and serializers
@@ -311,8 +314,9 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   def addDefaultKryoSerializer[T <: Serializer[_] with Serializable](
       `type`: Class[_],
       serializer: T)
-    : Unit = {
+    : StreamExecutionEnvironment = {
     javaEnv.addDefaultKryoSerializer(`type`, serializer)
+    this
   }
 
   /**
@@ -323,8 +327,12 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * @param serializerClass
    * The class of the serializer to use.
    */
-  def addDefaultKryoSerializer(`type`: Class[_], serializerClass: Class[_ <: Serializer[_]]) {
+  def addDefaultKryoSerializer(
+      `type`: Class[_],
+      serializerClass: Class[_ <: Serializer[_]])
+    : StreamExecutionEnvironment = {
     javaEnv.addDefaultKryoSerializer(`type`, serializerClass)
+    this
   }
 
   /**
@@ -336,8 +344,9 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   def registerTypeWithKryoSerializer[T <: Serializer[_] with Serializable](
       clazz: Class[_],
       serializer: T)
-    : Unit = {
+    : StreamExecutionEnvironment = {
     javaEnv.registerTypeWithKryoSerializer(clazz, serializer)
+    this
   }
 
   /**
@@ -354,8 +363,9 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * sure that only tags are written.
    *
    */
-  def registerType(typeClass: Class[_]) {
+  def registerType(typeClass: Class[_]): StreamExecutionEnvironment = {
     javaEnv.registerType(typeClass)
+    this
   }
 
   // --------------------------------------------------------------------------------------------
@@ -373,8 +383,9 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * @param characteristic The time characteristic.
    */
   @PublicEvolving
-  def setStreamTimeCharacteristic(characteristic: TimeCharacteristic) : Unit = {
+  def setStreamTimeCharacteristic(characteristic: TimeCharacteristic) : StreamExecutionEnvironment = {
     javaEnv.setStreamTimeCharacteristic(characteristic)
+    this
   }
 
   /**
@@ -384,7 +395,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * @return The time characteristic.
    */
   @PublicEvolving
-  def getStreamTimeCharacteristic = javaEnv.getStreamTimeCharacteristic()
+  def getStreamTimeCharacteristic: TimeCharacteristic = javaEnv.getStreamTimeCharacteristic()
 
   // --------------------------------------------------------------------------------------------
   // Data stream creations
@@ -622,7 +633,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * The program execution will be logged and displayed with a generated
    * default name.
    */
-  def execute() = javaEnv.execute()
+  def execute(): JobExecutionResult = javaEnv.execute()
 
   /**
    * Triggers the program execution. The environment will execute all parts of
@@ -631,7 +642,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * 
    * The program execution will be logged and displayed with the provided name.
    */
-  def execute(jobName: String) = javaEnv.execute(jobName)
+  def execute(jobName: String): JobExecutionResult = javaEnv.execute(jobName)
 
   /**
    * Creates the plan with which the system will execute the program, and
@@ -639,7 +650,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * flow graph. Note that this needs to be called, before the plan is
    * executed.
    */
-  def getExecutionPlan = javaEnv.getExecutionPlan
+  def getExecutionPlan: String = javaEnv.getExecutionPlan
 
   /**
    * Getter of the [[org.apache.flink.streaming.api.graph.StreamGraph]] of the streaming job.
@@ -647,7 +658,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * @return The StreamGraph representing the transformations
    */
   @Internal
-  def getStreamGraph = javaEnv.getStreamGraph
+  def getStreamGraph: StreamGraph = javaEnv.getStreamGraph
 
   /**
    * Getter of the wrapped [[org.apache.flink.streaming.api.environment.StreamExecutionEnvironment]]
@@ -655,7 +666,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * @return The encased ExecutionEnvironment
    */
   @Internal
-  def getWrappedStreamExecutionEnvironment = javaEnv
+  def getWrappedStreamExecutionEnvironment: JavaEnv = javaEnv
 
   /**
    * Returns a "closure-cleaned" version of the given function. Cleans only if closure cleaning


### PR DESCRIPTION
StreamExecutionEnvironment's set function return `this` instead of void

for example :

public void setNumberOfExecutionRetries(int numberOfExecutionRetries) { 
  config.setNumberOfExecutionRetries(numberOfExecutionRetries); 
}

change to:

public StreamExecutionEnvironment setNumberOfExecutionRetries(int numberOfExecutionRetries) { 
  config.setNumberOfExecutionRetries(numberOfExecutionRetries); 
  return this; 
}

- [X] General
  - The pull request references the related JIRA issue ("[FLINK-5175] StreamExecutionEnvironment's set function return `this` instead of void")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [X] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [X] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

