### PR TITLE
[FLINK-4554] [table] Add support for array types

### DIFF
--- a/docs/dev/table_api.md
+++ b/docs/dev/table_api.md
@@ -1470,7 +1470,14 @@ The Table API is built on top of Flink's DataSet and DataStream API. Internally,
 | `Types.INTERVAL_MONTHS`| `INTERVAL YEAR TO MONTH`    | `java.lang.Integer`    |
 | `Types.INTERVAL_MILLIS`| `INTERVAL DAY TO SECOND(3)` | `java.lang.Long`       |
 
-Advanced types such as generic types, composite types (e.g. POJOs or Tuples), and arrays can be fields of a row. Generic types and arrays are treated as a black box within Table API and SQL yet. Composite types, however, are fully supported types where fields of a composite type can be accessed using the `.get()` operator in Table API and dot operator (e.g. `MyTable.pojoColumn.myField`) in SQL. Composite types can also be flattened using `.flatten()` in Table API or `MyTable.pojoColumn.*` in SQL.
+
+Advanced types such as generic types, composite types (e.g. POJOs or Tuples), and array types (object or primitive arrays) can be fields of a row. 
+
+Generic types are treated as a black box within Table API and SQL yet.
+
+Composite types, however, are fully supported types where fields of a composite type can be accessed using the `.get()` operator in Table API and dot operator (e.g. `MyTable.pojoColumn.myField`) in SQL. Composite types can also be flattened using `.flatten()` in Table API or `MyTable.pojoColumn.*` in SQL.
+
+Array types can be access using the `myArray.at(1)` operator in Table API and `myArray[1]` operator in SQL. Array literals can be created using `array(1, 2, 3)` in Table API and `ARRAY[1, 2, 3]` in SQL.
 
 {% top %}
 
@@ -2038,6 +2045,50 @@ COMPOSITE.get(INT)
       </td>
     </tr>
 
+    <tr>
+      <td>
+        {% highlight java %}
+ARRAY.at(INT)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the element at a particular location in an array. The index starts at 1.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight java %}
+array(ANY [, ANY ]*)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Creates an array from a list of values. The array will be an array of objects (not primitives).</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight java %}
+ARRAY.cardinality()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the number of elements of an array.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+ARRAY.element()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the sole element of an array. Returns <code>null</code> if the collection is empty. Throws an exception if the array has more than one element.</p>
+      </td>
+    </tr>
+
   </tbody>
 </table>
 
@@ -2596,6 +2647,50 @@ COMPOSITE.get(INT)
       </td>
       <td>
         <p>Accesses the field of a Flink composite type (such as Tuple, POJO, etc.) by index or name and returns it's value. E.g. <code>'pojo.get("myField")</code> or <code>'tuple.get(0)</code>.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+ARRAY.at(INT)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the element at a particular location in an array. The index starts at 1.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+array(ANY [, ANY ]*)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Creates an array from a list of values. The array will be an array of objects (not primitives).</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+ARRAY.cardinality()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the number of elements of an array.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+ARRAY.element()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the sole element of an array. Returns <code>null</code> if the collection is empty. Throws an exception if the array has more than one element.</p>
       </td>
     </tr>
 
@@ -3368,8 +3463,6 @@ CAST(value AS type)
   </tbody>
 </table>
 
-
-<!-- Disabled temporarily in favor of composite type support
 <table class="table table-bordered">
   <thead>
     <tr>
@@ -3379,6 +3472,7 @@ CAST(value AS type)
   </thead>
 
   <tbody>
+  <!-- Disabled temporarily in favor of composite type support
     <tr>
       <td>
         {% highlight text %}
@@ -3400,9 +3494,32 @@ ROW (value [, value]* )
         <p>Creates a row from a list of values.</p>
       </td>
     </tr>
+-->
+
+    <tr>
+      <td>
+        {% highlight text %}
+array ‘[’ index ‘]’
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the element at a particular location in an array. The index starts at 1.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight text %}
+ARRAY ‘[’ value [, value ]* ‘]’
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Creates an array from a list of values.</p>
+      </td>
+    </tr>
+
   </tbody>
 </table>
--->
 
 <table class="table table-bordered">
   <thead>
@@ -3652,6 +3769,39 @@ tableName.compositeType.*
       </td>
       <td>
         <p>Converts a Flink composite type (such as Tuple, POJO, etc.) and all of its direct subtypes into a flat representation where every subtype is a separate field.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 40%">Array functions</th>
+      <th class="text-center">Description</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        {% highlight text %}
+CARDINALITY(ARRAY)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the number of elements of an array.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight text %}
+ELEMENT(ARRAY)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the sole element of an array. Returns <code>null</code> if the collection is empty. Throws an exception if the array has more than one element.</p>
       </td>
     </tr>
   </tbody>

