### PR TITLE
[FLINK-5642][query] fix a race condition with HeadListState

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -454,5 +455,11 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 		public boolean accept(File file, String s) {
 			return true;
 		}
+	}
+
+	@Override
+	@Test
+	@Ignore("Since RocksDB returns copies, we allow any operation and ignore this test")
+	public void testListStateIteratorRemove() {
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -161,7 +161,11 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				new RegisteredBackendStateMetaInfo<>(stateDesc.getType(), name, namespaceSerializer, new ArrayListSerializer<>(stateDesc.getSerializer()));
 
 		stateTable = tryRegisterStateTable(stateTable, newMetaInfo);
-		return new HeapListState<>(this, stateDesc, stateTable, keySerializer, namespaceSerializer);
+		if (stateDesc.isQueryable()) {
+			return new QueryableHeapListState<>(this, stateDesc, stateTable, keySerializer, namespaceSerializer);
+		} else {
+			return new HeapListState<>(this, stateDesc, stateTable, keySerializer, namespaceSerializer);
+		}
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
@@ -116,7 +116,13 @@ public class HeapListState<K, N, V>
 			list = new ArrayList<>();
 			keyedMap.put(backend.<K>getCurrentKey(), list);
 		}
-		list.add(value);
+		if (stateDesc.isQueryable()) {
+			synchronized (list) {
+				list.add(value);
+			}
+		} else {
+			list.add(value);
+		}
 	}
 	
 	@Override
@@ -143,6 +149,16 @@ public class HeapListState<K, N, V>
 			return null;
 		}
 
