### PR TITLE
[FLINK-5660] [state] Fix state cleanup of PendingCheckpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -416,6 +416,8 @@ public class PendingCheckpoint {
 							} catch (Exception e) {
 								LOG.warn("Could not properly dispose the pending checkpoint " +
 									"{} of job {}.", checkpointId, jobId, e);
+							} finally {
+								taskStates.clear();
 							}
 						}
 					});
@@ -423,7 +425,6 @@ public class PendingCheckpoint {
 				}
 			} finally {
 				discarded = true;
-				taskStates.clear();
 				notYetAcknowledgedTasks.clear();
 				acknowledgedTasks.clear();
 			}


### PR DESCRIPTION
When calling PendingCheckpoint.dispose, the state contained in a pending checkpoint
is discarded by an asynchronous task. Since this task accesses the taskStates field
we must not clear it in PendingCheckpoint.dispose. Instead we will clear it once
all state objects have been discarded from within the asynchronous task.
