### PR TITLE
[FLINK-5362] Implement methods to access BipartiteGraph properties

### DIFF
--- a/docs/dev/libs/gelly/bipartite_graph.md
+++ b/docs/dev/libs/gelly/bipartite_graph.md
@@ -99,6 +99,61 @@ Graph<String, String, Long, Long, Double> graph = BipartiteGraph.fromDataSet(top
 </div>
 </div>
 
+Graph Properties
+----------------
+
+Gelly includes the following methods for retrieving various Bipartite Graph properties and metrics:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+// get the top Vertex DataSet
+DataSet<Vertex<KT, VVT>> getTopVertices()
+
+// get the bottom Vertex DataSet
+DataSet<Vertex<KB, VVB>> getBottomVertices()
+
+// get the Edge DataSet
+DataSet<BipartiteEdge<KT, KB, EV>> getEdges()
+
+// get the IDs of the top vertices as a DataSet
+DataSet<KT> getTopVertexIds()
+
+// get the IDs of the bottom vertices as a DataSet
+DataSet<KB> getBottomVertexIds()
+
+// get the top-bottom pairs of the edge IDs as a DataSet
+DataSet<Tuple2<KT, KB>> getEdgeIds()
+
+// get a DataSet of <vertex ID, degree> pairs for top vertices
+DataSet<Tuple2<KT, LongValue>> topDegrees()
+
+// get a DataSet of <vertex ID, degree> pairs for bottom vertices
+DataSet<Tuple2<KB, LongValue>> bottomDegrees()
+
+// get the number of top vertices
+long numberOfTopVertices()
+
+// get the number of bottom vertices
+long numberOfBottomVertices()
+
+// get the number of edges
+long numberOfEdges()
+
+ // get tuple DataSet consisting of (topVertexId, bottomVertexId, topVertexValue, bottomVertexValue, edgeValue)
+public DataSet<Tuple5<KT, KB, VVT, VVB, EV>> getTuples() {
+
+{% endhighlight %}
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+// Scala API is not yet implemented
+{% endhighlight %}
+</div>
+</div>
+
+{% top %}
 
 Graph Transformations
 ---------------------

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
@@ -495,12 +495,18 @@ public class Graph<K, VV, EV> {
 	private static final class ProjectEdgeWithSrcValue<K, VV, EV> implements
 			FlatJoinFunction<Vertex<K, VV>, Edge<K, EV>, Tuple4<K, K, VV, EV>> {
 
+		private Tuple4<K, K, VV, EV> result = new Tuple4<>();
+
 		@Override
 		public void join(Vertex<K, VV> vertex, Edge<K, EV> edge, Collector<Tuple4<K, K, VV, EV>> collector)
 				throws Exception {
 
-			collector.collect(new Tuple4<>(edge.getSource(), edge.getTarget(), vertex.getValue(),
-					edge.getValue()));
+			result.f0 = edge.getSource();
+			result.f1 = edge.getTarget();
+			result.f2 = vertex.getValue();
+			result.f3 = edge.getValue();
+
+			collector.collect(result);
 		}
 	}
 
@@ -509,12 +515,19 @@ public class Graph<K, VV, EV> {
 	private static final class ProjectEdgeWithVertexValues<K, VV, EV> implements
 			FlatJoinFunction<Tuple4<K, K, VV, EV>, Vertex<K, VV>, Triplet<K, VV, EV>> {
 
+		private Triplet triplet = new Triplet();
+
 		@Override
 		public void join(Tuple4<K, K, VV, EV> tripletWithSrcValSet,
 						Vertex<K, VV> vertex, Collector<Triplet<K, VV, EV>> collector) throws Exception {
 
-			collector.collect(new Triplet<>(tripletWithSrcValSet.f0, tripletWithSrcValSet.f1,
-					tripletWithSrcValSet.f2, vertex.getValue(), tripletWithSrcValSet.f3));
+			triplet.f0 = tripletWithSrcValSet.f0;
+			triplet.f1 = tripletWithSrcValSet.f1;
+			triplet.f2 = tripletWithSrcValSet.f2;
+			triplet.f3 = vertex.getValue();
+			triplet.f4 = tripletWithSrcValSet.f3;
+
+			collector.collect(triplet);
 		}
 	}
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/bipartite/BipartiteGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/bipartite/BipartiteGraphTest.java
@@ -21,9 +21,11 @@ package org.apache.flink.graph.bipartite;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple5;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.test.util.TestBaseUtils;
+import org.apache.flink.types.LongValue;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -37,24 +39,125 @@ public class BipartiteGraphTest {
 	public void testGetTopVertices() throws Exception {
 		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph();
 
-		assertEquals(
-			Arrays.asList(
-				new Vertex<>(4, "top4"),
-				new Vertex<>(5, "top5"),
-				new Vertex<>(6, "top6")),
-			bipartiteGraph.getTopVertices().collect());
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getTopVertices().collect(),
+			"(4,top4)\n" +
+			"(5,top5)\n" +
+			"(6,top6)");
 	}
 
 	@Test
 	public void testGetBottomVertices() throws Exception {
 		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph();
 
-		assertEquals(
-			Arrays.asList(
-				new Vertex<>(1, "bottom1"),
-				new Vertex<>(2, "bottom2"),
-				new Vertex<>(3, "bottom3")),
-			bipartiteGraph.getBottomVertices().collect());
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getBottomVertices().collect(),
+			"(1,bottom1)\n" +
+			"(2,bottom2)\n" +
+			"(3,bottom3)");
+	}
+
+	@Test
+	public void testGetEdges() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph();
+
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getEdges().collect(),
+			"(4,1,4-1)\n" +
+			"(5,1,5-1)\n" +
+			"(5,2,5-2)\n" +
+			"(6,2,6-2)\n" +
+			"(6,3,6-3)");
+	}
+
+	@Test
+	public void testGetTopVerticesIds() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph();
+
+		DataSet<Integer> topVerticesIds = bipartiteGraph.getTopVertexIds();
+
+		TestBaseUtils.compareResultAsText(topVerticesIds.collect(),
+			"4\n5\n6");
+	}
+
+	@Test
+	public void testGetBottomVerticesIds() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph();
+
+		DataSet<Integer> bottomVerticesIds = bipartiteGraph.getBottomVertexIds();
+
+		TestBaseUtils.compareResultAsText(bottomVerticesIds.collect(),
+			"1\n2\n3");
+	}
+
+	@Test
+	public void testEdgeIds() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph();
+
+		DataSet<Tuple2<Integer, Integer>> edgeIds = bipartiteGraph.getEdgeIds();
+
+		TestBaseUtils.compareResultAsText(edgeIds.collect(),
+			"(4,1)\n" +
+			"(5,1)\n" +
+			"(5,2)\n" +
+			"(6,2)\n" +
+			"(6,3)");
+	}
+
+	@Test
+	public void testNumberOfTopVertices() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph();
+
+		assertEquals(3, bipartiteGraph.numberOfTopVertices());
+	}
+
+	@Test
+	public void testNumberOfBottomVertices() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph();
+
+		assertEquals(3, bipartiteGraph.numberOfBottomVertices());
+	}
+
+	@Test
+	public void testNumberOfEdges() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph();
+
+		assertEquals(5, bipartiteGraph.numberOfEdges());
+	}
+
+	@Test
+	public void testTopDegrees() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph();
+
+		DataSet<Tuple2<Integer, LongValue>> topDegrees = bipartiteGraph.topDegrees();
+
+		TestBaseUtils.compareResultAsText(topDegrees.collect(),
+			"(4,1)\n" +
+			"(5,2)\n" +
+			"(6,2)");
+	}
+
+	@Test
+	public void testBottomDegrees() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph();
+
+		DataSet<Tuple2<Integer, LongValue>> bottomDegrees = bipartiteGraph.bottomDegrees();
+
+		TestBaseUtils.compareResultAsText(bottomDegrees.collect(),
+			"(1,2)\n" +
+			"(2,2)\n" +
+			"(3,1)");
+	}
+
+	@Test
+	public void testGetTuples() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph();
+
+		DataSet<Tuple5<Integer, Integer, String, String, String>> tuples = bipartiteGraph.getTuples();
+
+		TestBaseUtils.compareResultAsText(tuples.collect(),
+			"(4,1,top4,bottom1,4-1)\n" +
+			"(5,1,top5,bottom1,5-1)\n" +
+			"(5,2,top5,bottom2,5-2)\n" +
+			"(6,2,top6,bottom2,6-2)\n" +
+			"(6,3,top6,bottom3,6-3)");
 	}
 
 	@Test
@@ -92,7 +195,6 @@ public class BipartiteGraphTest {
 		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph();
 		Graph<Integer, String, Projection<Integer, String, String, String>> graph = bipartiteGraph.projectionTopFull();
 
-		graph.getEdges().print();
 		compareGraph(graph, "4; 5; 6", "5,4; 4,5; 5,6; 6,5");
 
 		String expected =


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed


I've implemented methods to access `BipartiteGraph` properties similarly to methods that we have in `Graph` class.

I am not sure about the method name `getTuples` that I added to the class. `Graph` class has a similar method `getTriples`, but in case of a bipartite graph we do not return triplets (tuples with three values). Should I keep names consistent?