### PR TITLE
[FLINK-5259] [docs] wrong execution environment in batch retry delays…

### DIFF
--- a/docs/dev/batch/fault_tolerance.md
+++ b/docs/dev/batch/fault_tolerance.md
@@ -77,13 +77,13 @@ You can set the retry delay for each program as follows (the sample shows the Da
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 env.getConfig().setExecutionRetryDelay(5000); // 5000 milliseconds delay
 {% endhighlight %}
 </div>
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
-val env = StreamExecutionEnvironment.getExecutionEnvironment()
+val env = ExecutionEnvironment.getExecutionEnvironment()
 env.getConfig.setExecutionRetryDelay(5000) // 5000 milliseconds delay
 {% endhighlight %}
 </div>


### PR DESCRIPTION
At dev/batch/fault_tolerance.html#retry-delays StreamExecutionEnvironment is used in the example code, but this page is about batch fault tolerance.
