### PR TITLE
[FLINK-3921] StringParser encoding

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -57,9 +57,11 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 	 */
 	private static final Logger LOG = LoggerFactory.getLogger(DelimitedInputFormat.class);
 
-	// The charset used to convert strings to bytes; stored as String since
-	// since java.nio.charset.Charset is not serializable
-	protected String charsetName = "UTF-8";
+	// The charset used to convert strings to bytes
+	private String charsetName = "UTF-8";
+
+	// Charset is not serializable
+	private transient Charset charset;
 
 	/**
 	 * The default read buffer size = 1MB.
@@ -186,13 +188,17 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 	}
 
 	/**
-	 * Get the name of the character set used for the row delimiter, field
-	 * delimiter, comment string, and {@link FieldParser}.
+	 * Get the character set used for the row delimiter, field delimiter,
+	 * comment string, and {@link FieldParser}.
 	 *
-	 * @return name of the charset
+	 * @return the charset
 	 */
-	public String getCharset() {
-		return this.charsetName;
+	@PublicEvolving
+	public Charset getCharset() {
+		if (this.charset == null) {
+			this.charset = Charset.forName(charsetName);
+		}
+		return this.charset;
 	}
 
 	/**
@@ -205,8 +211,10 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 	 *
 	 * @param charset name of the charset
 	 */
+	@PublicEvolving
 	public void setCharset(String charset) {
 		this.charsetName = Preconditions.checkNotNull(charset);
+		this.charset = null;
 	}
 
 	public byte[] getDelimiter() {

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.TreeMap;
@@ -117,7 +116,7 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 
 	public void setCommentPrefix(String commentPrefix) {
 		if (commentPrefix != null) {
-			this.commentPrefix = commentPrefix.getBytes(Charset.forName(charsetName));
+			this.commentPrefix = commentPrefix.getBytes(getCharset());
 		} else {
 			this.commentPrefix = null;
 		}
@@ -128,7 +127,7 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 	}
 
 	public void setFieldDelimiter(String delimiter) {
-		this.fieldDelim = delimiter.getBytes(Charset.forName(charsetName));
+		this.fieldDelim = delimiter.getBytes(getCharset());
 	}
 
 	public boolean isLenient() {
@@ -276,8 +275,6 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 	public void open(FileInputSplit split) throws IOException {
 		super.open(split);
 
-		Charset charset = Charset.forName(charsetName);
-
 		// instantiate the parsers
 		FieldParser<?>[] parsers = new FieldParser<?>[fieldTypes.length];
 		
@@ -290,7 +287,7 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 
 				FieldParser<?> p = InstantiationUtil.instantiate(parserType, FieldParser.class);
 
-				p.setCharset(charset);
+				p.setCharset(getCharset());
 				if (this.quotedStringParsing) {
 					if (p instanceof StringParser) {
 						((StringParser)p).enableQuotedStringParsing(this.quoteCharacter);

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
@@ -74,9 +74,12 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 	private Class<?>[] fieldTypes = EMPTY_TYPES;
 	
 	protected boolean[] fieldIncluded = EMPTY_INCLUDED;
-		
+
+	// The byte representation of the delimiter is updated consistent with
+	// current charset.
 	private byte[] fieldDelim = DEFAULT_FIELD_DELIMITER;
-	
+	private String fieldDelimString = null;
+
 	private boolean lenient;
 	
 	private boolean skipFirstLineAsHeader;
@@ -85,7 +88,10 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 
 	private byte quoteCharacter;
 
+	// The byte representation of the comment prefix is updated consistent with
+	// current charset.
 	protected byte[] commentPrefix = null;
+	private String commentPrefixString = null;
 
 
 	// --------------------------------------------------------------------------------------------
@@ -110,6 +116,19 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 		return this.fieldTypes.length;
 	}
 
+	@Override
+	public void setCharset(String charset) {
+		super.setCharset(charset);
+
+		if (this.fieldDelimString != null) {
+			this.fieldDelim = fieldDelimString.getBytes(getCharset());
+		}
+
+		if (this.commentPrefixString != null) {
+			this.commentPrefix = commentPrefixString.getBytes(getCharset());
+		}
+	}
+
 	public byte[] getCommentPrefix() {
 		return commentPrefix;
 	}
@@ -120,6 +139,7 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 		} else {
 			this.commentPrefix = null;
 		}
+		this.commentPrefixString = commentPrefix;
 	}
 
 	public byte[] getFieldDelimiter() {
@@ -127,7 +147,12 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 	}
 
 	public void setFieldDelimiter(String delimiter) {
+		if (delimiter == null) {
+			throw new IllegalArgumentException("Delimiter must not be null");
+		}
+
 		this.fieldDelim = delimiter.getBytes(getCharset());
+		this.fieldDelimString = delimiter;
 	}
 
 	public boolean isLenient() {

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
@@ -25,7 +25,6 @@ import org.apache.flink.types.parser.FieldParser;
 import org.apache.flink.types.parser.StringParser;
 import org.apache.flink.types.parser.StringValueParser;
 import org.apache.flink.util.InstantiationUtil;
-import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,10 +44,6 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 	
 	
 	private static final Logger LOG = LoggerFactory.getLogger(GenericCsvInputFormat.class);
-
-	// The charset used to convert strings to bytes; stored as String since
-	// since java.nio.charset.Charset is not serializable
-	private String charsetName = "UTF-8";
 
 	private static final Class<?>[] EMPTY_TYPES = new Class<?>[0];
 	
@@ -271,30 +266,6 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 
 		this.fieldTypes = types.toArray(new Class<?>[types.size()]);
 		this.fieldIncluded = includedMask;
-	}
-
-	/**
-	 * Get the name of the character set used for the comment string, field
-	 * delimiter, and {@link FieldParser}.
-	 *
-	 * @return name of the charset
-	 */
-	public String getCharset() {
-		return this.charsetName;
-	}
-
-	/**
-	 * Set the name of the character set used for the comment string, field
-	 * delimiter, and {@link FieldParser}.
-	 *
-	 * The comment string and delimiter are interpreted when set. Each
-	 * {@link FieldParser} is configured in {@link #open(FileInputSplit)}.
-	 * Changing the charset thereafter may cause unexpected results.
-	 *
-	 * @param charset name of the charset
-	 */
-	public void setCharset(String charset) {
-		this.charsetName = Preconditions.checkNotNull(charset);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
@@ -19,11 +19,6 @@
 
 package org.apache.flink.types.parser;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.types.BooleanValue;
 import org.apache.flink.types.ByteValue;
@@ -33,6 +28,12 @@ import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.ShortValue;
 import org.apache.flink.types.StringValue;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A FieldParser is used parse a field from a sequence of bytes. Fields occur in a byte sequence and are terminated
@@ -77,9 +78,11 @@ public abstract class FieldParser<T> {
 		/** Invalid Boolean value **/
 		BOOLEAN_INVALID
 	}
-	
+
+	private Charset charset = Charset.forName("UTF-8");
+
 	private ParseErrorState errorState = ParseErrorState.NONE;
-	
+
 	/**
 	 * Parses the value of a field from the byte array, taking care of properly reset
 	 * the state of this parser.
@@ -217,7 +220,26 @@ public abstract class FieldParser<T> {
 
 		return limitedLength;
 	}
-	
+
+	/*
+	 * Gets the Charset for the parser.Default is set to ASCII
+	 *
+	 * @return The charset for the parser.
+	 */
+	public Charset getCharset() {
+		return this.charset;
+	}
+
+	/**
+	 * Sets the charset of the parser. Called by subclasses of the parser to set the type of charset
+	 * when doing a parse.
+	 *
+	 * @param charset The charset  to set.
+	 */
+	public void setCharset(Charset charset) {
+		this.charset = charset;
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  Mapping from types to parsers
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
@@ -32,6 +32,7 @@ import org.apache.flink.types.StringValue;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -79,7 +80,7 @@ public abstract class FieldParser<T> {
 		BOOLEAN_INVALID
 	}
 
-	private Charset charset = Charset.forName("UTF-8");
+	private Charset charset = StandardCharsets.UTF_8;
 
 	private ParseErrorState errorState = ParseErrorState.NONE;
 
@@ -105,9 +106,7 @@ public abstract class FieldParser<T> {
 
 	/**
 	 * Each parser's logic should be implemented inside this method
-	 *
-	 * @see {@link FieldParser#parseField(byte[], int, int, byte[], Object)}
-	 * */
+	 */
 	protected abstract int parseField(byte[] bytes, int startPos, int limit, byte[] delim, T reuse);
 
 	/**
@@ -221,20 +220,19 @@ public abstract class FieldParser<T> {
 		return limitedLength;
 	}
 
-	/*
-	 * Gets the Charset for the parser.Default is set to ASCII
+	/**
+	 * Gets the character set used for this parser.
 	 *
-	 * @return The charset for the parser.
+	 * @return the charset used for this parser.
 	 */
 	public Charset getCharset() {
 		return this.charset;
 	}
 
 	/**
-	 * Sets the charset of the parser. Called by subclasses of the parser to set the type of charset
-	 * when doing a parse.
+	 * Sets the character set used for this parser.
 	 *
-	 * @param charset The charset  to set.
+	 * @param charset charset used for this parser.
 	 */
 	public void setCharset(Charset charset) {
 		this.charset = charset;

--- a/flink-core/src/main/java/org/apache/flink/types/parser/StringParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/StringParser.java
@@ -63,11 +63,11 @@ public class StringParser extends FieldParser<String> {
 				// check for proper termination
 				if (i == limit) {
 					// either by end of line
-					this.result = new String(bytes, startPos + 1, i - startPos - 2);
+					this.result = new String(bytes, startPos + 1, i - startPos - 2, getCharset());
 					return limit;
 				} else if ( i < delimLimit && delimiterNext(bytes, i, delimiter)) {
 					// or following field delimiter
-					this.result = new String(bytes, startPos + 1, i - startPos - 2);
+					this.result = new String(bytes, startPos + 1, i - startPos - 2, getCharset());
 					return i + delimiter.length;
 				} else {
 					// no proper termination
@@ -87,14 +87,14 @@ public class StringParser extends FieldParser<String> {
 				if (limit == startPos) {
 					setErrorState(ParseErrorState.EMPTY_COLUMN); // mark empty column
 				}
-				this.result = new String(bytes, startPos, limit - startPos);
+				this.result = new String(bytes, startPos, limit - startPos, getCharset());
 				return limit;
 			} else {
 				// delimiter found.
 				if (i == startPos) {
 					setErrorState(ParseErrorState.EMPTY_COLUMN); // mark empty column
 				}
-				this.result = new String(bytes, startPos, i - startPos);
+				this.result = new String(bytes, startPos, i - startPos, getCharset());
 				return i + delimiter.length;
 			}
 		}

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatTest.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -208,20 +209,35 @@ public class DelimitedInputFormatTest {
 		// Unicode delimiter
 		String delimiter = "\u05c0\u05c0";
 
-		String myString = StringUtils.join(records, delimiter);
-		final FileInputSplit split = createTempFile(myString);
+		String fileContent = StringUtils.join(records, delimiter);
 
-		format.setDelimiter(delimiter);
-		format.configure(new Configuration());
-		format.open(split);
+		for (final String charset : new String[]{ "UTF-8", "UTF-16BE", "UTF-16LE" }) {
+			// use charset when instantiating the record String
+			DelimitedInputFormat<String> format = new DelimitedInputFormat<String>() {
+				@Override
+				public String readRecord(String reuse, byte[] bytes, int offset, int numBytes) throws IOException {
+					return new String(bytes, offset, numBytes, charset);
+				}
+			};
+			format.setFilePath("file:///some/file/that/will/not/be/read");
 
-		for (String record : records) {
-			String value = format.nextRecord(null);
-			assertEquals(record, value);
+			final FileInputSplit split = createTempFile(fileContent, charset);
+
+			format.setDelimiter(delimiter);
+			// use the same encoding to parse the file as used to read the file;
+			// the delimiter is reinterpreted when the charset is set
+			format.setCharset(charset);
+			format.configure(new Configuration());
+			format.open(split);
+
+			for (String record : records) {
+				String value = format.nextRecord(null);
+				assertEquals(record, value);
+			}
+
+			assertNull(format.nextRecord(null));
+			assertTrue(format.reachedEnd());
 		}
-
-		assertNull(format.nextRecord(null));
-		assertTrue(format.reachedEnd());
 	}
 
 	/**
@@ -387,19 +403,29 @@ public class DelimitedInputFormatTest {
 			fail(e.getMessage());
 		}
 	}
-	
-	private static FileInputSplit createTempFile(String contents) throws IOException {
+
+	static FileInputSplit createTempFile(String contents) throws IOException {
 		File tempFile = File.createTempFile("test_contents", "tmp");
 		tempFile.deleteOnExit();
-		
-		OutputStreamWriter wrt = new OutputStreamWriter(new FileOutputStream(tempFile));
-		wrt.write(contents);
-		wrt.close();
-		
+
+		try (Writer out = new OutputStreamWriter(new FileOutputStream(tempFile))) {
+			out.write(contents);
+		}
+
 		return new FileInputSplit(0, new Path(tempFile.toURI().toString()), 0, tempFile.length(), new String[] {"localhost"});
 	}
-	
-	
+
+	static FileInputSplit createTempFile(String contents, String charset) throws IOException {
+		File tempFile = File.createTempFile("test_contents", "tmp");
+		tempFile.deleteOnExit();
+
+		try (Writer out = new OutputStreamWriter(new FileOutputStream(tempFile), charset)) {
+			out.write(contents);
+		}
+
+		return new FileInputSplit(0, new Path(tempFile.toURI().toString()), 0, tempFile.length(), new String[] {"localhost"});
+	}
+
 	protected static final class MyTextInputFormat extends DelimitedInputFormat<String> {
 		private static final long serialVersionUID = 1L;
 		

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/GenericCsvInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/GenericCsvInputFormatTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.io;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.Path;
@@ -551,14 +552,12 @@ public class GenericCsvInputFormatTest {
 	@Test
 	public void testReadWithCharset() throws IOException {
 		// Unicode row fragments
-		String prefix = "\u020e\u021f";
-		String stem = "Flink";
-		String postfix = "\u020b\u020f";
+		String[] records = new String[]{"\u020e\u021f", "Flink", "\u020b\u020f"};
 
 		// Unicode delimiter
 		String delimiter = "\u05c0";
 
-		String fileContent = prefix + delimiter + stem + delimiter + postfix;
+		String fileContent = StringUtils.join(records, delimiter);
 
 		// StringValueParser is not configurable with a Charset so rely on StringParser
 		GenericCsvInputFormat<String[]> format = new GenericCsvInputFormat<String[]>() {
@@ -593,9 +592,9 @@ public class GenericCsvInputFormatTest {
 
 			// validate results
 			assertNotNull(values);
-			assertEquals(prefix, values[0]);
-			assertEquals(stem, values[1]);
-			assertEquals(postfix, values[2]);
+			for (int i = 0 ; i < records.length ; i++) {
+				assertEquals(records[i], values[i]);
+			}
 
 			assertNull(format.nextRecord(values));
 			assertTrue(format.reachedEnd());

--- a/flink-core/src/test/java/org/apache/flink/types/parser/VarLengthStringParserTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/parser/VarLengthStringParserTest.java
@@ -25,6 +25,8 @@ import org.apache.flink.types.StringValue;
 import org.apache.flink.types.Value;
 import org.junit.Test;
 
+import java.nio.charset.Charset;
+
 public class VarLengthStringParserTest {
 
 	public StringValueParser parser = new StringValueParser();
@@ -193,5 +195,23 @@ public class VarLengthStringParserTest {
 		startPos = 12;
 		startPos = parser.parseField(recBytes, startPos, recBytes.length, new byte[] {'|'}, s);
 		assertTrue(startPos < 0);
+	}
+
+	@Test
+	public void testParseValidMixedStringsWithCharset() {
+
+		Charset charset = Charset.forName("US-ASCII");
+		this.parser = new StringValueParser();
+		this.parser.enableQuotedStringParsing((byte) '@');
+
+		// check valid strings with out whitespaces and trailing delimiter
+		byte[] recBytes = "@abcde|gh@|@i@|jklmnopq|@rs@|tuv".getBytes();
+		StringValue s = new StringValue();
+
+		int startPos = 0;
+		parser.setCharset(charset);
+		startPos = parser.parseField(recBytes, startPos, recBytes.length, new byte[]{'|'}, s);
+		assertTrue(startPos == 11);
+		assertTrue(s.getValue().equals("abcde|gh"));
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/types/parser/VarLengthStringParserTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/parser/VarLengthStringParserTest.java
@@ -19,13 +19,15 @@
 
 package org.apache.flink.types.parser;
 
-import static org.junit.Assert.assertTrue;
-
 import org.apache.flink.types.StringValue;
 import org.apache.flink.types.Value;
 import org.junit.Test;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class VarLengthStringParserTest {
 
@@ -200,7 +202,7 @@ public class VarLengthStringParserTest {
 	@Test
 	public void testParseValidMixedStringsWithCharset() {
 
-		Charset charset = Charset.forName("US-ASCII");
+		Charset charset = StandardCharsets.US_ASCII;
 		this.parser = new StringValueParser();
 		this.parser.enableQuotedStringParsing((byte) '@');
 
@@ -211,7 +213,7 @@ public class VarLengthStringParserTest {
 		int startPos = 0;
 		parser.setCharset(charset);
 		startPos = parser.parseField(recBytes, startPos, recBytes.length, new byte[]{'|'}, s);
-		assertTrue(startPos == 11);
-		assertTrue(s.getValue().equals("abcde|gh"));
+		assertEquals(11, startPos);
+		assertEquals("abcde|gh", s.getValue());
 	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
@@ -18,24 +18,22 @@
 
 package org.apache.flink.api.java.io;
 
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Arrays;
-
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.Utils;
 import org.apache.flink.api.java.operators.DataSource;
+//CHECKSTYLE.OFF: AvoidStarImport - Needed for TupleGenerator
+import org.apache.flink.api.java.tuple.*;
+//CHECKSTYLE.ON: AvoidStarImport
 import org.apache.flink.api.java.typeutils.PojoTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.Preconditions;
 
-//CHECKSTYLE.OFF: AvoidStarImport - Needed for TupleGenerator
-import org.apache.flink.api.java.tuple.*;
-//CHECKSTYLE.ON: AvoidStarImport
+import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * A builder class to instantiate a CSV parsing data source. The CSV reader configures the field types,
@@ -66,7 +64,7 @@ public class CsvReader {
 	
 	protected boolean ignoreInvalidLines = false;
 
-	private Charset charset = Charset.forName("UTF-8");
+	private String charset = "UTF-8";
 	
 	// --------------------------------------------------------------------------------------------
 	
@@ -162,11 +160,12 @@ public class CsvReader {
 	}
 
 	/**
-	 * Gets the character set for the reader. Default is set to UTF-8.
+	 * Gets the character set for the reader. Default is UTF-8.
 	 *
 	 * @return The charset for the reader.
 	 */
-	public Charset getCharset() {
+	@PublicEvolving
+	public String getCharset() {
 		return this.charset;
 	}
 
@@ -175,7 +174,8 @@ public class CsvReader {
 	 *
 	 * @param charset The character set to set.
 	 */
-	public void setCharset(Charset charset) {
+	@PublicEvolving
+	public void setCharset(String charset) {
 		this.charset = Preconditions.checkNotNull(charset);
 	}
 
@@ -356,12 +356,12 @@ public class CsvReader {
 	// --------------------------------------------------------------------------------------------
 	
 	private void configureInputFormat(CsvInputFormat<?> format) {
+		format.setCharset(this.charset);
 		format.setDelimiter(this.lineDelimiter);
 		format.setFieldDelimiter(this.fieldDelimiter);
 		format.setCommentPrefix(this.commentPrefix);
 		format.setSkipFirstLineAsHeader(skipFirstLineAsHeader);
 		format.setLenient(ignoreInvalidLines);
-		format.setCharset(this.charset);
 		if (this.parseQuotedStrings) {
 			format.enableQuotedStringParsing(this.quoteCharacter);
 		}

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.io;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -64,6 +65,8 @@ public class CsvReader {
 	protected boolean skipFirstLineAsHeader = false;
 	
 	protected boolean ignoreInvalidLines = false;
+
+	private Charset charset = Charset.forName("UTF-8");
 	
 	// --------------------------------------------------------------------------------------------
 	
@@ -157,7 +160,25 @@ public class CsvReader {
 		this.commentPrefix = commentPrefix;
 		return this;
 	}
-	
+
+	/**
+	 * Gets the character set for the reader. Default is set to UTF-8.
+	 *
+	 * @return The charset for the reader.
+	 */
+	public Charset getCharset() {
+		return this.charset;
+	}
+
+	/**
+	 * Sets the charset of the reader
+	 *
+	 * @param charset The character set to set.
+	 */
+	public void setCharset(Charset charset) {
+		this.charset = Preconditions.checkNotNull(charset);
+	}
+
 	/**
 	 * Configures which fields of the CSV file should be included and which should be skipped. The
 	 * parser will look at the first {@code n} fields, where {@code n} is the length of the boolean
@@ -340,6 +361,7 @@ public class CsvReader {
 		format.setCommentPrefix(this.commentPrefix);
 		format.setSkipFirstLineAsHeader(skipFirstLineAsHeader);
 		format.setLenient(ignoreInvalidLines);
+		format.setCharset(this.charset);
 		if (this.parseQuotedStrings) {
 			format.enableQuotedStringParsing(this.quoteCharacter);
 		}

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/CSVReaderTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/CSVReaderTest.java
@@ -18,15 +18,9 @@
 
 package org.apache.flink.api.java.io;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.util.Arrays;
-
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.operators.DataSource;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.api.java.tuple.Tuple5;
@@ -47,7 +41,12 @@ import org.apache.flink.types.StringValue;
 import org.apache.flink.types.Value;
 import org.junit.Assert;
 import org.junit.Test;
-import org.apache.flink.api.java.ExecutionEnvironment;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for the CSV reader builder.
@@ -80,11 +79,11 @@ public class CSVReaderTest {
 	@Test
 	public void testCharset() {
 		CsvReader reader = getCsvReader();
-		assertEquals(reader.getCharset(), Charset.forName("UTF-8"));
-		reader.setCharset(Charset.forName("US-ASCII"));
-		assertEquals(reader.getCharset(), Charset.forName("US-ASCII"));
+		assertEquals("UTF-8", reader.getCharset());
+		reader.setCharset("US-ASCII");
+		assertEquals("US-ASCII", reader.getCharset());
 	}
-	
+
 	@Test
 	public void testIncludeFieldsDense() {
 		CsvReader reader = getCsvReader();

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/CSVReaderTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/CSVReaderTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
@@ -74,6 +75,14 @@ public class CSVReaderTest {
 		assertNull(reader.commentPrefix);
 		reader.ignoreComments("#");
 		assertEquals("#", reader.commentPrefix);
+	}
+
+	@Test
+	public void testCharset() {
+		CsvReader reader = getCsvReader();
+		assertEquals(reader.getCharset(), Charset.forName("UTF-8"));
+		reader.setCharset(Charset.forName("US-ASCII"));
+		assertEquals(reader.getCharset(), Charset.forName("US-ASCII"));
 	}
 	
 	@Test

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/CsvInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/CsvInputFormatTest.java
@@ -771,7 +771,7 @@ public class CsvInputFormatTest {
 		final CsvInputFormat<Tuple5<Integer, String, String, String, Double>> format = new TupleCsvInputFormat<Tuple5<Integer, String, String, String, Double>>(PATH, typeInfo);
 
 		format.setSkipFirstLineAsHeader(true);
-		format.setFieldDelimiter(',');
+		format.setFieldDelimiter(",");
 
 		format.configure(new Configuration());
 		format.open(split);
@@ -1077,7 +1077,7 @@ public class CsvInputFormatTest {
 		CsvInputFormat<Tuple2<String, String>> inputFormat = new TupleCsvInputFormat<Tuple2<String, String>>(new Path(tempFile.toURI().toString()), typeInfo, new boolean[]{true, false, true});
 
 		inputFormat.enableQuotedStringParsing('"');
-		inputFormat.setFieldDelimiter('|');
+		inputFormat.setFieldDelimiter("|");
 		inputFormat.setDelimiter('\n');
 
 		inputFormat.configure(new Configuration());
@@ -1107,7 +1107,7 @@ public class CsvInputFormatTest {
 		CsvInputFormat<Tuple2<String, String>> inputFormat = new TupleCsvInputFormat<>(new Path(tempFile.toURI().toString()), typeInfo);
 
 		inputFormat.enableQuotedStringParsing('"');
-		inputFormat.setFieldDelimiter('|');
+		inputFormat.setFieldDelimiter("|");
 		inputFormat.setDelimiter('\n');
 
 		inputFormat.configure(new Configuration());

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/io/RowCsvInputFormatTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/io/RowCsvInputFormatTest.scala
@@ -656,7 +656,7 @@ class RowCsvInputFormatTest {
 
     val format = new RowCsvInputFormat(PATH, typeInfo)
     format.setSkipFirstLineAsHeader(true)
-    format.setFieldDelimiter(',')
+    format.setFieldDelimiter(",")
     format.configure(new Configuration)
     format.open(split)
 
@@ -745,7 +745,7 @@ class RowCsvInputFormatTest {
       rowTypeInfo = typeInfo,
       includedFieldsMask = Array(true, false, true))
     inputFormat.enableQuotedStringParsing('"')
-    inputFormat.setFieldDelimiter('|')
+    inputFormat.setFieldDelimiter("|")
     inputFormat.setDelimiter('\n')
     inputFormat.configure(new Configuration)
 
@@ -776,7 +776,7 @@ class RowCsvInputFormatTest {
       new Path(tempFile.toURI.toString),
       rowTypeInfo = typeInfo)
     inputFormat.enableQuotedStringParsing('"')
-    inputFormat.setFieldDelimiter('|')
+    inputFormat.setFieldDelimiter("|")
     inputFormat.setDelimiter('\n')
     inputFormat.configure(new Configuration)
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/io/CsvInputFormatTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/io/CsvInputFormatTest.scala
@@ -56,7 +56,7 @@ class CsvInputFormatTest {
         createTypeInformation[(String, Integer, Double)]
           .asInstanceOf[CaseClassTypeInfo[(String, Integer, Double)]])
       format.setDelimiter("\n")
-      format.setFieldDelimiter('|')
+      format.setFieldDelimiter("|")
       format.setCommentPrefix("#")
       val parameters = new Configuration
       format.configure(parameters)
@@ -98,7 +98,7 @@ class CsvInputFormatTest {
         createTypeInformation[(String, Integer, Double)]
           .asInstanceOf[CaseClassTypeInfo[(String, Integer, Double)]])
       format.setDelimiter("\n")
-      format.setFieldDelimiter('|')
+      format.setFieldDelimiter("|")
       format.setCommentPrefix("//")
       val parameters = new Configuration
       format.configure(parameters)
@@ -443,7 +443,7 @@ class CsvInputFormatTest {
     val format = new PojoCsvInputFormat[POJOItem](PATH, typeInfo)
 
     format.setDelimiter('\n')
-    format.setFieldDelimiter(',')
+    format.setFieldDelimiter(",")
     format.configure(new Configuration)
     format.open(tempFile)
 
@@ -460,7 +460,7 @@ class CsvInputFormatTest {
     val format = new TupleCsvInputFormat[CaseClassItem](PATH, typeInfo)
 
     format.setDelimiter('\n')
-    format.setFieldDelimiter(',')
+    format.setFieldDelimiter(",")
     format.configure(new Configuration)
     format.open(tempFile)
 
@@ -477,7 +477,7 @@ class CsvInputFormatTest {
       PATH, typeInfo, Array("field2", "field1", "field3"))
 
     format.setDelimiter('\n')
-    format.setFieldDelimiter(',')
+    format.setFieldDelimiter(",")
     format.configure(new Configuration)
     format.open(tempFile)
 
@@ -495,7 +495,7 @@ class CsvInputFormatTest {
       Array(true, true, false, true, false))
 
     format.setDelimiter('\n')
-    format.setFieldDelimiter(',')
+    format.setFieldDelimiter(",")
     format.configure(new Configuration)
     format.open(tempFile)
 
@@ -511,7 +511,7 @@ class CsvInputFormatTest {
     val format = new PojoCsvInputFormat[TwitterPOJO](PATH, typeInfo)
 
     format.setDelimiter('\n')
-    format.setFieldDelimiter(',')
+    format.setFieldDelimiter(",")
     format.configure(new Configuration)
     format.open(tempFile)
 


### PR DESCRIPTION
This further modifies #2060:
- save charset as String which is serializable
- remove unused methods
- annotate new CsvReader methods as @PublicEvolving

This can be squashed into the first commit after review.