### PR TITLE
[FLINK-5515] remove unused kvState.getSerializedValue call in KvStateServerHandler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateServerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateServerHandler.java
@@ -239,8 +239,6 @@ class KvStateServerHandler extends ChannelInboundHandlerAdapter {
 
 					success = true;
 				} else {
-					kvState.getSerializedValue(serializedKeyAndNamespace);
-
 					// No data for the key/namespace. This is considered to be
 					// a failure.
 					ByteBuf unknownKey = KvStateRequestSerializer.serializeKvStateRequestFailure(


### PR DESCRIPTION
this seems like a simple left-over from a merge that is doing unnecessary extra work