### PR TITLE
[FLINK-5327] Remove IOEXception from StateObject::getStateSize

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/migration/state/MigrationStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/state/MigrationStreamStateHandle.java
@@ -50,7 +50,7 @@ public class MigrationStreamStateHandle implements StreamStateHandle {
 	}
 
 	@Override
-	public long getStateSize() throws IOException {
+	public long getStateSize() {
 		return delegate.getStateSize();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ChainedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ChainedStateHandle.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.util.Preconditions;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -85,7 +84,7 @@ public class ChainedStateHandle<T extends StateObject> implements StateObject {
 	}
 
 	@Override
-	public long getStateSize() throws IOException {
+	public long getStateSize() {
 		long sumStateSize = 0;
 
 		if (operatorStateHandles != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
@@ -111,7 +111,7 @@ public class KeyGroupsStateHandle implements StreamStateHandle {
 	}
 
 	@Override
-	public long getStateSize() throws IOException {
+	public long getStateSize() {
 		return stateHandle.getStateSize();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/MultiStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/MultiStreamStateHandle.java
@@ -58,7 +58,7 @@ public class MultiStreamStateHandle implements StreamStateHandle {
 	}
 
 	@Override
-	public long getStateSize() throws IOException {
+	public long getStateSize() {
 		return stateSize;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStateHandle.java
@@ -55,7 +55,7 @@ public class OperatorStateHandle implements StreamStateHandle {
 	}
 
 	@Override
-	public long getStateSize() throws IOException {
+	public long getStateSize() {
 		return delegateStateHandle.getStateSize();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
@@ -70,7 +70,7 @@ public class RetrievableStreamStateHandle<T extends Serializable> implements
 	}
 
 	@Override
-	public long getStateSize() throws IOException {
+	public long getStateSize() {
 		return wrappedStreamStateHandle.getStateSize();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateObject.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateObject.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.state;
 
-import java.io.IOException;
-
 /**
  * Base of all types that represent checkpointed state. Specializations are for
  * example {@link StateHandle StateHandles} (directly resolve to state).
@@ -45,7 +43,6 @@ public interface StateObject extends java.io.Serializable {
 	 * <p>If the the size is not known, return {@code 0}.
 	 *
 	 * @return Size of the state in bytes.
-	 * @throws IOException If the operation fails during size retrieval.
 	 */
-	long getStateSize() throws IOException;
+	long getStateSize();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
@@ -93,10 +93,9 @@ public class FileStateHandle implements StreamStateHandle {
 	 * Returns the file size in bytes.
 	 *
 	 * @return The file size in bytes.
-	 * @throws IOException Thrown if the file system cannot be accessed.
 	 */
 	@Override
-	public long getStateSize() throws IOException {
+	public long getStateSize() {
 		return stateSize;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import scala.concurrent.duration.Deadline;
 import scala.concurrent.duration.FiniteDuration;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
 
@@ -184,7 +183,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 		}
 
 		@Override
-		public long getStateSize() throws IOException {
+		public long getStateSize() {
 			return 0;
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -249,7 +249,7 @@ public class InterruptSensitiveRestoreTest {
 		public void discardState() throws Exception {}
 
 		@Override
-		public long getStateSize() throws IOException {
+		public long getStateSize() {
 			return 0;
 		}
 	}


### PR DESCRIPTION
The signature of ``StateObject::getStateSize`` declares throwing of an ``IOException``. This is an artefact of the state handle refactoring. After more refactoring, there is actually no implementor throwing an exception for this call. 

This PR removes the exception from the method signature