### PR TITLE
[FLINK-5300] Add more gentle file deletion procedure

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
@@ -319,7 +319,7 @@ public abstract class FileOutputFormat<IT> extends RichOutputFormat<IT> implemen
 			} catch (FileNotFoundException e) {
 				// ignore, may not be visible yet or may be already removed
 			} catch (Throwable t) {
-				LOG.error("Could not remove the incomplete file " + actualFilePath);
+				LOG.error("Could not remove the incomplete file " + actualFilePath + '.', t);
 			}
 		}
 	}

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.examples.java.wordcount.WordCount;
 import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
+import org.apache.flink.util.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -41,6 +42,11 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This test should logically be located in the 'flink-runtime' tests. However, this project
@@ -98,7 +104,7 @@ public class HDFSTest {
 		org.apache.hadoop.fs.Path result = new org.apache.hadoop.fs.Path(hdfsURI + "/result");
 		try {
 			FileSystem fs = file.getFileSystem();
-			Assert.assertTrue("Must be HadoopFileSystem", fs instanceof HadoopFileSystem);
+			assertTrue("Must be HadoopFileSystem", fs instanceof HadoopFileSystem);
 			
 			DopOneTestEnvironment.setAsContext();
 			try {
@@ -114,7 +120,7 @@ public class HDFSTest {
 				DopOneTestEnvironment.unsetAsContext();
 			}
 			
-			Assert.assertTrue("No result file present", hdfs.exists(result));
+			assertTrue("No result file present", hdfs.exists(result));
 			
 			// validate output:
 			org.apache.hadoop.fs.FSDataInputStream inStream = hdfs.open(result);
@@ -154,17 +160,61 @@ public class HDFSTest {
 			avroOut.close();
 
 
-			Assert.assertTrue("No result file present", hdfs.exists(result));
+			assertTrue("No result file present", hdfs.exists(result));
 			FileStatus[] files = hdfs.listStatus(result);
 			Assert.assertEquals(2, files.length);
 			for(FileStatus file : files) {
-				Assert.assertTrue("1.avro".equals(file.getPath().getName()) || "2.avro".equals(file.getPath().getName()));
+				assertTrue("1.avro".equals(file.getPath().getName()) || "2.avro".equals(file.getPath().getName()));
 			}
 
 		} catch (IOException e) {
 			e.printStackTrace();
 			Assert.fail(e.getMessage());
 		}
+	}
+
+	/**
+	 * Test that {@link FileUtils#deletePathIfEmpty(FileSystem, Path)} deletes the path if it is
+	 * empty. A path can only be empty if it is a directory which does not contain any
+	 * files/directories.
+	 */
+	@Test
+	public void testDeletePathIfEmpty() throws IOException {
+		final Path basePath = new Path(hdfsURI);
+		final Path directory = new Path(basePath, UUID.randomUUID().toString());
+		final Path directoryFile = new Path(directory, UUID.randomUUID().toString());
+		final Path singleFile = new Path(basePath, UUID.randomUUID().toString());
+
+		FileSystem fs = basePath.getFileSystem();
+
+		fs.mkdirs(directory);
+
+		byte[] data = "HDFSTest#testDeletePathIfEmpty".getBytes();
+
+		for (Path file: Arrays.asList(singleFile, directoryFile)) {
+			org.apache.flink.core.fs.FSDataOutputStream outputStream = fs.create(file, true);
+			outputStream.write(data);
+			outputStream.close();
+		}
+
+		// verify that the files have been created
+		assertTrue(fs.exists(singleFile));
+		assertTrue(fs.exists(directoryFile));
+
+		// delete the single file
+		assertFalse(FileUtils.deletePathIfEmpty(fs, singleFile));
+		assertTrue(fs.exists(singleFile));
+
+		// try to delete the non-empty directory
+		assertFalse(FileUtils.deletePathIfEmpty(fs, directory));
+		assertTrue(fs.exists(directory));
+
+		// delete the file contained in the directory
+		assertTrue(fs.delete(directoryFile, false));
+
+		// now the deletion should work
+		assertTrue(FileUtils.deletePathIfEmpty(fs, directory));
+		assertFalse(fs.exists(directory));
 	}
 
 	// package visible

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/AbstractFileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/AbstractFileStateHandle.java
@@ -22,6 +22,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.migration.runtime.state.AbstractCloseableHandle;
 import org.apache.flink.migration.runtime.state.StateObject;
+import org.apache.flink.util.FileUtils;
 
 import java.io.IOException;
 
@@ -68,11 +69,9 @@ public abstract class AbstractFileStateHandle extends AbstractCloseableHandle im
 	public void discardState() throws Exception {
 		getFileSystem().delete(filePath, false);
 
-		// send a call to delete the checkpoint directory containing the file. This will
-		// fail (and be ignored) when some files still exist
 		try {
-			getFileSystem().delete(filePath.getParent(), false);
-		} catch (IOException ignored) {}
+			FileUtils.deletePathIfEmpty(getFileSystem(), filePath.getParent());
+		} catch (Exception ignored) {}
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
@@ -22,6 +22,7 @@ import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.util.FileUtils;
 
 import java.io.IOException;
 
@@ -81,12 +82,9 @@ public class FileStateHandle implements StreamStateHandle {
 
 		fs.delete(filePath, false);
 
-		// send a call to delete the checkpoint directory containing the file. This will
-		// fail (and be ignored) when some files still exist
 		try {
-			fs.delete(filePath.getParent(), false);
-		} catch (IOException ignored) {
-		}
+			FileUtils.deletePathIfEmpty(fs, filePath.getParent());
+		} catch (Exception ignored) {}
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -267,10 +268,11 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 						outStream.close();
 						fs.delete(statePath, false);
 
-						// attempt to delete the parent (will fail and be ignored if the parent has more files)
 						try {
-							fs.delete(basePath, false);
-						} catch (IOException ignored) {}
+							FileUtils.deletePathIfEmpty(fs, basePath);
+						} catch (Exception ignored) {
+							LOG.debug("Could not delete the parent directory {}.", basePath, ignored);
+						}
 					}
 					catch (Exception e) {
 						LOG.warn("Cannot delete closed and discarded state stream for " + statePath, e);


### PR DESCRIPTION
Before deleting a parent directory always check the directory whether it contains some
files. If not, then try to delete the parent directory.

This will give a more gentle behaviour wrt storage systems which are not instructed to
delete a non-empty directory.

cc: @StefanRRichter 