### PR TITLE
[ FLINK-4905]  Kafka test instability IllegalStateException: Client is not started

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/Kafka08Fetcher.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/Kafka08Fetcher.java
@@ -300,6 +300,10 @@ public class Kafka08Fetcher<T> extends AbstractFetcher<T, TopicAndPartition> {
 					}
 				}
 				while (runningThreads > 0);
+
+				if (periodicCommitter != null) {
+					periodicCommitter.join();
+				}
 			}
 			catch (InterruptedException ignored) {
 				// waiting for the thread shutdown apparently got interrupted
@@ -312,7 +316,14 @@ public class Kafka08Fetcher<T> extends AbstractFetcher<T, TopicAndPartition> {
 			}
 
 			try {
-				zookeeperOffsetHandler.close();
+				//notifyCheckpointComplete can occur during the cancellation
+				// and call commitOffset on closed curatorClient
+				// so use CheckpointLock to close curatorClient.
+				//by contract CheckpointLock must not be null
+				final Object lock = sourceContext.getCheckpointLock();
+				synchronized (lock) {
+					zookeeperOffsetHandler.close();
+				}
 			}
 			catch (Throwable t) {
 				// we catch all here to preserve the original exception


### PR DESCRIPTION
Root cause of the issue: 
`notifyCheckpointComplete` can occur during the cancellation or `runFetchLoop` fail and call `commitOffset` on closed `curatorClient`, so use `CheckpointLock` to close `curatorClient`.
There is a diagram in the jira that describes behaviour of using `Kafka08Fetcher`.

Notes:
1. I don't like approach where `checkPointLock` is leaked into `SourceContext`, this may lead to deadlock.
2. Work with `ZookeeperOffsetHandler` can continue even after the call Kafka08Fetcher.cancel until the `Handler` will not be null.
3. `ZookeeperOffsetHandler` could have `ReadWriteLock` and use `writeLock` only for close operation, but I have doubt, Flink code base does not contain any `ReentrantLocks`. There is possibility to implement such logic without any locks by using lock-free approach.
4. Also in **jdk8**, we have powerful tool `StampedLock`. In which version of Flink we will be able to use **jdk8** features? 
