### PR TITLE
[FLINK-5016] [checkpointing] Split EventTimeWindowCheckpointingITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
@@ -51,12 +51,8 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -69,10 +65,13 @@ import static org.junit.Assert.fail;
  * This verifies that checkpointing works correctly with event time windows. This is more
  * strict than {@link WindowCheckpointingITCase} because for event-time the contents
  * of the emitted windows are deterministic.
+ *
+ * <p>Split into multiple test classes in order to decrease the runtime per backend
+ * and not run into CI infrastructure limits like no std output being emitted for
+ * I/O heavy variants.
  */
 @SuppressWarnings("serial")
-@RunWith(Parameterized.class)
-public class EventTimeWindowCheckpointingITCase extends TestLogger {
+public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLogger {
 
 	private static final int MAX_MEM_STATE_SIZE = 10 * 1024 * 1024;
 	private static final int PARALLELISM = 4;
@@ -85,8 +84,12 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 	private StateBackendEnum stateBackendEnum;
 	private AbstractStateBackend stateBackend;
 
-	public EventTimeWindowCheckpointingITCase(StateBackendEnum stateBackendEnum) {
+	AbstractEventTimeWindowCheckpointingITCase(StateBackendEnum stateBackendEnum) {
 		this.stateBackendEnum = stateBackendEnum;
+	}
+
+	enum StateBackendEnum {
+		MEM, FILE, ROCKSDB_FULLY_ASYNC
 	}
 
 	@BeforeClass
@@ -763,27 +766,6 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 			this.windowCounts.putAll(state);
 		}
 	}
-
-	// ------------------------------------------------------------------------
-	//  Parametrization for testing with different state backends
-	// ------------------------------------------------------------------------
-
-
-	@Parameterized.Parameters(name = "StateBackend = {0}")
-	@SuppressWarnings("unchecked,rawtypes")
-	public static Collection<Object[]> parameters(){
-		return Arrays.asList(new Object[][] {
-				{StateBackendEnum.MEM},
-				{StateBackendEnum.FILE},
-				{StateBackendEnum.ROCKSDB_FULLY_ASYNC}
-			}
-		);
-	}
-
-	private enum StateBackendEnum {
-		MEM, FILE, ROCKSDB_FULLY_ASYNC
-	}
-
 
 	// ------------------------------------------------------------------------
 	//  Utilities

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
@@ -53,7 +53,7 @@ import static org.junit.Assert.*;
  * This verfies that checkpointing works correctly with event time windows.
  *
  * <p>
- * This is a version of {@link EventTimeWindowCheckpointingITCase} for All-Windows.
+ * This is a version of {@link AbstractEventTimeWindowCheckpointingITCase} for All-Windows.
  */
 @SuppressWarnings("serial")
 public class EventTimeAllWindowCheckpointingITCase extends TestLogger {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/FileBackendEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/FileBackendEventTimeWindowCheckpointingITCase.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+public class FileBackendEventTimeWindowCheckpointingITCase extends AbstractEventTimeWindowCheckpointingITCase {
+
+	public FileBackendEventTimeWindowCheckpointingITCase() {
+		super(StateBackendEnum.FILE);
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/MemBackendEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/MemBackendEventTimeWindowCheckpointingITCase.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+public class MemBackendEventTimeWindowCheckpointingITCase extends AbstractEventTimeWindowCheckpointingITCase {
+
+	public MemBackendEventTimeWindowCheckpointingITCase() {
+		super(StateBackendEnum.MEM);
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RocksDbBackendEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RocksDbBackendEventTimeWindowCheckpointingITCase.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+public class RocksDbBackendEventTimeWindowCheckpointingITCase extends AbstractEventTimeWindowCheckpointingITCase {
+
+	public RocksDbBackendEventTimeWindowCheckpointingITCase() {
+		super(StateBackendEnum.ROCKSDB_FULLY_ASYNC);
+	}
+}


### PR DESCRIPTION
Split EventTimeWindowCheckpointingITCase up into multiple tests in order to not run into the no output to stdout CI limit (currently set to 5 minutes).