### PR TITLE
[FLINK-5485] [webfrontend] Mark compiled web frontend files as binary when processed by git diff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 *.bat text eol=crlf
-flink-runtime-web/web-dashboard/web/* linguist-vendored
+flink-runtime-web/web-dashboard/web/* linguist-vendored -diff
 


### PR DESCRIPTION
Particularly beneficial now that javascript is minified, we can mark compiled web frontend files as binary when processed by git diff.
  https://linux.die.net/man/5/gitattributes

This does not affect how files are displayed by github.