### PR TITLE
[FLINK-5281] Extend KafkaJsonTableSources to support nested data

### DIFF
--- a/docs/dev/table_api.md
+++ b/docs/dev/table_api.md
@@ -219,7 +219,8 @@ All sources that come with the `flink-table` dependency can be directly used by 
 To use the Kafka JSON source, you have to add the Kafka connector dependency to your project:
 
   - `flink-connector-kafka-0.8` for Kafka 0.8, and
-  - `flink-connector-kafka-0.9` for Kafka 0.9, respectively.
+  - `flink-connector-kafka-0.9` for Kafka 0.9, and
+  - `flink-connector-kafka-0.10` for Kafka 0.10, respectively.
 
 You can then create the source as follows (example for Kafka 0.8):
 

--- a/flink-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08JsonTableSinkTest.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08JsonTableSinkTest.java
@@ -42,7 +42,7 @@ public class Kafka08JsonTableSinkTest extends KafkaTableSinkTestBase {
 	@Override
 	@SuppressWarnings("unchecked")
 	protected SerializationSchema<Row> getSerializationSchema() {
-		return new JsonRowSerializationSchema(FIELD_NAMES);
+		return new JsonRowSerializationSchema(FIELD_NAMES, FIELD_TYPES);
 	}
 }
 

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09JsonTableSinkTest.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09JsonTableSinkTest.java
@@ -42,7 +42,7 @@ public class Kafka09JsonTableSinkTest extends KafkaTableSinkTestBase {
 	@Override
 	@SuppressWarnings("unchecked")
 	protected SerializationSchema<Row> getSerializationSchema() {
-		return new JsonRowSerializationSchema(FIELD_NAMES);
+		return new JsonRowSerializationSchema(FIELD_NAMES, FIELD_TYPES);
 	}
 }
 

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaJsonTableSink.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaJsonTableSink.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.streaming.connectors.kafka;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.types.Row;
 import org.apache.flink.streaming.connectors.kafka.partitioner.KafkaPartitioner;
 import org.apache.flink.streaming.util.serialization.JsonRowSerializationSchema;
@@ -41,7 +42,7 @@ public abstract class KafkaJsonTableSink extends KafkaTableSink {
 	}
 
 	@Override
