### PR TITLE
[FLINK-5499][JobManager]Reuse the resource location of prior execution attempt in allocating slot

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -261,6 +261,23 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 		}
 	}
 
+	/**
+	 * Just return the last assigned resource location if found
+	 *
+	 * @return The collection of TaskManagerLocation
+	 */
+	public List<TaskManagerLocation> getPriorAssignedResourceLocations() {
+		List<TaskManagerLocation> list = new ArrayList<>();
+		for (int i = priorExecutions.size() - 1 ; i >= 0 ; i--) {
+			Execution prior = priorExecutions.get(i) ;
+			if (prior.getAssignedResourceLocation() != null) {
+				list.add(prior.getAssignedResourceLocation());
+				break;
+			}
+		}
+		return list;
+	}
+
 	EvictingBoundedList<Execution> getCopyOfPriorExecutionsList() {
 		synchronized (priorExecutions) {
 			return new EvictingBoundedList<>(priorExecutions);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotPool.java
@@ -984,8 +984,8 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 
 		@Override
 		public Future<SimpleSlot> allocateSlot(ScheduledUnit task, boolean allowQueued) {
-			return gateway.allocateSlot(
-					task, ResourceProfile.UNKNOWN, Collections.<TaskManagerLocation>emptyList(), timeout);
+			return gateway.allocateSlot(task, ResourceProfile.UNKNOWN,
+					task.getTaskToExecute().getVertex().getPriorAssignedResourceLocations(), timeout);
 		}
 	}
 


### PR DESCRIPTION
Currently when schedule execution to request to allocate slot from **SlotPool**, the **TaskManagerLocation** parameter is empty collection. So for task fail over scenario, the new execution attempt may be deployed to different task managers. If setting rockDB as state backend, the performance is better if the data can be restored from local machine. So we try to reuse the **TaskManagerLocation** of prior execution attempt when allocating slot from **SlotPool**. If the **TaskManagerLocation** is empty from prior executions, the behavior is the same with current status.

@StephanEwen for review please!