### PR TITLE
[FLINK-5171] [runtime] fix wrong use of Preconditions.checkState in TaskManagerRunner

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -185,7 +185,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
 
 		final int rpcPort = configuration.getInteger(ConfigConstants.TASK_MANAGER_IPC_PORT_KEY, 0);
 
-		Preconditions.checkState(rpcPort < 0 || rpcPort >65535, "Invalid value for " +
+		Preconditions.checkState(rpcPort >= 0 && rpcPort <= 65535, "Invalid value for " +
 				"'%s' (port for the TaskManager actor system) : %d - Leave config parameter empty or " +
 				"use 0 to let the system choose port automatically.",
 			ConfigConstants.TASK_MANAGER_IPC_PORT_KEY, rpcPort);


### PR DESCRIPTION
This pr is for jira #[5171](https://issues.apache.org/jira/browse/FLINK-5171). 

Preconditions.checkState will check the first parameter is true, if not, it will throw an exception. but in TaskManagerRunner, it will throw an exception if rpc port is valid.