### PR TITLE
[FLINK-5421] Explicit restore method in Snapshotable interface

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -28,13 +28,10 @@ import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.util.AbstractID;
-
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
-
 import org.rocksdb.NativeLibraryLoader;
 import org.rocksdb.RocksDB;
 import org.slf4j.Logger;
@@ -46,7 +43,6 @@ import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
@@ -260,39 +256,6 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 				keySerializer,
 				numberOfKeyGroups,
 				keyGroupRange);
-	}
-
-	@Override
-	public <K> AbstractKeyedStateBackend<K> restoreKeyedStateBackend(
-			Environment env,
-			JobID jobID,
-			String operatorIdentifier,
-			TypeSerializer<K> keySerializer,
-			int numberOfKeyGroups,
-			KeyGroupRange keyGroupRange,
-			Collection<KeyGroupsStateHandle> restoredState,
-			TaskKvStateRegistry kvStateRegistry) throws Exception {
-
-		// first, make sure that the RocksDB JNI library is loaded
-		// we do this explicitly here to have better error handling
-		String tempDir = env.getTaskManagerInfo().getTmpDirectories()[0];
-		ensureRocksDBIsLoaded(tempDir);
-
-		lazyInitializeForJob(env, operatorIdentifier);
-
-		File instanceBasePath = new File(getDbPath(), UUID.randomUUID().toString());
-		return new RocksDBKeyedStateBackend<>(
-				jobID,
-				operatorIdentifier,
-				env.getUserClassLoader(),
-				instanceBasePath,
-				getDbOptions(),
-				getColumnOptions(),
-				kvStateRegistry,
-				keySerializer,
-				numberOfKeyGroups,
-				keyGroupRange,
-				restoredState);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
@@ -24,7 +24,6 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 
 import java.io.IOException;
-import java.util.Collection;
 
 /**
  * A state backend defines how state is stored and snapshotted during checkpoints.
@@ -59,41 +58,12 @@ public abstract class AbstractStateBackend implements java.io.Serializable {
 	) throws Exception;
 
 	/**
-	 * Creates a new {@link AbstractKeyedStateBackend} that restores its state from the given list
-	 * {@link KeyGroupsStateHandle KeyGroupStateHandles}.
-	 */
-	public abstract <K> AbstractKeyedStateBackend<K> restoreKeyedStateBackend(
-			Environment env,
-			JobID jobID,
-			String operatorIdentifier,
-			TypeSerializer<K> keySerializer,
-			int numberOfKeyGroups,
-			KeyGroupRange keyGroupRange,
-			Collection<KeyGroupsStateHandle> restoredState,
-			TaskKvStateRegistry kvStateRegistry
-	) throws Exception;
-
-
-	/**
 	 * Creates a new {@link OperatorStateBackend} that can be used for storing partitionable operator
 	 * state in checkpoint streams.
 	 */
 	public OperatorStateBackend createOperatorStateBackend(
 			Environment env,
-			String operatorIdentifier
-	) throws Exception {
+			String operatorIdentifier) throws Exception {
 		return new DefaultOperatorStateBackend(env.getUserClassLoader());
-	}
-
-	/**
-	 * Creates a new {@link OperatorStateBackend} that restores its state from the given collection of
-	 * {@link OperatorStateHandle}.
-	 */
-	public OperatorStateBackend restoreOperatorStateBackend(
-			Environment env,
-			String operatorIdentifier,
-			Collection<OperatorStateHandle> restoreSnapshots
-	) throws Exception {
-		return new DefaultOperatorStateBackend(env.getUserClassLoader(), restoreSnapshots);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/Snapshotable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/Snapshotable.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
+import java.util.Collection;
 import java.util.concurrent.RunnableFuture;
 
 /**
@@ -42,4 +43,12 @@ public interface Snapshotable<S extends StateObject> {
 			long checkpointId,
 			long timestamp,
 			CheckpointStreamFactory streamFactory) throws Exception;
+
+	/**
+	 * Restores state that was previously snapshotted from the provided parameters. Typically the parameters are state
+	 * handles from which the old state is read.
+	 *
+	 * @param state the old state to restore.
+	 */
+	void restore(Collection<S> state) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collection;
 
 /**
  * The file state backend is a state backend that stores the state of streaming jobs in a file system.
@@ -189,25 +187,6 @@ public class FsStateBackend extends AbstractStateBackend {
 				env.getUserClassLoader(),
 				numberOfKeyGroups,
 				keyGroupRange);
-	}
-
-	@Override
-	public <K> AbstractKeyedStateBackend<K> restoreKeyedStateBackend(
-			Environment env,
-			JobID jobID,
-			String operatorIdentifier,
-			TypeSerializer<K> keySerializer,
-			int numberOfKeyGroups,
-			KeyGroupRange keyGroupRange,
-			Collection<KeyGroupsStateHandle> restoredState,
-			TaskKvStateRegistry kvStateRegistry) throws Exception {
-		return new HeapKeyedStateBackend<>(
-				kvStateRegistry,
-				keySerializer,
-				env.getUserClassLoader(),
-				numberOfKeyGroups,
-				keyGroupRange,
-				restoredState);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -101,28 +101,6 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		LOG.info("Initializing heap keyed state backend with stream factory.");
 	}
 
-	public HeapKeyedStateBackend(
-			TaskKvStateRegistry kvStateRegistry,
-			TypeSerializer<K> keySerializer,
-			ClassLoader userCodeClassLoader,
-			int numberOfKeyGroups,
-			KeyGroupRange keyGroupRange,
-			Collection<KeyGroupsStateHandle> restoredState) throws Exception {
-		super(kvStateRegistry, keySerializer, userCodeClassLoader, numberOfKeyGroups, keyGroupRange);
-
-		LOG.info("Initializing heap keyed state backend from snapshot.");
-
-		if (LOG.isDebugEnabled()) {
-			LOG.debug("Restoring snapshot from state handles: {}.", restoredState);
-		}
-
-		if (MigrationUtil.isOldSavepointKeyedState(restoredState)) {
-			restoreOldSavepointKeyedState(restoredState);
-		} else {
-			restorePartitionedState(restoredState);
-		}
-	}
-
 	// ------------------------------------------------------------------------
 	//  state backend operations
 	// ------------------------------------------------------------------------
@@ -248,6 +226,21 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			KeyGroupRangeOffsets offsets = new KeyGroupRangeOffsets(keyGroupRange, keyGroupRangeOffsets);
 			final KeyGroupsStateHandle keyGroupsStateHandle = new KeyGroupsStateHandle(offsets, streamStateHandle);
 			return new DoneFuture<>(keyGroupsStateHandle);
+		}
+	}
+
+	@Override
+	public void restore(Collection<KeyGroupsStateHandle> restoredState) throws Exception {
+		LOG.info("Initializing heap keyed state backend from snapshot.");
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Restoring snapshot from state handles: {}.", restoredState);
+		}
+
+		if (MigrationUtil.isOldSavepointKeyedState(restoredState)) {
+			restoreOldSavepointKeyedState(restoredState);
+		} else {
+			restorePartitionedState(restoredState);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -26,11 +26,9 @@ import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
 
 import java.io.IOException;
-import java.util.Collection;
 
 /**
  * A {@link AbstractStateBackend} that stores all its data and checkpoints in memory and has no
@@ -92,24 +90,4 @@ public class MemoryStateBackend extends AbstractStateBackend {
 				numberOfKeyGroups,
 				keyGroupRange);
 	}
-
-	@Override
-	public <K> AbstractKeyedStateBackend<K> restoreKeyedStateBackend(
-			Environment env, JobID jobID,
-			String operatorIdentifier,
-			TypeSerializer<K> keySerializer,
-			int numberOfKeyGroups,
-			KeyGroupRange keyGroupRange,
-			Collection<KeyGroupsStateHandle> restoredState,
-			TaskKvStateRegistry kvStateRegistry) throws Exception {
-
-		return new HeapKeyedStateBackend<>(
-				kvStateRegistry,
-				keySerializer,
-				env.getUserClassLoader(),
-				numberOfKeyGroups,
-				keyGroupRange,
-				restoredState);
-	}
-
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -45,7 +45,9 @@ public class OperatorStateBackendTest {
 	}
 
 	private OperatorStateBackend createNewOperatorStateBackend() throws Exception {
-		return abstractStateBackend.createOperatorStateBackend(createMockEnvironment(), "test-operator");
+		return abstractStateBackend.createOperatorStateBackend(
+				createMockEnvironment(),
+				"test-operator");
 	}
 
 	@Test
@@ -131,8 +133,11 @@ public class OperatorStateBackendTest {
 
 			operatorStateBackend.dispose();
 
-			operatorStateBackend = abstractStateBackend.restoreOperatorStateBackend(
-					createMockEnvironment(), "testOperator", Collections.singletonList(stateHandle));
+			operatorStateBackend = abstractStateBackend.createOperatorStateBackend(
+					createMockEnvironment(),
+					"testOperator");
+
+			operatorStateBackend.restore(Collections.singletonList(stateHandle));
 
 			assertEquals(2, operatorStateBackend.getRegisteredStateNames().size());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -58,7 +58,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RunnableFuture;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -101,8 +107,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 				keySerializer,
 				numberOfKeyGroups,
 				keyGroupRange,
-				env.getTaskKvStateRegistry())
-;
+				env.getTaskKvStateRegistry());
 	}
 
 	protected <K> AbstractKeyedStateBackend<K> restoreKeyedBackend(TypeSerializer<K> keySerializer, KeyGroupsStateHandle state) throws Exception {
@@ -127,15 +132,21 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			KeyGroupRange keyGroupRange,
 			List<KeyGroupsStateHandle> state,
 			Environment env) throws Exception {
-		return getStateBackend().restoreKeyedStateBackend(
+
+		AbstractKeyedStateBackend<K> backend = getStateBackend().createKeyedStateBackend(
 				env,
 				new JobID(),
 				"test_op",
 				keySerializer,
 				numberOfKeyGroups,
 				keyGroupRange,
-				state,
 				env.getTaskKvStateRegistry());
+
+		if (null != state) {
+			backend.restore(state);
+		}
+
+		return backend;
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
@@ -52,7 +52,6 @@ import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointStreamFactory.CheckpointStateOutputStream;
 import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.OperatorStateCheckpointOutputStream;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.runtime.state.StreamStateHandle;
@@ -64,12 +63,10 @@ import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamFilter;
 import org.apache.flink.util.SerializedValue;
-
 import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.Collection;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
@@ -180,16 +177,6 @@ public class BlockingCheckpointsTest {
 				Environment env, JobID jobID, String operatorIdentifier,
 				TypeSerializer<K> keySerializer, int numberOfKeyGroups,
 				KeyGroupRange keyGroupRange, TaskKvStateRegistry kvStateRegistry) throws Exception {
-
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public <K> AbstractKeyedStateBackend<K> restoreKeyedStateBackend(
-				Environment env, JobID jobID, String operatorIdentifier,
-				TypeSerializer<K> keySerializer, int numberOfKeyGroups,
-				KeyGroupRange keyGroupRange, Collection<KeyGroupsStateHandle> restoredState,
-				TaskKvStateRegistry kvStateRegistry) throws Exception {
 
 			throw new UnsupportedOperationException();
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -138,12 +138,10 @@ public class InterruptSensitiveRestoreTest {
 		switch (mode) {
 			case OPERATOR_MANAGED:
 			case OPERATOR_RAW:
-				cfg.setStreamOperator(new StreamSource<>(new TestSourceOperator()));
-				break;
 			case KEYED_MANAGED:
 			case KEYED_RAW:
 				cfg.setStateKeySerializer(IntSerializer.INSTANCE);
-				cfg.setStreamOperator(new StreamSource<>(new TestSourceKeyed()));
+				cfg.setStreamOperator(new StreamSource<>(new TestSource()));
 				break;
 			case LEGACY:
 				cfg.setStreamOperator(new StreamSource<>(new TestSourceLegacy()));
@@ -369,7 +367,7 @@ public class InterruptSensitiveRestoreTest {
 		}
 	}
 
-	private static class TestSourceOperator implements SourceFunction<Object>, CheckpointedFunction {
+	private static class TestSource implements SourceFunction<Object>, CheckpointedFunction {
 		private static final long serialVersionUID = 1L;
 
 		@Override
@@ -389,29 +387,6 @@ public class InterruptSensitiveRestoreTest {
 		@Override
 		public void initializeState(FunctionInitializationContext context) throws Exception {
 			((StateInitializationContext)context).getRawOperatorStateInputs().iterator().next().getStream().read();
-		}
-	}
-
-	private static class TestSourceKeyed implements SourceFunction<Object>, CheckpointedFunction {
-		private static final long serialVersionUID = 1L;
-
-		@Override
-		public void run(SourceContext<Object> ctx) throws Exception {
-			fail("should never be called");
-		}
-
-		@Override
-		public void cancel() {}
-
-
-		@Override
-		public void snapshotState(FunctionSnapshotContext context) throws Exception {
-			fail("should never be called");
-		}
-
-		@Override
-		public void initializeState(FunctionInitializationContext context) throws Exception {
-			((StateInitializationContext)context).getRawKeyedStateInputs().iterator().next().getStream().read();
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.testutils.OneShotLatch;
@@ -44,8 +45,14 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.testutils.UnregisteredTaskMetricsGroup;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.ChainedStateHandle;
+import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TaskStateHandles;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
@@ -55,11 +62,11 @@ import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.util.SerializedValue;
-
 import org.junit.Test;
 
 import java.io.EOFException;
@@ -68,7 +75,9 @@ import java.io.Serializable;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executor;
 
 import static org.junit.Assert.assertEquals;
@@ -89,17 +98,63 @@ public class InterruptSensitiveRestoreTest {
 
 	private static final OneShotLatch IN_RESTORE_LATCH = new OneShotLatch();
 
-	@Test
-	public void testRestoreWithInterrupt() throws Exception {
+	private static final int OPERATOR_MANAGED = 0;
+	private static final int OPERATOR_RAW = 1;
+	private static final int KEYED_MANAGED = 2;
+	private static final int KEYED_RAW = 3;
+	private static final int LEGACY = 4;
 
+	@Test
+	public void testRestoreWithInterruptLegacy() throws Exception {
+		testRestoreWithInterrupt(LEGACY);
+	}
+
+	@Test
+	public void testRestoreWithInterruptOperatorManaged() throws Exception {
+		testRestoreWithInterrupt(OPERATOR_MANAGED);
+	}
+
+	@Test
+	public void testRestoreWithInterruptOperatorRaw() throws Exception {
+		testRestoreWithInterrupt(OPERATOR_RAW);
+	}
+
+	@Test
+	public void testRestoreWithInterruptKeyedManaged() throws Exception {
+		testRestoreWithInterrupt(KEYED_MANAGED);
+	}
+
+	@Test
+	public void testRestoreWithInterruptKeyedRaw() throws Exception {
+		testRestoreWithInterrupt(KEYED_RAW);
+	}
+
+	private void testRestoreWithInterrupt(int mode) throws Exception {
+
+		IN_RESTORE_LATCH.reset();
 		Configuration taskConfig = new Configuration();
 		StreamConfig cfg = new StreamConfig(taskConfig);
 		cfg.setTimeCharacteristic(TimeCharacteristic.ProcessingTime);
-		cfg.setStreamOperator(new StreamSource<>(new TestSource()));
+		switch (mode) {
+			case OPERATOR_MANAGED:
+			case OPERATOR_RAW:
+				cfg.setStreamOperator(new StreamSource<>(new TestSourceOperator()));
+				break;
+			case KEYED_MANAGED:
+			case KEYED_RAW:
+				cfg.setStateKeySerializer(IntSerializer.INSTANCE);
+				cfg.setStreamOperator(new StreamSource<>(new TestSourceKeyed()));
+				break;
+			case LEGACY:
+				cfg.setStreamOperator(new StreamSource<>(new TestSourceLegacy()));
+				break;
+			default:
+				throw new IllegalArgumentException();
+		}
 
 		StreamStateHandle lockingHandle = new InterruptLockingStateHandle();
 
-		Task task = createTask(taskConfig, lockingHandle);
+		Task task = createTask(taskConfig, lockingHandle, mode);
 
 		// start the task and wait until it is in "restore"
 		task.startTaskThread();
@@ -124,17 +179,50 @@ public class InterruptSensitiveRestoreTest {
 
 	private static Task createTask(
 			Configuration taskConfig,
-			StreamStateHandle state) throws IOException {
+			StreamStateHandle state,
+			int mode) throws IOException {
 
 		NetworkEnvironment networkEnvironment = mock(NetworkEnvironment.class);
 		when(networkEnvironment.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class)))
 				.thenReturn(mock(TaskKvStateRegistry.class));
 
-		ChainedStateHandle<StreamStateHandle> operatorState = new ChainedStateHandle<>(Collections.singletonList(state));
+
+		ChainedStateHandle<StreamStateHandle> operatorState = null;
 		List<KeyGroupsStateHandle> keyGroupStateFromBackend = Collections.emptyList();
 		List<KeyGroupsStateHandle> keyGroupStateFromStream = Collections.emptyList();
 		List<Collection<OperatorStateHandle>> operatorStateBackend = Collections.emptyList();
 		List<Collection<OperatorStateHandle>> operatorStateStream = Collections.emptyList();
+
+		Map<String, long[]> operatorStateMetadata = new HashMap<>(1);
+		operatorStateMetadata.put(DefaultOperatorStateBackend.DEFAULT_OPERATOR_STATE_NAME, new long[]{0});
+
+		KeyGroupRangeOffsets keyGroupRangeOffsets = new KeyGroupRangeOffsets(new KeyGroupRange(0,0));
+
+		Collection<OperatorStateHandle> operatorStateHandles =
+				Collections.singletonList(new OperatorStateHandle(operatorStateMetadata, state));
+
+		List<KeyGroupsStateHandle> keyGroupsStateHandles =
+				Collections.singletonList(new KeyGroupsStateHandle(keyGroupRangeOffsets, state));
+
+		switch (mode) {
+			case OPERATOR_MANAGED:
+				operatorStateBackend = Collections.singletonList(operatorStateHandles);
+				break;
+			case OPERATOR_RAW:
+				operatorStateStream = Collections.singletonList(operatorStateHandles);
+				break;
+			case KEYED_MANAGED:
+				keyGroupStateFromBackend = keyGroupsStateHandles;
+				break;
+			case KEYED_RAW:
+				keyGroupStateFromStream = keyGroupsStateHandles;
+				break;
+			case LEGACY:
+				operatorState = new ChainedStateHandle<>(Collections.singletonList(state));
+				break;
+			default:
+				throw new IllegalArgumentException();
+		}
 
 		TaskStateHandles taskStateHandles = new TaskStateHandles(
 			operatorState,
@@ -258,7 +346,7 @@ public class InterruptSensitiveRestoreTest {
 
 	// ------------------------------------------------------------------------
 
-	private static class TestSource implements SourceFunction<Object>, Checkpointed<Serializable> {
+	private static class TestSourceLegacy implements SourceFunction<Object>, Checkpointed<Serializable> {
 		private static final long serialVersionUID = 1L;
 
 		@Override
@@ -278,6 +366,52 @@ public class InterruptSensitiveRestoreTest {
 		@Override
 		public void restoreState(Serializable state) throws Exception {
 			fail("should never be called");
+		}
+	}
+
+	private static class TestSourceOperator implements SourceFunction<Object>, CheckpointedFunction {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void run(SourceContext<Object> ctx) throws Exception {
+			fail("should never be called");
+		}
+
+		@Override
+		public void cancel() {}
+
+
+		@Override
+		public void snapshotState(FunctionSnapshotContext context) throws Exception {
+			fail("should never be called");
+		}
+
+		@Override
+		public void initializeState(FunctionInitializationContext context) throws Exception {
+			((StateInitializationContext)context).getRawOperatorStateInputs().iterator().next().getStream().read();
+		}
+	}
+
+	private static class TestSourceKeyed implements SourceFunction<Object>, CheckpointedFunction {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void run(SourceContext<Object> ctx) throws Exception {
+			fail("should never be called");
+		}
+
+		@Override
+		public void cancel() {}
+
+
+		@Override
+		public void snapshotState(FunctionSnapshotContext context) throws Exception {
+			fail("should never be called");
+		}
+
+		@Override
+		public void initializeState(FunctionInitializationContext context) throws Exception {
+			((StateInitializationContext)context).getRawKeyedStateInputs().iterator().next().getStream().read();
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -192,12 +192,17 @@ public class AbstractStreamOperatorTestHarness<OUT> {
 					final StreamOperator<?> operator = (StreamOperator<?>) invocationOnMock.getArguments()[0];
 					final Collection<OperatorStateHandle> stateHandles = (Collection<OperatorStateHandle>) invocationOnMock.getArguments()[1];
 					OperatorStateBackend osb;
-					if (null == stateHandles) {
-						osb = stateBackend.createOperatorStateBackend(environment, operator.getClass().getSimpleName());
-					} else {
-						osb = stateBackend.restoreOperatorStateBackend(environment, operator.getClass().getSimpleName(), stateHandles);
-					}
+
+					osb = stateBackend.createOperatorStateBackend(
+							environment,
+							operator.getClass().getSimpleName());
+
 					mockTask.getCancelables().registerClosable(osb);
+
+					if (null != stateHandles) {
+						osb.restore(stateHandles);
+					}
+
 					return osb;
 				}
 			}).when(mockTask).createOperatorStateBackend(any(StreamOperator.class), any(Collection.class));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/KeyedOneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/KeyedOneInputStreamOperatorTestHarness.java
@@ -100,33 +100,24 @@ public class KeyedOneInputStreamOperatorTestHarness<K, IN, OUT>
 					final int numberOfKeyGroups = (Integer) invocationOnMock.getArguments()[1];
 					final KeyGroupRange keyGroupRange = (KeyGroupRange) invocationOnMock.getArguments()[2];
 
-					if(keyedStateBackend != null) {
+					if (keyedStateBackend != null) {
 						keyedStateBackend.dispose();
 					}
 
-					if (restoredKeyedState == null) {
-						keyedStateBackend = stateBackend.createKeyedStateBackend(
-								mockTask.getEnvironment(),
-								new JobID(),
-								"test_op",
-								keySerializer,
-								numberOfKeyGroups,
-								keyGroupRange,
-								mockTask.getEnvironment().getTaskKvStateRegistry());
-						return keyedStateBackend;
-					} else {
-						keyedStateBackend = stateBackend.restoreKeyedStateBackend(
-								mockTask.getEnvironment(),
-								new JobID(),
-								"test_op",
-								keySerializer,
-								numberOfKeyGroups,
-								keyGroupRange,
-								restoredKeyedState,
-								mockTask.getEnvironment().getTaskKvStateRegistry());
-						restoredKeyedState = null;
-						return keyedStateBackend;
+					keyedStateBackend = stateBackend.createKeyedStateBackend(
+							mockTask.getEnvironment(),
+							new JobID(),
+							"test_op",
+							keySerializer,
+							numberOfKeyGroups,
+							keyGroupRange,
+							mockTask.getEnvironment().getTaskKvStateRegistry());
+
+					if (restoredKeyedState != null) {
+						keyedStateBackend.restore(restoredKeyedState);
 					}
+
+					return keyedStateBackend;
 				}
 			}).when(mockTask).createKeyedStateBackend(any(TypeSerializer.class), anyInt(), any(KeyGroupRange.class));
 		} catch (Exception e) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/KeyedTwoInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/KeyedTwoInputStreamOperatorTestHarness.java
@@ -94,29 +94,18 @@ public class KeyedTwoInputStreamOperatorTestHarness<K, IN1, IN2, OUT>
 						keyedStateBackend.close();
 					}
 
-					if (restoredKeyedState == null) {
-						keyedStateBackend = stateBackend.createKeyedStateBackend(
-								mockTask.getEnvironment(),
-								new JobID(),
-								"test_op",
-								keySerializer,
-								numberOfKeyGroups,
-								keyGroupRange,
-								mockTask.getEnvironment().getTaskKvStateRegistry());
-						return keyedStateBackend;
-					} else {
-						keyedStateBackend = stateBackend.restoreKeyedStateBackend(
-								mockTask.getEnvironment(),
-								new JobID(),
-								"test_op",
-								keySerializer,
-								numberOfKeyGroups,
-								keyGroupRange,
-								restoredKeyedState,
-								mockTask.getEnvironment().getTaskKvStateRegistry());
-						restoredKeyedState = null;
-						return keyedStateBackend;
+					keyedStateBackend = stateBackend.createKeyedStateBackend(
+							mockTask.getEnvironment(),
+							new JobID(),
+							"test_op",
+							keySerializer,
+							numberOfKeyGroups,
+							keyGroupRange,
+							mockTask.getEnvironment().getTaskKvStateRegistry());
+					if (restoredKeyedState != null) {
+						keyedStateBackend.restore(restoredKeyedState);
 					}
+					return keyedStateBackend;
 				}
 			}).when(mockTask).createKeyedStateBackend(any(TypeSerializer.class), anyInt(), any(KeyGroupRange.class));
 		} catch (Exception e) {

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
@@ -32,13 +32,11 @@ import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Collection;
 
 import static org.junit.Assert.fail;
 
@@ -107,19 +105,6 @@ public class StateBackendITCase extends StreamingMultipleProgramsTestBase {
 				TypeSerializer<K> keySerializer,
 				int numberOfKeyGroups,
 				KeyGroupRange keyGroupRange,
-				TaskKvStateRegistry kvStateRegistry) throws Exception {
-			throw new SuccessException();
-		}
-
-		@Override
-		public <K> AbstractKeyedStateBackend<K> restoreKeyedStateBackend(
-				Environment env,
-				JobID jobID,
-				String operatorIdentifier,
-				TypeSerializer<K> keySerializer,
-				int numberOfKeyGroups,
-				KeyGroupRange keyGroupRange,
-				Collection<KeyGroupsStateHandle> restoredState,
 				TaskKvStateRegistry kvStateRegistry) throws Exception {
 			throw new SuccessException();
 		}


### PR DESCRIPTION
This PR introduces an explicit ``restore(...)`` method to match the ``snapshot(...)`` method in this interface.

Currently, restore happens implicitly in backends, i.e. when state handles are provided, backends execute restore logic in their constructors. This behaviour makes it hard for backends to participate in the task's lifecycle through ``CloseableRegistry``}, because we can only register backend objects after they have been constructed. As a result, for example, all restore operations that happen in the constructor are not responsive to cancelation.

This PR introduces an explicit restore, we can first create a backend object, then register it, and only then run restore.