### PR TITLE
[FLINK-5030] Support hostname verification

### DIFF
--- a/docs/setup/security-ssl.md
+++ b/docs/setup/security-ssl.md
@@ -22,118 +22,184 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-This page provides instructions on how to enable SSL for the network communication between different flink components.
+This page provides instructions on how to enable transport security (SSL) for the network communication between different flink components.
 
 ## SSL Configuration
 
-SSL can be enabled for all network communication between flink components. SSL keystores and truststore has to be deployed on each flink node and configured (conf/flink-conf.yaml) using keys in the security.ssl.* namespace (Please see the [configuration page](config.html) for details). SSL can be selectively enabled/disabled for different transports using the following flags. These flags are only applicable when security.ssl.enabled is set to true.
+SSL can be enabled for all network endpoints within Flink.  All endpoints share a common configuration.  SSL may be disabled for a given endpoint using the corresponding override option.
 
-* **taskmanager.data.ssl.enabled**: SSL flag for data communication between task managers
-* **blob.service.ssl.enabled**: SSL flag for blob service client/server communication
-* **akka.ssl.enabled**: SSL flag for the akka based control connection between the flink client, jobmanager and taskmanager 
-* **jobmanager.web.ssl.enabled**: Flag to enable https access to the jobmanager's web frontend
+See the [Configuration]({{site.baseurl}}/setup/config.html#ssl-settings) page for detailed options.
+
+Here's a summary of each endpoint's SSL features and override option.
+ 
+| Endpoint Name   | Override Option (1)                               | Default  | Trust Verifier (2)  | Hostname Verification |
+|-----------------|----------------------------------------------------|---------|---------------------|-----------------------|
+| Data Exchange   | `taskmanager.data.ssl.enabled`                     | `true`  | Flink               | Optional (3)          |
+| Blob Service    | `blob.service.ssl.enabled`                         | `true`  | Flink               | Optional (3)          |
+| Akka Remoting   | `akka.ssl.enabled`                                 | `true`  | Flink               | Never                 |
+| Web UI          | `jobmanager.web.ssl.enabled`                       | `true`  | Web Browser / Proxy | Always (4)            |
+| Artifact Server | `mesos.resourcemanager.artifactserver.ssl.enabled` | `true`  | Mesos Agent         | Always (4)            |
+
+(1) SSL must be also enabled with `security.ssl.enabled` which defaults to `false`. 
+
+(2) Indicates which process acts as the client who verifies the certificate against a truststore.
+
+(3) Configurable with `security.ssl.verify-hostname` which defaults to `true`.
+
+(4) Verification is performed by an external component (as per truststore location).
+
+## Certificate Requirements
+
+In some deployment modes, all endpoints share a common keystore and rely on a single certificate.  That certificate must be compatible with the configuration; depending on your environment, SSL may need to be disabled for some endpoints, and/or hostname verification disabled.   
+
+### Supporting Trust Verification
+
+The server certificate is verified against a set of trusted certificates as contained in a truststore.   The truststore may contain either the certificate of each node, or simply a common intermediate/CA certificate.
+
+The truststore configured for use by Flink is used for some, but not all, endpoints.   As shown in the column labeled 'trust verifier' in the
+above table, the Web UI and Artifact Server endpoints are accessed by external components, therefore the truststore of those components must be considered.
+
+For example, you may need to disable SSL on the Web UI and Artifact Server endpoints to use a self-signed certificate.
+
+### Supporting Hostname Verification
+
+Hostname verification is a step performed by an SSL client, that checks whether the certificate provided by the server matches the expected hostname of the connection URL.   This check is in addition to normal trust verification.  Use either a certificate containing multiple Subject Alternate Names (SANs) - one for each host - or a wildcard certificate.   A wildcard certificate is ideal for YARN/Mesos environments because the available hosts may change over time.
+
+Flink uses the canonical hostname (i.e. FQDN) for hostname verification purposes.   
 
 ## Deploying Keystores and Truststores
 
-You need to have a Java Keystore generated and copied to each node in the flink cluster. The common name or subject alternative names in the certificate should match the node's hostname and IP address. Keystores and truststores can be generated using the keytool utility (https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html). All flink components should have read access to the keystore and truststore files.
+### Standalone Mode
 
-### Example: Creating self signed CA and keystores for a 2 node cluster
+In local and standalone modes, copy or create a keystore and truststore on each node, and configure the `security.ssl.keystore` and `security.ssl.truststore` paths accordingly. 
 
-Execute the following keytool commands to create a truststore with a self signed CA
-~~~
-keytool -genkeypair -alias ca -keystore ca.keystore -dname "CN=Sample CA" -storepass password -keypass password -keyalg RSA -ext bc=ca:true
-keytool -keystore ca.keystore -storepass password -alias ca -exportcert > ca.cer
-keytool -importcert -keystore ca.truststore -alias ca -storepass password -noprompt -file ca.cer
-~~~
+### YARN Mode
 
-Now create keystores for each node with certificates signed by the above CA. Let node1.company.org and node2.company.org be the hostnames with IPs 192.168.1.1 and 192.168.1.2 respectively
+In YARN deployment mode, the configured paths are interpreted as local paths on each node.  Copy the keystore and truststore to the same location on each node.  Note that the `flink` CLI also uses the configured keystore and truststore.
 
-**Node 1**
-~~~
-keytool -genkeypair -alias node1 -keystore node1.keystore -dname "CN=node1.company.org" -ext SAN=dns:node1.company.org,ip:192.168.1.1 -storepass password -keypass password -keyalg RSA
-keytool -certreq -keystore node1.keystore -storepass password -alias node1 -file node1.csr
-keytool -gencert -keystore ca.keystore -storepass password -alias ca -ext SAN=dns:node1.company.org,ip:192.168.1.1 -infile node1.csr -outfile node1.cer
-keytool -importcert -keystore node1.keystore -storepass password -file ca.cer -alias ca -noprompt
-keytool -importcert -keystore node1.keystore -storepass password -file node1.cer -alias node1 -noprompt
-~~~
+Use the file-shipping functionality of `yarn-session.sh` to automatically copy the keystore and truststore to each node.
 
-**Node 2**
-~~~
-keytool -genkeypair -alias node2 -keystore node2.keystore -dname "CN=node2.company.org" -ext SAN=dns:node2.company.org,ip:192.168.1.2 -storepass password -keypass password -keyalg RSA
-keytool -certreq -keystore node2.keystore -storepass password -alias node2 -file node2.csr
-keytool -gencert -keystore ca.keystore -storepass password -alias ca -ext SAN=dns:node2.company.org,ip:192.168.1.2 -infile node2.csr -outfile node2.cer
-keytool -importcert -keystore node2.keystore -storepass password -file ca.cer -alias ca -noprompt
-keytool -importcert -keystore node2.keystore -storepass password -file node2.cer -alias node2 -noprompt
-~~~
+### Mesos Mode
 
-## Standalone Deployment
-Configure each node in the standalone cluster to pick up the keystore and truststore files present in the local file system.
+In Mesos deployment mode, the Application Master automatically copies the configured keystore and truststore to any TaskManagers that it launches.  It is not possible to  use a different keystore or truststore on each host.
 
-### Example: 2 node cluster
-* Generate 2 keystores, one for each node, and copy them to the filesystem on the respective node. Also copy the pulic key of the CA (which was used to sign the certificates in the keystore) as a Java truststore on both the nodes
-* Configure conf/flink-conf.yaml to pick up these files
+## Examples
 
-#### Node 1
-~~~
-security.ssl.enabled: true
-security.ssl.keystore: /usr/local/node1.keystore
-security.ssl.keystore-password: abc123
-security.ssl.key-password: abc123
-security.ssl.truststore: /usr/local/ca.truststore
-security.ssl.truststore-password: abc123
-~~~
+### Creating a Private Certificate Authority
 
-#### Node 2
-~~~
-security.ssl.enabled: true
-security.ssl.keystore: /usr/local/node2.keystore
-security.ssl.keystore-password: abc123
-security.ssl.key-password: abc123
-security.ssl.truststore: /usr/local/ca.truststore
-security.ssl.truststore-password: abc123
-~~~
+Execute the following keytool commands to create a keystore acting as a private certificate authority.
 
-* Restart the flink components to enable SSL for all of flink's internal communication
-* Verify by accessing the jobmanager's UI using https url. The task manager's path in the UI should show akka.ssl.tcp:// as the protocol
-* The blob server and task manager's data communication can be verified from the log files
+```
+$ keytool -genkeypair -alias ca -keystore ca.keystore -dname "CN=Sample CA" -storepass password -keypass password -keyalg RSA -ext bc=ca:true
+$ keytool -keystore ca.keystore -storepass password -alias ca -exportcert > ca.cer
+$ keytool -importcert -keystore ca.truststore -alias ca -storepass password -noprompt -file ca.cer
+```
 
-## YARN Deployment
-The keystores and truststore can be deployed in a YARN setup in multiple ways depending on the cluster setup. Following are 2 ways to achieve this
+The above produces a keystore (named `ca.keystore`) for signing certificate requests, as shown next.  
 
-### 1. Deploy keystores before starting the YARN session
-The keystores and truststore should be generated and deployed on all nodes in the YARN setup where flink components can potentially be executed. The same flink config file from the flink YARN client is used for all the flink components running in the YARN cluster. Therefore we need to ensure the keystore is deployed and accessible using the same filepath in all the YARN nodes.
+Configure Flink to use the generated truststore (named `ca.truststore`) since it contains the CA public certificate.
 
-#### Example config
+### Creating a Multi-Host Certificate
+
+Execute the following keytool commands to create a certificate containing a Subject Alternate Name (SAN) for each host and signed by the private CA.  Let `node1.example.com` and `node2.example.com` be the hostnames of nodes 1 and 2 respectively.
+
+```
+$ keytool -genkeypair -alias node -keystore node.keystore -dname "CN=example.com" -ext SAN=DNS:node1.example.com,DNS:node2.example.com -storepass password -keypass password -keyalg RSA
+$ keytool -certreq -keystore node.keystore -storepass password -alias node -file node.csr
+$ keytool -gencert -keystore ca.keystore -storepass password -alias ca -ext SAN=DNS:node1.example.com,DNS:node2.example.com -infile node.csr -outfile node.cer
+$ keytool -importcert -keystore node.keystore -storepass password -file ca.cer -alias ca -noprompt
+$ keytool -importcert -keystore node.keystore -storepass password -file node.cer -alias node -noprompt
+```
+
+The above produces a keystore named `node.keystore`.
+
+### Creating a Wildcard Certificate
+
+Execute the following keytool commands to create a wildcard certificate covering all nodes in the cluster and signed by the private CA.  Let `example.com` be the sub-domain of all nodes in the cluster.  Note that SANs aren't used in this scenario.
+
+```
+$ keytool -genkeypair -alias wildcard -keystore wildcard.keystore -dname "CN=*.example.com" -storepass password -keypass password -keyalg RSA
+$ keytool -certreq -keystore wildcard.keystore -storepass password -alias wildcard -file wildcard.csr
+$ keytool -gencert -keystore ca.keystore -storepass password -alias ca -infile wildcard.csr -outfile wildcard.cer
+$ keytool -importcert -keystore wildcard.keystore -storepass password -file ca.cer -alias ca -noprompt
+$ keytool -importcert -keystore wildcard.keystore -storepass password -file wildcard.cer -alias wildcard -noprompt
+```
+
+The above produces a keystore named `wildcard.keystore`.
+
+### Example: Standalone Deployment
+Configure each node in the standalone cluster to pick up the keystore and truststore that you've copied to the local file system.
+
+#### Configuration
 ~~~
 security.ssl.enabled: true
-security.ssl.keystore: /usr/local/node.keystore
-security.ssl.keystore-password: abc123
-security.ssl.key-password: abc123
-security.ssl.truststore: /usr/local/ca.truststore
-security.ssl.truststore-password: abc123
-~~~
-
-Now you can start the YARN session from the CLI like you would normally do.
-
-### 2. Use YARN cli to deploy the keystores and truststore
-We can use the YARN client's ship files option (-yt) to distribute the keystores and truststore. Since the same keystore will be deployed at all nodes, we need to ensure a single certificate in the keystore can be served for all nodes. This can be done by either using the Subject Alternative Name(SAN) extension in the certificate and setting it to cover all nodes (hostname and ip addresses) in the cluster or by using wildcard subdomain names (if the cluster is setup accordingly). 
-
-**Example**
-* Supply the following parameters to the keytool command when generating the keystore: -ext SAN=dns:node1.company.org,ip:192.168.1.1,dns:node2.company.org,ip:192.168.1.2
-* Copy the keystore and the CA's truststore into a local directory (at the cli's working directory), say deploy-keys/
-* Update the configuration to pick up the files from a relative path
-~~~
-security.ssl.enabled: true
-security.ssl.keystore: deploy-keys/node.keystore
+security.ssl.keystore: /etc/node.keystore
 security.ssl.keystore-password: password
 security.ssl.key-password: password
