### PR TITLE
[FLINK-5532] Make window assigners for aligned window operators non-extendable

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -1015,7 +1015,7 @@ public class WindowedStream<T, K, W extends Window> {
 			TypeInformation<R> resultType,
 			String functionName) {
 
-		if (windowAssigner instanceof SlidingAlignedProcessingTimeWindows && trigger == null && evictor == null) {
+		if (windowAssigner.getClass().equals(SlidingAlignedProcessingTimeWindows.class) && trigger == null && evictor == null) {
 			SlidingAlignedProcessingTimeWindows timeWindows = (SlidingAlignedProcessingTimeWindows) windowAssigner;
 			final long windowLength = timeWindows.getSize();
 			final long windowSlide = timeWindows.getSlide();
@@ -1046,7 +1046,7 @@ public class WindowedStream<T, K, W extends Window> {
 						windowLength, windowSlide);
 				return input.transform(opName, resultType, op);
 			}
-		} else if (windowAssigner instanceof TumblingAlignedProcessingTimeWindows && trigger == null && evictor == null) {
+		} else if (windowAssigner.getClass().equals(TumblingAlignedProcessingTimeWindows.class) && trigger == null && evictor == null) {
 			TumblingAlignedProcessingTimeWindows timeWindows = (TumblingAlignedProcessingTimeWindows) windowAssigner;
 			final long windowLength = timeWindows.getSize();
 			final long windowSlide = timeWindows.getSize();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingAlignedProcessingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/SlidingAlignedProcessingTimeWindows.java
@@ -35,7 +35,7 @@ import org.apache.flink.streaming.api.windowing.time.Time;
  * <p>
  * <b>WARNING:</b> Bear in mind that no rescaling and no backwards compatibility is supported.
  * */
-public class SlidingAlignedProcessingTimeWindows extends BaseAlignedWindowAssigner {
+public final class SlidingAlignedProcessingTimeWindows extends BaseAlignedWindowAssigner {
 
 	private static final long serialVersionUID = 3695562702662473688L;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingAlignedProcessingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingAlignedProcessingTimeWindows.java
@@ -35,11 +35,11 @@ import org.apache.flink.streaming.api.windowing.time.Time;
  * <p>
  * <b>WARNING:</b> Bear in mind that no rescaling and no backwards compatibility is supported.
  * */
-public class TumblingAlignedProcessingTimeWindows extends BaseAlignedWindowAssigner {
+public final class TumblingAlignedProcessingTimeWindows extends BaseAlignedWindowAssigner {
 
 	private static final long serialVersionUID = -6217477609512299842L;
 
-	protected TumblingAlignedProcessingTimeWindows(long size) {
+	public TumblingAlignedProcessingTimeWindows(long size) {
 		super(size);
 	}
 


### PR DESCRIPTION
Makes the TumblingAlignedProcessingTimeWindows and the
SlidingAlignedProcessingTimeWindows final so that users cannot
extend them.

R @aljoscha @StephanEwen 