### PR TITLE
[FLINK-5503] [log] Print error message in case MesosApplicationMaster Runner fails

### DIFF
--- a/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster.sh
+++ b/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster.sh
@@ -38,9 +38,14 @@ constructAppMasterClassPath() {
     echo $CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS
 }
 
+if [ "$FLINK_IDENT_STRING" = "" ]; then
+    FLINK_IDENT_STRING="$USER"
+fi
+
+
 CC_CLASSPATH=`manglePathList $(constructAppMasterClassPath)`
 
-log=flink-appmaster.log
+log="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}.log"
 log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback.xml"
 
 export FLINK_CONF_DIR

--- a/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster.sh
+++ b/flink-dist/src/main/flink-bin/mesos-bin/mesos-appmaster.sh
@@ -42,7 +42,6 @@ if [ "$FLINK_IDENT_STRING" = "" ]; then
     FLINK_IDENT_STRING="$USER"
 fi
 
-
 CC_CLASSPATH=`manglePathList $(constructAppMasterClassPath)`
 
 log="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-mesos-appmaster-${HOSTNAME}.log"
@@ -54,3 +53,10 @@ export FLINK_LIB_DIR
 
 $JAVA_RUN $JVM_ARGS -classpath "$CC_CLASSPATH" $log_setting org.apache.flink.mesos.runtime.clusterframework.MesosApplicationMasterRunner "$@"
 
+rc=$?
+
+if [[ $rc -ne 0 ]]; then
+    echo "Error while starting the mesos application master. Please check ${log} for more details."
+fi
+
+exit $rc


### PR DESCRIPTION
This PR is based on #3159.

This PR adds an error message to the mesos-appmaster.sh script which is printed in case
that the MesosApplicationMasterRunner fails.