### PR TITLE
[FLINK-5244] Implement methods for BipartiteGraph transformations

### DIFF
--- a/docs/dev/libs/gelly/bipartite_graph.md
+++ b/docs/dev/libs/gelly/bipartite_graph.md
@@ -103,6 +103,93 @@ Graph<String, String, Long, Long, Double> graph = BipartiteGraph.fromDataSet(top
 Graph Transformations
 ---------------------
 
+* <strong>Map</strong>: Gelly provides specialized methods for applying a map transformation on the vertex values or edge values. `mapTopVertices`, `mapBottomVertices`, and `mapEdges` return a new `BipartiteGraph`, where the IDs of the vertices (or edges) remain unchanged, while the values are transformed according to the provided user-defined map function. The map functions also allow changing the type of the vertex or edge values.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+BipartiteGraph<Long, Long, Long, Long, Long> graph = BipartiteGraph.fromDataSet(topVertices, bottomVertices edges, env);
+
+// increment each vertex value by one
+BipartiteGraph<Long, Long, Long, Long, Long> updatedGraph = graph.mapTopVertices(
+				new MapFunction<Vertex<Long, Long>, Long>() {
+					public Long map(Vertex<Long, Long> value) {
+						return value.getValue() + 1;
+					}
+				});
+{% endhighlight %}
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+// Scala API is not yet supported
+{% endhighlight %}
+</div>
+</div>
+
+* <strong>Filter</strong>: A filter transformation applies a user-defined filter function on the vertices or edges of the `BipartiteGraph`. `filterOnEdges` will create a sub-graph of the original graph, keeping only the edges that satisfy the provided predicate. Note that the vertex dataset will not be modified. Respectively, `filterOnTopVertices` and `filterOnTopVertices` apply a filter on the vertices of the graph. Edges whose top or/and bottom IDs do not satisfy the vertex predicate are removed from the resulting edge dataset. The `subgraph` method can be used to apply a filter function to the vertices and the edges at the same time.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+BipartiteGraph<Long, Long, Long, Long, Long> graph = ...
+
+graph.subgraph(
+		new FilterFunction<Vertex<Long, Long>>() {
+			   	public boolean filter(Vertex<Long, Long> vertex) {
+					// keep only top vertices with positive values
+					return (vertex.getValue() > 0);
+			   }
+		   },
+		new FilterFunction<Vertex<Long, Long>>() {
+			   	public boolean filter(Vertex<Long, Long> vertex) {
+					// keep only bottom vertices with positive values
+					return (vertex.getValue() > 0);
+			   }
+		   },
+		new FilterFunction<BipartiteEdge<Long, Long, Long>>() {
+				public boolean filter(BipartiteEdge<Long, Long, Long> edge) {
+					// keep only edges with negative values
+					return (edge.getValue() < 0);
+				}
+		})
+{% endhighlight %}
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+// Scala API is not yet supported
+{% endhighlight %}
+</div>
+</div>
+
+* <strong>Join</strong>: Gelly provides specialized methods for joining the vertex and edge datasets with other input datasets. `joinWithTopVertices` and `joinWithBottomVertices` join the vertices with a `Tuple2` input data set. The join is performed using the vertex ID and the first field of the `Tuple2` input as the join keys. The method returns a new `BipartiteGraph` where the vertex values have been updated according to a provided user-defined transformation function.
+Similarly, an input dataset can be joined with the edges, using one of three methods. `joinWithEdges` expects an input `DataSet` of `Tuple3` and joins on the composite key of both top and bottom vertex IDs.
+Note that if the input dataset contains a key multiple times, all Gelly join methods will only consider the first value encountered.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+BipartiteGraph<Long, Long, Double, Double, Double> graph = ...
+
+DataSet<Tuple2<Long, LongValue>> dataset = ...
+
+BipartiteGraph<Long, Long, Double, Double, Double> networkWithWeights = graph.joinWithTopVertices(
+				new VertexJoinFunction<Double, LongValue>() {
+					public Double vertexJoin(Double vertexValue, LongValue inputValue) {
+						return vertexValue / inputValue.getValue();
+					}
+				});
+{% endhighlight %}
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+// Scala API not yet supported
+{% endhighlight %}
+</div>
+</div>
 
 * <strong>Projection</strong>: Projection is a common operation for bipartite graphs that converts a bipartite graph into a regular graph. There are two types of projections: top and bottom projections. Top projection preserves only top nodes in the result graph and creates a link between them in a new graph only if there is an intermediate bottom node both top nodes connect to in the original graph. Bottom projection is the opposite to top projection, i.e. only preserves bottom nodes and connects a pair of nodes if they are connected in the original graph.
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/ApplyCoGroupToVertexValues.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/ApplyCoGroupToVertexValues.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph;
+
+import org.apache.flink.api.common.functions.CoGroupFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.util.Collector;
+
+import java.util.Iterator;
+
+/**
+ * Function that applies an instance of {@link VertexJoinFunction} on a result
+ * of a co-group between a dataset of vertices and a dataset of Tuple2.
+ *
+ * Used in {@link Graph#joinWithVertices(DataSet, VertexJoinFunction)},
+ * {@link org.apache.flink.graph.bipartite.BipartiteGraph#joinWithTopVertices(DataSet, VertexJoinFunction)},
+ * and {@link org.apache.flink.graph.bipartite.BipartiteGraph#joinWithBottomVertices(DataSet, VertexJoinFunction)}
+ *
+ * @param <K> the key type of vertices
+ * @param <VV> the value type of vertices
+ * @param <T> type of a second field in the Tuple2 dataset
+ */
+public class ApplyCoGroupToVertexValues<K, VV, T>
+	implements CoGroupFunction<Vertex<K, VV>, Tuple2<K, T>, Vertex<K, VV>> {
+
+	private VertexJoinFunction<VV, T> vertexJoinFunction;
+
+	public ApplyCoGroupToVertexValues(VertexJoinFunction<VV, T> mapper) {
+		this.vertexJoinFunction = mapper;
+	}
+
+	@Override
+	public void coGroup(Iterable<Vertex<K, VV>> vertices,
+						Iterable<Tuple2<K, T>> input, Collector<Vertex<K, VV>> collector) throws Exception {
+
+		final Iterator<Vertex<K, VV>> vertexIterator = vertices.iterator();
+		final Iterator<Tuple2<K, T>> inputIterator = input.iterator();
+
+		if (vertexIterator.hasNext()) {
+			if (inputIterator.hasNext()) {
+				final Tuple2<K, T> inputNext = inputIterator.next();
+
+				collector.collect(new Vertex<>(inputNext.f0, vertexJoinFunction
+					.vertexJoin(vertexIterator.next().f1, inputNext.f1)));
+			} else {
+				collector.collect(vertexIterator.next());
+			}
+		}
+	}
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
@@ -669,35 +669,6 @@ public class Graph<K, VV, EV> {
 		return new Graph<>(resultedVertices, this.edges, this.context);
 	}
 
-	private static final class ApplyCoGroupToVertexValues<K, VV, T>
-			implements CoGroupFunction<Vertex<K, VV>, Tuple2<K, T>, Vertex<K, VV>> {
-
-		private VertexJoinFunction<VV, T> vertexJoinFunction;
-
-		public ApplyCoGroupToVertexValues(VertexJoinFunction<VV, T> mapper) {
-			this.vertexJoinFunction = mapper;
-		}
-
-		@Override
-		public void coGroup(Iterable<Vertex<K, VV>> vertices,
-				Iterable<Tuple2<K, T>> input, Collector<Vertex<K, VV>> collector) throws Exception {
-
-			final Iterator<Vertex<K, VV>> vertexIterator = vertices.iterator();
-			final Iterator<Tuple2<K, T>> inputIterator = input.iterator();
-
-			if (vertexIterator.hasNext()) {
-				if (inputIterator.hasNext()) {
-					final Tuple2<K, T> inputNext = inputIterator.next();
-
-					collector.collect(new Vertex<>(inputNext.f0, vertexJoinFunction
-							.vertexJoin(vertexIterator.next().f1, inputNext.f1)));
-				} else {
-					collector.collect(vertexIterator.next());
-				}
-			}
-		}
-	}
-
 	/**
 	 * Joins the edge DataSet with an input DataSet on the composite key of both
 	 * source and target IDs and applies a user-defined transformation on the values

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/bipartite/BipartiteEdgeJoinFunction.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/bipartite/BipartiteEdgeJoinFunction.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.bipartite;
+
+import java.io.Serializable;
+
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.api.java.DataSet;
+
+/**
+ * Interface to be implemented by the transformation function
+ * applied in {@link BipartiteGraph#joinWithEdges(DataSet, BipartiteEdgeJoinFunction)}.
+ *
+ * @param <EV> the edge value type
+ * @param <T> the input value type
+ */
+public interface BipartiteEdgeJoinFunction<EV, T> extends Function, Serializable {
+
+	/**
+	 * Applies a transformation on the current edge value
+	 * and the value of the matched tuple of the input DataSet.
+	 *
+	 * @param edgeValue the current edge value
+	 * @param inputValue the value of the matched Tuple2 input
+	 * @return the new edge value
+	 */
+	EV edgeJoin(EV edgeValue, T inputValue) throws Exception;
+}
+

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/bipartite/BipartiteGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/bipartite/BipartiteGraphTest.java
@@ -18,11 +18,15 @@
 
 package org.apache.flink.graph.bipartite;
 
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
+import org.apache.flink.graph.VertexJoinFunction;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.junit.Test;
 
@@ -32,6 +36,8 @@ import static org.apache.flink.graph.generator.TestUtils.compareGraph;
 import static org.junit.Assert.assertEquals;
 
 public class BipartiteGraphTest {
+
+	private ExecutionEnvironment executionEnvironment = ExecutionEnvironment.createCollectionsEnvironment();
 
 	@Test
 	public void testGetTopVertices() throws Exception {
@@ -55,6 +61,188 @@ public class BipartiteGraphTest {
 				new Vertex<>(2, "bottom2"),
 				new Vertex<>(3, "bottom3")),
 			bipartiteGraph.getBottomVertices().collect());
+	}
+
+	@Test
+	public void testMapTopVertices() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph()
+			.mapTopVertices(new MapVertex());
+
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getTopVertices().collect(),
+			"(4,top4_mapped)\n" +
+			"(5,top5_mapped)\n" +
+			"(6,top6_mapped)");
+	}
+
+	@Test
+	public void testMapBottomVertices() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph()
+			.mapBottomVertices(new MapVertex());
+
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getBottomVertices().collect(),
+			"(1,bottom1_mapped)\n" +
+			"(2,bottom2_mapped)\n" +
+			"(3,bottom3_mapped)");
+	}
+
+	@Test
+	public void testMapEdges() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph()
+			.mapEdges(new MapEdge());
+
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getEdges().collect(),
+			"(4,1,4-1_mapped)\n" +
+			"(5,1,5-1_mapped)\n" +
+			"(5,2,5-2_mapped)\n" +
+			"(6,2,6-2_mapped)\n" +
+			"(6,3,6-3_mapped)");
+	}
+
+	@Test
+	public void testJoinWithTopVertices() throws Exception {
+		DataSet<Tuple2<Integer, String>> toJoin = executionEnvironment.fromCollection(Arrays.asList(
+			new Tuple2<>(4, "_val4"),
+			new Tuple2<>(5, "_val5")
+		));
+
+
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph()
+			.joinWithTopVertices(toJoin, new AppendVertexFunction());
+
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getTopVertices().collect(),
+			"(4,top4_val4)\n" +
+			"(5,top5_val5)\n" +
+			"(6,top6)");
+	}
+
+	@Test
+	public void testJoinWithBottomVertices() throws Exception {
+		DataSet<Tuple2<Integer, String>> toJoin = executionEnvironment.fromCollection(Arrays.asList(
+			new Tuple2<>(1, "_val1"),
+			new Tuple2<>(2, "_val2")
+		));
+
+
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph()
+			.joinWithBottomVertices(toJoin, new AppendVertexFunction());
+
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getBottomVertices().collect(),
+			"(1,bottom1_val1)\n" +
+			"(2,bottom2_val2)\n" +
+			"(3,bottom3)");
+	}
+
+	@Test
+	public void testJoinWithEdges() throws Exception {
+		DataSet<Tuple3<Integer, Integer, String>> toJoin = executionEnvironment.fromCollection(Arrays.asList(
+			new Tuple3<>(5, 1, "_val5-1"),
+			new Tuple3<>(5, 2, "_val5-2"),
+			new Tuple3<>(6, 2, "_val6-2")
+		));
+
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph()
+			.joinWithEdges(toJoin, new AppendEdgeFunction());
+
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getEdges().collect(),
+			"(4,1,4-1)\n" +
+			"(5,1,5-1_val5-1)\n" +
+			"(5,2,5-2_val5-2)\n" +
+			"(6,2,6-2_val6-2)\n" +
+			"(6,3,6-3)");
+	}
+
+	@Test
+	public void testFilterOnTopVertices() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph()
+			.filterOnTopVertices(new FilterFunction<Vertex<Integer, String>>() {
+				@Override
+				public boolean filter(Vertex<Integer, String> value) throws Exception {
+					return !value.getId().equals(4);
+				}
+			});
+
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getTopVertices().collect(),
+			"(5,top5)\n" +
+			"(6,top6)");
+
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getEdges().collect(),
+			"(5,1,5-1)\n" +
+			"(5,2,5-2)\n" +
+			"(6,2,6-2)\n" +
+			"(6,3,6-3)");
+	}
+
+	@Test
+	public void testSubgraph() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph()
+			.subgraph(
+				new FilterFunction<Vertex<Integer, String>>() {
+					@Override
+					public boolean filter(Vertex<Integer, String> value) throws Exception {
+						return !value.getId().equals(4);
+					}
+				},
+				new FilterFunction<Vertex<Integer, String>>() {
+					@Override
+					public boolean filter(Vertex<Integer, String> value) throws Exception {
+						return !value.getId().equals(3);
+					}
+				},
+				new FilterFunction<BipartiteEdge<Integer, Integer, String>>() {
+					@Override
+					public boolean filter(BipartiteEdge<Integer, Integer, String> value) throws Exception {
+						return !(value.getTopId().equals(5) && value.getBottomId().equals(2));
+					}
+				}
+			);
+
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getBottomVertices().collect(),
+			"(1,bottom1)\n" +
+			"(2,bottom2)");
+
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getTopVertices().collect(),
+			"(5,top5)\n" +
+			"(6,top6)");
+
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getEdges().collect(),
+			"(5,1,5-1)\n" +
+			"(6,2,6-2)");
+	}
+
+	@Test
+	public void testFilterOnBottomVertices() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph()
+			.filterOnBottomVertices(new FilterFunction<Vertex<Integer, String>>() {
+				@Override
+				public boolean filter(Vertex<Integer, String> value) throws Exception {
+					return !value.getId().equals(1);
+				}
+			});
+
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getBottomVertices().collect(),
+			"(2,bottom2)\n" +
+			"(3,bottom3)");
+
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getEdges().collect(),
+			"(5,2,5-2)\n" +
+			"(6,2,6-2)\n" +
+			"(6,3,6-3)");
+	}
+
+	@Test
+	public void testFilterOnEdges() throws Exception {
+		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph()
+			.filterOnEdges(new FilterFunction<BipartiteEdge<Integer, Integer, String>>() {
+				@Override
+				public boolean filter(BipartiteEdge<Integer, Integer, String> value) throws Exception {
+					return !value.getBottomId().equals(1);
+				}
+			});
+
+		TestBaseUtils.compareResultAsText(bipartiteGraph.getEdges().collect(),
+			"(5,2,5-2)\n" +
+			"(6,2,6-2)\n" +
+			"(6,3,6-3)");
 	}
 
 	@Test
