### PR TITLE
[maven] properly attach the CEP Scala source code

### DIFF
--- a/flink-libraries/flink-cep-scala/pom.xml
+++ b/flink-libraries/flink-cep-scala/pom.xml
@@ -93,6 +93,8 @@ under the License.
     </dependencies>
 
     <build>
+        <!-- Not strictly necessary because of the build-helper-maven-plugin below. -->
+        <sourceDirectory>src/main/scala</sourceDirectory>
         <plugins>
             <!-- Scala Compiler -->
             <plugin>
@@ -115,6 +117,41 @@ under the License.
 				<configuration>
 					<configLocation>${project.basedir}/../../tools/maven/scalastyle-config.xml</configLocation>
 				</configuration>
+			</plugin>
+
+			<!-- Adding scala source directories to build path for Eclipse and generating the sources jar -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>1.7</version>
+				<executions>
+					<!-- Add src/main/scala to eclipse build path -->
+					<execution>
+						<id>add-source</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>src/main/scala</source>
+							</sources>
+						</configuration>
+					</execution>
+					<!-- Add src/test/scala to eclipse build path -->
+					<execution>
+						<id>add-test-source</id>
+						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>add-test-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>src/test/scala</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Two options, either change the default Maven source directory from
'src/main/java' to 'src/main/scala' or use the build-helper-maven-plugin
to attach the Scala sources. Opting for both here to be in lines with
Maven standards and support Eclipse.