### PR TITLE
[FLINK-5363] Fire timers when window state is currently empty

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousEventTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousEventTimeTrigger.java
@@ -77,10 +77,11 @@ public class ContinuousEventTimeTrigger<W extends Window> extends Trigger<Object
 			return TriggerResult.FIRE;
 		}
 
-		ReducingState<Long> fireTimestamp = ctx.getPartitionedState(stateDesc);
-		if (fireTimestamp.get().equals(time)) {
-			fireTimestamp.clear();
-			fireTimestamp.add(time + interval);
+		ReducingState<Long> fireTimestampState = ctx.getPartitionedState(stateDesc);
+		Long fireTimestamp = fireTimestampState.get();
+		if (fireTimestamp != null && fireTimestamp.equals(time)) {
+			fireTimestampState.clear();
+			fireTimestampState.add(time + interval);
 			ctx.registerEventTimeTimer(time + interval);
 			return TriggerResult.FIRE;
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -331,6 +331,10 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		context.key = timer.getKey();
 		context.window = timer.getNamespace();
 
+		// Call the trigger early, even if the window is already empty. Some Triggers
+		// might have to clean up state.
+		TriggerResult triggerResult = context.onEventTime(timer.getTimestamp());
+
 		AppendingState<IN, ACC> windowState;
 		MergingWindowSet<W> mergingWindows = null;
 
@@ -357,7 +361,6 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 			return;
 		}
 
-		TriggerResult triggerResult = context.onEventTime(timer.getTimestamp());
 		if (triggerResult.isFire()) {
 			fire(context.window, contents);
 		}
@@ -371,6 +374,10 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	public void onProcessingTime(InternalTimer<K, W> timer) throws Exception {
 		context.key = timer.getKey();
 		context.window = timer.getNamespace();
+
+		// Call the trigger early, even if the window is already empty. Some Triggers
+		// might have to clean up state.
+		TriggerResult triggerResult = context.onProcessingTime(timer.getTimestamp());
 
 		AppendingState<IN, ACC> windowState;
 		MergingWindowSet<W> mergingWindows = null;
@@ -395,7 +402,6 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 			return;
 		}
 
-		TriggerResult triggerResult = context.onProcessingTime(timer.getTimestamp());
 		if (triggerResult.isFire()) {
 			fire(context.window, contents);
 		}


### PR DESCRIPTION
Before this change, when a Trigger sets a timer and that timer fires in
the future at a point when there is currently no data in the window
state, then that timer is being ignored.

This was a problem for some users because they manually set cleanup
timers and they need to be called because the trigger needs to cleanup
some state. (For normal time windows this is not a problem, but for
special cases built on top of GlobalWindows the old behaviour was
leading to problems.)