### PR TITLE
[FLINK-5369] [build] Rework jsr305 and logging dependencies

### DIFF
--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -54,6 +54,23 @@ under the License.
 		<module>flink-connector-filesystem</module>
 	</modules>
 
+	<!-- override these root dependencies as 'provided', so they don't end up
+		in the jars-with-dependencies (uber jars) of connectors and
+		user programs that depend on the connectors -->
+
+	<dependencies>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
 	<!-- See main pom.xml for explanation of profiles -->
 	<profiles>
 		<!--

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -47,6 +47,14 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
+		<!-- standard utilities -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<!-- managed version -->
+		</dependency>
+
+		<!-- for the fallback generic serializer -->
 		<dependency>
 			<groupId>com.esotericsoftware.kryo</groupId>
 			<artifactId>kryo</artifactId>
@@ -87,7 +95,28 @@ under the License.
 			<version>${asm.version}</version>
 		</dependency>
 
-		<!-- test dependencies -->
+		<!--
+			Because there are no logger implementation dependency in the root pom, we
+			add them here so that they are available during execution of code (core 
+			and example) in the IDE
+
+			NOTE: Once we are confident that users will use the newer quickstart templates,
+			we can drop these dependencies and only add them to 'flink-dist' and as test
+			dependencies
+		-->
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+		</dependency>
+
+		<!-- ================== test dependencies ================== -->
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils-junit</artifactId>

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -55,9 +55,17 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<!-- managed version -->
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-math3</artifactId>
 			<!-- managed version -->
 		</dependency>
+
+		<!-- test dependencies -->
 
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/flink-libraries/flink-cep-scala/pom.xml
+++ b/flink-libraries/flink-cep-scala/pom.xml
@@ -52,10 +52,31 @@ under the License.
         </dependency>
 
         <!-- We need to add this explicitly due to shading -->
+
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
             <version>${asm.version}</version>
+        </dependency>
+
+        <!-- the dependencies below are already provided in Flink -->
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-compiler</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- test dependencies -->

--- a/flink-libraries/flink-gelly-examples/pom.xml
+++ b/flink-libraries/flink-gelly-examples/pom.xml
@@ -61,6 +61,20 @@
 			<version>${project.version}</version>
 		</dependency>
 
+		<!-- to be able to execute the examples properly in common IDEs, we need to
+			restate these dependencies in 'compile' scope -->
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
 		<!-- test dependencies -->
 
 		<dependency>

--- a/flink-libraries/flink-gelly-scala/pom.xml
+++ b/flink-libraries/flink-gelly-scala/pom.xml
@@ -34,12 +34,28 @@ under the License.
     <packaging>jar</packaging>
 
     <dependencies>
+        
+        <!-- core dependencies -->
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-scala_2.10</artifactId>
             <version>${project.version}</version>
-			<scope>provided</scope>
+            <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients_2.10</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-gelly_2.10</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- We need to add this explicitly because through shading the dependency on asm seems
         to go away. -->
         <dependency>
@@ -47,16 +63,25 @@ under the License.
             <artifactId>asm</artifactId>
             <version>${asm.version}</version>
         </dependency>
+
+        <!-- the dependencies below are already provided in Flink -->
+
         <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-clients_2.10</artifactId>
-            <version>${project.version}</version>
-			<scope>provided</scope>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+            <scope>provided</scope>
         </dependency>
+
         <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-gelly_2.10</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-compiler</artifactId>
+            <scope>provided</scope>
         </dependency>
         
         <!-- test dependencies -->

--- a/flink-libraries/flink-gelly/pom.xml
+++ b/flink-libraries/flink-gelly/pom.xml
@@ -52,6 +52,12 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- test dependencies -->
 		
 		<dependency>

--- a/flink-libraries/flink-ml/pom.xml
+++ b/flink-libraries/flink-ml/pom.xml
@@ -50,6 +50,32 @@
 			<version>0.12</version>
 		</dependency>
 
+		<!-- the dependencies below are already provided in Flink -->
+
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-reflect</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-library</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-compiler</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-math3</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- test dependencies -->
 
 		<dependency>

--- a/flink-libraries/pom.xml
+++ b/flink-libraries/pom.xml
@@ -43,4 +43,22 @@ under the License.
 		<module>flink-cep</module>
 		<module>flink-cep-scala</module>
 	</modules>
