### PR TITLE
[FLINK-5615][query] execute the QueryableStateITCase for all three state back-ends

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
 import org.apache.flink.runtime.state.internal.InternalValueState;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
@@ -101,17 +100,6 @@ public class RocksDBValueState<K, N, V>
 			backend.db.put(columnFamily, writeOptions, key, keySerializationStream.toByteArray());
 		} catch (Exception e) {
 			throw new RuntimeException("Error while adding data to RocksDB", e);
-		}
-	}
-
-	@Override
-	public byte[] getSerializedValue(byte[] serializedKeyAndNamespace) throws Exception {
-		byte[] value = super.getSerializedValue(serializedKeyAndNamespace);
-
-		if (value != null) {
-			return value;
-		} else {
-			return KvStateRequestSerializer.serializeValue(stateDesc.getDefaultValue(), stateDesc.getSerializer());
 		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/query/AbstractQueryableStateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/query/AbstractQueryableStateITCase.java
@@ -67,6 +67,7 @@ import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import scala.concurrent.Await;
@@ -94,10 +95,6 @@ import static org.junit.Assert.fail;
 
 /**
  * Base class for queryable state integration tests with a configurable state backend.
- *
- * NOTE: {@link #stateBackend} must be set in a <tt>setUp()</tt> method before each test case
- * by a class that extends this class. Do not use a shared instance set by the constructor, for
- * example, as the tests may brake.
  */
 public abstract class AbstractQueryableStateITCase extends TestLogger {
 
@@ -111,7 +108,7 @@ public abstract class AbstractQueryableStateITCase extends TestLogger {
 	private final static int NUM_SLOTS = NUM_TMS * NUM_SLOTS_PER_TM;
 
 	/**
-	 * State backend to use - must be initialized by the extending classes!
+	 * State backend to use.
 	 */
 	protected AbstractStateBackend stateBackend;
 
@@ -155,6 +152,20 @@ public abstract class AbstractQueryableStateITCase extends TestLogger {
 			TEST_ACTOR_SYSTEM.shutdown();
 		}
 	}
+
+	@Before
+	public void setUp() throws Exception {
+		// NOTE: do not use a shared instance for all tests as the tests may brake
+		this.stateBackend = createStateBackend();
+	}
+
+	/**
+	 * Creates a state backend instance which is used in the {@link #setUp()} method before each
+	 * test case.
+	 *
+	 * @return a state backend instance for each unit test
+	 */
+	protected abstract AbstractStateBackend createStateBackend() throws Exception;
 
 	/**
 	 * Runs a simple topology producing random (key, 1) pairs at the sources (where

--- a/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCase.java
@@ -314,7 +314,7 @@ public class QueryableStateITCase extends TestLogger {
 			// don't explicitly check that all slots are available before
 			// submitting.
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 1000));
-			env.getCheckpointConfig().setCheckpointInterval(1000);
+			env.getCheckpointConfig().setCheckpointInterval(500);
 
 			DataStream<Tuple2<Integer, Long>> source = env
 					.addSource(new TestKeyRangeSource(numKeys));
@@ -375,18 +375,18 @@ public class QueryableStateITCase extends TestLogger {
 				countForKey = result.f1;
 
 				assertEquals("Key mismatch", key, result.f0.intValue());
-				success = countForKey > 1000; // Wait for some progress
+				success = countForKey > 3; // Wait for some progress
 			}
 
-			assertTrue("No progress for count", countForKey > 1000);
+			assertTrue("No progress for count", countForKey > 3);
 
 			long currentCheckpointId = TestKeyRangeSource.LATEST_CHECKPOINT_ID.get();
-			long waitUntilCheckpointId = currentCheckpointId + 5;
+			long waitUntilCheckpointId = currentCheckpointId + 2;
 
 			// Wait for some checkpoint after the query result
 			while (deadline.hasTimeLeft() &&
 					TestKeyRangeSource.LATEST_CHECKPOINT_ID.get() < waitUntilCheckpointId) {
-				Thread.sleep(500);
+				Thread.sleep(100);
 			}
 
 			assertTrue("Did not complete enough checkpoints to continue",
@@ -1261,6 +1261,8 @@ public class QueryableStateITCase extends TestLogger {
 					record.f0 = random.nextInt(numKeys);
 					ctx.collect(record);
 				}
+				// mild slow down
+				Thread.sleep(1);
 			}
 		}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCase.java
@@ -164,7 +164,7 @@ public class QueryableStateITCase extends TestLogger {
 	public void testQueryableState() throws Exception {
 		// Config
 		final Deadline deadline = TEST_TIMEOUT.fromNow();
-		final int numKeys = 1024;
+		final int numKeys = 256;
 
 		final QueryableStateClient client = new QueryableStateClient(cluster.configuration());
 
@@ -298,7 +298,7 @@ public class QueryableStateITCase extends TestLogger {
 	public void testQueryableStateWithTaskManagerFailure() throws Exception {
 		// Config
 		final Deadline deadline = TEST_TIMEOUT.fromNow();
-		final int numKeys = 1024;
+		final int numKeys = 256;
 
 		final QueryableStateClient client = new QueryableStateClient(cluster.configuration());
 
@@ -499,7 +499,7 @@ public class QueryableStateITCase extends TestLogger {
 	public void testDuplicateRegistrationFailsJob() throws Exception {
 		// Config
 		final Deadline deadline = TEST_TIMEOUT.fromNow();
-		final int numKeys = 1024;
+		final int numKeys = 256;
 
 		JobID jobId = null;
 

--- a/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCaseFsBackend.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCaseFsBackend.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.test.query;
 
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
@@ -28,12 +28,11 @@ import org.junit.rules.TemporaryFolder;
  */
 public class QueryableStateITCaseFsBackend extends AbstractQueryableStateITCase {
 
-
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-	@Before
-	public void setUp() throws Exception {
-		stateBackend = new FsStateBackend(temporaryFolder.newFolder().toURI().toString());
+	@Override
+	protected AbstractStateBackend createStateBackend() throws Exception {
+		return new FsStateBackend(temporaryFolder.newFolder().toURI().toString());
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCaseFsBackend.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCaseFsBackend.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.query;
+
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Several integration tests for queryable state using the {@link FsStateBackend}.
+ */
+public class QueryableStateITCaseFsBackend extends AbstractQueryableStateITCase {
+
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Before
+	public void setUp() throws Exception {
+		stateBackend = new FsStateBackend(temporaryFolder.newFolder().toURI().toString());
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCaseMemoryBackend.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCaseMemoryBackend.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.query;
+
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.junit.Before;
+
+/**
+ * Several integration tests for queryable state using the {@link MemoryStateBackend}.
+ */
+public class QueryableStateITCaseMemoryBackend extends AbstractQueryableStateITCase {
+
+	@Before
+	public void setUp() throws Exception {
+		stateBackend = new MemoryStateBackend();
+	}
+
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCaseMemoryBackend.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCaseMemoryBackend.java
@@ -18,17 +18,17 @@
 
 package org.apache.flink.test.query;
 
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
-import org.junit.Before;
 
 /**
  * Several integration tests for queryable state using the {@link MemoryStateBackend}.
  */
 public class QueryableStateITCaseMemoryBackend extends AbstractQueryableStateITCase {
 
-	@Before
-	public void setUp() throws Exception {
-		stateBackend = new MemoryStateBackend();
+	@Override
+	protected AbstractStateBackend createStateBackend() throws Exception {
+		return new MemoryStateBackend();
 	}
 
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCaseRocksDBBackend.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCaseRocksDBBackend.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.query;
+
+import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Several integration tests for queryable state using the {@link RocksDBStateBackend}.
+ */
+public class QueryableStateITCaseRocksDBBackend extends AbstractQueryableStateITCase {
+
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Before
+	public void setUp() throws Exception {
+		stateBackend = new RocksDBStateBackend(temporaryFolder.newFolder().toURI().toString());
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCaseRocksDBBackend.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/query/QueryableStateITCaseRocksDBBackend.java
@@ -19,7 +19,7 @@
 package org.apache.flink.test.query;
 
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
-import org.junit.Before;
+import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
@@ -28,12 +28,11 @@ import org.junit.rules.TemporaryFolder;
  */
 public class QueryableStateITCaseRocksDBBackend extends AbstractQueryableStateITCase {
 
-
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-	@Before
-	public void setUp() throws Exception {
-		stateBackend = new RocksDBStateBackend(temporaryFolder.newFolder().toURI().toString());
+	@Override
+	protected AbstractStateBackend createStateBackend() throws Exception {
+		return new RocksDBStateBackend(temporaryFolder.newFolder().toURI().toString());
 	}
 }


### PR DESCRIPTION
This extends the `QueryableStateITCase` so that it is able to run with any selected state backend. Some optimisations reduce the total runtime of the test cases so that we are able to run the tests with all three currently available backends, i.e. `MemoryStateBackend`, `FsStateBackend`, and `RocksDBStateBackend`, with little extra costs.

This is based upon #3193.