### PR TITLE
[FLINK-5399] Add more information to checkpoint result of TriggerSavepointSuccess

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendSavepointTest.java
@@ -82,7 +82,7 @@ public class CliFrontendSavepointTest {
 
 			String savepointPath = "expectedSavepointPath";
 
-			triggerResponse.success(new TriggerSavepointSuccess(jobId, savepointPath));
+			triggerResponse.success(new TriggerSavepointSuccess(jobId, -1, savepointPath, -1));
 
 			CliFrontend frontend = new MockCliFrontend(
 					CliFrontendTestUtils.getConfigDir(), jobManager);
@@ -214,7 +214,7 @@ public class CliFrontendSavepointTest {
 					any(FiniteDuration.class)))
 					.thenReturn(triggerResponse.future());
 			String savepointPath = "expectedSavepointPath";
-			triggerResponse.success(new TriggerSavepointSuccess(jobId, savepointPath));
+			triggerResponse.success(new TriggerSavepointSuccess(jobId, -1, savepointPath, -1));
 
 			CliFrontend frontend = new MockCliFrontend(
 					CliFrontendTestUtils.getConfigDir(), jobManager);

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -778,7 +778,12 @@ class JobManager(
                   override def apply(success: CompletedCheckpoint, cause: Throwable): Void = {
                     if (success != null) {
                       if (success.getExternalPath != null) {
-                        senderRef ! TriggerSavepointSuccess(jobId, success.getExternalPath)
+                        senderRef ! TriggerSavepointSuccess(
+                          jobId,
+                          success.getCheckpointID,
+                          success.getExternalPath,
+                          success.getTimestamp
+                        )
                       } else {
                         senderRef ! TriggerSavepointFailure(
                           jobId, new Exception("Savepoint has not been persisted."))

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
@@ -494,7 +494,12 @@ object JobManagerMessages {
     * @param jobId The job ID for which the savepoint was triggered.
     * @param savepointPath The path of the savepoint.
     */
-  case class TriggerSavepointSuccess(jobId: JobID, savepointPath: String)
+  case class TriggerSavepointSuccess(
+    jobId: JobID,
+    checkpointId: Long,
+    savepointPath: String,
+    triggerTime: Long
+  )
 
   /**
     * Response after a failed savepoint trigger containing the failure cause.


### PR DESCRIPTION
Add checkpointId and triggerTime to TriggerSavepointSuccess
We can record the history of trigger checkpoint out of Flink System.

- [X] General
  - The pull request references the related JIRA issue ("[FLINK-5399] Add more information to checkpoint result of TriggerSavepointSuccess")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [X] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [X] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
