### PR TITLE
[FLINK-5118] Fix inconsistent numBytesIn/Out metrics

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
@@ -24,7 +24,6 @@ import java.nio.ByteOrder;
 
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.util.DataOutputSerializer;
@@ -58,8 +57,6 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 
 	/** Limit of current {@link MemorySegment} of target buffer */
 	private int limit;
-
-	private transient Counter numBytesOut;
 
 	public SpanningRecordSerializer() {
 		this.serializationBuffer = new DataOutputSerializer(128);
@@ -97,10 +94,6 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 
 		int len = this.serializationBuffer.length();
 		this.lengthBuffer.putInt(0, len);
-		
-		if (numBytesOut != null) {
-			numBytesOut.inc(len + 4);
-		}
 
 		this.dataBuffer = this.serializationBuffer.wrapAsByteBuffer();
 
@@ -203,6 +196,5 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 
 	@Override
 	public void instantiateMetrics(TaskIOMetricGroup metrics) {
-		numBytesOut = metrics.getNumBytesOutCounter();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializer.java
@@ -99,7 +99,7 @@ public class SpanningRecordSerializer<T extends IOReadableWritable> implements R
 		this.lengthBuffer.putInt(0, len);
 		
 		if (numBytesOut != null) {
-			numBytesOut.inc(len);
+			numBytesOut.inc(len + 4);
 		}
 
 		this.dataBuffer = this.serializationBuffer.wrapAsByteBuffer();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.api.writer;
 
 import org.apache.flink.core.io.IOReadableWritable;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.event.AbstractEvent;
@@ -57,6 +58,8 @@ public class RecordWriter<T extends IOReadableWritable> {
 	private final RecordSerializer<T>[] serializers;
 
 	private final Random RNG = new XORShiftRandom();
+
+	private Counter numBytesOut;
 
 	public RecordWriter(ResultPartitionWriter writer) {
 		this(writer, new RoundRobinChannelSelector<T>());
@@ -113,6 +116,9 @@ public class RecordWriter<T extends IOReadableWritable> {
 				Buffer buffer = serializer.getCurrentBuffer();
 
 				if (buffer != null) {
+					if (numBytesOut != null) {
+						numBytesOut.inc(buffer.getSize());
+					}
 					writeAndClearBuffer(buffer, targetChannel, serializer);
 
 					// If this was a full record, we are done. Not breaking
@@ -140,6 +146,9 @@ public class RecordWriter<T extends IOReadableWritable> {
 				synchronized (serializer) {
 					Buffer buffer = serializer.getCurrentBuffer();
 					if (buffer != null) {
+						if (numBytesOut != null) {
+							numBytesOut.inc(buffer.getSize());
+						}
 						writeAndClearBuffer(buffer, targetChannel, serializer);
 					} else if (serializer.hasData()) {
 						// sanity check
@@ -167,6 +176,9 @@ public class RecordWriter<T extends IOReadableWritable> {
 					Buffer buffer = serializer.getCurrentBuffer();
 
 					if (buffer != null) {
+						if (numBytesOut != null) {
+							numBytesOut.inc(buffer.getSize());
+						}
 						targetPartition.writeBuffer(buffer, targetChannel);
 					}
 				} finally {
@@ -198,9 +210,7 @@ public class RecordWriter<T extends IOReadableWritable> {
 	 * @param metrics
      */
 	public void setMetricGroup(TaskIOMetricGroup metrics) {
-		for(RecordSerializer<?> serializer : serializers) {
-			serializer.instantiateMetrics(metrics);
-		}
+		numBytesOut = metrics.getNumBytesOutCounter();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.api.writer;
 
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.event.AbstractEvent;
@@ -59,7 +60,7 @@ public class RecordWriter<T extends IOReadableWritable> {
 
 	private final Random RNG = new XORShiftRandom();
 
-	private Counter numBytesOut;
+	private Counter numBytesOut = new SimpleCounter();
 
 	public RecordWriter(ResultPartitionWriter writer) {
 		this(writer, new RoundRobinChannelSelector<T>());
@@ -116,9 +117,7 @@ public class RecordWriter<T extends IOReadableWritable> {
 				Buffer buffer = serializer.getCurrentBuffer();
 
 				if (buffer != null) {
-					if (numBytesOut != null) {
-						numBytesOut.inc(buffer.getSize());
-					}
+					numBytesOut.inc(buffer.getSize());
 					writeAndClearBuffer(buffer, targetChannel, serializer);
 
 					// If this was a full record, we are done. Not breaking
@@ -146,9 +145,7 @@ public class RecordWriter<T extends IOReadableWritable> {
 				synchronized (serializer) {
 					Buffer buffer = serializer.getCurrentBuffer();
 					if (buffer != null) {
-						if (numBytesOut != null) {
-							numBytesOut.inc(buffer.getSize());
-						}
+						numBytesOut.inc(buffer.getSize());
 						writeAndClearBuffer(buffer, targetChannel, serializer);
 					} else if (serializer.hasData()) {
 						// sanity check
@@ -176,9 +173,7 @@ public class RecordWriter<T extends IOReadableWritable> {
 					Buffer buffer = serializer.getCurrentBuffer();
 
 					if (buffer != null) {
-						if (numBytesOut != null) {
-							numBytesOut.inc(buffer.getSize());
-						}
+						numBytesOut.inc(buffer.getSize());
 						targetPartition.writeBuffer(buffer, targetChannel);
 					}
 				} finally {


### PR DESCRIPTION
This PR fixes an issue regarding inconsistent numBytesIn/Out metrics.

Given 2 subsequent tasks A->B the numBytesOut count of A was lower than the numBytesIn(Local/Remote) count of B by a huge margin, although they should be (nearly) identical.

The problem is that A was counting how much bytes the serialized records were using, whereas B was counting how large the ```Buffer```s were that it received. A ```Buffer``` contains the following data:
```
|size_of_R1|R1|size_of_R2|R2|...
```
where as R1/R2 are serialized records and the sizes denote the serialized length of their respective record.

So, while A was adding ```sizeOf(R1)```, B was adding ```sizeOf(size_of_R1) + sizeOf(R1)```, which obviously leads to inconsistent counts.

A was simply not accounting for the added bytes that size_of_RX were using, which is what this PR is fixing by adding ```4``` after the serialization of each record.

cc @uce 