### PR TITLE
[FLINK-5678] [table] Fix User-defined Functions do not support all types of parameters

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/TableFunctionCallGen.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/TableFunctionCallGen.scala
@@ -18,12 +18,14 @@
 
 package org.apache.flink.table.codegen.calls
 
+import org.apache.commons.lang3.ClassUtils
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.codegen.CodeGenUtils._
 import org.apache.flink.table.codegen.GeneratedExpression.NEVER_NULL
 import org.apache.flink.table.codegen.{CodeGenException, CodeGenerator, GeneratedExpression}
 import org.apache.flink.table.functions.TableFunction
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils._
+import org.apache.flink.table.typeutils.TypeCheckUtils
 
 /**
   * Generates a call to user-defined [[TableFunction]].
@@ -51,6 +53,10 @@ class TableFunctionCallGen(
         .zip(operands)
         .map { case (paramClass, operandExpr) =>
           if (paramClass.isPrimitive) {
+            operandExpr
+          } else if (ClassUtils.isPrimitiveWrapper(paramClass)
+            && TypeCheckUtils.isTemporal(operandExpr.resultType)) {
+            // we use primitive to represent temporal types internally, so no casting need here
             operandExpr
           } else {
             val boxedTypeTerm = boxedTypeTermForTypeInfo(operandExpr.resultType)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/literals.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/literals.scala
@@ -68,6 +68,11 @@ case class Literal(value: Any, resultType: TypeInformation[_]) extends LeafExpre
         val decType = relBuilder.getTypeFactory.createSqlType(SqlTypeName.DECIMAL)
         relBuilder.getRexBuilder.makeExactLiteral(bigDecValue, decType)
 
+      // create BIGINT literals for long type
+      case BasicTypeInfo.LONG_TYPE_INFO =>
+        val bigint = java.math.BigDecimal.valueOf(value.asInstanceOf[Long])
+        relBuilder.getRexBuilder.makeBigintLiteral(bigint)
+
       // date/time
       case SqlTimeTypeInfo.DATE =>
         relBuilder.getRexBuilder.makeDateLiteral(dateToCalendar)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/UserDefinedFunctionUtils.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/UserDefinedFunctionUtils.scala
@@ -19,17 +19,17 @@
 
 package org.apache.flink.table.functions.utils
 
+import java.lang.{Long => JLong, Integer => JInt}
 import java.lang.reflect.{Method, Modifier}
 import java.sql.{Date, Time, Timestamp}
 
 import com.google.common.primitives.Primitives
 import org.apache.calcite.sql.SqlFunction
 import org.apache.flink.api.common.functions.InvalidTypesException
-import org.apache.flink.api.common.typeinfo.{AtomicType, TypeInformation}
-import org.apache.flink.api.common.typeutils.CompositeType
+import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.table.calcite.FlinkTypeFactory
-import org.apache.flink.table.api.{TableEnvironment, TableException, ValidationException}
+import org.apache.flink.table.api.{TableEnvironment, ValidationException}
 import org.apache.flink.table.functions.{ScalarFunction, TableFunction, UserDefinedFunction}
 import org.apache.flink.table.plan.schema.FlinkTableFunctionImpl
 import org.apache.flink.util.InstantiationUtil
@@ -320,8 +320,8 @@ object UserDefinedFunctionUtils {
   candidate == null ||
     candidate == expected ||
     expected.isPrimitive && Primitives.wrap(expected) == candidate ||
-    candidate == classOf[Date] && expected == classOf[Int] ||
-    candidate == classOf[Time] && expected == classOf[Int] ||
-    candidate == classOf[Timestamp] && expected == classOf[Long]
+    candidate == classOf[Date] && (expected == classOf[Int] || expected == classOf[JInt])  ||
+    candidate == classOf[Time] && (expected == classOf[Int] || expected == classOf[JInt]) ||
+    candidate == classOf[Timestamp] && (expected == classOf[Long] || expected == classOf[JLong])
 
 }

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/utils/UserDefinedScalarFunctions.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/utils/UserDefinedScalarFunctions.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.api.java.utils;
+
+import org.apache.flink.table.functions.ScalarFunction;
+
+public class UserDefinedScalarFunctions {
+
+	public static class JavaFunc0 extends ScalarFunction {
+		public long eval(Long l) {
+			return l + 1;
+		}
+	}
+
+	public static class JavaFunc1 extends ScalarFunction {
+		public String eval(Integer a, int b,  Long c) {
+			return a + " and " + b + " and " + c;
+		}
+	}
+
+}

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/utils/UserDefinedTableFunctions.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/utils/UserDefinedTableFunctions.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.api.java.utils;
+
+import org.apache.flink.table.functions.TableFunction;
+
+public class UserDefinedTableFunctions {
+
+	public static class JavaTableFunc0 extends TableFunction<Long> {
+		public void eval(Integer a, Long b, Long c) {
+			collect(a.longValue());
+			collect(b);
+			collect(c);
+		}
+	}
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.types.Row
 import org.apache.flink.table.api.Types
+import org.apache.flink.table.api.java.utils.UserDefinedScalarFunctions.{JavaFunc0, JavaFunc1}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils._
 import org.apache.flink.table.functions.ScalarFunction
@@ -179,6 +180,32 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       "+0 00:00:01.000")
   }
 
+  @Test
+  def testBoxedPrimitiveParameters(): Unit = {
+    val JavaFunc0 = new JavaFunc0()
+    val JavaFunc1 = new JavaFunc1()
+
+    testAllApis(
+      JavaFunc0('f8),
+      "JavaFunc0(f8)",
+      "JavaFunc0(f8)",
+      "1001"
+    )
+
+    testTableApi(
+      JavaFunc0(1000L),
+      "JavaFunc0(1000L)",
+      "1001"
+    )
+
+    testAllApis(
+      JavaFunc1('f4, 'f5, 'f6),
+      "JavaFunc1(f4, f5, f6)",
+      "JavaFunc1(f4, f5, f6)",
+      "7591 and 43810000 and 655906210000")
+
+  }
+
   // ----------------------------------------------------------------------------------------------
 
   override def testData: Any = {
@@ -222,7 +249,9 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
     "Func9" -> Func9,
     "Func10" -> Func10,
     "Func11" -> Func11,
-    "Func12" -> Func12
+    "Func12" -> Func12,
+    "JavaFunc0" -> new JavaFunc0,
+    "JavaFunc1" -> new JavaFunc1
   )
 }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/dataset/DataSetCorrelateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/dataset/DataSetCorrelateITCase.scala
@@ -17,12 +17,15 @@
  */
 package org.apache.flink.table.runtime.dataset
 
