### PR TITLE
[FLINK-5246] Don't discard checkpoint messages if they are unknown

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -735,14 +735,14 @@ public class CheckpointCoordinator {
 				if (recentPendingCheckpoints.contains(checkpointId)) {
 					wasPendingCheckpoint = true;
 					LOG.warn("Received late message for now expired checkpoint attempt {}.", checkpointId);
+
+					// try to discard the state so that we don't have lingering state lying around
+					discardState(message.getState());
 				}
 				else {
 					LOG.debug("Received message for an unknown checkpoint {}.", checkpointId);
 					wasPendingCheckpoint = false;
 				}
-
-				// try to discard the state so that we don't have lingering state lying around
-				discardState(message.getState());
 
 				return wasPendingCheckpoint;
 			}


### PR DESCRIPTION
This is the case if the savepoint coordinator has triggered a checkpoint. The corresponding
checkpoint messages are not known to the checkpoint coordinator and thus should not be
discarded. Instead, the JobManager will now discard all messages which have not been accepted
by neither the CheckpointCoordinator nor the SavepointCoordinator.