### PR TITLE
[FLINK-4912] Introduce RECONCILIATING state in ExecutionGraph and Exe…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/ExecutionState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/ExecutionState.java
@@ -25,15 +25,22 @@ package org.apache.flink.runtime.execution;
  * <pre>{@code
  *
  *     CREATED  -> SCHEDULED -> DEPLOYING -> RUNNING -> FINISHED
- *                     |            |          |
- *                     |            |   +------+
- *                     |            V   V
- *                     |         CANCELLING -----+----> CANCELED
- *                     |                         |
- *                     +-------------------------+
+ *            |         |            |          |
+ *            |         |            |   +------+
+ *            |         |            V   V
+ *            |         |         CANCELLING -----+----> CANCELED
+ *            |         |                         |
+ *            |        +-------------------------+
+ *            |
+ *            |                                   ... -> FAILED
+ *           V
+ *    RECONCILING  -> RUNNING | FINISHED | CANCELED | FAILED
  *
- *                                               ... -> FAILED
  * }</pre>
+ *
+ * <p>It is possible to enter the {@code RECONCILING} state from {@code CREATED}
+ * state if job manager fail over, and the {@code RECONCILING} state can switch into
+ * any existing task state.</p>
  *
  * <p>It is possible to enter the {@code FAILED} state from any other state.</p>
  *
@@ -56,8 +63,9 @@ public enum ExecutionState {
 	
 	CANCELED,
 	
-	FAILED;
+	FAILED,
 
+	RECONCILING;
 
 	public boolean isTerminal() {
 		return this == FINISHED || this == CANCELED || this == FAILED;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobStatus.java
@@ -51,7 +51,10 @@ public enum JobStatus {
 	 * The job has been suspended which means that it has been stopped but not been removed from a
 	 * potential HA job store.
 	 */
-	SUSPENDED(TerminalState.LOCALLY);
+	SUSPENDED(TerminalState.LOCALLY),
+
+	/** The job is currently reconciling and waits for task execution report to recover state. */
+	RECONCILING(TerminalState.NON_TERMINAL);
 	
 	// --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This is part of the non-disruptive JobManager failure recovery.

Add a JobStatus and ExecutionState **RECONCILING**.
If a job is started on a JobManager for recovery, the job status with all the executions transition to **RECONCILING** state.

From **RECONCILING**, execution can restore to any existing task states (execution reconciled with TaskManager).