### PR TITLE
[FLINK-5109] fix invalid content-encoding header of webmonitor

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/PipelineErrorHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/PipelineErrorHandler.java
@@ -64,7 +64,6 @@ public class PipelineErrorHandler extends SimpleChannelInboundHandler<Object> {
 						HttpResponseStatus.INTERNAL_SERVER_ERROR, Unpooled.wrappedBuffer(error.getBytes()));
 
 			response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/plain");
-			response.headers().set(HttpHeaders.Names.CONTENT_ENCODING, "utf-8");
 			response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, response.content().readableBytes());
 
 			ctx.writeAndFlush(response);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/RuntimeMonitorHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/RuntimeMonitorHandler.java
@@ -61,7 +61,7 @@ public class RuntimeMonitorHandler extends RuntimeMonitorHandlerBase {
 	private static final Charset ENCODING = Charset.forName("UTF-8");
 
 	public static final String WEB_MONITOR_ADDRESS_KEY = "web.monitor.address";
-	
+
 	private final RequestHandler handler;
 
 	public RuntimeMonitorHandler(
@@ -102,7 +102,6 @@ public class RuntimeMonitorHandler extends RuntimeMonitorHandlerBase {
 					: Unpooled.wrappedBuffer(e.getMessage().getBytes(ENCODING));
 			response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND, message);
 			response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/plain");
-			response.headers().set(HttpHeaders.Names.CONTENT_ENCODING, "utf-8");
 			response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, response.content().readableBytes());
 			LOG.debug("Error while handling request", e);
 		}
@@ -111,7 +110,6 @@ public class RuntimeMonitorHandler extends RuntimeMonitorHandlerBase {
 			response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
 					HttpResponseStatus.INTERNAL_SERVER_ERROR, Unpooled.wrappedBuffer(bytes));
 			response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/plain");
-			response.headers().set(HttpHeaders.Names.CONTENT_ENCODING, "utf-8");
 			response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, response.content().readableBytes());
 
 			LOG.debug("Error while handling request", e);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/ConstantTextHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/ConstantTextHandler.java
@@ -37,9 +37,9 @@ import java.io.UnsupportedEncodingException;
  */
 @ChannelHandler.Sharable
 public class ConstantTextHandler extends SimpleChannelInboundHandler<Routed> {
-	
+
 	private final byte[] encodedText;
-	
+
 	public ConstantTextHandler(String text) {
 		try {
 			this.encodedText = text.getBytes("UTF-8");
@@ -48,16 +48,15 @@ public class ConstantTextHandler extends SimpleChannelInboundHandler<Routed> {
 			throw new RuntimeException(e.getMessage(), e);
 		}
 	}
-	
+
 	@Override
 	protected void channelRead0(ChannelHandlerContext ctx, Routed routed) throws Exception {
 		HttpResponse response = new DefaultFullHttpResponse(
 			HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.wrappedBuffer(encodedText));
 
 		response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, encodedText.length);
-		response.headers().set(HttpHeaders.Names.CONTENT_ENCODING, "utf-8");
 		response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/plain");
-		
+
 		KeepAliveWrite.flush(ctx, routed.request(), response);
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/HandlerRedirectUtils.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/HandlerRedirectUtils.java
@@ -89,7 +89,6 @@ public class HandlerRedirectUtils {
 		HttpResponse redirectResponse = new DefaultFullHttpResponse(
 				HttpVersion.HTTP_1_1, HttpResponseStatus.TEMPORARY_REDIRECT);
 		redirectResponse.headers().set(HttpHeaders.Names.LOCATION, newLocation);
-		redirectResponse.headers().set(HttpHeaders.Names.CONTENT_ENCODING, "utf-8");
 		redirectResponse.headers().set(HttpHeaders.Names.CONTENT_LENGTH, 0);
 
 		return redirectResponse;
@@ -102,7 +101,6 @@ public class HandlerRedirectUtils {
 		HttpResponse unavailableResponse = new DefaultFullHttpResponse(
 				HttpVersion.HTTP_1_1, HttpResponseStatus.SERVICE_UNAVAILABLE, Unpooled.wrappedBuffer(bytes));
 
-		unavailableResponse.headers().set(HttpHeaders.Names.CONTENT_ENCODING, "utf-8");
 		unavailableResponse.headers().set(HttpHeaders.Names.CONTENT_LENGTH, bytes.length);
 		unavailableResponse.headers().set(HttpHeaders.Names.CONTENT_TYPE, MimeTypes.getMimeTypeForExtension("txt"));
 


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation --- not touched
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
