### PR TITLE
[FLINK-5320] Fix result TypeInformation in WindowedStream.fold

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -389,7 +389,7 @@ public class WindowedStream<T, K, W extends Window> {
 			Utils.getCallLocationName(), true);
 
 		TypeInformation<R> resultType = TypeExtractor.getUnaryOperatorReturnType(
-			function, WindowFunction.class, true, true, getInputType(), null, false);
+			function, WindowFunction.class, true, true, foldAccumulatorType, null, false);
 
 		return fold(initialValue, foldFunction, function, foldAccumulatorType, resultType);
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.test.checkpointing;
 
+import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.state.ValueState;
@@ -404,6 +405,77 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 						}
 					})
 					.addSink(new ValidatingSink(NUM_KEYS, NUM_ELEMENTS_PER_KEY / WINDOW_SIZE)).setParallelism(1);
+
+
+			tryExecute(env, "Tumbling Window Test");
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testPreAggregatedFoldingTumblingTimeWindow() {
+		final int NUM_ELEMENTS_PER_KEY = 3000;
+		final int WINDOW_SIZE = 100;
+		final int NUM_KEYS = 100;
+		FailingSource.reset();
+
+		try {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.createRemoteEnvironment(
+				"localhost", cluster.getLeaderRPCPort());
+
+			env.setParallelism(PARALLELISM);
+			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+			env.enableCheckpointing(100);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
+			env.getConfig().disableSysoutLogging();
+
+			env
+				.addSource(new FailingSource(NUM_KEYS, NUM_ELEMENTS_PER_KEY, NUM_ELEMENTS_PER_KEY / 3))
+				.rebalance()
+				.keyBy(0)
+				.timeWindow(Time.of(WINDOW_SIZE, MILLISECONDS))
+				.fold(new Tuple4<>(0L, 0L, 0L, new IntType(0)),
+					new FoldFunction<Tuple2<Long, IntType>, Tuple4<Long, Long, Long, IntType>>() {
+						@Override
+						public Tuple4<Long, Long, Long, IntType> fold(Tuple4<Long, Long, Long, IntType> accumulator,
+																	  Tuple2<Long, IntType> value) throws Exception {
+							accumulator.f0 = value.f0;
+							accumulator.f3 = new IntType(accumulator.f3.value + value.f1.value);
+							return accumulator;
+						}
+					},
+					new RichWindowFunction<Tuple4<Long, Long, Long, IntType>, Tuple4<Long, Long, Long, IntType>, Tuple, TimeWindow>() {
+
+						private boolean open = false;
+
+						@Override
+						public void open(Configuration parameters) {
+							assertEquals(PARALLELISM, getRuntimeContext().getNumberOfParallelSubtasks());
+							open = true;
+						}
+
+						@Override
+						public void apply(
+							Tuple tuple,
+							TimeWindow window,
+							Iterable<Tuple4<Long, Long, Long, IntType>> input,
+							Collector<Tuple4<Long, Long, Long, IntType>> out) {
+
+							// validate that the function has been opened properly
+							assertTrue(open);
+
+							for (Tuple4<Long, Long, Long, IntType> in: input) {
+								out.collect(new Tuple4<>(in.f0,
+									window.getStart(),
+									window.getEnd(),
+									in.f3));
+							}
+						}
+					})
+				.addSink(new ValidatingSink(NUM_KEYS, NUM_ELEMENTS_PER_KEY / WINDOW_SIZE)).setParallelism(1);
 
 
 			tryExecute(env, "Tumbling Window Test");


### PR DESCRIPTION
The resultType of the WindowFunction in WindowedStream.fold(ACC, FoldFunction, WindowFunction) can not be inferred correctly because it has the wrong argument, which can lead to an "InvalidTypesException: Input mismatch" exception. This PR corrects it.