### PR TITLE
[FLINK-4917] Deprecate "CheckpointedAsynchronously" interface

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedAsynchronously.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedAsynchronously.java
@@ -36,7 +36,20 @@ import java.io.Serializable;
  * <p>To be able to support asynchronous snapshots, the state returned by the
  * {@link #snapshotState(long, long)} method is typically a copy or shadow copy
  * of the actual state.</p>
- * @deprecated Please use {@link CheckpointedFunction}.
+ * @deprecated Please use {@link ListCheckpointed} and {@link CheckpointedFunction}.
+ *
+ * The short cut replacement via {@link ListCheckpointed}
+ * <pre>{@code
+ *  public class ExampleOperator implements ListCheckpointed<Integer> {
+ *
+ *		public List<Integer> snapshotState(long checkpointId, long timestamp) throws Exception {
+ *			 return Collections.singletonList(this.value);
+ *		}
+ *
+ *		public void restoreState(List<Integer> state) throws Exception {
+ *			this.value = state.get(0);
+ *		}
+ * }</pre>
  */
 @Deprecated
 @PublicEvolving

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedAsynchronously.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedAsynchronously.java
@@ -36,6 +36,7 @@ import java.io.Serializable;
  * <p>To be able to support asynchronous snapshots, the state returned by the
  * {@link #snapshotState(long, long)} method is typically a copy or shadow copy
  * of the actual state.</p>
+ * @deprecated Please use {@link CheckpointedFunction}.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedAsynchronously.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedAsynchronously.java
@@ -37,5 +37,6 @@ import java.io.Serializable;
  * {@link #snapshotState(long, long)} method is typically a copy or shadow copy
  * of the actual state.</p>
  */
+@Deprecated
 @PublicEvolving
 public interface CheckpointedAsynchronously<T extends Serializable> extends Checkpointed<T> {}


### PR DESCRIPTION
- [x] General
  - The pull request references the related JIRA issue ([FLINK-4917] Deprecate "CheckpointedAsynchronously" interface)
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
