### PR TITLE
[backport] [FLINK-5300] Add more gentle file deletion procedure

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
@@ -315,7 +315,7 @@ public abstract class FileOutputFormat<IT> extends RichOutputFormat<IT> implemen
 			} catch (FileNotFoundException e) {
 				// ignore, may not be visible yet or may be already removed
 			} catch (Throwable t) {
-				LOG.error("Could not remove the incomplete file " + actualFilePath);
+				LOG.error("Could not remove the incomplete file " + actualFilePath + '.', t);
 			}
 		}
 	}

--- a/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
@@ -18,6 +18,10 @@
 
 package org.apache.flink.util;
 
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -80,6 +84,35 @@ public final class FileUtils {
 	
 	public static void writeFileUtf8(File file, String contents) throws IOException {
 		writeFile(file, contents, "UTF-8");
+	}
+
+	// ------------------------------------------------------------------------
+	//  Deleting directories
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Deletes the path if it is empty (does not contain any other directories/files).
+	 *
+	 * @param fileSystem to use
+	 * @param path to be deleted if empty
+	 * @return true if the path could be deleted; otherwise false
+	 * @throws IOException if the delete operation fails
+	 */
+	public static boolean deletePathIfEmpty(FileSystem fileSystem, Path path) throws IOException {
+		FileStatus[] fileStatuses = null;
+
+		try {
+			fileStatuses = fileSystem.listStatus(path);
+		} catch (Exception ignored) {}
+
+		// if there are no more files or if we couldn't list the file status try to delete the path
+		if (fileStatuses == null || fileStatuses.length == 0) {
+			// attempt to delete the path (will fail and be ignored if the path now contains
+			// some files (possibly added concurrently))
+			return fileSystem.delete(path, false);
+		} else {
+			return false;
+		}
 	}
 	
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFileStateHandle.java
@@ -22,6 +22,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.AbstractCloseableHandle;
 import org.apache.flink.runtime.state.StateObject;
+import org.apache.flink.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,11 +73,9 @@ public abstract class AbstractFileStateHandle extends AbstractCloseableHandle im
 	public void discardState() throws Exception {
 		getFileSystem().delete(filePath, false);
 
-		// send a call to delete the checkpoint directory containing the file. This will
-		// fail (and be ignored) when some files still exist
 		try {
-			getFileSystem().delete(filePath.getParent(), false);
-		} catch (IOException ignored) {}
+			FileUtils.deletePathIfEmpty(getFileSystem(), filePath.getParent());
+		} catch (Exception ignored) {}
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.ExceptionUtils;
 
+import org.apache.flink.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -630,10 +631,11 @@ public class FsStateBackend extends AbstractStateBackend {
 						try {
 							fs.delete(statePath, false);
 
-							// attempt to delete the parent (will fail and be ignored if the parent has more files)
 							try {
-								fs.delete(basePath, false);
-							} catch (Throwable ignored) {}
+								FileUtils.deletePathIfEmpty(fs, basePath);
+							} catch (Throwable ignored) {
+								LOG.debug("Could not delete parent directory for path {}.", basePath, ignored);
+							}
 						} catch (Throwable ioE) {
 							LOG.warn("Could not delete stream file for {}.", statePath, ioE);
 						}
@@ -669,8 +671,10 @@ public class FsStateBackend extends AbstractStateBackend {
 								fs.delete(statePath, false);
 
 								try {
-									fs.delete(basePath, false);
-								} catch (Throwable ignored) {}
+									FileUtils.deletePathIfEmpty(fs, basePath);
+								} catch (Throwable ignored) {
+									LOG.debug("Could not delete parent directory for path {}.", basePath, ignored);
+								}
 							} catch (Throwable deleteException) {
 								LOG.warn("Could not delete close and discarded state stream for {}.", statePath, deleteException);
 							}
@@ -715,8 +719,10 @@ public class FsStateBackend extends AbstractStateBackend {
 							fs.delete(statePath, false);
 
 							try {
-								fs.delete(basePath, false);
-							} catch (Throwable ignored) {}
+								FileUtils.deletePathIfEmpty(fs, basePath);
+							} catch (Throwable ignored) {
+								LOG.debug("Could not delete parent directory for path {}.", basePath, ignored);
+							}
 						} catch (Throwable deleteException) {
 							LOG.warn("Could not delete close and discarded state stream for {}.", statePath, deleteException);
 						}


### PR DESCRIPTION
Backport of #2970 to the release-1.1 branch.

Before deleting a parent directory always check the directory whether it contains some
files. If not, then try to delete the parent directory.

This will give a more gentle behaviour wrt storage systems which are not instructed to
delete a non-empty directory.