--- a/docs/dev/table_api.md
+++ b/docs/dev/table_api.md
@@ -1477,7 +1477,7 @@ Generic types are treated as a black box within Table API and SQL yet.
 
 Composite types, however, are fully supported types where fields of a composite type can be accessed using the `.get()` operator in Table API and dot operator (e.g. `MyTable.pojoColumn.myField`) in SQL. Composite types can also be flattened using `.flatten()` in Table API or `MyTable.pojoColumn.*` in SQL.
 
-Array types can be access using the `myArray.at(1)` operator in Table API and `myArray[1]` operator in SQL. Array literals can be created using `array(1, 2, 3)` in Table API and `ARRAY[1, 2, 3]` in SQL.
+Array types can be accessed using the `myArray.at(1)` operator in Table API and `myArray[1]` operator in SQL. Array literals can be created using `array(1, 2, 3)` in Table API and `ARRAY[1, 2, 3]` in SQL.
 
 {% top %}
 
@@ -2052,7 +2052,7 @@ ARRAY.at(INT)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns the element at a particular location in an array. The index starts at 1.</p>
+        <p>Returns the element at a particular position in an array. The index starts at 1.</p>
       </td>
     </tr>
 
@@ -2085,7 +2085,7 @@ ARRAY.element()
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns the sole element of an array. Returns <code>null</code> if the collection is empty. Throws an exception if the array has more than one element.</p>
+        <p>Returns the sole element of an array with a single element. Returns <code>null</code> if the array is empty. Throws an exception if the array has more than one element.</p>
       </td>
     </tr>
 
@@ -2657,7 +2657,7 @@ ARRAY.at(INT)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns the element at a particular location in an array. The index starts at 1.</p>
+        <p>Returns the element at a particular position in an array. The index starts at 1.</p>
       </td>
     </tr>
 
@@ -2690,7 +2690,7 @@ ARRAY.element()
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns the sole element of an array. Returns <code>null</code> if the collection is empty. Throws an exception if the array has more than one element.</p>
+        <p>Returns the sole element of an array with a single element. Returns <code>null</code> if the array is empty. Throws an exception if the array has more than one element.</p>
       </td>
     </tr>
 
@@ -3503,7 +3503,7 @@ array ‘[’ index ‘]’
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns the element at a particular location in an array. The index starts at 1.</p>
+        <p>Returns the element at a particular position in an array. The index starts at 1.</p>
       </td>
     </tr>
 
@@ -3801,7 +3801,7 @@ ELEMENT(ARRAY)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns the sole element of an array. Returns <code>null</code> if the collection is empty. Throws an exception if the array has more than one element.</p>
+        <p>Returns the sole element of an array with a single element. Returns <code>null</code> if the array is empty. Throws an exception if the array has more than one element.</p>
       </td>
     </tr>
   </tbody>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/scala/table/expressionDsl.scala
@@ -474,15 +474,15 @@ trait ImplicitExpressionOperations {
   /**
     * Returns the number of elements of an array.
     *
-    * @return number of element
+    * @return number of elements
     */
   def cardinality() = ArrayCardinality(expr)
 
   /**
-    * Returns the sole element of an array. Returns null if the collection is empty.
-    * Throws an exception if the array has more than one element.
+    * Returns the sole element of an array with a single element. Returns null if the array is
+    * empty. Throws an exception if the array has more than one element.
     *
-    * @return first element of the array
+    * @return the first and only element of an array with a single element
     */
   def element() = ArrayElement(expr)
 }
