### PR TITLE
[FLINK-5580] [security] Fix path setting of shipped Kerberos keytabs in YARN mode

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -169,6 +169,8 @@ public class YarnApplicationMasterRunner {
 			LOG.debug("YARN dynamic properties: {}", dynamicProperties);
 
 			final Configuration flinkConfig = createConfiguration(currDir, dynamicProperties);
+
+			// set keytab principal and replace path with the local path of the shipped keytab file in NodeManager
 			if (keytabPath != null && remoteKeytabPrincipal != null) {
 				flinkConfig.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, keytabPath);
 				flinkConfig.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, remoteKeytabPrincipal);


### PR DESCRIPTION
This was causing Flink on YARN deployment to fail when using keytabs for Kerberos authentication.
Previously, the local path of the shipped keytab was set _after_ `SecurityConfiguration` was created, causing the picked up keytab path to be invalid and validation of the security configuration not passing.