+import java.sql.{Date, Timestamp}
+
 import org.apache.flink.api.scala._
 import org.apache.flink.types.Row
-import org.apache.flink.table.api.scala.batch.utils.{TableProgramsClusterTestBase, TableProgramsCollectionTestBase}
+import org.apache.flink.table.api.scala.batch.utils.TableProgramsClusterTestBase
 import org.apache.flink.table.api.scala.batch.utils.TableProgramsTestBase.TableConfigMode
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.java.utils.UserDefinedTableFunctions.JavaTableFunc0
 import org.apache.flink.table.utils._
 import org.apache.flink.test.util.TestBaseUtils
 import org.junit.Test
@@ -158,6 +161,27 @@ class DataSetCorrelateITCase(
     val results = result.collect()
     val expected = "Jack#22,ack\n" + "Jack#22,22\n" + "John#19,ohn\n" + "John#19,19\n" +
       "Anna#44,nna\n" + "Anna#44,44\n"
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test
+  def testSupportLongAndTemporalTypes(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+    val func0 = new JavaTableFunc0
+
+    val result = in
+        .where('a === 1)
+        .select(Date.valueOf("1990-10-14") as 'x,
+                1000L as 'y,
+                Timestamp.valueOf("1990-10-14 12:10:10") as 'z)
+        .join(func0('x, 'y, 'z) as 's)
+        .select('s)
+        .toDataSet[Row]
+
+    val results = result.collect()
+    val expected = "1000\n" + "655906210000\n" + "7591\n"
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

The bug of [FLINK-5678] (doesn't support Long and temporal types) is not only happen in TableFunctions but also ScalarFunctions. I fixed them and added some tests. @twalthr Could you have a look to make sure that I didn't miss anything ? 

