### PR TITLE
[FLINK-5612] Fix GlobPathFilter not-serializable exception

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -481,7 +481,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 			totalLength += pathFile.getLen();
 		}
 		// returns if unsplittable
-		if(unsplittable) {
+		if (unsplittable) {
 			int splitNum = 0;
 			for (final FileStatus file : files) {
 				final BlockLocation[] blocks = fs.getFileBlockLocations(file, 0, file.getLen());

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GlobFilePathFilter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GlobFilePathFilter.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.io;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.Preconditions;
 
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -52,8 +53,13 @@ public class GlobFilePathFilter extends FilePathFilter {
 
 	private static final long serialVersionUID = 1L;
 
-	private final ArrayList<PathMatcher> includeMatchers;
-	private final ArrayList<PathMatcher> excludeMatchers;
+	private final List<String> includePatterns;
+	private final List<String> excludePatterns;
+
+	// Path matchers are not serializable so we are delaying their
+	// creation until they are used
+	private ArrayList<PathMatcher> includeMatchers;
+	private ArrayList<PathMatcher> excludeMatchers;
 
 	/**
 	 * Constructor for GlobFilePathFilter that will match all files
@@ -69,8 +75,8 @@ public class GlobFilePathFilter extends FilePathFilter {
 	 * @param excludePatterns glob patterns for files to exclude
 	 */
 	public GlobFilePathFilter(List<String> includePatterns, List<String> excludePatterns) {
-		includeMatchers = buildPatterns(includePatterns);
-		excludeMatchers = buildPatterns(excludePatterns);
+		this.includePatterns = Preconditions.checkNotNull(includePatterns);
+		this.excludePatterns = Preconditions.checkNotNull(excludePatterns)	;
 	}
 
 	private ArrayList<PathMatcher> buildPatterns(List<String> patterns) {
@@ -86,7 +92,7 @@ public class GlobFilePathFilter extends FilePathFilter {
 
 	@Override
 	public boolean filterPath(Path filePath) {
-		if (includeMatchers.isEmpty() && excludeMatchers.isEmpty()) {
+		if (getIncludeMatchers().isEmpty() && getExcludeMatchers().isEmpty()) {
 			return false;
 		}
 
@@ -97,7 +103,7 @@ public class GlobFilePathFilter extends FilePathFilter {
 
 		final java.nio.file.Path nioPath = Paths.get(path);
 
-		for (PathMatcher matcher : includeMatchers) {
+		for (PathMatcher matcher : getIncludeMatchers()) {
 			if (matcher.matches(nioPath)) {
 				return shouldExclude(nioPath);
 			}
@@ -106,12 +112,27 @@ public class GlobFilePathFilter extends FilePathFilter {
 		return true;
 	}
 
+	public ArrayList<PathMatcher> getIncludeMatchers() {
+		if (includeMatchers == null) {
+			includeMatchers = buildPatterns(includePatterns);
+		}
+		return includeMatchers;
+	}
+
+	public ArrayList<PathMatcher> getExcludeMatchers() {
+		if (excludeMatchers == null) {
+			excludeMatchers = buildPatterns(excludePatterns);
+		}
+		return excludeMatchers;
+	}
+
 	private boolean shouldExclude(java.nio.file.Path nioPath) {
-		for (PathMatcher matcher : excludeMatchers) {
+		for (PathMatcher matcher : getExcludeMatchers()) {
 			if (matcher.matches(nioPath)) {
 				return true;
 			}
 		}
 		return false;
 	}
+
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GlobFilePathFilter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GlobFilePathFilter.java
@@ -58,8 +58,8 @@ public class GlobFilePathFilter extends FilePathFilter {
 
 	// Path matchers are not serializable so we are delaying their
 	// creation until they are used
-	transient private ArrayList<PathMatcher> includeMatchers;
-	transient private ArrayList<PathMatcher> excludeMatchers;
+	private transient ArrayList<PathMatcher> includeMatchers;
+	private transient ArrayList<PathMatcher> excludeMatchers;
 
 	/**
 	 * Constructor for GlobFilePathFilter that will match all files

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GlobFilePathFilter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GlobFilePathFilter.java
@@ -58,8 +58,8 @@ public class GlobFilePathFilter extends FilePathFilter {
 
 	// Path matchers are not serializable so we are delaying their
 	// creation until they are used
-	private ArrayList<PathMatcher> includeMatchers;
-	private ArrayList<PathMatcher> excludeMatchers;
+	transient private ArrayList<PathMatcher> includeMatchers;
+	transient private ArrayList<PathMatcher> excludeMatchers;
 
 	/**
 	 * Constructor for GlobFilePathFilter that will match all files
@@ -76,7 +76,7 @@ public class GlobFilePathFilter extends FilePathFilter {
 	 */
 	public GlobFilePathFilter(List<String> includePatterns, List<String> excludePatterns) {
 		this.includePatterns = Preconditions.checkNotNull(includePatterns);
-		this.excludePatterns = Preconditions.checkNotNull(excludePatterns)	;
+		this.excludePatterns = Preconditions.checkNotNull(excludePatterns);
 	}
 
 	private ArrayList<PathMatcher> buildPatterns(List<String> patterns) {
@@ -112,14 +112,14 @@ public class GlobFilePathFilter extends FilePathFilter {
 		return true;
 	}
 
-	public ArrayList<PathMatcher> getIncludeMatchers() {
+	private ArrayList<PathMatcher> getIncludeMatchers() {
 		if (includeMatchers == null) {
 			includeMatchers = buildPatterns(includePatterns);
 		}
 		return includeMatchers;
 	}
 
-	public ArrayList<PathMatcher> getExcludeMatchers() {
+	private ArrayList<PathMatcher> getExcludeMatchers() {
 		if (excludeMatchers == null) {
 			excludeMatchers = buildPatterns(excludePatterns);
 		}

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/GlobFilePathFilterTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/GlobFilePathFilterTest.java
@@ -161,6 +161,9 @@ public class GlobFilePathFilterTest {
 			Collections.singletonList("**"),
 			Collections.<String>emptyList());
 
-		CommonTestUtils.createCopySerializable(matcher);
+		GlobFilePathFilter matcherCopy = CommonTestUtils.createCopySerializable(matcher);
+		assertFalse(matcher.filterPath(new Path("a")));
+		assertFalse(matcher.filterPath(new Path("a/b")));
+		assertFalse(matcher.filterPath(new Path("a/b/c")));
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/GlobFilePathFilterTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/GlobFilePathFilterTest.java
@@ -20,6 +20,9 @@ package org.apache.flink.api.common.io;
 import org.apache.flink.core.fs.Path;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.util.Collections;
 
 import static org.junit.Assert.assertFalse;
@@ -27,13 +30,13 @@ import static org.junit.Assert.assertTrue;
 
 public class GlobFilePathFilterTest {
 	@Test
-	public void defaultConstructorCreateMatchAllFilter() {
+	public void testDefaultConstructorCreateMatchAllFilter() {
 		GlobFilePathFilter matcher = new GlobFilePathFilter();
 		assertFalse(matcher.filterPath(new Path("dir/file.txt")));
 	}
 
 	@Test
-	public void matchAllFilesByDefault() {
+	public void testMatchAllFilesByDefault() {
 		GlobFilePathFilter matcher = new GlobFilePathFilter(
 			Collections.<String>emptyList(),
 			Collections.<String>emptyList());
@@ -42,7 +45,7 @@ public class GlobFilePathFilterTest {
 	}
 
 	@Test
-	public void excludeFilesNotInIncludePatterns() {
+	public void testExcludeFilesNotInIncludePatterns() {
 		GlobFilePathFilter matcher = new GlobFilePathFilter(
 			Collections.singletonList("dir/*"),
 			Collections.<String>emptyList());
@@ -52,7 +55,7 @@ public class GlobFilePathFilterTest {
 	}
 
 	@Test
-	public void excludeFilesIfMatchesExclude() {
+	public void testExcludeFilesIfMatchesExclude() {
 		GlobFilePathFilter matcher = new GlobFilePathFilter(
 			Collections.singletonList("dir/*"),
 			Collections.singletonList("dir/file.txt"));
@@ -61,7 +64,7 @@ public class GlobFilePathFilterTest {
 	}
 
 	@Test
-	public void includeFileWithAnyCharacterMatcher() {
+	public void testIncludeFileWithAnyCharacterMatcher() {
 		GlobFilePathFilter matcher = new GlobFilePathFilter(
 			Collections.singletonList("dir/?.txt"),
 			Collections.<String>emptyList());
@@ -71,7 +74,7 @@ public class GlobFilePathFilterTest {
 	}
 
 	@Test
-	public void includeFileWithCharacterSetMatcher() {
+	public void testIncludeFileWithCharacterSetMatcher() {
 		GlobFilePathFilter matcher = new GlobFilePathFilter(
 			Collections.singletonList("dir/[acd].txt"),
 			Collections.<String>emptyList());
@@ -83,7 +86,7 @@ public class GlobFilePathFilterTest {
 	}
 
 	@Test
-	public void includeFileWithCharacterRangeMatcher() {
+	public void testIncludeFileWithCharacterRangeMatcher() {
 		GlobFilePathFilter matcher = new GlobFilePathFilter(
 			Collections.singletonList("dir/[a-d].txt"),
 			Collections.<String>emptyList());
@@ -96,7 +99,7 @@ public class GlobFilePathFilterTest {
 	}
 
 	@Test
-	public void excludeHDFSFile() {
+	public void testExcludeHDFSFile() {
 		GlobFilePathFilter matcher = new GlobFilePathFilter(
 			Collections.singletonList("**"),
 			Collections.singletonList("/dir/file2.txt"));
@@ -107,7 +110,7 @@ public class GlobFilePathFilterTest {
 	}
 
 	@Test
-	public void excludeFilenameWithStart() {
+	public void testExcludeFilenameWithStart() {
 		GlobFilePathFilter matcher = new GlobFilePathFilter(
 			Collections.singletonList("**"),
 			Collections.singletonList("\\*"));
@@ -118,7 +121,7 @@ public class GlobFilePathFilterTest {
 	}
 
 	@Test
-	public void singleStarPattern() {
+	public void testSingleStarPattern() {
 		GlobFilePathFilter matcher = new GlobFilePathFilter(
 			Collections.singletonList("*"),
 			Collections.<String>emptyList());
@@ -129,7 +132,7 @@ public class GlobFilePathFilterTest {
 	}
 
 	@Test
-	public void doubleStarPattern() {
+	public void testDoubleStarPattern() {
 		GlobFilePathFilter matcher = new GlobFilePathFilter(
 			Collections.singletonList("**"),
 			Collections.<String>emptyList());
@@ -137,5 +140,31 @@ public class GlobFilePathFilterTest {
 		assertFalse(matcher.filterPath(new Path("a")));
 		assertFalse(matcher.filterPath(new Path("a/b")));
 		assertFalse(matcher.filterPath(new Path("a/b/c")));
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testIncluePatternIsNull() {
+		new GlobFilePathFilter(
+			null,
+			Collections.<String>emptyList());
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testExcludePatternIsNull() {
+		new GlobFilePathFilter(
+			Collections.singletonList("**"),
+			null);
+	}
+
+	@Test
+	public void testGlobFilterSerializable() throws IOException {
+		GlobFilePathFilter matcher = new GlobFilePathFilter(
+			Collections.singletonList("**"),
+			Collections.<String>emptyList());
+
+		ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+		ObjectOutputStream out = new ObjectOutputStream(outStream);
+		out.writeObject(matcher);
+		out.close();
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/GlobFilePathFilterTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/GlobFilePathFilterTest.java
@@ -18,11 +18,10 @@
 package org.apache.flink.api.common.io;
 
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.testutils.CommonTestUtils;
 import org.junit.Test;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.ObjectOutputStream;
 import java.util.Collections;
 
 import static org.junit.Assert.assertFalse;
@@ -162,9 +161,6 @@ public class GlobFilePathFilterTest {
 			Collections.singletonList("**"),
 			Collections.<String>emptyList());
 
-		ByteArrayOutputStream outStream = new ByteArrayOutputStream();
-		ObjectOutputStream out = new ObjectOutputStream(outStream);
-		out.writeObject(matcher);
-		out.close();
+		CommonTestUtils.createCopySerializable(matcher);
 	}
 }


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed


Fixed GlobPathFilter serialization exception. As suggested in the JIRA I've made instantiation of PathMatcher's objects lazy to avoid their serialization.
