### PR TITLE
[FLINK-5634] Flink should not always redirect stdout to a file.	

### DIFF
--- a/flink-contrib/docker-flink/docker-entrypoint.sh
+++ b/flink-contrib/docker-flink/docker-entrypoint.sh
@@ -27,7 +27,7 @@ if [ "$1" == "jobmanager" ]; then
     sed -i -e "s/jobmanager.rpc.address: localhost/jobmanager.rpc.address: ${JOB_MANAGER_RPC_ADDRESS}/g" $FLINK_HOME/conf/flink-conf.yaml
 
     echo "config file: " && grep '^[^\n#]' $FLINK_HOME/conf/flink-conf.yaml
-    $FLINK_HOME/bin/jobmanager.sh start cluster
+    $FLINK_HOME/bin/jobmanager.sh start cluster --no-redirect-stdout
 elif [ "$1" == "taskmanager" ]; then
 
     sed -i -e "s/jobmanager.rpc.address: localhost/jobmanager.rpc.address: ${JOB_MANAGER_RPC_ADDRESS}/g" $FLINK_HOME/conf/flink-conf.yaml
@@ -35,7 +35,7 @@ elif [ "$1" == "taskmanager" ]; then
 
     echo "Starting Task Manager"
     echo "config file: " && grep '^[^\n#]' $FLINK_HOME/conf/flink-conf.yaml
-    $FLINK_HOME/bin/taskmanager.sh start
+    $FLINK_HOME/bin/taskmanager.sh start --no-redirect-stdout
 else
     $@
 fi

--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -18,10 +18,14 @@
 ################################################################################
 
 # Start/stop a Flink JobManager.
-USAGE="Usage: jobmanager.sh (start (local|cluster) [host] [webui-port]|stop|stop-all)"
+USAGE="Usage: jobmanager.sh (start (local|cluster) [--no-redirect-stdout] [host] [webui-port]|stop|stop-all)"
 
 STARTSTOP=$1
 EXECUTIONMODE=$2
+
+# Parse out --no-redirect-stdout flag if present
+[[ "$3" == "--no-redirect-stdout" ]] && redirect_flag="--no-redirect-stdout" && shift
+
 HOST=$3 # optional when starting multiple instances
 WEBUIPORT=$4 # optional when starting multiple instances
 
@@ -70,4 +74,4 @@ if [[ $STARTSTOP == "start" ]]; then
     fi
 fi
 
-"${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP jobmanager "${args[@]}"
+"${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP jobmanager "$redirect_flag" "${args[@]}"

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -18,9 +18,12 @@
 ################################################################################
 
 # Start/stop a Flink TaskManager.
-USAGE="Usage: taskmanager.sh (start|stop|stop-all)"
+USAGE="Usage: taskmanager.sh (start|stop|stop-all) [--no-redirect-stdout]"
 
 STARTSTOP=$1
+
+# Parse out --no-redirect-stdout flag
+[[ "$2" == "--no-redirect-stdout" ]] && redirect_flag="--no-redirect-stdout"
 
 bin=`dirname "$0"`
 bin=`cd "$bin"; pwd`
@@ -96,4 +99,4 @@ if [[ $STARTSTOP == "start" ]]; then
     args=("--configDir" "${FLINK_CONF_DIR}")
 fi
 
-"${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP taskmanager "${args[@]}"
+"${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP taskmanager "$redirect_flag" "${args[@]}"


### PR DESCRIPTION
Adding flag to flink-daemon.sh and related scripts so that we can actually log to the console -- which is better for Docker environments.  Also modifying Docker entrypoint to use this.

There is a follow on PR with many more changes to the Docker scripts and tooling based on this one.
