### PR TITLE
[FLINK-5155] Deprecate ValueStateDescriptor constructors with default value

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -371,8 +371,7 @@ public class RocksDBAsyncSnapshotTest {
 			ValueState<String> state = getPartitionedState(
 					VoidNamespace.INSTANCE,
 					VoidNamespaceSerializer.INSTANCE,
-					new ValueStateDescriptor<>("count",
-							StringSerializer.INSTANCE, "hello"));
+					new ValueStateDescriptor<>("count", StringSerializer.INSTANCE));
 
 		}
 
@@ -383,8 +382,7 @@ public class RocksDBAsyncSnapshotTest {
 			ValueState<String> state = getPartitionedState(
 					VoidNamespace.INSTANCE,
 					VoidNamespaceSerializer.INSTANCE,
-					new ValueStateDescriptor<>("count",
-							StringSerializer.INSTANCE, "hello"));
+					new ValueStateDescriptor<>("count", StringSerializer.INSTANCE));
 
 			state.update(element.getValue());
 		}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ValueStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ValueStateDescriptor.java
@@ -38,12 +38,16 @@ public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
 	 * 
 	 * <p>If this constructor fails (because it is not possible to describe the type via a class),
 	 * consider using the {@link #ValueStateDescriptor(String, TypeInformation, Object)} constructor.
-	 * 
+	 *
+	 * @deprecated Use {@link #ValueStateDescriptor(String, Class)} instead and manually manage
+	 * the default value by checking whether the contents of the state is {@code null}.
+	 *
 	 * @param name The (unique) name for the state.
 	 * @param typeClass The type of the values in the state.   
 	 * @param defaultValue The default value that will be set when requesting state without setting
 	 *                     a value before.
 	 */
+	@Deprecated
 	public ValueStateDescriptor(String name, Class<T> typeClass, T defaultValue) {
 		super(name, typeClass, defaultValue);
 	}
@@ -51,11 +55,15 @@ public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
 	/**
 	 * Creates a new {@code ValueStateDescriptor} with the given name and default value.
 	 *
+	 * @deprecated Use {@link #ValueStateDescriptor(String, TypeInformation)} instead and manually
+	 * manage the default value by checking whether the contents of the state is {@code null}.
+	 *
 	 * @param name The (unique) name for the state.
 	 * @param typeInfo The type of the values in the state.
 	 * @param defaultValue The default value that will be set when requesting state without setting
 	 *                     a value before.
 	 */
+	@Deprecated
 	public ValueStateDescriptor(String name, TypeInformation<T> typeInfo, T defaultValue) {
 		super(name, typeInfo, defaultValue);
 	}
@@ -64,13 +72,50 @@ public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
 	 * Creates a new {@code ValueStateDescriptor} with the given name, default value, and the specific
 	 * serializer.
 	 *
+	 * @deprecated Use {@link #ValueStateDescriptor(String, TypeSerializer)} instead and manually
+	 * manage the default value by checking whether the contents of the state is {@code null}.
+	 *
 	 * @param name The (unique) name for the state.
 	 * @param typeSerializer The type serializer of the values in the state.
 	 * @param defaultValue The default value that will be set when requesting state without setting
 	 *                     a value before.
 	 */
+	@Deprecated
 	public ValueStateDescriptor(String name, TypeSerializer<T> typeSerializer, T defaultValue) {
 		super(name, typeSerializer, defaultValue);
+	}
+
+	/**
+	 * Creates a new {@code ValueStateDescriptor} with the given name and type
+	 *
+	 * <p>If this constructor fails (because it is not possible to describe the type via a class),
+	 * consider using the {@link #ValueStateDescriptor(String, TypeInformation)} constructor.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param typeClass The type of the values in the state.
+	 */
+	public ValueStateDescriptor(String name, Class<T> typeClass) {
+		super(name, typeClass, null);
+	}
+
+	/**
+	 * Creates a new {@code ValueStateDescriptor} with the given name and type.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param typeInfo The type of the values in the state.
+	 */
+	public ValueStateDescriptor(String name, TypeInformation<T> typeInfo) {
+		super(name, typeInfo, null);
+	}
+
+	/**
+	 * Creates a new {@code ValueStateDescriptor} with the given name and the specific serializer.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param typeSerializer The type serializer of the values in the state.
+	 */
+	public ValueStateDescriptor(String name, TypeSerializer<T> typeSerializer) {
+		super(name, typeSerializer, null);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
@@ -102,8 +102,7 @@ abstract public class AbstractKeyedCEPPatternOperator<IN, KEY, OUT> extends Abst
 			nfaOperatorState = getPartitionedState(
 					new ValueStateDescriptor<NFA<IN>>(
 						NFA_OPERATOR_STATE_NAME,
-						new NFA.Serializer<IN>(),
-						null));
+						new NFA.Serializer<IN>()));
 		}
 
 		@SuppressWarnings("unchecked,rawtypes")
@@ -116,8 +115,7 @@ abstract public class AbstractKeyedCEPPatternOperator<IN, KEY, OUT> extends Abst
 						PRIORIRY_QUEUE_STATE_NAME,
 						new PriorityQueueSerializer<>(
 								streamRecordSerializer,
-								new PriorityQueueStreamRecordFactory<IN>()),
-						null));
+								new PriorityQueueStreamRecordFactory<IN>())));
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/QueryableStateClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/QueryableStateClientTest.java
@@ -268,7 +268,7 @@ public class QueryableStateClientTest {
 				servers[i] = new KvStateServer(InetAddress.getLocalHost(), 0, 1, 1, registries[i], serverStats[i]);
 				servers[i].start();
 				ValueStateDescriptor<Integer> descriptor =
-						new ValueStateDescriptor<>("any", IntSerializer.INSTANCE, null);
+						new ValueStateDescriptor<>("any", IntSerializer.INSTANCE);
 
 				RegisteredBackendStateMetaInfo<VoidNamespace, Integer> registeredBackendStateMetaInfo = new RegisteredBackendStateMetaInfo<>(
 						descriptor.getType(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/KvStateClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/KvStateClientTest.java
@@ -562,7 +562,7 @@ public class KvStateClientTest {
 			clientTaskExecutor = Executors.newFixedThreadPool(numClientsTasks);
 
 			// Create state
-			ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE, null);
+			ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE);
 			desc.setQueryable("any");
 
 			// Create servers

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/KvStateServerHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/KvStateServerHandlerTest.java
@@ -88,7 +88,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		EmbeddedChannel channel = new EmbeddedChannel(getFrameDecoder(), handler);
 
 		// Register state
-		ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE, null);
+		ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE);
 		desc.setQueryable("vanilla");
 
 		int numKeyGroups =1;
