### PR TITLE
[FLINK-5394] [Table API & SQL]the estimateRowCount method of DataSetCalc didn't work

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkRelBuilder.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkRelBuilder.scala
@@ -27,11 +27,13 @@ import org.apache.calcite.jdbc.CalciteSchema
 import org.apache.calcite.plan._
 import org.apache.calcite.prepare.CalciteCatalogReader
 import org.apache.calcite.rel.logical.LogicalAggregate
+import org.apache.calcite.rel.metadata.{JaninoRelMetadataProvider, RelMetadataQuery}
 import org.apache.calcite.rex.RexBuilder
 import org.apache.calcite.tools.RelBuilder.{AggCall, GroupKey}
 import org.apache.calcite.tools.{FrameworkConfig, RelBuilder}
 import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
 import org.apache.flink.table.expressions.WindowProperty
+import org.apache.flink.table.plan.cost.FlinkDefaultRelMetadataProvider
 import org.apache.flink.table.plan.logical.LogicalWindow
 import org.apache.flink.table.plan.logical.rel.LogicalWindowAggregate
 
@@ -83,6 +85,11 @@ object FlinkRelBuilder {
     planner.setExecutor(config.getExecutor)
     planner.addRelTraitDef(ConventionTraitDef.INSTANCE)
     val cluster = RelOptCluster.create(planner, new RexBuilder(typeFactory))
+    cluster.setMetadataProvider(FlinkDefaultRelMetadataProvider.INSTANCE)
+    // just set metadataProvider is not enough, see
+    // https://www.mail-archive.com/dev@calcite.apache.org/msg00930.html
+    RelMetadataQuery.THREAD_PROVIDERS.set(
+      JaninoRelMetadataProvider.of(cluster.getMetadataProvider))
     val calciteSchema = CalciteSchema.from(config.getDefaultSchema)
     val relOptSchema = new CalciteCatalogReader(
       calciteSchema,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/cost/FlinkDefaultRelMetadataProvider.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/cost/FlinkDefaultRelMetadataProvider.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.cost
+
+import com.google.common.collect.ImmutableList
+import org.apache.calcite.rel.metadata.{ChainedRelMetadataProvider, DefaultRelMetadataProvider, RelMetadataProvider}
+
+object FlinkDefaultRelMetadataProvider {
+    val INSTANCE: RelMetadataProvider = ChainedRelMetadataProvider.of(
+        ImmutableList.of(FlinkRelMdRowCount.SOURCE, DefaultRelMetadataProvider.INSTANCE))
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/cost/FlinkRelMdRowCount.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/cost/FlinkRelMdRowCount.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.cost
+
+import org.apache.calcite.rel.metadata.{ReflectiveRelMetadataProvider, RelMdRowCount, RelMetadataProvider, RelMetadataQuery}
+import org.apache.calcite.util.BuiltInMethod
+import org.apache.flink.table.plan.nodes.dataset.{DataSetCalc, DataSetSort}
+import java.lang.Double
+
+object FlinkRelMdRowCount extends RelMdRowCount {
+
+    val SOURCE: RelMetadataProvider = ReflectiveRelMetadataProvider.reflectiveSource(
+        BuiltInMethod.ROW_COUNT.method, this)
+
+    def getRowCount(rel: DataSetCalc, mq: RelMetadataQuery): Double = rel.estimateRowCount(mq)
+
+    def getRowCount(rel: DataSetSort, mq: RelMetadataQuery) : Double = rel.estimateRowCount(mq)
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetSort.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetSort.scala
@@ -77,10 +77,10 @@ class DataSetSort(
     if (inputRowCnt == null) {
       inputRowCnt
     } else {
-      val rowCount = Math.max(inputRowCnt - limitStart, 0D)
+      val rowCount = (inputRowCnt - limitStart).max(1.0)
       if (fetch != null) {
         val limit = RexLiteral.intValue(fetch)
-        Math.min(limit.toDouble, rowCount)
+        rowCount.min(limit)
       } else {
         rowCount
       }


### PR DESCRIPTION
This pr aims to fix a bug which is referenced by https://issues.apache.org/jira/browse/FLINK-5394.
The main changes including:
1. add FlinkRelMdRowCount and  FlinkDefaultRelMetadataProvider to override getRowCount  of some Flink RelNodes
2. add getRowCount method in DatasetSort to provide more accurate estimate