### PR TITLE
[FLINK-5464] [metrics] Prevent some NPEs

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerialization.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerialization.java
@@ -85,9 +85,11 @@ public class MetricDumpSerialization {
 			}
 
 			for (Map.Entry<Gauge<?>, Tuple2<QueryScopeInfo, String>> entry : gauges.entrySet()) {
-				serializeMetricInfo(dos, entry.getValue().f0);
-				serializeString(dos, entry.getValue().f1);
-				serializeGauge(dos, entry.getKey());
+				if (entry.getKey().getValue() != null) {
+					serializeMetricInfo(dos, entry.getValue().f0);
+					serializeString(dos, entry.getValue().f1);
+					serializeGauge(dos, entry.getKey());
+				}
 			}
 
 			for (Map.Entry<Histogram, Tuple2<QueryScopeInfo, String>> entry : histograms.entrySet()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -345,6 +345,10 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 	 * @param metric the metric to register
 	 */
 	protected void addMetric(String name, Metric metric) {
+		if (metric == null) {
+			LOG.warn("Ignoring attempted registration of a metric due to being null for name {}.", name);
+			return;
+		}
 		// add the metric only if the group is still open
 		synchronized (this) {
 			if (!closed) {


### PR DESCRIPTION
This PR prevents some NullPointerExceptions from occurring in the metric system.

- When registering a metric that is null the metric is ignored, and a warning is logged.
  - i.e ```group.counter("counter", null);```
- The MetricDumpSerialization completely ignores gauges if their value is null.