### PR TITLE
[FLINK-2662] [optimizer] Fix translation of broadcasted unions.

### DIFF
--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/BinaryUnionOpDescriptor.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/operators/BinaryUnionOpDescriptor.java
@@ -97,6 +97,10 @@ public class BinaryUnionOpDescriptor extends OperatorDescriptorDual {
 					in2.getPartitioning() == PartitioningProperty.FORCED_REBALANCED) {
 			newProps.setForcedRebalanced();
 		}
+		else if (in1.getPartitioning() == PartitioningProperty.FULL_REPLICATION &&
+			in2.getPartitioning() == PartitioningProperty.FULL_REPLICATION) {
+			newProps.setFullyReplicated();
+		}
 
 		return newProps;
 	}


### PR DESCRIPTION
Fix optimizer to support union with > 2 broadcasted inputs.

1. `BinaryUnionDescriptor` is changed to compute fully replicated global property if both inputs are fully replicated.
2. Enumeration of plans for binary union is changed to enforce local forward connection if input is fully replicated.
3. Add a test to check that union with three inputs can be on broadcasted side of join (fully replicated property is requested and pushed to all inputs of the union).