### PR TITLE
[FLINK-5396] [Build System] flink-dist replace scala version in opt.x…

### DIFF
--- a/tools/change-scala-version.sh
+++ b/tools/change-scala-version.sh
@@ -82,7 +82,11 @@ find "$BASEDIR/flink-dist" -name 'bin.xml' -not -path '*target*' -print \
   -exec bash -c "sed_i 's/\(<source>.*flink-dist\)'$FROM_SUFFIX'/\1'$TO_SUFFIX'/g' {}" \;
 find "$BASEDIR/flink-dist" -name 'bin.xml' -not -path '*target*' -print \
   -exec bash -c "sed_i 's/\(<include>org\.apache\.flink:flink-.*\)'$FROM_SUFFIX'<\/include>/\1'$TO_SUFFIX'<\/include>/g' {}" \;
-
+find "$BASEDIR/flink-dist" -name 'opt.xml' -not -path '*target*' -print \
+  -exec bash -c "sed_i 's/\(<source>\.\.\/flink-.*\)'$FROM_SUFFIX'/\1'$TO_SUFFIX'/g' {}" \;
+find "$BASEDIR/flink-dist" -name 'opt.xml' -not -path '*target*' -print \
+  -exec bash -c "sed_i 's/\(<destName>flink-.*\)'$FROM_SUFFIX'/\1'$TO_SUFFIX'/g' {}" \;
+  
 # fix for shading curator with Scala 2.11
 find "$BASEDIR/flink-runtime" -name 'pom.xml' -not -path '*target*' -print \
      -exec bash -c "sed_i 's/\(<include>org\.apache\.flink:flink-shaded-curator.*\)'$FROM_SUFFIX'<\/include>/\1'$TO_SUFFIX'<\/include>/g' {}" \;


### PR DESCRIPTION
flink-dist have configured for replacing bin.xml, but not opt.xml

- [X] General
  - The pull request references the related JIRA issue ("[FLINK-5396] flink-dist replace scala version in opt.xml by change-scala-version.sh")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [X] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [X] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