-	protected SerializationSchema<Row> createSerializationSchema(String[] fieldNames) {
-		return new JsonRowSerializationSchema(fieldNames);
+	protected SerializationSchema<Row> createSerializationSchema(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
+		return new JsonRowSerializationSchema(fieldNames, fieldTypes);
 	}
 }

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSink.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSink.java
@@ -78,9 +78,10 @@ public abstract class KafkaTableSink implements StreamTableSink<Row> {
 	 * Create serialization schema for converting table rows into bytes.
 	 *
 	 * @param fieldNames Field names in table rows.
+	 * @param fieldTypes Field types in table rows.
 	 * @return Instance of serialization schema
 	 */
-	protected abstract SerializationSchema<Row> createSerializationSchema(String[] fieldNames);
+	protected abstract SerializationSchema<Row> createSerializationSchema(String[] fieldNames, TypeInformation<?>[] fieldTypes);
 
 	/**
 	 * Create a deep copy of this sink.
@@ -116,7 +117,7 @@ public abstract class KafkaTableSink implements StreamTableSink<Row> {
 		copy.fieldTypes = Preconditions.checkNotNull(fieldTypes, "fieldTypes");
 		Preconditions.checkArgument(fieldNames.length == fieldTypes.length,
 			"Number of provided field names and types does not match.");
-		copy.serializationSchema = createSerializationSchema(fieldNames);
+		copy.serializationSchema = createSerializationSchema(fieldNames, fieldTypes);
 
 		return copy;
 	}

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/JsonRowSerializationSchema.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/JsonRowSerializationSchema.java
@@ -19,6 +19,9 @@ package org.apache.flink.streaming.util.serialization;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.connectors.kafka.internals.TypeUtil;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
@@ -37,34 +40,71 @@ public class JsonRowSerializationSchema implements SerializationSchema<Row> {
 	private final String[] fieldNames;
 	/** Object mapper that is used to create output JSON objects */
 	private static ObjectMapper mapper = new ObjectMapper();
+	private final TypeInformation<?>[] fieldTypes;
 
 	/**
 	 * Creates a JSON serialization schema for the given fields and types.
 	 *
 	 * @param fieldNames Names of JSON fields to parse.
 	 */
-	public JsonRowSerializationSchema(String[] fieldNames) {
+	public JsonRowSerializationSchema(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
 		this.fieldNames = Preconditions.checkNotNull(fieldNames);
+		this.fieldTypes = Preconditions.checkNotNull(fieldTypes);
+	}
+
+	public JsonRowSerializationSchema(String[] fieldNames, Class[] fieldTypes) {
+		this(fieldNames, TypeUtil.toTypeInfo(fieldTypes));
 	}
 
 	@Override
 	public byte[] serialize(Row row) {
-		if (row.getArity() != fieldNames.length) {
-			throw new IllegalStateException(String.format(
-				"Number of elements in the row %s is different from number of field names: %d", row, fieldNames.length));
-		}
-
-		ObjectNode objectNode = mapper.createObjectNode();
-
-		for (int i = 0; i < row.getArity(); i++) {
-			JsonNode node = mapper.valueToTree(row.getField(i));
-			objectNode.set(fieldNames[i], node);
-		}
+		ObjectNode objectNode = serializeRow(row, fieldNames, fieldTypes);
 
 		try {
 			return mapper.writeValueAsBytes(objectNode);
 		} catch (Exception e) {
 			throw new RuntimeException("Failed to serialize row", e);
+		}
+	}
+
+	private ObjectNode serializeRow(Row row, String[] fieldNames, TypeInformation<?>[] fieldTypes) {
+		verifyRowArity(row, fieldNames);
+		ObjectNode objectNode = mapper.createObjectNode();
+
+		for (int i = 0; i < row.getArity(); i++) {
+			TypeInformation<?> fieldType = fieldTypes[i];
+			Object rowField = row.getField(i);
+			JsonNode node = serializeToNode(i, rowField, fieldType);
+			objectNode.set(fieldNames[i], node);
+		}
+		return objectNode;
+	}
+
+	private void verifyRowArity(Row row, String[] fieldNames) {
+		if (row.getArity() != fieldNames.length) {
+			throw new IllegalStateException(String.format(
+				"Number of elements in the row %s is different from number of field names: %d", row, fieldNames.length));
+		}
+	}
+
+	private JsonNode serializeToNode(int pos, Object rowField, TypeInformation<?> fieldType) {
+		if (fieldType instanceof RowTypeInfo) {
+			return serializeRowToNode(pos, rowField, (RowTypeInfo) fieldType);
+		}
+		return mapper.valueToTree(rowField);
+	}
+
+	private JsonNode serializeRowToNode(int pos, Object rowField, RowTypeInfo rowTypeInfo) {
+		JsonNode node;
+		verifyRowField(pos, rowField);
+		node = serializeRow((Row) rowField, rowTypeInfo.getFieldNames(), rowTypeInfo.getFieldTypes());
+		return node;
+	}
+
+	private void verifyRowField(int i, Object rowField) {
+		if (! (rowField instanceof Row)) {
+			throw new IllegalStateException(
+				String.format("Expected Row type in position %d. Instead found: %s", i, rowField));
 		}
 	}
 }

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/JsonRowSerializationSchemaTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/JsonRowSerializationSchemaTest.java
@@ -16,9 +16,15 @@
  */
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.types.Row;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.connectors.kafka.internals.TypeUtil;
 import org.apache.flink.streaming.util.serialization.JsonRowDeserializationSchema;
 import org.apache.flink.streaming.util.serialization.JsonRowSerializationSchema;
+import org.apache.flink.types.Row;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -26,30 +32,84 @@ import java.io.IOException;
 import static org.junit.Assert.assertEquals;
 
 public class JsonRowSerializationSchemaTest {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+	private static final String[] FLAT_ROW_FIELDS_NAMES = new String[]{"f1", "f2", "f3"};
+	private static final Class[] FLAT_FOW_FIELD_TYPES = new Class[]{Integer.class, Boolean.class, String.class};
+	private static final String[] NESTED_ROW_FIELD_NAMES = new String[]{"f1", "f2"};
+	private static final TypeInformation<?>[] NESTED_ROW_FIELD_TYPES = new TypeInformation<?>[]{
+		TypeInformation.of(Integer.class),
+		createFlatRowTypeInfo()};
+
+	@Test
+	public void testRowSerializationFormat() throws IOException {
+		Row row = createFlatRow();
+
+		JsonNode actualObject = serializeToJsonObject(FLAT_ROW_FIELDS_NAMES, FLAT_FOW_FIELD_TYPES, row);
+		ObjectNode expectedObject = createFlatSerializedRow();
+
+		assertEquals(expectedObject, actualObject);
+	}
+
 	@Test
 	public void testRowSerialization() throws IOException {
-		String[] fieldNames = new String[] {"f1", "f2", "f3"};
-		Class[] fieldTypes = new Class[] {Integer.class, Boolean.class, String.class};
-		Row row = new Row(3);
-		row.setField(0, 1);
-		row.setField(1, true);
-		row.setField(2, "str");
+		Row row = createFlatRow();
 
-		Row resultRow = serializeAndDeserialize(fieldNames, fieldTypes, row);
+		Row resultRow = serializeAndDeserialize(FLAT_ROW_FIELDS_NAMES, FLAT_FOW_FIELD_TYPES, createFlatRow());
 		assertEqualRows(row, resultRow);
 	}
 
 	@Test
-	public void testSerializationOfTwoRows() throws IOException {
-		String[] fieldNames = new String[] {"f1", "f2", "f3"};
-		Class[] fieldTypes = new Class[] {Integer.class, Boolean.class, String.class};
-		Row row1 = new Row(3);
-		row1.setField(0, 1);
-		row1.setField(1, true);
-		row1.setField(2, "str");
+	public void testNestedRowSerialization() throws IOException {
+		Row row = createNestedRow();
 
-		JsonRowSerializationSchema serializationSchema = new JsonRowSerializationSchema(fieldNames);
-		JsonRowDeserializationSchema deserializationSchema = new JsonRowDeserializationSchema(fieldNames, fieldTypes);
+		Row resultRow = serializeAndDeserialize(NESTED_ROW_FIELD_NAMES, NESTED_ROW_FIELD_TYPES, row);
+		assertEqualRows(row, resultRow);
+	}
+
+	@Test
+	public void testNestedRowSerializationFormat() throws IOException {
+		Row row = createNestedRow();
+		byte[] bytes = serializeRow(row, NESTED_ROW_FIELD_NAMES, NESTED_ROW_FIELD_TYPES);
+
+		JsonNode actualObject = objectMapper.readTree(bytes);
+		ObjectNode nestedRowNode = createFlatSerializedRow();
+		JsonNode expectedObject = objectMapper.createObjectNode()
+			.put("f1", 1)
+			.set("f2", nestedRowNode);
+
+		assertEquals(expectedObject, actualObject);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testNestedRowSerializationWithIncorrectTypeInformation() throws IOException {
+		Row row = new Row(2);
+		row.setField(0, 1);
+		// Row instance expected at this position
+		row.setField(1, true);
+
+		serializeAndDeserialize(NESTED_ROW_FIELD_NAMES, NESTED_ROW_FIELD_TYPES, row);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testNestedRowSerializationWithNestedRowWithIncorrectNumberOfField() throws IOException {
+		Row nestedRow = new Row(1);
+		nestedRow.setField(0, 42);
+
+		Row row = new Row(2);
+		row.setField(0, 1);
+		// Row instance expected at this position
+		row.setField(1, nestedRow);
+
+		serializeAndDeserialize(NESTED_ROW_FIELD_NAMES, NESTED_ROW_FIELD_TYPES, row);
+	}
+
+	@Test
+	public void testSerializationOfTwoRows() throws IOException {
+		Row row1 = createFlatRow();
+
+		JsonRowSerializationSchema serializationSchema = new JsonRowSerializationSchema(FLAT_ROW_FIELDS_NAMES, FLAT_FOW_FIELD_TYPES);
+		JsonRowDeserializationSchema deserializationSchema = new JsonRowDeserializationSchema(FLAT_ROW_FIELDS_NAMES, FLAT_FOW_FIELD_TYPES);
 
 		byte[] bytes = serializationSchema.serialize(row1);
 		assertEqualRows(row1, deserializationSchema.deserialize(bytes));
@@ -65,7 +125,7 @@ public class JsonRowSerializationSchemaTest {
 
 	@Test(expected = NullPointerException.class)
 	public void testInputValidation() {
-		new JsonRowSerializationSchema(null);
+		new JsonRowSerializationSchema(null, new Class[] {Integer.class});
 	}
 
 	@Test(expected = IllegalStateException.class)
@@ -74,18 +134,63 @@ public class JsonRowSerializationSchemaTest {
 		Row row = new Row(1);
 		row.setField(0, 1);
 
-		JsonRowSerializationSchema serializationSchema = new JsonRowSerializationSchema(fieldNames);
+		JsonRowSerializationSchema serializationSchema = new JsonRowSerializationSchema(fieldNames, new Class[] {Integer.class, Boolean.class, String.class});
 		serializationSchema.serialize(row);
 	}
 
+	private JsonNode serializeToJsonObject(String[] fieldNames, Class[] fieldTypes, Row row) throws IOException {
+		return objectMapper.readTree(serializeRow(row, fieldNames, TypeUtil.toTypeInfo(fieldTypes)));
+	}
+
+	private byte[] serializeRow(Row row, String[] fieldNames, TypeInformation<?>[] fieldTypes) {
+		JsonRowSerializationSchema serializationSchema = new JsonRowSerializationSchema(fieldNames, fieldTypes);
+		return serializationSchema.serialize(row);
+	}
+
+	private ObjectNode createFlatSerializedRow() {
+		return objectMapper.createObjectNode()
+			.put("f1", 1)
+			.put("f2", true)
+			.put("f3", "str");
+	}
+
+	private Row createFlatRow() {
+		Row row = new Row(3);
+		row.setField(0, 1);
+		row.setField(1, true);
+		row.setField(2, "str");
+		return row;
+	}
+
 	private Row serializeAndDeserialize(String[] fieldNames, Class[] fieldTypes, Row row) throws IOException {
-		JsonRowSerializationSchema serializationSchema = new JsonRowSerializationSchema(fieldNames);
+		JsonRowSerializationSchema serializationSchema = new JsonRowSerializationSchema(fieldNames, fieldTypes);
 		JsonRowDeserializationSchema deserializationSchema = new JsonRowDeserializationSchema(fieldNames, fieldTypes);
 
 		byte[] bytes = serializationSchema.serialize(row);
 		return deserializationSchema.deserialize(bytes);
 	}
 
+	private Row serializeAndDeserialize(String[] fieldNames, TypeInformation<?>[] fieldTypes, Row row) throws IOException {
+		JsonRowSerializationSchema serializationSchema = new JsonRowSerializationSchema(fieldNames, fieldTypes);
+		JsonRowDeserializationSchema deserializationSchema = new JsonRowDeserializationSchema(fieldNames, fieldTypes);
+
+		byte[] bytes = serializationSchema.serialize(row);
+		return deserializationSchema.deserialize(bytes);
+	}
+
+	private Row createNestedRow() {
+		Row row = new Row(2);
+		row.setField(0, 1);
+		row.setField(1, createFlatRow());
+		return row;
+	}
+
+	static private RowTypeInfo createFlatRowTypeInfo() {
+		return new RowTypeInfo(
+			TypeUtil.toTypeInfo(new Class[] {Integer.class, Boolean.class, String.class}),
+			new String[] {"f1", "f2", "f3"}
+		);
+	}
 	private void assertEqualRows(Row expectedRow, Row resultRow) {
 		assertEquals("Deserialized row should have expected number of fields",
 			expectedRow.getArity(), resultRow.getArity());

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSinkTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSinkTestBase.java
@@ -43,7 +43,7 @@ public abstract class KafkaTableSinkTestBase {
 
 	private static final String TOPIC = "testTopic";
 	protected static final String[] FIELD_NAMES = new String[] {"field1", "field2"};
-	private static final TypeInformation[] FIELD_TYPES = TypeUtil.toTypeInfo(new Class[] {Integer.class, String.class});
+	protected static final TypeInformation[] FIELD_TYPES = TypeUtil.toTypeInfo(new Class[] {Integer.class, String.class});
 	private static final KafkaPartitioner<Row> PARTITIONER = new CustomPartitioner();
 	private static final Properties PROPERTIES = createSinkProperties();
 	@SuppressWarnings("unchecked")

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
@@ -87,6 +87,10 @@ public abstract class TupleTypeInfoBase<T> extends CompositeType<T> {
 		return totalFields;
 	}
 
+	public TypeInformation<?>[] getFieldTypes() {
+		return types;
+	}
+
 	@Override
 	public void getFlatFields(String fieldExpression, int offset, List<FlatFieldDescriptor> result) {
 


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed


I've added support for serialization and deserialization of nested Rows in Json serializer/deserializer. I tried not to change interfaces, but I wonder if would make sense to replace all `String[] fieldNames, TypeInformation<?>[] fieldTypes` pairs with `RowTypeInfo`. This will change the interface (but we are doing this anyway) but will make interfaces clearer and will help to avoid some code duplication.
@fhueske, what do you think about this?