### PR TITLE
[FLINK-4973] Let LatencyMarksEmitter use StreamTask's ProcessingTimeService

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
@@ -56,6 +56,16 @@ public abstract class ProcessingTimeService {
 	public abstract ScheduledFuture<?> registerTimer(long timestamp, ProcessingTimeCallback target);
 
 	/**
+	 * Registers a task to be executed repeatedly at a fixed rate.
+	 *
+	 * @param callback to be executed after the initial delay and then after each period
+	 * @param initialDelay initial delay to start executing callback
+	 * @param period after the initial delay after which the callback is executed
+	 * @return Scheduled future representing the task to be executed repeatedly
+	 */
+	public abstract ScheduledFuture<?> scheduleAtFixedRate(ProcessingTimeCallback callback, long initialDelay, long period);
+
+	/**
 	 * Returns <tt>true</tt> if the service has been shut down, <tt>false</tt> otherwise.
 	 */
 	public abstract boolean isTerminated();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/HeapInternalTimerServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/HeapInternalTimerServiceTest.java
@@ -176,8 +176,8 @@ public class HeapInternalTimerServiceTest {
 		assertEquals(2, timerService.numProcessingTimeTimers("hello"));
 		assertEquals(3, timerService.numProcessingTimeTimers("ciao"));
 
-		assertEquals(1, processingTimeService.getNumRegisteredTimers());
-		assertThat(processingTimeService.getRegisteredTimerTimestamps(), containsInAnyOrder(10L));
+		assertEquals(1, processingTimeService.getNumActiveTimers());
+		assertThat(processingTimeService.getActiveTimerTimestamps(), containsInAnyOrder(10L));
 
 		processingTimeService.setCurrentTime(10);
 
@@ -185,8 +185,8 @@ public class HeapInternalTimerServiceTest {
 		assertEquals(1, timerService.numProcessingTimeTimers("hello"));
 		assertEquals(2, timerService.numProcessingTimeTimers("ciao"));
 
-		assertEquals(1, processingTimeService.getNumRegisteredTimers());
-		assertThat(processingTimeService.getRegisteredTimerTimestamps(), containsInAnyOrder(20L));
+		assertEquals(1, processingTimeService.getNumActiveTimers());
+		assertThat(processingTimeService.getActiveTimerTimestamps(), containsInAnyOrder(20L));
 
 		processingTimeService.setCurrentTime(20);
 
@@ -194,18 +194,18 @@ public class HeapInternalTimerServiceTest {
 		assertEquals(0, timerService.numProcessingTimeTimers("hello"));
 		assertEquals(1, timerService.numProcessingTimeTimers("ciao"));
 
-		assertEquals(1, processingTimeService.getNumRegisteredTimers());
-		assertThat(processingTimeService.getRegisteredTimerTimestamps(), containsInAnyOrder(30L));
+		assertEquals(1, processingTimeService.getNumActiveTimers());
+		assertThat(processingTimeService.getActiveTimerTimestamps(), containsInAnyOrder(30L));
 
 		processingTimeService.setCurrentTime(30);
 
 		assertEquals(0, timerService.numProcessingTimeTimers());
 
-		assertEquals(0, processingTimeService.getNumRegisteredTimers());
+		assertEquals(0, processingTimeService.getNumActiveTimers());
 
 		timerService.registerProcessingTimeTimer("ciao", 40);
 
-		assertEquals(1, processingTimeService.getNumRegisteredTimers());
+		assertEquals(1, processingTimeService.getNumActiveTimers());
 	}
 
 	/**
@@ -233,15 +233,15 @@ public class HeapInternalTimerServiceTest {
 
 		assertEquals(1, timerService.numProcessingTimeTimers());
 
-		assertEquals(1, processingTimeService.getNumRegisteredTimers());
-		assertThat(processingTimeService.getRegisteredTimerTimestamps(), containsInAnyOrder(20L));
+		assertEquals(1, processingTimeService.getNumActiveTimers());
+		assertThat(processingTimeService.getActiveTimerTimestamps(), containsInAnyOrder(20L));
 
 		timerService.registerProcessingTimeTimer("ciao", 10);
 
 		assertEquals(2, timerService.numProcessingTimeTimers());
 
-		assertEquals(1, processingTimeService.getNumRegisteredTimers());
-		assertThat(processingTimeService.getRegisteredTimerTimestamps(), containsInAnyOrder(10L));
+		assertEquals(1, processingTimeService.getNumActiveTimers());
+		assertThat(processingTimeService.getActiveTimerTimestamps(), containsInAnyOrder(10L));
 	}
 
 	/**
@@ -266,8 +266,8 @@ public class HeapInternalTimerServiceTest {
 
 		assertEquals(1, timerService.numProcessingTimeTimers());
 
-		assertEquals(1, processingTimeService.getNumRegisteredTimers());
-		assertThat(processingTimeService.getRegisteredTimerTimestamps(), containsInAnyOrder(10L));
+		assertEquals(1, processingTimeService.getNumActiveTimers());
+		assertThat(processingTimeService.getActiveTimerTimestamps(), containsInAnyOrder(10L));
 
 		doAnswer(new Answer<Object>() {
 			@Override
@@ -279,8 +279,8 @@ public class HeapInternalTimerServiceTest {
 
 		processingTimeService.setCurrentTime(10);
 
-		assertEquals(1, processingTimeService.getNumRegisteredTimers());
-		assertThat(processingTimeService.getRegisteredTimerTimestamps(), containsInAnyOrder(20L));
+		assertEquals(1, processingTimeService.getNumActiveTimers());
+		assertThat(processingTimeService.getActiveTimerTimestamps(), containsInAnyOrder(20L));
 
 		doAnswer(new Answer<Object>() {
 			@Override
@@ -294,8 +294,8 @@ public class HeapInternalTimerServiceTest {
 
 		assertEquals(1, timerService.numProcessingTimeTimers());
 
-		assertEquals(1, processingTimeService.getNumRegisteredTimers());
-		assertThat(processingTimeService.getRegisteredTimerTimestamps(), containsInAnyOrder(30L));
+		assertEquals(1, processingTimeService.getNumActiveTimers());
+		assertThat(processingTimeService.getActiveTimerTimestamps(), containsInAnyOrder(30L));
 	}
 
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorTest.java
@@ -33,7 +33,6 @@ import org.apache.flink.streaming.api.operators.StoppableStreamSource;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.operators.StreamSourceContexts;
 import org.apache.flink.streaming.api.watermark.Watermark;
-import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
@@ -47,6 +46,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -181,42 +181,52 @@ public class StreamSourceOperatorTest {
 	 */
 	@Test
 	public void testLatencyMarkEmission() throws Exception {
-		final long now = System.currentTimeMillis();
-
 		final List<StreamElement> output = new ArrayList<>();
 
+		final long maxProcessingTime = 100L;
+		final long latencyMarkInterval = 10L;
+
+		final TestProcessingTimeService testProcessingTimeService = new TestProcessingTimeService();
+		testProcessingTimeService.setCurrentTime(0L);
+		final List<Long> processingTimes = Arrays.asList(1L, 10L, 11L, 21L, maxProcessingTime);
+
 		// regular stream source operator
-		final StoppableStreamSource<String, InfiniteSource<String>> operator =
-				new StoppableStreamSource<>(new InfiniteSource<String>());
+		final StreamSource<Long, ProcessingTimeServiceSource> operator =
+				new StreamSource<>(new ProcessingTimeServiceSource(testProcessingTimeService, processingTimes));
 
 		// emit latency marks every 10 milliseconds.
-		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0, 10);
-
-		// trigger an async cancel in a bit
-		new Thread("canceler") {
-			@Override
-			public void run() {
-				try {
-					Thread.sleep(200);
-				} catch (InterruptedException ignored) {}
-				operator.stop();
-			}
-		}.start();
+		setupSourceOperator(operator, TimeCharacteristic.EventTime, 0, latencyMarkInterval, testProcessingTimeService);
 
 		// run and wait to be stopped
-		operator.run(new Object(), new CollectorOutput<String>(output));
+		operator.run(new Object(), new CollectorOutput<Long>(output));
 
-		// ensure that there has been some output
-		assertTrue(output.size() > 0);
-		// and that its only latency markers
-		for(StreamElement se: output) {
+		int numberLatencyMarkers = (int) (maxProcessingTime / latencyMarkInterval) + 1;
+
+		assertEquals(
+			numberLatencyMarkers + 1, // + 1 is the final watermark element
+			output.size());
+
+		long timestamp = 0L;
+
+		int i = 0;
+		// and that its only latency markers + a final watermark
+		for (; i < output.size() - 1; i++) {
+			StreamElement se = output.get(i);
 			Assert.assertTrue(se.isLatencyMarker());
 			Assert.assertEquals(-1, se.asLatencyMarker().getVertexID());
 			Assert.assertEquals(0, se.asLatencyMarker().getSubtaskIndex());
-			Assert.assertTrue(se.asLatencyMarker().getMarkedTime() >= now);
+			Assert.assertTrue(se.asLatencyMarker().getMarkedTime() == timestamp);
+
+			timestamp += latencyMarkInterval;
 		}
+
+		Assert.assertTrue(output.get(i).isWatermark());
 	}
 
+	@Test
+	public void testLatencyMarksEmitterLifecycleIntegration() {
+
+	}
 
 	@Test
 	public void testAutomaticWatermarkContext() throws Exception {
@@ -339,6 +349,35 @@ public class StreamSourceOperatorTest {
 		@Override
 		public void stop() {
 			running = false;
+		}
+	}
+
+	private static final class ProcessingTimeServiceSource implements SourceFunction<Long> {
+
+		private final TestProcessingTimeService processingTimeService;
+		private final List<Long> processingTimes;
+
+		private boolean cancelled = false;
+
+		private ProcessingTimeServiceSource(TestProcessingTimeService processingTimeService, List<Long> processingTimes) {
+			this.processingTimeService = processingTimeService;
+			this.processingTimes = processingTimes;
+		}
+
+		@Override
+		public void run(SourceContext<Long> ctx) throws Exception {
+			for (Long processingTime : processingTimes) {
+				if (cancelled) {
+					break;
+				}
+
+				processingTimeService.setCurrentTime(processingTime);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			cancelled = true;
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TestProcessingTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TestProcessingTimeServiceTest.java
@@ -76,13 +76,13 @@ public class TestProcessingTimeServiceTest {
 			}
 		});
 
-		assertEquals(2, tp.getNumRegisteredTimers());
+		assertEquals(2, tp.getNumActiveTimers());
 
 		tp.setCurrentTime(35);
-		assertEquals(1, tp.getNumRegisteredTimers());
+		assertEquals(1, tp.getNumActiveTimers());
 
 		tp.setCurrentTime(40);
-		assertEquals(0, tp.getNumRegisteredTimers());
+		assertEquals(0, tp.getNumActiveTimers());
 
 		tp.shutdownService();
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
@@ -21,8 +21,10 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.streaming.runtime.operators.TestProcessingTimeServiceTest.ReferenceSettingExceptionHandler;
 
+import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -34,7 +36,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class SystemProcessingTimeServiceTest {
+public class SystemProcessingTimeServiceTest extends TestLogger {
 
 	@Test
 	public void testTriggerHoldsLock() throws Exception {
@@ -66,6 +68,134 @@ public class SystemProcessingTimeServiceTest {
 			}
 		}
 		finally {
+			timer.shutdownService();
+		}
+	}
+
+	/**
+	 * Tests that the schedule at fixed rate callback is called under the given lock
+	 */
+	@Test
+	public void testScheduleAtFixedRateHoldsLock() throws Exception {
+
+		final Object lock = new Object();
+		final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+
+		final SystemProcessingTimeService timer = new SystemProcessingTimeService(
+			new ReferenceSettingExceptionHandler(errorRef), lock);
+
+		final OneShotLatch awaitCallback = new OneShotLatch();
+
+		try {
+			assertEquals(0, timer.getNumTasksScheduled());
+
+			// schedule something
+			ScheduledFuture<?> future = timer.scheduleAtFixedRate(
+				new ProcessingTimeCallback() {
+					@Override
+					public void onProcessingTime(long timestamp) {
+						assertTrue(Thread.holdsLock(lock));
+
+						awaitCallback.trigger();
+					}
+				},
+				0L,
+				100L);
+
+			// wait until the first execution is active
+			awaitCallback.await();
+
+			// cancel periodic callback
+			future.cancel(true);
+
+			// check that no asynchronous error was reported
+			if (errorRef.get() != null) {
+				throw new Exception(errorRef.get());
+			}
+		}
+		finally {
+			timer.shutdownService();
+		}
+	}
+
+	/**
+	 * Tests that SystemProcessingTimeService#scheduleAtFixedRate is actually triggered multiple
+	 * times.
+	 */
+	@Test(timeout=10000)
+	public void testScheduleAtFixedRate() throws Exception {
+		final Object lock = new Object();
+		final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+		final long period = 10L;
+		final int countDown = 3;
+
+		final SystemProcessingTimeService timer = new SystemProcessingTimeService(
+			new ReferenceSettingExceptionHandler(errorRef), lock);
+
+		final CountDownLatch countDownLatch = new CountDownLatch(countDown);
+
+		try {
+			timer.scheduleAtFixedRate(new ProcessingTimeCallback() {
+				@Override
+				public void onProcessingTime(long timestamp) throws Exception {
+					countDownLatch.countDown();
+				}
+			}, 0L, period);
+
+			countDownLatch.await();
+
+			if (errorRef.get() != null) {
+				throw new Exception(errorRef.get());
+			}
+
+		} finally {
+			timer.shutdownService();
+		}
+	}
+
+	/**
+	 * Tests that shutting down the SystemProcessingTimeService will also cancel the scheduled at
+	 * fix rate future.
+	 */
+	@Test
+	public void testQuiesceAndAwaitingCancelsScheduledAtFixRateFuture() throws Exception {
+		final Object lock = new Object();
+		final AtomicReference<Throwable> errorRef = new AtomicReference<>();
+		final long period = 10L;
+
+		final SystemProcessingTimeService timer = new SystemProcessingTimeService(
+			new ReferenceSettingExceptionHandler(errorRef), lock);
+
+		try {
+			ScheduledFuture<?> scheduledFuture = timer.scheduleAtFixedRate(new ProcessingTimeCallback() {
+				@Override
+				public void onProcessingTime(long timestamp) throws Exception {
+				}
+			}, 0L, period);
+
+			assertFalse(scheduledFuture.isDone());
+
+			// this should cancel our future
+			timer.quiesceAndAwaitPending();
+
+			assertTrue(scheduledFuture.isCancelled());
+
+			scheduledFuture = timer.scheduleAtFixedRate(new ProcessingTimeCallback() {
+				@Override
+				public void onProcessingTime(long timestamp) throws Exception {
+					throw new Exception("Test exception.");
+				}
+			}, 0L, 100L);
+
+			assertNotNull(scheduledFuture);
+
+			assertEquals(0, timer.getNumTasksScheduled());
+
+			if (errorRef.get() != null) {
+				throw new Exception(errorRef.get());
+			}
+
+		} finally {
 			timer.shutdownService();
 		}
 	}
@@ -107,6 +237,21 @@ public class SystemProcessingTimeServiceTest {
 					@Override
 					public void onProcessingTime(long timestamp) {}
 				});
+
+				fail("should result in an exception");
+			}
+			catch (IllegalStateException e) {
+				// expected
+			}
+
+			try {
+				timer.scheduleAtFixedRate(
+					new ProcessingTimeCallback() {
+						@Override
+						public void onProcessingTime(long timestamp) {}
+					},
+					0L,
+					100L);
 
 				fail("should result in an exception");
 			}
@@ -206,6 +351,18 @@ public class SystemProcessingTimeServiceTest {
 
 			assertEquals(0, timer.getNumTasksScheduled());
 
+			future = timer.scheduleAtFixedRate(
+				new ProcessingTimeCallback() {
+					@Override
+					public void onProcessingTime(long timestamp) throws Exception {}
+				}, 10000000000L, 50L);
+
+			assertEquals(1, timer.getNumTasksScheduled());
+
+			future.cancel(false);
+
+			assertEquals(0, timer.getNumTasksScheduled());
+
 			// check that no asynchronous error was reported
 			if (errorRef.get() != null) {
 				throw new Exception(errorRef.get());
@@ -237,6 +394,35 @@ public class SystemProcessingTimeServiceTest {
 				throw new Exception("Exception in Timer");
 			}
 		});
+
+		latch.await();
+		assertTrue(exceptionWasThrown.get());
+	}
+
+	@Test
+	public void testExceptionReportingScheduleAtFixedRate() throws InterruptedException {
+		final AtomicBoolean exceptionWasThrown = new AtomicBoolean(false);
+		final OneShotLatch latch = new OneShotLatch();
+		final Object lock = new Object();
+
+		ProcessingTimeService timeServiceProvider = new SystemProcessingTimeService(
+			new AsyncExceptionHandler() {
+				@Override
+				public void handleAsyncException(String message, Throwable exception) {
+					exceptionWasThrown.set(true);
+					latch.trigger();
+				}
+			}, lock);
+
+		timeServiceProvider.scheduleAtFixedRate(
+			new ProcessingTimeCallback() {
+			@Override
+			public void onProcessingTime(long timestamp) throws Exception {
+				throw new Exception("Exception in Timer");
+			}
+		},
+			0L,
+			100L	);
 
 		latch.await();
 		assertTrue(exceptionWasThrown.get());


### PR DESCRIPTION
The LatencyMarksEmitter class uses now the StreamTask's ProcessingTimeService to schedule
latency mark emission. For that the ProcessingTimeService was extended to have the method
scheduleAtFixedRate to schedule repeated tasks. The latency mark emission is such a repeated
task.

cc @rmetzger.