### PR TITLE
[FLINK-5567] [Table API & SQL]Introduce and migrate current table statistics to FlinkStatistics

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/DataSetTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/DataSetTable.scala
@@ -18,34 +18,13 @@
 
 package org.apache.flink.table.plan.schema
 
-import java.lang.Double
-import java.util
-import java.util.Collections
-
-import org.apache.calcite.rel.{RelCollation, RelDistribution}
-import org.apache.calcite.schema.Statistic
-import org.apache.calcite.util.ImmutableBitSet
 import org.apache.flink.api.java.DataSet
+import org.apache.flink.table.plan.stats.{FlinkStatistics, TableStats}
 
 class DataSetTable[T](
     val dataSet: DataSet[T],
     override val fieldIndexes: Array[Int],
-    override val fieldNames: Array[String])
-  extends FlinkTable[T](dataSet.getType, fieldIndexes, fieldNames) {
-
-  override def getStatistic: Statistic = {
-    new DefaultDataSetStatistic
-  }
-
-}
-
-class DefaultDataSetStatistic extends Statistic {
-
-  override def getRowCount: Double = 1000d
-
-  override def getCollations: util.List[RelCollation] = Collections.emptyList()
-
-  override def isKey(columns: ImmutableBitSet): Boolean = false
-
-  override def getDistribution: RelDistribution = null
+    override val fieldNames: Array[String],
+    override val statistic: FlinkStatistics = FlinkStatistics.of(TableStats(1000L)))
+  extends FlinkTable[T](dataSet.getType, fieldIndexes, fieldNames, statistic) {
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/DataStreamTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/DataStreamTable.scala
@@ -19,10 +19,12 @@
 package org.apache.flink.table.plan.schema
 
 import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.table.plan.stats.FlinkStatistics
 
 class DataStreamTable[T](
     val dataStream: DataStream[T],
     override val fieldIndexes: Array[Int],
-    override val fieldNames: Array[String])
-  extends FlinkTable[T](dataStream.getType, fieldIndexes, fieldNames) {
+    override val fieldNames: Array[String],
+    override val statistic: FlinkStatistics = FlinkStatistics.UNKNOWN)
+  extends FlinkTable[T](dataStream.getType, fieldIndexes, fieldNames, statistic) {
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/FlinkTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/FlinkTable.scala
@@ -19,16 +19,19 @@
 package org.apache.flink.table.plan.schema
 
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory}
+import org.apache.calcite.schema.Statistic
 import org.apache.calcite.schema.impl.AbstractTable
 import org.apache.flink.api.common.typeinfo.{AtomicType, TypeInformation}
 import org.apache.flink.api.common.typeutils.CompositeType
-import org.apache.flink.table.api.{TableEnvironment, TableException}
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.plan.stats.FlinkStatistics
 
 abstract class FlinkTable[T](
     val typeInfo: TypeInformation[T],
     val fieldIndexes: Array[Int],
-    val fieldNames: Array[String])
+    val fieldNames: Array[String],
+    val statistic: FlinkStatistics)
   extends AbstractTable {
 
   if (fieldIndexes.length != fieldNames.length) {
@@ -63,5 +66,12 @@ abstract class FlinkTable[T](
     val flinkTypeFactory = typeFactory.asInstanceOf[FlinkTypeFactory]
     flinkTypeFactory.buildRowDataType(fieldNames, fieldTypes)
   }
+
+  /**
+    * Returns statistics of current table
+    *
+    * @return statistics of current table
+    */
+  override def getStatistic: Statistic = statistic
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/TableSourceTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/TableSourceTable.scala
@@ -19,11 +19,15 @@
 package org.apache.flink.table.plan.schema
 
 import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.plan.stats.FlinkStatistics
 import org.apache.flink.table.sources.TableSource
 
 /** Table which defines an external table via a [[TableSource]] */
-class TableSourceTable[T](val tableSource: TableSource[T])
+class TableSourceTable[T](
+    val tableSource: TableSource[T],
+    override val statistic: FlinkStatistics = FlinkStatistics.UNKNOWN)
   extends FlinkTable[T](
     typeInfo = tableSource.getReturnType,
     fieldIndexes = TableEnvironment.getFieldIndices(tableSource),
-    fieldNames = TableEnvironment.getFieldNames(tableSource))
+    fieldNames = TableEnvironment.getFieldNames(tableSource),
+    statistic)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/FlinkStatistics.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/FlinkStatistics.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stats
+
+import java.lang.Double
+import java.util.{Collections, List}
+
+import org.apache.calcite.rel.{RelCollation, RelDistribution}
+import org.apache.calcite.schema.Statistic
+import org.apache.calcite.util.ImmutableBitSet
+
+/**
+  * The class is responsible for provide statistics for flink table.
+  *
+  * @param tableStats
+  */
+class FlinkStatistics(tableStats: Option[TableStats]) extends Statistic {
+
+  /**
+    * Get table stats
+    *
+    * @return table stats
+    */
+  def getTableStats: TableStats = tableStats.getOrElse(null)
+
+  /**
+    * Get stats of specified column
+    *
+    * @param columnName which column to get stats
+    * @return stats of specified column
+    */
+  def getColumnStats(columnName: String): ColumnStats = tableStats match {
+    case Some(tStats) => tStats.colStats.get(columnName)
+    case None => null
+  }
+
+  /**
+    * Get number of rows in the table
+    *
+    * @return number of rows in the table
+    */
+  override def getRowCount: Double = tableStats match {
+    case Some(tStats) => tStats.rowCount.toDouble
+    case None => null
+  }
+
+  override def getCollations: List[RelCollation] = Collections.emptyList()
+
+  override def isKey(columns: ImmutableBitSet): Boolean = false
+
+  override def getDistribution: RelDistribution = null
+
+}
+
+/**
+  * Utility functions regarding FlinkStatistic
+  */
+object FlinkStatistics {
+
+  /** Represents a FlinkStatistic that knows nothing about a table */
+  val UNKNOWN: FlinkStatistics = new FlinkStatistics(None)
+
+  /**
+    * Returns a Flinkstatistic with a given tableStats.
+    *
+    * @param tableStats
+    * @return
+    */
+  def of(tableStats: TableStats): FlinkStatistics = new FlinkStatistics(Some(tableStats))
+
+}


### PR DESCRIPTION
This pr includes two commits, the first commit is Related to [https://github.com/apache/flink/pull/3196](url), the second commit is to introduce and migrate current table statistics to FlinkStatistics. So please focus on second commit when review this pr.
The main changes including:
1. Introduce FlinkStatistic class, which is an implementation of Calcite Statistic.
2. Integrate FlinkStatistic with FlinkTable. 