### PR TITLE
[FLINK-5489] maven release:prepare fails due to invalid JDOM comments…

### DIFF
--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -510,7 +510,7 @@ under the License.
 								</transformer>
 							</transformers>
 							<finalName>Kafka</finalName>
-							<!--- <outputFile>Kafka.jar</outputFile> -->
+							<!-- <outputFile>Kafka.jar</outputFile> -->
 							<filters>
 								<filter>
 									<artifact>*</artifact>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@ under the License.
 	</scm>
 
 	<modules>
-		<!--- Dummy module to force execution of the Maven Shade plugin (see Shade plugin below) -->
+		<!-- Dummy module to force execution of the Maven Shade plugin (see Shade plugin below) -->
 		<module>tools/force-shading</module>
 		<module>flink-annotations</module>
 		<module>flink-shaded-hadoop</module>
@@ -269,7 +269,7 @@ under the License.
 				<version>2.4</version>
 			</dependency>
 
-			<!--- commons collections needs to be pinned to this critical security fix version -->
+			<!-- commons collections needs to be pinned to this critical security fix version -->
 			<dependency>
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>

--- a/tools/force-shading/pom.xml
+++ b/tools/force-shading/pom.xml
@@ -28,7 +28,7 @@ under the License.
 		<version>14</version>
 	</parent>
 
-	<!---
+	<!--
 	This module is used a dependency in the root pom. It activates shading for all sub modules
 	through an include rule in the shading configuration. This assures that Maven always generates
 	an effective pom for all modules, i.e. get rid of Maven properties. In particular, this is needed


### PR DESCRIPTION
When I was trying to publish Flink to our internal artifactory, I found out that maven release:prepare has failed because the plugin complains about the some of the comments pom.xml do not conform with the JDOM format (More information on the JIRA).

This PR fixes the issue by making all comments conform to the JDOM format.