### PR TITLE
[FLINK-5368] Log msg if kafka topic doesn't have any partitions

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer09.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer09.java
@@ -208,6 +208,9 @@ public class FlinkKafkaConsumer09<T> extends FlinkKafkaConsumerBase<T> {
 				if (partitionsForTopic != null) {
 					partitions.addAll(convertToFlinkKafkaTopicPartition(partitionsForTopic));
 				}
+				else{
+					LOG.info("Unable to retrieve any partitions for the requested topic: {}", topic);
+				}
 			}
 		}
 


### PR DESCRIPTION
As a developer when reading data from many topics, I want Kafka consumer to show something if any topic is not available. 

The motivation is we read many topics as list at one time, and sometimes we fail to recognize that one or two topics' names have been changed or deprecated, and Flink Kafka connector didn't show the error.