### PR TITLE
[FLINK-5307] [metrics] Log reporter configuration

### DIFF
--- a/flink-metrics/flink-metrics-ganglia/src/main/java/org/apache/flink/metrics/ganglia/GangliaReporter.java
+++ b/flink-metrics/flink-metrics-ganglia/src/main/java/org/apache/flink/metrics/ganglia/GangliaReporter.java
@@ -71,6 +71,8 @@ public class GangliaReporter extends ScheduledDropwizardReporter {
 			builder.withDMax(dMax);
 			builder.withTMax(tMax);
 
+			log.info("Configured GangliaReporter with {host:{}, port:{}, dmax:{}, tmax:{}, ttl:{}, addressingMode:{}}",
+				host, port, dMax, tMax, ttl, addressingMode);			
 			return builder.build(gMetric);
 		} catch (IOException e) {
 			throw new RuntimeException("Error while instantiating GangliaReporter.", e);

--- a/flink-metrics/flink-metrics-graphite/src/main/java/org/apache/flink/metrics/graphite/GraphiteReporter.java
+++ b/flink-metrics/flink-metrics-graphite/src/main/java/org/apache/flink/metrics/graphite/GraphiteReporter.java
@@ -75,6 +75,7 @@ public class GraphiteReporter extends ScheduledDropwizardReporter {
 			prot = Protocol.TCP;
 		}
 
+		log.info("Configured GraphiteReporter with {host:{}, port:{}, protocol:{}}", host, port, prot);
 		switch(prot) {
 			case UDP:
 				return builder.build(new GraphiteUDP(host, port));				

--- a/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporter.java
+++ b/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporter.java
@@ -127,6 +127,7 @@ public class JMXReporter implements MetricReporter {
 				throw new RuntimeException("Could not start JMX server on any configured port. Ports: " + portsConfig);
 			}
 		}
+		LOG.info("Configured JMXReporter with {port:{}}", portsConfig);
 	}
 
 	@Override

--- a/flink-metrics/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporter.java
+++ b/flink-metrics/flink-metrics-statsd/src/main/java/org/apache/flink/metrics/statsd/StatsDReporter.java
@@ -72,8 +72,6 @@ public class StatsDReporter extends AbstractReporter implements Scheduled {
 
 		this.address = new InetSocketAddress(host, port);
 
-		LOG.info("Starting StatsDReporter to send metric reports to " + address);
-
 //		String conversionRate = config.getString(ARG_CONVERSION_RATE, "SECONDS");
 //		String conversionDuration = config.getString(ARG_CONVERSION_DURATION, "MILLISECONDS");
 //		this.rateFactor = TimeUnit.valueOf(conversionRate).toSeconds(1);
@@ -84,6 +82,7 @@ public class StatsDReporter extends AbstractReporter implements Scheduled {
 		} catch (SocketException e) {
 			throw new RuntimeException("Could not create datagram socket. ", e);
 		}
+		log.info("Configured StatsDReporter with {host:{}, port:{}}", host, port);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistry.java
@@ -116,6 +116,7 @@ public class MetricRegistry {
 
 					MetricConfig metricConfig = new MetricConfig();
 					reporterConfig.addAllToProperties(metricConfig);
+					LOG.info("Configuring {} with {}.", reporterClass.getSimpleName(), metricConfig);
 					reporterInstance.open(metricConfig);
 
 					if (reporterInstance instanceof Scheduled) {


### PR DESCRIPTION
With this PR the configuration for every reporter will be logged. Twice.

First, we log the `Properties` object that contains the configuration for each reporter _before_ passing it to the reporter. This allows users to detect missing properties that are result of typos in the reporter name or preceding parts of the config key, i.e "metrics.reporter".

This logs something like this:
```
2016-12-09 13:40:50,287 INFO  org.apache.flink.metrics.runtime.MetricRegistry                - Configuring StatsDReporter with {port=8125, host=localhost, class=org.apache.flink.metrics.statsd.StatsDReporter}
```

Second, we log in each reporter which properties were actually used from the configuration. In conjunction with the above this allows users to detect typos in specific properties, by checking which properties that were supposedly configured but not used in the end.

This logs:
```
2016-12-09 13:40:50,287 INFO  org.apache.flink.metrics.statsd.StatsDReporter                - Configured StatsDReporter with {host:localhost, port:8125}
```