### PR TITLE
[FLINK-5617] API stability check for Flink 1.2

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -156,6 +156,15 @@ under the License.
 							<exclude>org.apache.flink.api.common.ExecutionConfig#CONFIG_KEY</exclude>
 							<exclude>org.apache.flink.core.fs.FileSystem$FSKey</exclude>
 							<exclude>org.apache.flink.api.java.typeutils.WritableTypeInfo</exclude>
+							<!-- Breaking changes between 1.1 and 1.2. 
+							We ignore these changes because these are low-level, internal runtime configuration parameters -->
+							<exclude>org.apache.flink.configuration.ConfigConstants#DEFAULT_JOB_MANAGER_MAX_ATTEMPTS_HISTORY_SIZE</exclude>
+							<exclude>org.apache.flink.configuration.ConfigConstants#DEFAULT_NETWORK_REQUEST_BACKOFF_INITIAL</exclude>
+							<exclude>org.apache.flink.configuration.ConfigConstants#DEFAULT_NETWORK_REQUEST_BACKOFF_MAX</exclude>
+							<exclude>org.apache.flink.configuration.ConfigConstants#DEFAULT_TASK_CANCELLATION_TIMEOUT_MILLIS</exclude>
+							<exclude>org.apache.flink.configuration.ConfigConstants#ENABLE_QUARANTINE_MONITOR</exclude>
+							<exclude>org.apache.flink.configuration.ConfigConstants#NETWORK_REQUEST_BACKOFF_INITIAL_KEY</exclude>
+							<exclude>org.apache.flink.configuration.ConfigConstants#NETWORK_REQUEST_BACKOFF_MAX_KEY</exclude>
 						</excludes>
 					</parameter>
 				</configuration>

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.common;
 
 import com.esotericsoftware.kryo.Serializer;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
@@ -848,6 +849,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	}
 	
 	@Override
