### PR TITLE
[FLINK-5160] [refactor] SecurityUtils use OperatingSystem.getCurrentOperatingSys…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/OperatingSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/util/OperatingSystem.java
@@ -30,6 +30,7 @@ public enum OperatingSystem {
 	WINDOWS,
 	MAC_OS,
 	FREE_BSD,
+	SOLARIS,
 	UNKNOWN;
 	
 	// ------------------------------------------------------------------------
@@ -83,6 +84,16 @@ public enum OperatingSystem {
 	public static boolean isFreeBSD() {
 		return getCurrentOperatingSystem() == FREE_BSD;
 	}
+
+	/**
+	 * Checks whether the operating system this JVM runs on is Solaris.
+	 *
+	 * @return <code>true</code> if the operating system this JVM runs on is
+	 *         Solaris, <code>false</code> otherwise
+	 */
+	public static boolean isSolaris() {
+		return getCurrentOperatingSystem() == SOLARIS;
+	}
 	
 	/**
 	 * The enum constant for the operating system.
@@ -109,6 +120,10 @@ public enum OperatingSystem {
 		}
 		if (osName.startsWith(FREEBSD_OS_PREFIX)) {
 			return FREE_BSD;
+		}
+		String osNameLowerCase = osName.toLowerCase();
+		if (osNameLowerCase.contains(SOLARIS_OS_INFIX_1) || osNameLowerCase.contains(SOLARIS_OS_INFIX_2)) {
+			return SOLARIS;
 		}
 		
 		return UNKNOWN;
@@ -142,4 +157,14 @@ public enum OperatingSystem {
 	 * The expected prefix for FreeBSD.
 	 */
 	private static final String FREEBSD_OS_PREFIX = "FreeBSD";
+
+	/**
+	 * One expected infix for Solaris.
+	 */
+	private static final String SOLARIS_OS_INFIX_1 = "sunos";
+
+	/**
+	 * One expected infix for Solaris.
+	 */
+	private static final String SOLARIS_OS_INFIX_2 = "solaris";
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityUtilsTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.security;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.OperatingSystem;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -77,21 +78,29 @@ public class SecurityUtilsTest {
 
 	private String getOSUserName() throws Exception {
 		String userName = "";
-		String osName = System.getProperty( "os.name" ).toLowerCase();
-		String className = null;
-		String methodName = null;
+		OperatingSystem os = OperatingSystem.getCurrentOperatingSystem();
+		String className;
+		String methodName;
 
-		if( osName.contains( "windows" ) ){
-			className = "com.sun.security.auth.module.NTSystem";
-			methodName = "getName";
-		}
-		else if( osName.contains( "linux" ) || osName.contains( "mac" )  ){
-			className = "com.sun.security.auth.module.UnixSystem";
-			methodName = "getUsername";
-		}
-		else if( osName.contains( "solaris" ) || osName.contains( "sunos" ) ){
-			className = "com.sun.security.auth.module.SolarisSystem";
-			methodName = "getUsername";
+		switch(os) {
+			case LINUX:
+			case MAC_OS:
+				className = "com.sun.security.auth.module.UnixSystem";
+				methodName = "getUsername";
+				break;
+			case WINDOWS:
+				className = "com.sun.security.auth.module.NTSystem";
+				methodName = "getName";
+				break;
+			case SOLARIS:
+				className = "com.sun.security.auth.module.SolarisSystem";
+				methodName = "getUsername";
+				break;
+			case FREE_BSD:
+			case UNKNOWN:
+			default:
+				className = null;
+				methodName = null;
 		}
 
 		if( className != null ){


### PR DESCRIPTION
This is a follow-up refactoring to #2888 proposed by @StephanEwen .

It changes the `SecurityUtils#getOSUserName` method to use no longer parse the OS name itself but instead rely on the `OperatingSystem.getCurrentOperatingSystem` utility method.

The `OperatingSystem` enum had to be extended to include the Solaris OS since the affected code had a branch for it. The parsing for it was simply copied.

