### PR TITLE
[FLINK-5442] Ensure order of enum elements in StateDescriptor.Type

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
@@ -49,8 +49,9 @@ import static java.util.Objects.requireNonNull;
 @PublicEvolving
 public abstract class StateDescriptor<S extends State, T> implements Serializable {
 
+	// Do not change the order of the elements in this enum, ordinal is used in serialization
 	public enum Type {
-		VALUE, LIST, REDUCING, FOLDING, @Deprecated UNKNOWN
+		@Deprecated UNKNOWN, VALUE, LIST, REDUCING, FOLDING
 	}
 
 	private static final long serialVersionUID = 1L;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
@@ -96,4 +96,20 @@ public class SerializationProxiesTest {
 
 		Assert.assertEquals(name, metaInfo.getStateName());
 	}
+
+	/**
+	 * This test fixes the order of elements in the enum which is important for serialization. Do not modify this test
+	 * except if you are entirely sure what you are doing.
+	 */
+	@Test
+	public void testFixTypeOrder() {
+		// ensure all elements are covered
+		Assert.assertEquals(5, StateDescriptor.Type.values().length);
+		// fix the order of elements to keep serialization format stable
+		Assert.assertEquals(0, StateDescriptor.Type.UNKNOWN.ordinal());
+		Assert.assertEquals(1, StateDescriptor.Type.VALUE.ordinal());
+		Assert.assertEquals(2, StateDescriptor.Type.LIST.ordinal());
+		Assert.assertEquals(3, StateDescriptor.Type.REDUCING.ordinal());
+		Assert.assertEquals(4, StateDescriptor.Type.FOLDING.ordinal());
+	}
 }


### PR DESCRIPTION
This PR adds a test to ensure the order of elements in enum ``StateDescriptor.Type`` which is important for the serialization format.