### PR TITLE
[FLINK-5261] Clean up meters in ScheduledDropwizardReporter

### DIFF
--- a/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
@@ -93,11 +93,15 @@ public abstract class ScheduledDropwizardReporter implements MetricReporter, Sch
 		return meters;
 	}
 
-	Map<Gauge<?>, String> getGauges() { return gauges; }
 	@VisibleForTesting
+	Map<Gauge<?>, String> getGauges() {
+		return gauges;
+	}
 
-	Map<Histogram, String> getHistograms() { return histograms; }
 	@VisibleForTesting
+	Map<Histogram, String> getHistograms() {
+		return histograms;
+	}
 
 	// ------------------------------------------------------------------------
 	//  life cycle

--- a/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
@@ -21,12 +21,11 @@ package org.apache.flink.dropwizard;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Reporter;
 import com.codahale.metrics.ScheduledReporter;
-
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper;
 import org.apache.flink.dropwizard.metrics.DropwizardMeterWrapper;
 import org.apache.flink.dropwizard.metrics.FlinkCounterWrapper;
-import org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper;
 import org.apache.flink.dropwizard.metrics.FlinkGaugeWrapper;
 import org.apache.flink.dropwizard.metrics.FlinkHistogramWrapper;
 import org.apache.flink.dropwizard.metrics.FlinkMeterWrapper;

--- a/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
@@ -23,6 +23,7 @@ import com.codahale.metrics.Reporter;
 import com.codahale.metrics.ScheduledReporter;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.dropwizard.metrics.DropwizardMeterWrapper;
 import org.apache.flink.dropwizard.metrics.FlinkCounterWrapper;
 import org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper;
@@ -82,18 +83,21 @@ public abstract class ScheduledDropwizardReporter implements MetricReporter, Sch
 	//  Getters
 	// ------------------------------------------------------------------------
 
-	// used for testing purposes
+	@VisibleForTesting
 	Map<Counter, String> getCounters() {
 		return counters;
 	}
 
+	@VisibleForTesting
 	Map<Meter, String> getMeters() {
 		return meters;
 	}
 
 	Map<Gauge<?>, String> getGauges() { return gauges; }
+	@VisibleForTesting
 
 	Map<Histogram, String> getHistograms() { return histograms; }
+	@VisibleForTesting
 
 	// ------------------------------------------------------------------------
 	//  life cycle

--- a/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
@@ -91,6 +91,10 @@ public abstract class ScheduledDropwizardReporter implements MetricReporter, Sch
 		return meters;
 	}
 
+	Map<Gauge<?>, String> getGauges() { return gauges; }
+
+	Map<Histogram, String> getHistograms() { return histograms; }
+
 	// ------------------------------------------------------------------------
 	//  life cycle
 	// ------------------------------------------------------------------------
@@ -157,6 +161,8 @@ public abstract class ScheduledDropwizardReporter implements MetricReporter, Sch
 				fullName = gauges.remove(metric);
 			} else if (metric instanceof Histogram) {
 				fullName = histograms.remove(metric);
+			} else if (metric instanceof Meter) {
+				fullName = meters.remove(metric);
 			} else {
 				fullName = null;
 			}

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
@@ -24,9 +24,14 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.dropwizard.metrics.DropwizardMeterWrapper;
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.HistogramStatistics;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MetricConfig;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
@@ -122,6 +127,89 @@ public class ScheduledDropwizardReporterTest {
 		assertEquals(expectedCounterName, counters.get(myCounter));
 
 		metricRegistry.shutdown();
+	}
+
+	@Test
+	public void testMetricCleanup() {
+		TestingScheduledDropwizardReporter rep = new TestingScheduledDropwizardReporter();
+
+		MetricGroup mp = new UnregisteredMetricsGroup();
+
+		Counter c = new SimpleCounter();
+		Meter m = new Meter() {
+			@Override
+			public void markEvent() {
+			}
+
+			@Override
+			public void markEvent(long n) {
+			}
+
+			@Override
+			public double getRate() {
+				return 0;
+			}
+
+			@Override
+			public long getCount() {
+				return 0;
+			}
+		};
+		Histogram h = new Histogram() {
+			@Override
+			public void update(long value) {
+
+			}
+
+			@Override
+			public long getCount() {
+				return 0;
+			}
+
+			@Override
+			public HistogramStatistics getStatistics() {
+				return null;
+			}
+		};
+		Gauge g = new Gauge() {
+			@Override
+			public Object getValue() {
+				return null;
+			}
+		};
+
+		rep.notifyOfAddedMetric(c, "counter", mp);
+		assertEquals(1, rep.getCounters().size());
+		assertEquals(1, rep.registry.getCounters().size());
+
+		rep.notifyOfAddedMetric(m, "meter", mp);
+		assertEquals(1, rep.getMeters().size());
+		assertEquals(1, rep.registry.getMeters().size());
+
+		rep.notifyOfAddedMetric(h, "histogram", mp);
+		assertEquals(1, rep.getHistograms().size());
+		assertEquals(1, rep.registry.getHistograms().size());
+
+		rep.notifyOfAddedMetric(g, "gauge", mp);
+		assertEquals(1, rep.getGauges().size());
+		assertEquals(1, rep.registry.getGauges().size());
+
+
+		rep.notifyOfRemovedMetric(c, "counter", mp);
+		assertEquals(0, rep.getCounters().size());
+		assertEquals(0, rep.registry.getCounters().size());
+
+		rep.notifyOfRemovedMetric(m, "meter", mp);
+		assertEquals(0, rep.getMeters().size());
+		assertEquals(0, rep.registry.getMeters().size());
+
+		rep.notifyOfRemovedMetric(h, "histogram", mp);
+		assertEquals(0, rep.getHistograms().size());
+		assertEquals(0, rep.registry.getHistograms().size());
+
+		rep.notifyOfRemovedMetric(g, "gauge", mp);
+		assertEquals(0, rep.getGauges().size());
+		assertEquals(0, rep.registry.getGauges().size());
 	}
 
 	public static class TestingScheduledDropwizardReporter extends ScheduledDropwizardReporter {

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
@@ -129,6 +129,10 @@ public class ScheduledDropwizardReporterTest {
 		metricRegistry.shutdown();
 	}
 
+	/**
+	 * This test verifies that metrics are properly added and removed to/from the ScheduledDropwizardReporter and
+	 * the underlying Dropwizard MetricRegistry.
+	 */
 	@Test
 	public void testMetricCleanup() {
 		TestingScheduledDropwizardReporter rep = new TestingScheduledDropwizardReporter();


### PR DESCRIPTION
This PR fixes the metric-cleanup in the `ScheduledDropwizardReporter`. We were missing a separate branch for meters within `notifyOfRemovedMetric`.

I've also added a test case to make sure that all metric types are properly cleaned up, both on our and and from the Dropwizard registry.