### PR TITLE
[FLINK-5355] Handle AmazonKinesisException gracefully in Kinesis Streaming Connector

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -17,13 +17,13 @@
 
 package org.apache.flink.streaming.connectors.kinesis.proxy;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.kinesis.AmazonKinesisClient;
 import com.amazonaws.services.kinesis.model.DescribeStreamRequest;
 import com.amazonaws.services.kinesis.model.DescribeStreamResult;
 import com.amazonaws.services.kinesis.model.GetRecordsRequest;
 import com.amazonaws.services.kinesis.model.GetRecordsResult;
 import com.amazonaws.services.kinesis.model.GetShardIteratorResult;
-import com.amazonaws.services.kinesis.model.ProvisionedThroughputExceededException;
 import com.amazonaws.services.kinesis.model.LimitExceededException;
 import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
 import com.amazonaws.services.kinesis.model.StreamStatus;
@@ -193,11 +193,11 @@ public class KinesisProxy implements KinesisProxyInterface {
 		while (attempt <= getRecordsMaxAttempts && getRecordsResult == null) {
 			try {
 				getRecordsResult = kinesisClient.getRecords(getRecordsRequest);
-			} catch (ProvisionedThroughputExceededException ex) {
+			} catch (AmazonServiceException ex) {
 				long backoffMillis = fullJitterBackoff(
 					getRecordsBaseBackoffMillis, getRecordsMaxBackoffMillis, getRecordsExpConstant, attempt++);
-				LOG.warn("Got ProvisionedThroughputExceededException. Backing off for "
-					+ backoffMillis + " millis.");
+				LOG.warn("Got AmazonServiceException. Backing off for "
+					+ backoffMillis + " millis (" + ex.getErrorMessage() + ")");
 				Thread.sleep(backoffMillis);
 			}
 		}
@@ -237,11 +237,11 @@ public class KinesisProxy implements KinesisProxyInterface {
 			try {
 				getShardIteratorResult =
 					kinesisClient.getShardIterator(shard.getStreamName(), shard.getShard().getShardId(), shardIteratorType, startingSeqNum);
-			} catch (ProvisionedThroughputExceededException ex) {
+			} catch (AmazonServiceException ex) {
 				long backoffMillis = fullJitterBackoff(
 					getShardIteratorBaseBackoffMillis, getShardIteratorMaxBackoffMillis, getShardIteratorExpConstant, attempt++);
-				LOG.warn("Got ProvisionedThroughputExceededException. Backing off for "
-					+ backoffMillis + " millis.");
+				LOG.warn("Got AmazonServiceException. Backing off for "
+					+ backoffMillis + " millis (" + ex.getErrorMessage() + ")");
 				Thread.sleep(backoffMillis);
 			}
 		}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -272,15 +272,17 @@ public class KinesisProxy implements KinesisProxyInterface {
 	 *         <code>false</code>
 	 */
 	protected static boolean isRecoverableException(AmazonServiceException ex) {
-		if (ex.getErrorType() == null)
+		if (ex.getErrorType() == null) {
 			return false;
+		}
 
 		switch (ex.getErrorType()) {
 		case Client:
-			if (ex instanceof ProvisionedThroughputExceededException)
+			if (ex instanceof ProvisionedThroughputExceededException) {
 				return true;
-			else
+			} else {
 				return false;
+			}
 		case Service:
 		case Unknown:
 			return true;

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -263,11 +263,9 @@ public class KinesisProxy implements KinesisProxyInterface {
 	}
 
 	/**
-	 * Determines whether the exception can be recovered from using
-	 * exponential-backoff
+	 * Determines whether the exception is recoverable using exponential-backoff.
 	 * 
-	 * @param ex
-	 *            Exception to inspect
+	 * @param ex Exception to inspect
 	 * @return <code>true</code> if the exception can be recovered from, else
 	 *         <code>false</code>
 	 */
@@ -277,17 +275,13 @@ public class KinesisProxy implements KinesisProxyInterface {
 		}
 
 		switch (ex.getErrorType()) {
-		case Client:
-			if (ex instanceof ProvisionedThroughputExceededException) {
+			case Client:
+				return ex instanceof ProvisionedThroughputExceededException;
+			case Service:
+			case Unknown:
 				return true;
-			} else {
+			default:
 				return false;
-			}
-		case Service:
-		case Unknown:
-			return true;
-		default:
-			return false;
 		}
 	}
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
@@ -1,0 +1,49 @@
+/**
+ * 
+ */
+package org.apache.flink.streaming.connectors.kinesis.proxy;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.AmazonServiceException.ErrorType;
+import com.amazonaws.services.kinesis.model.ExpiredIteratorException;
+import com.amazonaws.services.kinesis.model.ProvisionedThroughputExceededException;
+
+/**
+ * Test for methods in the KinesisProxy class.
+ * 
+ */
+public class KinesisProxyTest {
+
+	@Test
+	public void testIsRecoverableExceptionWithProvisionedThroughputExceeded() {
+		final ProvisionedThroughputExceededException ex = new ProvisionedThroughputExceededException("asdf");
+		ex.setErrorType(ErrorType.Client);
+		assertTrue(KinesisProxy.isRecoverableException(ex));
+	}
+
+	@Test
+	public void testIsRecoverableExceptionWithServiceException() {
+		final AmazonServiceException ex = new AmazonServiceException("asdf");
+		ex.setErrorType(ErrorType.Service);
+		assertTrue(KinesisProxy.isRecoverableException(ex));
+	}
+
+	@Test
+	public void testIsRecoverableExceptionWithExpiredIteratorException() {
+		final ExpiredIteratorException ex = new ExpiredIteratorException("asdf");
+		ex.setErrorType(ErrorType.Client);
+		assertFalse(KinesisProxy.isRecoverableException(ex));
+	}
+
+	@Test
+	public void testIsRecoverableExceptionWithNullErrorType() {
+		final AmazonServiceException ex = new AmazonServiceException("asdf");
+		ex.setErrorType(null);
+		assertFalse(KinesisProxy.isRecoverableException(ex));
+	}
+
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
@@ -17,7 +17,8 @@
 
 package org.apache.flink.streaming.connectors.kinesis.proxy;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
 
@@ -27,8 +28,7 @@ import com.amazonaws.services.kinesis.model.ExpiredIteratorException;
 import com.amazonaws.services.kinesis.model.ProvisionedThroughputExceededException;
 
 /**
- * Test for methods in the KinesisProxy class.
- * 
+ * Test for methods in the {@link KinesisProxy} class.
  */
 public class KinesisProxyTest {
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
@@ -1,6 +1,20 @@
-/**
- * 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package org.apache.flink.streaming.connectors.kinesis.proxy;
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
My Flink job that consumes from a Kinesis stream must be restarted at least once daily due to an uncaught AmazonKinesisException when reading from Kinesis. The complete stacktrace looks like:

```
com.amazonaws.services.kinesis.model.AmazonKinesisException: null (Service: AmazonKinesis; Status Code: 500; Error Code: InternalFailure; Request ID: dc1b7a1a-1b97-1a32-8cd5-79a896a55223)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1545)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1183)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:964)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:676)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:650)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:633)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$300(AmazonHttpClient.java:601)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:583)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:447)
	at com.amazonaws.services.kinesis.AmazonKinesisClient.doInvoke(AmazonKinesisClient.java:1747)
	at com.amazonaws.services.kinesis.AmazonKinesisClient.invoke(AmazonKinesisClient.java:1723)
	at com.amazonaws.services.kinesis.AmazonKinesisClient.getRecords(AmazonKinesisClient.java:858)
	at org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxy.getRecords(KinesisProxy.java:193)
	at org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumer.getRecords(ShardConsumer.java:268)
	at org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumer.run(ShardConsumer.java:176)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```
It's interesting that the Kinesis endpoint returned a 500 status code, but that's outside the scope of this issue.

I think we can handle this exception in the same manner as a ProvisionedThroughputException: performing an exponential backoff and retrying a finite number of times before throwing an exception.