### PR TITLE
[FLINK-5350] don't overwrite an existing JAAS config

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/HadoopSecurityContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/HadoopSecurityContext.java
@@ -25,9 +25,8 @@ import java.security.PrivilegedExceptionAction;
 import java.util.concurrent.Callable;
 
 /*
- * Process-wide security context object which initializes UGI with appropriate security credentials and also it
- * creates in-memory JAAS configuration object which will serve appropriate ApplicationConfigurationEntry for the
- * connector login module implementation that authenticates Kerberos identity using SASL/JAAS based mechanism.
+ * Hadoop security context which runs a Callable with the previously
+ * initialized UGI and appropriate security credentials.
  */
 class HadoopSecurityContext implements SecurityContext {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityUtilsTest.java
@@ -19,6 +19,8 @@ package org.apache.flink.runtime.security;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
@@ -30,6 +32,12 @@ import static org.junit.Assert.fail;
  * Tests for the {@link SecurityUtils}.
  */
 public class SecurityUtilsTest {
+
+	@AfterClass
+	public static void afterClass() {
+		SecurityUtils.clearContext();
+		System.setProperty(SecurityUtils.JAVA_SECURITY_AUTH_LOGIN_CONFIG, "");
+	}
 
 	@Test
 	public void testCreateInsecureHadoopCtx() {
@@ -49,6 +57,21 @@ public class SecurityUtilsTest {
 		} catch (RuntimeException re) {
 			assertEquals("UGI passed cannot be null",re.getMessage());
 		}
+	}
+
+	@Test
+	/**
+	 * The Jaas configuration file provided should not be overridden.
+	 */
+	public void testJaasPropertyOverride() throws Exception {
+		String confFile = "jaas.conf";
+		System.setProperty(SecurityUtils.JAVA_SECURITY_AUTH_LOGIN_CONFIG, confFile);
+
+		SecurityUtils.install(new SecurityUtils.SecurityConfiguration(new Configuration()));
+
+		Assert.assertEquals(
+			confFile,
+			System.getProperty(SecurityUtils.JAVA_SECURITY_AUTH_LOGIN_CONFIG));
 	}
 
 


### PR DESCRIPTION
Users may want to use SASL/PLAIN https://tools.ietf.org/html/rfc4616 without Kerberos.