### PR TITLE
[Flink-5378] Update Scopt version to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -401,7 +401,7 @@ under the License.
 			<dependency>
 				<groupId>com.github.scopt</groupId>
 				<artifactId>scopt_${scala.binary.version}</artifactId>
-				<version>3.2.0</version>
+				<version>3.5.0</version>
 				<exclusions>
 					<exclusion>
 						<groupId>org.scala-lang</groupId>


### PR DESCRIPTION
This will also allow for using comma-separated values in the CLI.

Note, as per https://github.com/scopt/scopt/releases/tag/v3.5.0 Scopt 3.5.0 introduces two-column rendering for the usage text, which is enabled by default. From my point of view this is even better as it'S more compact and better to read.