### PR TITLE
[FLINK-5304] [table] Change method name from crossApply to join in Table API

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/functions/TableFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/functions/TableFunction.scala
@@ -64,11 +64,11 @@ import org.apache.flink.api.table.expressions.{Expression, TableFunctionCall}
   *
   *   // for Scala users
   *   val split = new Split()
-  *   table.crossApply(split('c) as ('s)).select('a, 's)
+  *   table.join(split('c) as ('s)).select('a, 's)
   *
   *   // for Java users
   *   tEnv.registerFunction("split", new Split())   // register table function first
-  *   table.crossApply("split(a) as (s)").select("a, s")
+  *   table.join("split(a) as (s)").select("a, s")
   *
   *   // for SQL users
   *   tEnv.registerFunction("split", new Split())   // register table function first

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/FlinkCorrelate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/FlinkCorrelate.scala
@@ -33,7 +33,7 @@ import org.apache.flink.api.table.{TableConfig, TableException}
 import scala.collection.JavaConverters._
 
 /**
-  * cross/outer apply a user-defined table function
+  * Join a user-defined table function
   */
 trait FlinkCorrelate {
 
@@ -63,7 +63,7 @@ trait FlinkCorrelate {
        """.stripMargin
 
     if (joinType == SemiJoinType.INNER) {
-      // cross apply
+      // cross join
       body +=
         s"""
            |if (!iter.hasNext()) {
@@ -71,9 +71,9 @@ trait FlinkCorrelate {
            |}
         """.stripMargin
     } else if (joinType == SemiJoinType.LEFT) {
-      // outer apply
+      // left outer join
 
-      // in case of outer apply and the returned row of table function is empty,
+      // in case of left outer join and the returned row of table function is empty,
       // fill all fields of row with null
       val input2NullExprs = input2AccessExprs.map { x =>
         GeneratedExpression(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetCorrelate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/dataset/DataSetCorrelate.scala
@@ -34,7 +34,7 @@ import org.apache.flink.api.table.plan.nodes.FlinkCorrelate
 import org.apache.flink.api.table.typeutils.TypeConverter._
 
 /**
-  * Flink RelNode which matches along with cross apply a user defined table function.
+  * Flink RelNode which matches along with join a user defined table function.
   */
 class DataSetCorrelate(
     cluster: RelOptCluster,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/datastream/DataStreamCorrelate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/plan/nodes/datastream/DataStreamCorrelate.scala
@@ -33,7 +33,7 @@ import org.apache.flink.api.table.typeutils.TypeConverter._
 import org.apache.flink.streaming.api.datastream.DataStream
 
 /**
-  * Flink RelNode which matches along with cross apply a user defined table function.
+  * Flink RelNode which matches along with join a user defined table function.
   */
 class DataStreamCorrelate(
     cluster: RelOptCluster,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/table.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/api/table/table.scala
@@ -611,11 +611,10 @@ class Table(
   }
 
   /**
-    * The Cross Apply operator returns rows from the outer table (table on the left of the
-    * operator) that produces matching values from the table-valued function (which is defined in
-    * the expression on the right side of the operator).
-    *
-    * The Cross Apply is equivalent to Inner Join, but it works with a table-valued function.
+    * Joins this [[Table]] to a user-defined [[org.apache.calcite.schema.TableFunction]]. Similar
+    * to an SQL cross join, but it works with a table function. It returns rows from the outer
+    * table (table on the left of the operator) that produces matching values from the table
+    * function (which is defined in the expression on the right side of the operator).
     *
     * Example:
     *
@@ -627,19 +626,18 @@ class Table(
     *   }
     *
     *   val split = new MySplitUDTF()
-    *   table.crossApply(split('c) as ('s)).select('a,'b,'c,'s)
+    *   table.join(split('c) as ('s)).select('a,'b,'c,'s)
     * }}}
     */
-  def crossApply(udtf: Expression): Table = {
-    applyInternal(udtf, JoinType.INNER)
+  def join(udtf: Expression): Table = {
+    joinUdtfInternal(udtf, JoinType.INNER)
   }
 
   /**
-    * The Cross Apply operator returns rows from the outer table (table on the left of the
-    * operator) that produces matching values from the table-valued function (which is defined in
-    * the expression on the right side of the operator).
-    *
-    * The Cross Apply is equivalent to Inner Join, but it works with a table-valued function.
+    * Joins this [[Table]] to a user-defined [[org.apache.calcite.schema.TableFunction]]. Similar
+    * to an SQL cross join, but it works with a table function. It returns rows from the outer
+    * table (table on the left of the operator) that produces matching values from the table
+    * function (which is defined in the expression on the right side of the operator).
     *
     * Example:
     *
@@ -653,20 +651,19 @@ class Table(
     *   TableFunction<String> split = new MySplitUDTF();
     *   tableEnv.registerFunction("split", split);
     *
-    *   table.crossApply("split(c) as (s)").select("a, b, c, s");
+    *   table.join("split(c) as (s)").select("a, b, c, s");
     * }}}
     */
-  def crossApply(udtf: String): Table = {
-    applyInternal(udtf, JoinType.INNER)
+  def join(udtf: String): Table = {
+    joinUdtfInternal(udtf, JoinType.INNER)
   }
 
   /**
-    * The Outer Apply operator returns all the rows from the outer table (table on the left of the
-    * Apply operator), and rows that do not match the condition from the table-valued function
-    * (which is defined in the expression on the right side of the operator).
-    * Rows with no matching condition are filled with null values.
-    *
-    * The Outer Apply is equivalent to Left Outer Join, but it works with a table-valued function.
+    * Joins this [[Table]] to a user-defined [[org.apache.calcite.schema.TableFunction]]. Similar
+    * to an SQL left outer join with ON TRUE, but it works with a table function. It returns all
+    * the rows from the outer table (table on the left of the operator), and rows that do not match
+    * the condition from the table function (which is defined in the expression on the right
+    * side of the operator). Rows with no matching condition are filled with null values.
     *
     * Example:
     *
@@ -678,20 +675,19 @@ class Table(
     *   }
     *
     *   val split = new MySplitUDTF()
-    *   table.outerApply(split('c) as ('s)).select('a,'b,'c,'s)
+    *   table.leftOuterJoin(split('c) as ('s)).select('a,'b,'c,'s)
     * }}}
     */
-  def outerApply(udtf: Expression): Table = {
-    applyInternal(udtf, JoinType.LEFT_OUTER)
+  def leftOuterJoin(udtf: Expression): Table = {
+    joinUdtfInternal(udtf, JoinType.LEFT_OUTER)
   }
 
   /**
-    * The Outer Apply operator returns all the rows from the outer table (table on the left of the
-    * Apply operator), and rows that do not match the condition from the table-valued function
-    * (which is defined in the expression on the right side of the operator).
-    * Rows with no matching condition are filled with null values.
-    *
-    * The Outer Apply is equivalent to Left Outer Join, but it works with a table-valued function.
+    * Joins this [[Table]] to a user-defined [[org.apache.calcite.schema.TableFunction]]. Similar
+    * to an SQL left outer join with ON TRUE, but it works with a table function. It returns all
+    * the rows from the outer table (table on the left of the operator), and rows that do not match
+    * the condition from the table function (which is defined in the expression on the right
+    * side of the operator). Rows with no matching condition are filled with null values.
     *
     * Example:
     *
@@ -705,19 +701,19 @@ class Table(
     *   TableFunction<String> split = new MySplitUDTF();
     *   tableEnv.registerFunction("split", split);
     *
-    *   table.outerApply("split(c) as (s)").select("a, b, c, s");
+    *   table.leftOuterJoin("split(c) as (s)").select("a, b, c, s");
     * }}}
     */
-  def outerApply(udtf: String): Table = {
-    applyInternal(udtf, JoinType.LEFT_OUTER)
+  def leftOuterJoin(udtf: String): Table = {
+    joinUdtfInternal(udtf, JoinType.LEFT_OUTER)
   }
 
-  private def applyInternal(udtfString: String, joinType: JoinType): Table = {
+  private def joinUdtfInternal(udtfString: String, joinType: JoinType): Table = {
     val udtf = ExpressionParser.parseExpression(udtfString)
-    applyInternal(udtf, joinType)
+    joinUdtfInternal(udtf, joinType)
   }
 
-  private def applyInternal(udtf: Expression, joinType: JoinType): Table = {
+  private def joinUdtfInternal(udtf: Expression, joinType: JoinType): Table = {
     var alias: Option[Seq[String]] = None
 
     // unwrap an Expression until we get a TableFunctionCall

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/sql/UserDefinedTableFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/batch/sql/UserDefinedTableFunctionTest.scala
@@ -28,7 +28,7 @@ import org.junit.Test
 class UserDefinedTableFunctionTest extends TableTestBase {
 
   @Test
-  def testCrossApply(): Unit = {
+  def testCrossJoin(): Unit = {
     val util = batchTestUtil()
     val func1 = new TableFunc1
     util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
@@ -74,7 +74,7 @@ class UserDefinedTableFunctionTest extends TableTestBase {
   }
 
   @Test
-  def testOuterApply(): Unit = {
+  def testLeftOuterJoin(): Unit = {
     val util = batchTestUtil()
     val func1 = new TableFunc1
     util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/stream/sql/UserDefinedTableFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/scala/stream/sql/UserDefinedTableFunctionTest.scala
@@ -28,7 +28,7 @@ import org.junit.Test
 class UserDefinedTableFunctionTest extends TableTestBase {
 
   @Test
-  def testCrossApply(): Unit = {
+  def testCrossJoin(): Unit = {
     val util = streamTestUtil()
     val func1 = new TableFunc1
     util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
@@ -74,7 +74,7 @@ class UserDefinedTableFunctionTest extends TableTestBase {
   }
 
   @Test
-  def testOuterApply(): Unit = {
+  def testLeftOuterJoin(): Unit = {
     val util = streamTestUtil()
     val func1 = new TableFunc1
     util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/dataset/DataSetCorrelateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/dataset/DataSetCorrelateITCase.scala
@@ -40,20 +40,20 @@ class DataSetCorrelateITCase(
   extends TableProgramsTestBase(mode, configMode) {
 
   @Test
-  def testCrossApply(): Unit = {
+  def testCrossJoin(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = TableEnvironment.getTableEnvironment(env, config)
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
 
     val func1 = new TableFunc1
-    val result = in.crossApply(func1('c) as 's).select('c, 's).toDataSet[Row]
+    val result = in.join(func1('c) as 's).select('c, 's).toDataSet[Row]
     val results = result.collect()
     val expected = "Jack#22,Jack\n" + "Jack#22,22\n" + "John#19,John\n" + "John#19,19\n" +
       "Anna#44,Anna\n" + "Anna#44,44\n"
     TestBaseUtils.compareResultAsText(results.asJava, expected)
 
     // with overloading
-    val result2 = in.crossApply(func1('c, "$") as 's).select('c, 's).toDataSet[Row]
+    val result2 = in.join(func1('c, "$") as 's).select('c, 's).toDataSet[Row]
     val results2 = result2.collect()
     val expected2 = "Jack#22,$Jack\n" + "Jack#22,$22\n" + "John#19,$John\n" +
       "John#19,$19\n" + "Anna#44,$Anna\n" + "Anna#44,$44\n"
@@ -61,13 +61,13 @@ class DataSetCorrelateITCase(
   }
 
   @Test
-  def testOuterApply(): Unit = {
+  def testLeftOuterJoin(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = TableEnvironment.getTableEnvironment(env, config)
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
 
     val func2 = new TableFunc2
-    val result = in.outerApply(func2('c) as ('s, 'l)).select('c, 's, 'l).toDataSet[Row]
+    val result = in.leftOuterJoin(func2('c) as ('s, 'l)).select('c, 's, 'l).toDataSet[Row]
     val results = result.collect()
     val expected = "Jack#22,Jack,4\n" + "Jack#22,22,2\n" + "John#19,John,4\n" +
       "John#19,19,2\n" + "Anna#44,Anna,4\n" + "Anna#44,44,2\n" + "nosharp,null,null"
@@ -82,7 +82,7 @@ class DataSetCorrelateITCase(
     val func0 = new TableFunc0
 
     val result = in
-      .crossApply(func0('c) as ('name, 'age))
+      .join(func0('c) as ('name, 'age))
       .select('c, 'name, 'age)
       .filter('age > 20)
       .toDataSet[Row]
@@ -100,7 +100,7 @@ class DataSetCorrelateITCase(
     val func2 = new TableFunc2
 
     val result = in
-      .crossApply(func2('c) as ('name, 'len))
+      .join(func2('c) as ('name, 'len))
       .select('c, 'name, 'len)
       .toDataSet[Row]
 
@@ -118,7 +118,7 @@ class DataSetCorrelateITCase(
 
     val hierarchy = new HierarchyTableFunction
     val result = in
-      .crossApply(hierarchy('c) as ('name, 'adult, 'len))
+      .join(hierarchy('c) as ('name, 'adult, 'len))
       .select('c, 'name, 'adult, 'len)
       .toDataSet[Row]
 
@@ -136,7 +136,7 @@ class DataSetCorrelateITCase(
 
     val pojo = new PojoTableFunc()
     val result = in
-      .crossApply(pojo('c))
+      .join(pojo('c))
       .select('c, 'name, 'age)
       .toDataSet[Row]
 
@@ -153,7 +153,7 @@ class DataSetCorrelateITCase(
     val func1 = new TableFunc1
 
     val result = in
-      .crossApply(func1('c.substring(2)) as 's)
+      .join(func1('c.substring(2)) as 's)
       .select('c, 's)
       .toDataSet[Row]
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/datastream/DataStreamCorrelateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/api/table/runtime/datastream/DataStreamCorrelateITCase.scala
@@ -32,7 +32,7 @@ import scala.collection.mutable
 class DataStreamCorrelateITCase extends StreamingMultipleProgramsTestBase {
 
   @Test
-  def testCrossApply(): Unit = {
+  def testCrossJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
@@ -41,7 +41,7 @@ class DataStreamCorrelateITCase extends StreamingMultipleProgramsTestBase {
     val func0 = new TableFunc0
 
     val result = t
-      .crossApply(func0('c) as('d, 'e))
+      .join(func0('c) as('d, 'e))
       .select('c, 'd, 'e)
       .toDataStream[Row]
 
@@ -53,7 +53,7 @@ class DataStreamCorrelateITCase extends StreamingMultipleProgramsTestBase {
   }
 
   @Test
-  def testOuterApply(): Unit = {
+  def testLeftOuterJoin(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
     StreamITCase.clear
@@ -62,7 +62,7 @@ class DataStreamCorrelateITCase extends StreamingMultipleProgramsTestBase {
     val func0 = new TableFunc0
 
     val result = t
-      .outerApply(func0('c) as('d, 'e))
+      .leftOuterJoin(func0('c) as('d, 'e))
       .select('c, 'd, 'e)
       .toDataStream[Row]
 


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

Currently, the UDTF in Table API is used with `crossApply`, but is used with JOIN in SQL. UDTF is something similar to Table, so it make sense to use `.join("udtf(c) as (s)")` in Table API too, and join is more familiar to users than `crossApply`. The `outerApply` should be renamed to `leftOuterJoin`. 