### PR TITLE
[FLINK-5190] [runtime] fix ZooKeeperLeaderRetrievalService close the …

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
@@ -96,7 +96,6 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 		client.getConnectionStateListenable().removeListener(connectionStateListener);
 
 		cache.close();
-		client.close();
 	}
 
 	@Override


### PR DESCRIPTION
This pr is for jira #[5190](https://issues.apache.org/jira/browse/FLINK-5190).

The zk client for ZooKeeperLeaderRetrievalService is pass from outside, if closing the zk client when stop, will influence others who want to use the zk client.