### PR TITLE
[docs] Clarify restart strategy defaults set by checkpointing

### DIFF
--- a/docs/dev/restart_strategies.md
+++ b/docs/dev/restart_strategies.md
@@ -28,8 +28,9 @@ In case that the job is submitted with a restart strategy, this strategy overrid
 
 The default restart strategy is set via Flink's configuration file `flink-conf.yaml`.
 The configuration parameter *restart-strategy* defines which strategy is taken.
-Per default, the no-restart strategy is used.
-When checkpointing is activated and no restart strategy has been configured, the job will be restarted infinitely often.
+If checkpointing is not enabled, the "no restart" strategy is used.
+If checkpointing is activated and the restart strategy has not been configured, the fixed-delay strategy is used with 
+`Integer.MAX_VALUE` restart attempts.
 See the following list of available restart strategies to learn what values are supported.
 
 Each restart strategy comes with its own set of parameters which control its behaviour.
@@ -111,18 +112,19 @@ restart-strategy: fixed-delay
   </thead>
   <tbody>
     <tr>
-        <td><it>restart-strategy.fixed-delay.attempts</it></td>
+        <td><code>restart-strategy.fixed-delay.attempts</code></td>
         <td>The number of times that Flink retries the execution before the job is declared as failed.</td>
-        <td>1</td>
+        <td>1, or <code>Integer.MAX_VALUE</code> if activated by checkpointing</td>
     </tr>
     <tr>
-        <td><it>restart-strategy.fixed-delay.delay</it></td>
+        <td><code>restart-strategy.fixed-delay.delay</code></td>
         <td>Delaying the retry means that after a failed execution, the re-execution does not start immediately, but only after a certain delay. Delaying the retries can be helpful when the program interacts with external systems where for example connections or pending transactions should reach a timeout before re-execution is attempted.</td>
-        <td><it>akka.ask.timeout</it></td>
+        <td><code>akka.ask.timeout</code>, or 10s if activated by checkpointing</td>
     </tr>
   </tbody>
 </table>
 
+For example:
 ~~~
 restart-strategy.fixed-delay.attempts: 3
 restart-strategy.fixed-delay.delay: 10 s

--- a/docs/dev/state.md
+++ b/docs/dev/state.md
@@ -358,4 +358,5 @@ Please note that records in flight in the loop edges (and the state changes asso
 
 ## Restart Strategies
 
-Flink supports different restart strategies which control how the jobs are restarted in case of a failure. For more information, see [Restart Strategies]({{ site.baseurl }}/dev/restart_strategies).
+Flink supports different restart strategies which control how the jobs are restarted in case of a failure. For more 
+information, see [Restart Strategies]({{ site.baseurl }}/dev/restart_strategies.html).

--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -162,24 +162,27 @@ will be used under the directory specified by jobmanager.web.tmpdir.
 
 - `high-availability.zookeeper.storageDir`: Required for HA. Directory for storing JobManager metadata; this is persisted in the state backend and only a pointer to this state is stored in ZooKeeper. Exactly like the checkpoint directory it must be accessible from the JobManager and a local filesystem should only be used for local deployments. Previously this key was named `recovery.zookeeper.storageDir`.
 
-- `blob.storage.directory`: Directory for storing blobs (such as user jar's) on the TaskManagers.
+- `blob.storage.directory`: Directory for storing blobs (such as user JARs) on the TaskManagers.
 
-- `blob.server.port`: Port definition for the blob server (serving user jar's) on the Taskmanagers. By default the port is set to 0, which means that the operating system is picking an ephemeral port. Flink also accepts a list of ports ("50100,50101"), ranges ("50100-50200") or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple JobManagers are running on the same machine.
+- `blob.server.port`: Port definition for the blob server (serving user JARs) on the TaskManagers. By default the port is set to 0, which means that the operating system is picking an ephemeral port. Flink also accepts a list of ports ("50100,50101"), ranges ("50100-50200") or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple JobManagers are running on the same machine.
 
 - `blob.service.ssl.enabled`: Flag to enable ssl for the blob client/server communication. This is applicable only when the global ssl flag security.ssl.enabled is set to true (DEFAULT: true).
 
-- `restart-strategy`: Default restart strategy to use in case that no restart strategy has been specified for the submitted job.
-Currently, it can be chosen from fixed delay restart strategy, failure rate restart strategy or no restart strategy.
-To use the fixed delay strategy you have to specify "fixed-delay".
-To use the failure rate strategy you have to specify "failure-rate".
-To turn the restart behaviour off you have to specify "none".
-Default value "none".
+- `restart-strategy`: Default [restart strategy]({{site.baseurl}}/dev/restart_strategies.html) to use in case no 
+restart strategy has been specified for the job.
+The options are:
+    - fixed delay strategy: "fixed-delay".
+    - failure rate strategy: "failure-rate".
+    - no restarts: "none"
+
+    Default value is "none" unless checkpointing is enabled for the job in which case the default is "fixed-delay".
 
 - `restart-strategy.fixed-delay.attempts`: Number of restart attempts, used if the default restart strategy is set to "fixed-delay".
-Default value is 1.
+Default value is 1, unless "fixed-delay" was activated by enabling checkpoints, in which case the default is `Integer.MAX_VALUE`.
 
 - `restart-strategy.fixed-delay.delay`: Delay between restart attempts, used if the default restart strategy is set to "fixed-delay".
-Default value is the `akka.ask.timeout`.
+Default value is the `akka.ask.timeout`, unless "fixed-delay" was activated by enabling checkpoints, in which case 
+the default is 10s.
 
 - `restart-strategy.failure-rate.max-failures-per-interval`: Maximum number of restarts in given time interval before failing a job in "failure-rate" strategy.
 Default value is 1.


### PR DESCRIPTION
- Added info about checkpointing changing the default restart
strategy in places where it was missing: the config page and the
section about the fixed-delay strategy
- Replaced no-restart with "no restart" so people don't think we're
 referring to a config value
- Replaced invalid <it> html tag with <code>
- Fixed bad link to restart strategies page from state.md

Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [ ] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
