### PR TITLE
[FLINK-5530] fix race condition in AbstractRocksDBState#getSerializedValue

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -158,8 +158,8 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 
 	protected void writeKeyWithGroupAndNamespace(
 			int keyGroup, K key, N namespace,
-			final ByteArrayOutputStreamWithPos keySerializationStream,
-			final DataOutputView keySerializationDateDataOutputView) throws IOException {
+			ByteArrayOutputStreamWithPos keySerializationStream,
+			DataOutputView keySerializationDateDataOutputView) throws IOException {
 
 		keySerializationStream.reset();
 		writeKeyGroup(keyGroup, keySerializationDateDataOutputView);
@@ -168,7 +168,7 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 	}
 
 	private void writeKeyGroup(
-			int keyGroup, final DataOutputView keySerializationDateDataOutputView)
+			int keyGroup, DataOutputView keySerializationDateDataOutputView)
 			throws IOException {
 
 		for (int i = backend.getKeyGroupPrefixBytes(); --i >= 0;) {
@@ -177,8 +177,8 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 	}
 
 	private void writeKey(
-			K key, final ByteArrayOutputStreamWithPos keySerializationStream,
-			final DataOutputView keySerializationDateDataOutputView) throws IOException {
+			K key, ByteArrayOutputStreamWithPos keySerializationStream,
+			DataOutputView keySerializationDateDataOutputView) throws IOException {
 
 		//write key
 		int beforeWrite = keySerializationStream.getPosition();
@@ -192,8 +192,8 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 	}
 
 	private void writeNameSpace(
-			N namespace, final ByteArrayOutputStreamWithPos keySerializationStream,
-			final DataOutputView keySerializationDateDataOutputView) throws IOException {
+			N namespace, ByteArrayOutputStreamWithPos keySerializationStream,
+			DataOutputView keySerializationDateDataOutputView) throws IOException {
 
 		int beforeWrite = keySerializationStream.getPosition();
 		namespaceSerializer.serialize(namespace, keySerializationDateDataOutputView);
@@ -206,15 +206,15 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 	}
 
 	private static void writeLengthFrom(
-			int fromPosition, final ByteArrayOutputStreamWithPos keySerializationStream,
-			final DataOutputView keySerializationDateDataOutputView) throws IOException {
+			int fromPosition, ByteArrayOutputStreamWithPos keySerializationStream,
+			DataOutputView keySerializationDateDataOutputView) throws IOException {
 
 		int length = keySerializationStream.getPosition() - fromPosition;
 		writeVariableIntBytes(length, keySerializationDateDataOutputView);
 	}
 
 	private static void writeVariableIntBytes(
-			int value, final DataOutputView keySerializationDateDataOutputView)
+			int value, DataOutputView keySerializationDateDataOutputView)
 			throws IOException {
 
 		do {

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -156,11 +156,10 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 			this.keySerializationDateDataOutputView);
 	}
 
