### PR TITLE
[FLINK-5170] [runtime] fix mis judge of hostname in AkkaUtils

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -115,7 +115,7 @@ object AkkaUtils {
   }
 
   def getAkkaConfig(configuration: Configuration, hostname: String, port: Int): Config = {
-    getAkkaConfig(configuration, if (hostname == null) Some((hostname, port)) else None)
+    getAkkaConfig(configuration, if (hostname != null) Some((hostname, port)) else None)
   }
 
   /**


### PR DESCRIPTION
This pr is for jira #[5170](https://issues.apache.org/jira/browse/FLINK-5170).

in AkkaUtil.scala, 
def getAkkaConfig(configuration: Configuration, hostname: String, port: Int): Config =
{ getAkkaConfig(configuration, if (hostname == null) Some((hostname, port)) else None) }

when hostname is specified, it use None.
