### PR TITLE
[FLINK-5390] [yarn] Fix for proper closing input and output streams, in case of errors

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -721,10 +721,10 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			try {
 				File fp = File.createTempFile(appId.toString(), null);
 				fp.deleteOnExit();
-				FileOutputStream input = new FileOutputStream(fp);
-				ObjectOutputStream obInput = new ObjectOutputStream(input);
-				obInput.writeObject(jobGraph);
-				input.close();
+				try (FileOutputStream output = new FileOutputStream(fp);
+					ObjectOutputStream obOutput = new ObjectOutputStream(output);){
+					obOutput.writeObject(jobGraph);
+				}
 				LocalResource jobgraph = Records.newRecord(LocalResource.class);
 				Path remoteJobGraph =
 						Utils.setupLocalResource(fs, appId.toString(), new Path(fp.toURI()), jobgraph, fs.getHomeDirectory());

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkApplicationMasterRunner.java
@@ -53,6 +53,7 @@ import javax.annotation.concurrent.GuardedBy;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 
 /**
@@ -271,10 +272,12 @@ public class YarnFlinkApplicationMasterRunner extends AbstractYarnFlinkApplicati
 		if (jobGraphFile != null) {
 			File fp = new File(jobGraphFile);
 			if (fp.isFile()) {
-				FileInputStream input = new FileInputStream(fp);
-				ObjectInputStream obInput = new ObjectInputStream(input);
-				jg = (JobGraph) obInput.readObject();
-				input.close();
+				try (FileInputStream input = new FileInputStream(fp);
+					ObjectInputStream obInput = new ObjectInputStream(input);) {
+					jg = (JobGraph) obInput.readObject();
+				} catch (IOException e) {
+					LOG.warn("Failed to read job graph file", e);
+				}
 			}
 		}
 		if (jg == null) {


### PR DESCRIPTION
[FLINK-5390] input should be closed in finally block in YarnFlinkApplicationMasterRunner#loadJobGraph()