### PR TITLE
[FLINK-4861] [build] Package optional project artifacts

### DIFF
--- a/flink-connectors/flink-avro/pom.xml
+++ b/flink-connectors/flink-avro/pom.xml
@@ -154,22 +154,6 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
-			<!-- package uber-jar as optional package for distribution -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<finalName>${project.artifactId}-${project.version}-uber</finalName>
-				</configuration>
-			</plugin>
 		</plugins>
 		
 		<pluginManagement>
@@ -228,4 +212,5 @@ under the License.
 			</plugins>
 		</pluginManagement>
 	</build>
+
 </project>

--- a/flink-connectors/flink-avro/pom.xml
+++ b/flink-connectors/flink-avro/pom.xml
@@ -154,6 +154,22 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 		
 		<pluginManagement>
@@ -212,5 +228,4 @@ under the License.
 			</plugins>
 		</pluginManagement>
 	</build>
-
 </project>

--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -87,6 +87,22 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/flink-connectors/flink-connector-elasticsearch/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch/pom.xml
@@ -84,6 +84,22 @@ under the License.
 					<rerunFailingTestsCount>3</rerunFailingTestsCount>
 				</configuration>
 			</plugin>
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/flink-connectors/flink-connector-elasticsearch2/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch2/pom.xml
@@ -80,4 +80,24 @@ under the License.
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-connectors/flink-connector-filesystem/pom.xml
+++ b/flink-connectors/flink-connector-filesystem/pom.xml
@@ -157,6 +157,23 @@ under the License.
 					<reuseForks>false</reuseForks>
 				</configuration>
 			</plugin>
+
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/flink-connectors/flink-connector-flume/pom.xml
+++ b/flink-connectors/flink-connector-flume/pom.xml
@@ -170,6 +170,23 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-connectors/flink-connector-kafka-0.10/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.10/pom.xml
@@ -199,6 +199,22 @@ under the License.
 					<argLine>-Xms256m -Xmx1000m -Dlog4j.configuration=${log4j.configuration} -Dmvn.forkNumber=${surefire.forkNumber} -XX:-UseGCOverheadLimit</argLine>
 				</configuration>
 			</plugin>
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	

--- a/flink-connectors/flink-connector-kafka-0.8/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.8/pom.xml
@@ -213,6 +213,22 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	

--- a/flink-connectors/flink-connector-kafka-0.9/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.9/pom.xml
@@ -206,6 +206,22 @@ under the License.
 				<inherited>true</inherited>
 				<extensions>true</extensions>
 			</plugin>
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -157,6 +157,16 @@ under the License.
 							</relocations>
 						</configuration>
 					</execution>
+					<!-- package uber-jar as optional package for distribution -->
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>${project.artifactId}-${project.version}-uber</finalName>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 		</plugins>

--- a/flink-connectors/flink-connector-nifi/pom.xml
+++ b/flink-connectors/flink-connector-nifi/pom.xml
@@ -83,6 +83,22 @@ under the License.
 					<rerunFailingTestsCount>3</rerunFailingTestsCount>
 				</configuration>
 			</plugin>
+            <!-- package uber-jar as optional package for distribution -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <finalName>${project.artifactId}-${project.version}-uber</finalName>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
 

--- a/flink-connectors/flink-connector-rabbitmq/pom.xml
+++ b/flink-connectors/flink-connector-rabbitmq/pom.xml
@@ -73,4 +73,24 @@ under the License.
 
 	</dependencies>
 
+	<build>
+		<plugins>
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-connectors/flink-connector-twitter/pom.xml
+++ b/flink-connectors/flink-connector-twitter/pom.xml
@@ -89,6 +89,16 @@ under the License.
 							</transformers>
 						</configuration>
 					</execution>
+					<!-- package uber-jar as optional package for distribution -->
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>${project.artifactId}-${project.version}-uber</finalName>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 		</plugins>

--- a/flink-connectors/flink-hadoop-compatibility/pom.xml
+++ b/flink-connectors/flink-hadoop-compatibility/pom.xml
@@ -176,6 +176,23 @@ under the License.
 					<configLocation>${project.basedir}/../../tools/maven/scalastyle-config.xml</configLocation>
 				</configuration>
 			</plugin>
