### PR TITLE
[FLINK-5226] [table] Use correct DataSetCostFactory and improve DataSetCalc costs.

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/FlinkRelBuilder.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/FlinkRelBuilder.scala
@@ -79,7 +79,7 @@ object FlinkRelBuilder {
     val typeFactory = new FlinkTypeFactory(typeSystem)
 
     // create context instances with Flink type factory
-    val planner = new VolcanoPlanner(Contexts.empty())
+    val planner = new VolcanoPlanner(config.getCostFactory, Contexts.empty())
     planner.setExecutor(config.getExecutor)
     planner.addRelTraitDef(ConventionTraitDef.INSTANCE)
     val cluster = RelOptCluster.create(planner, new RexBuilder(typeFactory))

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetCalc.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetCalc.scala
@@ -32,6 +32,8 @@ import TypeConverter._
 import org.apache.flink.api.table.BatchTableEnvironment
 import org.apache.calcite.rex._
 
+import scala.collection.JavaConverters._
+
 /**
   * Flink RelNode which matches along with LogicalCalc.
   *
@@ -73,7 +75,11 @@ class DataSetCalc(
 
     val child = this.getInput
     val rowCnt = metadata.getRowCount(child)
-    val exprCnt = calcProgram.getExprCount
+
+    // compute number of non-field access expressions (computations, conditions, etc.)
+    //   we only want to account for computations, not for simple projections.
+    val exprCnt = calcProgram.getExprList.asScala.toList.count(!_.isInstanceOf[RexInputRef])
+
     planner.getCostFactory.makeCost(rowCnt, rowCnt * exprCnt, 0)
   }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/sql/SetOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/sql/SetOperatorsTest.scala
@@ -43,15 +43,23 @@ class SetOperatorsTest extends TableTestBase {
             "DataSetCalc",
             binaryNode(
               "DataSetJoin",
-              batchTableNode(1),
+              unaryNode(
+                "DataSetCalc",
+                batchTableNode(1),
+                term("select", "b_long")
+              ),
               unaryNode(
                 "DataSetAggregate",
-                batchTableNode(0),
+                unaryNode(
+                  "DataSetCalc",
+                  batchTableNode(0),
+                  term("select", "a_long")
+                ),
                 term("groupBy", "a_long"),
                 term("select", "a_long")
               ),
               term("where", "=(a_long, b_long)"),
-              term("join", "b_long", "b_int", "b_string", "a_long"),
+              term("join", "b_long", "a_long"),
               term("joinType", "InnerJoin")
             ),
             term("select", "true AS $f0", "a_long")

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/sql/SingleRowJoinTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/sql/SingleRowJoinTest.scala
@@ -48,20 +48,23 @@ class SingleRowJoinTest extends TableTestBase {
               "DataSetUnion",
               unaryNode(
                 "DataSetValues",
-                batchTableNode(0),
-                tuples(List(null, null)),
-                term("values", "a1", "a2")
+                unaryNode(
+                  "DataSetCalc",
+                  batchTableNode(0),
+                  term("select", "a1")
+                ),
+                tuples(List(null)),
+                term("values", "a1")
               ),
-              term("union","a1","a2")
+              term("union","a1")
             ),
             term("select", "COUNT(a1) AS cnt")
           ),
-          term("where", "true"),
+          term("where", "=(CAST(a1), cnt)"),
           term("join", "a1", "a2", "cnt"),
           term("joinType", "NestedLoopJoin")
         ),
-        term("select", "a1", "a2"),
-        term("where", "=(CAST(a1), cnt)")
+        term("select", "a1", "a2")
       )
 
     util.verifySql(query, expected)
@@ -89,20 +92,23 @@ class SingleRowJoinTest extends TableTestBase {
               "DataSetUnion",
               unaryNode(
                 "DataSetValues",
-                batchTableNode(0),
-                tuples(List(null, null)),
-                term("values", "a1", "a2")
+                unaryNode(
+                  "DataSetCalc",
+                  batchTableNode(0),
+                  term("select", "a1")
+                ),
+                tuples(List(null)),
+                term("values", "a1")
               ),
-              term("union","a1","a2")
+              term("union", "a1")
             ),
             term("select", "COUNT(a1) AS cnt")
           ),
-          term("where", "true"),
+          term("where", "<(a1, cnt)"),
           term("join", "a1", "a2", "cnt"),
           term("joinType", "NestedLoopJoin")
         ),
-        term("select", "a1", "a2"),
-        term("where", "<(a1, cnt)")
+        term("select", "a1", "a2")
       )
 
     util.verifySql(query, expected)


### PR DESCRIPTION
- Improved DataSetCalc costs make projections cheap and help to push them down.
- Adapted existing tests that check optimized plans