### PR TITLE
[FLINK-5575][docs] reworked the mechanism that warns users about …

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -44,7 +44,6 @@ download_url: "http://flink.apache.org/downloads.html"
 # will be printed pointing to the docs of the latest stable version.
 is_latest: true
 is_stable: false
-latest_stable_url: http://ci.apache.org/projects/flink/flink-docs-release-1.1
 
 previous_docs:
   1.1: http://ci.apache.org/projects/flink/flink-docs-release-1.1

--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -54,20 +54,16 @@ under the License.
     <![endif]-->
   </head>
   <body>
+    {% if site.is_stable %}
+    {% unless site.is_latest %}
+    <div style="position:fixed; bottom:0; left:0; z-index:99999; width:100%; text-align:center; padding:15px; border-top:1px dashed #CE4B65; background:#f6f0e3; font-weight:bold">
+       This documentation is for an out-of-date version of Apache Flink. We recommend you use <a href="https://flink.apache.org/q/stable-docs.html">the latest stable version</a>.
+    </div>
+    {% endunless %}
+    {% endif %}
+
     <!-- Main content. -->
     <div class="container">
-      {% if site.is_stable %}
-      {% unless site.is_latest %}
-      <div class="row">
-        <div class="col-sm-12">
-          <div class="alert alert-info">
-              <strong>Note</strong>: This documentation is for Flink version <strong>{{ site.version }}</strong>. There is a more recent stable version available. Please consider updating and <a href="{{ site.latest_stable_url }}">check out the documentation for that version</a>.
-          </div>
-        </div>
-      </div>
-      {% endunless %}
-      {% endif %}
-
       {% comment %}
       This is the base for all content. The content from the layouts found in
       the _layouts directory goes here.


### PR DESCRIPTION
…newer docs so that only the most recent out-of-date release has to be updated when a new release is made available.

Defining latest_stable_url wasn't a very scalable approach, since this value would have to be updated in every old release. This has been replaced with a redirect from flink.apache.org/q/stable-docs.html.

It would make sense to merge this PR into the release-1.2 branch, though it isn't strictly necessary.

Also, release-1.1 will need to be updated when 1.2 is released.