-	protected void writeKeyWithGroupAndNamespace(int keyGroup, K key,
-		N namespace,
-		final ByteArrayOutputStreamWithPos keySerializationStream,
-		final DataOutputView keySerializationDateDataOutputView) throws
-		IOException {
+	protected void writeKeyWithGroupAndNamespace(
+			int keyGroup, K key, N namespace,
+			final ByteArrayOutputStreamWithPos keySerializationStream,
+			final DataOutputView keySerializationDateDataOutputView) throws IOException {
 
 		keySerializationStream.reset();
 		writeKeyGroup(keyGroup, keySerializationDateDataOutputView);
@@ -168,19 +167,18 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 		writeNameSpace(namespace, keySerializationStream, keySerializationDateDataOutputView);
 	}
 
-	private void writeKeyGroup(int keyGroup,
-		final DataOutputView keySerializationDateDataOutputView) throws
-		IOException {
+	private void writeKeyGroup(
+			int keyGroup, final DataOutputView keySerializationDateDataOutputView)
+			throws IOException {
 
 		for (int i = backend.getKeyGroupPrefixBytes(); --i >= 0;) {
 			keySerializationDateDataOutputView.writeByte(keyGroup >>> (i << 3));
 		}
 	}
 
-	private void writeKey(K key,
-		final ByteArrayOutputStreamWithPos keySerializationStream,
-		final DataOutputView keySerializationDateDataOutputView) throws
-		IOException {
+	private void writeKey(
+			K key, final ByteArrayOutputStreamWithPos keySerializationStream,
+			final DataOutputView keySerializationDateDataOutputView) throws IOException {
 
 		//write key
 		int beforeWrite = keySerializationStream.getPosition();
@@ -193,10 +191,9 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 		}
 	}
 
-	private void writeNameSpace(N namespace,
-		final ByteArrayOutputStreamWithPos keySerializationStream,
-		final DataOutputView keySerializationDateDataOutputView) throws
-		IOException {
+	private void writeNameSpace(
+			N namespace, final ByteArrayOutputStreamWithPos keySerializationStream,
+			final DataOutputView keySerializationDateDataOutputView) throws IOException {
 
 		int beforeWrite = keySerializationStream.getPosition();
 		namespaceSerializer.serialize(namespace, keySerializationDateDataOutputView);
@@ -208,18 +205,17 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 		}
 	}
 
-	private static void writeLengthFrom(int fromPosition,
-		final ByteArrayOutputStreamWithPos keySerializationStream,
-		final DataOutputView keySerializationDateDataOutputView) throws
-		IOException {
+	private static void writeLengthFrom(
+			int fromPosition, final ByteArrayOutputStreamWithPos keySerializationStream,
+			final DataOutputView keySerializationDateDataOutputView) throws IOException {
 
 		int length = keySerializationStream.getPosition() - fromPosition;
 		writeVariableIntBytes(length, keySerializationDateDataOutputView);
 	}
 
-	private static void writeVariableIntBytes(int value,
-		final DataOutputView keySerializationDateDataOutputView) throws
-		IOException {
+	private static void writeVariableIntBytes(
+			int value, final DataOutputView keySerializationDateDataOutputView)
+			throws IOException {
 
 		do {
 			keySerializationDateDataOutputView.writeByte(value);

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -134,7 +134,7 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 		int keyGroup = KeyGroupRangeAssignment.assignToKeyGroup(des.f0, backend.getNumberOfKeyGroups());
 
 		// we cannot reuse the keySerializationStream member since this method
-		// is called concurrently to the other ones and it may this contain garbage
+		// is called concurrently to the other ones and it may thus contain garbage
 		ByteArrayOutputStreamWithPos tmpKeySerializationStream =
 			new ByteArrayOutputStreamWithPos(128);
 		DataOutputViewStreamWrapper tmpKeySerializationDateDataOutputView =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -48,12 +48,15 @@ import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
 import org.apache.flink.runtime.state.heap.AbstractHeapState;
 import org.apache.flink.runtime.state.heap.StateTable;
 import org.apache.flink.types.IntValue;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RunnableFuture;
 
@@ -240,6 +243,132 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		assertEquals("u3", getSerializedValue(restoredKvState2, 3, keySerializer, VoidNamespace.INSTANCE, namespaceSerializer, valueSerializer));
 
 		backend.dispose();
+	}
+
+	/**
+	 * Tests {@link ValueState#value()} and {@link KvState#getSerializedValue(byte[])}
+	 * accessing the state concurrently. They should not get in the way of each
+	 * other.
+	 */
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testValueStateRace() throws Exception {
+		final AbstractKeyedStateBackend<Integer> backend =
+			createKeyedBackend(IntSerializer.INSTANCE);
+		final Integer namespace = Integer.valueOf(1);
+
+		final ValueStateDescriptor<String> kvId =
+			new ValueStateDescriptor<>("id", String.class);
+		kvId.initializeSerializerUnlessSet(new ExecutionConfig());
+
+		final TypeSerializer<Integer> keySerializer = IntSerializer.INSTANCE;
+		final TypeSerializer<Integer> namespaceSerializer =
+			IntSerializer.INSTANCE;
+		final TypeSerializer<String> valueSerializer = kvId.getSerializer();
+
+		final ValueState<String> state = backend
+			.getPartitionedState(namespace, IntSerializer.INSTANCE, kvId);
+
+		@SuppressWarnings("unchecked")
+		final KvState<Integer> kvState = (KvState<Integer>) state;
+
+		/**
+		 * 1) Test that ValueState#value() before and after
+		 * KvState#getSerializedValue(byte[]) return the same value.
+		 */
+
+		// set some key and namespace
+		final int key1 = 1;
+		backend.setCurrentKey(key1);
+		kvState.setCurrentNamespace(2);
+		state.update("2");
+		assertEquals("2", state.value());
+
+		// query another key and namespace
+		assertNull(getSerializedValue(kvState, 3, keySerializer,
+			namespace, IntSerializer.INSTANCE,
+			valueSerializer));
+
+		// the state should not have changed!
+		assertEquals("2", state.value());
+
+		// re-set values
+		kvState.setCurrentNamespace(namespace);
+
+		/**
+		 * 2) Test two threads concurrently using ValueState#value() and
+		 * KvState#getSerializedValue(byte[]).
+		 */
+
+		// some modifications to the state
+		final int key2 = 10;
+		backend.setCurrentKey(key2);
+		assertNull(state.value());
+		assertNull(getSerializedValue(kvState, key2, keySerializer,
+			namespace, namespaceSerializer, valueSerializer));
+		state.update("1");
+
+		boolean getterSuccess;
+		final Throwable[] throwables = {null, null};
+
+		final Thread getter = new Thread("State getter") {
+			@Override
+			public void run() {
+				try {
+					while (!isInterrupted() && throwables[1] == null) {
+						assertEquals("1", state.value());
+					}
+				} catch (Throwable a) {
+					throwables[0] = a;
+				}
+			}
+		};
+
+		final Thread serializedGetter = new Thread("Serialized state getter") {
+			@Override
+			public void run() {
+				try {
+					while(!isInterrupted() && throwables[0] == null) {
+						final String serializedValue =
+							getSerializedValue(kvState, key2, keySerializer,
+								namespace, namespaceSerializer,
+								valueSerializer);
+						assertEquals("1", serializedValue);
+					}
+				} catch (Throwable a) {
+					throwables[1] = a;
+				}
+			}
+		};
+
+		getter.start();
+		serializedGetter.start();
+
+		// run both threads for max 100ms
+		Timer t = new Timer("stopper");
+		t.schedule(new TimerTask() {
+			@Override
+			public void run() {
+				getter.interrupt();
+				serializedGetter.interrupt();
+				this.cancel();
+			}
+		}, 100);
+
+		// wait for both threads to finish
+		getter.join();
+		serializedGetter.join();
+		t.cancel(); // if not executed yet
+
+		// clean up
+		backend.dispose();
+
+		// re-throw any assertion error
+		if (throwables[0] != null) {
+			ExceptionUtils.rethrow(throwables[0]);
+		} else if (throwables[1] != null) {
+			ExceptionUtils.rethrow(throwables[1]);
+		}
 	}
 
 	@Test

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CheckedThread.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CheckedThread.java
@@ -37,6 +37,25 @@ public abstract class CheckedThread extends Thread {
 	// ------------------------------------------------------------------------
 
 	/**
+	 * Unnamed checked thread.
+	 */
+	public CheckedThread() {
+		super();
+	}
+
+	/**
+	 * Checked thread with a name.
+	 *
+	 * @param name
+	 * 		the name of the new thread
+	 *
+	 * @see Thread#Thread(String)
+	 */
+	public CheckedThread(final String name) {
+		super(name);
+	}
+
+	/**
 	 * This method needs to be overwritten to contain the main work logic.
 	 * It takes the role of {@link Thread#run()}, but should propagate exceptions.
 	 *


### PR DESCRIPTION
`AbstractRocksDBState#getSerializedValue()` uses the same key serialisation
stream as the ordinary state access methods but is called in parallel during
state queries thus violating the assumption of only one thread accessing it.

This may lead to either wrong results in queries or corrupt data while queries
are executed.