### PR TITLE
[FLINK-5229] [tm] Discard completed checkpoints if a subsequent operator's checkpoint fails

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
@@ -26,9 +26,12 @@ package org.apache.flink.util;
 
 import org.apache.flink.annotation.Internal;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 @Internal
 public final class ExceptionUtils {
@@ -138,6 +141,53 @@ public final class ExceptionUtils {
 		}
 		else {
 			throw new IOException(t);
+		}
+	}
+
+	/**
+	 * Adds a new exception as a {@link Throwable#addSuppressed(Throwable) suppressed exception}
+	 * to a prior exception, or returns the new exception, if no prior exception exists.
+	 *
+	 * <pre>{@code
+	 *
+	 * public void closeAllThings() throws Exception {
+	 *     Exception ex = null;
+	 *     try {
+	 *         component.shutdown();
+	 *     } catch (Exception e) {
+	 *         ex = firstOrSuppressed(e, ex);
+	 *     }
+	 *     try {
+	 *         anotherComponent.stop();
+	 *     } catch (Exception e) {
+	 *         ex = firstOrSuppressed(e, ex);
+	 *     }
+	 *     try {
+	 *         lastComponent.shutdown();
+	 *     } catch (Exception e) {
+	 *         ex = firstOrSuppressed(e, ex);
+	 *     }
+	 *
+	 *     if (ex != null) {
+	 *         throw ex;
+	 *     }
+	 * }
+	 * }</pre>
+	 *
+	 * @param newException The newly occurred exception
+	 * @param previous     The previously occurred exception, possibly null.
+	 *
+	 * @return The new exception, if no previous exception exists, or the previous exception with the
+	 *         new exception in the list of suppressed exceptions.
+	 */
+	public static <T extends Throwable> T firstOrSuppressed(T newException, @Nullable T previous) {
+		checkNotNull(newException, "newException");
+
+		if (previous == null) {
+			return newException;
+		} else {
+			previous.addSuppressed(newException);
+			return previous;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -237,21 +237,23 @@ public class PendingCheckpoint {
 					executor.execute(new Runnable() {
 						@Override
 						public void run() {
-							try {
-								for (TaskState taskState: taskStates.values()) {
+							for (TaskState taskState: taskStates.values()) {
+								try {
 									taskState.discard(userClassLoader);
+								} catch (Exception e) {
+									LOG.warn("Could not properly dispose the task state " +
+										"belonging to vertex {} of checkpoint {} and job {}.",
+										taskState.getJobVertexID(), checkpointId, jobId, e);
 								}
-							} catch (Exception e) {
-								LOG.warn("Could not properly dispose the pending checkpoint " +
-									"{} of job {}.", checkpointId, jobId, e);
 							}
+
+							taskStates.clear();
 						}
 					});
 
 				}
 			} finally {
 				discarded = true;
-				taskStates.clear();
 				notYetAcknowledgedTasks.clear();
 				acknowledgedTasks.clear();
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsynchronousKvStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsynchronousKvStateSnapshot.java
@@ -52,11 +52,6 @@ public abstract class AsynchronousKvStateSnapshot<K, N, S extends State, SD exte
 	}
 
 	@Override
-	public void discardState() throws Exception {
-		throw new RuntimeException("This should never be called and probably points to a bug.");
-	}
-
-	@Override
 	public long getStateSize() throws Exception {
 		throw new RuntimeException("This should never be called and probably points to a bug.");
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsynchronousStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsynchronousStateHandle.java
@@ -35,9 +35,4 @@ public abstract class AsynchronousStateHandle<T> implements StateHandle<T> {
 	public final T getState(ClassLoader userCodeClassLoader) throws Exception {
 		throw new UnsupportedOperationException("This must not be called. This is likely an internal bug.");
 	}
-
-	@Override
-	public final void discardState() throws Exception {
-		throw new UnsupportedOperationException("This must not be called. This is likely an internal bug.");
-	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskAsyncCheckpointTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskAsyncCheckpointTest.java
@@ -194,6 +194,11 @@ public class StreamTaskAsyncCheckpointTest {
 		}
 
 		@Override
+		public void discardState() throws Exception {
+			// noop
+		}
+
+		@Override
 		public long getStateSize() {
 			return 0;
 		}


### PR DESCRIPTION
In case of a failure of any StreamOperator#snapshotState method, all up to this point created
StreamTaskStates will be discarded. This ensures that a failing checkpoint operation of a chained
operator won't leave orphaned checkpoint data behind.

cc @uce, @StephanEwen.