@@ -227,7 +227,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		registry.registerListener(registryListener);
 
 		// Register state
-		ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE, null);
+		ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE);
 		desc.setQueryable("vanilla");
 
 		backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, desc);
@@ -372,7 +372,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		registry.registerListener(registryListener);
 
 		// Register state
-		ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE, null);
+		ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE);
 		desc.setQueryable("vanilla");
 
 		backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, desc);
@@ -511,7 +511,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		registry.registerListener(registryListener);
 
 		// Register state
-		ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE, null);
+		ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE);
 		desc.setQueryable("vanilla");
 
 		ValueState<Integer> state = backend.getPartitionedState(
@@ -607,7 +607,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		registry.registerListener(registryListener);
 
 		// Register state
-		ValueStateDescriptor<byte[]> desc = new ValueStateDescriptor<>("any", BytePrimitiveArraySerializer.INSTANCE, null);
+		ValueStateDescriptor<byte[]> desc = new ValueStateDescriptor<>("any", BytePrimitiveArraySerializer.INSTANCE);
 		desc.setQueryable("vanilla");
 
 		ValueState<byte[]> state = backend.getPartitionedState(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/KvStateServerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/KvStateServerTest.java
@@ -105,7 +105,7 @@ public class KvStateServerTest {
 
 			registry.registerListener(registryListener);
 
-			ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE, null);
+			ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>("any", IntSerializer.INSTANCE);
 			desc.setQueryable("vanilla");
 
 			ValueState<Integer> state = backend.getPartitionedState(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -144,7 +144,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		CheckpointStreamFactory streamFactory = createStreamFactory();
 		AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
 
-		ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class, null);
+		ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class);
 		kvId.initializeSerializerUnlessSet(new ExecutionConfig());
 
 		TypeSerializer<Integer> keySerializer = IntSerializer.INSTANCE;
@@ -242,8 +242,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 				new KeyGroupRange(0, 0),
 				new DummyEnvironment("test_op", 1, 0));
 
-		ValueStateDescriptor<String> desc1 = new ValueStateDescriptor<>("a-string", StringSerializer.INSTANCE, null);
-		ValueStateDescriptor<Integer> desc2 = new ValueStateDescriptor<>("an-integer", IntSerializer.INSTANCE, null);
+		ValueStateDescriptor<String> desc1 = new ValueStateDescriptor<>("a-string", StringSerializer.INSTANCE);
+		ValueStateDescriptor<Integer> desc2 = new ValueStateDescriptor<>("an-integer", IntSerializer.INSTANCE);
 
 		desc1.initializeSerializerUnlessSet(new ExecutionConfig());
 		desc2.initializeSerializerUnlessSet(new ExecutionConfig());
@@ -811,7 +811,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 				new KeyGroupRange(0, MAX_PARALLELISM - 1),
 				new DummyEnvironment("test", 1, 0));
 
