### PR TITLE
[FLINK-5670] Properly clean up local RocksDB directories

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -208,10 +208,6 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 		isInitialized = true;
 	}
 
-	private File getDbPath() {
-		return new File(new File(getNextStoragePath(), jobId.toString()), operatorIdentifier);
-	}
-
 	private File getNextStoragePath() {
 		int ni = nextDirectory + 1;
 		ni = ni >= initializedDbBasePaths.length ? 0 : ni;
@@ -243,7 +239,8 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 
 		lazyInitializeForJob(env, operatorIdentifier);
 
-		File instanceBasePath = new File(getDbPath(), UUID.randomUUID().toString());
+		File instanceBasePath =
+				new File(getNextStoragePath(), "job-" + jobId.toString() + "_op-" + operatorIdentifier + "_uid-" + UUID.randomUUID());
 
 		return new RocksDBKeyedStateBackend<>(
 				jobID,


### PR DESCRIPTION
We have to change the instance path to not include too many nested
directories, otherwise the Keyed backend cannot properly clean up the
whole directory hierachy.