### PR TITLE
[FLINK-5168] Scaladoc annotation link use [[]] instead of {@link}

### DIFF
--- a/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
+++ b/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
@@ -294,7 +294,7 @@ object Graph {
 }
 
 /**
- * Represents a graph consisting of [[Edge]] edgs and [[Vertex]] vertices.
+ * Represents a graph consisting of [[Edge]] edges and [[Vertex]] vertices.
  *
  * @param jgraph the underlying java api Graph.
  * @tparam K the key type for vertex and edge identifiers

--- a/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
+++ b/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
@@ -294,7 +294,7 @@ object Graph {
 }
 
 /**
- * Represents a graph consisting of {@link Edge edges} and {@link Vertex vertices}.
+ * Represents a graph consisting of [[Edge]] edgs and [[Vertex]] vertices.
  *
  * @param jgraph the underlying java api Graph.
  * @tparam K the key type for vertex and edge identifiers

--- a/flink-libraries/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/GellyScalaAPICompletenessTest.scala
+++ b/flink-libraries/flink-gelly-scala/src/test/scala/org/apache/flink/graph/scala/test/GellyScalaAPICompletenessTest.scala
@@ -26,7 +26,7 @@ import org.junit.Test
 
 /**
  * This checks whether the Gelly Scala API is up to feature parity with the Java API.
- * Implements the {@link ScalaAPICompletenessTest} for Gelly.
+ * Implements the [[ScalaAPICompletenessTestBase]] for Gelly.
  */
 class GellyScalaAPICompletenessTest extends ScalaAPICompletenessTestBase {
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/RegisteredMesosWorkerNode.scala
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/RegisteredMesosWorkerNode.scala
@@ -22,7 +22,7 @@ import org.apache.flink.mesos.runtime.clusterframework.store.MesosWorkerStore
 import org.apache.flink.runtime.clusterframework.types.{ResourceID, ResourceIDRetrievable}
 
 /**
-  * A representation of a registered Mesos task managed by the {@link MesosFlinkResourceManager}.
+  * A representation of a registered Mesos task managed by the [[MesosFlinkResourceManager]].
   */
 case class RegisteredMesosWorkerNode(task: MesosWorkerStore.Worker) extends ResourceIDRetrievable {
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -697,7 +697,7 @@ class DataStream[T](stream: JavaStream[T]) {
    * For the second case and when the watermarks are required to lag behind the maximum
    * timestamp seen so far in the elements of the stream by a fixed amount of time, and this
    * amount is known in advance, use the
-   * {@link org.apache.flink.streaming.api.functions.TimestampExtractorWithFixedAllowedLateness}.
+   * [[org.apache.flink.streaming.api.functions.TimestampExtractorWithFixedAllowedLateness]].
    *
    * For cases where watermarks should be created in an irregular fashion, for example
    * based on certain markers that some element carry, use the

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/SplitStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/SplitStream.scala
@@ -23,10 +23,10 @@ import org.apache.flink.streaming.api.datastream.{ SplitStream => SplitJavaStrea
 
 /**
  * The SplitStream represents an operator that has been split using an
- * {@link OutputSelector}. Named outputs can be selected using the
- * {@link #select} function. To apply a transformation on the whole output simply call
+ * [[org.apache.flink.streaming.api.collector.selector.OutputSelector]].
+ * Named outputs can be selected using the [[SplitStream#select()]] function.
+ * To apply a transformation on the whole output simply call
  * the appropriate method on this stream.
- *
  */
 @Public
 class SplitStream[T](javaStream: SplitJavaStream[T]) extends DataStream[T](javaStream){

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -502,9 +502,8 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     *          The files to be excluded from the processing
     * @return The data stream that represents the data read from the given file
     *
-    * @deprecated Use {@link FileInputFormat#setFilesFilter(FilePathFilter)} to set a filter and
-    *         {@link StreamExecutionEnvironment#readFile(FileInputFormat,
-      *              String, FileProcessingMode, long)}
+    * @deprecated Use [[FileInputFormat#setFilesFilter(FilePathFilter)]] to set a filter and
+    * [[StreamExecutionEnvironment#readFile(FileInputFormat, String, FileProcessingMode, long)]]
     */
   @PublicEvolving
   @Deprecated

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamingOperatorsITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamingOperatorsITCase.scala
@@ -58,8 +58,8 @@ class StreamingOperatorsITCase extends ScalaStreamingMultipleProgramsTestBase {
     * The stream is grouped by the first field. For each group, the resulting stream is folded by
     * summing up the second tuple field.
     *
-    * This test relies on the hash function used by the {@link DataStream#keyBy}, which is
-    * assumed to be {@link MathUtils#murmurHash}.
+    * This test relies on the hash function used by the [[DataStream#keyBy]], which is
+    * assumed to be [[MathUtils#murmurHash]].
     */
   @Test
   def testGroupedFoldOperator(): Unit = {


### PR DESCRIPTION
`{@link StreamExecutionEnvironment#readFile(FileInputFormat, * String, FileProcessingMode, long)}`

==>

`[StreamExecutionEnvironment#readFile(FileInputFormat, String, FileProcessingMode, long)]`

- [X] General
  - The pull request references the related JIRA issue ("[FLINK-5168] Scaladoc annotation link use [[]] instead of {@link}")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [X] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [X] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

