### PR TITLE
[FLINK-5397] Do not replace ObjectStreamClass on deserialization of m…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/migration/util/MigrationInstantiationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/migration/util/MigrationInstantiationUtil.java
@@ -33,25 +33,25 @@ public final class MigrationInstantiationUtil {
 
 	public static class ClassLoaderObjectInputStream extends InstantiationUtil.ClassLoaderObjectInputStream {
 
+		private static final String FLINK_BASE_PACKAGE = "apache.flink.";
+		private static final String FLINK_MIGRATION_PACKAGE = "apache.flink.migration.";
+
 		public ClassLoaderObjectInputStream(InputStream in, ClassLoader classLoader) throws IOException {
 			super(in, classLoader);
 		}
 
 		@Override
-		protected ObjectStreamClass readClassDescriptor()
-				throws IOException, ClassNotFoundException {
-			ObjectStreamClass objectStreamClass = super.readClassDescriptor();
-			String className = objectStreamClass.getName();
-			if (className.contains("apache.flink.")) {
-				className = className.replace("apache.flink.", "apache.flink.migration.");
+		protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+			String className = desc.getName();
+			if (className.contains(FLINK_BASE_PACKAGE)) {
+				className = className.replace(FLINK_BASE_PACKAGE, FLINK_MIGRATION_PACKAGE);
 				try {
-					Class<?> clazz = Class.forName(className, false, classLoader);
-					objectStreamClass = ObjectStreamClass.lookup(clazz);
-				} catch (Exception ignored) {
+					return classLoader != null ? Class.forName(className, false, classLoader) : Class.forName(className);
+				} catch (ClassNotFoundException ignored) {
 
 				}
 			}
-			return objectStreamClass;
+			return super.resolveClass(desc);
 		}
 	}
 	

--- a/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
@@ -59,7 +59,7 @@ public final class InstantiationUtil {
 		}
 
 		@Override
-		public Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+		protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
 			if (classLoader != null) {
 				String name = desc.getName();
 				try {


### PR DESCRIPTION
This PR fixes [FLINK-5397] by not replacing the ObjectStreamClass in ``readClassDescriptor()`` during deserialization of classes that should be replaced from the migration package. Instead, we replace the class directly in ``resolveClass(...)``.