### PR TITLE
[FLINK-5249] [docs] description of datastream rescaling doesn't match…

### DIFF
--- a/docs/dev/datastream_api.md
+++ b/docs/dev/datastream_api.md
@@ -1008,19 +1008,18 @@ dataStream.rebalance();
             The subset of downstream operations to which the upstream operation sends
             elements depends on the degree of parallelism of both the upstream and downstream operation.
             For example, if the upstream operation has parallelism 2 and the downstream operation
-            has parallelism 4, then one upstream operation would distribute elements to two
+            has parallelism 6, then one upstream operation would distribute elements to three
             downstream operations while the other upstream operation would distribute to the other
-            two downstream operations. If, on the other hand, the downstream operation has parallelism
-            2 while the upstream operation has parallelism 4 then two upstream operations would
-            distribute to one downstream operation while the other two upstream operations would
-            distribute to the other downstream operations.
+            three downstream operations. If, on the other hand, the downstream operation has parallelism
+            2 while the upstream operation has parallelism 6 then three upstream operations would
+            distribute to one downstream operation while the other three upstream operations would
+            distribute to the other downstream operation.
         </p>
         <p>
             In cases where the different parallelisms are not multiples of each other one or several
             downstream operations will have a differing number of inputs from upstream operations.
-
         </p>
-        </p>
+        <p>
             Please see this figure for a visualization of the connection pattern in the above
             example:
         </p>


### PR DESCRIPTION
In docs/dev/datastream_api.html#physical-partitioning the figure shows a parallelism of 2 rescaling to 6 and back to 2 – while the text assumes 4, rather than 6. This makes the explanation very confusing.

See the figure at the end of [this section](https://ci.apache.org/projects/flink/flink-docs-release-1.2/dev/datastream_api.html#physical-partitioning).