-		ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class, null);
+		ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class);
 		kvId.initializeSerializerUnlessSet(new ExecutionConfig());
 
 		ValueState<String> state = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
@@ -893,7 +893,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			CheckpointStreamFactory streamFactory = createStreamFactory();
 			AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
 
-			ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class, null);
+			ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class);
 			kvId.initializeSerializerUnlessSet(new ExecutionConfig());
 
 			ValueState<String> state = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
@@ -916,7 +916,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 				(TypeSerializer<String>) (TypeSerializer<?>) FloatSerializer.INSTANCE;
 
 			try {
-				kvId = new ValueStateDescriptor<>("id", fakeStringSerializer, null);
+				kvId = new ValueStateDescriptor<>("id", fakeStringSerializer);
 
 				state = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
 
@@ -1248,8 +1248,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 		ValueStateDescriptor<Integer> desc = new ValueStateDescriptor<>(
 				"test",
-				IntSerializer.INSTANCE,
-				null);
+				IntSerializer.INSTANCE);
 		desc.setQueryable("banana");
 
 		backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, desc);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -652,8 +652,7 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 	public QueryableStateStream<KEY, T> asQueryableState(String queryableStateName) {
 		ValueStateDescriptor<T> valueStateDescriptor = new ValueStateDescriptor<T>(
 				UUID.randomUUID().toString(),
-				getType(),
-				null);
+				getType());
 
 		return asQueryableState(queryableStateName, valueStateDescriptor);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedFold.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedFold.java
@@ -71,7 +71,7 @@ public class StreamGroupedFold<IN, OUT, KEY>
 			initialValue = outTypeSerializer.deserialize(in);
 		}
 		
-		ValueStateDescriptor<OUT> stateId = new ValueStateDescriptor<>(STATE_NAME, outTypeSerializer, null);
+		ValueStateDescriptor<OUT> stateId = new ValueStateDescriptor<>(STATE_NAME, outTypeSerializer);
 		values = getPartitionedState(stateId);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedReduce.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedReduce.java
