### PR TITLE
FLINK-5517 Upgrade hbase version to 1.3.0

### DIFF
--- a/flink-connectors/flink-hbase/pom.xml
+++ b/flink-connectors/flink-hbase/pom.xml
@@ -34,7 +34,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<hbase.version>1.2.3</hbase.version>
+		<hbase.version>1.3.0</hbase.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
In the thread 'Help using HBase with Flink 1.1.4', Giuliano reported seeing:
```
java.lang.IllegalAccessError: tried to access method com.google.common.base.Stopwatch.<init>()V from class org.apache.hadoop.hbase.zookeeper.MetaTableLocator
```
The above has been solved by HBASE-14963

Upgrading to hbase 1.3.0 release would give better user experience.