### PR TITLE
[hotfix] properly encapsulate the original exception in JobClient

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
@@ -222,7 +222,7 @@ public class JobClient {
 					allURLs[pos++] = blobClient.getURL(blobKey);
 				} catch (Exception e) {
 					blobClient.shutdown();
-					throw new JobRetrievalException(jobID, "Failed to download BlobKey " + blobKey);
+					throw new JobRetrievalException(jobID, "Failed to download BlobKey " + blobKey, e);
 				}
 			}
 


### PR DESCRIPTION
In the job client, an exception was re-thrown without including the original exception. This commit adds the original exception.