### PR TITLE
[FLINK-5224] [table] Improve UDTF: emit rows directly instead of buffering them

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -167,12 +167,12 @@ class CodeGenerator(
   /**
     * @return code block of constructor statements of the function
     */
-  def reuseConstructorCode(funcName: String): String = {
+  def reuseConstructorCode(className: String): String = {
     reusableConstructorStatements.map { case (params, body) =>
-      j"""
-         public $funcName($params) throws Exception {
-           $body
-         }
+      s"""
+         |public $className($params) throws Exception {
+         |  $body
+         |}
        """.stripMargin
     }.mkString("", "\n", "\n")
   }
@@ -355,21 +355,21 @@ class CodeGenerator(
     * @return instance of GeneratedFunction
     */
   def generateTableFunctionCollector(
-    name: String,
-    bodyCode: String,
-    returnType: TypeInformation[Any])
-  : GeneratedFunction[TableFunctionCollector[Any]] = {
+      name: String,
+      bodyCode: String,
+      returnType: TypeInformation[Any])
+    : GeneratedCollector = {
 
-    val funcName = newName(name)
+    val className = newName(name)
     val input1TypeClass = boxedTypeTermForTypeInfo(input1)
     val input2TypeClass = boxedTypeTermForTypeInfo(returnType)
 
     val funcCode = j"""
-      public class $funcName extends ${classOf[TableFunctionCollector[_]].getCanonicalName} {
+      public class $className extends ${classOf[TableFunctionCollector[_]].getCanonicalName} {
 
         ${reuseMemberCode()}
 
-        public $funcName() throws Exception {
+        public $className() throws Exception {
           ${reuseInitCode()}
         }
 
@@ -388,7 +388,7 @@ class CodeGenerator(
       }
     """.stripMargin
 
-    GeneratedFunction[TableFunctionCollector[Any]](funcName, returnType, funcCode)
+    GeneratedCollector(className, funcCode)
   }
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -39,6 +39,7 @@ import org.apache.flink.table.codegen.Indenter.toISC
 import org.apache.flink.table.codegen.calls.FunctionGenerator
 import org.apache.flink.table.codegen.calls.ScalarOperators._
 import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.runtime.TableFunctionCollector
 import org.apache.flink.table.typeutils.TypeConverter
 import org.apache.flink.table.typeutils.TypeCheckUtils._
 
@@ -129,6 +130,10 @@ class CodeGenerator(
   // (inputTerm, index) -> expr
   private val reusableInputUnboxingExprs = mutable.Map[(String, Int), GeneratedExpression]()
 
+  // set of constructor statements that will be added only once
+  // we use a LinkedHashSet to keep the insertion order
+  private val reusableConstructorStatements = mutable.LinkedHashSet[(String, String)]()
+
   /**
     * @return code block of statements that need to be placed in the member area of the Function
     *         (e.g. member variables and their initialization)
@@ -157,6 +162,19 @@ class CodeGenerator(
     */
   def reuseInputUnboxingCode(): String = {
     reusableInputUnboxingExprs.values.map(_.code).mkString("", "\n", "\n")
+  }
+
+  /**
+    * @return code block of constructor statements of the function
+    */
+  def reuseConstructorCode(funcName: String): String = {
+    reusableConstructorStatements.map { case (params, body) =>
+      j"""
+         public $funcName($params) throws Exception {
+           $body
+         }
+       """.stripMargin
+    }.mkString("", "\n", "\n")
   }
 
   /**
@@ -257,6 +275,8 @@ class CodeGenerator(
           ${reuseInitCode()}
         }
 
+        ${reuseConstructorCode(funcName)}
+
         @Override
         public ${samHeader._1} throws Exception {
           ${samHeader._2.mkString("\n")}
@@ -323,6 +343,52 @@ class CodeGenerator(
     """.stripMargin
 
     GeneratedFunction[GenericInputFormat[T]](funcName, returnType, funcCode)
+  }
+
+  /**
+    * Generates a [[TableFunctionCollector]] that can be passed to Java compiler.
+    *
+    * @param name Class name of the table function collector. Must not be unique but has to be a
+    *             valid Java class identifier.
+    * @param bodyCode body code for the collector method
+    * @param returnType The type information of the element collected by the collector
+    * @return instance of GeneratedFunction
+    */
+  def generateTableFunctionCollector(
+    name: String,
+    bodyCode: String,
+    returnType: TypeInformation[Any])
+  : GeneratedFunction[TableFunctionCollector[Any]] = {
+
+    val funcName = newName(name)
+    val input1TypeClass = boxedTypeTermForTypeInfo(input1)
+    val input2TypeClass = boxedTypeTermForTypeInfo(returnType)
+
+    val funcCode = j"""
+      public class $funcName extends ${classOf[TableFunctionCollector[_]].getCanonicalName} {
+
+        ${reuseMemberCode()}
+
+        public $funcName() throws Exception {
+          ${reuseInitCode()}
+        }
+
+        @Override
+        public void collect(Object record) throws Exception {
+          super.collect(record);
+          $input1TypeClass $input1Term = ($input1TypeClass) getInput();
+          $input2TypeClass $input2Term = ($input2TypeClass) record;
+          ${reuseInputUnboxingCode()}
+          $bodyCode
+        }
+
+        @Override
+        public void close() {
+        }
+      }
+    """.stripMargin
+
+    GeneratedFunction[TableFunctionCollector[Any]](funcName, returnType, funcCode)
   }
 
   /**
@@ -1413,6 +1479,33 @@ class CodeGenerator(
        """.stripMargin
     reusableInitStatements.add(constructorAccessibility)
     fieldTerm
+  }
+
+
+  /**
+    * Adds a reusable constructor statement with the given parameter types.
+    *
+    * @param parameterTypes The parameter types to construct the function
+    * @return member variable terms
+    */
+  def addReusableConstructor(parameterTypes: Class[_]*): Array[String] = {
+    val parameters = mutable.ListBuffer[String]()
+    val fieldTerms = mutable.ListBuffer[String]()
+    var body = "this();\n"
+
+    parameterTypes.zipWithIndex.foreach { case (t, index) =>
+      val classQualifier = t.getCanonicalName
+      val fieldTerm = newName(s"instance_${classQualifier.replace('.', '$')}")
+      val field = s"transient $classQualifier $fieldTerm = null;"
+      reusableMemberStatements.add(field)
+      fieldTerms += fieldTerm
+      parameters += s"$classQualifier arg$index"
+      body += s"$fieldTerm = arg$index;\n"
+    }
+
+    reusableConstructorStatements.add((parameters.mkString(","), body))
+
+    fieldTerms.toArray
   }
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -171,6 +171,7 @@ class CodeGenerator(
     reusableConstructorStatements.map { case (params, body) =>
       s"""
          |public $className($params) throws Exception {
+         |  this();
          |  $body
          |}
        """.stripMargin
@@ -1491,7 +1492,7 @@ class CodeGenerator(
   def addReusableConstructor(parameterTypes: Class[_]*): Array[String] = {
     val parameters = mutable.ListBuffer[String]()
     val fieldTerms = mutable.ListBuffer[String]()
-    var body = "this();\n"
+    val body = mutable.ListBuffer[String]()
 
     parameterTypes.zipWithIndex.foreach { case (t, index) =>
       val classQualifier = t.getCanonicalName
@@ -1500,10 +1501,11 @@ class CodeGenerator(
       reusableMemberStatements.add(field)
       fieldTerms += fieldTerm
       parameters += s"$classQualifier arg$index"
-      body += s"$fieldTerm = arg$index;\n"
+      body += s"$fieldTerm = arg$index;"
     }
 
-    reusableConstructorStatements.add((parameters.mkString(","), body))
+    reusableConstructorStatements.add(
+      (parameters.mkString(","), body.mkString("", "\n", "\n")))
 
     fieldTerms.toArray
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/TableFunctionCallGen.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/TableFunctionCallGen.scala
@@ -69,7 +69,6 @@ class TableFunctionCallGen(
     val functionCallCode =
       s"""
         |${parameters.map(_.code).mkString("\n")}
-        |$functionReference.clear();
         |$functionReference.eval(${parameters.map(_.resultTerm).mkString(", ")});
         |""".stripMargin
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/generated.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/generated.scala
@@ -41,3 +41,10 @@ object GeneratedExpression {
 }
 
 case class GeneratedFunction[T](name: String, returnType: TypeInformation[Any], code: String)
+
+/**
+  * Describes a generated [[org.apache.flink.util.Collector]].
+  * @param name The class name of the generated Collector.
+  * @param code The code of the generated Collector.
+  */
+case class GeneratedCollector(name: String, code: String)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/TableFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/TableFunction.scala
@@ -18,10 +18,9 @@
 
 package org.apache.flink.table.functions
 
-import java.util
-
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.expressions.{Expression, TableFunctionCall}
+import org.apache.flink.util.Collector
 
 /**
   * Base class for a user-defined table function (UDTF). A user-defined table functions works on
@@ -99,27 +98,26 @@ abstract class TableFunction[T] extends UserDefinedFunction {
 
   // ----------------------------------------------------------------------------------------------
 
-  private val rows: util.ArrayList[T] = new util.ArrayList[T]()
-
   /**
     * Emit an output row.
     *
     * @param row the output row
     */
   protected def collect(row: T): Unit = {
-    // cache rows for now, maybe immediately process them further
-    rows.add(row)
+    collector.collect(row)
   }
 
-  /**
-    * Internal use. Get an iterator of the buffered rows.
-    */
-  def getRowsIterator = rows.iterator()
+  // ----------------------------------------------------------------------------------------------
+
+  /** The code generated collector used to emit row. */
+  private var collector: Collector[T] = _
 
   /**
-    * Internal use. Clear buffered rows.
+    * Internal use. Sets the current collector.
     */
-  def clear() = rows.clear()
+  def setCollector(collector: Collector[T]): Unit = {
+    this.collector = collector
+  }
 
   // ----------------------------------------------------------------------------------------------
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/TableFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/TableFunction.scala
@@ -115,7 +115,7 @@ abstract class TableFunction[T] extends UserDefinedFunction {
   /**
     * Internal use. Sets the current collector.
     */
-  def setCollector(collector: Collector[T]): Unit = {
+  private[flink] final def setCollector(collector: Collector[T]): Unit = {
     this.collector = collector
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetCorrelate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetCorrelate.scala
@@ -27,7 +27,6 @@ import org.apache.calcite.sql.SemiJoinType
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.DataSet
 import org.apache.flink.table.api.BatchTableEnvironment
-import org.apache.flink.table.codegen.CodeGenerator
 import org.apache.flink.table.functions.utils.TableSqlFunction
 import org.apache.flink.table.plan.nodes.FlinkCorrelate
 import org.apache.flink.table.typeutils.TypeConverter._
@@ -102,26 +101,17 @@ class DataSetCorrelate(
     val pojoFieldMapping = sqlFunction.getPojoFieldMapping
     val udtfTypeInfo = sqlFunction.getRowTypeInfo.asInstanceOf[TypeInformation[Any]]
 
-    val generator = new CodeGenerator(
+    val mapFunc = correlateMapFunction(
       config,
-      false,
       inputDS.getType,
-      Some(udtfTypeInfo),
-      None,
-      Some(pojoFieldMapping))
-
-    val (flatMap, collector) = generateFunction(
-      generator,
       udtfTypeInfo,
       getRowType,
+      joinType,
       rexCall,
       condition,
-      config,
-      joinType,
       expectedType,
+      Some(pojoFieldMapping),
       ruleDescription)
-
-    val mapFunc = correlateMapFunction(flatMap, collector)
 
     inputDS.flatMap(mapFunc).name(correlateOpName(rexCall, sqlFunction, relRowType))
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CorrelateFlatMapRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CorrelateFlatMapRunner.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime
+
+import org.apache.flink.api.common.functions.{FlatMapFunction, RichFlatMapFunction}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.table.codegen.Compiler
+import org.apache.flink.util.Collector
+import org.slf4j.{Logger, LoggerFactory}
+
+class CorrelateFlatMapRunner[IN, OUT](
+    flatMapName: String,
+    flatMapCode: String,
+    collectorName: String,
+    collectorCode: String,
+    @transient returnType: TypeInformation[OUT])
+  extends RichFlatMapFunction[IN, OUT]
+  with ResultTypeQueryable[OUT]
+  with Compiler[Any] {
+
+  val LOG: Logger = LoggerFactory.getLogger(this.getClass)
+
+  private var function: FlatMapFunction[IN, OUT] = _
+  private var collector: TableFunctionCollector[_] = _
+
+  override def open(parameters: Configuration): Unit = {
+    LOG.debug(s"Compiling TableFunctionCollector: $collectorName \n\n Code:\n$collectorCode")
+    val clazz = compile(getRuntimeContext.getUserCodeClassLoader, collectorName, collectorCode)
+    LOG.debug("Instantiating TableFunctionCollector.")
+    collector = clazz.newInstance().asInstanceOf[TableFunctionCollector[_]]
+
+    LOG.debug(s"Compiling FlatMapFunction: $flatMapName \n\n Code:\n$flatMapCode")
+    val flatMapClazz = compile(getRuntimeContext.getUserCodeClassLoader, flatMapName, flatMapCode)
+    val constructor = flatMapClazz.getConstructor(classOf[TableFunctionCollector[_]])
+    LOG.debug("Instantiating FlatMapFunction.")
+    function = constructor.newInstance(collector).asInstanceOf[FlatMapFunction[IN, OUT]]
+  }
+
+  override def flatMap(in: IN, out: Collector[OUT]): Unit = {
+    collector.setCollector(out)
+    collector.setInput(in)
+    collector.reset()
+    function.flatMap(in, out)
+  }
+
+  override def getProducedType: TypeInformation[OUT] = returnType
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/TableFunctionCollector.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/TableFunctionCollector.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.runtime
+
+import org.apache.flink.util.Collector
+
+/**
+  * The basic implementation of collector for [[org.apache.calcite.schema.TableFunction]].
+  */
+abstract class TableFunctionCollector[T] extends Collector[T] {
+
+  var input: Any = _
+  var collector: Collector[_] = _
+  var collected: Boolean = _
+
+  /**
+    * Gets the input row from left table,
+    * which will be used to cross join with the result of table function.
+    */
+  def setInput(input: Any): Unit = {
+    this.input = input
+  }
+
+  /**
+    * Gets the input value from left table,
+    * which will be used to cross join with the result of table function.
+    */
+  def getInput: Any = {
+    input
+  }
+
+  /**
+    * Sets the current collector, which used to emit the final row.
+    */
+  def setCollector(collector: Collector[_]): Unit = {
+    this.collector = collector
+  }
+
+  /**
+    * Gets the internal collector which used to emit the final row.
+    */
+  def getCollector: Collector[_] = {
+    this.collector
+  }
+
+  /**
+    * Resets the flag to indicate whether [[collect(T)]] has been called.
+    */
+  def reset(): Unit = {
+    collected = false
+  }
+
+  /**
+    * Whether [[collect(T)]] has been called.
+    * @return True if [[collect(T)]] has been called.
+    */
+  def isCollected: Boolean = collected
+
+
+  override def collect(record: T): Unit = {
+    collected = true
+  }
+
+}
+
+

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/TableFunctionCollector.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/TableFunctionCollector.scala
@@ -20,16 +20,16 @@ package org.apache.flink.table.runtime
 import org.apache.flink.util.Collector
 
 /**
-  * The basic implementation of collector for [[org.apache.calcite.schema.TableFunction]].
+  * The basic implementation of collector for [[org.apache.flink.table.functions.TableFunction]].
   */
 abstract class TableFunctionCollector[T] extends Collector[T] {
 
-  var input: Any = _
-  var collector: Collector[_] = _
-  var collected: Boolean = _
+  private var input: Any = _
+  private var collector: Collector[_] = _
+  private var collected: Boolean = _
 
   /**
-    * Gets the input row from left table,
+    * Sets the input row from left table,
     * which will be used to cross join with the result of table function.
     */
   def setInput(input: Any): Unit = {


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed


This PR is an improvement for user-defined table function in Flink TableAPI & SQL. I didn't add new tests because the existing tests are sufficient.

The core design is code generating a `Collector` and register it into the instance of `TableFunction`, and emit the rows generated by the UDTF directly instead of buffering them.
