### PR TITLE
[FLINK-5663] Prevent leaking SafetyNetCloseableRegistry though InheritableThreadLocal

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -550,8 +550,8 @@ public class Task implements Runnable, TaskActions {
 			//  check for canceling as a shortcut
 			// ----------------------------
 
-			// init closeable registry for this task
-			FileSystem.createFileSystemCloseableRegistryForTask();
+			// activate safety net for task thread
+			FileSystem.createAndSetFileSystemCloseableRegistryForThread();
 
 			// first of all, get a user-code classloader
 			// this may involve downloading the job's JAR files and/or classes
@@ -775,7 +775,8 @@ public class Task implements Runnable, TaskActions {
 
 				// remove all files in the distributed cache
 				removeCachedFiles(distributedCacheEntries, fileCache);
-				FileSystem.disposeFileSystemCloseableRegistryForTask();
+				// close and de-activate safety net for task thread
+				FileSystem.closeAndDisposeFileSystemCloseableRegistryForThread();
 
 				notifyFinalState();
 			}


### PR DESCRIPTION
This PR prevents the `SafetyNetCloseableRegistry` from leaking into pooled threads through `InheritableThreadLocal`. 

As first step, we use `ThreadLocal` instead of `InheritableThreadLocal` to hold the closeable registries.

Additionally, we also create safety nets for the file system at the scope of the checkpointing thread. We hope that this covers already covers most cases. Other threads could actually also create safety nets for their scope right now.

As a last change, we made the reaper thread a singleton, because we could potentially create more registries now and it is not required to have one reaper thread per registry. 