### PR TITLE
[FLINK-5576] extend deserialization functions of KvStateRequestSerializer to detect unconsumed bytes

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializer.java
@@ -488,24 +488,32 @@ public final class KvStateRequestSerializer {
 	 */
 	public static <T> List<T> deserializeList(byte[] serializedValue, TypeSerializer<T> serializer) throws IOException {
 		if (serializedValue != null) {
-			DataInputDeserializer in = new DataInputDeserializer(serializedValue, 0, serializedValue.length);
+			final DataInputDeserializer in =
+				new DataInputDeserializer(serializedValue, 0, serializedValue.length);
 
-			List<T> result = new ArrayList<>();
-			while (in.available() > 0) {
-				result.add(serializer.deserialize(in));
+			try {
+				final List<T> result = new ArrayList<>();
+				while (in.available() > 0) {
+					result.add(serializer.deserialize(in));
 
-				// The expected binary format has a single byte separator. We
-				// want a consistent binary format in order to not need any
-				// special casing during deserialization. A "cleaner" format
-				// would skip this extra byte, but would require a memory copy
-				// for RocksDB, which stores the data serialized in this way
-				// for lists.
-				if (in.available() > 0) {
-					in.readByte();
+					// The expected binary format has a single byte separator. We
+					// want a consistent binary format in order to not need any
+					// special casing during deserialization. A "cleaner" format
+					// would skip this extra byte, but would require a memory copy
+					// for RocksDB, which stores the data serialized in this way
+					// for lists.
+					if (in.available() > 0) {
+						in.readByte();
+					}
 				}
-			}
 
-			return result;
+				return result;
+			} catch (IOException e) {
+				throw new IOException(
+						"Unable to deserialize value. " +
+							"This indicates a mismatch in the value serializers " +
+							"used by the KvState instance and this access.", e);
+			}
 		} else {
 			return null;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializer.java
@@ -429,8 +429,16 @@ public final class KvStateRequestSerializer {
 		if (serializedValue == null) {
 			return null;
 		} else {
-			DataInputDeserializer deser = new DataInputDeserializer(serializedValue, 0, serializedValue.length);
-			return serializer.deserialize(deser);
+			final DataInputDeserializer deser =
+				new DataInputDeserializer(serializedValue, 0, serializedValue.length);
+			final T value = serializer.deserialize(deser);
+			if (deser.available() > 0) {
+				throw new IOException(
+					"Unconsumed bytes in the deserialized value. " +
+						"This indicates a mismatch in the value serializers " +
+						"used by the KvState instance and this access.");
+			}
+			return value;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/DataInputDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/DataInputDeserializer.java
@@ -55,7 +55,7 @@ public class DataInputDeserializer implements DataInputView, java.io.Serializabl
 	}
 
 	// ------------------------------------------------------------------------
-	//  Chaning buffers
+	//  Changing buffers
 	// ------------------------------------------------------------------------
 	
 	public void setBuffer(ByteBuffer buffer) {
@@ -98,7 +98,7 @@ public class DataInputDeserializer implements DataInputView, java.io.Serializabl
 
 	public int available() {
 		if (position < end) {
-			return end - position - 1;
+			return end - position;
 		} else {
 			return 0;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializerTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.query.KvStateID;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -221,6 +222,43 @@ public class KvStateRequestSerializerTest {
 		long actualValue = KvStateRequestSerializer.deserializeValue(serializedValue, valueSerializer);
 
 		assertEquals(expectedValue, actualValue);
+	}
+
+	/**
+	 * Tests value deserialization with too few bytes.
+	 */
+	@Test(expected = IOException.class)
+	public void testDeserializeValueEmpty() throws Exception {
+		KvStateRequestSerializer.deserializeValue(new byte[] {}, LongSerializer.INSTANCE);
+	}
+
+	/**
+	 * Tests value deserialization with too few bytes.
+	 */
+	@Test(expected = IOException.class)
+	public void testDeserializeValueTooShort() throws Exception {
+		// 1 byte (incomplete Long)
+		KvStateRequestSerializer.deserializeValue(new byte[] {1}, LongSerializer.INSTANCE);
+	}
+
+	/**
+	 * Tests value deserialization with too many bytes.
+	 */
+	@Test(expected = IOException.class)
+	public void testDeserializeValueTooMany1() throws Exception {
+		// Long + 1 byte
+		KvStateRequestSerializer.deserializeValue(new byte[] {1, 1, 1, 1, 1, 1, 1, 1, 2},
+			LongSerializer.INSTANCE);
+	}
+
+	/**
+	 * Tests value deserialization with too many bytes.
+	 */
+	@Test(expected = IOException.class)
+	public void testDeserializeValueTooMany2() throws Exception {
+		// Long + 2 bytes
+		KvStateRequestSerializer.deserializeValue(new byte[] {1, 1, 1, 1, 1, 1, 1, 1, 2, 2},
+			LongSerializer.INSTANCE);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializerTest.java
@@ -288,6 +288,35 @@ public class KvStateRequestSerializerTest {
 		assertEquals(expectedValue, actualValue.get(0).longValue());
 	}
 
+	/**
+	 * Tests list deserialization with too few bytes.
+	 */
+	@Test
+	public void testDeserializeListEmpty() throws Exception {
+		List<Long> actualValue = KvStateRequestSerializer
+			.deserializeList(new byte[] {}, LongSerializer.INSTANCE);
+		assertEquals(0, actualValue.size());
+	}
+
+	/**
+	 * Tests list deserialization with too few bytes.
+	 */
+	@Test(expected = IOException.class)
+	public void testDeserializeListTooShort1() throws Exception {
+		// 1 byte (incomplete Long)
+		KvStateRequestSerializer.deserializeList(new byte[] {1}, LongSerializer.INSTANCE);
+	}
+
+	/**
+	 * Tests list deserialization with too few bytes.
+	 */
+	@Test(expected = IOException.class)
+	public void testDeserializeListTooShort2() throws Exception {
+		// Long + 1 byte (separator) + 1 byte (incomplete Long)
+		KvStateRequestSerializer.deserializeList(new byte[] {1, 1, 1, 1, 1, 1, 1, 1, 2, 3},
+			LongSerializer.INSTANCE);
+	}
+
 	private byte[] randomByteArray(int capacity) {
 		byte[] bytes = new byte[capacity];
 		ThreadLocalRandom.current().nextBytes(bytes);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/DataInputDeserializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/DataInputDeserializerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Test suite for the {@link DataInputDeserializer} class.
+ */
+public class DataInputDeserializerTest {
+
+	@Test
+	public void testAvailable() throws Exception {
+		byte[] bytes;
+		DataInputDeserializer dis;
+
+		bytes = new byte[] {};
+		dis = new DataInputDeserializer(bytes, 0, bytes.length);
+		Assert.assertEquals(bytes.length, dis.available());
+
+		bytes = new byte[] {1, 2, 3};
+		dis = new DataInputDeserializer(bytes, 0, bytes.length);
+		Assert.assertEquals(bytes.length, dis.available());
+
+		dis.readByte();
+		Assert.assertEquals(2, dis.available());
+		dis.readByte();
+		Assert.assertEquals(1, dis.available());
+		dis.readByte();
+		Assert.assertEquals(0, dis.available());
+
+		try {
+			dis.readByte();
+		} catch (IOException e) {
+			// ignore
+		}
+		Assert.assertEquals(0, dis.available());
+	}
+}


### PR DESCRIPTION
`KvStateRequestSerializer#deserializeValue()` deserializes a given byte array. This is used by clients and unit tests and it is fair to assume that these byte arrays represent a complete value since we do not offer a method to continue reading from the middle of the array anyway. Therefore, we can treat unconsumed bytes as errors, e.g. from a wrong serializer being used, and throw an `IOException` with an appropriate failure message.

Similarly, this adds a better failure message to exceptions in `KvStateRequestSerializer#deserializeList()` by wrapping the original `IOException` into a new one with an appropriate error message just as in #3172.

The new unit tests require #3171 to be accepted first on which this PR is also based.