### PR TITLE
[FLINK-5496] [mesos] Relocate Mesos Protobuf dependency to avoid version conflicts

### DIFF
--- a/flink-mesos/pom.xml
+++ b/flink-mesos/pom.xml
@@ -255,7 +255,9 @@ under the License.
 				</configuration>
 			</plugin>
 
-			<!-- Relocate curator -->
+			<!-- Relocate Mesos Protobuf dependency. Mesos 1.0.1 requires Protobuf 2.6.1 whereas
+			 Flakka pulls in Protobuf 2.5.0. It might be feasible to set Protobuf to version 2.6.1,
+			 but we shade to be on the safe side. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
@@ -270,21 +272,14 @@ under the License.
 							<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
 							<artifactSet>
 								<includes combine.children="append">
-									<include>org.apache.flink:flink-shaded-curator-recipes</include>
 									<include>com.google.protobuf:*</include>
-									<include>com.google.guava:guava</include>
 									<include>org.apache.mesos:*</include>
-									<include>com.netflix.fenzo:*</include>
 								</includes>
 							</artifactSet>
-							<relocations combine.children="override">
+							<relocations combine.children="append">
 								<relocation>
-									<pattern>org.apache.curator</pattern>
-									<shadedPattern>org.apache.flink.mesos.shaded.org.apache.curator</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>com.google</pattern>
-									<shadedPattern>org.apache.flink.mesos.shaded.com.google</shadedPattern>
+									<pattern>com.google.protobuf</pattern>
+									<shadedPattern>org.apache.flink.mesos.shaded.com.google.protobuf</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
@@ -73,6 +73,7 @@ import java.net.URL;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -315,7 +316,7 @@ public class MesosApplicationMasterRunner {
 			LOG.debug("Starting Mesos Flink Resource Manager");
 
 			// create the worker store to persist task information across restarts
-			MesosWorkerStore workerStore = createWorkerStore(config);
+			MesosWorkerStore workerStore = createWorkerStore(config, ioExecutor);
 
 			// we need the leader retrieval service here to be informed of new
 			// leader session IDs, even though there can be only one leader ever
@@ -497,7 +498,7 @@ public class MesosApplicationMasterRunner {
 		return mesos;
 	}
 
-	private static MesosWorkerStore createWorkerStore(Configuration flinkConfig) throws Exception {
+	private static MesosWorkerStore createWorkerStore(Configuration flinkConfig, Executor executor) throws Exception {
 		MesosWorkerStore workerStore;
 		HighAvailabilityMode recoveryMode = HighAvailabilityMode.fromConfig(flinkConfig);
 		if (recoveryMode == HighAvailabilityMode.NONE) {
@@ -506,7 +507,7 @@ public class MesosApplicationMasterRunner {
 		else if (recoveryMode == HighAvailabilityMode.ZOOKEEPER) {
 			// note: the store is responsible for closing the client.
 			CuratorFramework client = ZooKeeperUtils.startCuratorFramework(flinkConfig);
-			workerStore = ZooKeeperMesosWorkerStore.createMesosWorkerStore(client, flinkConfig);
+			workerStore = ZooKeeperMesosWorkerStore.createMesosWorkerStore(client, flinkConfig, executor);
 		}
 		else {
 			throw new IllegalConfigurationException("Unexpected recovery mode '" + recoveryMode + ".");

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/store/ZooKeeperMesosWorkerStore.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/store/ZooKeeperMesosWorkerStore.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -72,10 +73,10 @@ public class ZooKeeperMesosWorkerStore implements MesosWorkerStore {
 
 	@SuppressWarnings("unchecked")
 	ZooKeeperMesosWorkerStore(
-		CuratorFramework client,
-		String storePath,
-		RetrievableStateStorageHelper<Worker> stateStorage
-	) throws Exception {
+			CuratorFramework client,
+			String storePath,
+			RetrievableStateStorageHelper<Worker> stateStorage,
+			Executor executor) throws Exception {
 		checkNotNull(storePath, "storePath");
 		checkNotNull(stateStorage, "stateStorage");
 
@@ -100,8 +101,8 @@ public class ZooKeeperMesosWorkerStore implements MesosWorkerStore {
 
 		// using late-binding as a workaround for shaded curator dependency of flink-runtime.
 		this.workersInZooKeeper = ZooKeeperStateHandleStore.class
-			.getConstructor(CuratorFramework.class, RetrievableStateStorageHelper.class)
-			.newInstance(storeFacade, stateStorage);
+			.getConstructor(CuratorFramework.class, RetrievableStateStorageHelper.class, Executor.class)
+			.newInstance(storeFacade, stateStorage, executor);
 	}
 
 	@Override
@@ -284,7 +285,8 @@ public class ZooKeeperMesosWorkerStore implements MesosWorkerStore {
 	 */
 	public static ZooKeeperMesosWorkerStore createMesosWorkerStore(
 			CuratorFramework client,
-			Configuration configuration) throws Exception {
+			Configuration configuration,
+			Executor executor) throws Exception {
 
 		checkNotNull(configuration, "Configuration");
 
@@ -297,6 +299,9 @@ public class ZooKeeperMesosWorkerStore implements MesosWorkerStore {
 		);
 
 		return new ZooKeeperMesosWorkerStore(
-			client, zooKeeperMesosWorkerStorePath, stateStorage);
+			client,
+			zooKeeperMesosWorkerStorePath,
+			stateStorage,
+			executor);
 	}
 }

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -379,7 +379,6 @@ under the License.
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-						
 							<artifactSet>
 								<includes combine.children="append">
 									<include>org.apache.flink:flink-shaded-curator-recipes</include>


### PR DESCRIPTION
This PR is based on #3155.

Only relocate Mesos Protobuf dependency in flink-mesos. This avoids problems with Mesos
because Flink pulls in Protobuf 2.5.0 via Flakka.