+
+	<!-- override these root dependencies as 'provided', so they don't end up
+		in the jars-with-dependencies (uber jars) of connectors and
+		user programs that depend on the connectors -->
+
+	<dependencies>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
 </project>

--- a/flink-metrics/pom.xml
+++ b/flink-metrics/pom.xml
@@ -41,4 +41,22 @@ under the License.
 		<module>flink-metrics-jmx</module>
 		<module>flink-metrics-statsd</module>
 	</modules>
+
+	<!-- override these root dependencies as 'provided', so they don't end up
+		in the jars-with-dependencies. They are already contained
+		in the flink-dist build -->
+
+	<dependencies>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
 </project>

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -31,6 +31,8 @@ under the License.
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<flink.version>1.2-SNAPSHOT</flink.version>
+		<slf4j.version>1.7.7</slf4j.version>
+		<log4j.version>1.2.17</log4j.version>
 	</properties>
 
 	<repositories>
@@ -72,6 +74,7 @@ under the License.
 	-->
 
 	<dependencies>
+		<!-- Apache Flink dependencies -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-java</artifactId>
@@ -87,15 +90,31 @@ under the License.
 			<artifactId>flink-clients_2.10</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
+
+		<!-- explicitly add a standard loggin framework, as Flink does not (in the future) have
+			a hard dependency on one specific framework by default -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<version>${slf4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>${log4j.version}</version>
+		</dependency>
+		
 	</dependencies>
 
 	<profiles>
 		<profile>
 			<!-- Profile for packaging correct JAR files -->
 			<id>build-jar</id>
+
 			<activation>
 				<activeByDefault>false</activeByDefault>
 			</activation>
+
 			<dependencies>
 				<dependency>
 					<groupId>org.apache.flink</groupId>
@@ -113,6 +132,17 @@ under the License.
 					<groupId>org.apache.flink</groupId>
 					<artifactId>flink-clients_2.10</artifactId>
 					<version>${flink.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+					<version>${log4j.version}</version>
 					<scope>provided</scope>
 				</dependency>
 			</dependencies>
@@ -191,6 +221,8 @@ under the License.
 									versions of these dependencies.
 
 									-->
+
+									<exclude>log4j:log4j</exclude>
 									<exclude>org.scala-lang:scala-library</exclude>
 									<exclude>org.scala-lang:scala-compiler</exclude>
 									<exclude>org.scala-lang:scala-reflect</exclude>

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -46,6 +46,8 @@ under the License.
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<flink.version>1.2-SNAPSHOT</flink.version>
+		<slf4j.version>1.7.7</slf4j.version>
+		<log4j.version>1.2.17</log4j.version>
 	</properties>
 
 	<!-- 
@@ -73,6 +75,7 @@ under the License.
 	-->
 
 	<dependencies>
+		<!-- Apache Flink dependencies -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-scala_2.10</artifactId>
@@ -87,6 +90,19 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-clients_2.10</artifactId>
 			<version>${flink.version}</version>
+		</dependency>
+		
+		<!-- explicitly add a standard loggin framework, as Flink does not (in the future) have
+			a hard dependency on one specific framework by default -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<version>${slf4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>${log4j.version}</version>
 		</dependency>
 	</dependencies>
 
@@ -114,6 +130,17 @@ under the License.
 					<groupId>org.apache.flink</groupId>
 					<artifactId>flink-clients_2.10</artifactId>
 					<version>${flink.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+					<version>${log4j.version}</version>
 					<scope>provided</scope>
 				</dependency>
 			</dependencies>
@@ -196,6 +223,7 @@ under the License.
 
 									-->
 
+									<exclude>log4j:log4j</exclude>
 									<exclude>org.scala-lang:scala-library</exclude>
 									<exclude>org.scala-lang:scala-compiler</exclude>
 									<exclude>org.scala-lang:scala-reflect</exclude>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -57,6 +57,11 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
+		
+		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 		</dependency>

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -44,12 +44,6 @@ under the License.
 			<artifactId>flink-java</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-optimizer_2.10</artifactId>
-			<version>${project.version}</version>
-		</dependency>
 
 		<dependency>
 			<groupId>org.scala-lang</groupId>

--- a/flink-shaded-hadoop/pom.xml
+++ b/flink-shaded-hadoop/pom.xml
@@ -38,15 +38,6 @@ under the License.
 		<module>flink-shaded-hadoop2</module>
 	</modules>
 
-	<dependencies>
-		<!-- Flink already includes JSR 305. Setting this to provided excludes it from the dependencies-->
-		<dependency>
-			<groupId>com.google.code.findbugs</groupId>
-			<artifactId>jsr305</artifactId>
-			<scope>provided</scope>
-		</dependency>
-	</dependencies>
-
 	<profiles>
 		<profile>
 			<id>include-yarn-tests</id>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@ under the License.
 		<flink.forkCount>1C</flink.forkCount>
 		<flink.reuseForks>true</flink.reuseForks>
 		<log4j.configuration>log4j-test.properties</log4j.configuration>
-		<slf4j.version>1.7.7</slf4j.version>
 		<guava.version>18.0</guava.version>
 		<akka.version>2.3-custom</akka.version>
 		<java.version>1.7</java.version>
@@ -125,35 +124,21 @@ under the License.
 			<version>1.2-SNAPSHOT</version>
 		</dependency>
 
-		<!-- Add the 'javax.annotation' annotations (JSR305), such as '@Nullable' -->
+		<!-- Root dependencies for all projects -->
+
+		<!-- Logging API -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<!-- 'javax.annotation' classes like '@Nullable' -->
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>
 			<artifactId>jsr305</artifactId>
 		</dependency>
-		
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.3.2</version>
-		</dependency>
 
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>${slf4j.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>${slf4j.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
+		<!-- test dependencies -->
 
 		<dependency>
 			<groupId>junit</groupId>
@@ -197,6 +182,7 @@ under the License.
 	</dependencies>
 
 	<!-- this section defines the module versions that are used if nothing else is specified. -->
+	
 	<dependencyManagement>
 		<!-- WARN: 
 			DO NOT put 	guava, 
@@ -215,7 +201,31 @@ under the License.
 				<artifactId>jsr305</artifactId>
 				<version>1.3.9</version>
 			</dependency>
-			
+
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>1.7.7</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-log4j12</artifactId>
+				<version>1.7.7</version>
+			</dependency>
+
+			<dependency>
+				<groupId>log4j</groupId>
+				<artifactId>log4j</artifactId>
+				<version>1.2.17</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>3.3.2</version>
+			</dependency>
+
 			<!-- Make sure we use a consistent avro version throughout the project -->
 			<dependency>
 				<groupId>org.apache.avro</groupId>


### PR DESCRIPTION
Currently, every project in Flink has a hard (compile scope) dependency on the `jsr305`, `slf4j`, and `log4j` artifacts. That way they are pulled into every fat jar, including user fat jars as soon as they refer to a connector or library.
    
This commit changes the behavior in two ways:
    
  1. The commit removes the concrete logger dependencies from the root pom file. Instead, it adds them to the `flink-core` project. That way, all modules that refer to 'flink-core' will have those dependencies as well, but the projects that have `flink-core` as provided (connectors, libraries, user programs, etc) will have those dependencies transitively as provided as well.
    
  2. The commit overrides the `slf4j` and `jsr305` dependencies in the parents of `flink-connectors`, `flink-libraries`, and `flink-metrics` and sets them to *provided*. That way all core projects pull the logger classes, but all projects that are not part of `flink-dist` (and rather bundled into *fat jars*) will not bundle these dependencies again.
    
The flink-dist puts the dependencies into the fat jar (slf4j, jsr305) or the lib folder (log4j).

### Example projects

The example projects need `slf4j` in the class path. Since the `flink-gelly-examples` project is a subproject of `flink-libraries`, it re-overwrites its dependency to *compile* scope.
I think this is an indicator that the project is misplaced and should rather be part of `flink-examples`.

### Looking Forward

Ideally, no Flink project should directly reference a concrete logging framework (like *log4j*), but only `flink-dist` should add this to the `lib` directory. That way the logging framework is perfectly pluggable for everyone that references Flink projects (today it needs explicit exclusion of the log4j dependency).

The quickstarts and tests should also pull in a default logging framework, to enable local logging. This pull request prepares that, but still keeps `log4j` in the classpath of `flink-core` (as before) to not break any existing Flink projects (based on prior quickstarts) executing in the IDE.