### PR TITLE
[FLINK-5380] Fix task metrics reuse for single-operator chains

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -234,9 +234,9 @@ public class StreamingJobGraphGenerator {
 				config.setChainIndex(chainIndex);
 				config.setOperatorName(streamGraph.getStreamNode(currentNodeId).getOperatorName());
 				chainedConfigs.get(startNodeId).put(currentNodeId, config);
-				if (chainableOutputs.isEmpty()) {
-					config.setChainEnd();
-				}
+			}
+			if (chainableOutputs.isEmpty()) {
+				config.setChainEnd();
 			}
 
 			return transitiveOutEdges;


### PR DESCRIPTION
This PR fixes the chain end detection in the `StreamingJobGraphGenerator`, which fixes the re-use of metrics for tasks consisting of only a single operator, which fixes the display in the WebInterface.

I've also added a test to make sure that chain start and end are set correctly. Before the fix, `assertTrue(sourceConfig.isChainEnd());` would have failed.