### PR TITLE
[FLINK-5178] allow BlobCache to use a distributed file system irrespective of the HA mode

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -273,6 +273,12 @@ The following parameters configure Flink's JobManager and TaskManagers.
 
 - `task.cancellation-interval`: Time interval between two successive task cancellation attempts in milliseconds (DEFAULT: **30000**).
 
+- `high-availability.storageDir`: Even if not configured for High Availability (HA)
+as mentioned below, this parameter may be used if a distributed file system is
+available to be used instead of serving BLOBs from the blob server only. We may
+thus leverage from the load balancing by the distributed file system.
+Also see the [High Availability (HA)](#high-availability-ha) section below.
+
 ### Distributed Coordination (via Akka)
 
 - `akka.ask.timeout`: Timeout used for all futures and blocking Akka calls. If Flink fails due to timeouts then you should try to increase this value. Timeouts can be caused by slow machines or a congested network. The timeout value requires a time-unit specifier (ms/s/min/h/d) (DEFAULT: **10 s**).

--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -486,13 +486,13 @@ Previously this key was named `recovery.mode` and the default value was `standal
 
 - `high-availability.zookeeper.path.root`: (Default `/flink`) Defines the root dir under which the ZooKeeper HA mode will create namespace directories. Previously this ket was named `recovery.zookeeper.path.root`.
 
-- `high-availability.zookeeper.path.namespace`: (Default `/default_ns` in standalone cluster mode, or the <yarn-application-id> under YARN) Defines the subdirectory under the root dir where the ZooKeeper HA mode will create znodes. This allows to isolate multiple applications on the same ZooKeeper. Previously this key was named `recovery.zookeeper.path.namespace`.
+- `high-availability.cluster-id`: (Default `/default_ns` in standalone cluster mode, or the <yarn-application-id> under YARN) Defines the subdirectory under the root dir where the ZooKeeper HA mode will create znodes. This allows to isolate multiple applications on the same ZooKeeper. Previously this key was named `recovery.zookeeper.path.namespace` and `high-availability.zookeeper.path.namespace`.
 
 - `high-availability.zookeeper.path.latch`: (Default `/leaderlatch`) Defines the znode of the leader latch which is used to elect the leader. Previously this key was named `recovery.zookeeper.path.latch`.
 
 - `high-availability.zookeeper.path.leader`: (Default `/leader`) Defines the znode of the leader which contains the URL to the leader and the current leader session ID. Previously this key was named `recovery.zookeeper.path.leader`.
 
-- `high-availability.zookeeper.storageDir`: Defines the directory in the state backend where the JobManager metadata will be stored (ZooKeeper only keeps pointers to it). Required for HA. Previously this key was named `recovery.zookeeper.storageDir`.
+- `high-availability.storageDir`: Defines the directory in the state backend where the JobManager metadata will be stored (ZooKeeper only keeps pointers to it). Required for HA. Previously this key was named `recovery.zookeeper.storageDir` and `high-availability.zookeeper.storageDir`.
 
 - `high-availability.zookeeper.client.session-timeout`: (Default `60000`) Defines the session timeout for the ZooKeeper session in ms. Previously this key was named `recovery.zookeeper.client.session-timeout`
 

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
@@ -29,7 +29,7 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.examples.java.wordcount.WordCount;
-import org.apache.flink.runtime.blob.BlobRecoveryITCase;
+import org.apache.flink.runtime.blob.BlobRecoveryITCaseHA;
 import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.util.FileUtils;
@@ -233,7 +233,7 @@ public class HDFSTest {
 		config.setString(ConfigConstants.STATE_BACKEND, "ZOOKEEPER");
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
 
-		BlobRecoveryITCase.testBlobServerRecovery(config);
+		BlobRecoveryITCaseHA.testBlobServerRecovery(config);
 	}
 
 	// package visible

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagerLogHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagerLogHandler.java
@@ -150,7 +150,7 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 			scala.concurrent.Future<Object> portFuture = jobManager.ask(JobManagerMessages.getRequestBlobManagerPort(), timeout);
 			scala.concurrent.Future<BlobCache> cacheFuture = portFuture.map(new Mapper<Object, BlobCache>() {
 				@Override
-				public BlobCache apply(Object result) {
+				public BlobCache checkedApply(Object result) throws IOException {
 					Option<String> hostOption = jobManager.actor().path().address().host();
 					String host = hostOption.isDefined() ? hostOption.get() : "localhost";
 					int port = (int) result;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
@@ -47,6 +47,7 @@ public final class BlobCache implements BlobService {
 
 	private final InetSocketAddress serverAddress;
 
+	/** Root directory for local file storage */
 	private final File storageDir;
 
 	private final AtomicBoolean shutdownRequested = new AtomicBoolean();
@@ -60,7 +61,14 @@ public final class BlobCache implements BlobService {
 	/** Configuration for the blob client like ssl parameters required to connect to the blob server */
 	private final Configuration blobClientConfig;
 
-
+	/**
+	 * Instantiates a new BLOB cache.
+	 *
+	 * @param serverAddress
+	 * 		address of the {@link BlobServer} to use for fetching files from
+	 * @param blobClientConfig
+	 * 		global configuration
+	 */
 	public BlobCache(InetSocketAddress serverAddress, Configuration blobClientConfig) {
 		if (serverAddress == null || blobClientConfig == null) {
 			throw new NullPointerException();
@@ -202,8 +210,13 @@ public final class BlobCache implements BlobService {
 	}
 
 	/**
-	 * Deletes the file associated with the given key from the BLOB cache and BLOB server.
+	 * Deletes the file associated with the given key from the BLOB cache and
+	 * BLOB server.
+	 *
 	 * @param key referring to the file to be deleted
+	 * @throws IOException
+	 *         thrown if an I/O error occurs while transferring the request to
+	 *         the BLOB server or if the BLOB server cannot delete the file
 	 */
 	public void deleteGlobal(BlobKey key) throws IOException {
 		BlobClient bc = createClient();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
@@ -21,11 +21,10 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.FileUtils;
-
+import org.apache.flink.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -187,9 +186,9 @@ public final class BlobCache implements BlobService {
 				catch (Throwable t) {
 					// we use "catch (Throwable)" to keep the root exception. Otherwise that exception
 					// it would be replaced by any exception thrown in the finally block
-					closeSilently(os);
-					closeSilently(is);
-					closeSilently(bc);
+					IOUtils.closeQuietly(os);
+					IOUtils.closeQuietly(is);
+					IOUtils.closeQuietly(bc);
 
 					if (t instanceof IOException) {
 						throw (IOException) t;
@@ -291,19 +290,4 @@ public final class BlobCache implements BlobService {
 		return this.storageDir;
 	}
 
-	// ------------------------------------------------------------------------
-	//  Miscellaneous
-	// ------------------------------------------------------------------------
-
-	private void closeSilently(Closeable closeable) {
-		if (closeable != null) {
-			try {
-				closeable.close();
-			} catch (Throwable t) {
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("Error while closing resource after BLOB transfer.", t);
-				}
-			}
-		}
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
@@ -39,9 +39,13 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * The BLOB cache implements a local cache for content-addressable BLOBs. When requesting BLOBs through the
- * {@link BlobCache#getURL} methods, the BLOB cache will first attempt serve the file from its local cache. Only if the
- * local cache does not contain the desired BLOB, the BLOB cache will try to download it from the BLOB server.
+ * The BLOB cache implements a local cache for content-addressable BLOBs.
+ *
+ * <p>When requesting BLOBs through the {@link BlobCache#getURL} methods, the
+ * BLOB cache will first attempt to serve the file from its local cache. Only if
+ * the local cache does not contain the desired BLOB, the BLOB cache will try to
+ * download it from a distributed file system (if available) or the BLOB
+ * server.</p>
  */
 public final class BlobCache implements BlobService {
 
@@ -52,6 +56,9 @@ public final class BlobCache implements BlobService {
 
 	/** Root directory for local file storage */
 	private final File storageDir;
+
+	/** Blob store for distributed file storage, e.g. in HA */
+	private final BlobStore blobStore;
 
 	private final AtomicBoolean shutdownRequested = new AtomicBoolean();
 
@@ -73,13 +80,14 @@ public final class BlobCache implements BlobService {
 	 * 		global configuration
 	 *
 	 * @throws IOException
-	 * 		thrown if the local file storage cannot be created or
+	 * 		thrown if the (local or distributed) file storage cannot be created or
 	 * 		is not usable
 	 */
 	public BlobCache(InetSocketAddress serverAddress,
 		Configuration blobClientConfig) throws IOException {
 		this.serverAddress = checkNotNull(serverAddress);
 		this.blobClientConfig = checkNotNull(blobClientConfig);
+		this.blobStore = BlobUtils.createBlobStoreFromConfig(blobClientConfig);
 
 		// configure and create the storage directory
 		String storageDirectory = blobClientConfig.getString(ConfigConstants.BLOB_STORAGE_DIRECTORY_KEY, null);
@@ -116,86 +124,97 @@ public final class BlobCache implements BlobService {
 
 		final File localJarFile = BlobUtils.getStorageLocation(storageDir, requiredBlob);
 
-		if (!localJarFile.exists()) {
-
-			final byte[] buf = new byte[BlobServerProtocol.BUFFER_SIZE];
-
-			// loop over retries
-			int attempt = 0;
-			while (true) {
-
-				if (attempt == 0) {
-					LOG.info("Downloading {} from {}", requiredBlob, serverAddress);
-				} else {
-					LOG.info("Downloading {} from {} (retry {})", requiredBlob, serverAddress, attempt);
-				}
-
-				try {
-					BlobClient bc = null;
-					InputStream is = null;
-					OutputStream os = null;
-
-					try {
-						bc = new BlobClient(serverAddress, blobClientConfig);
-						is = bc.get(requiredBlob);
-						os = new FileOutputStream(localJarFile);
-
-						while (true) {
-							final int read = is.read(buf);
-							if (read < 0) {
-								break;
-							}
-							os.write(buf, 0, read);
-						}
-
-						// we do explicitly not use a finally block, because we want the closing
-						// in the regular case to throw exceptions and cause the writing to fail.
-						// But, the closing on exception should not throw further exceptions and
-						// let us keep the root exception
-						os.close();
-						os = null;
-						is.close();
-						is = null;
-						bc.close();
-						bc = null;
-
-						// success, we finished
-						break;
-					}
-					catch (Throwable t) {
-						// we use "catch (Throwable)" to keep the root exception. Otherwise that exception
-						// it would be replaced by any exception thrown in the finally block
-						closeSilently(os);
-						closeSilently(is);
-						closeSilently(bc);
-
-						if (t instanceof IOException) {
-							throw (IOException) t;
-						} else {
-							throw new IOException(t.getMessage(), t);
-						}
-					}
-				}
-				catch (IOException e) {
-					String message = "Failed to fetch BLOB " + requiredBlob + " from " + serverAddress +
-						" and store it under " + localJarFile.getAbsolutePath();
-					if (attempt < numFetchRetries) {
-						attempt++;
-						if (LOG.isDebugEnabled()) {
-							LOG.debug(message + " Retrying...", e);
-						} else {
-							LOG.error(message + " Retrying...");
-						}
-					}
-					else {
-						LOG.error(message + " No retries left.", e);
-						throw new IOException(message, e);
-					}
-				}
-			} // end loop over retries
+		if (localJarFile.exists()) {
+			return localJarFile.toURI().toURL();
 		}
 
-		return localJarFile.toURI().toURL();
+		// first try the distributed blob store (if available)
+		try {
+			blobStore.get(requiredBlob, localJarFile);
+		} catch (Exception e) {
+			LOG.info("Failed to copy from blob store. Downloading from BLOB server instead.", e);
+		}
+
+		if (localJarFile.exists()) {
+			return localJarFile.toURI().toURL();
+		}
+
+		// fallback: download from the BlobServer
+		final byte[] buf = new byte[BlobServerProtocol.BUFFER_SIZE];
+
+		// loop over retries
+		int attempt = 0;
+		while (true) {
+
+			if (attempt == 0) {
+				LOG.info("Downloading {} from {}", requiredBlob, serverAddress);
+			} else {
+				LOG.info("Downloading {} from {} (retry {})", requiredBlob, serverAddress, attempt);
+			}
+
+			try {
+				BlobClient bc = null;
+				InputStream is = null;
+				OutputStream os = null;
+
+				try {
+					bc = new BlobClient(serverAddress, blobClientConfig);
+					is = bc.get(requiredBlob);
+					os = new FileOutputStream(localJarFile);
+
+					while (true) {
+						final int read = is.read(buf);
+						if (read < 0) {
+							break;
+						}
+						os.write(buf, 0, read);
+					}
+
+					// we do explicitly not use a finally block, because we want the closing
+					// in the regular case to throw exceptions and cause the writing to fail.
+					// But, the closing on exception should not throw further exceptions and
+					// let us keep the root exception
+					os.close();
+					os = null;
+					is.close();
+					is = null;
+					bc.close();
+					bc = null;
+
+					// success, we finished
+					return localJarFile.toURI().toURL();
+				}
+				catch (Throwable t) {
+					// we use "catch (Throwable)" to keep the root exception. Otherwise that exception
+					// it would be replaced by any exception thrown in the finally block
+					closeSilently(os);
+					closeSilently(is);
+					closeSilently(bc);
+
+					if (t instanceof IOException) {
+						throw (IOException) t;
+					} else {
+						throw new IOException(t.getMessage(), t);
+					}
+				}
+			}
+			catch (IOException e) {
+				String message = "Failed to fetch BLOB " + requiredBlob + " from " + serverAddress +
+					" and store it under " + localJarFile.getAbsolutePath();
+				if (attempt < numFetchRetries) {
+					attempt++;
+					if (LOG.isDebugEnabled()) {
+						LOG.debug(message + " Retrying...", e);
+					} else {
+						LOG.error(message + " Retrying...");
+					}
+				}
+				else {
+					LOG.error(message + " No retries left.", e);
+					throw new IOException(message, e);
+				}
+			}
+		} // end loop over retries
 	}
 
 	/**
@@ -223,6 +242,8 @@ public final class BlobCache implements BlobService {
 		// delete locally
 		delete(key);
 		// then delete on the BLOB server
+		// (don't use the distributed storage directly - this way the blob
+		// server is aware of the delete operation, too)
 		try (BlobClient bc = createClient()) {
 			bc.delete(key);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
@@ -71,8 +71,13 @@ public final class BlobCache implements BlobService {
 	 * 		address of the {@link BlobServer} to use for fetching files from
 	 * @param blobClientConfig
 	 * 		global configuration
+	 *
+	 * @throws IOException
+	 * 		thrown if the local file storage cannot be created or
+	 * 		is not usable
 	 */
-	public BlobCache(InetSocketAddress serverAddress, Configuration blobClientConfig) {
+	public BlobCache(InetSocketAddress serverAddress,
+		Configuration blobClientConfig) throws IOException {
 		this.serverAddress = checkNotNull(serverAddress);
 		this.blobClientConfig = checkNotNull(blobClientConfig);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
@@ -35,6 +35,9 @@ import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * The BLOB cache implements a local cache for content-addressable BLOBs. When requesting BLOBs through the
  * {@link BlobCache#getURL} methods, the BLOB cache will first attempt serve the file from its local cache. Only if the
@@ -70,13 +73,8 @@ public final class BlobCache implements BlobService {
 	 * 		global configuration
 	 */
 	public BlobCache(InetSocketAddress serverAddress, Configuration blobClientConfig) {
-		if (serverAddress == null || blobClientConfig == null) {
-			throw new NullPointerException();
-		}
-
-		this.serverAddress = serverAddress;
-
-		this.blobClientConfig = blobClientConfig;
+		this.serverAddress = checkNotNull(serverAddress);
+		this.blobClientConfig = checkNotNull(blobClientConfig);
 
 		// configure and create the storage directory
 		String storageDirectory = blobClientConfig.getString(ConfigConstants.BLOB_STORAGE_DIRECTORY_KEY, null);
@@ -109,9 +107,7 @@ public final class BlobCache implements BlobService {
 	 * @throws IOException Thrown if an I/O error occurs while downloading the BLOBs from the BLOB server.
 	 */
 	public URL getURL(final BlobKey requiredBlob) throws IOException {
-		if (requiredBlob == null) {
-			throw new IllegalArgumentException("BLOB key cannot be null.");
-		}
+		checkArgument(requiredBlob != null, "BLOB key cannot be null.");
 
 		final File localJarFile = BlobUtils.getStorageLocation(storageDir, requiredBlob);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
@@ -215,13 +215,11 @@ public final class BlobCache implements BlobService {
 	 *         the BLOB server or if the BLOB server cannot delete the file
 	 */
 	public void deleteGlobal(BlobKey key) throws IOException {
-		BlobClient bc = createClient();
-		try {
-			delete(key);
+		// delete locally
+		delete(key);
+		// then delete on the BLOB server
+		try (BlobClient bc = createClient()) {
 			bc.delete(key);
-		}
-		finally {
-			bc.close();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -590,7 +590,8 @@ public final class BlobClient implements Closeable {
 	 * @param key
 	 *        the key to identify the BLOB
 	 * @throws IOException
-	 *         thrown if an I/O error occurs while transferring the request to the BLOB server
+	 *         thrown if an I/O error occurs while transferring the request to
+	 *         the BLOB server or if the BLOB server cannot delete the file
 	 */
 	public void delete(BlobKey key) throws IOException {
 		if (key == null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -74,10 +74,10 @@ public class BlobServer extends Thread implements BlobService {
 	/** Indicates whether a shutdown of server component has been requested. */
 	private final AtomicBoolean shutdownRequested = new AtomicBoolean();
 
-	/** Is the root directory for file storage */
+	/** Root directory for local file storage */
 	private final File storageDir;
 
-	/** Blob store for HA */
+	/** Blob store for distributed file storage, e.g. in HA */
 	private final BlobStore blobStore;
 
 	/** Set of currently running threads */
@@ -96,7 +96,9 @@ public class BlobServer extends Thread implements BlobService {
 	 * Instantiates a new BLOB server and binds it to a free network port.
 	 *
 	 * @throws IOException
-	 *         thrown if the BLOB server cannot bind to a free network port
+	 * 		thrown if the BLOB server cannot bind to a free network port or if, in
+	 * 		HA mode, the (distributed) file storage cannot be created or is not
+	 * 		usable
 	 */
 	public BlobServer(Configuration config) throws IOException {
 		this(config, createBlobStoreFromConfig(config));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -97,9 +97,8 @@ public class BlobServer extends Thread implements BlobService {
 	 * Instantiates a new BLOB server and binds it to a free network port.
 	 *
 	 * @throws IOException
-	 * 		thrown if the BLOB server cannot bind to a free network port or if, in
-	 * 		HA mode, the (distributed) file storage cannot be created or is not
-	 * 		usable
+	 * 		thrown if the BLOB server cannot bind to a free network port or if the
+	 * 		(local or distributed) file storage cannot be created or is not usable
 	 */
 	public BlobServer(Configuration config) throws IOException {
 		this(config, createBlobStoreFromConfig(config));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -480,7 +480,7 @@ public class BlobServer extends Thread implements BlobService {
 
 			return new FileSystemBlobStore(fileSystem, storagePath);
 		} else {
-			throw new IllegalConfigurationException("Unexpected high availability mode '" + highAvailabilityMode + ".");
+			throw new IllegalConfigurationException("Unexpected high availability mode '" + highAvailabilityMode + "'.");
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -21,11 +21,9 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.ZookeeperHaServices;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.FileUtils;
@@ -50,7 +48,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly;
 
 /**
  * This class implements the BLOB server. The BLOB server is responsible for listening for incoming requests and
@@ -454,31 +451,9 @@ public class BlobServer extends Thread implements BlobService {
 		HighAvailabilityMode highAvailabilityMode = HighAvailabilityMode.fromConfig(config);
 
 		if (highAvailabilityMode == HighAvailabilityMode.NONE) {
-		return new VoidBlobStore();
+			return new VoidBlobStore();
 		} else if (highAvailabilityMode == HighAvailabilityMode.ZOOKEEPER) {
-			final String storagePath = config.getValue(HighAvailabilityOptions.HA_STORAGE_PATH);
-			if (isNullOrWhitespaceOnly(storagePath)) {
-				throw new IllegalConfigurationException("Configuration is missing the mandatory parameter: " +
-						HighAvailabilityOptions.HA_STORAGE_PATH);
-			}
-
-			final Path path;
-			try {
-				path = new Path(storagePath);
-			} catch (Exception e) {
-				throw new IOException("Invalid path for highly available storage (" +
-						HighAvailabilityOptions.HA_STORAGE_PATH.key() + ')', e);
-			}
-
-			final FileSystem fileSystem;
-			try {
-				fileSystem = path.getFileSystem();
-			} catch (Exception e) {
-				throw new IOException("Could not create FileSystem for highly available storage (" +
-						HighAvailabilityOptions.HA_STORAGE_PATH.key() + ')', e);
-			}
-
-			return new FileSystemBlobStore(fileSystem, storagePath);
+			return ZookeeperHaServices.createBlobStore(config);
 		} else {
 			throw new IllegalConfigurationException("Unexpected high availability mode '" + highAvailabilityMode + "'.");
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -316,6 +316,12 @@ public class BlobServer extends Thread implements BlobService {
 				LOG.error("BLOB server failed to properly clean up its storage directory.");
 			}
 
+			// only if not in HA mode: also clean up the blobStorage and delete all files
+			if (HighAvailabilityMode.fromConfig(blobServiceConfiguration) ==
+				HighAvailabilityMode.NONE) {
+				blobStore.cleanUp();
+			}
+
 			// Remove shutdown hook to prevent resource leaks, unless this is invoked by the
 			// shutdown hook itself
 			if (shutdownHook != null && shutdownHook != Thread.currentThread()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -109,10 +110,8 @@ public class BlobServer extends Thread implements BlobService {
 	}
 
 	private BlobServer(Configuration config, BlobStore blobStore) throws IOException {
-		checkNotNull(config);
+		this.blobServiceConfiguration = checkNotNull(config);
 		this.blobStore = checkNotNull(blobStore);
-
-		this.blobServiceConfiguration = config;
 
 		// configure and create the storage directory
 		String storageDirectory = config.getString(ConfigConstants.BLOB_STORAGE_DIRECTORY_KEY, null);
@@ -357,9 +356,7 @@ public class BlobServer extends Thread implements BlobService {
 	 */
 	@Override
 	public URL getURL(BlobKey requiredBlob) throws IOException {
-		if (requiredBlob == null) {
-			throw new IllegalArgumentException("Required BLOB cannot be null.");
-		}
+		checkArgument(requiredBlob != null, "BLOB key cannot be null.");
 
 		final File localFile = BlobUtils.getStorageLocation(storageDir, requiredBlob);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -21,9 +21,7 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.highavailability.ZookeeperHaServices;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.FileUtils;
@@ -101,7 +99,7 @@ public class BlobServer extends Thread implements BlobService {
 	 * 		(local or distributed) file storage cannot be created or is not usable
 	 */
 	public BlobServer(Configuration config) throws IOException {
-		this(config, createBlobStoreFromConfig(config));
+		this(config, BlobUtils.createBlobStoreFromConfig(config));
 	}
 
 	public BlobServer(Configuration config, HighAvailabilityServices haServices) throws IOException {
@@ -445,15 +443,4 @@ public class BlobServer extends Thread implements BlobService {
 		}
 	}
 
-	private static BlobStore createBlobStoreFromConfig(Configuration config) throws IOException {
-		HighAvailabilityMode highAvailabilityMode = HighAvailabilityMode.fromConfig(config);
-
-		if (highAvailabilityMode == HighAvailabilityMode.NONE) {
-			return new VoidBlobStore();
-		} else if (highAvailabilityMode == HighAvailabilityMode.ZOOKEEPER) {
-			return ZookeeperHaServices.createBlobStore(config);
-		} else {
-			throw new IllegalConfigurationException("Unexpected high availability mode '" + highAvailabilityMode + "'.");
-		}
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
@@ -168,6 +168,14 @@ class BlobServerConnection extends Thread {
 	 *         thrown if an I/O error occurs while reading/writing data from/to the respective streams
 	 */
 	private void get(InputStream inputStream, OutputStream outputStream, byte[] buf) throws IOException {
+		/**
+		 * Retrieve the file from the (distributed?) BLOB store and store it
+		 * locally, then send it to the service which requested it.
+		 *
+		 * Instead, we could send it from the distributed store directly but
+		 * chances are high that if there is one request, there will be more
+		 * so a local cache makes more sense.
+		 */
 
 		File blobFile;
 		try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobStore.java
@@ -68,14 +68,18 @@ public interface BlobStore {
 	void get(JobID jobId, String key, File localFile) throws Exception;
 
 	/**
-	 * Deletes a blob.
+	 * Tries to delete a blob from storage.
+	 *
+	 * <p>NOTE: This also tries to delete any created directories if empty.</p>
 	 *
 	 * @param blobKey The blob ID
 	 */
 	void delete(BlobKey blobKey);
 
 	/**
-	 * Deletes a blob.
+	 * Tries to delete a blob from storage.
+	 *
+	 * <p>NOTE: This also tries to delete any created directories if empty.</p>
 	 *
 	 * @param jobId The JobID part of ID for the blob
 	 * @param key   The String part of ID for the blob
@@ -83,7 +87,9 @@ public interface BlobStore {
 	void delete(JobID jobId, String key);
 
 	/**
-	 * Deletes blobs.
+	 * Tries to delete all blobs for the given job from storage.
+	 *
+	 * <p>NOTE: This also tries to delete any created directories if empty.</p>
 	 *
 	 * @param jobId The JobID part of all blobs to delete
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobStore.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.api.common.JobID;
 
 import java.io.File;
+import java.io.IOException;
 
 /**
  * A blob store.
@@ -32,9 +33,9 @@ public interface BlobStore {
 	 *
 	 * @param localFile The file to copy
 	 * @param blobKey   The ID for the file in the blob store
-	 * @throws Exception If the copy fails
+	 * @throws IOException If the copy fails
 	 */
-	void put(File localFile, BlobKey blobKey) throws Exception;
+	void put(File localFile, BlobKey blobKey) throws IOException;
 
 	/**
 	 * Copies a local file to the blob store.
@@ -44,18 +45,18 @@ public interface BlobStore {
 	 * @param localFile The file to copy
 	 * @param jobId     The JobID part of ID for the file in the blob store
 	 * @param key       The String part of ID for the file in the blob store
-	 * @throws Exception If the copy fails
+	 * @throws IOException If the copy fails
 	 */
-	void put(File localFile, JobID jobId, String key) throws Exception;
+	void put(File localFile, JobID jobId, String key) throws IOException;
 
 	/**
 	 * Copies a blob to a local file.
 	 *
 	 * @param blobKey   The blob ID
 	 * @param localFile The local file to copy to
-	 * @throws Exception If the copy fails
+	 * @throws IOException If the copy fails
 	 */
-	void get(BlobKey blobKey, File localFile) throws Exception;
+	void get(BlobKey blobKey, File localFile) throws IOException;
 
 	/**
 	 * Copies a blob to a local file.
@@ -63,9 +64,9 @@ public interface BlobStore {
 	 * @param jobId     The JobID part of ID for the blob
 	 * @param key       The String part of ID for the blob
 	 * @param localFile The local file to copy to
-	 * @throws Exception If the copy fails
+	 * @throws IOException If the copy fails
 	 */
-	void get(JobID jobId, String key, File localFile) throws Exception;
+	void get(JobID jobId, String key, File localFile) throws IOException;
 
 	/**
 	 * Tries to delete a blob from storage.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -138,9 +138,13 @@ public class BlobUtils {
 				HighAvailabilityOptions.HA_STORAGE_PATH.key() + ')', e);
 		}
 
-		final String clusterId =
-			configuration.getValue(HighAvailabilityOptions.HA_CLUSTER_ID);
-		storagePath += "/" + clusterId;
+		// only include the cluster ID in actual HA setups:
+		if (HighAvailabilityMode.fromConfig(configuration) !=
+			HighAvailabilityMode.NONE) {
+			final String clusterId =
+				configuration.getValue(HighAvailabilityOptions.HA_CLUSTER_ID);
+			storagePath += "/" + clusterId;
+		}
 
 		return new FileSystemBlobStore(fileSystem, storagePath);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -66,8 +66,13 @@ public class BlobUtils {
 	 * Creates a storage directory for a blob service.
 	 *
 	 * @return the storage directory used by a BLOB service
+	 *
+	 * @throws IOException
+	 * 		thrown if the (local or distributed) file storage cannot be created or
+	 * 		is not usable
 	 */
-	static File initStorageDirectory(String storageDirectory) {
+	static File initStorageDirectory(String storageDirectory) throws
+		IOException {
 		File baseDir;
 		if (StringUtils.isNullOrWhitespaceOnly(storageDirectory)) {
 			baseDir = new File(System.getProperty("java.io.tmpdir"));
@@ -91,7 +96,7 @@ public class BlobUtils {
 		}
 
 		// max attempts exceeded to find a storage directory
-		throw new RuntimeException("Could not create storage directory for BLOB store in '" + baseDir + "'.");
+		throw new IOException("Could not create storage directory for BLOB store in '" + baseDir + "'.");
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -21,20 +21,15 @@ package org.apache.flink.runtime.blob;
 import com.google.common.io.BaseEncoding;
 import org.apache.commons.io.FileUtils;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.Path;
-import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.StringUtils;
 import org.slf4j.Logger;
 
 import java.io.EOFException;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.net.URI;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -364,32 +359,6 @@ public class BlobUtils {
 	 */
 	static String getRecoveryPath(String basePath, JobID jobId) {
 		return String.format("%s/%s", basePath, JOB_DIR_PREFIX + jobId.toString());
-	}
-
-	/**
-	 * Copies the file from the recovery path to the local file.
-	 */
-	static void copyFromRecoveryPath(String recoveryPath, File localBlobFile) throws Exception {
-		if (recoveryPath == null) {
-			throw new IllegalStateException("Failed to determine recovery path.");
-		}
-
-		if (!localBlobFile.createNewFile()) {
-			throw new IllegalStateException("Failed to create new local file to copy to");
-		}
-
-		URI uri = new URI(recoveryPath);
-		Path path = new Path(recoveryPath);
-
-		if (FileSystem.get(uri).exists(path)) {
-			try (InputStream is = FileSystem.get(uri).open(path)) {
-				FileOutputStream fos = new FileOutputStream(localBlobFile);
-				IOUtils.copyBytes(is, fos); // closes the streams
-			}
-		}
-		else {
-			throw new IOException("Cannot find required BLOB at '" + recoveryPath + "' for recovery.");
-		}
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -336,7 +336,7 @@ public class BlobUtils {
 	 */
 	static String getRecoveryPath(String basePath, BlobKey blobKey) {
 		// format: $base/cache/blob_$key
-		return String.format("%s/cache/%s", basePath, BLOB_FILE_PREFIX + blobKey.toString());
+		return String.format("%s/cache/%s%s", basePath, BLOB_FILE_PREFIX, blobKey.toString());
 	}
 
 	/**
@@ -348,8 +348,8 @@ public class BlobUtils {
 	 */
 	static String getRecoveryPath(String basePath, JobID jobId, String key) {
 		// format: $base/job_$id/blob_$key
-		return String.format("%s/%s/%s", basePath, JOB_DIR_PREFIX + jobId.toString(),
-				BLOB_FILE_PREFIX + encodeKey(key));
+		return String.format("%s/%s%s/%s%s", basePath, JOB_DIR_PREFIX, jobId.toString(),
+				BLOB_FILE_PREFIX, encodeKey(key));
 	}
 
 	/**
@@ -358,7 +358,7 @@ public class BlobUtils {
 	 * <p>The returned path can be used with the state backend for recovery purposes.
 	 */
 	static String getRecoveryPath(String basePath, JobID jobId) {
-		return String.format("%s/%s", basePath, JOB_DIR_PREFIX + jobId.toString());
+		return String.format("%s/%s%s", basePath, JOB_DIR_PREFIX, jobId.toString());
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -102,25 +102,20 @@ public class FileSystemBlobStore implements BlobStore {
 
 		final Path fromPath = new Path(fromBlobPath);
 
-		try {
-			if (fileSystem.exists(fromPath)) {
-				try (InputStream is = fileSystem.open(fromPath);
-					FileOutputStream fos = new FileOutputStream(toFile)) {
-					LOG.debug("Copying from {} to {}.", fromBlobPath, toFile);
-					IOUtils.copyBytes(is, fos); // closes the streams
-				}
-			} else {
-				throw new IOException(fromBlobPath + " does not exist.");
-			}
-		} catch (Exception e) {
+		boolean success = false;
+		try (InputStream is = fileSystem.open(fromPath);
+			FileOutputStream fos = new FileOutputStream(toFile)) {
+			LOG.debug("Copying from {} to {}.", fromBlobPath, toFile);
+			IOUtils.copyBytes(is, fos); // closes the streams
+			success = true;
+		} finally {
 			// if the copy fails, we need to remove the target file because
 			// outside code relies on a correct file as long as it exists
-			try {
-				toFile.delete();
-			} catch (Exception e1) {
-				// ignore
+			if (!success) {
+				try {
+					toFile.delete();
+				} catch (Throwable ignored) {}
 			}
-			throw e;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -64,16 +64,16 @@ public class FileSystemBlobStore implements BlobStore {
 	// - Put ------------------------------------------------------------------
 
 	@Override
-	public void put(File localFile, BlobKey blobKey) throws Exception {
+	public void put(File localFile, BlobKey blobKey) throws IOException {
 		put(localFile, BlobUtils.getRecoveryPath(basePath, blobKey));
 	}
 
 	@Override
-	public void put(File localFile, JobID jobId, String key) throws Exception {
+	public void put(File localFile, JobID jobId, String key) throws IOException {
 		put(localFile, BlobUtils.getRecoveryPath(basePath, jobId, key));
 	}
 
-	private void put(File fromFile, String toBlobPath) throws Exception {
+	private void put(File fromFile, String toBlobPath) throws IOException {
 		try (OutputStream os = fileSystem.create(new Path(toBlobPath), true)) {
 			LOG.debug("Copying from {} to {}.", fromFile, toBlobPath);
 			Files.copy(fromFile, os);
@@ -83,16 +83,16 @@ public class FileSystemBlobStore implements BlobStore {
 	// - Get ------------------------------------------------------------------
 
 	@Override
-	public void get(BlobKey blobKey, File localFile) throws Exception {
+	public void get(BlobKey blobKey, File localFile) throws IOException {
 		get(BlobUtils.getRecoveryPath(basePath, blobKey), localFile);
 	}
 
 	@Override
-	public void get(JobID jobId, String key, File localFile) throws Exception {
+	public void get(JobID jobId, String key, File localFile) throws IOException {
 		get(BlobUtils.getRecoveryPath(basePath, jobId, key), localFile);
 	}
 
-	private void get(String fromBlobPath, File toFile) throws Exception {
+	private void get(String fromBlobPath, File toFile) throws IOException {
 		checkNotNull(fromBlobPath, "Blob path");
 		checkNotNull(toFile, "File");
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/VoidBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/VoidBlobStore.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.api.common.JobID;
 
 import java.io.File;
+import java.io.IOException;
 
 /**
  * A blob store doing nothing.
@@ -28,19 +29,19 @@ import java.io.File;
 public class VoidBlobStore implements BlobStore {
 
 	@Override
-	public void put(File localFile, BlobKey blobKey) throws Exception {
+	public void put(File localFile, BlobKey blobKey) throws IOException {
 	}
 
 	@Override
-	public void put(File localFile, JobID jobId, String key) throws Exception {
+	public void put(File localFile, JobID jobId, String key) throws IOException {
 	}
 
 	@Override
-	public void get(BlobKey blobKey, File localFile) throws Exception {
+	public void get(BlobKey blobKey, File localFile) throws IOException {
 	}
 
 	@Override
-	public void get(JobID jobId, String key, File localFile) throws Exception {
+	public void get(JobID jobId, String key, File localFile) throws IOException {
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
@@ -209,7 +209,13 @@ public class JobClient {
 			Option<String> jmHost = jobManager.actor().path().address().host();
 			String jmHostname = jmHost.isDefined() ? jmHost.get() : "localhost";
 			InetSocketAddress serverAddress = new InetSocketAddress(jmHostname, props.blobManagerPort());
-			final BlobCache blobClient = new BlobCache(serverAddress, config);
+			final BlobCache blobClient;
+			try {
+				blobClient = new BlobCache(serverAddress, config);
+			} catch (IOException e) {
+				throw new JobRetrievalException(jobID,
+					"Failed to setup blob cache", e);
+			}
 
 			final Collection<BlobKey> requiredJarFiles = props.requiredJarFiles();
 			final Collection<URL> requiredClasspaths = props.requiredClasspaths();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -37,10 +37,11 @@ import org.apache.flink.runtime.blob.BlobService;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * For each job graph that is submitted to the system the library cache manager maintains
@@ -73,7 +74,7 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 	// --------------------------------------------------------------------------------------------
 
 	public BlobLibraryCacheManager(BlobService blobService, long cleanupInterval) {
-		this.blobService = blobService;
+		this.blobService = checkNotNull(blobService);
 
 		// Initializing the clean up task
 		this.cleanupTimer = new Timer(true);
@@ -91,8 +92,8 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 	@Override
 	public void registerTask(JobID jobId, ExecutionAttemptID task, Collection<BlobKey> requiredJarFiles,
 			Collection<URL> requiredClasspaths) throws IOException {
-		Preconditions.checkNotNull(jobId, "The JobId must not be null.");
-		Preconditions.checkNotNull(task, "The task execution id must not be null.");
+		checkNotNull(jobId, "The JobId must not be null.");
+		checkNotNull(task, "The task execution id must not be null.");
 
 		if (requiredJarFiles == null) {
 			requiredJarFiles = Collections.emptySet();
@@ -153,8 +154,8 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 	
 	@Override
 	public void unregisterTask(JobID jobId, ExecutionAttemptID task) {
-		Preconditions.checkNotNull(jobId, "The JobId must not be null.");
-		Preconditions.checkNotNull(task, "The task execution id must not be null.");
+		checkNotNull(jobId, "The JobId must not be null.");
+		checkNotNull(task, "The task execution id must not be null.");
 
 		synchronized (lockObject) {
 			LibraryCacheEntry entry = cacheEntries.get(jobId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ZookeeperHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ZookeeperHaServices.java
@@ -23,11 +23,8 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
-import org.apache.flink.configuration.IllegalConfigurationException;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.blob.BlobStore;
-import org.apache.flink.runtime.blob.FileSystemBlobStore;
+import org.apache.flink.runtime.blob.BlobUtils;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.ZooKeeperCheckpointRecoveryFactory;
 import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore;
@@ -39,7 +36,6 @@ import java.io.IOException;
 import java.util.concurrent.Executor;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly;
 
 /**
  * An implementation of the {@link HighAvailabilityServices} using Apache ZooKeeper.
@@ -154,47 +150,7 @@ public class ZookeeperHaServices implements HighAvailabilityServices {
 
 	@Override
 	public BlobStore createBlobStore() throws IOException {
-		return createBlobStore(configuration);
-	}
-
-	/**
-	 * Creates the BLOB store in which BLOBs are stored in a highly-available
-	 * fashion.
-	 *
-	 * @param configuration configuration to extract the storage path from
-	 * @return Blob store
-	 * @throws IOException if the blob store could not be created
-	 */
-	public static BlobStore createBlobStore(
-		final Configuration configuration) throws IOException {
-		String storagePath = configuration.getValue(
-			HighAvailabilityOptions.HA_STORAGE_PATH);
-		if (isNullOrWhitespaceOnly(storagePath)) {
-			throw new IllegalConfigurationException("Configuration is missing the mandatory parameter: " +
-					HighAvailabilityOptions.HA_STORAGE_PATH);
-		}
-
-		final Path path;
-		try {
-			path = new Path(storagePath);
-		} catch (Exception e) {
-			throw new IOException("Invalid path for highly available storage (" +
-					HighAvailabilityOptions.HA_STORAGE_PATH.key() + ')', e);
-		}
-
-		final FileSystem fileSystem;
-		try {
-			fileSystem = path.getFileSystem();
-		} catch (Exception e) {
-			throw new IOException("Could not create FileSystem for highly available storage (" +
-					HighAvailabilityOptions.HA_STORAGE_PATH.key() + ')', e);
-		}
-
-		final String clusterId =
-			configuration.getValue(HighAvailabilityOptions.HA_CLUSTER_ID);
-		storagePath += "/" + clusterId;
-
-		return new FileSystemBlobStore(fileSystem, storagePath);
+		return BlobUtils.createHaBlobStore(configuration);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ZookeeperHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ZookeeperHaServices.java
@@ -167,7 +167,7 @@ public class ZookeeperHaServices implements HighAvailabilityServices {
 	 */
 	public static BlobStore createBlobStore(
 		final Configuration configuration) throws IOException {
-		final String storagePath = configuration.getValue(
+		String storagePath = configuration.getValue(
 			HighAvailabilityOptions.HA_STORAGE_PATH);
 		if (isNullOrWhitespaceOnly(storagePath)) {
 			throw new IllegalConfigurationException("Configuration is missing the mandatory parameter: " +
@@ -189,6 +189,10 @@ public class ZookeeperHaServices implements HighAvailabilityServices {
 			throw new IOException("Could not create FileSystem for highly available storage (" +
 					HighAvailabilityOptions.HA_STORAGE_PATH.key() + ')', e);
 		}
+
+		final String clusterId =
+			configuration.getValue(HighAvailabilityOptions.HA_CLUSTER_ID);
+		storagePath += "/" + clusterId;
 
 		return new FileSystemBlobStore(fileSystem, storagePath);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ZookeeperHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/ZookeeperHaServices.java
@@ -154,7 +154,21 @@ public class ZookeeperHaServices implements HighAvailabilityServices {
 
 	@Override
 	public BlobStore createBlobStore() throws IOException {
-		final String storagePath = configuration.getValue(HighAvailabilityOptions.HA_STORAGE_PATH);
+		return createBlobStore(configuration);
+	}
+
+	/**
+	 * Creates the BLOB store in which BLOBs are stored in a highly-available
+	 * fashion.
+	 *
+	 * @param configuration configuration to extract the storage path from
+	 * @return Blob store
+	 * @throws IOException if the blob store could not be created
+	 */
+	public static BlobStore createBlobStore(
+		final Configuration configuration) throws IOException {
+		final String storagePath = configuration.getValue(
+			HighAvailabilityOptions.HA_STORAGE_PATH);
 		if (isNullOrWhitespaceOnly(storagePath)) {
 			throw new IllegalConfigurationException("Configuration is missing the mandatory parameter: " +
 					HighAvailabilityOptions.HA_STORAGE_PATH);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -794,11 +794,20 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 
 		InetSocketAddress address = new InetSocketAddress(jobMasterGateway.getAddress(), blobPort);
 
-		BlobCache blobCache = new BlobCache(address, taskManagerConfiguration.getConfiguration());
-
-		LibraryCacheManager libraryCacheManager = new BlobLibraryCacheManager(
-			blobCache,
-			taskManagerConfiguration.getCleanupInterval());
+		final LibraryCacheManager libraryCacheManager;
+		try {
+			final BlobCache blobCache = new BlobCache(address, taskManagerConfiguration.getConfiguration());
+			libraryCacheManager = new BlobLibraryCacheManager(
+				blobCache,
+				taskManagerConfiguration.getCleanupInterval());
+		} catch (IOException e) {
+			// Can't pass the IOException up - we need a RuntimeException anyway
+			// two levels up where this is run asynchronously. Also, we don't
+			// know whether this is caught in the thread running this method.
+			final String message = "Could not create BLOB cache or library cache.";
+			log.error(message, e);
+			throw new RuntimeException(message, e);
+		}
 
 		ResultPartitionConsumableNotifier resultPartitionConsumableNotifier = new RpcResultPartitionConsumableNotifier(
 			jobManagerLeaderId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -796,7 +796,7 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 
 		final LibraryCacheManager libraryCacheManager;
 		try {
-			final BlobCache blobCache = new BlobCache(address, taskManagerConfiguration.getConfiguration());
+			final BlobCache blobCache = new BlobCache(address, taskManagerConfiguration.getConfiguration(), haServices);
 			libraryCacheManager = new BlobLibraryCacheManager(
 				blobCache,
 				taskManagerConfiguration.getCleanupInterval());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
@@ -51,6 +51,19 @@ public class BlobCacheRetriesTest {
 
 	/**
 	 * A test where the connection fails twice and then the get operation succeeds
+	 * (with a shared distributed storage path set).
+	 */
+	@Test
+	public void testBlobFetchRetriesDistributedFs() {
+		final Configuration config = new Configuration();
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
+			temporaryFolder.getRoot().getPath());
+
+		testBlobFetchRetries(config);
+	}
+
+	/**
+	 * A test where the connection fails twice and then the get operation succeeds
 	 * (with high availability set).
 	 */
 	@Test
@@ -137,6 +150,19 @@ public class BlobCacheRetriesTest {
 	@Test
 	public void testBlobFetchWithTooManyFailures() {
 		final Configuration config = new Configuration();
+
+		testBlobFetchWithTooManyFailures(config);
+	}
+
+	/**
+	 * A test where the connection fails twice and then the get operation succeeds
+	 * (with a shared distributed storage path set).
+	 */
+	@Test
+	public void testBlobFetchWithTooManyFailuresDistributedFs() {
+		final Configuration config = new Configuration();
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
+			temporaryFolder.getRoot().getPath());
 
 		testBlobFetchWithTooManyFailures(config);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
@@ -55,6 +55,31 @@ public class BlobCacheSuccessTest {
 	}
 
 	/**
+	 * BlobCache with no HA mode but a distributed storage path. The cache can
+	 * thus download files from the file system directly and does not need to
+	 * download BLOBs from the BlobServer.
+	 */
+	@Test
+	public void testBlobCacheDistributedFs() {
+		Configuration config = new Configuration();
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
+			temporaryFolder.getRoot().getPath());
+		uploadFileGetTest(config, true, true);
+	}
+
+	/**
+	 * BlobCache with no HA mode but a distributed storage path which is not
+	 * accessible. The cache must thus download files from the BlobServer.
+	 */
+	@Test
+	public void testBlobCacheDistributedFsFallback() {
+		Configuration config = new Configuration();
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
+			temporaryFolder.getRoot().getPath());
+		uploadFileGetTest(config, false, false);
+	}
+
+	/**
 	 * BlobCache is configured in HA mode and the cache can download files from
 	 * the file system directly and does not need to download BLOBs from the
 	 * BlobServer.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
@@ -135,21 +135,20 @@ public class BlobCacheSuccessTest {
 				}
 			}
 
+			// just in case parameters are still read from the server,
+			// create a separate configuration object for the cache
+			final Configuration cacheConfig = new Configuration(config);
+			if (!cacheHasAccessToFs) {
+				cacheConfig.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
+					temporaryFolder.getRoot().getPath() + "/does-not-exist");
+			}
+
 			if (cacheWorksWithoutServer) {
+				// fake non-HA mode so the BLOB server does not remove files
+				config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
 				// Now, shut down the BLOB server, the BLOBs must still be accessible through the cache.
 				blobServer.shutdown();
 				blobServer = null;
-			}
-
-			final Configuration cacheConfig;
-			if (cacheHasAccessToFs) {
-				cacheConfig = config;
-			} else {
-				// just in case parameters are still read from the server,
-				// create a separate configuration object for the cache
-				cacheConfig = new Configuration(config);
-				cacheConfig.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
-					temporaryFolder.getRoot().getPath() + "/does-not-exist");
 			}
 
 			blobCache = new BlobCache(serverAddress, cacheConfig);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -150,6 +151,7 @@ public class BlobRecoveryITCase {
 			client.delete(jobId[1], testKey[1]);
 
 			// Verify everything is clean
+			assertTrue("HA storage directory does not exist", fs.exists(new Path(storagePath)));
 			if (fs.exists(blobServerPath)) {
 				final org.apache.flink.core.fs.FileStatus[] recoveryFiles =
 					fs.listStatus(blobServerPath);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
@@ -61,7 +61,8 @@ public class BlobRecoveryITCase {
 	}
 
 	public static void testBlobServerRecovery(final Configuration config) throws IOException {
-		String storagePath = config.getString(HighAvailabilityOptions.HA_STORAGE_PATH);
+		final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
+		String storagePath = config.getString(HighAvailabilityOptions.HA_STORAGE_PATH) + "/" + clusterId;
 		Random rand = new Random();
 
 		BlobServer[] server = new BlobServer[2];
@@ -69,7 +70,6 @@ public class BlobRecoveryITCase {
 		BlobClient client = null;
 
 		try {
-
 			for (int i = 0; i < server.length; i++) {
 				server[i] = new BlobServer(config);
 				serverAddress[i] = new InetSocketAddress("localhost", server[i].getPort());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.blob;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -26,9 +25,9 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,22 +43,8 @@ import static org.junit.Assert.fail;
 
 public class BlobRecoveryITCase {
 
-	private File recoveryDir;
-
-	@Before
-	public void setUp() throws Exception {
-		recoveryDir = new File(FileUtils.getTempDirectory(), "BlobRecoveryITCaseDir");
-		if (!recoveryDir.exists() && !recoveryDir.mkdirs()) {
-			throw new IllegalStateException("Failed to create temp directory for test");
-		}
-	}
-
-	@After
-	public void cleanUp() throws Exception {
-		if (recoveryDir != null) {
-			FileUtils.deleteDirectory(recoveryDir);
-		}
-	}
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	/**
 	 * Tests that with {@link HighAvailabilityMode#ZOOKEEPER} distributed JARs are recoverable from any
@@ -70,7 +55,7 @@ public class BlobRecoveryITCase {
 		Configuration config = new Configuration();
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
 		config.setString(ConfigConstants.STATE_BACKEND, "FILESYSTEM");
-		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, recoveryDir.getPath());
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.getRoot().getPath());
 
 		testBlobServerRecovery(config);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCaseDfs.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCaseDfs.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class BlobRecoveryITCaseDfs extends BlobRecoveryITCaseHA {
+
+	/**
+	 * Tests that with {@link HighAvailabilityMode#NONE} distributed JARs are recoverable from any
+	 * participating BlobServer when a common storage directory is set, e.g. on a distributed file
+	 * system.
+	 */
+	@Test
+	@Override
+	public void testBlobServerRecovery() throws Exception {
+		Configuration config = new Configuration();
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.getRoot().getPath());
+
+		testBlobServerRecovery(config);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
@@ -85,16 +85,7 @@ public class BlobServerDeleteTest {
 			fail(e.getMessage());
 		}
 		finally {
-			if (client != null) {
-				try {
-					client.close();
-				} catch (Throwable t) {
-					t.printStackTrace();
-				}
-			}
-			if (server != null) {
-				server.shutdown();
-			}
+			cleanup(server, client);
 		}
 	}
 
@@ -157,16 +148,7 @@ public class BlobServerDeleteTest {
 			fail(e.getMessage());
 		}
 		finally {
-			if (client != null) {
-				try {
-					client.close();
-				} catch (Throwable t) {
-					t.printStackTrace();
-				}
-			}
-			if (server != null) {
-				server.shutdown();
-			}
+			cleanup(server, client);
 		}
 	}
 
@@ -205,16 +187,7 @@ public class BlobServerDeleteTest {
 			fail(e.getMessage());
 		}
 		finally {
-			if (client != null) {
-				try {
-					client.close();
-				} catch (Throwable t) {
-					t.printStackTrace();
-				}
-			}
-			if (server != null) {
-				server.shutdown();
-			}
+			cleanup(server, client);
 		}
 	}
 
@@ -254,16 +227,7 @@ public class BlobServerDeleteTest {
 			fail(e.getMessage());
 		}
 		finally {
-			if (client != null) {
-				try {
-					client.close();
-				} catch (Throwable t) {
-					t.printStackTrace();
-				}
-			}
-			if (server != null) {
-				server.shutdown();
-			}
+			cleanup(server, client);
 		}
 	}
 
@@ -312,16 +276,20 @@ public class BlobServerDeleteTest {
 			fail(e.getMessage());
 		}
 		finally {
-			if (client != null) {
-				try {
-					client.close();
-				} catch (Throwable t) {
-					t.printStackTrace();
-				}
+			cleanup(server, client);
+		}
+	}
+
+	private void cleanup(BlobServer server, BlobClient client) {
+		if (client != null) {
+			try {
+				client.close();
+			} catch (Throwable t) {
+				t.printStackTrace();
 			}
-			if (server != null) {
-				server.shutdown();
-			}
+		}
+		if (server != null) {
+			server.shutdown();
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.runtime.blob;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.OperatingSystem;
 import org.junit.Test;
 
@@ -38,7 +38,11 @@ import static org.junit.Assume.assumeTrue;
  */
 public class BlobServerDeleteTest {
 
-	private final Random rnd = new Random();
+	protected final Random rnd = new Random();
+
+	protected Configuration getConfiguration() {
+		return new Configuration();
+	}
 
 	@Test
 	public void testDeleteSingle() {
@@ -46,7 +50,7 @@ public class BlobServerDeleteTest {
 		BlobClient client = null;
 
 		try {
-			Configuration config = new Configuration();
+			Configuration config = getConfiguration();
 			server = new BlobServer(config);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -95,7 +99,7 @@ public class BlobServerDeleteTest {
 		BlobClient client = null;
 
 		try {
-			Configuration config = new Configuration();
+			Configuration config = getConfiguration();
 			server = new BlobServer(config);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -158,7 +162,7 @@ public class BlobServerDeleteTest {
 		BlobClient client = null;
 
 		try {
-			Configuration config = new Configuration();
+			Configuration config = getConfiguration();
 			server = new BlobServer(config);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -197,7 +201,7 @@ public class BlobServerDeleteTest {
 		BlobClient client = null;
 
 		try {
-			Configuration config = new Configuration();
+			Configuration config = getConfiguration();
 			server = new BlobServer(config);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -239,7 +243,7 @@ public class BlobServerDeleteTest {
 		BlobClient client = null;
 
 		try {
-			Configuration config = new Configuration();
+			Configuration config = getConfiguration();
 			server = new BlobServer(config);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -280,7 +284,7 @@ public class BlobServerDeleteTest {
 		}
 	}
 
-	private void cleanup(BlobServer server, BlobClient client) {
+	protected void cleanup(BlobServer server, BlobClient client) {
 		if (client != null) {
 			try {
 				client.close();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDfsDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDfsDeleteTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests how DELETE requests behave.
+ */
+public class BlobServerDfsDeleteTest extends BlobServerDeleteTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Override
+	protected Configuration getConfiguration() {
+		Configuration config = new Configuration();
+
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
+			temporaryFolder.getRoot().getPath());
+		return config;
+	}
+
+	protected void cleanup(BlobServer server, BlobClient client, BlobCache cache) {
+		cleanup(server, client);
+		if (cache != null) {
+			cache.shutdown();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDfsGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDfsGetTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests how failing GET requests behave in the presence of failures.
+ * Successful GET requests are tested in conjunction with the PUT
+ * requests.
+ */
+public class BlobServerDfsGetTest extends BlobServerGetTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Override
+	protected Configuration getConfiguration() {
+		Configuration config = new Configuration();
+
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
+			temporaryFolder.getRoot().getPath());
+		return config;
+	}
+
+	/**
+	 * Verify everything is clean below <tt>recoveryDir/default</tt>.
+	 *
+	 * @param config
+	 */
+	@Override
+	protected void verifyClean(Configuration config) {
+		File[] recoveryFiles = temporaryFolder.getRoot().listFiles();
+		assertEquals("Unclean state backend: " + Arrays.toString(recoveryFiles),
+			0, recoveryFiles.length);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDfsPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDfsPutTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for successful and failing PUT operations against the BLOB server,
+ * and successful GET operations. This version uses a temporary directory
+ * which is shared between the blob server and the blob client.
+ */
+public class BlobServerDfsPutTest extends BlobServerPutTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Override
+	protected Configuration getConfiguration() {
+		Configuration config = new Configuration();
+
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
+			temporaryFolder.getRoot().getPath());
+		return config;
+	}
+
+	/**
+	 * Verify everything is clean below <tt>recoveryDir/default</tt>.
+	 *
+	 * @param config
+	 */
+	@Override
+	protected void verifyClean(Configuration config) {
+		File[] recoveryFiles = temporaryFolder.getRoot().listFiles();
+		assertEquals("Unclean state backend: " + Arrays.toString(recoveryFiles),
+			0, recoveryFiles.length);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -23,12 +23,15 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-
 import java.io.InputStream;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
 import java.util.Random;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests how failing GET requests behave in the presence of failures.
@@ -39,13 +42,17 @@ public class BlobServerGetTest {
 
 	private final Random rnd = new Random();
 
+	protected Configuration getConfiguration() {
+		return new Configuration();
+	}
+
 	@Test
 	public void testGetFailsDuringLookup() {
 		BlobServer server = null;
 		BlobClient client = null;
+		Configuration config = getConfiguration();
 
 		try {
-			Configuration config = new Configuration();
 			server = new BlobServer(config);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -61,6 +68,7 @@ public class BlobServerGetTest {
 			// delete all files to make sure that GET requests fail
 			File blobFile = server.getStorageLocation(key);
 			assertTrue(blobFile.delete());
+			server.getBlobStore().delete(key);
 
 			// issue a GET request that fails
 			try {
@@ -87,15 +95,17 @@ public class BlobServerGetTest {
 				server.shutdown();
 			}
 		}
+
+		verifyClean(config);
 	}
 
 	@Test
 	public void testGetFailsDuringStreaming() {
 		BlobServer server = null;
 		BlobClient client = null;
+		Configuration config = getConfiguration();
 
 		try {
-			Configuration config = new Configuration();
 			server = new BlobServer(config);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -146,5 +156,16 @@ public class BlobServerGetTest {
 				server.shutdown();
 			}
 		}
+
+		verifyClean(config);
+	}
+
+	/**
+	 * Verify everything is clean in a shared storage directory (if available).
+	 *
+	 * @param config
+	 */
+	protected void verifyClean(Configuration config) {
+		// nothing to do here
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.runtime.blob;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.OperatingSystem;
 import org.junit.Test;
 
@@ -30,7 +30,11 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.util.Random;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -41,13 +45,17 @@ public class BlobServerPutTest {
 
 	private final Random rnd = new Random();
 
+	protected Configuration getConfiguration() {
+		return new Configuration();
+	}
+
 	@Test
 	public void testPutBufferSuccessful() {
 		BlobServer server = null;
 		BlobClient client = null;
 
+		Configuration config = getConfiguration();
 		try {
-			Configuration config = new Configuration();
 			server = new BlobServer(config);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -112,16 +120,17 @@ public class BlobServerPutTest {
 				server.shutdown();
 			}
 		}
-	}
 
+		verifyClean(config);
+	}
 
 	@Test
 	public void testPutStreamSuccessful() {
 		BlobServer server = null;
 		BlobClient client = null;
 
+		Configuration config = getConfiguration();
 		try {
-			Configuration config = new Configuration();
 			server = new BlobServer(config);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -160,6 +169,8 @@ public class BlobServerPutTest {
 				server.shutdown();
 			}
 		}
+
+		verifyClean(config);
 	}
 
 	@Test
@@ -167,8 +178,8 @@ public class BlobServerPutTest {
 		BlobServer server = null;
 		BlobClient client = null;
 
+		Configuration config = getConfiguration();
 		try {
-			Configuration config = new Configuration();
 			server = new BlobServer(config);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -207,6 +218,8 @@ public class BlobServerPutTest {
 				server.shutdown();
 			}
 		}
+
+		verifyClean(config);
 	}
 
 	@Test
@@ -217,8 +230,8 @@ public class BlobServerPutTest {
 		BlobClient client = null;
 
 		File tempFileDir = null;
+		Configuration config = getConfiguration();
 		try {
-			Configuration config = new Configuration();
 			server = new BlobServer(config);
 
 			// make sure the blob server cannot create any files in its storage dir
@@ -271,6 +284,8 @@ public class BlobServerPutTest {
 				server.shutdown();
 			}
 		}
+
+		verifyClean(config);
 	}
 
 	@Test
@@ -281,8 +296,8 @@ public class BlobServerPutTest {
 		BlobClient client = null;
 
 		File tempFileDir = null;
+		Configuration config = getConfiguration();
 		try {
-			Configuration config = new Configuration();
 			server = new BlobServer(config);
 
 			// make sure the blob server cannot create any files in its storage dir
@@ -338,6 +353,8 @@ public class BlobServerPutTest {
 				server.shutdown();
 			}
 		}
+
+		verifyClean(config);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -404,5 +421,14 @@ public class BlobServerPutTest {
 				return -1;
 			}
 		}
+	}
+
+	/**
+	 * Verify everything is clean in a shared storage directory (if available).
+	 *
+	 * @param config
+	 */
+	protected void verifyClean(Configuration config) {
+		// nothing to do here
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRangeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRangeTest.java
@@ -40,6 +40,7 @@ public class BlobServerRangeTest extends TestLogger {
 		Configuration conf = new Configuration();
 		conf.setString(ConfigConstants.BLOB_SERVER_PORT, "0");
 		BlobServer srv = new BlobServer(conf);
+		srv.shutdown();
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
 
 public class BlobUtilsTest {
 
@@ -55,8 +56,9 @@ public class BlobUtilsTest {
 		assertTrue(blobUtilsTestDirectory.delete());
 	}
 
-	@Test(expected = Exception.class)
-	public void testExceptionOnCreateStorageDirectoryFailure() {
+	@Test(expected = IOException.class)
+	public void testExceptionOnCreateStorageDirectoryFailure() throws
+		IOException {
 		// Should throw an Exception
 		BlobUtils.initStorageDirectory(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS).getAbsolutePath());
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -62,12 +62,12 @@ public class BlobLibraryCacheRecoveryITCase {
 		BlobCache cache = null;
 		BlobLibraryCacheManager libCache = null;
 
-		try {
-			Configuration config = new Configuration();
-			config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-			config.setString(ConfigConstants.STATE_BACKEND, "FILESYSTEM");
-			config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.getRoot().getAbsolutePath());
+		Configuration config = new Configuration();
+		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+		config.setString(ConfigConstants.STATE_BACKEND, "FILESYSTEM");
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.getRoot().getAbsolutePath());
 
+		try {
 			for (int i = 0; i < server.length; i++) {
 				server[i] = new BlobServer(config);
 				serverAddress[i] = new InetSocketAddress("localhost", server[i].getPort());
@@ -144,8 +144,10 @@ public class BlobLibraryCacheRecoveryITCase {
 				client.delete(keys.get(1));
 			}
 
-			// Verify everything is clean
-			File[] recoveryFiles = temporaryFolder.getRoot().listFiles();
+			// Verify everything is clean below recoveryDir/<cluster_id>
+			final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
+			File haBlobStoreDir = new File(temporaryFolder.getRoot(), clusterId);
+			File[] recoveryFiles = haBlobStoreDir.listFiles();
 			assertEquals("Unclean state backend: " + Arrays.toString(recoveryFiles), 0, recoveryFiles.length);
 		}
 		finally {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class BlobLibraryCacheRecoveryITCase {
 
@@ -148,6 +149,7 @@ public class BlobLibraryCacheRecoveryITCase {
 			final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
 			File haBlobStoreDir = new File(temporaryFolder.getRoot(), clusterId);
 			File[] recoveryFiles = haBlobStoreDir.listFiles();
+			assertNotNull("HA storage directory does not exist", recoveryFiles);
 			assertEquals("Unclean state backend: " + Arrays.toString(recoveryFiles), 0, recoveryFiles.length);
 		}
 		finally {


### PR DESCRIPTION
Allow the BlobServer and BlobCache to use a distributed file system for distributing BLOBs even if not in HA-mode. For this, we always try to use the path given by the `high-availability.storageDir` config option and, if accessible, set it up appropriately.

This builds upon https://github.com/apache/flink/pull/3084