### PR TITLE
[FLINK-5682] Fix scala version in flink-streaming-scala POM file

### DIFF
--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -51,16 +51,19 @@ under the License.
 		<dependency>
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-reflect</artifactId>
+            <version>${scala.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-compiler</artifactId>
+            <version>${scala.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
 Fix scala version in flink-streaming-scala POM file.
In flink-streaming-scala, it doesn't define the scala library version,
when build Flink for scala 2.10, it still possiblely includes scala 2.11