-security.ssl.truststore: deploy-keys/ca.truststore
+security.ssl.truststore: /etc/ca.truststore
 security.ssl.truststore-password: password
 ~~~
-* Start the YARN session using the -yt parameter
-~~~
-flink run -m yarn-cluster -yt deploy-keys/ TestJob.jar
-~~~
 
-When deployed using YARN, flink's web dashboard is accessible through YARN proxy's Tracking URL. To ensure that the YARN proxy is able to access flink's https url you need to configure YARN proxy to accept flink's SSL certificates. Add the custom CA certificate into Java's default trustore on the YARN Proxy node.
+Restart the flink JobManager and TaskManager as necessary.
 
+### Example: YARN Deployment
+The keystore and truststore can be deployed to YARN in numerous ways depending on the cluster setup. Following are 2 ways to achieve this:
+
+#### 1. Deploy keystore/truststore manually to all nodes
+Copy the keystore and truststore to all nodes in the YARN cluster where flink components can potentially be executed. Since the same configuration file is used by all nodes, copy the files to the same path on all nodes.
+
+Now, start the YARN session from the CLI as normal.
+
+#### 2. Use file-shipping to deploy the keystores and truststore
+We can use the Flink client's ship files option (-yt) to distribute the keystore and truststore.  
+
+Copy the keystore and truststore to a directory on the client called `certs/`.  The directory must be within the working directory from where you execute the CLI command.
+
+```
+security.ssl.enabled: true
+security.ssl.keystore: certs/node.keystore
+security.ssl.keystore-password: password
+security.ssl.key-password: password
+security.ssl.truststore: certs/ca.truststore
+security.ssl.truststore-password: password
+```
+
+Start the YARN session using the `-yt` parameter:
+```
+$ flink run -m yarn-cluster -yt certs/ WordCount.jar
+```
+
+When deployed using YARN, Flink's web dashboard is accessible through the YARN UI (via the Tracking URL).   YARN encapsulates the web dashboard behind a proxy 
+whose truststore must contain your CA certificate.  The YARN proxy uses Java's default truststore (see the [JSSE Reference Guide](http://docs.oracle.com/javase/7/docs/technotes/guides/security/jsse/JSSERefGuide.html#X509TrustManager) for details).
+
+## Troubleshooting
+
+### General Suggestions
+
+- Increase Flink's log verbosity.
+- Enable SSL debug information:
+```
+$ export JVM_ARGS=$JVM_ARGS -Djavax.net.debug=ssl
+```
+- Disable hostname verification.
+- Selectively disable SSL on Flink endpoints.
+
+### Specific Issues
+
+##### "Unable to find valid certification path to requested target"
+This message indicates that the keystore certificate could not be validated with the provided truststore.
+
+##### "java.security.cert.CertificateException: No name matching &lt;host&gt; found"
+This message indicates a hostname verification failure.
+
+##### Connection timeout (CLI)
+May indicate a trust verification failure between the CLI and the Job Manager, since Akka silently rejects untrusted connections.
+
+##### Task Manager fails to start (Mesos-only)
+Mesos may be unable to download artifacts from the AppMaster's internal HTTP(s) server.  
+- Look at the `stderr` file in the Mesos task container for fetcher-related errors.
+- Disable SSL on the Artifact Server endpoint.
+
+##### Job fails during execution
+May indicate a hostname verification or other SSL issue within the Netty-based Data Exchange endpoint, since such
+connections are made on-demand during job execution.

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -1208,7 +1208,7 @@ public final class ConfigConstants {
 	
 	// ------------------------- JobManager Web Frontend ----------------------
 
-	/** The config key for the address of the JobManager web frontend. */
+	/** The config key for the bind address of the JobManager web frontend. */
 	public static final ConfigOption<String> DEFAULT_JOB_MANAGER_WEB_FRONTEND_ADDRESS =
 		key("jobmanager.web.address")
 			.noDefaultValue();

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
@@ -206,13 +206,13 @@ public class MesosApplicationMasterRunner {
 		try {
 			// ------- (1) load and parse / validate all configurations -------
 
-			// Note that we use the "appMasterHostname" given by the system, to make sure
+			// Note that we use the "appMasterAddress" given by the system, to make sure
 			// we use the hostnames consistently throughout akka.
 			// for akka "localhost" and "localhost.localdomain" are different actors.
-			final String appMasterHostname = InetAddress.getLocalHost().getHostName();
+			final InetAddress appMasterAddress = InetAddress.getLocalHost();
 
 			// Mesos configuration
-			final MesosConfiguration mesosConfig = createMesosConfig(config, appMasterHostname);
+			final MesosConfiguration mesosConfig = createMesosConfig(config, appMasterAddress);
 
 			// JM configuration
 			int numberProcessors = Hardware.getNumberCPUCores();
@@ -247,7 +247,7 @@ public class MesosApplicationMasterRunner {
 
 			// try to start the actor system, JobManager and JobManager actor system
 			// using the configured address and ports
-			actorSystem = BootstrapTools.startActorSystem(config, appMasterHostname, listeningPort, LOG);
+			actorSystem = BootstrapTools.startActorSystem(config, appMasterAddress.getHostName(), listeningPort, LOG);
 
 			Address address = AkkaUtils.getAddress(actorSystem);
 			final String akkaHostname = address.host().get();
@@ -260,7 +260,7 @@ public class MesosApplicationMasterRunner {
 			final int artifactServerPort = config.getInteger(ConfigConstants.MESOS_ARTIFACT_SERVER_PORT_KEY,
 				ConfigConstants.DEFAULT_MESOS_ARTIFACT_SERVER_PORT);
 			final String artifactServerPrefix = UUID.randomUUID().toString();
-			artifactServer = new MesosArtifactServer(artifactServerPrefix, akkaHostname, artifactServerPort, config);
+			artifactServer = new MesosArtifactServer(artifactServerPrefix, appMasterAddress, artifactServerPort, config);
 
 			// ----------------- (3) Generate the configuration for the TaskManagers -------------------
 
@@ -309,7 +309,7 @@ public class MesosApplicationMasterRunner {
 
 			webMonitor = BootstrapTools.startWebMonitorIfConfigured(config, actorSystem, jobManager, LOG);
 			if(webMonitor != null) {
-				final URL webMonitorURL = new URL("http", appMasterHostname, webMonitor.getServerPort(), "/");
+				final URL webMonitorURL = webMonitor.getServerURL();
 				mesosConfig.frameworkInfo().setWebuiUrl(webMonitorURL.toExternalForm());
 			}
 
@@ -448,10 +448,10 @@ public class MesosApplicationMasterRunner {
 	/**
 	 * Loads and validates the ResourceManager Mesos configuration from the given Flink configuration.
 	 */
-	public static MesosConfiguration createMesosConfig(Configuration flinkConfig, String hostname) {
+	public static MesosConfiguration createMesosConfig(Configuration flinkConfig, InetAddress serverAddress) {
 
 		Protos.FrameworkInfo.Builder frameworkInfo = Protos.FrameworkInfo.newBuilder()
-			.setHostname(hostname);
+			.setHostname(serverAddress.getCanonicalHostName());
 		Protos.Credential.Builder credential = null;
 
 		if(!flinkConfig.containsKey(ConfigConstants.MESOS_MASTER_URL)) {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -78,6 +78,7 @@ import org.apache.flink.runtime.webmonitor.metrics.JobMetricsHandler;
 import org.apache.flink.runtime.webmonitor.metrics.JobVertexMetricsHandler;
 import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
 import org.apache.flink.runtime.webmonitor.metrics.TaskManagerMetricsHandler;
+import org.apache.flink.util.NetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.concurrent.ExecutionContext$;
@@ -89,7 +90,9 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.URL;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
@@ -136,6 +139,8 @@ public class WebRuntimeMonitor implements WebMonitor {
 
 	private Channel serverChannel;
 
+	private final URL serverURL;
+
 	private final File webRootDir;
 
 	private final File uploadDir;
@@ -161,7 +166,12 @@ public class WebRuntimeMonitor implements WebMonitor {
 		
 		final WebMonitorConfig cfg = new WebMonitorConfig(config);
 
-		final String configuredAddress = cfg.getWebFrontendAddress();
+		// determine the web runtime monitor's advertised server address and bind address
+		// the server address is the FQDN of the JM server address
+		final InetAddress jmAddress = InetAddress.getByName(
+			config.getString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, null));
+		final String configuredBindAddress = cfg.getWebFrontendAddress() != null ?
+			cfg.getWebFrontendAddress() : NetUtils.getWildcardIPAddress();
 
 		final int configuredPort = cfg.getWebFrontendPort();
 		if (configuredPort < 0) {
@@ -403,19 +413,15 @@ public class WebRuntimeMonitor implements WebMonitor {
 				.channel(NioServerSocketChannel.class)
 				.childHandler(initializer);
 
-		ChannelFuture ch;
-		if (configuredAddress == null) {
-			ch = this.bootstrap.bind(configuredPort);
-		} else {
-			ch = this.bootstrap.bind(configuredAddress, configuredPort);
-		}
+		ChannelFuture ch = this.bootstrap.bind(configuredBindAddress, configuredPort);
 		this.serverChannel = ch.sync().channel();
 
 		InetSocketAddress bindAddress = (InetSocketAddress) serverChannel.localAddress();
-		String address = bindAddress.getAddress().getHostAddress();
 		int port = bindAddress.getPort();
+		this.serverURL = new URL(
+			serverSSLContext != null ? "https" : "http", jmAddress.getCanonicalHostName(), port, "");
 
-		LOG.info("Web frontend listening at " + address + ':' + port);
+		LOG.info("Web frontend listening at " + serverURL);
 	}
 
 	@Override
@@ -486,6 +492,11 @@ public class WebRuntimeMonitor implements WebMonitor {
 		}
 
 		return -1;
+	}
+
+	@Override
+	public URL getServerURL() {
+		return serverURL;
 	}
 
 	private void cleanup() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -99,11 +99,11 @@ public final class BlobClient implements Closeable {
 			}
 
 			if (clientSSLContext != null) {
-
-				LOG.info("Using ssl connection to the blob server");
+				LOG.info("Using SSL connection to the blob server at {}",
+					serverAddress.getAddress().getCanonicalHostName());
 
 				SSLSocket sslSocket = (SSLSocket) clientSSLContext.getSocketFactory().createSocket(
-					serverAddress.getAddress(),
+					serverAddress.getAddress().getCanonicalHostName(),
 					serverAddress.getPort());
 
 				// Enable hostname verification for remote SSL connections

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
@@ -177,7 +177,7 @@ class NettyClient {
 				// SSL handler should be added first in the pipeline
 				if (clientSSLContext != null) {
 					SSLEngine sslEngine = clientSSLContext.createSSLEngine(
-						serverSocketAddress.getAddress().getHostAddress(),
+						serverSocketAddress.getAddress().getCanonicalHostName(),
 						serverSocketAddress.getPort());
 					sslEngine.setUseClientMode(true);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitor.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.webmonitor;
 
+import java.net.URL;
+
 /**
  * Interface for web monitors. Defines life-cycle methods and properties.
  */
@@ -45,4 +47,9 @@ public interface WebMonitor {
 	 * @return The port where the web server is listening, or -1, if no server is running.
 	 */
 	int getServerPort();
+
+	/**
+	 * Gets the advertised URL that the web server is listening at.
+     */
+	URL getServerURL();
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -32,7 +32,6 @@ import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameter
 import org.apache.flink.runtime.jobmanager.JobManager;
 import org.apache.flink.runtime.jobmanager.MemoryArchivist;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
-import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.runtime.process.ProcessReaper;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.taskmanager.TaskManager;
@@ -352,14 +351,8 @@ public class YarnApplicationMasterRunner {
 			LOG.debug("Starting Web Frontend");
 
 			webMonitor = BootstrapTools.startWebMonitorIfConfigured(config, actorSystem, jobManager, LOG);
-
-			String protocol = "http://";
-			if (config.getBoolean(ConfigConstants.JOB_MANAGER_WEB_SSL_ENABLED,
-				ConfigConstants.DEFAULT_JOB_MANAGER_WEB_SSL_ENABLED) && SSLUtils.getSSLEnabled(config)) {
-				protocol = "https://";
-			}
-			final String webMonitorURL = webMonitor == null ? null :
-				protocol + appMasterHostname + ":" + webMonitor.getServerPort();
+			final String webMonitorURL =
+				webMonitor != null ? webMonitor.getServerURL().toExternalForm() : null;
 
 			// 3: Flink's Yarn ResourceManager
 			LOG.debug("Starting YARN Flink Resource Manager");

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
@@ -214,7 +214,7 @@ public class YarnClusterClient extends ClusterClient {
 	@Override
 	public String getWebInterfaceURL() {
 		// there seems to be a difference between HD 2.2.0 and 2.6.0
-		if(!trackingURL.startsWith("http://")) {
+		if(!trackingURL.startsWith("http://") && !trackingURL.startsWith("https://")) {
 			return "http://" + trackingURL;
 		} else {
 			return trackingURL;


### PR DESCRIPTION
Fixes FLINK-5030

- updated SSL documentation
- use canonical hostname for (netty/blob) client-to-server connections
- ensure that a valid address is advertised for webui (not the bind
address which might be 0.0.0.0)
- improved configuration validation for keystore/truststore
- advertise the FQDN of the AppMaster to Mesos
- improved handling of SSL exceptions due to handshake failure
- incorporate recent changes to JM address configuration
- fix client to accurately report https
