### PR TITLE
[backport] [FLINK-5643] Fix NPE in StateUtil

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
@@ -78,7 +78,9 @@ public class StateUtil {
 			if (!stateFuture.cancel(true)) {
 				StateObject stateObject = FutureUtil.runIfNotDoneAndGet(stateFuture);
 
-				stateObject.discardState();
+				if (null != stateObject) {
+					stateObject.discardState();
+				}
 			}
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateUtilTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+
+import java.util.concurrent.RunnableFuture;
+
+public class StateUtilTest extends TestLogger {
+
+	/**
+	 * Tests that {@link StateUtil#discardStateFuture} can handle state futures with null value.
+	 */
+	@Test
+	public void testDiscardRunnableFutureWithNullValue() throws Exception {
+		RunnableFuture<StateHandle<?>> stateFuture = new DoneFuture<>(null);
+		StateUtil.discardStateFuture(stateFuture);
+	}
+}


### PR DESCRIPTION
Backport of #3212 onto `release-1.2`.

Introduces a null check to deal with state futures which have a null value.
