### PR TITLE
[FLINK-5480] Introduce user-provided hash for JobVertexes

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
@@ -97,24 +97,31 @@ public class CassandraSink<IN> {
 	}
 
 	/**
-	 * Sets an additional, user provided hash for this operator.
+	 * Sets an user provided hash for this operator. This will be used AS IS the create the JobVertexID.
 	 * <p/>
 	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
 	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions).
 	 * <p/>
-	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
-	 * submission will fail. Furthermore, you cannot assign user-specified hash to intermediate nodes in an operator
-	 * chain and trying so will let your job fail.
+	 * <p><strong>Important</strong>: this should be used as a workaround or for trouble shooting. The provided hash
+	 * needs to be unique per transformation and job. Otherwise, job submission will fail. Furthermore, you cannot
+	 * assign user-specified hash to intermediate nodes in an operator chain and trying so will let your job fail.
 	 *
-	 * @param hash the user provided hash for this operator.
+	 * <p>
+	 * A use case for this is in migration between Flink versions or changing the jobs in a way that changes the
+	 * automatically generated hashes. In this case, providing the previous hashes directly through this method (e.g.
+	 * obtained from old logs) can help to reestablish a lost mapping from states to their target operator.
+	 * <p/>
+	 *
+	 * @param uidHash The user provided hash for this operator. This will become the JobVertexID, which is shown in the
+	 *                 logs and web ui.
 	 * @return The operator with the user provided hash.
 	 */
 	@PublicEvolving
