### PR TITLE
[FLINK-4993] Don't Allow Trigger.onMerge() to return TriggerResult

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/GlobalWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/GlobalWindows.java
@@ -92,9 +92,7 @@ public class GlobalWindows extends WindowAssigner<Object, GlobalWindow> {
 		public void clear(GlobalWindow window, TriggerContext ctx) throws Exception {}
 
 		@Override
-		public TriggerResult onMerge(GlobalWindow window,
-				OnMergeContext ctx) {
-			return TriggerResult.CONTINUE;
+		public void onMerge(GlobalWindow window, OnMergeContext ctx) {
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousEventTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousEventTimeTrigger.java
@@ -109,13 +109,12 @@ public class ContinuousEventTimeTrigger<W extends Window> extends Trigger<Object
 	}
 
 	@Override
-	public TriggerResult onMerge(W window, OnMergeContext ctx) throws Exception {
+	public void onMerge(W window, OnMergeContext ctx) throws Exception {
 		ctx.mergePartitionedState(stateDesc);
 		Long nextFireTimestamp = ctx.getPartitionedState(stateDesc).get();
 		if (nextFireTimestamp != null) {
 			ctx.registerEventTimeTimer(nextFireTimestamp);
 		}
-		return TriggerResult.CONTINUE;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousProcessingTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousProcessingTimeTrigger.java
@@ -97,10 +97,9 @@ public class ContinuousProcessingTimeTrigger<W extends Window> extends Trigger<O
 	}
 
 	@Override
-	public TriggerResult onMerge(W window,
+	public void onMerge(W window,
 			OnMergeContext ctx) {
 		ctx.mergePartitionedState(stateDesc);
-		return TriggerResult.CONTINUE;
 	}
 
 	@VisibleForTesting

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/CountTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/CountTrigger.java
@@ -76,13 +76,8 @@ public class CountTrigger<W extends Window> extends Trigger<Object, W> {
 	}
 
 	@Override
-	public TriggerResult onMerge(W window, OnMergeContext ctx) throws Exception {
+	public void onMerge(W window, OnMergeContext ctx) throws Exception {
 		ctx.mergePartitionedState(stateDesc);
-		ReducingState<Long> count = ctx.getPartitionedState(stateDesc);
-		if (count.get() >= maxCount) {
-			return TriggerResult.FIRE;
-		}
-		return TriggerResult.CONTINUE;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/EventTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/EventTimeTrigger.java
@@ -67,10 +67,9 @@ public class EventTimeTrigger extends Trigger<Object, TimeWindow> {
 	}
 
 	@Override
-	public TriggerResult onMerge(TimeWindow window,
+	public void onMerge(TimeWindow window,
 			OnMergeContext ctx) {
 		ctx.registerEventTimeTimer(window.maxTimestamp());
-		return TriggerResult.CONTINUE;
 	}
 
 	@Override
@@ -88,4 +87,6 @@ public class EventTimeTrigger extends Trigger<Object, TimeWindow> {
 	public static EventTimeTrigger create() {
 		return new EventTimeTrigger();
 	}
+
+
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ProcessingTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ProcessingTimeTrigger.java
@@ -58,10 +58,9 @@ public class ProcessingTimeTrigger extends Trigger<Object, TimeWindow> {
 	}
 
 	@Override
-	public TriggerResult onMerge(TimeWindow window,
+	public void onMerge(TimeWindow window,
 			OnMergeContext ctx) {
 		ctx.registerProcessingTimeTimer(window.maxTimestamp());
-		return TriggerResult.CONTINUE;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/PurgingTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/PurgingTrigger.java
@@ -70,9 +70,8 @@ public class PurgingTrigger<T, W extends Window> extends Trigger<T, W> {
 	}
 
 	@Override
-	public TriggerResult onMerge(W window, OnMergeContext ctx) throws Exception {
-		TriggerResult triggerResult = nestedTrigger.onMerge(window, ctx);
-		return triggerResult.isFire() ? TriggerResult.FIRE_AND_PURGE : triggerResult;
+	public void onMerge(W window, OnMergeContext ctx) throws Exception {
+		nestedTrigger.onMerge(window, ctx);
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
@@ -104,7 +104,7 @@ public abstract class Trigger<T, W extends Window> implements Serializable {
 	 * @param window The new window that results from the merge.
 	 * @param ctx A context object that can be used to register timer callbacks and access state.
 	 */
-	public TriggerResult onMerge(W window, OnMergeContext ctx) throws Exception {
+	public void onMerge(W window, OnMergeContext ctx) throws Exception {
 		throw new RuntimeException("This trigger does not support merging.");
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -32,7 +32,6 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.TypeInfoParser;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.streaming.api.datastream.WindowedStream;
 import org.apache.flink.streaming.api.environment.LocalStreamEnvironment;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -2451,10 +2450,9 @@ public class WindowOperatorTest extends TestLogger {
 		}
 
 		@Override
-		public TriggerResult onMerge(TimeWindow window,
+		public void onMerge(TimeWindow window,
 									 OnMergeContext ctx) {
 			ctx.registerEventTimeTimer(window.maxTimestamp());
-			return TriggerResult.CONTINUE;
 		}
 
 		@Override


### PR DESCRIPTION
Allowing Trigger.onMerge() to return a TriggerResult is not necessary
since an onMerge() call will always be followed by an onElement() call
when adding the element that caused the merging to the merged window.
Having this complicates the internal logic of the WindowOperator and
makes writing Triggers more confusing than it has to be.