### PR TITLE
[FLINK-5335] Allow ListCheckpointed user functions to return null

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ListCheckpointed.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ListCheckpointed.java
@@ -41,6 +41,7 @@ public interface ListCheckpointed<T extends Serializable> {
 	 * @param checkpointId The ID of the checkpoint.
 	 * @param timestamp Timestamp of the checkpoint.
 	 * @return The operator state in a list of redistributable, atomic sub-states.
+	 *         Should not return null, but empty list instead.
 	 * @throws Exception Thrown if the creation of the state object failed. This causes the
 	 *                   checkpoint to fail. The system may decide to fail the operation (and trigger
 	 *                   recovery), or to discard this checkpoint attempt and to continue running

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
@@ -106,15 +106,17 @@ public abstract class AbstractUdfStreamOperator<OUT, F extends Function>
 		} else if (userFunction instanceof ListCheckpointed) {
 			@SuppressWarnings("unchecked")
 			List<Serializable> partitionableState = ((ListCheckpointed<Serializable>) userFunction).
-							snapshotState(context.getCheckpointId(), context.getCheckpointTimestamp());
+					snapshotState(context.getCheckpointId(), context.getCheckpointTimestamp());
 
 			ListState<Serializable> listState = getOperatorStateBackend().
 					getSerializableListState(DefaultOperatorStateBackend.DEFAULT_OPERATOR_STATE_NAME);
 
 			listState.clear();
 
-			for (Serializable statePartition : partitionableState) {
-				listState.add(statePartition);
+			if (null != partitionableState) {
+				for (Serializable statePartition : partitionableState) {
+					listState.add(statePartition);
+				}
 			}
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/checkpoint/ListCheckpointedTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/checkpoint/ListCheckpointedTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.checkpoint;
+
+import org.apache.flink.api.common.functions.AbstractRichFunction;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
+import org.apache.flink.streaming.runtime.tasks.OperatorStateHandles;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ListCheckpointedTest {
+
+	@Test
+	public void testUDFReturningNull() throws Exception {
+		TestUserFunction userFunction = new TestUserFunction(null);
+		AbstractStreamOperatorTestHarness<Integer> testHarness =
+				new AbstractStreamOperatorTestHarness<>(new TestOperator(userFunction), 1, 1, 0);
+		testHarness.open();
+		OperatorStateHandles snapshot = testHarness.snapshot(0L, 0L);
+		testHarness.initializeState(snapshot);
+		Assert.assertTrue(userFunction.isRestored());
+	}
+
+	@Test
+	public void testUDFReturningEmpty() throws Exception {
+		TestUserFunction userFunction = new TestUserFunction(Collections.<Integer>emptyList());
+		AbstractStreamOperatorTestHarness<Integer> testHarness =
+				new AbstractStreamOperatorTestHarness<>(new TestOperator(userFunction), 1, 1, 0);
+		testHarness.open();
+		OperatorStateHandles snapshot = testHarness.snapshot(0L, 0L);
+		testHarness.initializeState(snapshot);
+		Assert.assertTrue(userFunction.isRestored());
+	}
+
+	@Test
+	public void testUDFReturningData() throws Exception {
+		TestUserFunction userFunction = new TestUserFunction(Arrays.asList(1, 2, 3));
+		AbstractStreamOperatorTestHarness<Integer> testHarness =
+				new AbstractStreamOperatorTestHarness<>(new TestOperator(userFunction), 1, 1, 0);
+		testHarness.open();
+		OperatorStateHandles snapshot = testHarness.snapshot(0L, 0L);
+		testHarness.initializeState(snapshot);
+		Assert.assertTrue(userFunction.isRestored());
+	}
+
+
+	private static class TestUserFunction extends AbstractRichFunction implements ListCheckpointed<Integer> {
+
+		private final List<Integer> expected;
+		private boolean restored;
+
+		public TestUserFunction(List<Integer> expected) {
+			this.expected = expected;
+			this.restored = false;
+		}
+
+		@Override
+		public List<Integer> snapshotState(long checkpointId, long timestamp) throws Exception {
+			return expected;
+		}
+
+		@Override
+		public void restoreState(List<Integer> state) throws Exception {
+			if (null != expected) {
+				Assert.assertEquals(expected, state);
+			} else {
+				Assert.assertTrue(state.isEmpty());
+			}
+			restored = true;
+		}
+
+		public boolean isRestored() {
+			return restored;
+		}
+	}
+
+	private static class TestOperator extends AbstractUdfStreamOperator<Integer, TestUserFunction> {
+
+		private final StreamTask<?, ?> containingTask;
+		private final CloseableRegistry closeableRegistry;
+
+		public TestOperator(TestUserFunction userFunction) throws Exception {
+			super(userFunction);
+			this.closeableRegistry = new CloseableRegistry();
+			this.containingTask = mock(StreamTask.class);
+			when(containingTask.getCancelables()).thenReturn(closeableRegistry);
+		}
+
+		@Override
+		public StreamTask<?, ?> getContainingTask() {
+			return containingTask;
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -131,6 +131,27 @@ public class StateInitializationContextImplTest {
 	@Test
 	public void getOperatorStateStreams() throws Exception {
 
+		int i = 0;
+		int s = 0;
+		for (StatePartitionStreamProvider streamProvider : initializationContext.getRawOperatorStateInputs()) {
+			if (0 == i % 4) {
+				++i;
+			}
+			Assert.assertNotNull(streamProvider);
+			try (InputStream is = streamProvider.getStream()) {
+				DataInputView div = new DataInputViewStreamWrapper(is);
+
+				int val = div.readInt();
+				Assert.assertEquals(i * NUM_HANDLES + s, val);
+			}
+
+			++s;
+			if (s == i % 4) {
+				s = 0;
+				++i;
+			}
+		}
+
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -33,7 +33,6 @@ import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
-import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
@@ -144,15 +143,6 @@ public class AbstractStreamOperatorTestHarness<OUT> {
 		when(mockTask.getExecutionConfig()).thenReturn(executionConfig);
 		when(mockTask.getUserCodeClassLoader()).thenReturn(this.getClass().getClassLoader());
 		when(mockTask.getCancelables()).thenReturn(this.closableRegistry);
-		when(mockTask.createOperatorStateBackend(any(StreamOperator.class), any(Collection.class))).
-				thenAnswer(new Answer<OperatorStateBackend>() {
-					@Override
-					public OperatorStateBackend answer(InvocationOnMock invocationOnMock) throws Throwable {
-						return new DefaultOperatorStateBackend(
-								getClass().getClassLoader(),
-								invocationOnMock.getArgumentAt(1, Collection.class));
-					}
-		});
 
 		doAnswer(new Answer<Void>() {
 			@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
@@ -143,6 +144,15 @@ public class AbstractStreamOperatorTestHarness<OUT> {
 		when(mockTask.getExecutionConfig()).thenReturn(executionConfig);
 		when(mockTask.getUserCodeClassLoader()).thenReturn(this.getClass().getClassLoader());
 		when(mockTask.getCancelables()).thenReturn(this.closableRegistry);
+		when(mockTask.createOperatorStateBackend(any(StreamOperator.class), any(Collection.class))).
+				thenAnswer(new Answer<OperatorStateBackend>() {
+					@Override
+					public OperatorStateBackend answer(InvocationOnMock invocationOnMock) throws Throwable {
+						return new DefaultOperatorStateBackend(
+								getClass().getClassLoader(),
+								invocationOnMock.getArgumentAt(1, Collection.class));
+					}
+		});
 
 		doAnswer(new Answer<Void>() {
 			@Override


### PR DESCRIPTION
Currently, it is not allowed to return ``null`` as result for the methods in ``ListCheckpointed``. From a usability perspective, I think it is nicer to allow this. This PR introduces proper handling for ``null`` plus additional unit tests for ``ListCheckpointed``