-	public CassandraSink<IN> setAdditionalNodeHash(String hash) {
+	public CassandraSink<IN> setUidHash(String uidHash) {
 		if (useDataStreamSink) {
-			getSinkTransformation().provideAdditionalNodeHash(hash);
+			getSinkTransformation().setUidHash(uidHash);
 		} else {
-			getStreamTransformation().provideAdditionalNodeHash(hash);
+			getStreamTransformation().setUidHash(uidHash);
 		}
 		return this;
 	}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
@@ -95,6 +95,28 @@ public class CassandraSink<IN> {
 	}
 
 	/**
+	 * Sets an additional, user provided hash for this operator.
+	 *
+	 * <p/>
+	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
+	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions.
+	 *
+	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
+	 * submission will fail.
+	 *
+	 * @param hash the user provided hash for this operator.
+	 * @return The operator with the user provided hash.
+	 */
+	public CassandraSink<IN> provideAdditionalNodeHash(String hash) {
+		if (useDataStreamSink) {
+			getSinkTransformation().provideAdditionalNodeHash(hash);
+		} else {
+			getStreamTransformation().provideAdditionalNodeHash(hash);
+		}
+		return this;
+	}
+
+	/**
 	 * Sets the parallelism for this sink. The degree must be higher than zero.
 	 *
 	 * @param parallelism The parallelism for this sink.

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
@@ -100,7 +100,7 @@ public class CassandraSink<IN> {
 	 * Sets an additional, user provided hash for this operator.
 	 * <p/>
 	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
-	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions.
+	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions).
 	 * <p/>
 	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
 	 * submission will fail. Furthermore, you cannot assign user-specified hash to intermediate nodes in an operator

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.cassandra;
 
 import com.datastax.driver.core.Cluster;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple;
@@ -85,6 +86,7 @@ public class CassandraSink<IN> {
 	 * @param uid The unique user-specified ID of this transformation.
 	 * @return The operator with the specified ID.
 	 */
+	@PublicEvolving
 	public CassandraSink<IN> uid(String uid) {
 		if (useDataStreamSink) {
 			getSinkTransformation().setUid(uid);
@@ -96,18 +98,19 @@ public class CassandraSink<IN> {
 
 	/**
 	 * Sets an additional, user provided hash for this operator.
-	 *
 	 * <p/>
 	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
 	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions.
-	 *
+	 * <p/>
 	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
-	 * submission will fail.
+	 * submission will fail. Furthermore, you cannot assign user-specified hash to intermediate nodes in an operator
+	 * chain and trying so will let your job fail.
 	 *
 	 * @param hash the user provided hash for this operator.
 	 * @return The operator with the user provided hash.
 	 */
-	public CassandraSink<IN> provideAdditionalNodeHash(String hash) {
+	@PublicEvolving
+	public CassandraSink<IN> setAdditionalNodeHash(String hash) {
 		if (useDataStreamSink) {
 			getSinkTransformation().provideAdditionalNodeHash(hash);
 		} else {

--- a/flink-streaming-java/src/main/java/org/apache/flink/migration/streaming/api/graph/StreamGraphHasherV1.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/migration/streaming/api/graph/StreamGraphHasherV1.java
@@ -130,7 +130,7 @@ public class StreamGraphHasherV1 implements StreamGraphHasher {
 			boolean isChainingEnabled) {
 
 		// Check for user-specified ID
-		String userSpecifiedHash = node.getTransformationId();
+		String userSpecifiedHash = node.getTransformationUID();
 
 		if (userSpecifiedHash == null) {
 			// Check that all input nodes have their hashes computed
@@ -192,7 +192,7 @@ public class StreamGraphHasherV1 implements StreamGraphHasher {
 	 * Generates a hash from a user-specified ID.
 	 */
 	private byte[] generateUserSpecifiedHash(StreamNode node, Hasher hasher) {
-		hasher.putString(node.getTransformationId(), Charset.forName("UTF-8"));
+		hasher.putString(node.getTransformationUID(), Charset.forName("UTF-8"));
 
 		return hasher.hash().asBytes();
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -77,6 +77,25 @@ public class DataStreamSink<T> {
 	}
 
 	/**
+	 * Sets an additional, user provided hash for this operator.
+	 *
+	 * <p/>
+	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
+	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions.
+	 *
+	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
+	 * submission will fail.
+	 *
+	 * @param hash the user provided hash for this operator.
+	 * @return The operator with the user provided hash.
+	 */
+	@PublicEvolving
+	public DataStreamSink<T> provideAdditionalNodeHash(String hash) {
+		transformation.setUid(hash);
+		return this;
+	}
+
+	/**
 	 * Sets the parallelism for this sink. The degree must be higher than zero.
 	 *
 	 * @param parallelism The parallelism for this sink.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -80,7 +80,7 @@ public class DataStreamSink<T> {
 	 * Sets an additional, user provided hash for this operator.
 	 * <p/>
 	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
-	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions.
+	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions).
 	 * <p/>
 	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
 	 * submission will fail. Furthermore, you cannot assign user-specified hash to intermediate nodes in an operator

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -78,19 +78,19 @@ public class DataStreamSink<T> {
 
 	/**
 	 * Sets an additional, user provided hash for this operator.
-	 *
 	 * <p/>
 	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
 	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions.
-	 *
+	 * <p/>
 	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
-	 * submission will fail.
+	 * submission will fail. Furthermore, you cannot assign user-specified hash to intermediate nodes in an operator
+	 * chain and trying so will let your job fail.
 	 *
 	 * @param hash the user provided hash for this operator.
 	 * @return The operator with the user provided hash.
 	 */
 	@PublicEvolving
-	public DataStreamSink<T> provideAdditionalNodeHash(String hash) {
+	public DataStreamSink<T> setAdditionalNodeHash(String hash) {
 		transformation.setUid(hash);
 		return this;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -77,21 +77,28 @@ public class DataStreamSink<T> {
 	}
 
 	/**
-	 * Sets an additional, user provided hash for this operator.
+	 * Sets an user provided hash for this operator. This will be used AS IS the create the JobVertexID.
 	 * <p/>
 	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
 	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions).
 	 * <p/>
-	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
-	 * submission will fail. Furthermore, you cannot assign user-specified hash to intermediate nodes in an operator
-	 * chain and trying so will let your job fail.
+	 * <p><strong>Important</strong>: this should be used as a workaround or for trouble shooting. The provided hash
+	 * needs to be unique per transformation and job. Otherwise, job submission will fail. Furthermore, you cannot
+	 * assign user-specified hash to intermediate nodes in an operator chain and trying so will let your job fail.
 	 *
-	 * @param hash the user provided hash for this operator.
+	 * <p>
+	 * A use case for this is in migration between Flink versions or changing the jobs in a way that changes the
+	 * automatically generated hashes. In this case, providing the previous hashes directly through this method (e.g.
+	 * obtained from old logs) can help to reestablish a lost mapping from states to their target operator.
+	 * <p/>
+	 *
+	 * @param uidHash The user provided hash for this operator. This will become the JobVertexID, which is shown in the
+	 *                 logs and web ui.
 	 * @return The operator with the user provided hash.
 	 */
 	@PublicEvolving
-	public DataStreamSink<T> setAdditionalNodeHash(String hash) {
-		transformation.setUid(hash);
+	public DataStreamSink<T> setUidHash(String uidHash) {
+		transformation.setUidHash(uidHash);
 		return this;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -87,6 +87,26 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 		return this;
 	}
 
+
+	/**
+	 * Sets an additional, user provided hash for this operator.
+	 *
+	 * <p/>
+	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
+	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions.
+	 *
+	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
+	 * submission will fail.
+	 *
+	 * @param hash the user provided hash for this operator.
+	 * @return The operator with the user provided hash.
+	 */
+	@PublicEvolving
+	public SingleOutputStreamOperator<T> provideAdditionalNodeHash(String hash) {
+		transformation.provideAdditionalNodeHash(hash);
+		return this;
+	}
+
 	/**
 	 * Sets the parallelism for this operator. The degree must be 1 or more.
 	 * 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -88,21 +88,28 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 	}
 
 	/**
-	 * Sets an additional, user provided hash for this operator.
+	 * Sets an user provided hash for this operator. This will be used AS IS the create the JobVertexID.
 	 * <p/>
 	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
 	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions).
 	 * <p/>
-	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
-	 * submission will fail. Furthermore, you cannot assign user-specified hash to intermediate nodes in an operator
-	 * chain and trying so will let your job fail.
+	 * <p><strong>Important</strong>: this should be used as a workaround or for trouble shooting. The provided hash
+	 * needs to be unique per transformation and job. Otherwise, job submission will fail. Furthermore, you cannot
+	 * assign user-specified hash to intermediate nodes in an operator chain and trying so will let your job fail.
 	 *
-	 * @param hash the user provided hash for this operator.
+	 * <p>
+	 * A use case for this is in migration between Flink versions or changing the jobs in a way that changes the
+	 * automatically generated hashes. In this case, providing the previous hashes directly through this method (e.g.
+	 * obtained from old logs) can help to reestablish a lost mapping from states to their target operator.
+	 * <p/>
+	 *
+	 * @param uidHash The user provided hash for this operator. This will become the JobVertexID, which is shown in the
+	 *                 logs and web ui.
 	 * @return The operator with the user provided hash.
 	 */
 	@PublicEvolving
-	public SingleOutputStreamOperator<T> setAdditionalNodeHash(String hash) {
-		transformation.provideAdditionalNodeHash(hash);
+	public SingleOutputStreamOperator<T> setUidHash(String uidHash) {
+		transformation.setUidHash(uidHash);
 		return this;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -91,7 +91,7 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 	 * Sets an additional, user provided hash for this operator.
 	 * <p/>
 	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
-	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions.
+	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions).
 	 * <p/>
 	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
 	 * submission will fail. Furthermore, you cannot assign user-specified hash to intermediate nodes in an operator

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -87,22 +87,21 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 		return this;
 	}
 
-
 	/**
 	 * Sets an additional, user provided hash for this operator.
-	 *
 	 * <p/>
 	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
 	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions.
-	 *
+	 * <p/>
 	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
-	 * submission will fail.
+	 * submission will fail. Furthermore, you cannot assign user-specified hash to intermediate nodes in an operator
+	 * chain and trying so will let your job fail.
 	 *
 	 * @param hash the user provided hash for this operator.
 	 * @return The operator with the user provided hash.
 	 */
 	@PublicEvolving
-	public SingleOutputStreamOperator<T> provideAdditionalNodeHash(String hash) {
+	public SingleOutputStreamOperator<T> setAdditionalNodeHash(String hash) {
 		transformation.provideAdditionalNodeHash(hash);
 		return this;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -17,18 +17,6 @@
 
 package org.apache.flink.streaming.api.graph;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.io.InputFormat;
@@ -41,6 +29,7 @@ import org.apache.flink.api.java.typeutils.MissingTypeInfo;
 import org.apache.flink.optimizer.plan.StreamingPlan;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -49,7 +38,6 @@ import org.apache.flink.streaming.api.operators.StoppableStreamSource;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
-import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.streaming.runtime.partitioner.ConfigurableStreamPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
@@ -62,6 +50,18 @@ import org.apache.flink.streaming.runtime.tasks.StreamIterationTail;
 import org.apache.flink.streaming.runtime.tasks.TwoInputStreamTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Class representing the streaming topology. It contains all the information
@@ -472,10 +472,17 @@ public class StreamGraph extends StreamingPlan {
 		getStreamNode(vertexID).setInputFormat(inputFormat);
 	}
 
-	void setTransformationId(Integer nodeId, String transformationId) {
+	void setTransformationUID(Integer nodeId, String transformationId) {
 		StreamNode node = streamNodes.get(nodeId);
 		if (node != null) {
-			node.setTransformationId(transformationId);
+			node.setTransformationUID(transformationId);
+		}
+	}
+
+	void setTransformationUserHash(Integer nodeId, String nodeHash) {
+		StreamNode node = streamNodes.get(nodeId);
+		if (node != null) {
+			node.setUserHash(nodeHash);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -208,7 +208,10 @@ public class StreamGraphGenerator {
 			streamGraph.setBufferTimeout(transform.getId(), transform.getBufferTimeout());
 		}
 		if (transform.getUid() != null) {
-			streamGraph.setTransformationId(transform.getId(), transform.getUid());
+			streamGraph.setTransformationUID(transform.getId(), transform.getUid());
+		}
+		if (transform.getUserProvidedNodeHash() != null) {
+			streamGraph.setTransformationUserHash(transform.getId(), transform.getUserProvidedNodeHash());
 		}
 
 		return transformedIds;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphHasherV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphHasherV2.java
@@ -148,7 +148,7 @@ public class StreamGraphHasherV2 implements StreamGraphHasher {
 			boolean isChainingEnabled) {
 
 		// Check for user-specified ID
-		String userSpecifiedHash = node.getTransformationId();
+		String userSpecifiedHash = node.getTransformationUID();
 
 		if (userSpecifiedHash == null) {
 			// Check that all input nodes have their hashes computed
@@ -210,7 +210,7 @@ public class StreamGraphHasherV2 implements StreamGraphHasher {
 	 * Generates a hash from a user-specified ID.
 	 */
 	private byte[] generateUserSpecifiedHash(StreamNode node, Hasher hasher) {
-		hasher.putString(node.getTransformationId(), Charset.forName("UTF-8"));
+		hasher.putString(node.getTransformationUID(), Charset.forName("UTF-8"));
 
 		return hasher.hash().asBytes();
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphUserHashHasher.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphUserHashHasher.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph;
+
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
+import org.apache.flink.util.StringUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * StreamGraphHasher that works with user provided hashes.
+ */
+public class StreamGraphUserHashHasher implements StreamGraphHasher {
+	@Override
+	public Map<Integer, byte[]> traverseStreamGraphAndGenerateHashes(StreamGraph streamGraph) {
+		HashMap<Integer, byte[]> hashResult = new HashMap<>();
+		for (StreamNode streamNode : streamGraph.getStreamNodes()) {
+			String userHash = streamNode.getUserHash();
+			if (null != userHash) {
+
+				for (StreamEdge inEdge : streamNode.getInEdges()) {
+					if (isChainable(inEdge, streamGraph.isChainingEnabled())) {
+						throw new UnsupportedOperationException("Cannot assign user-specified hash "
+								+ "to intermediate node in chain. This will be supported in future "
+								+ "versions of Flink. As a work around start new chain at task "
+								+ streamNode.getOperatorName() + ".");
+					}
+				}
+
+				hashResult.put(streamNode.getId(), StringUtils.hexStringToByte(userHash));
+			}
+		}
+
+		return hashResult;
+	}
+
+	private boolean isChainable(StreamEdge edge, boolean isChainingEnabled) {
+		StreamNode upStreamVertex = edge.getSourceVertex();
+		StreamNode downStreamVertex = edge.getTargetVertex();
+
+		StreamOperator<?> headOperator = upStreamVertex.getOperator();
+		StreamOperator<?> outOperator = downStreamVertex.getOperator();
+
+		return downStreamVertex.getInEdges().size() == 1
+				&& outOperator != null
+				&& headOperator != null
+				&& upStreamVertex.isSameSlotSharingGroup(downStreamVertex)
+				&& outOperator.getChainingStrategy() == ChainingStrategy.ALWAYS
+				&& (headOperator.getChainingStrategy() == ChainingStrategy.HEAD ||
+				headOperator.getChainingStrategy() == ChainingStrategy.ALWAYS)
+				&& (edge.getPartitioner() instanceof ForwardPartitioner)
+				&& upStreamVertex.getParallelism() == downStreamVertex.getParallelism()
+				&& isChainingEnabled;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphUserHashHasher.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphUserHashHasher.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * StreamGraphHasher that works with user provided hashes. This us useful in case we want to set (alternative) hashes
+ * StreamGraphHasher that works with user provided hashes. This is useful in case we want to set (alternative) hashes
  * explicitly, e.g. to provide a way of manual backwards compatibility between versions when the mechanism of generating
  * hashes has changed in an incompatible way.
  *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -69,7 +69,8 @@ public class StreamNode implements Serializable {
 
 	private InputFormat<?, ?> inputFormat;
 
-	private String transformationId;
+	private String transformationUID;
+	private String userHash;
 
 	public StreamNode(StreamExecutionEnvironment env,
 		Integer id,
@@ -272,12 +273,20 @@ public class StreamNode implements Serializable {
 		this.stateKeySerializer = stateKeySerializer;
 	}
 
-	public String getTransformationId() {
-		return transformationId;
+	public String getTransformationUID() {
+		return transformationUID;
 	}
 
-	void setTransformationId(String transformationId) {
-		this.transformationId = transformationId;
+	void setTransformationUID(String transformationId) {
+		this.transformationUID = transformationId;
+	}
+
+	public String getUserHash() {
+		return userHash;
+	}
+
+	public void setUserHash(String userHash) {
+		this.userHash = userHash;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -185,7 +185,7 @@ public class StreamingJobGraphGenerator {
 			List<StreamEdge> nonChainableOutputs = new ArrayList<StreamEdge>();
 
 			for (StreamEdge outEdge : streamGraph.getStreamNode(currentNodeId).getOutEdges()) {
-				if (isChainable(outEdge)) {
+				if (isChainable(outEdge, streamGraph)) {
 					chainableOutputs.add(outEdge);
 				} else {
 					nonChainableOutputs.add(outEdge);
@@ -426,7 +426,7 @@ public class StreamingJobGraphGenerator {
 		}
 	}
 
-	private boolean isChainable(StreamEdge edge) {
+	public static boolean isChainable(StreamEdge edge, StreamGraph streamGraph) {
 		StreamNode upStreamVertex = edge.getSourceVertex();
 		StreamNode downStreamVertex = edge.getTargetVertex();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -51,8 +51,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -89,7 +89,7 @@ public class StreamingJobGraphGenerator {
 	public StreamingJobGraphGenerator(StreamGraph streamGraph) {
 		this.streamGraph = streamGraph;
 		this.defaultStreamGraphHasher = new StreamGraphHasherV2();
-		this.legacyStreamGraphHashers = Collections.<StreamGraphHasher>singletonList(new StreamGraphHasherV1());
+		this.legacyStreamGraphHashers = Arrays.asList(new StreamGraphHasherV1(), new StreamGraphUserHashHasher());
 	}
 
 	private void init() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
@@ -212,7 +212,7 @@ public abstract class StreamTransformation<T> {
 	 * Sets an additional, user provided hash for this operator.
 	 * <p/>
 	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
-	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions.
+	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions).
 	 * <p/>
 	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
 	 * submission will fail. Furthermore, you cannot assign user-specified hash to intermediate nodes in an operator

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
@@ -210,17 +210,20 @@ public abstract class StreamTransformation<T> {
 
 	/**
 	 * Sets an additional, user provided hash for this operator.
-	 *
 	 * <p/>
 	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
 	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions.
-	 *
+	 * <p/>
 	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
-	 * submission will fail.
+	 * submission will fail. Furthermore, you cannot assign user-specified hash to intermediate nodes in an operator
+	 * chain and trying so will let your job fail.
 	 *
 	 * @param nodeHash the user provided hash for this operator.
 	 */
 	public void provideAdditionalNodeHash(String nodeHash) {
+		Preconditions.checkNotNull(nodeHash);
+		Preconditions.checkArgument(nodeHash.matches("^[0-9A-Fa-f]{32}$"),
+				"Node hash must be a 32 character String that describes a hex code. Found: " + nodeHash);
 		this.userProvidedNodeHash = nodeHash;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
@@ -209,22 +209,31 @@ public abstract class StreamTransformation<T> {
 	}
 
 	/**
-	 * Sets an additional, user provided hash for this operator.
+	 * Sets an user provided hash for this operator. This will be used AS IS the create the JobVertexID.
 	 * <p/>
 	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
 	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions).
 	 * <p/>
-	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
-	 * submission will fail. Furthermore, you cannot assign user-specified hash to intermediate nodes in an operator
-	 * chain and trying so will let your job fail.
+	 * <p><strong>Important</strong>: this should be used as a workaround or for trouble shooting. The provided hash
+	 * needs to be unique per transformation and job. Otherwise, job submission will fail. Furthermore, you cannot
+	 * assign user-specified hash to intermediate nodes in an operator chain and trying so will let your job fail.
 	 *
-	 * @param nodeHash the user provided hash for this operator.
+	 * <p>
+	 * A use case for this is in migration between Flink versions or changing the jobs in a way that changes the
+	 * automatically generated hashes. In this case, providing the previous hashes directly through this method (e.g.
+	 * obtained from old logs) can help to reestablish a lost mapping from states to their target operator.
+	 * <p/>
+	 *
+	 * @param uidHash The user provided hash for this operator. This will become the JobVertexID, which is shown in the
+	 *                 logs and web ui.
 	 */
-	public void provideAdditionalNodeHash(String nodeHash) {
-		Preconditions.checkNotNull(nodeHash);
-		Preconditions.checkArgument(nodeHash.matches("^[0-9A-Fa-f]{32}$"),
-				"Node hash must be a 32 character String that describes a hex code. Found: " + nodeHash);
-		this.userProvidedNodeHash = nodeHash;
+	public void setUidHash(String uidHash) {
+
+		Preconditions.checkNotNull(uidHash);
+		Preconditions.checkArgument(uidHash.matches("^[0-9A-Fa-f]{32}$"),
+				"Node hash must be a 32 character String that describes a hex code. Found: " + uidHash);
+
+		this.userProvidedNodeHash = uidHash;
 	}
 
 	/**
@@ -237,7 +246,8 @@ public abstract class StreamTransformation<T> {
 	}
 
 	/**
-	 * Sets an ID for this {@link StreamTransformation}.
+	 * Sets an ID for this {@link StreamTransformation}. This is will later be hashed to a uidHash which is then used to
+	 * create the JobVertexID (that is shown in logs and the web ui).
 	 *
 	 * <p>The specified ID is used to assign the same operator ID across job
 	 * submissions (for example when starting a job from a savepoint).

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
@@ -99,10 +99,12 @@ public abstract class StreamTransformation<T> {
 
 	// This is used to assign a unique ID to every StreamTransformation
 	protected static Integer idCounter = 0;
+
 	public static int getNewNodeId() {
 		idCounter++;
 		return idCounter;
 	}
+
 
 	protected final int id;
 
@@ -129,6 +131,8 @@ public abstract class StreamTransformation<T> {
 	 * field is independent from this.
 	 */
 	private String uid;
+
+	private String userProvidedNodeHash;
 
 	protected long bufferTimeout = -1;
 
@@ -202,6 +206,31 @@ public abstract class StreamTransformation<T> {
 	 */
 	public void setMaxParallelism(int maxParallelism) {
 		this.maxParallelism = maxParallelism;
+	}
+
+	/**
+	 * Sets an additional, user provided hash for this operator.
+	 *
+	 * <p/>
+	 * <p>The user provided hash is an alternative to the generated hashes, that is considered when identifying an
+	 * operator through the default hash mechanics fails (e.g. because of changes between Flink versions.
+	 *
+	 * <p><strong>Important</strong>: this hash needs to be unique per transformation and job. Otherwise, job
+	 * submission will fail.
+	 *
+	 * @param nodeHash the user provided hash for this operator.
+	 */
+	public void provideAdditionalNodeHash(String nodeHash) {
+		this.userProvidedNodeHash = nodeHash;
+	}
+
+	/**
+	 * Gets the user provided hash.
+	 *
+	 * @return The user provided hash.
+	 */
+	public String getUserProvidedNodeHash() {
+		return userProvidedNodeHash;
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/StreamingJobGraphGeneratorNodeHashTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/StreamingJobGraphGeneratorNodeHashTest.java
@@ -32,8 +32,10 @@ import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.util.TestLogger;
+import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -45,6 +47,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests the {@link StreamNode} hash assignment during translation from {@link StreamGraph} to
@@ -420,6 +423,43 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 				.addSink(new NoOpSinkFunction());
 
 		env.getStreamGraph().getJobGraph();
+	}
+
+	@Test
+	public void testUserProvidedHashing() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment();
+
+		List<String> userHashes = Arrays.asList("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+		env.addSource(new NoOpSourceFunction(), "src").provideAdditionalNodeHash(userHashes.get(0))
+				.map(new NoOpMapFunction())
+				.filter(new NoOpFilterFunction())
+				.keyBy(new NoOpKeySelector())
+				.reduce(new NoOpReduceFunction()).name("reduce").provideAdditionalNodeHash(userHashes.get(1));
+
+		StreamGraph streamGraph = env.getStreamGraph();
+		int idx = 1;
+		for (JobVertex jobVertex : streamGraph.getJobGraph().getVertices()) {
+			Assert.assertEquals(jobVertex.getIdAlternatives().get(1).toString(), userHashes.get(idx));
+			--idx;
+		}
+	}
+
+	@Test
+	public void testUserProvidedHashingOnChainNotSupported() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment();
+
+		env.addSource(new NoOpSourceFunction(), "src").provideAdditionalNodeHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+				.map(new NoOpMapFunction()).provideAdditionalNodeHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+				.filter(new NoOpFilterFunction()).provideAdditionalNodeHash("cccccccccccccccccccccccccccccccc")
+				.keyBy(new NoOpKeySelector())
+				.reduce(new NoOpReduceFunction()).name("reduce").provideAdditionalNodeHash("dddddddddddddddddddddddddddddddd");
+
+		try {
+			env.getStreamGraph().getJobGraph();
+			fail();
+		} catch (UnsupportedOperationException ignored) {
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/StreamingJobGraphGeneratorNodeHashTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/StreamingJobGraphGeneratorNodeHashTest.java
@@ -431,11 +431,11 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 
 		List<String> userHashes = Arrays.asList("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 
-		env.addSource(new NoOpSourceFunction(), "src").provideAdditionalNodeHash(userHashes.get(0))
+		env.addSource(new NoOpSourceFunction(), "src").setAdditionalNodeHash(userHashes.get(0))
 				.map(new NoOpMapFunction())
 				.filter(new NoOpFilterFunction())
 				.keyBy(new NoOpKeySelector())
-				.reduce(new NoOpReduceFunction()).name("reduce").provideAdditionalNodeHash(userHashes.get(1));
+				.reduce(new NoOpReduceFunction()).name("reduce").setAdditionalNodeHash(userHashes.get(1));
 
 		StreamGraph streamGraph = env.getStreamGraph();
 		int idx = 1;
@@ -449,11 +449,11 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 	public void testUserProvidedHashingOnChainNotSupported() {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment();
 
-		env.addSource(new NoOpSourceFunction(), "src").provideAdditionalNodeHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-				.map(new NoOpMapFunction()).provideAdditionalNodeHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
-				.filter(new NoOpFilterFunction()).provideAdditionalNodeHash("cccccccccccccccccccccccccccccccc")
+		env.addSource(new NoOpSourceFunction(), "src").setAdditionalNodeHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+				.map(new NoOpMapFunction()).setAdditionalNodeHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+				.filter(new NoOpFilterFunction()).setAdditionalNodeHash("cccccccccccccccccccccccccccccccc")
 				.keyBy(new NoOpKeySelector())
-				.reduce(new NoOpReduceFunction()).name("reduce").provideAdditionalNodeHash("dddddddddddddddddddddddddddddddd");
+				.reduce(new NoOpReduceFunction()).name("reduce").setAdditionalNodeHash("dddddddddddddddddddddddddddddddd");
 
 		try {
 			env.getStreamGraph().getJobGraph();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/StreamingJobGraphGeneratorNodeHashTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/StreamingJobGraphGeneratorNodeHashTest.java
@@ -431,11 +431,11 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 
 		List<String> userHashes = Arrays.asList("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 
-		env.addSource(new NoOpSourceFunction(), "src").setAdditionalNodeHash(userHashes.get(0))
+		env.addSource(new NoOpSourceFunction(), "src").setUidHash(userHashes.get(0))
 				.map(new NoOpMapFunction())
 				.filter(new NoOpFilterFunction())
 				.keyBy(new NoOpKeySelector())
-				.reduce(new NoOpReduceFunction()).name("reduce").setAdditionalNodeHash(userHashes.get(1));
+				.reduce(new NoOpReduceFunction()).name("reduce").setUidHash(userHashes.get(1));
 
 		StreamGraph streamGraph = env.getStreamGraph();
 		int idx = 1;
@@ -449,11 +449,11 @@ public class StreamingJobGraphGeneratorNodeHashTest extends TestLogger {
 	public void testUserProvidedHashingOnChainNotSupported() {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment();
 
-		env.addSource(new NoOpSourceFunction(), "src").setAdditionalNodeHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-				.map(new NoOpMapFunction()).setAdditionalNodeHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
-				.filter(new NoOpFilterFunction()).setAdditionalNodeHash("cccccccccccccccccccccccccccccccc")
+		env.addSource(new NoOpSourceFunction(), "src").setUidHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+				.map(new NoOpMapFunction()).setUidHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+				.filter(new NoOpFilterFunction()).setUidHash("cccccccccccccccccccccccccccccccc")
 				.keyBy(new NoOpKeySelector())
-				.reduce(new NoOpReduceFunction()).name("reduce").setAdditionalNodeHash("dddddddddddddddddddddddddddddddd");
+				.reduce(new NoOpReduceFunction()).name("reduce").setUidHash("dddddddddddddddddddddddddddddddd");
 
 		try {
 			env.getStreamGraph().getJobGraph();

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -201,6 +201,28 @@ class DataStream[T](stream: JavaStream[T]) {
   }
 
   /**
+    * Sets an additional, user provided hash for this operator.
+    *
+    * <p/>
+    * <p>The user provided hash is an alternative to the generated hashes,
+    * that is considered when identifying an operator through the default
+    * hash mechanics fails (e.g. because of changes between Flink versions.
+    *
+    * <p><strong>Important</strong>: this hash needs to be unique per
+    * transformation and job. Otherwise, job submission will fail.
+    *
+    * @param hash the user provided hash for this operator.
+    * @return The operator with the user provided hash.
+    */
+  @PublicEvolving
+  def provideAdditionalNodeHash(hash: String) : DataStream[T] = javaStream match {
+    case stream : SingleOutputStreamOperator[T] =>
+      asScalaStream(stream.provideAdditionalNodeHash(hash))
+    case _ => throw new UnsupportedOperationException("Only supported for operators.")
+      this
+  }
+
+  /**
    * Turns off chaining for this operator so thread co-location will not be
    * used as an optimization. </p> Chaining can be turned off for the whole
    * job by [[StreamExecutionEnvironment.disableOperatorChaining()]]

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -209,15 +209,17 @@ class DataStream[T](stream: JavaStream[T]) {
     * hash mechanics fails (e.g. because of changes between Flink versions.
     *
     * <p><strong>Important</strong>: this hash needs to be unique per
-    * transformation and job. Otherwise, job submission will fail.
+    * transformation and job. Furthermore, you cannot assign
+    * user-specified hash to intermediate nodes in an operator
+    * chain. Otherwise, job submission will fail.
     *
     * @param hash the user provided hash for this operator.
     * @return The operator with the user provided hash.
     */
   @PublicEvolving
-  def provideAdditionalNodeHash(hash: String) : DataStream[T] = javaStream match {
+  def setAdditionalNodeHash(hash: String) : DataStream[T] = javaStream match {
     case stream : SingleOutputStreamOperator[T] =>
-      asScalaStream(stream.provideAdditionalNodeHash(hash))
+      asScalaStream(stream.setAdditionalNodeHash(hash))
     case _ => throw new UnsupportedOperationException("Only supported for operators.")
       this
   }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -201,25 +201,25 @@ class DataStream[T](stream: JavaStream[T]) {
   }
 
   /**
-    * Sets an additional, user provided hash for this operator.
-    *
+    * Sets an user provided hash for this operator. This will be used AS IS the create
+    * the JobVertexID.
     * <p/>
-    * <p>The user provided hash is an alternative to the generated hashes,
-    * that is considered when identifying an operator through the default
-    * hash mechanics fails (e.g. because of changes between Flink versions.
-    *
-    * <p><strong>Important</strong>: this hash needs to be unique per
-    * transformation and job. Furthermore, you cannot assign
-    * user-specified hash to intermediate nodes in an operator
-    * chain. Otherwise, job submission will fail.
+    * <p>The user provided hash is an alternative to the generated hashes, that is
+    * considered when identifying an operator through the default hash mechanics fails
+    * (e.g. because of changes between Flink versions).
+    * <p/>
+    * <p><strong>Important</strong>: this should be used as a workaround or for trouble
+    * shooting. The provided hash needs to be unique per transformation and job. Otherwise,
+    * job submission will fail. Furthermore, you cannot assign user-specified hash to
+    * intermediate nodes in an operator chain and trying so will let your job fail.
     *
     * @param hash the user provided hash for this operator.
     * @return The operator with the user provided hash.
     */
   @PublicEvolving
-  def setAdditionalNodeHash(hash: String) : DataStream[T] = javaStream match {
+  def setUidHash(hash: String) : DataStream[T] = javaStream match {
     case stream : SingleOutputStreamOperator[T] =>
-      asScalaStream(stream.setAdditionalNodeHash(hash))
+      asScalaStream(stream.setUidHash(hash))
     case _ => throw new UnsupportedOperationException("Only supported for operators.")
       this
   }


### PR DESCRIPTION
This PR allows users to provided (alternative) hashes for operators in a StreamGraph. This can make migration between Flink versions easier, in case the automatically produced hashes between versions are incompatible. For example, users could just copy the old hashes from the web ui to their job.