### PR TITLE
[backport] [FLINK-5504] Create mesos-appmaster log file in log directory

### DIFF
--- a/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster.sh
+++ b/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster.sh
@@ -38,9 +38,14 @@ constructAppMasterClassPath() {
     echo $CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS
 }
 
+if [ "$FLINK_IDENT_STRING" = "" ]; then
+    FLINK_IDENT_STRING="$USER"
+fi
+
+
 CC_CLASSPATH=`manglePathList $(constructAppMasterClassPath)`
 
-log=flink-appmaster.log
+log="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}.log"
 log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml"
 
 export FLINK_CONF_DIR


### PR DESCRIPTION
Backport of #3159 onto the `release-1.2` branch.

This PR prepends the FLINK_LOG_DIR env variable pointing to Flink's logging
directory to the logging file name.
