### PR TITLE
[FLINK-5562] [gelly] Driver fixes for release-1.2

### DIFF
--- a/docs/dev/libs/gelly/index.md
+++ b/docs/dev/libs/gelly/index.md
@@ -63,7 +63,8 @@ Add the following dependency to your `pom.xml` to use Gelly.
 </div>
 </div>
 
-Note that Gelly is currently not part of the binary distribution. See linking with it for cluster execution [here]({{ site.baseurl }}/dev/linking.html).
+Note that Gelly is not part of the binary distribution. See [linking]({{ site.baseurl }}/dev/linking.html) for
+instructions on packaging Gelly libraries into Flink user programs.
 
 The remaining sections provide a description of available methods and present several examples of how to use Gelly and how to mix it with the Flink DataSet API.
 
@@ -71,15 +72,15 @@ Running Gelly Examples
 ----------------------
 
 The Gelly library and examples jars are provided in the [Flink distribution](https://flink.apache.org/downloads.html "Apache Flink: Downloads")
-in the folder **opt/lib/gelly** (for versions older than Flink 1.2 these can be manually downloaded from
+in the folder **opt** (for versions older than Flink 1.2 these can be manually downloaded from
 [Maven Central](http://search.maven.org/#search|ga|1|flink%20gelly).
 
 To run the Gelly examples the **flink-gelly** (for Java) or **flink-gelly-scala** (for Scala) jar must be copied to
 Flink's **lib** directory.
 
 ~~~bash
-cp opt/lib/gelly/flink-gelly_*.jar lib/
-cp opt/lib/gelly/flink-gelly-scala_*.jar lib/
+cp opt/flink-gelly_*.jar lib/
+cp opt/flink-gelly-scala_*.jar lib/
 ~~~
 
 Gelly's examples jar includes both drivers for the library methods as well as additional example algorithms. After
@@ -87,7 +88,7 @@ configuring and starting the cluster, list the available algorithm classes:
 
 ~~~bash
 ./bin/start-cluster.sh
-./bin/flink run opt/lib/gelly/flink-gelly-examples_*.jar
+./bin/flink run opt/flink-gelly-examples_*.jar
 ~~~
 
 The Gelly drivers can generate [RMat](http://www.cs.cmu.edu/~christos/PUBLICATIONS/siam04.pdf) graph data or read the
@@ -95,7 +96,7 @@ edge list from a CSV file. Each node in a cluster must have access to the input 
 directed generated graph:
 
 ~~~bash
-./bin/flink run -c org.apache.flink.graph.drivers.GraphMetrics opt/lib/gelly/flink-gelly-examples_*.jar \
+./bin/flink run -c org.apache.flink.graph.drivers.GraphMetrics opt/flink-gelly-examples_*.jar \
     --directed true --input rmat
 ~~~
 
@@ -110,14 +111,14 @@ Run a few algorithms and monitor the job progress in Flink's Web UI:
 ~~~bash
 wget -O - http://snap.stanford.edu/data/bigdata/communities/com-lj.ungraph.txt.gz | gunzip -c > com-lj.ungraph.txt
 
-./bin/flink run -q -c org.apache.flink.graph.drivers.GraphMetrics opt/lib/gelly/flink-gelly-examples_*.jar \
+./bin/flink run -q -c org.apache.flink.graph.drivers.GraphMetrics opt/flink-gelly-examples_*.jar \
     --directed true --input csv --type integer --input_filename com-lj.ungraph.txt --input_field_delimiter '\t'
 
-./bin/flink run -q -c org.apache.flink.graph.drivers.ClusteringCoefficient opt/lib/gelly/flink-gelly-examples_*.jar \
+./bin/flink run -q -c org.apache.flink.graph.drivers.ClusteringCoefficient opt/flink-gelly-examples_*.jar \
     --directed true --input csv --type integer --input_filename com-lj.ungraph.txt  --input_field_delimiter '\t' \
     --output hash
 
-./bin/flink run -q -c org.apache.flink.graph.drivers.JaccardIndex opt/lib/gelly/flink-gelly-examples_*.jar \
+./bin/flink run -q -c org.apache.flink.graph.drivers.JaccardIndex opt/flink-gelly-examples_*.jar \
     --input csv --type integer --simplify true --input_filename com-lj.ungraph.txt --input_field_delimiter '\t' \
     --output hash
 ~~~

--- a/flink-dist/src/main/assemblies/opt.xml
+++ b/flink-dist/src/main/assemblies/opt.xml
@@ -53,6 +53,13 @@
 		</file>
 
 		<file>
+			<source>../flink-libraries/flink-gelly-examples/target/flink-gelly-examples_2.10-${project.version}.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-gelly-examples_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
 			<source>../flink-libraries/flink-gelly-scala/target/flink-gelly-scala_2.10-${project.version}-jar-with-dependencies.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-gelly-scala_2.10-${project.version}.jar</destName>

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/ClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/ClusteringCoefficient.java
@@ -78,7 +78,7 @@ public class ClusteringCoefficient {
 			.appendln(WordUtils.wrap("This algorithm returns tuples containing the vertex ID, the degree of" +
 				" the vertex, and the number of edges between vertex neighbors.", 80))
 			.appendNewLine()
-			.appendln("usage: ClusteringCoefficient --directed <true | false> --input <csv | rmat [options]> --output <print | hash | csv [options]>")
+			.appendln("usage: ClusteringCoefficient --directed <true | false> --input <csv | rmat> --output <print | hash | csv>")
 			.appendNewLine()
 			.appendln("options:")
 			.appendln("  --input csv --type <integer | string> [--simplify <true | false>] --input_filename FILENAME [--input_line_delimiter LINE_DELIMITER] [--input_field_delimiter FIELD_DELIMITER]")

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/Graph500.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/Graph500.java
@@ -31,7 +31,6 @@ import org.apache.flink.api.java.utils.DataSetUtils;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.client.program.ProgramParametrizationException;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.asm.simple.undirected.Simplify;
 import org.apache.flink.graph.generator.RMatGraph;
 import org.apache.flink.graph.generator.random.JDKRandomGeneratorFactory;
 import org.apache.flink.graph.generator.random.RandomGenerableFactory;
@@ -53,8 +52,6 @@ public class Graph500 {
 
 	private static final int DEFAULT_EDGE_FACTOR = 16;
 
-	private static final boolean DEFAULT_SIMPLIFY = false;
-
 	private static final boolean DEFAULT_CLIP_AND_FLIP = true;
 
 	private static String getUsage(String message) {
@@ -68,6 +65,9 @@ public class Graph500 {
 			.appendNewLine()
 			.appendln("Note: this does not yet implement permutation of vertex labels or edges.")
 			.appendNewLine()
+			.appendln("usage: Graph500 --directed <true | false> --simplify <true | false> --output <print | hash | csv>")
+			.appendNewLine()
+			.appendln("options:")
 			.appendln("  --output print")
 			.appendln("  --output hash")
 			.appendln("  --output csv --output_filename FILENAME [--output_line_delimiter LINE_DELIMITER] [--output_field_delimiter FIELD_DELIMITER]")
@@ -84,6 +84,17 @@ public class Graph500 {
 		ParameterTool parameters = ParameterTool.fromArgs(args);
 		env.getConfig().setGlobalJobParameters(parameters);
 
+		if (! parameters.has("directed")) {
+			throw new ProgramParametrizationException(getUsage("must declare execution mode as '--directed true' or '--directed false'"));
+		}
+		boolean directed = parameters.getBoolean("directed");
+
+		if (! parameters.has("simplify")) {
+			throw new ProgramParametrizationException(getUsage("must declare '--simplify true' or '--simplify false'"));
+		}
+		boolean simplify = parameters.getBoolean("simplify");
+
+
 		// Generate RMat graph
 		int scale = parameters.getInt("scale", DEFAULT_SCALE);
 		int edgeFactor = parameters.getInt("edge_factor", DEFAULT_EDGE_FACTOR);
@@ -93,14 +104,23 @@ public class Graph500 {
 		long vertexCount = 1L << scale;
 		long edgeCount = vertexCount * edgeFactor;
 
-		boolean simplify = parameters.getBoolean("simplify", DEFAULT_SIMPLIFY);
 		boolean clipAndFlip = parameters.getBoolean("clip_and_flip", DEFAULT_CLIP_AND_FLIP);
 
 		Graph<LongValue, NullValue, NullValue> graph = new RMatGraph<>(env, rnd, vertexCount, edgeCount)
 			.generate();
 
-		if (simplify) {
-			graph = graph.run(new Simplify<LongValue, NullValue, NullValue>(clipAndFlip));
+		if (directed) {
+			if (simplify) {
+				graph = graph
+					.run(new org.apache.flink.graph.asm.simple.directed.Simplify<LongValue, NullValue, NullValue>());
+			}
+		} else {
+			if (simplify) {
+				graph = graph
+					.run(new org.apache.flink.graph.asm.simple.undirected.Simplify<LongValue, NullValue, NullValue>(clipAndFlip));
+			} else {
+				graph = graph.getUndirected();
+			}
 		}
 
 		DataSet<Tuple2<LongValue,LongValue>> edges = graph
@@ -110,15 +130,17 @@ public class Graph500 {
 		// Print, hash, or write RMat graph to disk
 		switch (parameters.get("output", "")) {
 		case "print":
+			System.out.println();
 			edges.print();
 			break;
 
 		case "hash":
+			System.out.println();
 			System.out.println(DataSetUtils.checksumHashCode(edges));
 			break;
 
 		case "csv":
-			String filename = parameters.get("filename");
+			String filename = parameters.getRequired("output_filename");
 
 			String lineDelimiter = StringEscapeUtils.unescapeJava(
 				parameters.get("output_line_delimiter", CsvOutputFormat.DEFAULT_LINE_DELIMITER));
@@ -137,6 +159,7 @@ public class Graph500 {
 		JobExecutionResult result = env.getLastJobExecutionResult();
 
 		NumberFormat nf = NumberFormat.getInstance();
+		System.out.println();
 		System.out.println("Execution runtime: " + nf.format(result.getNetRuntime()) + " ms");
 	}
 }

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/GraphMetrics.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/GraphMetrics.java
@@ -63,7 +63,7 @@ public class GraphMetrics {
 			.appendNewLine()
 			.appendln(WordUtils.wrap("Computes vertex and edge metrics on a directed or undirected graph.", 80))
 			.appendNewLine()
-			.appendln("usage: GraphMetrics --directed <true | false> --input <csv | rmat [options]>")
+			.appendln("usage: GraphMetrics --directed <true | false> --input <csv | rmat>")
 			.appendNewLine()
 			.appendln("options:")
 			.appendln("  --input csv --type <integer | string> [--simplify <true | false>] --input_filename FILENAME [--input_line_delimiter LINE_DELIMITER] [--input_field_delimiter FIELD_DELIMITER]")
@@ -98,7 +98,7 @@ public class GraphMetrics {
 					parameters.get("input_field_delimiter", CsvOutputFormat.DEFAULT_FIELD_DELIMITER));
 
 				GraphCsvReader reader = Graph
-					.fromCsvReader(parameters.get("input_filename"), env)
+					.fromCsvReader(parameters.getRequired("input_filename"), env)
 						.ignoreCommentsEdges("#")
 						.lineDelimiterEdges(lineDelimiter)
 						.fieldDelimiterEdges(fieldDelimiter);
@@ -225,14 +225,17 @@ public class GraphMetrics {
 
 		env.execute("Graph Metrics");
 
+		System.out.println();
 		System.out.print("Vertex metrics:\n  ");
 		System.out.println(vm.getResult().toString().replace(";", "\n "));
-		System.out.print("\nEdge metrics:\n  ");
+		System.out.println();
+		System.out.print("Edge metrics:\n  ");
 		System.out.println(em.getResult().toString().replace(";", "\n "));
 
 		JobExecutionResult result = env.getLastJobExecutionResult();
 
 		NumberFormat nf = NumberFormat.getInstance();
-		System.out.println("\nExecution runtime: " + nf.format(result.getNetRuntime()) + " ms");
+		System.out.println();
+		System.out.println("Execution runtime: " + nf.format(result.getNetRuntime()) + " ms");
 	}
 }

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/HITS.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/HITS.java
@@ -69,7 +69,7 @@ public class HITS {
 				" scores for every vertex in a directed graph. A good \"hub\" links to good \"authorities\"" +
 				" and good \"authorities\" are linked from good \"hubs\".", 80))
 			.appendNewLine()
-			.appendln("usage: HITS --input <csv | rmat [options]> --output <print | hash | csv [options]>")
+			.appendln("usage: HITS --input <csv | rmat> --output <print | hash | csv>")
 			.appendNewLine()
 			.appendln("options:")
 			.appendln("  --input csv --type <integer | string> --input_filename FILENAME [--input_line_delimiter LINE_DELIMITER] [--input_field_delimiter FIELD_DELIMITER]")
@@ -104,7 +104,7 @@ public class HITS {
 					parameters.get("input_field_delimiter", CsvOutputFormat.DEFAULT_FIELD_DELIMITER));
 
 				GraphCsvReader reader = Graph
-					.fromCsvReader(parameters.get("input_filename"), env)
+					.fromCsvReader(parameters.getRequired("input_filename"), env)
 						.ignoreCommentsEdges("#")
 						.lineDelimiterEdges(lineDelimiter)
 						.fieldDelimiterEdges(fieldDelimiter);
@@ -157,17 +157,19 @@ public class HITS {
 
 		switch (parameters.get("output", "")) {
 			case "print":
+				System.out.println();
 				for (Object e: hits.collect()) {
 					System.out.println(((Result)e).toVerboseString());
 				}
 				break;
 
 			case "hash":
+				System.out.println();
 				System.out.println(DataSetUtils.checksumHashCode(hits));
 				break;
 
 			case "csv":
-				String filename = parameters.get("output_filename");
+				String filename = parameters.getRequired("output_filename");
 
 				String lineDelimiter = StringEscapeUtils.unescapeJava(
 					parameters.get("output_line_delimiter", CsvOutputFormat.DEFAULT_LINE_DELIMITER));
@@ -177,7 +179,7 @@ public class HITS {
 
 				hits.writeAsCsv(filename, lineDelimiter, fieldDelimiter);
 
-				env.execute();
+				env.execute("HITS");
 				break;
 			default:
 				throw new ProgramParametrizationException(getUsage("invalid output type"));
@@ -186,6 +188,7 @@ public class HITS {
 		JobExecutionResult result = env.getLastJobExecutionResult();
 
 		NumberFormat nf = NumberFormat.getInstance();
+		System.out.println();
 		System.out.println("Execution runtime: " + nf.format(result.getNetRuntime()) + " ms");
 	}
 }

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/JaccardIndex.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/JaccardIndex.java
@@ -75,7 +75,7 @@ public class JaccardIndex {
 			.appendln(WordUtils.wrap("This algorithm returns 4-tuples containing two vertex IDs, the" +
 				" number of shared neighbors, and the number of distinct neighbors.", 80))
 			.appendNewLine()
-			.appendln("usage: JaccardIndex --input <csv | rmat [options]> --output <print | hash | csv [options]>")
+			.appendln("usage: JaccardIndex --input <csv | rmat> --output <print | hash | csv>")
 			.appendNewLine()
 			.appendln("options:")
 			.appendln("  --input csv --type <integer | string> [--simplify <true | false>] --input_filename FILENAME [--input_line_delimiter LINE_DELIMITER] [--input_field_delimiter FIELD_DELIMITER]")
@@ -110,7 +110,7 @@ public class JaccardIndex {
 					parameters.get("input_field_delimiter", CsvOutputFormat.DEFAULT_FIELD_DELIMITER));
 
 				GraphCsvReader reader = Graph
-					.fromCsvReader(parameters.get("input_filename"), env)
+					.fromCsvReader(parameters.getRequired("input_filename"), env)
 						.ignoreCommentsEdges("#")
 						.lineDelimiterEdges(lineDelimiter)
 						.fieldDelimiterEdges(fieldDelimiter);
@@ -137,7 +137,7 @@ public class JaccardIndex {
 
 						if (parameters.getBoolean("simplify", false)) {
 							graph = graph
-								.run(new org.apache.flink.graph.asm.simple.directed.Simplify<StringValue, NullValue, NullValue>()
+								.run(new org.apache.flink.graph.asm.simple.undirected.Simplify<StringValue, NullValue, NullValue>(false)
 									.setParallelism(little_parallelism));
 						}
 
@@ -189,6 +189,7 @@ public class JaccardIndex {
 
 		switch (parameters.get("output", "")) {
 			case "print":
+				System.out.println();
 				for (Object e: ji.collect()) {
 					Result result = (Result)e;
 					System.out.println(result.toVerboseString());
@@ -196,11 +197,12 @@ public class JaccardIndex {
 				break;
 
 			case "hash":
+				System.out.println();
 				System.out.println(DataSetUtils.checksumHashCode(ji));
 				break;
 
 			case "csv":
-				String filename = parameters.get("output_filename");
+				String filename = parameters.getRequired("output_filename");
 
 				String lineDelimiter = StringEscapeUtils.unescapeJava(
 					parameters.get("output_line_delimiter", CsvOutputFormat.DEFAULT_LINE_DELIMITER));
@@ -220,6 +222,7 @@ public class JaccardIndex {
 		JobExecutionResult result = env.getLastJobExecutionResult();
 
 		NumberFormat nf = NumberFormat.getInstance();
+		System.out.println();
 		System.out.println("Execution runtime: " + nf.format(result.getNetRuntime()) + " ms");
 	}
 }

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/TriangleListing.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/TriangleListing.java
@@ -116,7 +116,7 @@ public class TriangleListing {
 					parameters.get("input_field_delimiter", CsvOutputFormat.DEFAULT_FIELD_DELIMITER));
 
 				GraphCsvReader reader = Graph
-					.fromCsvReader(parameters.get("input_filename"), env)
+					.fromCsvReader(parameters.getRequired("input_filename"), env)
 						.ignoreCommentsEdges("#")
 						.lineDelimiterEdges(lineDelimiter)
 						.fieldDelimiterEdges(fieldDelimiter);
@@ -284,6 +284,7 @@ public class TriangleListing {
 
 		switch (parameters.get("output", "")) {
 			case "print":
+				System.out.println();
 				if (directedAlgorithm) {
 					for (Object e: tl.collect()) {
 						org.apache.flink.graph.library.clustering.directed.TriangleListing.Result result =
@@ -296,11 +297,12 @@ public class TriangleListing {
 				break;
 
 			case "hash":
+				System.out.println();
 				System.out.println(DataSetUtils.checksumHashCode(tl));
 				break;
 
 			case "csv":
-				String filename = parameters.get("output_filename");
+				String filename = parameters.getRequired("output_filename");
 
 				String lineDelimiter = StringEscapeUtils.unescapeJava(
 					parameters.get("output_line_delimiter", CsvOutputFormat.DEFAULT_LINE_DELIMITER));
@@ -324,6 +326,7 @@ public class TriangleListing {
 		JobExecutionResult result = env.getLastJobExecutionResult();
 
 		NumberFormat nf = NumberFormat.getInstance();
+		System.out.println();
 		System.out.println("Execution runtime: " + nf.format(result.getNetRuntime()) + " ms");
 	}
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/AbstractGraphAnalytic.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/AbstractGraphAnalytic.java
@@ -38,14 +38,12 @@ implements GraphAnalytic<K, VV, EV, T> {
 	public GraphAnalytic<K, VV, EV, T> run(Graph<K, VV, EV> input)
 			throws Exception {
 		env = input.getContext();
-		return null;
+		return this;
 	}
 
 	@Override
 	public T execute()
 			throws Exception {
-		Preconditions.checkNotNull(env);
-
 		env.execute();
 		return getResult();
 	}
@@ -54,7 +52,6 @@ implements GraphAnalytic<K, VV, EV, T> {
 	public T execute(String jobName)
 			throws Exception {
 		Preconditions.checkNotNull(jobName);
-		Preconditions.checkNotNull(env);
 
 		env.execute(jobName);
 		return getResult();

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/AnalyticHelper.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/AnalyticHelper.java
@@ -18,11 +18,13 @@
 
 package org.apache.flink.graph;
 
+import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.io.RichOutputFormat;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.AbstractID;
+import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -74,6 +76,10 @@ extends RichOutputFormat<T> {
 	 * @return The value of the accumulator with the given name
 	 */
 	public <A> A getAccumulator(ExecutionEnvironment env, String accumulatorName) {
-		return env.getLastJobExecutionResult().getAccumulatorResult(id + SEPARATOR + accumulatorName);
+		JobExecutionResult result = env.getLastJobExecutionResult();
+
+		Preconditions.checkNotNull(result, "No result found for job, was execute() called before getting the result?");
+
+		return result.getAccumulatorResult(id + SEPARATOR + accumulatorName);
 	}
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/TriangleListing.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/TriangleListing.java
@@ -443,19 +443,17 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		}
 
 		private String maskToString(byte mask, int shift) {
-			switch((mask >>> shift) & 0b000011) {
-				case 0b01:
-					// EdgeOrder.FORWARD
-					return "->";
-				case 0b10:
-					// EdgeOrder.REVERSE
-					return "<-";
-				case 0b11:
-					// EdgeOrder.MUTUAL
-					return "<->";
-				default:
-					throw new IllegalArgumentException("Bitmask is missing an edge (mask = "
-						+ mask + ", shift = " + shift);
+			int edgeMask = (mask >>> shift) & 0b000011;
+
+			if (edgeMask == EdgeOrder.FORWARD.getBitmask()) {
+				return "->";
+			} else if (edgeMask == EdgeOrder.REVERSE.getBitmask()) {
+				return "<-";
+			} else if (edgeMask == EdgeOrder.MUTUAL.getBitmask()) {
+				return "<->";
+			} else {
+				throw new IllegalArgumentException("Bitmask is missing an edge (mask = "
+					+ mask + ", shift = " + shift);
 			}
 		}
 	}


### PR DESCRIPTION
[FLINK-5562] [gelly] Driver fixes

Improve parametrization and output formatting.


[hotfix] [build] Include flink-gelly-examples in opt/

Adds the flink-gelly-examples jar to the opt/ directory of the binary
release artifacts. The examples jar is referenced in the online documentation.

Corrects the file paths in the Gelly quickstart documentation.


[hotfix] [gelly] Fix TriangleListing EdgeOrder

The edge bitmask was swapped in ed09dba.