### PR TITLE
[FLINK-5584]support sliding-count row-window on streaming sql

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
@@ -237,6 +237,8 @@ abstract class BatchTableEnvironment(
     */
   protected def getBuiltInRuleSet: RuleSet = FlinkRuleSets.DATASET_OPT_RULES
 
+  protected def getPreOptRuleSet: RuleSet = FlinkRuleSets.DATASET_PRE_OPT_RULES
+
   /**
     * Generates the optimized [[RelNode]] tree from the original relational node tree.
     *

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -117,6 +117,14 @@ object FlinkRuleSets {
   )
 
   /**
+    * RuleSet to optimize plans for window
+    */
+  val DATASET_PRE_OPT_RULES: RuleSet = RuleSets.ofList(
+
+    ProjectToWindowRule.PROJECT
+  )
+
+  /**
   * RuleSet to optimize plans for stream / DataStream execution
   */
   val DATASTREAM_OPT_RULES: RuleSet = RuleSets.ofList(
@@ -141,6 +149,7 @@ object FlinkRuleSets {
       ProjectFilterTransposeRule.INSTANCE,
       FilterProjectTransposeRule.INSTANCE,
       ProjectRemoveRule.INSTANCE,
+      ProjectMergeRule.INSTANCE,
 
       // simplify expressions rules
       ReduceExpressionsRule.FILTER_INSTANCE,
@@ -151,6 +160,7 @@ object FlinkRuleSets {
       UnionEliminatorRule.INSTANCE,
 
       // translate to DataStream nodes
+      DataStreamWindowRule.INSTANCE,
       DataStreamAggregateRule.INSTANCE,
       DataStreamCalcRule.INSTANCE,
       DataStreamScanRule.INSTANCE,
@@ -159,6 +169,14 @@ object FlinkRuleSets {
       DataStreamCorrelateRule.INSTANCE,
       StreamTableSourceScanRule.INSTANCE,
       PushProjectIntoStreamTableSourceScanRule.INSTANCE
+  )
+
+  /**
+    * RuleSet to optimize plans for window
+    */
+  val DATASTREAM_PRE_OPT_RULES: RuleSet = RuleSets.ofList(
+
+    ProjectToWindowRule.PROJECT
   )
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamWindowRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamWindowRule.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.datastream
+
+import org.apache.calcite.plan.volcano.RelSubset
+import org.apache.calcite.plan.{Convention, RelOptRule, RelOptRuleCall, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rel.logical.LogicalWindow
+import org.apache.calcite.rex.{RexInputRef, RexLiteral}
+import org.apache.flink.table.api.{SlidingWindow, TableException}
+import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
+import org.apache.flink.table.plan.nodes.datastream.{DataStreamAggregate, DataStreamConvention}
+import org.apache.flink.table.runtime.aggregate.AggregateUtil._
+import org.apache.flink.table.expressions.ExpressionParser
+
+import scala.collection.JavaConversions._
+
+/**
+  * Rule to convert a LogicalWindow into a DataStreamAggregate.
+  */
+class DataStreamWindowRule
+  extends ConverterRule(
+    classOf[LogicalWindow],
+    Convention.NONE,
+    DataStreamConvention.INSTANCE,
+    "DataStreamWindowRule")
+{
+
+  override def convert(rel: RelNode): RelNode = {
+    val agg: LogicalWindow = rel.asInstanceOf[LogicalWindow]
+    val traitSet: RelTraitSet = rel.getTraitSet.replace(DataStreamConvention.INSTANCE)
+    val convInput: RelNode = RelOptRule.convert(agg.getInput, DataStreamConvention.INSTANCE)
+
+    val inputRowType = convInput.asInstanceOf[RelSubset].getOriginal.getRowType
+
+    if (agg.groups.size > 1) {
+      for (i <- 0 until agg.groups.size - 1)
+        if (agg.groups(i).toString != agg.groups(i + 1).toString) {
+          throw new UnsupportedOperationException(
+            "Unsupport different window in the same projection")
+        }
+    }
+
+    val win = agg.groups(0)
+    val namedAgg =
+      for (i <- 0 until agg.groups.size; aggCalls = agg.groups(i).getAggregateCalls(agg);
+           j <- 0 until aggCalls.size)
+        yield new CalcitePair[AggregateCall, String](aggCalls.get(j), "w" + i + "$o" + j)
+
+    if (win.isRows) {
+      val rowIdx: RexInputRef =
+        if (win.lowerBound.getOffset == null) win.upperBound.getOffset.asInstanceOf[RexInputRef]
+        else win.lowerBound.getOffset.asInstanceOf[RexInputRef]
+      val rowsExpr = RexLiteral.intValue(
+        agg.constants.get(rowIdx.getIndex - inputRowType.getFieldCount)) + ".rows"
+
+      new DataStreamAggregate(
+        new SlidingWindow(ExpressionParser.parseExpression(rowsExpr),
+          ExpressionParser.parseExpression("1.rows")).toLogicalWindow,
+        Seq[NamedWindowProperty](),
+        rel.getCluster,
+        traitSet,
+        convInput,
+        namedAgg,
+        rel.getRowType,
+        inputRowType,
+        win.keys.toArray)
+    } else null
+  }
+}
+
+object DataStreamWindowRule {
+  val INSTANCE: RelOptRule = new DataStreamWindowRule
+}
+

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/TableEnvironmentTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/TableEnvironmentTest.scala
@@ -286,6 +286,8 @@ class MockTableEnvironment extends TableEnvironment(new TableConfig) {
 
   override protected def getBuiltInRuleSet: RuleSet = ???
 
+  override protected def getPreOptRuleSet: RuleSet = ???
+
   override def sql(query: String): Table = ???
 }
 


### PR DESCRIPTION
Calcite has already support sliding-count row-window, the grammar look like:
select sum(amount) over (rows 10 preceding) from Order;
select sum(amount) over (partition by user rows 10 preceding) from Order;
And it will parse the sql as a LogicalWindow relnode, the logical Window contains aggregate func info and window info, it's similar to Flink LogicalWIndowAggregate, so we can add an convert rule to directly convert LogicalWindow into DataStreamAggregate relnode.

1. Add HepPlanner to do the window optimize, cause valcano planner can not choose the ProjectToWindow optimize as the best.
2. Add DataStreamWindowRule.scala to convert LogicalWindow to DataStreamAggregate.