@@ -92,7 +280,6 @@ public class BipartiteGraphTest {
 		BipartiteGraph<Integer, Integer, String, String, String> bipartiteGraph = createBipartiteGraph();
 		Graph<Integer, String, Projection<Integer, String, String, String>> graph = bipartiteGraph.projectionTopFull();
 
-		graph.getEdges().print();
 		compareGraph(graph, "4; 5; 6", "5,4; 4,5; 5,6; 6,5");
 
 		String expected =
@@ -119,8 +306,6 @@ public class BipartiteGraphTest {
 	}
 
 	private BipartiteGraph<Integer, Integer, String, String, String> createBipartiteGraph() {
-		ExecutionEnvironment executionEnvironment = ExecutionEnvironment.createCollectionsEnvironment();
-
 		DataSet<Vertex<Integer, String>> topVertices = executionEnvironment.fromCollection(Arrays.asList(
 			new Vertex<>(4, "top4"),
 			new Vertex<>(5, "top5"),
@@ -142,5 +327,33 @@ public class BipartiteGraphTest {
 		));
 
 		return BipartiteGraph.fromDataSet(topVertices, bottomVertices, edges, executionEnvironment);
+	}
+
+	private static class MapVertex implements MapFunction<Vertex<Integer,String>, String> {
+		@Override
+		public String map(Vertex<Integer, String> value) throws Exception {
+			return value.getValue() + "_mapped";
+		}
+	}
+
+	private static class MapEdge implements MapFunction<BipartiteEdge<Integer, Integer, String>, String> {
+		@Override
+		public String map(BipartiteEdge<Integer, Integer, String> value) throws Exception {
+			return value.getValue() + "_mapped";
+		}
+	}
+
+	private static class AppendVertexFunction implements VertexJoinFunction<String, String> {
+		@Override
+		public String vertexJoin(String vertexValue, String inputValue) throws Exception {
+			return vertexValue + inputValue;
+		}
+	}
+
+	private static class AppendEdgeFunction implements BipartiteEdgeJoinFunction<String, String> {
+		@Override
+        public String edgeJoin(String edgeValue, String inputValue) throws Exception {
+            return edgeValue + inputValue;
+        }
 	}
 }


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed


This PR implements map, filter, subgraph, and join methods for BipartiteGraph. There are few more methods that we can implement, but I think that PR is already too big at this stage.

Do we need to support `translate` methods like `translateTopVertexValues`, `translateTopVertexIds`? If so would it make sense to an interface `BipartiteGraphAlgorithm` and ability to run these algorithms in `BipartiteGraph`?