### PR TITLE
[FLINK-5285] Abort checkpoint only once in BarrierTracker

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
@@ -313,6 +313,9 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 				currentCheckpointId = barrierId;
 				startOfAlignmentTimestamp = 0L;
 				latestAlignmentDurationNanos = 0L;
+
+				notifyAbort(currentCheckpointId, new CheckpointDeclineSubsumedException(barrierId));
+
 				notifyAbortOnCancellationBarrier(barrierId);
 			}
 
@@ -422,7 +425,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 		startOfAlignmentTimestamp = System.nanoTime();
 
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("Starting stream alignment for checkpoint " + checkpointId);
+			LOG.debug("Starting stream alignment for checkpoint " + checkpointId + '.');
 		}
 	}
 


### PR DESCRIPTION
Prevent an interleaved sequence of cancellation markers for two consecutive checkpoints
to trigger a flood of cancellation markers for down stream operators. This is done by
aborting each checkpoint only once and don't re-create checkpoint barrier counts for already
aborted checkpoints.

cc @StephanEwen 