### PR TITLE
[FLINK-5326] [network] Check release flag of parent in reader

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -234,6 +234,8 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 	}
 
 	private void handleException(Channel channel, Throwable cause) throws IOException {
+		LOG.debug("Encountered error while consuming partitions", cause);
+
 		fatalError = true;
 		releaseAllResources();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -70,7 +70,7 @@ class PipelinedSubpartitionView implements ResultSubpartitionView {
 
 	@Override
 	public boolean isReleased() {
-		return isReleased.get();
+		return isReleased.get() || parent.isReleased();
 	}
 
 	@Override


### PR DESCRIPTION
In `PipelinedSubpartitionView`, there is a possible race with releasing the parent subpartition and querying for a buffer in the view.

The parent partition release clears all buffers in locked scope and releases the view outside of the lock. If concurrently the view is queried for a buffer it might get `null`, which is only allowed if the view was released.

Because the release is only forwarded out of the lock scope, this can happen before the release has propagated.

As a solution, we check the parent release status as well in the view. This is how it is handled in the spilled views, too.

This surfaced with the recent refactorings, because the previous consumption model required multiple rounds of `get, registerListener, isReleased` calls, which hid this problem. The added parent isReleased call does not affect normal operation as it is only checked when the returned buffer is null, which only happens when the partition is consumed or released. 

---

This needs to be applied to `release-1.1`, too.

cc @StephanEwen 