@@ -45,7 +45,7 @@ public class StreamGroupedReduce<IN> extends AbstractUdfStreamOperator<IN, Reduc
 	@Override
 	public void open() throws Exception {
 		super.open();
-		ValueStateDescriptor<IN> stateId = new ValueStateDescriptor<>(STATE_NAME, serializer, null);
+		ValueStateDescriptor<IN> stateId = new ValueStateDescriptor<>(STATE_NAME, serializer);
 		values = getPartitionedState(stateId);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/DeltaTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/DeltaTrigger.java
@@ -46,7 +46,7 @@ public class DeltaTrigger<T, W extends Window> extends Trigger<T, W> {
 	private DeltaTrigger(double threshold, DeltaFunction<T> deltaFunction, TypeSerializer<T> stateSerializer) {
 		this.deltaFunction = deltaFunction;
 		this.threshold = threshold;
-		stateDesc = new ValueStateDescriptor<>("last-element", stateSerializer, null);
+		stateDesc = new ValueStateDescriptor<>("last-element", stateSerializer);
 
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
@@ -491,7 +491,7 @@ public class AbstractStreamOperatorTest {
 		private transient InternalTimerService<VoidNamespace> timerService;
 
 		private final ValueStateDescriptor<String> stateDescriptor =
-				new ValueStateDescriptor<>("state", StringSerializer.INSTANCE, null);
+				new ValueStateDescriptor<>("state", StringSerializer.INSTANCE);
 
 		@Override
 		public void open() throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/ProcessOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/ProcessOperatorTest.java
@@ -349,7 +349,7 @@ public class ProcessOperatorTest extends TestLogger {
 		private static final long serialVersionUID = 1L;
 
 		private final ValueStateDescriptor<Integer> state =
-				new ValueStateDescriptor<>("seen-element", IntSerializer.INSTANCE,  null);
+				new ValueStateDescriptor<>("seen-element", IntSerializer.INSTANCE);
 
 		private final TimeDomain timeDomain;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
@@ -77,7 +77,7 @@ public class StreamingRuntimeContextTest {
 				createMockEnvironment(),
 				Collections.<String, Accumulator<?, ?>>emptyMap());
 
-		ValueStateDescriptor<TaskInfo> descr = new ValueStateDescriptor<>("name", TaskInfo.class, null);
+		ValueStateDescriptor<TaskInfo> descr = new ValueStateDescriptor<>("name", TaskInfo.class);
 		context.getState(descr);
 		
 		StateDescriptor<?, ?> descrIntercepted = (StateDescriptor<?, ?>) descriptorCapture.get();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoProcessOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoProcessOperatorTest.java
@@ -398,7 +398,7 @@ public class CoProcessOperatorTest extends TestLogger {
 		private static final long serialVersionUID = 1L;
 
 		private final ValueStateDescriptor<String> state =
-				new ValueStateDescriptor<>("seen-element", StringSerializer.INSTANCE, null);
+				new ValueStateDescriptor<>("seen-element", StringSerializer.INSTANCE);
 
 		@Override
 		public void processElement1(Integer value, Context ctx, Collector<String> out) throws Exception {
@@ -479,7 +479,7 @@ public class CoProcessOperatorTest extends TestLogger {
 		private static final long serialVersionUID = 1L;
 
 		private final ValueStateDescriptor<String> state =
-				new ValueStateDescriptor<>("seen-element", StringSerializer.INSTANCE, null);
+				new ValueStateDescriptor<>("seen-element", StringSerializer.INSTANCE);
 
 		@Override
 		public void processElement1(Integer value, Context ctx, Collector<String> out) throws Exception {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -474,8 +474,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
   def asQueryableState(queryableStateName: String) : QueryableStateStream[K, T] = {
     val stateDescriptor = new ValueStateDescriptor(
       queryableStateName,
-      dataType.createSerializer(executionConfig),
-      null.asInstanceOf[T])
+      dataType.createSerializer(executionConfig))
 
     asQueryableState(queryableStateName, stateDescriptor)
   }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/StatefulFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/StatefulFunction.scala
@@ -47,7 +47,7 @@ trait StatefulFunction[I, O, S] extends RichFunction {
   }
 
   override def open(c: Configuration) = {
-    val info = new ValueStateDescriptor[S]("state", stateSerializer, null.asInstanceOf[S])
+    val info = new ValueStateDescriptor[S]("state", stateSerializer)
     state = getRuntimeContext().getState(info)
   }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/StatefulUDFSavepointMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/StatefulUDFSavepointMigrationITCase.java
@@ -358,7 +358,7 @@ public class StatefulUDFSavepointMigrationITCase extends SavepointMigrationTestB
 				new Tuple2<>("hello", 42L);
 
 		private final ValueStateDescriptor<Long> stateDescriptor =
-				new ValueStateDescriptor<Long>("state-name", LongSerializer.INSTANCE, null);
+				new ValueStateDescriptor<Long>("state-name", LongSerializer.INSTANCE);
 
 		@Override
 		public void flatMap(Tuple2<Long, Long> value, Collector<Tuple2<Long, Long>> out) throws Exception {
@@ -385,7 +385,7 @@ public class StatefulUDFSavepointMigrationITCase extends SavepointMigrationTestB
 		private transient Tuple2<String, Long> restoredState;
 
 		private final ValueStateDescriptor<Long> stateDescriptor =
-				new ValueStateDescriptor<Long>("state-name", LongSerializer.INSTANCE, null);
+				new ValueStateDescriptor<Long>("state-name", LongSerializer.INSTANCE);
 
 		@Override
 		public void open(Configuration parameters) throws Exception {
@@ -419,7 +419,7 @@ public class StatefulUDFSavepointMigrationITCase extends SavepointMigrationTestB
 		private static final long serialVersionUID = 1L;
 
 		private final ValueStateDescriptor<Long> stateDescriptor =
-				new ValueStateDescriptor<Long>("state-name", LongSerializer.INSTANCE, null);
+				new ValueStateDescriptor<Long>("state-name", LongSerializer.INSTANCE);
 
 		@Override
 		public void flatMap(Tuple2<Long, Long> value, Collector<Tuple2<Long, Long>> out) throws Exception {
@@ -434,7 +434,7 @@ public class StatefulUDFSavepointMigrationITCase extends SavepointMigrationTestB
 		private static final long serialVersionUID = 1L;
 
 		private final ValueStateDescriptor<Long> stateDescriptor =
-				new ValueStateDescriptor<Long>("state-name", LongSerializer.INSTANCE, null);
+				new ValueStateDescriptor<Long>("state-name", LongSerializer.INSTANCE);
 
 		@Override
 		public void open(Configuration parameters) throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCase.java
@@ -603,8 +603,7 @@ public class QueryableStateITCase extends TestLogger {
 			// Value state
 			ValueStateDescriptor<Tuple2<Integer, Long>> valueState = new ValueStateDescriptor<>(
 					"any",
-					source.getType(),
-					null);
+					source.getType());
 
 			QueryableStateStream<Integer, Tuple2<Integer, Long>> queryableState =
 					source.keyBy(new KeySelector<Tuple2<Integer, Long>, Integer>() {


### PR DESCRIPTION
I left usage of this in a lot of places to ensure that we don't break anything. The rest of places where the default-value constructer is used should be tackled once we remove that constructor.

R: @StephanEwen for review