+
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/flink-connectors/flink-hbase/pom.xml
+++ b/flink-connectors/flink-hbase/pom.xml
@@ -61,6 +61,22 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/flink-connectors/flink-hcatalog/pom.xml
+++ b/flink-connectors/flink-hcatalog/pom.xml
@@ -176,6 +176,22 @@ under the License.
 				</configuration>
 			</plugin>
 
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/flink-connectors/flink-jdbc/pom.xml
+++ b/flink-connectors/flink-jdbc/pom.xml
@@ -68,4 +68,25 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-contrib/flink-storm-examples/pom.xml
+++ b/flink-contrib/flink-storm-examples/pom.xml
@@ -364,6 +364,17 @@ under the License.
 							</transformers>
 						</configuration>
 					</execution>
+
+					<!-- package uber-jar as optional package for distribution -->
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>${project.artifactId}-${project.version}-uber</finalName>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 		</plugins>

--- a/flink-contrib/flink-storm/pom.xml
+++ b/flink-contrib/flink-storm/pom.xml
@@ -152,4 +152,24 @@ under the License.
 		
 	</dependencies>
 
+	<build>
+		<plugins>
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -137,7 +137,188 @@ under the License.
 			<artifactId>flink-yarn_2.10</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
+
+		<!-- the following dependencies are packaged in opt/ -->
+
+		<!-- start optional Flink connectors -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-cassandra_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-elasticsearch_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-elasticsearch2_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-filesystem_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-flume_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka-0.8_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka-0.9_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka-0.10_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka-base_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-nifi_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-rabbitmq_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-redis_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-twitter_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-hadoop-compatibility_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-hbase_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-hcatalog</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-jdbc</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<!-- end optional Flink streaming connectors -->
+
+		<!-- start optional Flink metrics reporters -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-metrics-dropwizard</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-metrics-ganglia</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-metrics-graphite</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-metrics-statsd</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<!-- end optional Flink metrics reporters -->
+
+		<!-- start optional Flink libraries -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-cep_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-cep-scala_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-gelly_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-gelly-scala_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-gelly-examples_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-ml_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-storm_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-storm-examples_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<!-- end optional Flink libraries -->
 	</dependencies>
 
 	<profiles>
@@ -272,6 +453,20 @@ under the License.
 						<configuration>
 							<descriptors>
 								<descriptor>src/main/assemblies/bin.xml</descriptor>
+							</descriptors>
+							<finalName>flink-${project.version}-bin</finalName>
+							<appendAssemblyId>false</appendAssemblyId>
+						</configuration>
+					</execution>
+					<execution>
+						<id>opt</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<descriptors>
+								<descriptor>src/main/assemblies/opt.xml</descriptor>
 							</descriptors>
 							<finalName>flink-${project.version}-bin</finalName>
 							<appendAssemblyId>false</appendAssemblyId>

--- a/flink-dist/src/main/assemblies/opt.xml
+++ b/flink-dist/src/main/assemblies/opt.xml
@@ -30,13 +30,6 @@
 	<files>
 		<!-- Connectors -->
 		<file>
-			<source>../flink-connectors/flink-avro/target/flink-avro_2.10-${project.version}-uber.jar</source>
-			<outputDirectory>opt/</outputDirectory>
-			<destName>flink-avro_2.10-${project.version}.jar</destName>
-			<fileMode>0644</fileMode>
-		</file>
-
-		<file>
 			<source>../flink-connectors/flink-connector-cassandra/target/flink-connector-cassandra_2.10-${project.version}-uber.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-connector-cassandra_2.10-${project.version}.jar</destName>

