### PR TITLE
Fix typo in variable name

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GlobFilePathFilter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GlobFilePathFilter.java
@@ -90,8 +90,8 @@ public class GlobFilePathFilter extends FilePathFilter {
 			return false;
 		}
 
-		for (PathMatcher mather : includeMatchers) {
-			if (mather.matches(Paths.get(filePath.getPath()))) {
+		for (PathMatcher matcher : includeMatchers) {
+			if (matcher.matches(Paths.get(filePath.getPath()))) {
 				return shouldExclude(filePath);
 			}
 		}


### PR DESCRIPTION
- Fixed a typo in the variable name
- `mvn clean verify` has been executed successfully locally 

