### PR TITLE
[docker] improve Dockerfile host configuration

### DIFF
--- a/flink-contrib/docker-flink/Dockerfile
+++ b/flink-contrib/docker-flink/Dockerfile
@@ -22,14 +22,19 @@ FROM java:8-jre-alpine
 RUN apk add --no-cache bash snappy
 
 # Configure Flink version
-ARG FLINK_VERSION=1.1.1
-ARG HADOOP_VERSION=27
-ARG SCALA_VERSION=2.11
+ENV FLINK_VERSION=1.1.1
+ENV HADOOP_VERSION=27
+ENV SCALA_VERSION=2.11
 
 # Flink environment variables
-ARG FLINK_INSTALL_PATH=/opt
+ENV FLINK_INSTALL_PATH=/opt
 ENV FLINK_HOME $FLINK_INSTALL_PATH/flink
 ENV PATH $PATH:$FLINK_HOME/bin
+
+# These can be mapped from the host to the container using
+# $ docker run -t flink -p 8081:8081 -p 6123:6123 jobmanager
+EXPOSE 8081
+EXPOSE 6123
 
 # Install build dependencies and flink
 RUN set -x && \

--- a/flink-contrib/docker-flink/docker-compose.yml
+++ b/flink-contrib/docker-flink/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     ports:
       - "48081:8081"
     command: jobmanager
+    environment:
+      - JOB_MANAGER_RPC_ADDRESS="jobmanager"
 
   taskmanager:
     image: flink
@@ -37,3 +39,5 @@ services:
     command: taskmanager
     links:
       - "jobmanager:jobmanager"
+    environment:
+      - JOB_MANAGER_RPC_ADDRESS="jobmanager"

--- a/flink-contrib/docker-flink/docker-entrypoint.sh
+++ b/flink-contrib/docker-flink/docker-entrypoint.sh
@@ -18,20 +18,19 @@
 # limitations under the License.
 ################################################################################
 
-if [ "$1" = "jobmanager" ]; then
-    echo "Starting Job Manager"
-    #sed -i -e "s/jobmanager.rpc.address: localhost/jobmanager.rpc.address: `hostname -f`/g" $FLINK_HOME/conf/flink-conf.yaml
+### If unspecified, the hostname of the container is taken as the JobManager address
+JOB_MANAGER_RPC_ADDRESS=${JOB_MANAGER_RPC_ADDRESS:-`hostname -f`}
+###
 
-    # make use of container linking and exploit the jobmanager entry in /etc/hosts
-    sed -i -e "s/jobmanager.rpc.address: localhost/jobmanager.rpc.address: jobmanager/g" $FLINK_HOME/conf/flink-conf.yaml
+if [ "$1" == "jobmanager" ]; then
+    echo "Starting Job Manager"
+    sed -i -e "s/jobmanager.rpc.address: localhost/jobmanager.rpc.address: ${JOB_MANAGER_RPC_ADDRESS}/g" $FLINK_HOME/conf/flink-conf.yaml
 
     echo "config file: " && grep '^[^\n#]' $FLINK_HOME/conf/flink-conf.yaml
     $FLINK_HOME/bin/jobmanager.sh start cluster
-elif [ "$1" = "taskmanager" ]; then
+elif [ "$1" == "taskmanager" ]; then
 
-    # make use of container linking and exploit the jobmanager entry in /etc/hosts
-    sed -i -e "s/jobmanager.rpc.address: localhost/jobmanager.rpc.address: jobmanager/g" $FLINK_HOME/conf/flink-conf.yaml
-
+    sed -i -e "s/jobmanager.rpc.address: localhost/jobmanager.rpc.address: ${JOB_MANAGER_RPC_ADDRESS}/g" $FLINK_HOME/conf/flink-conf.yaml
     sed -i -e "s/taskmanager.numberOfTaskSlots: 1/taskmanager.numberOfTaskSlots: `grep -c ^processor /proc/cpuinfo`/g" $FLINK_HOME/conf/flink-conf.yaml
 
     echo "Starting Task Manager"
@@ -40,3 +39,6 @@ elif [ "$1" = "taskmanager" ]; then
 else
     $@
 fi
+
+# prevent script to exit
+tail -f /dev/null


### PR DESCRIPTION
- configure job manager address for both operation modes
- introduce argument to specify the external job manager address
- replace ARG with ENV for backwards-compatibility
- EXPOSE web port and RPC port