### PR TITLE
[FLINK-5566] [Table API & SQL]Introduce structure to hold table and column level statistics

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/ColumnStats.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/ColumnStats.scala
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.plan.stats
 
+import java.lang.{Double, Long, Integer, Number}
+
 /**
   * column statistics
   *
@@ -31,19 +33,19 @@ package org.apache.flink.table.plan.stats
 case class ColumnStats(
     ndv: Long,
     nullCount: Long,
-    avgLen: Long,
-    maxLen: Long,
-    max: Option[Any],
-    min: Option[Any]) {
+    avgLen: Double,
+    maxLen: Integer,
+    max: Number,
+    min: Number) {
 
   override def toString: String = {
     val columnStatsStr = Seq(
-      s"ndv=$ndv",
-      s"nullCount=$nullCount",
-      s"avgLen=$avgLen",
-      s"maxLen=$maxLen",
-      if (max.isDefined) s"max=${max.get}" else "",
-      if (min.isDefined) s"min=${min.get}"  else ""
+      if (ndv != null) s"ndv=$ndv" else "",
+      if (nullCount != null) s"nullCount=$nullCount" else "",
+      if (avgLen != null) s"avgLen=$avgLen" else "",
+      if (maxLen != null) s"maxLen=$maxLen" else "",
+      if (max != null) s"max=${max}" else "",
+      if (min != null) s"min=${min}" else ""
     ).filter(_.nonEmpty).mkString(", ")
 
     s"ColumnStats(${columnStatsStr})"

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/ColumnStats.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/ColumnStats.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stats
+
+/**
+  * column statistics
+  *
+  * @param ndv       number of distinct values
+  * @param nullCount number of nulls
+  * @param avgLen    average length of column values
+  * @param maxLen    max length of column values
+  * @param max       max value of column values
+  * @param min       min value of column values
+  */
+case class ColumnStats(
+    ndv: Long,
+    nullCount: Long,
+    avgLen: Long,
+    maxLen: Long,
+    max: Option[Any],
+    min: Option[Any]) {
+
+  override def toString: String = {
+    val columnStatsStr = Seq(
+      s"ndv=$ndv",
+      s"nullCount=$nullCount",
+      s"avgLen=$avgLen",
+      s"maxLen=$maxLen",
+      if (max.isDefined) s"max=${max.get}" else "",
+      if (min.isDefined) s"min=${min.get}"  else ""
+    ).filter(_.nonEmpty).mkString(", ")
+
+    s"ColumnStats(${columnStatsStr})"
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/TableStats.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/TableStats.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stats
+
+/**
+  * Table statistics
+  *
+  * @param rowCount cardinality of table
+  * @param colStats statistics of table columns
+  */
+case class TableStats(rowCount: Long, colStats: Map[String, ColumnStats] = Map.empty)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/TableStats.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/TableStats.scala
@@ -18,10 +18,13 @@
 
 package org.apache.flink.table.plan.stats
 
+import java.lang.Long
+import java.util.{Map, HashMap}
+
 /**
   * Table statistics
   *
   * @param rowCount cardinality of table
   * @param colStats statistics of table columns
   */
-case class TableStats(rowCount: Long, colStats: Map[String, ColumnStats] = Map.empty)
+case class TableStats(rowCount: Long, colStats: Map[String, ColumnStats] = new HashMap())


### PR DESCRIPTION
This pr aims to introduce structure to hold table and column level statistics.
TableStats： Responsible for hold table level statistics
ColumnStats: Responsible for hold column level statistics.