--- a/flink-dist/src/main/assemblies/opt.xml
+++ b/flink-dist/src/main/assemblies/opt.xml
@@ -1,0 +1,233 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<assembly
+	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+	<id>opt</id>
+	<formats>
+		<format>dir</format>
+	</formats>
+
+	<includeBaseDirectory>true</includeBaseDirectory>
+	<baseDirectory>flink-${project.version}</baseDirectory>
+
+	<files>
+		<!-- Connectors -->
+		<file>
+			<source>../flink-connectors/flink-avro/target/flink-avro_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-avro_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-connectors/flink-connector-cassandra/target/flink-connector-cassandra_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-connector-cassandra_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-connectors/flink-connector-elasticsearch/target/flink-connector-elasticsearch_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-connector-elasticsearch_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-connectors/flink-connector-elasticsearch2/target/flink-connector-elasticsearch2_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-connector-elasticsearch2_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-connectors/flink-connector-filesystem/target/flink-connector-filesystem_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-connector-filesystem_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-connectors/flink-connector-flume/target/flink-connector-flume_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-connector-flume_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-connectors/flink-connector-kafka-0.8/target/flink-connector-kafka-0.8_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-connector-kafka-0.8_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-connectors/flink-connector-kafka-0.9/target/flink-connector-kafka-0.9_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-connector-kafka-0.9_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-connectors/flink-connector-kafka-0.10/target/flink-connector-kafka-0.10_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-connector-kafka-0.10_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-connectors/flink-connector-nifi/target/flink-connector-nifi_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-connector-nifi_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-connectors/flink-connector-rabbitmq/target/flink-connector-rabbitmq_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-connector-rabbitmq_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-connectors/flink-connector-twitter/target/flink-connector-twitter_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-connector-twitter_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-connectors/flink-hadoop-compatibility/target/flink-hadoop-compatibility_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-connector-hadoop-compatibility_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-connectors/flink-hbase/target/flink-hbase_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-connector-hbase_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-connectors/flink-hcatalog/target/flink-hcatalog-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-connector-hcatalog-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-connectors/flink-jdbc/target/flink-jdbc-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-connector-jdbc-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<!-- Storm -->
+		<file>
+			<source>../flink-contrib/flink-storm/target/flink-storm_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-storm_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-contrib/flink-storm-examples/target/flink-storm-examples_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-storm-examples_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<!-- CEP -->
+		<file>
+			<source>../flink-libraries/flink-cep/target/flink-cep_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-cep_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-libraries/flink-cep-scala/target/flink-cep-scala_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-cep-scala_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<!-- Gelly -->
+		<file>
+			<source>../flink-libraries/flink-gelly/target/flink-gelly_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-gelly_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-libraries/flink-gelly-examples/target/flink-gelly-examples_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-gelly-examples_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-libraries/flink-gelly-scala/target/flink-gelly-scala_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-gelly-scala_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<!-- ML -->
+		<file>
+			<source>../flink-libraries/flink-ml/target/flink-ml_2.10-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-ml_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<!-- Metrics -->
+		<file>
+			<source>../flink-metrics/flink-metrics-ganglia/target/flink-metrics-ganglia-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-metrics-ganglia-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-metrics/flink-metrics-graphite/target/flink-metrics-graphite-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-metrics-graphite-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-metrics/flink-metrics-statsd/target/flink-metrics-statsd-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-metrics-statsd-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-metrics/flink-metrics-dropwizard/target/flink-metrics-dropwizard-${project.version}-uber.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-metrics-dropwizard-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+	</files>
+</assembly>

--- a/flink-libraries/flink-cep-scala/pom.xml
+++ b/flink-libraries/flink-cep-scala/pom.xml
@@ -116,7 +116,23 @@ under the License.
 					<configLocation>${project.basedir}/../../tools/maven/scalastyle-config.xml</configLocation>
 				</configuration>
 			</plugin>
+
+            <!-- package uber-jar as optional package for distribution -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <finalName>${project.artifactId}-${project.version}-uber</finalName>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-    
 </project>

--- a/flink-libraries/flink-cep/pom.xml
+++ b/flink-libraries/flink-cep/pom.xml
@@ -106,6 +106,23 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- package uber-jar as optional package for distribution -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <finalName>${project.artifactId}-${project.version}-uber</finalName>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/flink-libraries/flink-gelly-examples/pom.xml
+++ b/flink-libraries/flink-gelly-examples/pom.xml
@@ -199,7 +199,23 @@
 					<configLocation>${project.basedir}/../../tools/maven/scalastyle-config.xml</configLocation>
 				</configuration>
 			</plugin>
