### PR TITLE
Insert necessary closing parentheses into the "Basic API Concepts" document.

### DIFF
--- a/docs/dev/api_concepts.md
+++ b/docs/dev/api_concepts.md
@@ -610,9 +610,9 @@ reduce, etc), four methods: `open`, `close`, `getRuntimeContext`, and
 `setRuntimeContext`. These are useful for parameterizing the function
 (see [Passing Parameters to Functions]({{ site.baseurl }}/dev/batch/index.html#passing-parameters-to-functions)),
 creating and finalizing local state, accessing broadcast variables (see
-[Broadcast Variables]({{ site.baseurl }}/dev/batch/index.html#broadcast-variables), and for accessing runtime
+[Broadcast Variables]({{ site.baseurl }}/dev/batch/index.html#broadcast-variables)), and for accessing runtime
 information such as accumulators and counters (see
-[Accumulators and Counters](#accumulators--counters), and information
+[Accumulators and Counters](#accumulators--counters)), and information
 on iterations (see [Iterations]({{ site.baseurl }}/dev/batch/iterations.html)).
 
 {% top %}


### PR DESCRIPTION
This is a trivial fix and there is no related JIRA issue according to http://flink.apache.org/contribute-documentation.html#before-you-start-working-on-the-documentation-