### PR TITLE
[FLINK-5135][JM]ResourceProfile for slot request should be expanded to correspond with ResourceSpec

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/Operator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/Operator.java
@@ -26,10 +26,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.operators.util.UserCodeWrapper;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.Visitable;
-
-import static java.util.Objects.requireNonNull;
 
 /**
 * Abstract base class for all operators. An operator is a source, sink, or it applies an operation to
@@ -48,14 +45,13 @@ public abstract class Operator<OUT> implements Visitable<Operator<?>> {
 		
 	private int parallelism = ExecutionConfig.PARALLELISM_DEFAULT;  // the number of parallel instances to use
 
+	private ResourceSpec minResource;
+	private ResourceSpec maxResource;
+
 	/**
 	 * The return type of the user function.
 	 */
 	protected final OperatorInformation<OUT> operatorInfo;
-
-	private ResourceSpec minResource;
-
-	private ResourceSpec maxResource;
 
 	// --------------------------------------------------------------------------------------------
 
@@ -194,43 +190,35 @@ public abstract class Operator<OUT> implements Visitable<Operator<?>> {
 
 	/**
 	 * Gets the minimum resource for this contract instance. The minimum resource denotes how many
-	 * resources will be needed in the minimum for the user function during the execution. If it is not setted
-	 * by user, the system will create an empty resource.
+	 * resources will be needed in the minimum for the user function during the execution.
 	 *
-	 * @return The minimum resource.
+	 * @return The minimum resource of this operator.
 	 */
 	public ResourceSpec getMinResource() {
-		return this.minResource != null ? minResource : ResourceSpec.UNKNOWN;
+		return this.minResource != null ? this.minResource : ResourceSpec.UNKNOWN;
 	}
 
 	/**
-	 * Gets the minimum resource for this contract instance. The minimum resource denotes how many
-	 * resources will be needed in the maximum for the user function during the execution. If it is not setted
-	 * by user, the system will create an empty resource.
+	 * Gets the maximum resource for this contract instance. The maximum resource denotes how many
+	 * resources will be needed in the maximum for the user function during the execution.
 	 *
-	 * @return The maximum resource.
+	 * @return The maximum resource of this operator.
 	 */
 	public ResourceSpec getMaxResource() {
-		return this.maxResource != null ? maxResource : ResourceSpec.UNKNOWN;
+		return this.maxResource != null ? this.maxResource : ResourceSpec.UNKNOWN;
 	}
 
 	/**
 	 * Sets the minimum and maximum resources for this contract instance. The resource denotes
-	 * how many resources will be needed by user function during the execution. And the resource can be dynamic
-	 * resize between minimum and maximum resources.
+	 * how many memories and vcores of the user function will be consumed during the execution.
 	 *
-	 * @param minResource The minimum of the resource.
-	 * @param maxResource The maximum of the resource.
+	 * @param minResource The minimum resource of this operator.
+	 * @param maxResource The maximum resource of this operator.
 	 */
-	public  void setResource(ResourceSpec minResource, ResourceSpec maxResource) {
-		requireNonNull(minResource, "minimum resource must not be null.");
-		requireNonNull(maxResource, "maximum resource must not be null.");
-		Preconditions.checkArgument(minResource.lessThan(maxResource), "The maximum resource must be greater than minimum resource.");
-
+	public void setResource(ResourceSpec minResource, ResourceSpec maxResource) {
 		this.minResource = minResource;
 		this.maxResource = maxResource;
 	}
-	
 	
 	/**
 	 * Gets the user code wrapper. In the case of a pact, that object will be the stub with the user function,

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/Operator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/Operator.java
@@ -26,7 +26,10 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.operators.util.UserCodeWrapper;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.Visitable;
+
+import static java.util.Objects.requireNonNull;
 
 /**
 * Abstract base class for all operators. An operator is a source, sink, or it applies an operation to
@@ -49,6 +52,10 @@ public abstract class Operator<OUT> implements Visitable<Operator<?>> {
 	 * The return type of the user function.
 	 */
 	protected final OperatorInformation<OUT> operatorInfo;
+
+	private ResourceSpec minResource;
+
+	private ResourceSpec maxResource;
 
 	// --------------------------------------------------------------------------------------------
 
@@ -183,6 +190,45 @@ public abstract class Operator<OUT> implements Visitable<Operator<?>> {
 	 */
 	public void setParallelism(int parallelism) {
 		this.parallelism = parallelism;
+	}
+
+	/**
+	 * Gets the minimum resource for this contract instance. The minimum resource denotes how many
+	 * resources will be needed in the minimum for the user function during the execution. If it is not setted
+	 * by user, the system will create an empty resource.
+	 *
+	 * @return The minimum resource.
+	 */
+	public ResourceSpec getMinResource() {
+		return this.minResource != null ? minResource : ResourceSpec.UNKNOWN;
+	}
+
+	/**
+	 * Gets the minimum resource for this contract instance. The minimum resource denotes how many
+	 * resources will be needed in the maximum for the user function during the execution. If it is not setted
+	 * by user, the system will create an empty resource.
+	 *
+	 * @return The maximum resource.
+	 */
+	public ResourceSpec getMaxResource() {
+		return this.maxResource != null ? maxResource : ResourceSpec.UNKNOWN;
+	}
+
+	/**
+	 * Sets the minimum and maximum resources for this contract instance. The resource denotes
+	 * how many resources will be needed by user function during the execution. And the resource can be dynamic
+	 * resize between minimum and maximum resources.
+	 *
+	 * @param minResource The minimum of the resource.
+	 * @param maxResource The maximum of the resource.
+	 */
+	public  void setResource(ResourceSpec minResource, ResourceSpec maxResource) {
+		requireNonNull(minResource, "minimum resource must not be null.");
+		requireNonNull(maxResource, "maximum resource must not be null.");
+		Preconditions.checkArgument(minResource.lessThan(maxResource), "The maximum resource must be greater than minimum resource.");
+
+		this.minResource = minResource;
+		this.maxResource = maxResource;
 	}
 	
 	

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.operators;
+
+import org.apache.flink.annotation.Internal;
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+
+/**
+ * Describe the different resource factors of the operator.
+ * The resource may be merged for chained operators when generating job graph.
+ *
+ * <p>Resource provides {@link #lessThan(ResourceSpec)} method to compare these fields in sequence:
+ * <ol>
+ *     <li>CPU cores</li>
+ *     <li>Heap Memory Size</li>
+ *     <li>Direct Memory Size</li>
+ *     <li>Native Memory Size</li>
+ *     <li>State Size</li>
+ * </ol>
+ */
+@Internal
+public class ResourceSpec implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	public static final ResourceSpec UNKNOWN = new ResourceSpec(-1.0, -1L, -1L, -1L, -1L);
+
+	/** How many cpu cores are needed, use double so we can specify cpu like 0.1 */
+	private double cpuCores;
+
+	/** How many java heap memory in mb are needed */
+	private long heapMemoryInMB;
+
+	/** How many nio direct memory in mb are needed */
+	private long directMemoryInMB;
+
+	/** How many native memory in mb are needed */
+	private long nativeMemoryInMB;
+
+	/** How many state size are used */
+	private long stateSize;
+
+	/**
+	 * Creates a new ResourceSpec with basic common resources.
+	 *
+	 * @param cpuCores The number of CPU cores (possibly fractional, i.e., 0.2 cores)
+	 * @param heapMemoryInMB The size of the java heap memory, in megabytes.
+	 */
+	public ResourceSpec(double cpuCores, long heapMemoryInMB) {
+		this.cpuCores = cpuCores;
+		this.heapMemoryInMB = heapMemoryInMB;
+	}
+
+	/**
+	 * Creates a new ResourceSpec with full resources.
+	 *
+	 * @param cpuCores The number of CPU cores (possibly fractional, i.e., 0.2 cores)
+	 * @param heapMemoryInMB The size of the java heap memory, in megabytes.
+	 * @param directMemoryInMB The size of the java nio direct memory, in megabytes.
+	 * @param nativeMemoryInMB The size of the native memory, in megabytes.
+	 * @param stateSize The state size for storing in checkpoint.
+	 */
+	public ResourceSpec(
+			double cpuCores,
+			long heapMemoryInMB,
+			long directMemoryInMB,
+			long nativeMemoryInMB,
+			long stateSize) {
+		this.cpuCores = cpuCores;
+		this.heapMemoryInMB = heapMemoryInMB;
+		this.directMemoryInMB = directMemoryInMB;
+		this.nativeMemoryInMB = nativeMemoryInMB;
+		this.stateSize = stateSize;
+	}
+
+	public void merge(ResourceSpec other) {
+		this.cpuCores = Math.max(this.cpuCores, other.getCpuCores());
+		this.heapMemoryInMB += other.getHeapMemory();
+		this.directMemoryInMB += other.getDirectMemory();
+		this.nativeMemoryInMB += other.getNativeMemory();
+		this.stateSize += other.getStateSize();
+	}
+
+	public double getCpuCores() {
+		return this.cpuCores;
+	}
+
+	public long getHeapMemory() {
+		return this.heapMemoryInMB;
+	}
+
+	public long getDirectMemory() {
+		return this.directMemoryInMB;
+	}
+
+	public long getNativeMemory() {
+		return this.nativeMemoryInMB;
+	}
+
+	public long getStateSize() {
+		return this.stateSize;
+	}
+
+	public boolean lessThan(@Nonnull ResourceSpec other) {
+		int cmp1 = Double.compare(this.cpuCores, other.cpuCores);
+		int cmp2 = Long.compare(this.heapMemoryInMB, other.heapMemoryInMB);
+		int cmp3 = Long.compare(this.directMemoryInMB, other.directMemoryInMB);
+		int cmp4 = Long.compare(this.nativeMemoryInMB, other.nativeMemoryInMB);
+		int cmp5 = Long.compare(this.stateSize, other.stateSize);
+		if (cmp1 <= 0 && cmp2 <= 0 && cmp3 <= 0 && cmp4 <= 0 && cmp5 <= 0) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == this) {
+			return true;
+		} else if (obj != null && obj.getClass() == ResourceSpec.class) {
+			ResourceSpec that = (ResourceSpec) obj;
+			return this.cpuCores == that.cpuCores &&
+				this.heapMemoryInMB == that.heapMemoryInMB &&
+				this.directMemoryInMB == that.directMemoryInMB &&
+				this.nativeMemoryInMB == that.nativeMemoryInMB &&
+				this.stateSize == that.stateSize;
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "ResourceSpec{" +
+			"cpuCores=" + cpuCores +
+			", heapMemoryInMB=" + heapMemoryInMB +
+			", directMemoryInMB=" + directMemoryInMB +
+			", nativeMemoryInMB=" + nativeMemoryInMB +
+			", stateSize=" + stateSize +
+			'}';
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -46,16 +46,16 @@ public class ResourceSpec implements Serializable {
 	private final double cpuCores;
 
 	/** How many java heap memory in mb are needed */
-	private final long heapMemoryInMB;
+	private final int heapMemoryInMB;
 
 	/** How many nio direct memory in mb are needed */
-	private final long directMemoryInMB;
+	private final int directMemoryInMB;
 
 	/** How many native memory in mb are needed */
-	private final long nativeMemoryInMB;
+	private final int nativeMemoryInMB;
 
 	/** How many state size in mb are used */
-	private final long stateSizeInMB;
+	private final int stateSizeInMB;
 
 	/**
 	 * Creates a new ResourceSpec with basic common resources.
@@ -63,7 +63,7 @@ public class ResourceSpec implements Serializable {
 	 * @param cpuCores The number of CPU cores (possibly fractional, i.e., 0.2 cores)
 	 * @param heapMemoryInMB The size of the java heap memory, in megabytes.
 	 */
-	public ResourceSpec(double cpuCores, long heapMemoryInMB) {
+	public ResourceSpec(double cpuCores, int heapMemoryInMB) {
 		this.cpuCores = cpuCores;
 		this.heapMemoryInMB = heapMemoryInMB;
 		this.directMemoryInMB = 0;
@@ -82,10 +82,10 @@ public class ResourceSpec implements Serializable {
 	 */
 	public ResourceSpec(
 			double cpuCores,
-			long heapMemoryInMB,
-			long directMemoryInMB,
-			long nativeMemoryInMB,
-			long stateSizeInMB) {
+			int heapMemoryInMB,
+			int directMemoryInMB,
+			int nativeMemoryInMB,
+			int stateSizeInMB) {
 		this.cpuCores = cpuCores;
 		this.heapMemoryInMB = heapMemoryInMB;
 		this.directMemoryInMB = directMemoryInMB;
@@ -114,19 +114,19 @@ public class ResourceSpec implements Serializable {
 		return this.cpuCores;
 	}
 
-	public long getHeapMemory() {
+	public int getHeapMemory() {
 		return this.heapMemoryInMB;
 	}
 
-	public long getDirectMemory() {
+	public int getDirectMemory() {
 		return this.directMemoryInMB;
 	}
 
-	public long getNativeMemory() {
+	public int getNativeMemory() {
 		return this.nativeMemoryInMB;
 	}
 
-	public long getStateSize() {
+	public int getStateSize() {
 		return this.stateSizeInMB;
 	}
 
@@ -153,10 +153,10 @@ public class ResourceSpec implements Serializable {
 	 */
 	public boolean lessThanOrEqual(@Nonnull ResourceSpec other) {
 		int cmp1 = Double.compare(this.cpuCores, other.cpuCores);
-		int cmp2 = Long.compare(this.heapMemoryInMB, other.heapMemoryInMB);
-		int cmp3 = Long.compare(this.directMemoryInMB, other.directMemoryInMB);
-		int cmp4 = Long.compare(this.nativeMemoryInMB, other.nativeMemoryInMB);
-		int cmp5 = Long.compare(this.stateSizeInMB, other.stateSizeInMB);
+		int cmp2 = Integer.compare(this.heapMemoryInMB, other.heapMemoryInMB);
+		int cmp3 = Integer.compare(this.directMemoryInMB, other.directMemoryInMB);
+		int cmp4 = Integer.compare(this.nativeMemoryInMB, other.nativeMemoryInMB);
+		int cmp5 = Integer.compare(this.stateSizeInMB, other.stateSizeInMB);
 		if (cmp1 <= 0 && cmp2 <= 0 && cmp3 <= 0 && cmp4 <= 0 && cmp5 <= 0) {
 			return true;
 		} else {

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/DataSink.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/DataSink.java
@@ -314,8 +314,10 @@ public class DataSink<T> {
 	 * @return The data sink with set minimum and maximum resource.
 	 */
 	public DataSink<T> setResource(ResourceSpec minResource, ResourceSpec maxResource) {
-		Preconditions.checkArgument(minResource != null && maxResource != null && minResource.lessThanOrEqual(maxResource),
-			"The min and max resources must be not null and the max resource must be greater than the min resource.");
+		Preconditions.checkArgument(minResource != null && maxResource != null,
+			"The min and max resources must be not null.");
+		Preconditions.checkArgument(minResource.isValid() && maxResource.isValid() && minResource.lessThanOrEqual(maxResource),
+			"The values in resource must be not less than 0 and the max resource must be greater than the min resource.");
 
 		this.minResource = minResource;
 		this.maxResource = maxResource;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/DataSink.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/DataSink.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.common.operators.Keys;
 import org.apache.flink.api.common.operators.Operator;
 import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.common.operators.Ordering;
+import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.operators.UnaryOperatorInformation;
 import org.apache.flink.api.common.typeinfo.NothingTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -50,6 +51,10 @@ public class DataSink<T> {
 	private String name;
 	
 	private int parallelism = ExecutionConfig.PARALLELISM_DEFAULT;
+
+	private ResourceSpec minResource = ResourceSpec.UNKNOWN;
+
+	private ResourceSpec maxResource = ResourceSpec.UNKNOWN;
 
 	private Configuration parameters;
 
@@ -275,6 +280,45 @@ public class DataSink<T> {
 			"The parallelism of an operator must be at least 1.");
 
 		this.parallelism = parallelism;
+
+		return this;
+	}
+
+	/**
+	 * Returns the minimum resource of this data sink. If no minimum resource has been set,
+	 * it returns the default empty resource.
+	 *
+	 * @return The minimum resource of this data sink.
+	 */
+	public ResourceSpec getMinResource() {
+		return this.minResource;
+	}
+
+	/**
+	 * Returns the minimum resource of this data sink. If no maximum resource has been set,
+	 * it returns the default empty resource.
+	 *
+	 * @return The maximum resource of this data sink.
+	 */
+	public ResourceSpec getMaxResource() {
+		return this.maxResource;
+	}
+
+	/**
+	 * Sets the minimum and maximum resources for this data sink. This overrides the default empty resource.
+	 *	The minimum resource must be satisfied and the maximum resource specifies the upper bound
+	 * for dynamic resource resize.
+	 *
+	 * @param minResource The minimum resource for this data sink.
+	 * @param maxResource The maximum resource for this data sink.
+	 * @return The data sink with set minimum and maximum resource.
+	 */
+	public DataSink<T> setResource(ResourceSpec minResource, ResourceSpec maxResource) {
+		Preconditions.checkArgument(minResource != null && maxResource != null && minResource.lessThanOrEqual(maxResource),
+			"The min and max resources must be not null and the max resource must be greater than the min resource.");
+
+		this.minResource = minResource;
+		this.maxResource = maxResource;
 
 		return this;
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/OperatorTranslation.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/OperatorTranslation.java
@@ -63,6 +63,8 @@ public class OperatorTranslation {
 		
 		// translate the sink itself and connect it to the input
 		GenericDataSinkBase<T> translatedSink = sink.translateToDataFlow(input);
+
+		translatedSink.setResource(sink.getMinResource(), sink.getMaxResource());
 				
 		return translatedSink;
 	}
@@ -91,16 +93,25 @@ public class OperatorTranslation {
 		Operator<T> dataFlowOp;
 		
 		if (dataSet instanceof DataSource) {
-			dataFlowOp = ((DataSource<T>) dataSet).translateToDataFlow();
+			DataSource<T> dataSource = (DataSource<T>) dataSet;
+			dataFlowOp = dataSource.translateToDataFlow();
+			dataFlowOp.setResource(dataSource.getMinResource(), dataSource.getMaxResource());
 		}
 		else if (dataSet instanceof SingleInputOperator) {
-			dataFlowOp = translateSingleInputOperator((SingleInputOperator<?, ?, ?>) dataSet);
+			SingleInputOperator<?, ?, ?> singleInputOperator = (SingleInputOperator<?, ?, ?>) dataSet;
+			dataFlowOp = translateSingleInputOperator(singleInputOperator);
+			dataFlowOp.setResource(singleInputOperator.getMinResource(), singleInputOperator.getMaxResource());
 		}
 		else if (dataSet instanceof TwoInputOperator) {
-			dataFlowOp = translateTwoInputOperator((TwoInputOperator<?, ?, ?, ?>) dataSet);
+			TwoInputOperator<?, ?, ?, ?> twoInputOperator = (TwoInputOperator<?, ?, ?, ?>) dataSet;
+			dataFlowOp = translateTwoInputOperator(twoInputOperator);
+			dataFlowOp.setResource(twoInputOperator.getMinResource(), twoInputOperator.getMaxResource());
 		}
 		else if (dataSet instanceof BulkIterationResultSet) {
-			dataFlowOp = translateBulkIteration((BulkIterationResultSet<?>) dataSet);
+			BulkIterationResultSet bulkIterationResultSet = (BulkIterationResultSet<?>) dataSet;
+			dataFlowOp = translateBulkIteration(bulkIterationResultSet);
+			dataFlowOp.setResource(bulkIterationResultSet.getIterationHead().getMinResource(),
+				bulkIterationResultSet.getIterationHead().getMaxResource());
 		}
 		else if (dataSet instanceof DeltaIterationResultSet) {
 			dataFlowOp = translateDeltaIteration((DeltaIterationResultSet<?, ?>) dataSet);

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plan/PlanNode.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plan/PlanNode.java
@@ -19,6 +19,7 @@
 package org.apache.flink.optimizer.plan;
 
 import org.apache.flink.api.common.operators.Operator;
+import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.operators.util.FieldSet;
 import org.apache.flink.optimizer.CompilerException;
 import org.apache.flink.optimizer.costs.Costs;
@@ -311,6 +312,14 @@ public abstract class PlanNode implements Visitable<PlanNode>, DumpableNode<Plan
 	
 	public long getGuaranteedAvailableMemory() {
 		return this.template.getMinimalMemoryAcrossAllSubTasks();
+	}
+
+	public ResourceSpec getMinResource() {
+		return this.template.getOperator().getMinResource();
+	}
+
+	public ResourceSpec getMaxResource() {
+		return this.template.getOperator().getMaxResource();
 	}
 
 	public Map<OptimizerNode, PlanNode> getBranchPlan() {

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -28,7 +28,6 @@ import org.apache.flink.api.common.aggregators.LongSumAggregator;
 import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.cache.DistributedCache.DistributedCacheEntry;
 import org.apache.flink.api.common.distributions.DataDistribution;
-import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.operators.util.UserCodeWrapper;
 import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
 import org.apache.flink.configuration.GlobalConfiguration;
@@ -525,22 +524,20 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 					
 					// update name of container task
 					String containerTaskName = container.getName();
-					ResourceSpec minResource = container.getMinResource();
-					ResourceSpec maxResource = container.getMaxResource();
 					if (containerTaskName.startsWith("CHAIN ")) {
 						container.setName(containerTaskName + " -> " + chainedTask.getTaskName());
 					} else {
 						container.setName("CHAIN " + containerTaskName + " -> " + chainedTask.getTaskName());
 					}
-					minResource.merge(node.getMinResource());
-					maxResource.merge(node.getMaxResource());
+
+					//update the resource of container task
+					container.setResource(container.getMinResource().merge(node.getMinResource()),
+						container.getMaxResource().merge(node.getMaxResource()));
 
 					this.chainedTasksInSequence.add(chainedTask);
 					return;
 				}
-				else if (node instanceof BulkPartialSolutionPlanNode ||
-						node instanceof WorksetPlanNode)
-				{
+				else if (node instanceof BulkPartialSolutionPlanNode || node instanceof WorksetPlanNode) {
 					// merged iteration head task. the task that the head is merged with will take care of it
 					return;
 				} else {
@@ -833,8 +830,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 		} else {
 			// create task vertex
 			vertex = new JobVertex(taskName);
-			vertex.setMinResource(node.getMinResource());
-			vertex.setMaxResource(node.getMaxResource());
+			vertex.setResource(node.getMinResource(), node.getMaxResource());
 			vertex.setInvokableClass((this.currentIteration != null && node.isOnDynamicPath()) ? IterationIntermediateTask.class : BatchTask.class);
 			
 			config = new TaskConfig(vertex.getConfiguration());
@@ -860,8 +856,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 		final DriverStrategy ds = node.getDriverStrategy();
 		final JobVertex vertex = new JobVertex(taskName);
 		final TaskConfig config = new TaskConfig(vertex.getConfiguration());
-		vertex.setMinResource(node.getMinResource());
-		vertex.setMaxResource(node.getMaxResource());
+		vertex.setResource(node.getMinResource(), node.getMaxResource());
 		vertex.setInvokableClass( (this.currentIteration != null && node.isOnDynamicPath()) ? IterationIntermediateTask.class : BatchTask.class);
 		
 		// set user code
@@ -890,8 +885,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 		final InputFormatVertex vertex = new InputFormatVertex(node.getNodeName());
 		final TaskConfig config = new TaskConfig(vertex.getConfiguration());
 
-		vertex.setMinResource(node.getMinResource());
-		vertex.setMaxResource(node.getMaxResource());
+		vertex.setResource(node.getMinResource(), node.getMaxResource());
 		vertex.setInvokableClass(DataSourceTask.class);
 		vertex.setFormatDescription(getDescriptionForUserCode(node.getProgramOperator().getUserCodeWrapper()));
 
@@ -907,8 +901,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 		final OutputFormatVertex vertex = new OutputFormatVertex(node.getNodeName());
 		final TaskConfig config = new TaskConfig(vertex.getConfiguration());
 
-		vertex.setMinResource(node.getMinResource());
-		vertex.setMaxResource(node.getMaxResource());
+		vertex.setResource(node.getMinResource(), node.getMaxResource());
 		vertex.setInvokableClass(DataSinkTask.class);
 		vertex.setFormatDescription(getDescriptionForUserCode(node.getProgramOperator().getUserCodeWrapper()));
 		
@@ -971,8 +964,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 			// everything else happens in the post visit, after the input (the initial partial solution)
 			// is connected.
 			headVertex = new JobVertex("PartialSolution ("+iteration.getNodeName()+")");
-			headVertex.setMinResource(iteration.getMinResource());
-			headVertex.setMaxResource(iteration.getMaxResource());
+			headVertex.setResource(iteration.getMinResource(), iteration.getMaxResource());
 			headVertex.setInvokableClass(IterationHeadTask.class);
 			headConfig = new TaskConfig(headVertex.getConfiguration());
 			headConfig.setDriver(NoOpDriver.class);
@@ -1041,8 +1033,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 			// everything else happens in the post visit, after the input (the initial partial solution)
 			// is connected.
 			headVertex = new JobVertex("IterationHead("+iteration.getNodeName()+")");
-			headVertex.setMinResource(iteration.getMinResource());
-			headVertex.setMaxResource(iteration.getMaxResource());
+			headVertex.setResource(iteration.getMinResource(), iteration.getMaxResource());
 			headVertex.setInvokableClass(IterationHeadTask.class);
 			headConfig = new TaskConfig(headVertex.getConfiguration());
 			headConfig.setDriver(NoOpDriver.class);
@@ -1283,8 +1274,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 		
 		// --------------------------- create the sync task ---------------------------
 		final JobVertex sync = new JobVertex("Sync(" + bulkNode.getNodeName() + ")");
-		sync.setMinResource(bulkNode.getMinResource());
-		sync.setMaxResource(bulkNode.getMaxResource());
+		sync.setResource(bulkNode.getMinResource(), bulkNode.getMaxResource());
 		sync.setInvokableClass(IterationSynchronizationSinkTask.class);
 		sync.setParallelism(1);
 		this.auxVertices.add(sync);
@@ -1421,8 +1411,7 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 		final TaskConfig syncConfig;
 		{
 			final JobVertex sync = new JobVertex("Sync (" + iterNode.getNodeName() + ")");
-			sync.setMinResource(iterNode.getMinResource());
-			sync.setMaxResource(iterNode.getMaxResource());
+			sync.setResource(iterNode.getMinResource(), iterNode.getMaxResource());
 			sync.setInvokableClass(IterationSynchronizationSinkTask.class);
 			sync.setParallelism(1);
 			this.auxVertices.add(sync);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.clusterframework.types;
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Describe the resource profile of the slot, either when requiring or offering it. The profile can be
@@ -36,7 +37,7 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 
 	private static final long serialVersionUID = 1L;
 
-	public static final ResourceProfile UNKNOWN = new ResourceProfile(-1.0, -1L, -1L, -1L);
+	public static final ResourceProfile UNKNOWN = new ResourceProfile(-1.0, -1, -1, -1);
 
 	// ------------------------------------------------------------------------
 
@@ -44,13 +45,13 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 	private final double cpuCores;
 
 	/** How many heap memory in mb are needed */
-	private final long heapMemoryInMB;
+	private final int heapMemoryInMB;
 
 	/** How many direct memory in mb are needed */
-	private final long directMemoryInMB;
+	private final int directMemoryInMB;
 
 	/** How many native memory in mb are needed */
-	private final long nativeMemoryInMB;
+	private final int nativeMemoryInMB;
 
 	// ------------------------------------------------------------------------
 
@@ -62,7 +63,7 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 	 * @param directMemoryInMB The size of the direct memory, in megabytes.
 	 * @param nativeMemoryInMB The size of the native memory, in megabytes.
 	 */
-	public ResourceProfile(double cpuCores, long heapMemoryInMB, long directMemoryInMB, long nativeMemoryInMB) {
+	public ResourceProfile(double cpuCores, int heapMemoryInMB, int directMemoryInMB, int nativeMemoryInMB) {
 		this.cpuCores = cpuCores;
 		this.heapMemoryInMB = heapMemoryInMB;
 		this.directMemoryInMB = directMemoryInMB;
@@ -75,7 +76,7 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 	 * @param cpuCores The number of CPU cores (possibly fractional, i.e., 0.2 cores)
 	 * @param heapMemoryInMB The size of the heap memory, in megabytes.
 	 */
-	public ResourceProfile(double cpuCores, long heapMemoryInMB) {
+	public ResourceProfile(double cpuCores, int heapMemoryInMB) {
 		this.cpuCores = cpuCores;
 		this.heapMemoryInMB = heapMemoryInMB;
 		this.directMemoryInMB = 0;
@@ -108,7 +109,7 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 	 * Get the heap memory needed in MB
 	 * @return The heap memory in MB
 	 */
-	public long getHeapMemoryInMB() {
+	public int getHeapMemoryInMB() {
 		return heapMemoryInMB;
 	}
 
@@ -116,7 +117,7 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 	 * Get the direct memory needed in MB
 	 * @return The direct memory in MB
 	 */
-	public long getDirectMemoryInMB() {
+	public int getDirectMemoryInMB() {
 		return directMemoryInMB;
 	}
 
@@ -124,7 +125,7 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 	 * Get the native memory needed in MB
 	 * @return The native memory in MB
 	 */
-	public long getNativeMemoryInMB() {
+	public int getNativeMemoryInMB() {
 		return nativeMemoryInMB;
 	}
 
@@ -143,7 +144,7 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 
 	@Override
 	public int compareTo(@Nonnull ResourceProfile other) {
-		int cmp1 = Long.compare(this.heapMemoryInMB + this.directMemoryInMB + this.nativeMemoryInMB,
+		int cmp1 = Integer.compare(this.heapMemoryInMB + this.directMemoryInMB + this.nativeMemoryInMB,
 			other.heapMemoryInMB + other.directMemoryInMB + other.nativeMemoryInMB);
 		int cmp2 = Double.compare(this.cpuCores, other.cpuCores);
 		return (cmp1 != 0) ? cmp1 : cmp2; 
@@ -153,11 +154,7 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 
 	@Override
 	public int hashCode() {
-		long cpuBits = Double.doubleToRawLongBits(cpuCores);
-		return (int) (cpuBits ^ (cpuBits >>> 32) ^
-			heapMemoryInMB ^ (heapMemoryInMB >> 32) ^
-			directMemoryInMB ^ (directMemoryInMB >> 32) ^
-			nativeMemoryInMB ^ (nativeMemoryInMB >> 32));
+		return Objects.hash(cpuCores, heapMemoryInMB, directMemoryInMB, nativeMemoryInMB);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotPool.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.instance;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -924,8 +925,16 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 
 		@Override
 		public Future<SimpleSlot> allocateSlot(ScheduledUnit task, boolean allowQueued) {
+			// Currently just use the min resource for allocating slot, for future resource resize feature,
+			// the request of both min and max resources will be sent to resource manager.
+			ResourceSpec minResource = task.getTaskToExecute().getVertex().getJobVertex().getJobVertex().getMinResource();
+			ResourceProfile resourceProfile = new ResourceProfile(
+				minResource.getCpuCores(),
+				minResource.getHeapMemory(),
+				minResource.getDirectMemory(),
+				minResource.getNativeMemory());
 			return gateway.allocateSlot(
-					task, ResourceProfile.UNKNOWN, Collections.<TaskManagerLocation>emptyList(), timeout);
+					task, resourceProfile, Collections.<TaskManagerLocation>emptyList(), timeout);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -506,11 +506,8 @@ public class JobVertex implements java.io.Serializable {
 		return maxResource;
 	}
 
-	public void setMinResource(ResourceSpec minResource) {
+	public void setResource(ResourceSpec minResource, ResourceSpec maxResource) {
 		this.minResource = minResource;
-	}
-
-	public void setMaxResource(ResourceSpec maxResource) {
 		this.maxResource = maxResource;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobgraph;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.InputSplitSource;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
@@ -94,6 +95,12 @@ public class JobVertex implements java.io.Serializable {
 	/** Optional, the JSON for the optimizer properties of the operator result,
 	 * to be included in the JSON plan */
 	private String resultOptimizerProperties;
+
+	/** Optional, the minimum resource of the operator */
+	private ResourceSpec minResource;
+
+	/** Optional, the maximum resource of the operator */
+	private ResourceSpec maxResource;
 
 	// --------------------------------------------------------------------------------------------
 
@@ -489,6 +496,22 @@ public class JobVertex implements java.io.Serializable {
 
 	public void setResultOptimizerProperties(String resultOptimizerProperties) {
 		this.resultOptimizerProperties = resultOptimizerProperties;
+	}
+
+	public ResourceSpec getMinResource() {
+		return minResource;
+	}
+
+	public ResourceSpec getMaxResource() {
+		return maxResource;
+	}
+
+	public void setMinResource(ResourceSpec minResource) {
+		this.minResource = minResource;
+	}
+
+	public void setMaxResource(ResourceSpec maxResource) {
+		this.maxResource = maxResource;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -172,7 +172,7 @@ public class TaskManagerServices {
 		final List<ResourceProfile> resourceProfiles = new ArrayList<>(taskManagerServicesConfiguration.getNumberOfSlots());
 
 		for (int i = 0; i < taskManagerServicesConfiguration.getNumberOfSlots(); i++) {
-			resourceProfiles.add(new ResourceProfile(1.0, 42L));
+			resourceProfiles.add(new ResourceProfile(1.0, 42));
 		}
 
 		final TimerService<AllocationID> timerService = new TimerService<>(new ScheduledThreadPoolExecutor(1));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
@@ -53,7 +53,7 @@ public class SlotManagerTest {
 
 	private static final double DEFAULT_TESTING_CPU_CORES = 1.0;
 
-	private static final long DEFAULT_TESTING_MEMORY = 512;
+	private static final int DEFAULT_TESTING_MEMORY = 512;
 
 	private static final ResourceProfile DEFAULT_TESTING_PROFILE =
 		new ResourceProfile(DEFAULT_TESTING_CPU_CORES, DEFAULT_TESTING_MEMORY);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -86,7 +86,7 @@ public class TaskExecutorITCase {
 		final String jmAddress = "jm";
 		final UUID jmLeaderId = UUID.randomUUID();
 		final JobID jobId = new JobID();
-		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1L);
+		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
 
 		testingHAServices.setResourceManagerLeaderElectionService(rmLeaderElectionService);
 		testingHAServices.setResourceManagerLeaderRetriever(rmLeaderRetrievalService);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -102,10 +102,10 @@ public class DataStreamSink<T> {
 	 * @return The sink with set minimum and maximum resource.
 	 */
 	public DataStreamSink<T> setResource(ResourceSpec minResource, ResourceSpec maxResource) {
-		requireNonNull(minResource, "minimum resource must not be null.");
-		requireNonNull(maxResource, "maximum resource must not be null.");
-		Preconditions.checkArgument(minResource.lessThanOrEqual(maxResource),
-			"The maximum resource must be greater than minimum resource.");
+		Preconditions.checkArgument(minResource != null && maxResource != null,
+			"The min and max resources must be not null.");
+		Preconditions.checkArgument(minResource.isValid() && maxResource.isValid() && minResource.lessThanOrEqual(maxResource),
+			"The values in resource must be not less than 0 and the max resource must be greater than the min resource.");
 
 		transformation.setResource(minResource, maxResource);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -20,9 +20,13 @@ package org.apache.flink.streaming.api.datastream;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
+import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.api.transformations.SinkTransformation;
+import org.apache.flink.util.Preconditions;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A Stream Sink. This is used for emitting elements from a streaming topology.
@@ -84,6 +88,27 @@ public class DataStreamSink<T> {
 	 */
 	public DataStreamSink<T> setParallelism(int parallelism) {
 		transformation.setParallelism(parallelism);
+		return this;
+	}
+
+	/**
+	 * Sets the minimum and maximum resource for this sink.
+	 *
+	 * The minimum resource must be satisfied and the maximum resource specifies the upper bound
+	 * for dynamic resource resize.
+	 *
+	 * @param minResource The minimum resource for this sink.
+	 * @param maxResource The maximum resource for this sink
+	 * @return The sink with set minimum and maximum resource.
+	 */
+	public DataStreamSink<T> setResource(ResourceSpec minResource, ResourceSpec maxResource) {
+		requireNonNull(minResource, "minimum resource must not be null.");
+		requireNonNull(maxResource, "maximum resource must not be null.");
+		Preconditions.checkArgument(minResource.lessThanOrEqual(maxResource),
+			"The maximum resource must be greater than minimum resource.");
+
+		transformation.setResource(minResource, maxResource);
+
 		return this;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -26,8 +26,6 @@ import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.api.transformations.SinkTransformation;
 import org.apache.flink.util.Preconditions;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * A Stream Sink. This is used for emitting elements from a streaming topology.
  *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.datastream;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.functions.InvalidTypesException;
+import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.TypeInfoParser;
@@ -120,6 +121,26 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 		Preconditions.checkArgument(maxParallelism > 0, "The maximum parallelism must be greater than 0.");
 
 		transformation.setMaxParallelism(maxParallelism);
+
+		return this;
+	}
+
+	/**
+	 * Sets the minimum and maximum resource for this operator.
+	 *
+	 * The minimum resource must be satisfied and the maximum resource specifies the upper bound
+	 * for dynamic resource resize.
+	 *
+	 * @param minResource Minimum resource.
+	 * @param maxResource Maximum resource.
+	 * @return The operator with set minimum and maximum resource.
+	 */
+	public SingleOutputStreamOperator<T> setResource(ResourceSpec minResource, ResourceSpec maxResource) {
+		requireNonNull(minResource, "minimum resource must not be null.");
+		requireNonNull(maxResource, "maximum resource must not be null.");
+		Preconditions.checkArgument(minResource.lessThan(maxResource), "The maximum resource must be greater than minimum resource.");
+
+		transformation.setResource(minResource, maxResource);
 
 		return this;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -131,14 +131,15 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 	 * The minimum resource must be satisfied and the maximum resource specifies the upper bound
 	 * for dynamic resource resize.
 	 *
-	 * @param minResource Minimum resource.
-	 * @param maxResource Maximum resource.
+	 * @param minResource The minimum resource for this operator.
+	 * @param maxResource The maximum resource for this operator.
 	 * @return The operator with set minimum and maximum resource.
 	 */
 	public SingleOutputStreamOperator<T> setResource(ResourceSpec minResource, ResourceSpec maxResource) {
-		requireNonNull(minResource, "minimum resource must not be null.");
-		requireNonNull(maxResource, "maximum resource must not be null.");
-		Preconditions.checkArgument(minResource.lessThan(maxResource), "The maximum resource must be greater than minimum resource.");
+		Preconditions.checkArgument(minResource != null && maxResource != null,
+			"The min and max resources must be not null.");
+		Preconditions.checkArgument(minResource.isValid() && maxResource.isValid() && minResource.lessThanOrEqual(maxResource),
+			"The values in resource must be not less than 0 and the max resource must be greater than the min resource.");
 
 		transformation.setResource(minResource, maxResource);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -423,6 +424,12 @@ public class StreamGraph extends StreamingPlan {
 	public void setMaxParallelism(int vertexID, int maxParallelism) {
 		if (getStreamNode(vertexID) != null) {
 			getStreamNode(vertexID).setMaxParallelism(maxParallelism);
+		}
+	}
+
+	public void setResource(int vertexID, ResourceSpec minResource, ResourceSpec maxResource) {
+		if (getStreamNode(vertexID) != null) {
+			getStreamNode(vertexID).setResource(minResource, maxResource);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -213,6 +213,12 @@ public class StreamGraphGenerator {
 			streamGraph.setTransformationId(transform.getId(), transform.getUid());
 		}
 		if (transform.getMinResource() != null && transform.getMaxResource() != null) {
+			AbstractStateBackend stateBackend = env.getStateBackend();
+			if (stateBackend != null) {
+				ResourceSpec minStateResource = stateBackend.estimateResource(transform.getMinResource().getStateSize());
+				ResourceSpec maxStateResource = stateBackend.estimateResource(transform.getMaxResource().getStateSize());
+				transform.setResource(transform.getMinResource().merge(minStateResource), transform.getMaxResource().merge(maxStateResource));
+			}
 			streamGraph.setResource(transform.getId(), transform.getMinResource(), transform.getMaxResource());
 		}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -18,8 +18,10 @@
 package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.InputFormatSourceFunction;
@@ -210,8 +212,13 @@ public class StreamGraphGenerator {
 		if (transform.getUid() != null) {
 			streamGraph.setTransformationId(transform.getId(), transform.getUid());
 		}
-
 		if (transform.getMinResource() != null && transform.getMaxResource() != null) {
+			AbstractStateBackend stateBackend = env.getStateBackend();
+			if (stateBackend != null) {
+				ResourceSpec minStateResource = stateBackend.estimateResource(transform.getMinResource().getStateSize());
+				ResourceSpec maxStateResource = stateBackend.estimateResource(transform.getMaxResource().getStateSize());
+				transform.setResource(transform.getMinResource().merge(minStateResource), transform.getMaxResource().merge(maxStateResource));
+			}
 			streamGraph.setResource(transform.getId(), transform.getMinResource(), transform.getMaxResource());
 		}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -211,6 +211,10 @@ public class StreamGraphGenerator {
 			streamGraph.setTransformationId(transform.getId(), transform.getUid());
 		}
 
+		if (transform.getMinResource() != null && transform.getMaxResource() != null) {
+			streamGraph.setResource(transform.getId(), transform.getMinResource(), transform.getMaxResource());
+		}
+
 		return transformedIds;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -213,12 +213,6 @@ public class StreamGraphGenerator {
 			streamGraph.setTransformationId(transform.getId(), transform.getUid());
 		}
 		if (transform.getMinResource() != null && transform.getMaxResource() != null) {
-			AbstractStateBackend stateBackend = env.getStateBackend();
-			if (stateBackend != null) {
-				ResourceSpec minStateResource = stateBackend.estimateResource(transform.getMinResource().getStateSize());
-				ResourceSpec maxStateResource = stateBackend.estimateResource(transform.getMaxResource().getStateSize());
-				transform.setResource(transform.getMinResource().merge(minStateResource), transform.getMaxResource().merge(maxStateResource));
-			}
 			streamGraph.setResource(transform.getId(), transform.getMinResource(), transform.getMaxResource());
 		}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
@@ -70,6 +71,9 @@ public class StreamNode implements Serializable {
 	private InputFormat<?, ?> inputFormat;
 
 	private String transformationId;
+
+	private ResourceSpec minResource;
+	private ResourceSpec maxResource;
 
 	public StreamNode(StreamExecutionEnvironment env,
 		Integer id,
@@ -278,6 +282,19 @@ public class StreamNode implements Serializable {
 
 	void setTransformationId(String transformationId) {
 		this.transformationId = transformationId;
+	}
+
+	public ResourceSpec getMinResource() {
+		return minResource != null ? minResource : ResourceSpec.UNKNOWN;
+	}
+
+	public ResourceSpec getMaxResource() {
+		return maxResource != null ? maxResource : ResourceSpec.UNKNOWN;
+	}
+
+	public void setResource(ResourceSpec minResource, ResourceSpec maxResource) {
+		this.minResource = minResource;
+		this.maxResource = maxResource;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -268,7 +268,7 @@ public class StreamingJobGraphGenerator {
 	private ResourceSpec createChainedMinResource(Integer vertexID, List<StreamEdge> chainedOutputs) {
 		ResourceSpec minResource = streamGraph.getStreamNode(vertexID).getMinResource();
 		for (StreamEdge chainable : chainedOutputs) {
-			minResource.merge(chainedMinResource.get(chainable.getTargetId()));
+			minResource = minResource.merge(chainedMinResource.get(chainable.getTargetId()));
 		}
 		return minResource;
 	}
@@ -276,7 +276,7 @@ public class StreamingJobGraphGenerator {
 	private ResourceSpec createChainedMaxResource(Integer vertexID, List<StreamEdge> chainedOutputs) {
 		ResourceSpec maxResource = streamGraph.getStreamNode(vertexID).getMaxResource();
 		for (StreamEdge chainable : chainedOutputs) {
-			maxResource.merge(chainedMaxResource.get(chainable.getTargetId()));
+			maxResource = maxResource.merge(chainedMaxResource.get(chainable.getTargetId()));
 		}
 		return maxResource;
 	}
@@ -309,8 +309,7 @@ public class StreamingJobGraphGenerator {
 					jobVertexId);
 		}
 
-		jobVertex.setMinResource(chainedMinResource.get(streamNodeId));
-		jobVertex.setMaxResource(chainedMaxResource.get(streamNodeId));
+		jobVertex.setResource(chainedMinResource.get(streamNodeId), chainedMaxResource.get(streamNodeId));
 
 		jobVertex.setInvokableClass(streamNode.getJobVertexClass());
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -22,6 +22,7 @@ import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.operators.util.UserCodeObjectWrapper;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -92,6 +93,8 @@ public class StreamingJobGraphGenerator {
 
 	private Map<Integer, StreamConfig> vertexConfigs;
 	private Map<Integer, String> chainedNames;
+	private Map<Integer, ResourceSpec> chainedMinResource;
+	private Map<Integer, ResourceSpec> chainedMaxResource;
 
 	public StreamingJobGraphGenerator(StreamGraph streamGraph) {
 		this.streamGraph = streamGraph;
@@ -103,6 +106,8 @@ public class StreamingJobGraphGenerator {
 		this.chainedConfigs = new HashMap<>();
 		this.vertexConfigs = new HashMap<>();
 		this.chainedNames = new HashMap<>();
+		this.chainedMinResource = new HashMap<>();
+		this.chainedMaxResource = new HashMap<>();
 		this.physicalEdgesInOrder = new ArrayList<>();
 	}
 
@@ -200,6 +205,8 @@ public class StreamingJobGraphGenerator {
 			}
 
 			chainedNames.put(currentNodeId, createChainedName(currentNodeId, chainableOutputs));
+			chainedMinResource.put(currentNodeId, createChainedMinResource(currentNodeId, chainableOutputs));
+			chainedMaxResource.put(currentNodeId, createChainedMaxResource(currentNodeId, chainableOutputs));
 
 			StreamConfig config = currentNodeId.equals(startNodeId)
 					? createJobVertex(startNodeId, hashes)
@@ -258,6 +265,22 @@ public class StreamingJobGraphGenerator {
 		}
 	}
 
+	private ResourceSpec createChainedMinResource(Integer vertexID, List<StreamEdge> chainedOutputs) {
+		ResourceSpec minResource = streamGraph.getStreamNode(vertexID).getMinResource();
+		for (StreamEdge chainable : chainedOutputs) {
+			minResource.merge(chainedMinResource.get(chainable.getTargetId()));
+		}
+		return minResource;
+	}
+
+	private ResourceSpec createChainedMaxResource(Integer vertexID, List<StreamEdge> chainedOutputs) {
+		ResourceSpec maxResource = streamGraph.getStreamNode(vertexID).getMaxResource();
+		for (StreamEdge chainable : chainedOutputs) {
+			maxResource.merge(chainedMaxResource.get(chainable.getTargetId()));
+		}
+		return maxResource;
+	}
+
 	private StreamConfig createJobVertex(
 			Integer streamNodeId,
 			Map<Integer, byte[]> hashes) {
@@ -285,6 +308,9 @@ public class StreamingJobGraphGenerator {
 					chainedNames.get(streamNodeId),
 					jobVertexId);
 		}
+
+		jobVertex.setMinResource(chainedMinResource.get(streamNodeId));
+		jobVertex.setMaxResource(chainedMaxResource.get(streamNodeId));
 
 		jobVertex.setInvokableClass(streamNode.getJobVertexClass());
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.transformations;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.InvalidTypesException;
+import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.MissingTypeInfo;
 import org.apache.flink.streaming.api.graph.StreamGraph;
@@ -133,6 +134,10 @@ public abstract class StreamTransformation<T> {
 	protected long bufferTimeout = -1;
 
 	private String slotSharingGroup;
+
+	private ResourceSpec minResource;
+
+	private ResourceSpec maxResource;
 
 	/**
 	 * Creates a new {@code StreamTransformation} with the given name, output type and parallelism.
@@ -319,6 +324,35 @@ public abstract class StreamTransformation<T> {
 	 */
 	public long getBufferTimeout() {
 		return bufferTimeout;
+	}
+
+	/**
+	 * Sets the minimum and maximum resource for this stream transformation.
+	 *
+	 * @param minResource The minimum resource of this transformation.
+	 * @param maxResource The maximum resource of this transformation.
+	 */
+	public void setResource(ResourceSpec minResource, ResourceSpec maxResource) {
+		this.minResource = minResource;
+		this.maxResource = maxResource;
+	}
+
+	/**
+	 * Gets the minimum resource of this stream transformation.
+	 *
+	 * @return The minimum resource of this transformation.
+	 */
+	public ResourceSpec getMinResource() {
+		return minResource;
+	}
+
+	/**
+	 * Gets the maximum resource of this stream transformation.
+	 *
+	 * @return The maximum resource of this transformation.
+	 */
+	public ResourceSpec getMaxResource() {
+		return maxResource;
 	}
 
 	/**


### PR DESCRIPTION
Currently the **ResourceProfile** only contains cpu cores and memory properties. The memory should be expanded to different types such as heap memory, direct memory and native memory which corresponds with memory in **ResourceSpec**.

It contains the related un-merging codes for [FLINK-5132] [FLINK-5133] [FLINK-5134]. And the modifications for [FLINK-5135] only includes **SlotPool** and **ResourceProfile**.