### PR TITLE
[FLINK-5088] [network] Add capacity limit option to partitions

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -228,6 +228,10 @@ public final class ConfigConstants {
 
 	public static final String NETWORK_REQUEST_BACKOFF_MAX_KEY = "taskmanager.net.request-backoff.max";
 
+	/** Queue length for bounded pipelined partitions. 0 indicates unbounded. */
+	@PublicEvolving
+	public static final String NETWORK_PIPELINED_BOUNDED_QUEUE_LENGTH_KEY = "taskmanager.net.max-out-queue-length";
+
 	/**
 	 * Config parameter defining the size of memory buffers used by the network stack and the memory manager.
 	 */
@@ -846,6 +850,9 @@ public final class ConfigConstants {
 
 	/** Maximum backoff for partition requests of input channels. */
 	public static final int DEFAULT_NETWORK_REQUEST_BACKOFF_MAX = 10000;
+
+	/** Queue length for bounded pipelined partitions. 0 indicates unbounded. */
+	public static final int DEFAULT_NETWORK_PIPELINED_BOUNDED_QUEUE_LENGTH = 0;
 
 	/**
 	 * Default size of memory segments in the network stack and the memory manager.

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -228,9 +228,12 @@ public final class ConfigConstants {
 
 	public static final String NETWORK_REQUEST_BACKOFF_MAX_KEY = "taskmanager.net.request-backoff.max";
 
-	/** Queue length for bounded pipelined partitions. 0 indicates unbounded. */
+	/**
+	 * Maximum queue length for bounded pipelined partitions on both the
+	 * outbound and inbound side. 0 indicates unbounded.
+	 */
 	@PublicEvolving
-	public static final String NETWORK_PIPELINED_BOUNDED_QUEUE_LENGTH_KEY = "taskmanager.net.max-out-queue-length";
+	public static final String NETWORK_PIPELINED_BOUNDED_QUEUE_LENGTH_KEY = "taskmanager.net.max-queue-length";
 
 	/**
 	 * Config parameter defining the size of memory buffers used by the network stack and the memory manager.
@@ -851,7 +854,10 @@ public final class ConfigConstants {
 	/** Maximum backoff for partition requests of input channels. */
 	public static final int DEFAULT_NETWORK_REQUEST_BACKOFF_MAX = 10000;
 
-	/** Queue length for bounded pipelined partitions. 0 indicates unbounded. */
+	/**
+	 * Maximum queue length for bounded pipelined partitions on both the
+	 * outbound and inbound side. 0 indicates unbounded.
+	 */
 	public static final int DEFAULT_NETWORK_PIPELINED_BOUNDED_QUEUE_LENGTH = 0;
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/PartialInputChannelDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/PartialInputChannelDeploymentDescriptor.java
@@ -49,16 +49,20 @@ public class PartialInputChannelDeploymentDescriptor {
 	/** The partition connection index. */
 	private final int partitionConnectionIndex;
 
+	private final boolean capacityBoundedInput;
+
 	public PartialInputChannelDeploymentDescriptor(
 			IntermediateDataSetID resultId,
 			ResultPartitionID partitionID,
 			InstanceConnectionInfo partitionConnectionInfo,
-			int partitionConnectionIndex) {
+			int partitionConnectionIndex,
+			boolean capacityBoundedInput) {
 
 		this.resultId = checkNotNull(resultId);
 		this.partitionID = checkNotNull(partitionID);
 		this.partitionConnectionInfo = checkNotNull(partitionConnectionInfo);
 		this.partitionConnectionIndex = partitionConnectionIndex;
+		this.capacityBoundedInput = capacityBoundedInput;
 	}
 
 	/**
@@ -85,7 +89,7 @@ public class PartialInputChannelDeploymentDescriptor {
 					new ConnectionID(partitionConnectionInfo, partitionConnectionIndex));
 		}
 
-		return new InputChannelDeploymentDescriptor(partitionID, partitionLocation);
+		return new InputChannelDeploymentDescriptor(partitionID, partitionLocation, capacityBoundedInput);
 	}
 
 	public IntermediateDataSetID getResultId() {
@@ -99,7 +103,8 @@ public class PartialInputChannelDeploymentDescriptor {
 	 */
 	public static PartialInputChannelDeploymentDescriptor fromEdge(
 			IntermediateResultPartition partition,
-			Execution producer) {
+			Execution producer,
+			boolean capacityBoundedInput) {
 
 		final ResultPartitionID partitionId = new ResultPartitionID(
 				partition.getPartitionId(), producer.getAttemptId());
@@ -111,6 +116,6 @@ public class PartialInputChannelDeploymentDescriptor {
 		final int partitionConnectionIndex = result.getConnectionIndex();
 
 		return new PartialInputChannelDeploymentDescriptor(
-				resultId, partitionId, partitionConnectionInfo, partitionConnectionIndex);
+				resultId, partitionId, partitionConnectionInfo, partitionConnectionIndex, capacityBoundedInput);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
@@ -55,7 +55,7 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 
 	private AccumulatorRegistry.Reporter reporter;
 
-	private transient Counter numBytesOut;
+	private Counter numBytesOut;
 
 	public SpanningRecordSerializer() {
 		this.serializationBuffer = new DataOutputSerializer(128);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -18,13 +18,24 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.configuration.ConfigConstants;
+
 public enum ResultPartitionType {
 
 	BLOCKING(true, false, false),
 
 	PIPELINED(false, true, true),
 
-	PIPELINED_PERSISTENT(true, true, true);
+	/**
+	 * Pipelined partitions with a bounded queue for buffers. The queue size is
+	 * is configured via {@link ConfigConstants#DEFAULT_NETWORK_PIPELINED_BOUNDED_QUEUE_LENGTH}.
+	 *
+	 * For streaming jobs a fixed limit should help avoid that single downstream
+	 * operators get a disproportionally large backlog. For batch jobs, it will
+	 * be best to keep this unlimited ({@link #PIPELINED} and let the local buffer
+	 * pools limit how much is queued.
+	 */
+	PIPELINED_BOUNDED(false, true, true);
 
 	/** Does the partition live longer than the consuming task? */
 	private final boolean isPersistent;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -71,9 +71,11 @@ public abstract class ResultSubpartition {
 		return parent.getFailureCause();
 	}
 
-	abstract public boolean add(Buffer buffer) throws IOException;
+	abstract public boolean add(Buffer buffer, boolean capacityConstrained) throws IOException, InterruptedException;
 
-	abstract public void finish() throws IOException;
+	abstract public boolean addIfCapacityAvailable(Buffer buffer) throws IOException;
+
+	abstract public void finish() throws IOException, InterruptedException;
 
 	abstract public void release() throws IOException;
 
@@ -82,5 +84,4 @@ public abstract class ResultSubpartition {
 	abstract int releaseMemory() throws IOException;
 
 	abstract public boolean isReleased();
-
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -83,7 +83,7 @@ class SpillableSubpartition extends ResultSubpartition {
 	}
 
 	@Override
-	public boolean add(Buffer buffer) throws IOException {
+	public boolean add(Buffer buffer, boolean capacityConstrained) throws IOException {
 		checkNotNull(buffer);
 
 		synchronized (buffers) {
@@ -105,9 +105,14 @@ class SpillableSubpartition extends ResultSubpartition {
 	}
 
 	@Override
+	public boolean addIfCapacityAvailable(Buffer buffer) throws IOException {
+		return add(buffer, false);
+	}
+
+	@Override
 	public void finish() throws IOException {
 		synchronized (buffers) {
-			if (add(EventSerializer.toBuffer(EndOfPartitionEvent.INSTANCE))) {
+			if (add(EventSerializer.toBuffer(EndOfPartitionEvent.INSTANCE), false)) {
 				isFinished = true;
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -207,7 +207,7 @@ public class SingleInputGate implements InputGate {
 		return consumedResultId;
 	}
 
-	BufferProvider getBufferProvider() {
+	public BufferProvider getBufferProvider() {
 		return bufferPool;
 	}
 
@@ -543,7 +543,7 @@ public class SingleInputGate implements InputGate {
 	// ------------------------------------------------------------------------
 
 	@VisibleForTesting
-	Map<IntermediateResultPartitionID, InputChannel> getInputChannels() {
+	public Map<IntermediateResultPartitionID, InputChannel> getInputChannels() {
 		return inputChannels;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -518,7 +518,8 @@ public class SingleInputGate implements InputGate {
 				partitionId);
 	}
 
-	private void queueChannel(InputChannel channel) {
+	@VisibleForTesting
+	void queueChannel(InputChannel channel) {
 		int availableChannels;
 
 		synchronized (inputChannelsWithData) {
@@ -557,8 +558,10 @@ public class SingleInputGate implements InputGate {
 			ExecutionAttemptID executionId,
 			InputGateDeploymentDescriptor igdd,
 			NetworkEnvironment networkEnvironment,
-			IOMetricGroup metrics) {
+			IOMetricGroup metrics,
+			int channelCapacityLimit) {
 
+		checkArgument(channelCapacityLimit >= 0);
 		final IntermediateDataSetID consumedResultId = checkNotNull(igdd.getConsumedResultId());
 
 		final int consumedSubpartitionIndex = igdd.getConsumedSubpartitionIndex();
@@ -591,7 +594,8 @@ public class SingleInputGate implements InputGate {
 						partitionLocation.getConnectionId(),
 						networkEnvironment.getConnectionManager(),
 						networkEnvironment.getPartitionRequestInitialAndMaxBackoff(),
-						metrics
+						metrics,
+						channelCapacityLimit
 				);
 			}
 			else if (partitionLocation.isUnknown()) {
@@ -600,7 +604,8 @@ public class SingleInputGate implements InputGate {
 						networkEnvironment.getTaskEventDispatcher(),
 						networkEnvironment.getConnectionManager(),
 						networkEnvironment.getPartitionRequestInitialAndMaxBackoff(),
-						metrics
+						metrics,
+						channelCapacityLimit
 				);
 			}
 			else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -29,6 +29,7 @@ import scala.Tuple2;
 
 import java.io.IOException;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -48,6 +49,8 @@ public class UnknownInputChannel extends InputChannel {
 
 	private final IOMetricGroup metrics;
 
+	private final int channelCapacityLimit;
+
 	public UnknownInputChannel(
 			SingleInputGate gate,
 			int channelIndex,
@@ -56,15 +59,19 @@ public class UnknownInputChannel extends InputChannel {
 			TaskEventDispatcher taskEventDispatcher,
 			ConnectionManager connectionManager,
 			Tuple2<Integer, Integer> partitionRequestInitialAndMaxBackoff,
-			IOMetricGroup metrics) {
+			IOMetricGroup metrics,
+			int channelCapacityLimit) {
 
 		super(gate, channelIndex, partitionId, partitionRequestInitialAndMaxBackoff, null);
+
+		checkArgument(channelCapacityLimit >= 0);
 
 		this.partitionManager = checkNotNull(partitionManager);
 		this.taskEventDispatcher = checkNotNull(taskEventDispatcher);
 		this.connectionManager = checkNotNull(connectionManager);
 		this.partitionRequestInitialAndMaxBackoff = checkNotNull(partitionRequestInitialAndMaxBackoff);
 		this.metrics = checkNotNull(metrics);
+		this.channelCapacityLimit = channelCapacityLimit;
 	}
 
 	@Override
@@ -114,7 +121,7 @@ public class UnknownInputChannel extends InputChannel {
 	// ------------------------------------------------------------------------
 
 	public RemoteInputChannel toRemoteInputChannel(ConnectionID producerAddress) {
-		return new RemoteInputChannel(inputGate, channelIndex, partitionId, checkNotNull(producerAddress), connectionManager, partitionRequestInitialAndMaxBackoff, metrics);
+		return new RemoteInputChannel(inputGate, channelIndex, partitionId, checkNotNull(producerAddress), connectionManager, partitionRequestInitialAndMaxBackoff, metrics, channelCapacityLimit);
 	}
 
 	public LocalInputChannel toLocalInputChannel() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/shipping/OutputCollector.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/shipping/OutputCollector.java
@@ -83,7 +83,7 @@ public class OutputCollector<T> implements Collector<T> {
 		for (RecordWriter<?> writer : writers) {
 			try {
 				writer.flush();
-			} catch (IOException e) {
+			} catch (IOException|InterruptedException e) {
 				throw new RuntimeException(e.getMessage(), e);
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -325,6 +325,11 @@ public class Task implements Runnable {
 
 		int counter = 0;
 
+		// Queue capacity for bounded pipelined partitions
+		int pipelinedBoundedQueueLength = taskManagerConfig.getConfiguration().getInteger(
+			ConfigConstants.NETWORK_PIPELINED_BOUNDED_QUEUE_LENGTH_KEY,
+			ConfigConstants.DEFAULT_NETWORK_PIPELINED_BOUNDED_QUEUE_LENGTH);
+
 		for (ResultPartitionDeploymentDescriptor desc: resultPartitionDeploymentDescriptors) {
 			ResultPartitionID partitionId = new ResultPartitionID(desc.getPartitionId(), executionId);
 
@@ -337,7 +342,8 @@ public class Task implements Runnable {
 					networkEnvironment.getPartitionManager(),
 					networkEnvironment.getPartitionConsumableNotifier(),
 					ioManager,
-					desc.sendScheduleOrUpdateConsumersMessage());
+					desc.sendScheduleOrUpdateConsumersMessage(),
+					pipelinedBoundedQueueLength);
 
 			writers[counter] = new ResultPartitionWriter(producedPartitions[counter]);
 
@@ -353,7 +359,7 @@ public class Task implements Runnable {
 		for (InputGateDeploymentDescriptor inputGateDeploymentDescriptor: inputGateDeploymentDescriptors) {
 			SingleInputGate gate = SingleInputGate.create(
 					taskNameWithSubtaskAndId, jobId, executionId, inputGateDeploymentDescriptor, networkEnvironment,
-					metricGroup.getIOMetricGroup());
+					metricGroup.getIOMetricGroup(), pipelinedBoundedQueueLength);
 
 			inputGates[counter] = gate;
 			inputGatesById.put(gate.getConsumedResultId(), gate);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -59,6 +59,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -150,7 +151,7 @@ public class RecordWriterTest {
 
 			// Verify that buffer have been requested, but only one has been written out.
 			verify(bufferProvider, times(2)).requestBufferBlocking();
-			verify(partitionWriter, times(1)).writeBuffer(any(Buffer.class), anyInt());
+			verify(partitionWriter, times(1)).writeBuffer(any(Buffer.class), anyInt(), anyBoolean());
 
 			// Verify that the written out buffer has only been recycled once
 			// (by the partition writer).
@@ -186,7 +187,7 @@ public class RecordWriterTest {
 
 					throw new RuntimeException("Expected test Exception");
 				}
-			}).when(partitionWriter).writeBuffer(any(Buffer.class), anyInt());
+			}).when(partitionWriter).writeBuffer(any(Buffer.class), anyInt(), anyBoolean());
 
 			RecordWriter<IntValue> recordWriter = new RecordWriter<>(partitionWriter);
 
@@ -207,7 +208,7 @@ public class RecordWriterTest {
 			}
 
 			// Verify expected methods have been called
-			verify(partitionWriter, times(1)).writeBuffer(any(Buffer.class), anyInt());
+			verify(partitionWriter, times(1)).writeBuffer(any(Buffer.class), anyInt(), anyBoolean());
 			verify(bufferPool, times(1)).requestBufferBlocking();
 
 			try {
@@ -222,7 +223,7 @@ public class RecordWriterTest {
 			}
 
 			// Verify expected methods have been called
-			verify(partitionWriter, times(2)).writeBuffer(any(Buffer.class), anyInt());
+			verify(partitionWriter, times(2)).writeBuffer(any(Buffer.class), anyInt(), anyBoolean());
 			verify(bufferPool, times(2)).requestBufferBlocking();
 
 			try {
@@ -236,7 +237,7 @@ public class RecordWriterTest {
 			}
 
 			// Verify expected methods have been called
-			verify(partitionWriter, times(3)).writeBuffer(any(Buffer.class), anyInt());
+			verify(partitionWriter, times(3)).writeBuffer(any(Buffer.class), anyInt(), anyBoolean());
 			verify(bufferPool, times(3)).requestBufferBlocking();
 
 			try {
@@ -251,7 +252,7 @@ public class RecordWriterTest {
 			}
 
 			// Verify expected methods have been called
-			verify(partitionWriter, times(4)).writeBuffer(any(Buffer.class), anyInt());
+			verify(partitionWriter, times(4)).writeBuffer(any(Buffer.class), anyInt(), anyBoolean());
 			verify(bufferPool, times(4)).requestBufferBlocking();
 
 			try {
@@ -266,7 +267,7 @@ public class RecordWriterTest {
 			}
 
 			// Verify expected methods have been called
-			verify(partitionWriter, times(5)).writeBuffer(any(Buffer.class), anyInt());
+			verify(partitionWriter, times(5)).writeBuffer(any(Buffer.class), anyInt(), anyBoolean());
 			verify(bufferPool, times(5)).requestBufferBlocking();
 		}
 		finally {
@@ -294,7 +295,7 @@ public class RecordWriterTest {
 
 		// Fill a buffer, but don't write it out.
 		recordWriter.emit(new IntValue(0));
-		verify(partitionWriter, never()).writeBuffer(any(Buffer.class), anyInt());
+		verify(partitionWriter, never()).writeBuffer(any(Buffer.class), anyInt(), anyBoolean());
 
 		// Clear all buffers.
 		recordWriter.clearBuffers();
@@ -409,7 +410,7 @@ public class RecordWriterTest {
 	 */
 	private ResultPartitionWriter createCollectingPartitionWriter(
 			final Queue<BufferOrEvent>[] queues,
-			BufferProvider bufferProvider) throws IOException {
+			BufferProvider bufferProvider) throws IOException, InterruptedException {
 
 		int numChannels = queues.length;
 
@@ -425,7 +426,7 @@ public class RecordWriterTest {
 				queues[targetChannel].add(new BufferOrEvent(buffer, targetChannel));
 				return null;
 			}
-		}).when(partitionWriter).writeBuffer(any(Buffer.class), anyInt());
+		}).when(partitionWriter).writeBuffer(any(Buffer.class), anyInt(), anyBoolean());
 
 		doAnswer(new Answer<Void>() {
 			@Override
@@ -471,7 +472,7 @@ public class RecordWriterTest {
 	}
 
 	private ResultPartitionWriter createResultPartitionWriter(BufferProvider bufferProvider)
-			throws IOException {
+			throws IOException, InterruptedException {
 
 		ResultPartitionWriter partitionWriter = mock(ResultPartitionWriter.class);
 		when(partitionWriter.getBufferProvider()).thenReturn(checkNotNull(bufferProvider));
@@ -485,7 +486,7 @@ public class RecordWriterTest {
 
 				return null;
 			}
-		}).when(partitionWriter).writeBuffer(any(Buffer.class), anyInt());
+		}).when(partitionWriter).writeBuffer(any(Buffer.class), anyInt(), anyBoolean());
 
 		return partitionWriter;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriterTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.api.writer;
+
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.util.TestBufferFactory;
+import org.apache.flink.runtime.io.network.util.TestInfiniteBufferProvider;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ResultPartitionWriterTest {
+
+	/**
+	 * Tests that the result partition writer calls the correct partition
+	 * methods and sets the correct flags. This mostly important for
+	 * indicating whether we want to be capacity constrained or not.
+	 */
+	@Test
+	public void testCorrectCallForwarding() throws Exception {
+		ResultPartitionID partitionId = new ResultPartitionID();
+		BufferProvider bufferProvider = new TestInfiniteBufferProvider();
+		int numSubPartitions = 123;
+
+		ResultPartition partition = mock(ResultPartition.class);
+		when(partition.getPartitionId()).thenReturn(partitionId);
+		when(partition.getBufferProvider()).thenReturn(bufferProvider);
+		when(partition.getNumberOfSubpartitions()).thenReturn(numSubPartitions);
+
+		ResultPartitionWriter writer = new ResultPartitionWriter(partition);
+
+		// - Properties -
+		assertEquals(partitionId, writer.getPartitionId());
+		assertEquals(bufferProvider, writer.getBufferProvider());
+		assertEquals(numSubPartitions, writer.getNumberOfOutputChannels());
+
+		Buffer buffer = TestBufferFactory.getMockBuffer();
+
+		// - Buffer write calls -
+
+		// Back pressure flag
+		writer.writeBuffer(buffer, 0, false);
+		verify(partition, times(1)).add(eq(buffer), eq(0), eq(false));
+
+		writer.writeBuffer(buffer, 1, true);
+		verify(partition, times(1)).add(eq(buffer), eq(1), eq(true));
+
+		// Capacity constraint variants
+		writer.tryWriteBuffer(buffer, 2);
+		verify(partition, times(1)).addBufferIfCapacityAvailable(eq(buffer), eq(2));
+
+		// - Event calls -
+
+		writer.writeEvent(new CheckpointBarrier(123, 220), 3);
+		verify(partition, times(1)).add(Matchers.argThat(new ArgumentMatcher<Buffer>() {
+			@Override
+			public boolean matches(Object arg) {
+				Buffer buffer = (Buffer) arg;
+				return !buffer.isBuffer();
+			}
+		}), eq(3), eq(false));
+
+		// Reset and check all add calls
+		Mockito.reset(partition);
+		when(partition.getNumberOfSubpartitions()).thenReturn(numSubPartitions);
+
+		writer.writeEventToAllChannels(new CheckpointBarrier(221, 1123));
+
+		for (int i = 0; i < numSubPartitions; i++) {
+			verify(partition, times(1)).add(any(Buffer.class), eq(i), eq(false));
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateConcurrentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateConcurrentTest.java
@@ -73,7 +73,7 @@ public class InputGateConcurrentTest {
 					resultPartitionManager, mock(TaskEventDispatcher.class), new DummyIOMetricGroup());
 			gate.setInputChannel(new IntermediateResultPartitionID(), channel);
 
-			partitions[i] = new PipelinedSubpartition(0, resultPartition);
+			partitions[i] = new PipelinedSubpartition(0, resultPartition, 0);
 			sources[i] = new PipelinedSubpartitionSource(partitions[i]);
 		}
 
@@ -108,7 +108,7 @@ public class InputGateConcurrentTest {
 		for (int i = 0; i < numChannels; i++) {
 			RemoteInputChannel channel = new RemoteInputChannel(
 					gate, i, new ResultPartitionID(), mock(ConnectionID.class),
-					connManager, new Tuple2<>(0, 0), new DummyIOMetricGroup());
+					connManager, new Tuple2<>(0, 0), new DummyIOMetricGroup(), 0);
 			gate.setInputChannel(new IntermediateResultPartitionID(), channel);
 
 			sources[i] = new RemoteChannelSource(channel);
@@ -158,7 +158,7 @@ public class InputGateConcurrentTest {
 		for (int i = 0, local = 0; i < numChannels; i++) {
 			if (localOrRemote.get(i)) {
 				// local channel
-				PipelinedSubpartition psp = new PipelinedSubpartition(0, resultPartition);
+				PipelinedSubpartition psp = new PipelinedSubpartition(0, resultPartition, 0);
 				localPartitions[local++] = psp;
 				sources[i] = new PipelinedSubpartitionSource(psp);
 
@@ -170,7 +170,7 @@ public class InputGateConcurrentTest {
 				//remote channel
 				RemoteInputChannel channel = new RemoteInputChannel(
 						gate, i, new ResultPartitionID(), mock(ConnectionID.class),
-						connManager, new Tuple2<>(0, 0), new DummyIOMetricGroup());
+						connManager, new Tuple2<>(0, 0), new DummyIOMetricGroup(), 0);
 				gate.setInputChannel(new IntermediateResultPartitionID(), channel);
 
 				sources[i] = new RemoteChannelSource(channel);
@@ -206,7 +206,7 @@ public class InputGateConcurrentTest {
 
 		@Override
 		void addBuffer(Buffer buffer) throws Exception {
-			partition.add(buffer);
+			partition.add(buffer, false);
 		}
 	}
 
@@ -221,7 +221,7 @@ public class InputGateConcurrentTest {
 
 		@Override
 		void addBuffer(Buffer buffer) throws Exception {
-			channel.onBuffer(buffer, seq++);
+			channel.onBuffer(buffer, seq++, null);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
@@ -112,7 +112,7 @@ public class PartialConsumePipelinedResultTest {
 
 			for (int i = 0; i < 8; i++) {
 				final Buffer buffer = writer.getBufferProvider().requestBufferBlocking();
-				writer.writeBuffer(buffer, 0);
+				writer.writeBuffer(buffer, 0, false);
 
 				Thread.sleep(50);
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -30,7 +30,11 @@ import org.apache.flink.runtime.io.network.util.TestSubpartitionConsumer;
 import org.apache.flink.runtime.io.network.util.TestSubpartitionProducer;
 import org.junit.AfterClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -45,10 +49,29 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@RunWith(Parameterized.class)
 public class PipelinedSubpartitionTest extends SubpartitionTestBase {
+
+	@Parameterized.Parameters
+	public static Collection<Object[]> data() {
+		// The capacity limit tests are mostly
+		// relevant for the slow/fast consumer tests
+
+		return Arrays.asList(new Object[][]{
+			{0}, // unbounded
+			{1}, // single buffer capacity limit
+			{4} // 4 buffers capacity limit
+		});
+	}
 
 	/** Executor service for concurrent produce/consume tests */
 	private final static ExecutorService executorService = Executors.newCachedThreadPool();
+
+	private final int capacityLimit;
+
+	public PipelinedSubpartitionTest(int capacityLimit) {
+		this.capacityLimit = capacityLimit;
+	}
 
 	@AfterClass
 	public static void shutdownExecutorService() throws Exception {
@@ -59,7 +82,7 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 	PipelinedSubpartition createSubpartition() {
 		final ResultPartition parent = mock(ResultPartition.class);
 
-		return new PipelinedSubpartition(0, parent, 0);
+		return new PipelinedSubpartition(0, parent, capacityLimit);
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -59,7 +59,7 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 	PipelinedSubpartition createSubpartition() {
 		final ResultPartition parent = mock(ResultPartition.class);
 
-		return new PipelinedSubpartition(0, parent);
+		return new PipelinedSubpartition(0, parent, 0);
 	}
 
 	@Test
@@ -98,7 +98,7 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 		verify(listener, times(1)).notifyBuffersAvailable(eq(0L));
 
 		// Add data to the queue...
-		subpartition.add(createBuffer());
+		subpartition.add(createBuffer(), false);
 
 		// ...should have resulted in a notification
 		verify(listener, times(1)).notifyBuffersAvailable(eq(1L));
@@ -108,7 +108,7 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 		assertNull(view.getNextBuffer());
 
 		// Add data to the queue...
-		subpartition.add(createBuffer());
+		subpartition.add(createBuffer(), false);
 		verify(listener, times(2)).notifyBuffersAvailable(eq(1L));
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -20,9 +20,11 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.io.network.util.TestBufferFactory;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -40,7 +42,7 @@ public class ResultPartitionTest {
 			// Pipelined, send message => notify
 			ResultPartitionConsumableNotifier notifier = mock(ResultPartitionConsumableNotifier.class);
 			ResultPartition partition = createPartition(notifier, ResultPartitionType.PIPELINED, true);
-			partition.add(TestBufferFactory.createBuffer(), 0);
+			partition.add(TestBufferFactory.createBuffer(), 0, true);
 			verify(notifier, times(1)).notifyPartitionConsumable(any(JobID.class), any(ResultPartitionID.class));
 		}
 
@@ -48,7 +50,7 @@ public class ResultPartitionTest {
 			// Pipelined, don't send message => don't notify
 			ResultPartitionConsumableNotifier notifier = mock(ResultPartitionConsumableNotifier.class);
 			ResultPartition partition = createPartition(notifier, ResultPartitionType.PIPELINED, false);
-			partition.add(TestBufferFactory.createBuffer(), 0);
+			partition.add(TestBufferFactory.createBuffer(), 0, true);
 			verify(notifier, never()).notifyPartitionConsumable(any(JobID.class), any(ResultPartitionID.class));
 		}
 
@@ -56,7 +58,7 @@ public class ResultPartitionTest {
 			// Blocking, send message => don't notify
 			ResultPartitionConsumableNotifier notifier = mock(ResultPartitionConsumableNotifier.class);
 			ResultPartition partition = createPartition(notifier, ResultPartitionType.BLOCKING, true);
-			partition.add(TestBufferFactory.createBuffer(), 0);
+			partition.add(TestBufferFactory.createBuffer(), 0, true);
 			verify(notifier, never()).notifyPartitionConsumable(any(JobID.class), any(ResultPartitionID.class));
 		}
 
@@ -64,9 +66,32 @@ public class ResultPartitionTest {
 			// Blocking, don't send message => don't notify
 			ResultPartitionConsumableNotifier notifier = mock(ResultPartitionConsumableNotifier.class);
 			ResultPartition partition = createPartition(notifier, ResultPartitionType.BLOCKING, false);
-			partition.add(TestBufferFactory.createBuffer(), 0);
+			partition.add(TestBufferFactory.createBuffer(), 0, true);
 			verify(notifier, never()).notifyPartitionConsumable(any(JobID.class), any(ResultPartitionID.class));
 		}
+	}
+
+	/**
+	 * Tests that the pipelined bounded queue length config is correctly forwarded.
+	 */
+	@Test
+	public void testPipelinedBoundedQueueLengthConfig() throws Exception {
+		int queueLength = 28;
+
+		ResultPartition partition = new ResultPartition(
+			"The Owner",
+			new JobID(),
+			new ResultPartitionID(),
+			ResultPartitionType.PIPELINED_BOUNDED,
+			1,
+			new ResultPartitionManager(),
+			mock(ResultPartitionConsumableNotifier.class),
+			new IOManagerAsync(),
+			false,
+			queueLength);
+
+		PipelinedSubpartition subpartition = (PipelinedSubpartition) partition.getSubPartition(0);
+		assertEquals(queueLength, subpartition.getMaxAllowedQueueLength());
 	}
 
 	// ------------------------------------------------------------------------
@@ -84,6 +109,7 @@ public class ResultPartitionTest {
 			mock(ResultPartitionManager.class),
 			notifier,
 			mock(IOManager.class),
-			sendScheduleOrUpdateConsumersMessage);
+			sendScheduleOrUpdateConsumersMessage,
+			0);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
@@ -48,7 +48,7 @@ public abstract class SubpartitionTestBase extends TestLogger {
 		try {
 			subpartition.finish();
 
-			assertFalse(subpartition.add(mock(Buffer.class)));
+			assertFalse(subpartition.add(mock(Buffer.class), false));
 		} finally {
 			if (subpartition != null) {
 				subpartition.release();
@@ -63,7 +63,7 @@ public abstract class SubpartitionTestBase extends TestLogger {
 		try {
 			subpartition.release();
 
-			assertFalse(subpartition.add(mock(Buffer.class)));
+			assertFalse(subpartition.add(mock(Buffer.class), false));
 		} finally {
 			if (subpartition != null) {
 				subpartition.release();
@@ -88,7 +88,7 @@ public abstract class SubpartitionTestBase extends TestLogger {
 	private void verifyViewReleasedAfterParentRelease(ResultSubpartition partition) throws Exception {
 		// Add a buffer
 		Buffer buffer = TestBufferFactory.createBuffer();
-		partition.add(buffer);
+		partition.add(buffer, false);
 		partition.finish();
 
 		TestInfiniteBufferProvider buffers = new TestInfiniteBufferProvider();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -121,7 +121,8 @@ public class LocalInputChannelTest {
 					partitionManager,
 					partitionConsumableNotifier,
 					ioManager,
-					true);
+					true,
+					0);
 
 			// Create a buffer pool for this partition
 			partition.registerBufferPool(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -142,7 +142,7 @@ public class SingleInputGateTest {
 		// Unknown
 		ResultPartitionID unknownPartitionId = new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID());
 
-		InputChannel unknown = new UnknownInputChannel(inputGate, 1, unknownPartitionId, partitionManager, taskEventDispatcher, mock(ConnectionManager.class), new Tuple2<Integer, Integer>(0, 0), new UnregisteredTaskMetricsGroup.DummyIOMetricGroup());
+		InputChannel unknown = new UnknownInputChannel(inputGate, 1, unknownPartitionId, partitionManager, taskEventDispatcher, mock(ConnectionManager.class), new Tuple2<Integer, Integer>(0, 0), new UnregisteredTaskMetricsGroup.DummyIOMetricGroup(), 0);
 
 		// Set channels
 		inputGate.setInputChannel(localPartitionId.getPartitionId(), local);
@@ -162,7 +162,7 @@ public class SingleInputGateTest {
 		verify(taskEventDispatcher, times(1)).publish(any(ResultPartitionID.class), any(TaskEvent.class));
 
 		// After the update, the pending event should be send to local channel
-		inputGate.updateInputChannel(new InputChannelDeploymentDescriptor(new ResultPartitionID(unknownPartitionId.getPartitionId(), unknownPartitionId.getProducerId()), ResultPartitionLocation.createLocal()));
+		inputGate.updateInputChannel(new InputChannelDeploymentDescriptor(new ResultPartitionID(unknownPartitionId.getPartitionId(), unknownPartitionId.getProducerId()), ResultPartitionLocation.createLocal(), false));
 
 		verify(partitionManager, times(2)).createSubpartitionView(any(ResultPartitionID.class), anyInt(), any(BufferProvider.class), any(BufferAvailabilityListener.class));
 		verify(taskEventDispatcher, times(2)).publish(any(ResultPartitionID.class), any(TaskEvent.class));
@@ -194,14 +194,15 @@ public class SingleInputGateTest {
 			partitionManager,
 			new TaskEventDispatcher(),
 			new LocalConnectionManager(),
-			new Tuple2<Integer, Integer>(0, 0), new UnregisteredTaskMetricsGroup.DummyIOMetricGroup());
+			new Tuple2<Integer, Integer>(0, 0), new UnregisteredTaskMetricsGroup.DummyIOMetricGroup(),
+			0);
 
 		inputGate.setInputChannel(unknown.partitionId.getPartitionId(), unknown);
 
 		// Update to a local channel and verify that no request is triggered
 		inputGate.updateInputChannel(new InputChannelDeploymentDescriptor(
 			unknown.partitionId,
-			ResultPartitionLocation.createLocal()));
+			ResultPartitionLocation.createLocal(), false));
 
 		verify(partitionManager, never()).createSubpartitionView(
 			any(ResultPartitionID.class), anyInt(), any(BufferProvider.class), any(BufferAvailabilityListener.class));
@@ -234,7 +235,7 @@ public class SingleInputGateTest {
 			new TaskEventDispatcher(),
 			new LocalConnectionManager(),
 			new Tuple2<>(0, 0),
-			new UnregisteredTaskMetricsGroup.DummyIOMetricGroup());
+			new UnregisteredTaskMetricsGroup.DummyIOMetricGroup(), 0);
 
 		inputGate.setInputChannel(unknown.partitionId.getPartitionId(), unknown);
 
@@ -296,15 +297,18 @@ public class SingleInputGateTest {
 			// Local
 			new InputChannelDeploymentDescriptor(
 				partitionIds[0],
-				ResultPartitionLocation.createLocal()),
+				ResultPartitionLocation.createLocal(),
+				false),
 			// Remote
 			new InputChannelDeploymentDescriptor(
 				partitionIds[1],
-				ResultPartitionLocation.createRemote(new ConnectionID(new InetSocketAddress("localhost", 5000), 0))),
+				ResultPartitionLocation.createRemote(new ConnectionID(new InetSocketAddress("localhost", 5000), 0)),
+				false),
 			// Unknown
 			new InputChannelDeploymentDescriptor(
 				partitionIds[2],
-				ResultPartitionLocation.createUnknown())};
+				ResultPartitionLocation.createUnknown(),
+				false)};
 
 		InputGateDeploymentDescriptor gateDesc = new InputGateDeploymentDescriptor(new IntermediateDataSetID(), 0, channelDescs);
 
@@ -324,7 +328,8 @@ public class SingleInputGateTest {
 			new ExecutionAttemptID(),
 			gateDesc,
 			netEnv,
-			new UnregisteredTaskMetricsGroup.DummyIOMetricGroup());
+			new UnregisteredTaskMetricsGroup.DummyIOMetricGroup(),
+			0);
 
 		Map<IntermediateResultPartitionID, InputChannel> channelMap = gate.getInputChannels();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPartitionProducer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPartitionProducer.java
@@ -77,12 +77,12 @@ public class TestPartitionProducer implements Callable<Boolean> {
 				int targetChannelIndex = bufferOrEvent.getChannelIndex();
 
 				if (bufferOrEvent.isBuffer()) {
-					partition.add(bufferOrEvent.getBuffer(), targetChannelIndex);
+					partition.add(bufferOrEvent.getBuffer(), targetChannelIndex, false);
 				}
 				else if (bufferOrEvent.isEvent()) {
 					final Buffer buffer = EventSerializer.toBuffer(bufferOrEvent.getEvent());
 
-					partition.add(buffer, targetChannelIndex);
+					partition.add(buffer, targetChannelIndex, false);
 				}
 				else {
 					throw new IllegalStateException("BufferOrEvent instance w/o buffer nor event.");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestSubpartitionProducer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestSubpartitionProducer.java
@@ -75,12 +75,12 @@ public class TestSubpartitionProducer implements Callable<Boolean> {
 
 			while ((bufferOrEvent = source.getNextBufferOrEvent()) != null) {
 				if (bufferOrEvent.isBuffer()) {
-					subpartition.add(bufferOrEvent.getBuffer());
+					subpartition.add(bufferOrEvent.getBuffer(), false);
 				}
 				else if (bufferOrEvent.isEvent()) {
 					final Buffer buffer = EventSerializer.toBuffer(bufferOrEvent.getEvent());
 
-					subpartition.add(buffer);
+					subpartition.add(buffer, false);
 				}
 				else {
 					throw new IllegalStateException("BufferOrEvent instance w/o buffer nor event.");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -58,6 +58,7 @@ import java.util.concurrent.Future;
 
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -165,7 +166,7 @@ public class MockEnvironment implements Environment {
 
 					return null;
 				}
-			}).when(mockWriter).writeBuffer(any(Buffer.class), anyInt());
+			}).when(mockWriter).writeBuffer(any(Buffer.class), anyInt(), anyBoolean());
 
 			outputs.add(mockWriter);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -636,7 +636,7 @@ public class TaskManagerTest extends TestLogger {
 						new InputGateDeploymentDescriptor(
 								new IntermediateDataSetID(),
 								0, new InputChannelDeploymentDescriptor[]{
-										new InputChannelDeploymentDescriptor(new ResultPartitionID(partitionId, eid1), ResultPartitionLocation.createLocal())
+										new InputChannelDeploymentDescriptor(new ResultPartitionID(partitionId, eid1), ResultPartitionLocation.createLocal(), false)
 								}
 						);
 
@@ -781,7 +781,7 @@ public class TaskManagerTest extends TestLogger {
 						new InputGateDeploymentDescriptor(
 								new IntermediateDataSetID(),
 								0, new InputChannelDeploymentDescriptor[]{
-										new InputChannelDeploymentDescriptor(new ResultPartitionID(partitionId, eid1), ResultPartitionLocation.createLocal())
+										new InputChannelDeploymentDescriptor(new ResultPartitionID(partitionId, eid1), ResultPartitionLocation.createLocal(), false)
 								}
 						);
 
@@ -930,7 +930,7 @@ public class TaskManagerTest extends TestLogger {
 
 				final InputChannelDeploymentDescriptor[] icdd =
 						new InputChannelDeploymentDescriptor[] {
-								new InputChannelDeploymentDescriptor(partitionId, loc)};
+								new InputChannelDeploymentDescriptor(partitionId, loc, false)};
 
 				final InputGateDeploymentDescriptor igdd =
 						new InputGateDeploymentDescriptor(resultId, 0, icdd);
@@ -1028,7 +1028,7 @@ public class TaskManagerTest extends TestLogger {
 
 				final InputChannelDeploymentDescriptor[] icdd =
 						new InputChannelDeploymentDescriptor[] {
-								new InputChannelDeploymentDescriptor(partitionId, loc)};
+								new InputChannelDeploymentDescriptor(partitionId, loc, false)};
 
 				final InputGateDeploymentDescriptor igdd =
 						new InputGateDeploymentDescriptor(resultId, 0, icdd);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -25,8 +25,10 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.ResultPartitionLocation;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
@@ -36,13 +38,17 @@ import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.network.ConnectionID;
+import org.apache.flink.runtime.io.network.LocalConnectionManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
+import org.apache.flink.runtime.io.network.netty.PartitionStateChecker;
 import org.apache.flink.runtime.io.network.partition.PipelinedSubpartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
@@ -51,6 +57,7 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.messages.TaskManagerMessages;
 import org.apache.flink.runtime.messages.TaskMessages;
+import org.apache.flink.runtime.metrics.groups.IOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.operators.testutils.DummyInvokable;
 import org.apache.flink.util.SerializedValue;
@@ -58,10 +65,12 @@ import org.apache.flink.util.TestLogger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import scala.Tuple2;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -688,6 +697,10 @@ public class TaskTest extends TestLogger {
 		task.getExecutingThread().join();
 	}
 
+	/**
+	 * Tests that the configured capacity limit for bounded queues is correctly
+	 * forwarded to remote input channels and pipelined partitions.
+	 */
 	@Test
 	public void testPipelinedBoundedQueueLengthConfig() throws Exception {
 		LibraryCacheManager libCache = mock(LibraryCacheManager.class);
@@ -695,8 +708,9 @@ public class TaskTest extends TestLogger {
 
 		{
 			// Custom config
+			int expectedCapacityLimit = 122;
 			Configuration taskManagerConfig = new Configuration();
-			taskManagerConfig.setInteger(ConfigConstants.NETWORK_PIPELINED_BOUNDED_QUEUE_LENGTH_KEY, 122);
+			taskManagerConfig.setInteger(ConfigConstants.NETWORK_PIPELINED_BOUNDED_QUEUE_LENGTH_KEY, expectedCapacityLimit);
 
 			List<ResultPartitionDeploymentDescriptor> rpdd = new ArrayList<>();
 			rpdd.add(new ResultPartitionDeploymentDescriptor(
@@ -706,9 +720,26 @@ public class TaskTest extends TestLogger {
 				1,
 				true));
 
+			IntermediateDataSetID dataSetId = new IntermediateDataSetID();
+			ResultPartitionID partitionId = new ResultPartitionID();
+
+			List<InputGateDeploymentDescriptor> igdd = new ArrayList<>();
+			igdd.add(new InputGateDeploymentDescriptor(
+				dataSetId,
+				0,
+				new InputChannelDeploymentDescriptor[]{
+					new InputChannelDeploymentDescriptor(
+						partitionId,
+						ResultPartitionLocation.createRemote(new ConnectionID(InetSocketAddress.createUnresolved("localhost", 12223), 102302)),
+						true)
+				}));
+
 			NetworkEnvironment networkEnvironment = mock(NetworkEnvironment.class);
 			when(networkEnvironment.getPartitionManager()).thenReturn(new ResultPartitionManager());
 			when(networkEnvironment.getPartitionConsumableNotifier()).thenReturn(mock(ResultPartitionConsumableNotifier.class));
+			when(networkEnvironment.getPartitionStateChecker()).thenReturn(mock(PartitionStateChecker.class));
+			when(networkEnvironment.getPartitionRequestInitialAndMaxBackoff()).thenReturn(new Tuple2<>(0, 0));
+			when(networkEnvironment.getConnectionManager()).thenReturn(new LocalConnectionManager());
 
 			Task task = createTask(
 				DummyInvokable.class,
@@ -716,14 +747,21 @@ public class TaskTest extends TestLogger {
 				networkEnvironment,
 				taskManagerConfig,
 				new ExecutionConfig(),
-				rpdd);
+				rpdd,
+				igdd);
 
 			ResultPartition partition = task.getProducedPartitions()[0];
 			PipelinedSubpartition subpartition = (PipelinedSubpartition) partition.getSubPartition(0);
-			assertEquals(122, subpartition.getMaxAllowedQueueLength());
+			assertEquals(expectedCapacityLimit, subpartition.getMaxAllowedQueueLength());
+
+			SingleInputGate gate = task.getInputGateById(dataSetId);
+			RemoteInputChannel inputChannel = (RemoteInputChannel) gate.getInputChannels().get(partitionId.getPartitionId());
+			assertEquals(expectedCapacityLimit, inputChannel.getCapacityLimit());
 		}
 
 		{
+			int expectedCapacityLimit = ConfigConstants.DEFAULT_NETWORK_PIPELINED_BOUNDED_QUEUE_LENGTH;
+
 			// Default config
 			List<ResultPartitionDeploymentDescriptor> rpdd = new ArrayList<>();
 			rpdd.add(new ResultPartitionDeploymentDescriptor(
@@ -733,9 +771,26 @@ public class TaskTest extends TestLogger {
 				1,
 				true));
 
+			IntermediateDataSetID dataSetId = new IntermediateDataSetID();
+			ResultPartitionID partitionId = new ResultPartitionID();
+
+			List<InputGateDeploymentDescriptor> igdd = new ArrayList<>();
+			igdd.add(new InputGateDeploymentDescriptor(
+				dataSetId,
+				0,
+				new InputChannelDeploymentDescriptor[]{
+					new InputChannelDeploymentDescriptor(
+						partitionId,
+						ResultPartitionLocation.createRemote(new ConnectionID(InetSocketAddress.createUnresolved("localhost", 12223), 102302)),
+						true)
+				}));
+
 			NetworkEnvironment networkEnvironment = mock(NetworkEnvironment.class);
 			when(networkEnvironment.getPartitionManager()).thenReturn(new ResultPartitionManager());
 			when(networkEnvironment.getPartitionConsumableNotifier()).thenReturn(mock(ResultPartitionConsumableNotifier.class));
+			when(networkEnvironment.getPartitionStateChecker()).thenReturn(mock(PartitionStateChecker.class));
+			when(networkEnvironment.getPartitionRequestInitialAndMaxBackoff()).thenReturn(new Tuple2<>(0, 0));
+			when(networkEnvironment.getConnectionManager()).thenReturn(new LocalConnectionManager());
 
 			Task task = createTask(
 				DummyInvokable.class,
@@ -743,11 +798,16 @@ public class TaskTest extends TestLogger {
 				networkEnvironment,
 				new Configuration(),
 				new ExecutionConfig(),
-				rpdd);
+				rpdd,
+				igdd);
 
 			ResultPartition partition = task.getProducedPartitions()[0];
 			PipelinedSubpartition subpartition = (PipelinedSubpartition) partition.getSubPartition(0);
-			assertEquals(ConfigConstants.DEFAULT_NETWORK_PIPELINED_BOUNDED_QUEUE_LENGTH, subpartition.getMaxAllowedQueueLength());
+			assertEquals(expectedCapacityLimit, subpartition.getMaxAllowedQueueLength());
+
+			SingleInputGate gate = task.getInputGateById(dataSetId);
+			RemoteInputChannel inputChannel = (RemoteInputChannel) gate.getInputChannels().get(partitionId.getPartitionId());
+			assertEquals(expectedCapacityLimit, inputChannel.getCapacityLimit());
 		}
 	}
 
@@ -830,7 +890,7 @@ public class TaskTest extends TestLogger {
 		Configuration taskManagerConfig,
 		ExecutionConfig execConfig) throws IOException {
 
-		return createTask(invokable, libCache, networkEnvironment, taskManagerConfig, execConfig, Collections.<ResultPartitionDeploymentDescriptor>emptyList());
+		return createTask(invokable, libCache, networkEnvironment, taskManagerConfig, execConfig, Collections.<ResultPartitionDeploymentDescriptor>emptyList(), Collections.<InputGateDeploymentDescriptor>emptyList());
 	}
 
 	private Task createTask(
@@ -839,7 +899,8 @@ public class TaskTest extends TestLogger {
 		NetworkEnvironment networkEnvironment,
 		Configuration taskManagerConfig,
 		ExecutionConfig execConfig,
-		Collection<ResultPartitionDeploymentDescriptor> rpdd) throws IOException {
+		Collection<ResultPartitionDeploymentDescriptor> rpdd,
+		Collection<InputGateDeploymentDescriptor> igdd) throws IOException {
 		
 		JobID jobId = new JobID();
 		JobVertexID jobVertexId = new JobVertexID();
@@ -861,6 +922,9 @@ public class TaskTest extends TestLogger {
 			1,
 			invokable.getName(),
 			new Configuration());
+
+		TaskMetricGroup metricGroup = mock(TaskMetricGroup.class);
+		when(metricGroup.getIOMetricGroup()).thenReturn(mock(IOMetricGroup.class));
 		
 		return new Task(
 			jobInformation,
@@ -869,7 +933,7 @@ public class TaskTest extends TestLogger {
 			0,
 			0,
 			rpdd,
-			Collections.<InputGateDeploymentDescriptor>emptyList(),
+			igdd,
 			0,
 			null,
 			mock(MemoryManager.class),
@@ -882,7 +946,7 @@ public class TaskTest extends TestLogger {
 			libCache,
 			mock(FileCache.class),
 			new TaskManagerRuntimeInfo("localhost", taskManagerConfig, System.getProperty("java.io.tmpdir")),
-			mock(TaskMetricGroup.class));
+			metricGroup);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -371,17 +371,17 @@ public class StreamingJobGraphGenerator {
 			downStreamVertex.connectNewDataSetAsInput(
 				headVertex,
 				DistributionPattern.POINTWISE,
-				ResultPartitionType.PIPELINED);
+				ResultPartitionType.PIPELINED_BOUNDED);
 		} else if (partitioner instanceof RescalePartitioner){
 			downStreamVertex.connectNewDataSetAsInput(
 				headVertex,
 				DistributionPattern.POINTWISE,
-				ResultPartitionType.PIPELINED);
+				ResultPartitionType.PIPELINED_BOUNDED);
 		} else {
 			downStreamVertex.connectNewDataSetAsInput(
 					headVertex,
 					DistributionPattern.ALL_TO_ALL,
-					ResultPartitionType.PIPELINED);
+					ResultPartitionType.PIPELINED_BOUNDED);
 		}
 
 		if (LOG.isDebugEnabled()) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
@@ -99,7 +99,7 @@ public class RecordWriterOutput<OUT> implements Output<StreamRecord<OUT>> {
 	}
 	
 	
-	public void flush() throws IOException {
+	public void flush() throws IOException, InterruptedException {
 		recordWriter.flush();
 	}
 	

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamRecordWriter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamRecordWriter.java
@@ -139,18 +139,17 @@ public class StreamRecordWriter<T extends IOReadableWritable> extends RecordWrit
 	 * The thread is daemonic, because it is only a utility thread.
 	 */
 	private class OutputFlusher extends Thread {
-		
+
 		private final long timeout;
-		
+
 		private volatile boolean running = true;
 
-		
 		OutputFlusher(String name, long timeout) {
 			super(name);
 			setDaemon(true);
 			this.timeout = timeout;
 		}
-		
+
 		public void terminate() {
 			running = false;
 			interrupt();
@@ -170,10 +169,10 @@ public class StreamRecordWriter<T extends IOReadableWritable> extends RecordWrit
 							throw new Exception(e);
 						}
 					}
-					
+
 					// any errors here should let the thread come to a halt and be
 					// recognized by the writer 
-					flush();
+					tryFlush();
 				}
 			}
 			catch (Throwable t) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamRecordWriter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamRecordWriter.java
@@ -48,9 +48,7 @@ public class StreamRecordWriter<T extends IOReadableWritable> extends RecordWrit
 
 	/** The exception encountered in the flushing thread */
 	private Throwable flusherException;
-	
-	
-	
+
 	public StreamRecordWriter(ResultPartitionWriter writer, ChannelSelector<T> channelSelector, long timeout) {
 		this(writer, channelSelector, timeout, null);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -173,7 +173,7 @@ public class OperatorChain<OUT> {
 	 *
 	 * @throws IOException Thrown, if the buffered data cannot be pushed into the output streams.
 	 */
-	public void flushOutputs() throws IOException {
+	public void flushOutputs() throws IOException, InterruptedException {
 		for (RecordWriterOutput<?> streamOutput : getStreamOutputs()) {
 			streamOutput.flush();
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamRecordWriterTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamRecordWriterTest.java
@@ -26,6 +26,9 @@ import org.apache.flink.runtime.io.network.api.writer.RoundRobinChannelSelector;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.util.TestInfiniteBufferProvider;
+import org.apache.flink.types.ByteValue;
 import org.apache.flink.types.LongValue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,15 +38,24 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * This test uses the PowerMockRunner runner to work around the fact that the 
+ * This test uses the PowerMockRunner runner to work around the fact that the
  * {@link ResultPartitionWriter} class is final.
  */
 @RunWith(PowerMockRunner.class)
@@ -59,64 +71,104 @@ public class StreamRecordWriterTest {
 		FailingWriter<LongValue> testWriter = null;
 		try {
 			ResultPartitionWriter mockResultPartitionWriter = getMockWriter(5);
-			
+
 			// test writer that flushes every 5ms and fails after 3 flushes
 			testWriter = new FailingWriter<LongValue>(mockResultPartitionWriter,
-					new RoundRobinChannelSelector<LongValue>(), 5, 3);
-			
+				new RoundRobinChannelSelector<LongValue>(), 5, 3);
+
 			try {
 				long deadline = System.currentTimeMillis() + 20000; // in max 20 seconds (conservative)
 				long l = 0L;
-				
+
 				while (System.currentTimeMillis() < deadline) {
 					testWriter.emit(new LongValue(l++));
 				}
-				
+
 				fail("This should have failed with an exception");
-			}
-			catch (IOException e) {
+			} catch (IOException e) {
 				assertNotNull(e.getCause());
 				assertTrue(e.getCause().getMessage().contains("Test Exception"));
 			}
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
-		}
-		finally {
+		} finally {
 			if (testWriter != null) {
 				testWriter.close();
 			}
 		}
 	}
-	
+
+	/**
+	 * Tests that the output flusher only calls try flush.
+	 */
+	@Test
+	public void testOutputFlusherUsesTryFlush() throws Exception {
+		BufferProvider bufferProvider = new TestInfiniteBufferProvider();
+		final CountDownLatch latch = new CountDownLatch(10);
+
+		ResultPartition partition = mock(ResultPartition.class);
+		when(partition.getNumberOfSubpartitions()).thenReturn(1);
+		when(partition.addBufferIfCapacityAvailable(any(Buffer.class), anyInt())).thenAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+				latch.countDown();
+				return null;
+			}
+		});
+		when(partition.getBufferProvider()).thenReturn(bufferProvider);
+
+		StreamRecordWriter<ByteValue> writer = new StreamRecordWriter<>(
+			new ResultPartitionWriter(partition),
+			new RoundRobinChannelSelector<ByteValue>(),
+			2);
+
+		ByteValue value = new ByteValue();
+		value.setValue((byte) 12);
+
+		long deadline = System.currentTimeMillis() + 30_000;
+		while (latch.getCount() != 0 && System.currentTimeMillis() <= deadline) {
+			writer.emit(value);
+			Thread.sleep(10);
+		}
+
+		assertEquals(0, latch.getCount());
+
+		// There is a very low probability that the main test thread
+		// emits so many records that it actually writes out the
+		// buffer itself (at which point add is called). If this test
+		// is flakey on CI infra, rethink this line.
+		verify(partition, never()).add(any(Buffer.class), anyInt(), anyBoolean());
+		verify(partition, atLeast(10)).addBufferIfCapacityAvailable(any(Buffer.class), eq(0));
+	}
+
 	private static ResultPartitionWriter getMockWriter(int numPartitions) throws Exception {
 		BufferProvider mockProvider = mock(BufferProvider.class);
 		when(mockProvider.requestBufferBlocking()).thenAnswer(new Answer<Buffer>() {
 			@Override
 			public Buffer answer(InvocationOnMock invocation) {
 				return new Buffer(
-						MemorySegmentFactory.allocateUnpooledSegment(4096),
-						FreeingBufferRecycler.INSTANCE);
+					MemorySegmentFactory.allocateUnpooledSegment(4096),
+					FreeingBufferRecycler.INSTANCE);
 			}
 		});
-		
+
 		ResultPartitionWriter mockWriter = mock(ResultPartitionWriter.class);
 		when(mockWriter.getBufferProvider()).thenReturn(mockProvider);
 		when(mockWriter.getNumberOfOutputChannels()).thenReturn(numPartitions);
-		
-		
+
+
 		return mockWriter;
 	}
-	
+
 	// ------------------------------------------------------------------------
-	
+
 	private static class FailingWriter<T extends IOReadableWritable> extends StreamRecordWriter<T> {
-		
+
 		private int flushesBeforeException;
-		
+
 		private FailingWriter(ResultPartitionWriter writer, ChannelSelector<T> channelSelector,
-								long timeout, int flushesBeforeException) {
+							  long timeout, int flushesBeforeException) {
 			super(writer, channelSelector, timeout);
 			this.flushesBeforeException = flushesBeforeException;
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamRecordWriterTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamRecordWriterTest.java
@@ -27,10 +27,8 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.types.LongValue;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -38,8 +36,11 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * This test uses the PowerMockRunner runner to work around the fact that the 
@@ -121,7 +122,15 @@ public class StreamRecordWriterTest {
 		}
 
 		@Override
-		public void flush() throws IOException {
+		public void tryFlush() throws IOException {
+			if (flushesBeforeException-- <= 0) {
+				throw new IOException("Test Exception");
+			}
+			super.tryFlush();
+		}
+
+		@Override
+		public void flush() throws IOException, InterruptedException {
 			if (flushesBeforeException-- <= 0) {
 				throw new IOException("Test Exception");
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -62,6 +62,7 @@ import java.util.concurrent.Future;
 
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -170,7 +171,7 @@ public class StreamMockEnvironment implements Environment {
 
 					return null;
 				}
-			}).when(mockWriter).writeBuffer(any(Buffer.class), anyInt());
+			}).when(mockWriter).writeBuffer(any(Buffer.class), anyInt(), anyBoolean());
 
 			// Add events to the output list
 			doAnswer(new Answer<Void>() {


### PR DESCRIPTION
We worked with @StephanEwen on this. The changes build on top of FLINK-5159 (see #2882). Only the most recent commit is relevant.

# Changes

The goal of the changes was to allow limiting the capacity of produced partitions in addition to the back pressure that is introduced via the buffer pools. 

## PIPELINED_BOUNDED partition type

This adds a further result partition type (`PIPELINED_BOUNDED`) that is translated to pipelined runtime partitions that can configure a maximum capacity for their output queues via:

    taskmanager.net.max-out-queue-length

By default, they have unbounded length (`0`) and behave like regular PIPELINED results.

## RemoteInputChannel capacity limit

If the outbound queues are limited, we need to capacity limit the inbound remote channels, too. Otherwise, we only shift the problem to the receiver, which potentially consume the bounded queues fast and buffers the data.

## Known Issues

For the time being the back pressure stats reported in the web interface are not correct as they only take the buffer pools into account. If we keep the default at unlimited, it should be OK to address this in a follow up.