@@ -577,6 +577,10 @@ trait ImplicitExpressionConversions {
 // ------------------------------------------------------------------------------------------------
 // Expressions with no parameters
 // ------------------------------------------------------------------------------------------------
+
+// we disable the object checker here as it checks for capital letters of objects
+// but we want that objects look like functions in certain cases e.g. array(1, 2, 3)
+// scalastyle:off object.name
 
 /**
   * Returns the current SQL date in UTC time zone.
@@ -684,5 +688,4 @@ object array {
   }
 }
 
-
-
+// scalastyle:on object.name

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenUtils.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenUtils.scala
@@ -195,7 +195,7 @@ object CodeGenUtils {
 
   def requireInteger(genExpr: GeneratedExpression) =
     if (!TypeCheckUtils.isInteger(genExpr.resultType)) {
-      throw new CodeGenException("Array expression type expected.")
+      throw new CodeGenException("Integer expression type expected.")
     }
 
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenUtils.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/CodeGenUtils.scala
@@ -155,7 +155,6 @@ object CodeGenUtils {
   def enumValueOf[T <: Enum[T]](cls: Class[_], stringValue: String): Enum[_] =
     Enum.valueOf(cls.asInstanceOf[Class[T]], stringValue).asInstanceOf[Enum[_]]
 
-
   // ----------------------------------------------------------------------------------------------
 
   def requireNumeric(genExpr: GeneratedExpression) =
@@ -187,6 +186,16 @@ object CodeGenUtils {
   def requireTimeInterval(genExpr: GeneratedExpression) =
     if (!TypeCheckUtils.isTimeInterval(genExpr.resultType)) {
       throw new CodeGenException("Interval expression type expected.")
+    }
+
+  def requireArray(genExpr: GeneratedExpression) =
+    if (!TypeCheckUtils.isArray(genExpr.resultType)) {
+      throw new CodeGenException("Array expression type expected.")
+    }
+
+  def requireInteger(genExpr: GeneratedExpression) =
+    if (!TypeCheckUtils.isInteger(genExpr.resultType)) {
+      throw new CodeGenException("Array expression type expected.")
     }
 
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/ExpressionReducer.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/codegen/ExpressionReducer.scala
@@ -63,7 +63,7 @@ class ExpressionReducer(config: TableConfig)
         )
 
       // we don't support object literals yet, we skip those constant expressions
-      case (SqlTypeName.ANY, _) | (SqlTypeName.ROW, _) => None
+      case (SqlTypeName.ANY, _) | (SqlTypeName.ROW, _) | (SqlTypeName.ARRAY, _) => None
 
       case (_, e) => Some(e)
     }
@@ -101,7 +101,7 @@ class ExpressionReducer(config: TableConfig)
       val unreduced = constExprs.get(i)
       unreduced.getType.getSqlTypeName match {
         // we insert the original expression for object literals
-        case SqlTypeName.ANY | SqlTypeName.ROW =>
+        case SqlTypeName.ANY | SqlTypeName.ROW | SqlTypeName.ARRAY =>
           reducedValues.add(unreduced)
         case _ =>
           val literal = rexBuilder.makeLiteral(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/ExpressionParser.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/ExpressionParser.scala
@@ -48,6 +48,7 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
 
   // Keyword
 
+  lazy val ARRAY: Keyword = Keyword("Array")
   lazy val AS: Keyword = Keyword("as")
   lazy val COUNT: Keyword = Keyword("count")
   lazy val AVG: Keyword = Keyword("avg")
@@ -88,7 +89,7 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
   lazy val FLATTEN: Keyword = Keyword("flatten")
 
   def functionIdent: ExpressionParser.Parser[String] =
-    not(AS) ~ not(COUNT) ~ not(AVG) ~ not(MIN) ~ not(MAX) ~
+    not(ARRAY) ~ not(AS) ~ not(COUNT) ~ not(AVG) ~ not(MIN) ~ not(MAX) ~
       not(SUM) ~ not(START) ~ not(END)~ not(CAST) ~ not(NULL) ~
       not(IF) ~> super.ident
 
@@ -298,6 +299,9 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
 
   // prefix operators
 
+  lazy val prefixArray: PackratParser[Expression] =
+    ARRAY ~ "(" ~> repsep(expression, ",") <~ ")" ^^ { elements => ArrayConstructor(elements) }
+
   lazy val prefixSum: PackratParser[Expression] =
     SUM ~ "(" ~> expression <~ ")" ^^ { e => Sum(e) }
 
@@ -372,7 +376,8 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
     FLATTEN ~ "(" ~> composite <~ ")" ^^ { e => Flattening(e) }
 
   lazy val prefixed: PackratParser[Expression] =
-    prefixSum | prefixMin | prefixMax | prefixCount | prefixAvg | prefixStart | prefixEnd |
+    prefixArray | prefixSum | prefixMin | prefixMax | prefixCount | prefixAvg |
+      prefixStart | prefixEnd |
       prefixCast | prefixAs | prefixTrim | prefixTrimWithoutArgs | prefixIf | prefixExtract |
       prefixFloor | prefixCeil | prefixGet | prefixFlattening |
       prefixFunctionCall | prefixFunctionCallOneArg // function call must always be at the end

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/array.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/array.scala
@@ -82,7 +82,13 @@ case class ArrayElementAt(array: Expression, index: Expression) extends Expressi
     array.resultType match {
       case _: ObjectArrayTypeInfo[_, _] | _: PrimitiveArrayTypeInfo[_] =>
         if (index.resultType == INT_TYPE_INFO) {
-          ValidationSuccess
+          // check for common user mistake
+          index match {
+            case Literal(value: Int, INT_TYPE_INFO) if value < 1 =>
+              ValidationFailure(
+                s"Array element access needs an index starting at 1 but was $value.")
+            case _ => ValidationSuccess
+          }
         } else {
           ValidationFailure(
             s"Array element access needs an integer index but was '${index.resultType}'.")

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/array.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/array.scala
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.expressions
+
+import org.apache.calcite.rex.RexNode
+import org.apache.calcite.sql.fun.SqlStdOperatorTable
+import org.apache.calcite.tools.RelBuilder
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo.INT_TYPE_INFO
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, PrimitiveArrayTypeInfo, TypeInformation}
+import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo
+import org.apache.flink.api.table.FlinkRelBuilder
+import org.apache.flink.api.table.validate.{ValidationFailure, ValidationResult, ValidationSuccess}
+
+import scala.collection.JavaConverters._
+
+case class ArrayConstructor(elements: Seq[Expression]) extends Expression {
+
+  override private[flink] def children: Seq[Expression] = elements
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    val relDataType = relBuilder
+      .asInstanceOf[FlinkRelBuilder]
+      .getTypeFactory
+      .createTypeFromTypeInfo(resultType)
+    val values = elements.map(_.toRexNode).toList.asJava
+    relBuilder
+      .getRexBuilder
+      .makeCall(relDataType, SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR, values)
+  }
+
+  override def toString = s"array(${elements.mkString(", ")})"
+
+  override private[flink] def resultType = ObjectArrayTypeInfo.getInfoFor(elements.head.resultType)
+
+  override private[flink] def validateInput(): ValidationResult = {
+    if (elements.isEmpty) {
+      return ValidationFailure("Empty arrays are not supported yet.")
+    }
+    val elementType = elements.head.resultType
+    if (!elements.forall(_.resultType == elementType)) {
+      ValidationFailure("Not all elements of the array have the same type.")
+    } else {
+      ValidationSuccess
+    }
+  }
+}
+
+case class ArrayElementAt(array: Expression, index: Expression) extends Expression {
+
+  override private[flink] def children: Seq[Expression] = Seq(array, index)
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder
+      .getRexBuilder
+      .makeCall(SqlStdOperatorTable.ITEM, array.toRexNode, index.toRexNode)
+  }
+
+  override def toString = s"($array).at($index)"
+
+  override private[flink] def resultType = array.resultType match {
+    case oati: ObjectArrayTypeInfo[_, _] => oati.getComponentInfo
+    case pati: PrimitiveArrayTypeInfo[_] => pati.getComponentType
+  }
+
+  override private[flink] def validateInput(): ValidationResult = {
+    array.resultType match {
+      case _: ObjectArrayTypeInfo[_, _] | _: PrimitiveArrayTypeInfo[_] =>
+        if (index.resultType == INT_TYPE_INFO) {
+          ValidationSuccess
+        } else {
+          ValidationFailure(
+            s"Array element access needs an integer index but was '${index.resultType}'.")
+        }
+      case other@_ => ValidationFailure(s"Array expected but was '$other'.")
+    }
+  }
+}
+
+case class ArrayCardinality(array: Expression) extends Expression {
+
+  override private[flink] def children: Seq[Expression] = Seq(array)
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder
+      .getRexBuilder
+      .makeCall(SqlStdOperatorTable.CARDINALITY, array.toRexNode)
+  }
+
+  override def toString = s"($array).cardinality()"
+
+  override private[flink] def resultType = BasicTypeInfo.INT_TYPE_INFO
+
+  override private[flink] def validateInput(): ValidationResult = {
+    array.resultType match {
+      case _: ObjectArrayTypeInfo[_, _] | _: PrimitiveArrayTypeInfo[_] => ValidationSuccess
+      case other@_ => ValidationFailure(s"Array expected but was '$other'.")
+    }
+  }
+}
+
+case class ArrayElement(array: Expression) extends Expression {
+
+  override private[flink] def children: Seq[Expression] = Seq(array)
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder
+      .getRexBuilder
+      .makeCall(SqlStdOperatorTable.ELEMENT, array.toRexNode)
+  }
+
+  override def toString = s"($array).element()"
+
+  override private[flink] def resultType = array.resultType match {
+    case oati: ObjectArrayTypeInfo[_, _] => oati.getComponentInfo
+    case pati: PrimitiveArrayTypeInfo[_] => pati.getComponentType
+  }
+
+  override private[flink] def validateInput(): ValidationResult = {
+    array.resultType match {
+      case _: ObjectArrayTypeInfo[_, _] | _: PrimitiveArrayTypeInfo[_] => ValidationSuccess
+      case other@_ => ValidationFailure(s"Array expected but was '$other'.")
+    }
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/comparison.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/expressions/comparison.scala
@@ -36,7 +36,6 @@ abstract class BinaryComparison extends BinaryExpression {
 
   override private[flink] def resultType = BOOLEAN_TYPE_INFO
 
-  // TODO: tighten this rule once we implemented type coercion rules during validation
   override private[flink] def validateInput(): ValidationResult =
     (left.resultType, right.resultType) match {
       case (lType, rType) if isNumeric(lType) && isNumeric(rType) => ValidationSuccess
@@ -56,7 +55,6 @@ case class EqualTo(left: Expression, right: Expression) extends BinaryComparison
   override private[flink] def validateInput(): ValidationResult =
     (left.resultType, right.resultType) match {
       case (lType, rType) if isNumeric(lType) && isNumeric(rType) => ValidationSuccess
-      // TODO widen this rule once we support custom objects as types (FLINK-3916)
       case (lType, rType) if lType == rType => ValidationSuccess
       case (lType, rType) =>
         ValidationFailure(s"Equality predicate on incompatible types: $lType and $rType")
@@ -71,7 +69,6 @@ case class NotEqualTo(left: Expression, right: Expression) extends BinaryCompari
   override private[flink] def validateInput(): ValidationResult =
     (left.resultType, right.resultType) match {
       case (lType, rType) if isNumeric(lType) && isNumeric(rType) => ValidationSuccess
-      // TODO widen this rule once we support custom objects as types (FLINK-3916)
       case (lType, rType) if lType == rType => ValidationSuccess
       case (lType, rType) =>
         ValidationFailure(s"Inequality predicate on incompatible types: $lType and $rType")

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/ProjectionTranslator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/ProjectionTranslator.scala
@@ -143,7 +143,13 @@ object ProjectionTranslator {
       case sfc @ ScalarFunctionCall(clazz, args) =>
         val newArgs: Seq[Expression] = args
           .map(replaceAggregationsAndProperties(_, tableEnv, aggNames, propNames))
-        sfc.makeCopy(Array(clazz,newArgs))
+        sfc.makeCopy(Array(clazz, newArgs))
+
+      // array constructor
+      case c @ ArrayConstructor(args) =>
+        val newArgs = c.elements
+          .map(replaceAggregationsAndProperties(_, tableEnv, aggNames, propNames))
+        c.makeCopy(Array(newArgs))
 
       // General expression
       case e: Expression =>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/schema/ArrayRelDataType.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/schema/ArrayRelDataType.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.plan.schema
+
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.sql.`type`.ArraySqlType
+import org.apache.flink.api.common.typeinfo.TypeInformation
+
+/**
+  * Flink distinguishes between primitive arrays (int[], double[], ...) and
+  * object arrays (Integer[], MyPojo[], ...). This custom type considers the two cases.
+  */
+class ArrayRelDataType(
+    val typeInfo: TypeInformation[_],
+    elementType: RelDataType,
+    isNullable: Boolean)
+  extends ArraySqlType(
+    elementType,
+    isNullable) {
+
+  override def toString = s"ARRAY($typeInfo)"
+
+  def canEqual(other: Any): Boolean = other.isInstanceOf[ArrayRelDataType]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ArrayRelDataType =>
+      super.equals(that) &&
+        (that canEqual this) &&
+        typeInfo == that.typeInfo
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    typeInfo.hashCode()
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/schema/ArrayRelDataType.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/schema/ArrayRelDataType.scala
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 
 /**
   * Flink distinguishes between primitive arrays (int[], double[], ...) and
-  * object arrays (Integer[], MyPojo[], ...). This custom type considers the two cases.
+  * object arrays (Integer[], MyPojo[], ...). This custom type supports both cases.
   */
 class ArrayRelDataType(
     val typeInfo: TypeInformation[_],

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/typeutils/TypeCheckUtils.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/typeutils/TypeCheckUtils.scala
@@ -17,8 +17,9 @@
  */
 package org.apache.flink.api.table.typeutils
 
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{BIG_DEC_TYPE_INFO, BOOLEAN_TYPE_INFO, STRING_TYPE_INFO}
-import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, SqlTimeTypeInfo, NumericTypeInfo, TypeInformation}
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{BIG_DEC_TYPE_INFO, BOOLEAN_TYPE_INFO, INT_TYPE_INFO, STRING_TYPE_INFO}
+import org.apache.flink.api.common.typeinfo._
+import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo
 import org.apache.flink.api.table.validate._
 
 object TypeCheckUtils {
@@ -61,8 +62,15 @@ object TypeCheckUtils {
 
   def isDecimal(dataType: TypeInformation[_]): Boolean = dataType == BIG_DEC_TYPE_INFO
 
+  def isInteger(dataType: TypeInformation[_]): Boolean = dataType == INT_TYPE_INFO
+
+  def isArray(dataType: TypeInformation[_]): Boolean = dataType match {
+    case _: ObjectArrayTypeInfo[_, _] | _: PrimitiveArrayTypeInfo[_] => true
+    case _ => false
+  }
+
   def isComparable(dataType: TypeInformation[_]): Boolean =
-    classOf[Comparable[_]].isAssignableFrom(dataType.getTypeClass)
+    classOf[Comparable[_]].isAssignableFrom(dataType.getTypeClass) && !isArray(dataType)
 
   def assertNumericExpr(
       dataType: TypeInformation[_],

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/validate/FunctionCatalog.scala
@@ -185,7 +185,12 @@ object FunctionCatalog {
     "localTime" -> classOf[LocalTime],
     "localTimestamp" -> classOf[LocalTimestamp],
     "quarter" -> classOf[Quarter],
-    "temporalOverlaps" -> classOf[TemporalOverlaps]
+    "temporalOverlaps" -> classOf[TemporalOverlaps],
+
+    // array
+    "cardinality" -> classOf[ArrayCardinality],
+    "at" -> classOf[ArrayElementAt],
+    "element" -> classOf[ArrayElement]
 
     // TODO implement function overloading here
     // "floor" -> classOf[TemporalFloor]
@@ -258,6 +263,11 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     SqlStdOperatorTable.MIN,
     SqlStdOperatorTable.MAX,
     SqlStdOperatorTable.AVG,
+    // ARRAY OPERATORS
+    SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR,
+    SqlStdOperatorTable.ITEM,
+    SqlStdOperatorTable.CARDINALITY,
+    SqlStdOperatorTable.ELEMENT,
     // SPECIAL OPERATORS
     SqlStdOperatorTable.ROW,
     SqlStdOperatorTable.OVERLAPS,

--- a/flink-libraries/flink-table/src/test/resources/log4j-test.properties
+++ b/flink-libraries/flink-table/src/test/resources/log4j-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-log4j.rootLogger=INFO, testlogger
+log4j.rootLogger=OFF, testlogger
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.testlogger=org.apache.log4j.ConsoleAppender

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/expressions/ArrayTypeTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/expressions/ArrayTypeTest.scala
@@ -31,6 +31,11 @@ import org.junit.Test
 class ArrayTypeTest extends ExpressionTestBase {
 
   @Test(expected = classOf[ValidationException])
+  def testObviousInvalidIndexTableApi(): Unit = {
+    testTableApi('f2.at(0), "FAIL", "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
   def testEmptyArraySql(): Unit = {
     testSqlApi("ARRAY[]", "FAIL")
   }
@@ -73,8 +78,20 @@ class ArrayTypeTest extends ExpressionTestBase {
   }
 
   @Test(expected = classOf[ValidationException])
+  def testElementNonArraySql(): Unit = {
+    testSqlApi(
+      "ELEMENT(f0)",
+      "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
   def testCardinalityOnNonArray(): Unit = {
     testTableApi('f0.cardinality(), "FAIL", "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testCardinalityOnNonArraySql(): Unit = {
+    testSqlApi("CARDINALITY(f0)", "FAIL")
   }
 
   @Test

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/expressions/ArrayTypeTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/expressions/ArrayTypeTest.scala
@@ -1,0 +1,342 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.table.expressions
+
+import java.sql.Date
+
+import org.apache.flink.api.common.typeinfo.{PrimitiveArrayTypeInfo, TypeInformation}
+import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo
+import org.apache.flink.api.scala.table._
+import org.apache.flink.api.table.expressions.utils.ExpressionTestBase
+import org.apache.flink.api.table.typeutils.RowTypeInfo
+import org.apache.flink.api.table.{Row, Types, ValidationException}
+import org.junit.Test
+
+class ArrayTypeTest extends ExpressionTestBase {
+
+  @Test(expected = classOf[ValidationException])
+  def testEmptyArraySql(): Unit = {
+    testSqlApi("ARRAY[]", "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testEmptyArrayTableApi(): Unit = {
+    testTableApi("FAIL", "array()", "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testNullArraySql(): Unit = {
+    testSqlApi("ARRAY[NULL]", "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testDifferentTypesArraySql(): Unit = {
+    testSqlApi("ARRAY[1, TRUE]", "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testDifferentTypesArrayTableApi(): Unit = {
+    testTableApi("FAIL", "array(1, true)", "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testUnsupportedComparison(): Unit = {
+    testAllApis(
+      'f2 <= 'f5.at(1),
+      "f2 <= f5.at(1)",
+      "f2 <= f5[1]",
+      "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testElementNonArray(): Unit = {
+    testTableApi(
+      'f0.element(),
+      "FAIL",
+      "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testCardinalityOnNonArray(): Unit = {
+    testTableApi('f0.cardinality(), "FAIL", "FAIL")
+  }
+
+  @Test
+  def testArrayLiterals(): Unit = {
+    // primitive literals
+    testAllApis(array(1, 2, 3), "array(1, 2, 3)", "ARRAY[1, 2, 3]", "[1, 2, 3]")
+
+    testAllApis(
+      array(true, true, true),
+      "array(true, true, true)",
+      "ARRAY[TRUE, TRUE, TRUE]",
+      "[true, true, true]")
+
+    // object literals
+    testTableApi(array(BigDecimal(1), BigDecimal(1)), "array(1p, 1p)", "[1, 1]")
+
+    testAllApis(
+      array(array(array(1), array(1))),
+      "array(array(array(1), array(1)))",
+      "ARRAY[ARRAY[ARRAY[1], ARRAY[1]]]",
+      "[[[1], [1]]]")
+
+    testAllApis(
+      array(1 + 1, 3 * 3),
+      "array(1 + 1, 3 * 3)",
+      "ARRAY[1 + 1, 3 * 3]",
+      "[2, 9]")
+
+    testAllApis(
+      array(Null(Types.INT), 1),
+      "array(Null(INT), 1)",
+      "ARRAY[NULLIF(1,1), 1]",
+      "[null, 1]")
+
+    testAllApis(
+      array(array(Null(Types.INT), 1)),
+      "array(array(Null(INT), 1))",
+      "ARRAY[ARRAY[NULLIF(1,1), 1]]",
+      "[[null, 1]]")
+
+    // implicit conversion
+    testTableApi(
+      Array(1, 2, 3),
+      "array(1, 2, 3)",
+      "[1, 2, 3]")
+
+    testTableApi(
+      Array[Integer](1, 2, 3),
+      "array(1, 2, 3)",
+      "[1, 2, 3]")
+
+    testAllApis(
+      Array(Date.valueOf("1985-04-11")),
+      "array('1985-04-11'.toDate)",
+      "ARRAY[DATE '1985-04-11']",
+      "[1985-04-11]")
+
+    testAllApis(
+      Array(BigDecimal(2.0002), BigDecimal(2.0003)),
+      "Array(2.0002p, 2.0003p)",
+      "ARRAY[CAST(2.0002 AS DECIMAL), CAST(2.0003 AS DECIMAL)]",
+      "[2.0002, 2.0003]")
+
+    testAllApis(
+      Array(Array(x = true)),
+      "Array(Array(true))",
+      "ARRAY[ARRAY[TRUE]]",
+      "[[true]]")
+
+    testAllApis(
+      Array(Array(1, 2, 3), Array(3, 2, 1)),
+      "Array(Array(1, 2, 3), Array(3, 2, 1))",
+      "ARRAY[ARRAY[1, 2, 3], ARRAY[3, 2, 1]]",
+      "[[1, 2, 3], [3, 2, 1]]")
+  }
+
+  @Test
+  def testArrayField(): Unit = {
+    testAllApis(
+      array('f0, 'f1),
+      "array(f0, f1)",
+      "ARRAY[f0, f1]",
+      "[null, 42]")
+
+    testAllApis(
+      array('f0, 'f1),
+      "array(f0, f1)",
+      "ARRAY[f0, f1]",
+      "[null, 42]")
+
+    testAllApis(
+      'f2,
+      "f2",
+      "f2",
+      "[1, 2, 3]")
+
+    testAllApis(
+      'f3,
+      "f3",
+      "f3",
+      "[1984-03-12, 1984-02-10]")
+
+    testAllApis(
+      'f5,
+      "f5",
+      "f5",
+      "[[1, 2, 3], null]")
+
+    testAllApis(
+      'f6,
+      "f6",
+      "f6",
+      "[1, null, null, 4]")
+
+    testAllApis(
+      'f2,
+      "f2",
+      "f2",
+      "[1, 2, 3]")
+
+    testAllApis(
+      'f2.at(1),
+      "f2.at(1)",
+      "f2[1]",
+      "1")
+
+    testAllApis(
+      'f3.at(1),
+      "f3.at(1)",
+      "f3[1]",
+      "1984-03-12")
+
+    testAllApis(
+      'f3.at(2),
+      "f3.at(2)",
+      "f3[2]",
+      "1984-02-10")
+
+    testAllApis(
+      'f5.at(1).at(2),
+      "f5.at(1).at(2)",
+      "f5[1][2]",
+      "2")
+
+    testAllApis(
+      'f5.at(2).at(2),
+      "f5.at(2).at(2)",
+      "f5[2][2]",
+      "null")
+
+    testAllApis(
+      'f4.at(2).at(2),
+      "f4.at(2).at(2)",
+      "f4[2][2]",
+      "null")
+  }
+
+  @Test
+  def testArrayOperations(): Unit = {
+    // cardinality
+    testAllApis(
+      'f2.cardinality(),
+      "f2.cardinality()",
+      "CARDINALITY(f2)",
+      "3")
+
+    testAllApis(
+      'f4.cardinality(),
+      "f4.cardinality()",
+      "CARDINALITY(f4)",
+      "null")
+
+    // element
+    testAllApis(
+      'f9.element(),
+      "f9.element()",
+      "ELEMENT(f9)",
+      "1")
+
+    testAllApis(
+      'f8.element(),
+      "f8.element()",
+      "ELEMENT(f8)",
+      "4.0")
+
+    testAllApis(
+      'f10.element(),
+      "f10.element()",
+      "ELEMENT(f10)",
+      "null")
+
+    testAllApis(
+      'f4.element(),
+      "f4.element()",
+      "ELEMENT(f4)",
+      "null")
+
+    // comparison
+    testAllApis(
+      'f2 === 'f5.at(1),
+      "f2 === f5.at(1)",
+      "f2 = f5[1]",
+      "true")
+
+    testAllApis(
+      'f6 === array(1, 2, 3),
+      "f6 === array(1, 2, 3)",
+      "f6 = ARRAY[1, 2, 3]",
+      "false")
+
+    testAllApis(
+      'f2 !== 'f5.at(1),
+      "f2 !== f5.at(1)",
+      "f2 <> f5[1]",
+      "false")
+
+    testAllApis(
+      'f2 === 'f7,
+      "f2 === f7",
+      "f2 = f7",
+      "false")
+
+    testAllApis(
+      'f2 !== 'f7,
+      "f2 !== f7",
+      "f2 <> f7",
+      "true")
+  }
+
+  // ----------------------------------------------------------------------------------------------
+
+  case class MyCaseClass(string: String, int: Int)
+
+  override def testData: Any = {
+    val testData = new Row(11)
+    testData.setField(0, null)
+    testData.setField(1, 42)
+    testData.setField(2, Array(1, 2, 3))
+    testData.setField(3, Array(Date.valueOf("1984-03-12"), Date.valueOf("1984-02-10")))
+    testData.setField(4, null)
+    testData.setField(5, Array(Array(1, 2, 3), null))
+    testData.setField(6, Array[Integer](1, null, null, 4))
+    testData.setField(7, Array(1, 2, 3, 4))
+    testData.setField(8, Array(4.0))
+    testData.setField(9, Array[Integer](1))
+    testData.setField(10, Array[Integer]())
+    testData
+  }
+
+  override def typeInfo: TypeInformation[Any] = {
+    new RowTypeInfo(Seq(
+      Types.INT,
+      Types.INT,
+      PrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO,
+      ObjectArrayTypeInfo.getInfoFor(Types.DATE),
+      ObjectArrayTypeInfo.getInfoFor(ObjectArrayTypeInfo.getInfoFor(Types.INT)),
+      ObjectArrayTypeInfo.getInfoFor(PrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO),
+      ObjectArrayTypeInfo.getInfoFor(Types.INT),
+      PrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO,
+      PrimitiveArrayTypeInfo.DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO,
+      ObjectArrayTypeInfo.getInfoFor(Types.INT),
+      ObjectArrayTypeInfo.getInfoFor(Types.INT)
+    )).asInstanceOf[TypeInformation[Any]]
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/expressions/SqlExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/expressions/SqlExpressionTest.scala
@@ -135,11 +135,13 @@ class SqlExpressionTest extends ExpressionTestBase {
     testSqlApi("CAST(2 AS DOUBLE)", "2.0")
   }
 
-  @Ignore // TODO we need a special code path that flattens ROW types
   @Test
   def testValueConstructorFunctions(): Unit = {
-    testSqlApi("ROW('hello world', 12)", "hello world") // test base only returns field 0
-    testSqlApi("('hello world', 12)", "hello world") // test base only returns field 0
+    // TODO we need a special code path that flattens ROW types
+    // testSqlApi("ROW('hello world', 12)", "hello world") // test base only returns field 0
+    // testSqlApi("('hello world', 12)", "hello world") // test base only returns field 0
+    testSqlApi("ARRAY[TRUE, FALSE][2]", "false")
+    testSqlApi("ARRAY[TRUE, TRUE]", "[true, true]")
   }
 
   @Test
@@ -153,6 +155,12 @@ class SqlExpressionTest extends ExpressionTestBase {
     testSqlApi("EXTRACT(DAY FROM DATE '1990-12-01')", "1")
     testSqlApi("EXTRACT(DAY FROM INTERVAL '19 12:10:10.123' DAY TO SECOND(3))", "19")
     testSqlApi("QUARTER(DATE '2016-04-12')", "2")
+  }
+
+  @Test
+  def testArrayFunctions(): Unit = {
+    testSqlApi("CARDINALITY(ARRAY[TRUE, TRUE, FALSE])", "3")
+    testSqlApi("ELEMENT(ARRAY['HELLO WORLD'])", "HELLO WORLD")
   }
 
   override def testData: Any = new Row(0)

--- a/tools/maven/scalastyle-config.xml
+++ b/tools/maven/scalastyle-config.xml
@@ -68,11 +68,11 @@
    <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
   </parameters>
  </check>
-<!-- <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">--> 
-<!--  <parameters>--> 
-<!--   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>--> 
-<!--  </parameters>--> 
-<!-- </check>--> 
+ <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
  <check level="error" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>

--- a/tools/maven/scalastyle-config.xml
+++ b/tools/maven/scalastyle-config.xml
@@ -68,11 +68,11 @@
    <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
   </parameters>
  </check>
- <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
-  <parameters>
-   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
-  </parameters>
- </check>
+<!-- <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">--> 
+<!--  <parameters>--> 
+<!--   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>--> 
+<!--  </parameters>--> 
+<!-- </check>--> 
  <check level="error" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>


### PR DESCRIPTION
This PR adds array support for the Table API and SQL. It adds support for both primitive arrays and object arrays. It adds literals, element access, comparison and the functions `ELEMENT` and `CARDINALITY`.