### PR TITLE
[FLINK-4870] [FLINK-5162] Fix issues on windows related to Path/URI generation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -81,7 +81,7 @@ class FileSystemBlobStore implements BlobStore {
 	}
 
 	private void put(File fromFile, String toBlobPath) throws Exception {
-		try (OutputStream os = FileSystem.get(new URI(toBlobPath))
+		try (OutputStream os = FileSystem.get(new Path(toBlobPath).toUri())
 				.create(new Path(toBlobPath), true)) {
 
 			LOG.debug("Copying from {} to {}.", fromFile, toBlobPath);
@@ -109,8 +109,8 @@ class FileSystemBlobStore implements BlobStore {
 			throw new IllegalStateException("Failed to create target file to copy to");
 		}
 
-		final URI fromUri = new URI(fromBlobPath);
 		final Path fromPath = new Path(fromBlobPath);
+		final URI fromUri = fromPath.toUri();
 
 		if (FileSystem.get(fromUri).exists(fromPath)) {
 			try (InputStream is = FileSystem.get(fromUri).open(fromPath)) {
@@ -146,8 +146,8 @@ class FileSystemBlobStore implements BlobStore {
 		try {
 			LOG.debug("Deleting {}.", blobPath);
 
-			FileSystem fs = FileSystem.get(new URI(blobPath));
 			Path path = new Path(blobPath);
+			FileSystem fs = FileSystem.get(path.toUri());
 
 			fs.delete(path, true);
 
@@ -159,7 +159,7 @@ class FileSystemBlobStore implements BlobStore {
 			} catch (IOException ignored) {}
 		}
 		catch (Exception e) {
-			LOG.warn("Failed to delete blob at " + blobPath);
+			LOG.warn("Failed to delete blob at " + blobPath, e);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -124,8 +123,9 @@ public class ContinuousFileMonitoringFunction<OUT>
 
 	@Override
 	public void run(SourceFunction.SourceContext<TimestampedFileInputSplit> context) throws Exception {
-		FileSystem fileSystem = FileSystem.get(new URI(path));
-		if (!fileSystem.exists(new Path(path))) {
+		Path p = new Path(path);
+		FileSystem fileSystem = FileSystem.get(p.toUri());
+		if (!fileSystem.exists(p)) {
 			throw new FileNotFoundException("The provided file path " + path + " does not exist.");
 		}
 


### PR DESCRIPTION
This PR fixes the FileSystemBlocStore and ContinuousFileMonitoringFunction on Windows.

In both classes an URI is generated from a String and given to a Flink FileSystem instance. However, on Windows it is a hard requirement that all URI's that are generated first go through the Path class.