### PR TITLE
[FLINK-5635] Improve Docker tooling to make it easier to build images and launch Flink via Docker tools

### DIFF
--- a/flink-contrib/docker-flink/Dockerfile
+++ b/flink-contrib/docker-flink/Dockerfile
@@ -21,11 +21,6 @@ FROM java:8-jre-alpine
 # Install requirements
 RUN apk add --no-cache bash snappy
 
-# Configure Flink version
-ENV FLINK_VERSION=1.1.1
-ENV HADOOP_VERSION=27
-ENV SCALA_VERSION=2.11
-
 # Flink environment variables
 ENV FLINK_INSTALL_PATH=/opt
 ENV FLINK_HOME $FLINK_INSTALL_PATH/flink
@@ -36,22 +31,25 @@ ENV PATH $PATH:$FLINK_HOME/bin
 EXPOSE 8081
 EXPOSE 6123
 
+# flink-dist can point to a directory, a tarball on the local system, or a url to a tarball
+ARG flink_dist=NOT_SET
+
 # Install build dependencies and flink
+ADD $flink_dist $FLINK_INSTALL_PATH
 RUN set -x && \
   mkdir -p $FLINK_INSTALL_PATH && \
-  apk --update add --virtual build-dependencies curl && \
-  curl -s $(curl -s https://www.apache.org/dyn/closer.cgi\?preferred\=true)flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-hadoop${HADOOP_VERSION}-scala_${SCALA_VERSION}.tgz | \
-  tar xvz -C $FLINK_INSTALL_PATH && \
-  ln -s $FLINK_INSTALL_PATH/flink-$FLINK_VERSION $FLINK_HOME && \
+  ln -s $FLINK_INSTALL_PATH/flink-* $FLINK_HOME && \
   addgroup -S flink && adduser -D -S -H -G flink -h $FLINK_HOME flink && \
-  chown -R flink:flink $FLINK_INSTALL_PATH/flink-$FLINK_VERSION && \
+  chown -R flink:flink $FLINK_INSTALL_PATH/flink-* && \
   chown -h flink:flink $FLINK_HOME && \
-  sed -i -e "s/echo \$mypid >> \$pid/echo \$mypid >> \$pid \&\& wait/g" $FLINK_HOME/bin/flink-daemon.sh && \
-  apk del build-dependencies && \
-  rm -rf /var/cache/apk/*
+  sed -i -e "s/echo \$mypid >> \$pid/echo \$mypid >> \$pid \&\& wait/g" $FLINK_HOME/bin/flink-daemon.sh
 
 # Configure container
 USER flink
 ADD docker-entrypoint.sh $FLINK_HOME/bin/
+
+# Overwrite default logging settings.  This will additionally log to stdout so we can use 'docker logs'
+ADD log4j.properties $FLINK_HOME/conf/
+
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["sh", "-c"]

--- a/flink-contrib/docker-flink/build.sh
+++ b/flink-contrib/docker-flink/build.sh
@@ -18,4 +18,82 @@
 # limitations under the License.
 ################################################################################
 
-docker build -t "flink" .
+usage() {
+  cat <<HERE
+Usage:
+  build.sh --from-local-dist [--image-name <image>]
+  build.sh --from-release --flink-version <x.x.x> --hadoop-version <x.x> --scala-version <x.xx> [--image-name <image>]
+  build.sh --help
+
+  If the --image-name flag is not used the built image name will be 'flink'.
+HERE
+  exit 1
+}
+
+while [[ $# -ge 1 ]]
+do
+key="$1"
+  case $key in
+    --from-local-dist)
+    FROM_LOCAL="true"
+    ;;
+    --from-release)
+    FROM_RELEASE="true"
+    ;;
+    --image-name)
+    IMAGE_NAME="$2"
+    shift
+    ;;
+    --flink-version)
+    FLINK_VERSION="$2"
+    shift
+    ;;
+    --hadoop-version)
+    HADOOP_VERSION="$(echo "$2" | sed 's/\.//')"
+    shift
+    ;;
+    --scala-version)
+    SCALA_VERSION="$2"
+    shift
+    ;;
+    --help)
+    usage
+    ;;
+    *)
+    # unknown option
+    ;;
+  esac
+  shift
+done
+
+IMAGE_NAME=${IMAGE_NAME:-flink}
+
+TMPDIR=_TMP_
+mkdir -p "${TMPDIR}"
+
+if [ -n "${FROM_RELEASE}" ]; then
+
+  [[ -n "${FLINK_VERSION}" ]] && [[ -n "${HADOOP_VERSION}" ]] && [[ -n "${SCALA_VERSION}" ]] || usage
+
+  FLINK_BASE_URL="$(curl -s https://www.apache.org/dyn/closer.cgi\?preferred\=true)flink/flink-${FLINK_VERSION}/"
+  FLINK_DIST_FILE_NAME="flink-${FLINK_VERSION}-bin-hadoop${HADOOP_VERSION}-scala_${SCALA_VERSION}.tgz"
+  CURL_OUTPUT="${TMPDIR}/${FLINK_DIST_FILE_NAME}"
+
+  echo "Downloading ${FLINK_DIST_FILE_NAME} from ${FLINK_BASE_URL}"
+  curl -s ${FLINK_BASE_URL}${FLINK_DIST_FILE_NAME} --output ${CURL_OUTPUT}
+
+  FLINK_DIST="${CURL_OUTPUT}"
+
+elif [ -n "${FROM_LOCAL}" ]; then
+
+    DIST_DIR="../../flink-dist/target/flink-*-bin"
+    FLINK_DIST="${TMPDIR}/flink.tgz"
+    echo "Using flink dist: ${DIST_DIR}"
+    tar -C ${DIST_DIR} -cvzf "${FLINK_DIST}" .
+else
+  usage
+fi
+
+docker build --build-arg flink_dist="${FLINK_DIST}" -t "${IMAGE_NAME}" .
+
+rm -rf "${TMPDIR}"

--- a/flink-contrib/docker-flink/create-docker-swarm-service.sh
+++ b/flink-contrib/docker-flink/create-docker-swarm-service.sh
@@ -1,5 +1,23 @@
 #!/bin/sh
 
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 usage() {
   cat <<HERE
 Usage:

--- a/flink-contrib/docker-flink/create-docker-swarm-service.sh
+++ b/flink-contrib/docker-flink/create-docker-swarm-service.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+usage() {
+  cat <<HERE
+Usage:
+  create-docker-swarm-service.sh [--image-name <image>] <service-name> <service-port>
+
+  If the --image-name flag is not used the service will use the 'flink' image.
+HERE
+  exit 1
+}
+
+if [ "$1" == "--image-name" ]; then
+  IMAGE_NAME="$2"
+  shift; shift
+else
+  IMAGE_NAME=flink
+fi
+
+[[ $# -ne 2 ]] && usage
+
+SERVICE_BASE_NAME="$1"
+SERVICE_PORT="${2}"
+JOB_MANAGER_NAME=${SERVICE_BASE_NAME}-jobmanager
+TASK_MANAGER_NAME=${SERVICE_BASE_NAME}-taskmanager
+JOB_MANAGER_RPC_ADDRESS=${JOB_MANAGER_NAME}
+OVERLAY_NETWORK_NAME=${SERVICE_BASE_NAME}
+
+# Create overlay network
+docker network create -d overlay ${OVERLAY_NETWORK_NAME}
+
+# Create the jobmanager service
+docker service create --name ${JOB_MANAGER_NAME} --env JOB_MANAGER_RPC_ADDRESS=${JOB_MANAGER_RPC_ADDRESS} -p ${SERVICE_PORT}:8081 --network ${OVERLAY_NETWORK_NAME} ${IMAGE_NAME} jobmanager
+
+# Create the taskmanger service (scale this out as needed)
+docker service create --name ${TASK_MANAGER_NAME} --env JOB_MANAGER_RPC_ADDRESS=${JOB_MANAGER_RPC_ADDRESS} --network ${OVERLAY_NETWORK_NAME} ${IMAGE_NAME} taskmanager

--- a/flink-contrib/docker-flink/docker-compose.yml
+++ b/flink-contrib/docker-flink/docker-compose.yml
@@ -16,21 +16,22 @@
 # limitations under the License.
 ################################################################################
 
-version: "2"
+# Set the FLINK_DOCKER_IMAGE_NAME environment variable to override the image name to use
+
+version: "2.1"
 services:
   jobmanager:
-    image: flink
-    container_name: "jobmanager"
+    image: ${FLINK_DOCKER_IMAGE_NAME:-flink}
     expose:
       - "6123"
     ports:
-      - "48081:8081"
+      - "8081:8081"
     command: jobmanager
     environment:
-      - JOB_MANAGER_RPC_ADDRESS="jobmanager"
+      - JOB_MANAGER_RPC_ADDRESS=jobmanager
 
   taskmanager:
-    image: flink
+    image: ${FLINK_DOCKER_IMAGE_NAME:-flink}
     expose:
       - "6121"
       - "6122"
@@ -40,4 +41,4 @@ services:
     links:
       - "jobmanager:jobmanager"
     environment:
-      - JOB_MANAGER_RPC_ADDRESS="jobmanager"
+      - JOB_MANAGER_RPC_ADDRESS=jobmanager

--- a/flink-contrib/docker-flink/docker-entrypoint.sh
+++ b/flink-contrib/docker-flink/docker-entrypoint.sh
@@ -27,7 +27,7 @@ if [ "$1" == "jobmanager" ]; then
     sed -i -e "s/jobmanager.rpc.address: localhost/jobmanager.rpc.address: ${JOB_MANAGER_RPC_ADDRESS}/g" $FLINK_HOME/conf/flink-conf.yaml
 
     echo "config file: " && grep '^[^\n#]' $FLINK_HOME/conf/flink-conf.yaml
-    $FLINK_HOME/bin/jobmanager.sh start cluster
+    $FLINK_HOME/bin/jobmanager.sh start cluster --no-redirect-stdout
 elif [ "$1" == "taskmanager" ]; then
 
     sed -i -e "s/jobmanager.rpc.address: localhost/jobmanager.rpc.address: ${JOB_MANAGER_RPC_ADDRESS}/g" $FLINK_HOME/conf/flink-conf.yaml
@@ -35,7 +35,7 @@ elif [ "$1" == "taskmanager" ]; then
 
     echo "Starting Task Manager"
     echo "config file: " && grep '^[^\n#]' $FLINK_HOME/conf/flink-conf.yaml
-    $FLINK_HOME/bin/taskmanager.sh start
+    $FLINK_HOME/bin/taskmanager.sh start --no-redirect-stdout
 else
     $@
 fi

--- a/flink-contrib/docker-flink/log4j.properties
+++ b/flink-contrib/docker-flink/log4j.properties
@@ -1,0 +1,47 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# This affects logging for both user code and Flink
+log4j.rootLogger=INFO, file, console
+
+# Uncomment this if you want to _only_ change Flink's logging
+#log4j.logger.org.apache.flink=INFO
+
+# The following lines keep the log level of common libraries/connectors on
+# log level INFO. The root logger does not override this. You have to manually
+# change the log levels here.
+log4j.logger.akka=INFO
+log4j.logger.org.apache.kafka=INFO
+log4j.logger.org.apache.hadoop=INFO
+log4j.logger.org.apache.zookeeper=INFO
+
+# Log all infos in the given file
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.file=${log.file}
+log4j.appender.file.append=false
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+# Log to stdout as well
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+# Suppress the irrelevant (wrong) warnings from the Netty channel handler
+log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, file, console

--- a/flink-contrib/docker-flink/remove-docker-swarm-service.sh
+++ b/flink-contrib/docker-flink/remove-docker-swarm-service.sh
@@ -1,5 +1,23 @@
 #!/bin/sh
 
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 usage() {
   cat <<HERE
 Usage:

--- a/flink-contrib/docker-flink/remove-docker-swarm-service.sh
+++ b/flink-contrib/docker-flink/remove-docker-swarm-service.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+usage() {
+  cat <<HERE
+Usage:
+  remove-docker-swarm-service.sh <service-name> 
+HERE
+  exit 1
+}
+
+[[ $# -ne 1 ]] && usage
+
+SERVICE_BASE_NAME="$1"
+JOB_MANAGER_NAME=${SERVICE_BASE_NAME}-jobmanager
+TASK_MANAGER_NAME=${SERVICE_BASE_NAME}-taskmanager
+OVERLAY_NETWORK_NAME=${SERVICE_BASE_NAME}
+
+# Remove taskmanager service
+docker service rm ${TASK_MANAGER_NAME}
+
+# Remove jobmanager service
+docker service rm ${JOB_MANAGER_NAME}
+
+# Remove overlay network
+docker network rm ${OVERLAY_NETWORK_NAME}

--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -18,10 +18,14 @@
 ################################################################################
 
 # Start/stop a Flink JobManager.
-USAGE="Usage: jobmanager.sh (start (local|cluster) [host] [webui-port]|stop|stop-all)"
+USAGE="Usage: jobmanager.sh (start (local|cluster) [--no-redirect-stdout] [host] [webui-port]|stop|stop-all)"
 
 STARTSTOP=$1
 EXECUTIONMODE=$2
+
+# Parse out --no-redirect-stdout flag if present
+[[ "$3" == "--no-redirect-stdout" ]] && redirect_flag="--no-redirect-stdout" && shift
+
 HOST=$3 # optional when starting multiple instances
 WEBUIPORT=$4 # optional when starting multiple instances
 
@@ -70,4 +74,4 @@ if [[ $STARTSTOP == "start" ]]; then
     fi
 fi
 
-"${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP jobmanager "${args[@]}"
+"${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP jobmanager "$redirect_flag" "${args[@]}"

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -18,9 +18,12 @@
 ################################################################################
 
 # Start/stop a Flink TaskManager.
-USAGE="Usage: taskmanager.sh (start|stop|stop-all)"
+USAGE="Usage: taskmanager.sh (start|stop|stop-all) [--no-redirect-stdout]"
 
 STARTSTOP=$1
+
+# Parse out --no-redirect-stdout flag
+[[ "$2" == "--no-redirect-stdout" ]] && redirect_flag="--no-redirect-stdout"
 
 bin=`dirname "$0"`
 bin=`cd "$bin"; pwd`
@@ -96,4 +99,4 @@ if [[ $STARTSTOP == "start" ]]; then
     args=("--configDir" "${FLINK_CONF_DIR}")
 fi
 
-"${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP taskmanager "${args[@]}"
+"${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP taskmanager "$redirect_flag" "${args[@]}"


### PR DESCRIPTION
Improvements for Docker on Flink experience.

This PR depends on this other one:  https://github.com/apache/flink/pull/3204

The changes you see to the Flink launch scripts (taskmanager.sh, jobmanager.sh, and flink-daemon.sh) are from https://github.com/apache/flink/pull/3204.

- Modifying Dockerfile to allow building from local flink-dist as well as release URLs
- Making image name configurable so it's easier for user's to use this to build an publish their own images
- Logging to stdout rather than just files
- Adding scripts to deploy seamlessly on Docker Swarm without host networking
- Updating Docker Compose scripts to work correctly for deploying locally
- Generally parameterizing things so these Docker scripts are more generally useful and self-documenting
- Provides options so that you can deploy multiple Flink services with unique names on Docker Swarm
- This should all work well with the new Docker "stack" stuff as well.

Example usage:

```
# Build a Docker image from your local flink build
./build.sh --from-local-dist --image-name "dataartisans/flink"
```

```
# Build a Docker image from an official release
./build.sh --from-release --flink-verison 1.2.0 --hadoop-version 2.7 --scala-version 2.11 --image-name "dataartisans/flink"
```
```
# Run with Docker Compose
docker-compose up -d
docker-compose scale taskmanager=4
```
```
# Run on Docker Swarm
./create-docker-swarm-service.sh --image-name "dataartisans/flink" my-flink-service my-flink-port
```
```
# Shut down
./remove-docker-swarm-service.sh --image-name "dataartisans/flink" my-flink-service
```
