### PR TITLE
[FLINK-5262][docs] Introduce Gemfile.lock to avoid dependency range conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ atlassian-ide-plugin.xml
 out/
 /docs/api
 /docs/content
-/docs/Gemfile.lock
 /docs/.bundle
 /docs/.rubydeps
 *.ipr

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,0 +1,88 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.4.0)
+    blankslate (2.1.2.4)
+    classifier-reborn (2.0.4)
+      fast-stemmer (~> 1.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.11.1)
+    colorator (0.1)
+    execjs (2.7.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    fast-stemmer (1.0.2)
+    ffi (1.9.14)
+    jekyll (2.5.3)
+      classifier-reborn (~> 2.0)
+      colorator (~> 0.1)
+      jekyll-coffeescript (~> 1.0)
+      jekyll-gist (~> 1.0)
+      jekyll-paginate (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 2.6.1)
+      mercenary (~> 0.3.3)
+      pygments.rb (~> 0.6.0)
+      redcarpet (~> 3.1)
+      safe_yaml (~> 1.0)
+      toml (~> 0.1.0)
+    jekyll-coffeescript (1.0.1)
+      coffee-script (~> 2.2)
+    jekyll-gist (1.4.0)
+      octokit (~> 4.3.0)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.10.0)
+    libv8 (3.16.14.17)
+    liquid (2.6.3)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    multipart-post (2.0.0)
+    octokit (4.3.0)
+      sawyer (~> 0.7.0, >= 0.5.3)
+    parslet (1.5.0)
+      blankslate (~> 2.0)
+    posix-spawn (0.3.12)
+    pygments.rb (0.6.3)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.2.0)
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.7)
+      ffi (>= 0.5.0)
+    redcarpet (3.3.4)
+    ref (2.0.0)
+    safe_yaml (1.0.4)
+    sass (3.4.22)
+    sawyer (0.7.0)
+      addressable (>= 2.3.5, < 2.5)
+      faraday (~> 0.8, < 0.10)
+    therubyracer (0.12.2)
+      libv8 (~> 3.16.14.0)
+      ref
+    toml (0.1.2)
+      parslet (~> 1.5.0)
+    yajl-ruby (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll (= 2.5.3)
+  kramdown (= 1.10.0)
+  pygments.rb (= 0.6.3)
+  therubyracer (= 0.12.2)
+
+RUBY VERSION
+   ruby 2.3.1p112
+
+BUNDLED WITH
+   1.13.2


### PR DESCRIPTION
The Gemfile for specifying the Ruby dependencies of our documentation
has fixed dependency versions to avoid incompatible changes with
different versions of the dependencies. However, Ruby's dependency
management allows artifacts to specify ranges for dependencies. This can
be problematic.

For instance, we use 'jekyll' version 2.5.3 which depends on
'jekyll-gist' ~> 1.0 which means 1.0 >= version < 2.0. This may resolve
'jekyll-gist' 1.4.0 which depends on 'octokit' ~> 4.2 which may be 4.2
\>= versions < 5.0. Too bad, 'octokit' starting with 4.4 depends on Ruby
version >= 2.0 which is not available on our build servers.

Since we already use the improved version of Rubys build system called
'bundler', we can mitigate this problem by checking in a Gemfile.lock
file which specifies the exact versions of all dependencies required to
build the docs.