+	@Internal
 	public ArchivedExecutionConfig archive() {
 		return new ArchivedExecutionConfig(this);
 	}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -25,6 +25,7 @@
 
 package org.apache.flink.core.fs;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -97,6 +98,7 @@ public abstract class FileSystem {
 	 * Create a SafetyNetCloseableRegistry for a Task. This method should be called at the beginning of the task's
 	 * main thread.
 	 */
+	@Internal
 	public static void createFileSystemCloseableRegistryForTask() {
 		SafetyNetCloseableRegistry oldRegistry = REGISTRIES.get();
 		if (null != oldRegistry) {
@@ -111,6 +113,7 @@ public abstract class FileSystem {
 	 * Create a SafetyNetCloseableRegistry for a Task. This method should be called at the end of the task's
 	 * main thread or when the task should be canceled.
 	 */
+	@Internal
 	public static void disposeFileSystemCloseableRegistryForTask() {
 		SafetyNetCloseableRegistry registry = REGISTRIES.get();
 		if (null != registry) {
@@ -200,6 +203,7 @@ public abstract class FileSystem {
 		}
 	}
 
+	@Internal
 	public static FileSystem getUnguardedFileSystem(URI uri) throws IOException {
 		FileSystem fs;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/AllWindowedStream.java
@@ -197,7 +197,7 @@ public class AllWindowedStream<T, W extends Window> {
 	 * @param function The window function.
 	 * @return The data stream that is the result of applying the window function to the window.
 	 */
-
+	@PublicEvolving
 	public <R> SingleOutputStreamOperator<R> reduce(ReduceFunction<T> reduceFunction, AllWindowFunction<T, R, W> function) {
 		TypeInformation<T> inType = input.getType();
 		TypeInformation<R> resultType = TypeExtractor.getUnaryOperatorReturnType(
@@ -219,6 +219,7 @@ public class AllWindowedStream<T, W extends Window> {
 	 * @param resultType Type information for the result type of the window function
 	 * @return The data stream that is the result of applying the window function to the window.
 	 */
+	@PublicEvolving
 	public <R> SingleOutputStreamOperator<R> reduce(ReduceFunction<T> reduceFunction, AllWindowFunction<T, R, W> function, TypeInformation<R> resultType) {
 		if (reduceFunction instanceof RichFunction) {
 			throw new UnsupportedOperationException("ReduceFunction of reduce can not be a RichFunction.");
@@ -328,6 +329,7 @@ public class AllWindowedStream<T, W extends Window> {
 	 * @param function The window function.
 	 * @return The data stream that is the result of applying the window function to the window.
 	 */
+	@PublicEvolving
 	public <ACC, R> SingleOutputStreamOperator<R> fold(ACC initialValue, FoldFunction<T, ACC> foldFunction, AllWindowFunction<ACC, R, W> function) {
 
 		TypeInformation<ACC> foldAccumulatorType = TypeExtractor.getFoldReturnTypes(foldFunction, input.getType(),
@@ -354,6 +356,7 @@ public class AllWindowedStream<T, W extends Window> {
 	 * @param resultType Type information for the result type of the window function
 	 * @return The data stream that is the result of applying the window function to the window.
 	 */
+	@PublicEvolving
 	public <ACC, R> SingleOutputStreamOperator<R> fold(ACC initialValue,
 			FoldFunction<T, ACC> foldFunction,
 			AllWindowFunction<ACC, R, W> function,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -224,6 +224,7 @@ public class WindowedStream<T, K, W extends Window> {
 	 * @param function The window function.
 	 * @return The data stream that is the result of applying the window function to the window.
 	 */
+	@PublicEvolving
 	public <R> SingleOutputStreamOperator<R> reduce(ReduceFunction<T> reduceFunction, WindowFunction<T, R, K, W> function) {
 		return reduce(reduceFunction, function, LegacyWindowOperatorType.NONE);
 	}
@@ -241,6 +242,7 @@ public class WindowedStream<T, K, W extends Window> {
 	 * @param resultType Type information for the result type of the window function
 	 * @return The data stream that is the result of applying the window function to the window.
 	 */
+	@PublicEvolving
 	public <R> SingleOutputStreamOperator<R> reduce(
 		ReduceFunction<T> reduceFunction,
 		WindowFunction<T, R, K, W> function,
@@ -404,6 +406,7 @@ public class WindowedStream<T, K, W extends Window> {
 	 * @param function The window function.
 	 * @return The data stream that is the result of applying the window function to the window.
 	 */
+	@PublicEvolving
 	public <ACC, R> SingleOutputStreamOperator<R> fold(ACC initialValue, FoldFunction<T, ACC> foldFunction, WindowFunction<ACC, R, K, W> function) {
 
 		TypeInformation<ACC> foldAccumulatorType = TypeExtractor.getFoldReturnTypes(foldFunction, input.getType(),
@@ -430,6 +433,7 @@ public class WindowedStream<T, K, W extends Window> {
 	 * @param resultType Type information for the result type of the window function
 	 * @return The data stream that is the result of applying the window function to the window.
 	 */
+	@PublicEvolving
 	public <ACC, R> SingleOutputStreamOperator<R> fold(ACC initialValue,
 			FoldFunction<T, ACC> foldFunction,
 			WindowFunction<ACC, R, K, W> function,

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -237,7 +237,7 @@ under the License.
 				<artifactId>japicmp-maven-plugin</artifactId>
 				<configuration>
 					<parameter>
-						<excludes>
+						<excludes combine.children="append">
 							<!-- Exclude generated classes from api compatibility checks -->
 							<exclude>*\$\$anon\$*</exclude>
 						</excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -1235,7 +1235,7 @@ under the License.
 							<dependency>
 								<groupId>org.apache.flink</groupId>
 								<artifactId>${project.artifactId}</artifactId>
-								<version>1.0.0</version>
+								<version>1.1.4</version>
 								<type>${project.packaging}</type>
 							</dependency>
 						</oldVersion>

--- a/tools/collect_japicmp_reports.sh
+++ b/tools/collect_japicmp_reports.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+HERE=` basename "$PWD"`
+if [[ "$HERE" != "tools" ]]; then
+    echo "Please only execute in the tools/ directory";
+    exit 1;
+fi
+
+cp ../flink-core/target/japicmp/japicmp.html flink-core.html
+cp ../flink-java/target/japicmp/japicmp.html flink-java.html
+cp ../flink-scala/target/japicmp/japicmp.html flink-scala.html
+cp ../flink-streaming-java/target/japicmp/japicmp.html flink-streaming-java.html
+


### PR DESCRIPTION
With this PR, I'm marking some of the new methods in Flink 1.2 as public evolving / internal, instead of public.

There are the reports for the covered modules:
http://people.apache.org/~rmetzger/rel-1.2-japicmp/

@aljoscha and @kl0u: Are the `fold()` and `reduce()` methods intentionally in the `@Public` scope? http://people.apache.org/~rmetzger/rel-1.2-japicmp/flink-streaming-java.html