### PR TITLE
[FLINK-5640][build]configure the explicit Unit Test file suffix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -964,6 +964,8 @@ under the License.
 					<compilerArgument>-Xlint:all</compilerArgument>
 				</configuration>
 			</plugin>
+
+			<!--surefire for unit tests and integration tests-->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
@@ -979,6 +981,7 @@ under the License.
 					<argLine>-Xms256m -Xmx800m -Dmvn.forkNumber=${surefire.forkNumber} -XX:-UseGCOverheadLimit</argLine>
 				</configuration>
 				<executions>
+					<!--execute all the unit tests-->
 					<execution>
 						<id>default-test</id>
 						<phase>test</phase>
@@ -986,12 +989,16 @@ under the License.
 							<goal>test</goal>
 						</goals>
 						<configuration>
+							<includes>
+								<include>**/*Test.*</include>
+							</includes>
 							<excludes>
 								<exclude>**/*ITCase.*</exclude>
 								<exclude>${flink-fast-tests-pattern}</exclude>
 							</excludes>
 						</configuration>
 					</execution>
+					<!--execute all the integration tests-->
 					<execution>
 						<id>integration-tests</id>
 						<phase>integration-test</phase>


### PR DESCRIPTION
There are four types of Unit Test file: *ITCase.java, *Test.java, *ITSuite.scala, *Suite.scala
File name ending with "IT.java" is integration test. File name ending with "Test.java"  is unit test.

It's clear for Surefire plugin of default-test execution to declare that "*Test.*" is Java Unit Test.

The test file statistics:
* Suite  total: 10
* ITCase  total: 378
* Test  total: 1008
* ITSuite  total: 14