### PR TITLE
Swap the pattern matching order

### DIFF
--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/nn/QuadTree.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/nn/QuadTree.scala
@@ -102,8 +102,8 @@ class QuadTree(
       }.sum
 
       distMetric match {
-        case _: SquaredEuclideanDistanceMetric => minDist
         case _: EuclideanDistanceMetric => math.sqrt(minDist)
+        case _: SquaredEuclideanDistanceMetric => minDist
         case _ => throw new IllegalArgumentException(s" Error: metric must be" +
           s" Euclidean or SquaredEuclidean!")
       }


### PR DESCRIPTION
Swap the pattern matching order, because `EuclideanDistanceMetric extends SquaredEuclideanDistanceMetric extends DistanceMetric`, otherwise the EuclideanDistance cannot be executed:

```
[WARNING] /Users/fokkodriesprong/Desktop/flink-fokko/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/nn/QuadTree.scala:106: warning: unreachable code
[WARNING]         case _: EuclideanDistanceMetric => math.sqrt(minDist)
[WARNING]                                                     ^
[WARNING] warning: Class org.apache.log4j.Level not found - continuing with a stub.
[WARNING] warning: there were 1 feature warning(s); re-run with -feature for details
[WARNING] three warnings found
```