+
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/flink-libraries/flink-gelly-scala/pom.xml
+++ b/flink-libraries/flink-gelly-scala/pom.xml
@@ -191,7 +191,23 @@ under the License.
 					<configLocation>${project.basedir}/../../tools/maven/scalastyle-config.xml</configLocation>
 				</configuration>
 			</plugin>
+
+            <!-- package uber-jar as optional package for distribution -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <finalName>${project.artifactId}-${project.version}-uber</finalName>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/flink-libraries/flink-gelly/pom.xml
+++ b/flink-libraries/flink-gelly/pom.xml
@@ -69,4 +69,25 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-libraries/flink-ml/pom.xml
+++ b/flink-libraries/flink-ml/pom.xml
@@ -155,6 +155,23 @@
 					<configLocation>${project.basedir}/../../tools/maven/scalastyle-config.xml</configLocation>
 				</configuration>
 			</plugin>
+
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-metrics/flink-metrics-dropwizard/pom.xml
+++ b/flink-metrics/flink-metrics-dropwizard/pom.xml
@@ -92,6 +92,23 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-metrics/flink-metrics-ganglia/pom.xml
+++ b/flink-metrics/flink-metrics-ganglia/pom.xml
@@ -92,6 +92,23 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-metrics/flink-metrics-graphite/pom.xml
+++ b/flink-metrics/flink-metrics-graphite/pom.xml
@@ -86,6 +86,23 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-metrics/flink-metrics-statsd/pom.xml
+++ b/flink-metrics/flink-metrics-statsd/pom.xml
@@ -63,4 +63,25 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<!-- package uber-jar as optional package for distribution -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<finalName>${project.artifactId}-${project.version}-uber</finalName>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
Package the Flink connectors, metrics, and libraries into subdirectories of a new opt directory in the release/snapshot tarballs.

I'm not aware of a way to place the maven-shade-plugin configuration in the parent pom and conditionally enable it for a subset of modules.

$ ls build-target/opt
flink-avro_2.10-1.2-SNAPSHOT.jar
flink-cep_2.10-1.2-SNAPSHOT.jar
flink-cep-scala_2.10-1.2-SNAPSHOT.jar
flink-connector-cassandra_2.10-1.2-SNAPSHOT.jar
flink-connector-elasticsearch_2.10-1.2-SNAPSHOT.jar
flink-connector-elasticsearch2_2.10-1.2-SNAPSHOT.jar
flink-connector-filesystem_2.10-1.2-SNAPSHOT.jar
flink-connector-flume_2.10-1.2-SNAPSHOT.jar
flink-connector-hadoop-compatibility_2.10-1.2-SNAPSHOT.jar
flink-connector-hbase_2.10-1.2-SNAPSHOT.jar
flink-connector-hcatalog-1.2-SNAPSHOT.jar
flink-connector-jdbc-1.2-SNAPSHOT.jar
flink-connector-kafka-0.10_2.10-1.2-SNAPSHOT.jar
flink-connector-kafka-0.8_2.10-1.2-SNAPSHOT.jar
flink-connector-kafka-0.9_2.10-1.2-SNAPSHOT.jar
flink-connector-nifi_2.10-1.2-SNAPSHOT.jar
flink-connector-rabbitmq_2.10-1.2-SNAPSHOT.jar
flink-connector-redis_2.10-1.2-SNAPSHOT.jar
flink-connector-twitter_2.10-1.2-SNAPSHOT.jar
flink-gelly_2.10-1.2-SNAPSHOT.jar
flink-gelly-examples_2.10-1.2-SNAPSHOT.jar
flink-gelly-scala_2.10-1.2-SNAPSHOT.jar
flink-metrics-dropwizard-1.2-SNAPSHOT.jar
flink-metrics-ganglia-1.2-SNAPSHOT.jar
flink-metrics-graphite-1.2-SNAPSHOT.jar
flink-metrics-statsd-1.2-SNAPSHOT.jar
flink-ml_2.10-1.2-SNAPSHOT.jar
flink-storm_2.10-1.2-SNAPSHOT.jar
flink-storm-examples_2.10-1.2-SNAPSHOT.jar