### PR TITLE
[FLINK-5464] Improve MetricDumpSerialization error handling

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricFetcher.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.messages.webmonitor.RequestJobDetails;
+import org.apache.flink.runtime.metrics.dump.MetricDumpSerialization;
 import org.apache.flink.runtime.metrics.dump.MetricQueryService;
 import org.apache.flink.runtime.metrics.dump.MetricDump;
 import org.apache.flink.runtime.webmonitor.JobManagerRetriever;
@@ -42,7 +43,6 @@ import scala.concurrent.Future;
 import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -191,8 +191,8 @@ public class MetricFetcher {
 		logErrorOnFailure(metricQueryFuture, "Fetching metrics failed.");
 	}
 
-	private void addMetrics(Object result) throws IOException {
-		byte[] data = (byte[]) result;
+	private void addMetrics(Object result) {
+		MetricDumpSerialization.MetricSerializationResult data = (MetricDumpSerialization.MetricSerializationResult) result;
 		List<MetricDump> dumpedMetrics = deserializer.deserialize(data);
 		for (MetricDump metric : dumpedMetrics) {
 			metrics.add(metric);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerialization.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerialization.java
@@ -17,19 +17,20 @@
  */
 package org.apache.flink.runtime.metrics.dump;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.HistogramStatistics;
 import org.apache.flink.metrics.Meter;
+import org.apache.flink.runtime.util.DataInputDeserializer;
+import org.apache.flink.runtime.util.DataOutputSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
+import java.io.DataInput;
+import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -50,12 +51,27 @@ public class MetricDumpSerialization {
 	private MetricDumpSerialization() {
 	}
 
+	public static class MetricSerializationResult {
+		public final byte[] data;
+		public final int numCounters;
+		public final int numGauges;
+		public final int numMeters;
+		public final int numHistograms;
+		
+		public MetricSerializationResult(byte[] data, int numCounters, int numGauges, int numMeters, int numHistograms) {
+			this.data = data;
+			this.numCounters = numCounters;
+			this.numGauges = numGauges;
+			this.numMeters = numMeters;
+			this.numHistograms = numHistograms;
+		}
+	}
+
 	//-------------------------------------------------------------------------
 	// Serialization
 	//-------------------------------------------------------------------------
 	public static class MetricDumpSerializer {
-		private ByteArrayOutputStream baos = new ByteArrayOutputStream(4096);
-		private DataOutputStream dos = new DataOutputStream(baos);
+		private DataOutputSerializer buffer = new DataOutputSerializer(1024 * 32);
 
 		/**
 		 * Serializes the given metrics and returns the resulting byte array.
@@ -64,122 +80,148 @@ public class MetricDumpSerialization {
 		 * @param gauges     gauges to serialize
 		 * @param histograms histograms to serialize
 		 * @return byte array containing the serialized metrics
-		 * @throws IOException
 		 */
-		public byte[] serialize(
+		public MetricSerializationResult serialize(
 			Map<Counter, Tuple2<QueryScopeInfo, String>> counters,
 			Map<Gauge<?>, Tuple2<QueryScopeInfo, String>> gauges,
 			Map<Histogram, Tuple2<QueryScopeInfo, String>> histograms,
-			Map<Meter, Tuple2<QueryScopeInfo, String>> meters) throws IOException {
-				
-			baos.reset();
-			dos.writeInt(counters.size());
-			dos.writeInt(gauges.size());
-			dos.writeInt(histograms.size());
-			dos.writeInt(meters.size());
+			Map<Meter, Tuple2<QueryScopeInfo, String>> meters) {
 
+			buffer.clear();
+
+			int numCounters = 0;
 			for (Map.Entry<Counter, Tuple2<QueryScopeInfo, String>> entry : counters.entrySet()) {
-				serializeMetricInfo(dos, entry.getValue().f0);
-				serializeString(dos, entry.getValue().f1);
-				serializeCounter(dos, entry.getKey());
+				try {
+					serializeCounter(buffer, entry.getValue().f0, entry.getValue().f1, entry.getKey());
+					numCounters++;
+				} catch (Exception e) {
+					LOG.warn("Failed to serialize counter.", e);
+				}
 			}
 
+			int numGauges = 0;
 			for (Map.Entry<Gauge<?>, Tuple2<QueryScopeInfo, String>> entry : gauges.entrySet()) {
-				serializeMetricInfo(dos, entry.getValue().f0);
-				serializeString(dos, entry.getValue().f1);
-				serializeGauge(dos, entry.getKey());
+				try {
+					serializeGauge(buffer, entry.getValue().f0, entry.getValue().f1, entry.getKey());
+					numGauges++;
+				} catch (Exception e) {
+					LOG.warn("Failed to serialize gauge.", e);
+				}
 			}
 
+			int numHistograms = 0;
 			for (Map.Entry<Histogram, Tuple2<QueryScopeInfo, String>> entry : histograms.entrySet()) {
-				serializeMetricInfo(dos, entry.getValue().f0);
-				serializeString(dos, entry.getValue().f1);
-				serializeHistogram(dos, entry.getKey());
+				try {
+					serializeHistogram(buffer, entry.getValue().f0, entry.getValue().f1, entry.getKey());
+					numHistograms++;
+				} catch (Exception e) {
+					LOG.warn("Failed to serialize histogram.", e);
+				}
 			}
 
+			int numMeters = 0;
 			for (Map.Entry<Meter, Tuple2<QueryScopeInfo, String>> entry : meters.entrySet()) {
-				serializeMetricInfo(dos, entry.getValue().f0);
-				serializeString(dos, entry.getValue().f1);
-				serializeMeter(dos, entry.getKey());
+				try {
+					serializeMeter(buffer, entry.getValue().f0, entry.getValue().f1, entry.getKey());
+					numMeters++;
+				} catch (Exception e) {
+					LOG.warn("Failed to serialize meter.", e);
+				}
 			}
-			return baos.toByteArray();
+			return new MetricSerializationResult(buffer.getCopyOfBuffer(), numCounters, numGauges, numMeters, numHistograms);
 		}
 
 		public void close() {
-			try {
-				dos.close();
-			} catch (Exception e) {
-				LOG.debug("Failed to close OutputStream.", e);
-			}
-			try {
-				baos.close();
-			} catch (Exception e) {
-				LOG.debug("Failed to close OutputStream.", e);
-			}
+			buffer = null;
 		}
 	}
 
-	private static void serializeMetricInfo(DataOutputStream dos, QueryScopeInfo info) throws IOException {
-		serializeString(dos, info.scope);
-		dos.writeByte(info.getCategory());
+	private static void serializeMetricInfo(DataOutput out, QueryScopeInfo info) throws IOException {
+		out.writeUTF(info.scope);
+		out.writeByte(info.getCategory());
 		switch (info.getCategory()) {
 			case INFO_CATEGORY_JM:
 				break;
 			case INFO_CATEGORY_TM:
 				String tmID = ((QueryScopeInfo.TaskManagerQueryScopeInfo) info).taskManagerID;
-				serializeString(dos, tmID);
+				out.writeUTF(tmID);
 				break;
 			case INFO_CATEGORY_JOB:
 				QueryScopeInfo.JobQueryScopeInfo jobInfo = (QueryScopeInfo.JobQueryScopeInfo) info;
-				serializeString(dos, jobInfo.jobID);
+				out.writeUTF(jobInfo.jobID);
 				break;
 			case INFO_CATEGORY_TASK:
 				QueryScopeInfo.TaskQueryScopeInfo taskInfo = (QueryScopeInfo.TaskQueryScopeInfo) info;
-				serializeString(dos, taskInfo.jobID);
-				serializeString(dos, taskInfo.vertexID);
-				dos.writeInt(taskInfo.subtaskIndex);
+				out.writeUTF(taskInfo.jobID);
+				out.writeUTF(taskInfo.vertexID);
+				out.writeInt(taskInfo.subtaskIndex);
 				break;
 			case INFO_CATEGORY_OPERATOR:
 				QueryScopeInfo.OperatorQueryScopeInfo operatorInfo = (QueryScopeInfo.OperatorQueryScopeInfo) info;
-				serializeString(dos, operatorInfo.jobID);
-				serializeString(dos, operatorInfo.vertexID);
-				dos.writeInt(operatorInfo.subtaskIndex);
-				serializeString(dos, operatorInfo.operatorName);
+				out.writeUTF(operatorInfo.jobID);
+				out.writeUTF(operatorInfo.vertexID);
+				out.writeInt(operatorInfo.subtaskIndex);
+				out.writeUTF(operatorInfo.operatorName);
 				break;
+			default:
+				throw new IOException("Unknown scope category: " + info.getCategory());
 		}
 	}
 
-	private static void serializeString(DataOutputStream dos, String string) throws IOException {
-		byte[] bytes = string.getBytes();
-		dos.writeInt(bytes.length);
-		dos.write(bytes);
+	private static void serializeCounter(DataOutput out, QueryScopeInfo info, String name, Counter counter) throws IOException {
+		long count = counter.getCount();
+		serializeMetricInfo(out, info);
+		out.writeUTF(name);
+		out.writeLong(count);
 	}
 
-	private static void serializeCounter(DataOutputStream dos, Counter counter) throws IOException {
-		dos.writeLong(counter.getCount());
+	private static void serializeGauge(DataOutput out, QueryScopeInfo info, String name, Gauge<?> gauge) throws IOException {
+		Object value = gauge.getValue();
+		if (value == null) {
+			throw new NullPointerException("Value returned by gauge " + name + " was null.");
+		}
+		String stringValue = gauge.getValue().toString();
+		if (stringValue == null) {
+			throw new NullPointerException("toString() of the value returned by gauge " + name + " returned null.");
+		}
+		serializeMetricInfo(out, info);
+		out.writeUTF(name);
+		out.writeUTF(stringValue);
 	}
 
-	private static void serializeGauge(DataOutputStream dos, Gauge<?> gauge) throws IOException {
-		serializeString(dos, gauge.getValue().toString());
-	}
-
-	private static void serializeHistogram(DataOutputStream dos, Histogram histogram) throws IOException {
+	private static void serializeHistogram(DataOutput out, QueryScopeInfo info, String name, Histogram histogram) throws IOException {
 		HistogramStatistics stat = histogram.getStatistics();
+		long min = stat.getMin();
+		long max = stat.getMax();
+		double mean = stat.getMean();
+		double mediam = stat.getQuantile(0.5);
+		double stddev = stat.getStdDev();
+		double p75 = stat.getQuantile(0.75);
+		double p90 = stat.getQuantile(0.90);
+		double p95 = stat.getQuantile(0.95);
+		double p98 = stat.getQuantile(0.98);
+		double p99 = stat.getQuantile(0.99);
+		double p999 = stat.getQuantile(0.999);
 
-		dos.writeLong(stat.getMin());
-		dos.writeLong(stat.getMax());
-		dos.writeDouble(stat.getMean());
-		dos.writeDouble(stat.getQuantile(0.5));
-		dos.writeDouble(stat.getStdDev());
-		dos.writeDouble(stat.getQuantile(0.75));
-		dos.writeDouble(stat.getQuantile(0.90));
-		dos.writeDouble(stat.getQuantile(0.95));
-		dos.writeDouble(stat.getQuantile(0.98));
-		dos.writeDouble(stat.getQuantile(0.99));
-		dos.writeDouble(stat.getQuantile(0.999));
+		serializeMetricInfo(out, info);
+		out.writeUTF(name);
+		out.writeLong(min);
+		out.writeLong(max);
+		out.writeDouble(mean);
+		out.writeDouble(mediam);
+		out.writeDouble(stddev);
+		out.writeDouble(p75);
+		out.writeDouble(p90);
+		out.writeDouble(p95);
+		out.writeDouble(p98);
+		out.writeDouble(p99);
+		out.writeDouble(p999);
 	}
 
-	private static void serializeMeter(DataOutputStream dos, Meter meter) throws IOException {
-		dos.writeDouble(meter.getRate());
+	private static void serializeMeter(DataOutput out, QueryScopeInfo info, String name, Meter meter) throws IOException {
+		serializeMetricInfo(out, info);
+		out.writeUTF(name);
+		out.writeDouble(meter.getRate());
 	}
 
 	//-------------------------------------------------------------------------
@@ -191,62 +233,66 @@ public class MetricDumpSerialization {
 		 *
 		 * @param data serialized metrics
 		 * @return A list containing the deserialized metrics.
-		 * @throws IOException
 		 */
-		public List<MetricDump> deserialize(byte[] data) throws IOException {
-			ByteArrayInputStream bais = new ByteArrayInputStream(data);
-			DataInputStream dis = new DataInputStream(bais);
 
-			int numCounters = dis.readInt();
-			int numGauges = dis.readInt();
-			int numHistograms = dis.readInt();
-			int numMeters = dis.readInt();
+		public List<MetricDump> deserialize(MetricDumpSerialization.MetricSerializationResult data) {
+			DataInputView in = new DataInputDeserializer(data.data, 0, data.data.length);
 
-			List<MetricDump> metrics = new ArrayList<>(numCounters + numGauges + numHistograms);
+			List<MetricDump> metrics = new ArrayList<>(data.numCounters + data.numGauges + data.numHistograms + data.numMeters);
 
-			for (int x = 0; x < numCounters; x++) {
-				metrics.add(deserializeCounter(dis));
+			for (int x = 0; x < data.numCounters; x++) {
+				try {
+					metrics.add(deserializeCounter(in));
+				} catch (Exception e) {
+					LOG.warn("Failed to deserialize counter.", e);
+				}
 			}
 
-			for (int x = 0; x < numGauges; x++) {
-				metrics.add(deserializeGauge(dis));
+			for (int x = 0; x < data.numGauges; x++) {
+				try {
+					metrics.add(deserializeGauge(in));
+				} catch (Exception e) {
+					LOG.warn("Failed to deserialize gauge.", e);
+				}
 			}
 
-			for (int x = 0; x < numHistograms; x++) {
-				metrics.add(deserializeHistogram(dis));
+			for (int x = 0; x < data.numHistograms; x++) {
+				try {
+					metrics.add(deserializeHistogram(in));
+				} catch (Exception e) {
+					LOG.warn("Failed to deserialize histogram.", e);
+				}
 			}
 
-			for (int x = 0; x < numMeters; x++) {
-				metrics.add(deserializeMeter(dis));
+			for (int x = 0; x < data.numMeters; x++) {
+				try {
+					metrics.add(deserializeMeter(in));
+				} catch (Exception e) {
+					LOG.warn("Failed to deserialize meter.", e);
+				}
 			}
-
 			return metrics;
 		}
 	}
 
-	private static String deserializeString(DataInputStream dis) throws IOException {
-		int stringLength = dis.readInt();
-		byte[] bytes = new byte[stringLength];
-		dis.readFully(bytes);
-		return new String(bytes);
+
+	private static MetricDump.CounterDump deserializeCounter(DataInputView dis) throws IOException {
+		QueryScopeInfo scope = deserializeMetricInfo(dis);
+		String name = dis.readUTF();
+		long count = dis.readLong();
+		return new MetricDump.CounterDump(scope, name, count);
 	}
 
-	private static MetricDump.CounterDump deserializeCounter(DataInputStream dis) throws IOException {
+	private static MetricDump.GaugeDump deserializeGauge(DataInputView dis) throws IOException {
 		QueryScopeInfo scope = deserializeMetricInfo(dis);
-		String name = deserializeString(dis);
-		return new MetricDump.CounterDump(scope, name, dis.readLong());
-	}
-
-	private static MetricDump.GaugeDump deserializeGauge(DataInputStream dis) throws IOException {
-		QueryScopeInfo scope = deserializeMetricInfo(dis);
-		String name = deserializeString(dis);
-		String value = deserializeString(dis);
+		String name = dis.readUTF();
+		String value = dis.readUTF();
 		return new MetricDump.GaugeDump(scope, name, value);
 	}
 
-	private static MetricDump.HistogramDump deserializeHistogram(DataInputStream dis) throws IOException {
+	private static MetricDump.HistogramDump deserializeHistogram(DataInputView dis) throws IOException {
 		QueryScopeInfo info = deserializeMetricInfo(dis);
-		String name = deserializeString(dis);
+		String name = dis.readUTF();
 		long min = dis.readLong();
 		long max = dis.readLong();
 		double mean = dis.readDouble();
@@ -261,42 +307,42 @@ public class MetricDumpSerialization {
 		return new MetricDump.HistogramDump(info, name, min, max, mean, median, stddev, p75, p90, p95, p98, p99, p999);
 	}
 
-	private static MetricDump.MeterDump deserializeMeter(DataInputStream dis) throws IOException {
+	private static MetricDump.MeterDump deserializeMeter(DataInputView dis) throws IOException {
 		QueryScopeInfo info = deserializeMetricInfo(dis);
-		String name = deserializeString(dis);
+		String name = dis.readUTF();
 		double rate = dis.readDouble();
 		return new MetricDump.MeterDump(info, name, rate);
 	}
 
-	private static QueryScopeInfo deserializeMetricInfo(DataInputStream dis) throws IOException {
+	private static QueryScopeInfo deserializeMetricInfo(DataInput dis) throws IOException {
 		String jobID;
 		String vertexID;
 		int subtaskIndex;
 
-		String scope = deserializeString(dis);
+		String scope = dis.readUTF();
 		byte cat = dis.readByte();
 		switch (cat) {
 			case INFO_CATEGORY_JM:
 				return new QueryScopeInfo.JobManagerQueryScopeInfo(scope);
 			case INFO_CATEGORY_TM:
-				String tmID = deserializeString(dis);
+				String tmID = dis.readUTF();
 				return new QueryScopeInfo.TaskManagerQueryScopeInfo(tmID, scope);
 			case INFO_CATEGORY_JOB:
-				jobID = deserializeString(dis);
+				jobID = dis.readUTF();
 				return new QueryScopeInfo.JobQueryScopeInfo(jobID, scope);
 			case INFO_CATEGORY_TASK:
-				jobID = deserializeString(dis);
-				vertexID = deserializeString(dis);
+				jobID = dis.readUTF();
+				vertexID = dis.readUTF();
 				subtaskIndex = dis.readInt();
 				return new QueryScopeInfo.TaskQueryScopeInfo(jobID, vertexID, subtaskIndex, scope);
 			case INFO_CATEGORY_OPERATOR:
-				jobID = deserializeString(dis);
-				vertexID = deserializeString(dis);
+				jobID = dis.readUTF();
+				vertexID = dis.readUTF();
 				subtaskIndex = dis.readInt();
-				String operatorName = deserializeString(dis);
+				String operatorName = dis.readUTF();
 				return new QueryScopeInfo.OperatorQueryScopeInfo(jobID, vertexID, subtaskIndex, operatorName, scope);
 			default:
-				throw new IOException("sup");
+				throw new IOException("Unknown scope category: " + cat);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricQueryService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricQueryService.java
@@ -106,7 +106,7 @@ public class MetricQueryService extends UntypedActor {
 					this.meters.remove(metric);
 				}
 			} else if (message instanceof CreateDump) {
-				byte[] dump = serializer.serialize(counters, gauges, histograms, meters);
+				MetricDumpSerialization.MetricSerializationResult dump = serializer.serialize(counters, gauges, histograms, meters);
 				getSender().tell(dump, getSelf());
 			} else {
 				LOG.warn("MetricQueryServiceActor received an invalid message. " + message.toString());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -345,6 +345,10 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 	 * @param metric the metric to register
 	 */
 	protected void addMetric(String name, Metric metric) {
+		if (metric == null) {
+			LOG.warn("Ignoring attempted registration of a metric due to being null for name {}.", name);
+			return;
+		}
 		// add the metric only if the group is still open
 		synchronized (this) {
 			if (!closed) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerializerTest.java
@@ -53,7 +53,6 @@ public class MetricDumpSerializerTest {
 
 		SimpleCounter c1 = new SimpleCounter();
 		SimpleCounter c2 = new SimpleCounter();
-		SimpleCounter c3 = new SimpleCounter();
 
 		c1.inc(1);
 		c2.inc(2);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerializerTest.java
@@ -27,7 +27,9 @@ import org.apache.flink.runtime.metrics.util.TestingHistogram;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -64,10 +66,24 @@ public class MetricDumpSerializerTest {
 			Collections.<Meter, Tuple2<QueryScopeInfo, String>>emptyMap());
 		
 		// no metrics should be serialized
-		Assert.assertEquals(0, output.data.length);
+		Assert.assertEquals(0, output.serializedMetrics.length);
 
 		List<MetricDump> deserialized = deserializer.deserialize(output);
 		Assert.assertEquals(0, deserialized.size());
+	}
+
+	@Test
+	public void testJavaSerialization() throws IOException {
+		MetricDumpSerialization.MetricDumpSerializer serializer = new MetricDumpSerialization.MetricDumpSerializer();
+
+		final ByteArrayOutputStream bos = new ByteArrayOutputStream(1024);
+		final ObjectOutputStream oos = new ObjectOutputStream(bos);
+
+		oos.writeObject(serializer.serialize(
+			new HashMap<Counter, Tuple2<QueryScopeInfo,String>>(),
+			new HashMap<Gauge<?>, Tuple2<QueryScopeInfo,String>>(),
+			new HashMap<Histogram, Tuple2<QueryScopeInfo,String>>(),
+			new HashMap<Meter, Tuple2<QueryScopeInfo,String>>()));
 	}
 
 	@Test


### PR DESCRIPTION
Rework of #3103.

The key change introduced in the previous PR remains; if a gauge returns null it is not serialized.

However, I've extended the PR to harden the entire serialization process against exceptions. The major gain here is that a single failed serialization does no longer destroys the entire dump; instead it is simply omitted.

In order to allow that I had to replace the ```OutputStream```s with a ```ByteBuffer```. The former doesn't really allow you to handle failures in between serialization steps, as you can't reset the stream in any way. The ```ByteBuffer``` is manually resized if a ```BufferOverflowException``` occurs.

* ```MetricDump(De)Serializer#(de)serialize``` will no longer throw any exception but catch and log them instead
* Exceptions during the serialization of a metric will cause that metric to be skipped.
* added test for handling of gauge returning null
* added test for manual resizing of backing array