### PR TITLE
[FLINK-5276] [eg] Check for null when archiving prior execution attempts

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -132,7 +132,7 @@ public class ExecutionVertex implements Serializable {
 		this.jobVertex = jobVertex;
 		this.subTaskIndex = subTaskIndex;
 
-		this.resultPartitions = new LinkedHashMap<IntermediateResultPartitionID, IntermediateResultPartition>(producedDataSets.length, 1);
+		this.resultPartitions = new LinkedHashMap<>(producedDataSets.length, 1);
 
 		for (IntermediateResult result : producedDataSets) {
 			IntermediateResultPartition irp = new IntermediateResultPartition(result, this, subTaskIndex);
@@ -580,7 +580,10 @@ public class ExecutionVertex implements Serializable {
 
 		// prepare previous executions for archiving
 		for (Execution exec : priorExecutions) {
-			exec.prepareForArchiving();
+			// The bounded list returns null for evicted executions
+			if (exec != null) {
+				exec.prepareForArchiving();
+			}
 		}
 
 		// clear the unnecessary fields in this class


### PR DESCRIPTION
The `EvictingBoundedList` returns the default value for all evicted elements. This could lead to NPE when archiving an `ExecutionVertex`.

/cc @StefanRRichter 