+		if (stateDesc.isQueryable()) {
+			synchronized (result) {
+				return serializeList(result);
+			}
+		} else {
+			return serializeList(result);
+		}
+	}
+
+	private byte[] serializeList(final ArrayList<V> result) throws java.io.IOException {
 		TypeSerializer<V> serializer = stateDesc.getSerializer();
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/QueryableHeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/QueryableHeapListState.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.heap;
+
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayList;
+
+/**
+ * Heap-backed partitioned {@link org.apache.flink.api.common.state.ListState} that is snapshotted
+ * into files and supports state queries.
+ *
+ * As opposed to {@link HeapListState}, this class avoids some race conditions that occur when
+ * state queries access state concurrently to operators changing state.
+ *
+ * @param <K> The type of the key.
+ * @param <N> The type of the namespace.
+ * @param <V> The type of the value.
+ */
+public class QueryableHeapListState<K, N, V> extends HeapListState<K, N, V> {
+
+	/**
+	 * Private class extending ArrayList which forbids {@link #remove(int)} that is used by {@link
+	 * #iterator()}'s remove function.
+	 * <p>
+	 * This is useful for the {@link HeapListState#get()} function that returns an {@link Iterable}.
+	 * By using {@link Iterable#iterator()}, the user may call {@link java.util.Iterator#remove}
+	 * which modifies the list. {@link HeapListState#get()}, however, should only return a copy but
+	 * actually returns on the real value which queryable state reads concurrently. In order not to
+	 * create any races during structural changes, we thus forbid {@link #remove(int)}.
+	 * <p>
+	 * <em>Note:</em> we only make the {@link #remove(int)} function unsupported so this is not a
+	 * real immutable arraylist. Also, future changes in {@link ArrayList} are not covered since we
+	 * do not have control over its iterator class.
+	 *
+	 * @param <V>
+	 * 		list element type
+	 */
+	private static class QueryableStateArrayList<V> extends ArrayList<V> {
+		private static final long serialVersionUID = 1L;
+
+		/**
+		 * Unsupported operation.
+		 *
+		 * @throw UnsupportedOperationException always thrown
+		 * @deprecated unsupported
+		 */
+		@Deprecated
+		@Override
+		public V remove(final int index) {
+			throw new UnsupportedOperationException(
+				"Structural changes to queryable list state are not allowed.");
+		}
+	}
+
+	/**
+	 * Creates a new key/value state for the given hash map of key/value pairs.
+	 *
+	 * @param backend The state backend backing that created this state.
+	 * @param stateDesc The state identifier for the state. This contains name
+	 *                           and can create a default state value.
+	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
+	 */
+	public QueryableHeapListState(
+		KeyedStateBackend<K> backend,
+		ListStateDescriptor<V> stateDesc,
+		StateTable<K, N, ArrayList<V>> stateTable,
+		TypeSerializer<K> keySerializer,
+		TypeSerializer<N> namespaceSerializer) {
+		super(backend, stateDesc, stateTable, keySerializer, namespaceSerializer);
+	}
+
+	@Override
+	public void add(V value) {
+		Preconditions.checkState(currentNamespace != null, "No namespace set.");
+		Preconditions.checkState(backend.getCurrentKey() != null, "No key set.");
+
+		if (value == null) {
+			clear();
+			return;
+		}
+
+		ArrayList<V> list = creatingGetListState();
+		synchronized (list) {
+			list.add(value);
+		}
+	}
+
+	protected ArrayList<V> newList() {
+		return new QueryableStateArrayList<>();
+	}
+
+	@Override
+	public byte[] getSerializedValue(K key, N namespace) throws Exception {
+		Preconditions.checkState(namespace != null, "No namespace given.");
+		Preconditions.checkState(key != null, "No key given.");
+
+		ArrayList<V> result = nonCreatingGetListState(key, namespace);
+		if (result == null) {
+			return null;
+		}
+
+		synchronized (result) {
+			return serializeList(result);
+		}
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -1120,6 +1120,97 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		}
 	}
 
+	/**
+	 * Tests {@link ListState#add(Object)} and {@link InternalKvState#getSerializedValue(byte[])}
+	 * accessing the state concurrently for queryable state (otherwise the state is not accessed
+	 * concurrently). They should not get in the way of each other.
+	 */
+	@Test
+	public void testListStateRace() throws Exception {
+		final AbstractKeyedStateBackend<Integer> backend =
+			createKeyedBackend(IntSerializer.INSTANCE);
+		final Integer namespace = 1;
+
+		final ListStateDescriptor<String> kvId = new ListStateDescriptor<>("id", String.class);
+		kvId.setQueryable("testListStateRace");
+		kvId.initializeSerializerUnlessSet(new ExecutionConfig());
+
+		final TypeSerializer<Integer> keySerializer = IntSerializer.INSTANCE;
+		final TypeSerializer<Integer> namespaceSerializer = IntSerializer.INSTANCE;
+		final TypeSerializer<String> valueSerializer = kvId.getSerializer();
+
+		final ListState<String> state = backend
+			.getPartitionedState(namespace, IntSerializer.INSTANCE, kvId);
+
+		final InternalKvState<Integer> kvState = (InternalKvState<Integer>) state;
+
+		// some modifications to the state
+		final int key = 10;
+		backend.setCurrentKey(key);
+		assertNull(state.get());
+		assertNull(getSerializedList(kvState, key, keySerializer,
+			namespace, namespaceSerializer, valueSerializer));
+		final String strVal = "1";
+		state.add(strVal);
+
+		final CheckedThread writer = new CheckedThread("State writer") {
+			@Override
+			public void go() throws Exception {
+				while (!isInterrupted()) {
+					// some list state modifications
+					state.clear();
+					state.add(strVal);
+					Thread.yield();
+				}
+			}
+		};
+
+		final CheckedThread serializedGetter = new CheckedThread("Serialized state getter") {
+			@Override
+			public void go() throws Exception {
+				while(!isInterrupted() && writer.isAlive()) {
+					final List<String> serializedValue =
+						getSerializedList(kvState, key, keySerializer,
+							namespace, namespaceSerializer,
+							valueSerializer);
+					if (serializedValue != null) {
+						for (String str : serializedValue) {
+							assertEquals(strVal, str);
+						}
+					}
+					Thread.yield();
+				}
+			}
+		};
+
+		writer.start();
+		serializedGetter.start();
+
+		// run both threads for max 100ms
+		Timer t = new Timer("stopper");
+		t.schedule(new TimerTask() {
+			@Override
+			public void run() {
+				writer.interrupt();
+				serializedGetter.interrupt();
+				this.cancel();
+			}
+		}, 100);
+
+		// wait for both threads to finish
+		try {
+			// serializedGetter will finish if its assertion fails or if writer is not alive any more
+			serializedGetter.sync();
+			// if serializedGetter crashed, writer will not know -> interrupt just in case
+			writer.interrupt();
+			writer.sync();
+			t.cancel(); // if not executed yet
+		} finally {
+			// clean up
+			backend.dispose();
+		}
+	}
+
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testReducingStateRestoreWithWrongSerializers() {


### PR DESCRIPTION
The idiom behind `AppendingState#get()` is to return a copy of the value behind or at least not to allow changes to the underlying state storage. However, the heap state backend returns the original `ArrayList` which is not thread-safe. In contrast to the operator/window evictor thread where only one accesses the state at a time, queryable state may access state any time in order not to slow down normal operation. Any structural changes to `ArrayList` are thus unsafe which is why this PR:
* synchronizes access to structure-changing methods on that list (only for queryable state),
* forbids `ArrayList#remove()` (only for queryable state) that is available through `Iterator#remove()` which is the only structural change the API offers on the `Iterable` that `HeapListState#get()` returns.