### PR TITLE
[FLINK-5024] [core] Refactor the interface of State and StateDescriptor

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.api.common.state.SimpleStateDescriptor;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -46,7 +47,7 @@ import java.io.IOException;
  * @param <S> The type of {@link State}.
  * @param <SD> The type of {@link StateDescriptor}.
  */
-public abstract class AbstractRocksDBState<K, N, S extends State, SD extends StateDescriptor<S, V>, V>
+public abstract class AbstractRocksDBState<K, N, S extends State, SD extends SimpleStateDescriptor<?, S>>
 		implements InternalKvState<N>, State {
 
 	/** Serializer for the namespace */

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
@@ -44,7 +44,7 @@ import java.util.Collection;
  * @param <R> The type of the value returned from the state
  */
 public class RocksDBAggregatingState<K, N, T, ACC, R>
-	extends AbstractRocksDBState<K, N, AggregatingState<T, R>, AggregatingStateDescriptor<T, ACC, R>, ACC>
+	extends AbstractRocksDBState<K, N, AggregatingState<T, R>, AggregatingStateDescriptor<T, ACC, R>>
 	implements InternalAggregatingState<N, T, R> {
 
 	/** Serializer for the values */

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
@@ -41,7 +41,7 @@ import java.io.IOException;
  * @param <ACC> The type of the value in the folding state.
  */
 public class RocksDBFoldingState<K, N, T, ACC>
-	extends AbstractRocksDBState<K, N, FoldingState<T, ACC>, FoldingStateDescriptor<T, ACC>, ACC>
+	extends AbstractRocksDBState<K, N, FoldingState<T, ACC>, FoldingStateDescriptor<T, ACC>>
 	implements InternalFoldingState<N, T, ACC> {
 
 	/** Serializer for the values */
@@ -101,7 +101,7 @@ public class RocksDBFoldingState<K, N, T, ACC>
 			DataOutputViewStreamWrapper out = new DataOutputViewStreamWrapper(keySerializationStream);
 			if (valueBytes == null) {
 				keySerializationStream.reset();
-				valueSerializer.serialize(foldFunction.fold(stateDesc.getDefaultValue(), value), out);
+				valueSerializer.serialize(foldFunction.fold(stateDesc.getInitialValue(), value), out);
 				backend.db.put(columnFamily, writeOptions, key, keySerializationStream.toByteArray());
 			} else {
 				ACC oldValue = valueSerializer.deserialize(new DataInputViewStreamWrapper(new ByteArrayInputStreamWithPos(valueBytes)));

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -47,7 +47,7 @@ import java.util.List;
  * @param <V> The type of the values in the list state.
  */
 public class RocksDBListState<K, N, V>
-	extends AbstractRocksDBState<K, N, ListState<V>, ListStateDescriptor<V>, V>
+	extends AbstractRocksDBState<K, N, ListState<V>, ListStateDescriptor<V>>
 	implements InternalListState<N, V> {
 
 	/** Serializer for the values */

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -43,7 +43,7 @@ import java.util.Collection;
  * @param <V> The type of value that the state state stores.
  */
 public class RocksDBReducingState<K, N, V>
-	extends AbstractRocksDBState<K, N, ReducingState<V>, ReducingStateDescriptor<V>, V>
+	extends AbstractRocksDBState<K, N, ReducingState<V>, ReducingStateDescriptor<V>>
 	implements InternalReducingState<N, V> {
 
 	/** Serializer for the values */

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -39,7 +39,7 @@ import java.io.IOException;
  * @param <V> The type of value that the state state stores.
  */
 public class RocksDBValueState<K, N, V>
-	extends AbstractRocksDBState<K, N, ValueState<V>, ValueStateDescriptor<V>, V>
+	extends AbstractRocksDBState<K, N, ValueState<V>, ValueStateDescriptor<V>>
 	implements InternalValueState<N, V> {
 
 	/** Serializer for the values */

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/migration/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/migration/contrib/streaming/state/RocksDBStateBackend.java
@@ -18,8 +18,8 @@
 package org.apache.flink.migration.contrib.streaming.state;
 
 import org.apache.flink.api.common.state.ValueState;
-import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.migration.api.common.state.ValueStateDescriptor;
 import org.apache.flink.migration.runtime.state.AbstractStateBackend;
 import org.apache.flink.migration.runtime.state.KvStateSnapshot;
 import org.apache.flink.migration.runtime.state.StateHandle;

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/AggregatingStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/AggregatingStateDescriptor.java
@@ -36,11 +36,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <OUT> The type of the values that are returned from the state.
  */
 @PublicEvolving
-public class AggregatingStateDescriptor<IN, ACC, OUT> extends StateDescriptor<AggregatingState<IN, OUT>, ACC> {
+public class AggregatingStateDescriptor<IN, ACC, OUT> extends SimpleStateDescriptor<ACC, AggregatingState<IN, OUT>> {
 	private static final long serialVersionUID = 1L;
 
 	/** The aggregation function for the state */
 	private final AggregateFunction<IN, ACC, OUT> aggFunction;
+
+	// ------------------------------------------------------------------------
 
 	/**
 	 * Creates a new state descriptor with the given name, function, and type.
@@ -57,7 +59,7 @@ public class AggregatingStateDescriptor<IN, ACC, OUT> extends StateDescriptor<Ag
 			AggregateFunction<IN, ACC, OUT> aggFunction,
 			Class<ACC> stateType) {
 
-		super(name, stateType, null);
+		super(name, stateType);
 		this.aggFunction = checkNotNull(aggFunction);
 	}
 
@@ -73,7 +75,7 @@ public class AggregatingStateDescriptor<IN, ACC, OUT> extends StateDescriptor<Ag
 			AggregateFunction<IN, ACC, OUT> aggFunction,
 			TypeInformation<ACC> stateType) {
 
-		super(name, stateType, null);
+		super(name, stateType);
 		this.aggFunction = checkNotNull(aggFunction);
 	}
 
@@ -89,10 +91,12 @@ public class AggregatingStateDescriptor<IN, ACC, OUT> extends StateDescriptor<Ag
 			AggregateFunction<IN, ACC, OUT> aggFunction,
 			TypeSerializer<ACC> typeSerializer) {
 
-		super(name, typeSerializer, null);
+		super(name, typeSerializer);
 		this.aggFunction = checkNotNull(aggFunction);
 	}
 
+	// ------------------------------------------------------------------------
+	//  Aggregating State Descriptor
 	// ------------------------------------------------------------------------
 
 	@Override
@@ -113,6 +117,8 @@ public class AggregatingStateDescriptor<IN, ACC, OUT> extends StateDescriptor<Ag
 	}
 
 	// ------------------------------------------------------------------------
+	//  Standard Utils
+	// ------------------------------------------------------------------------
 
 	@Override
 	public boolean equals(Object o) {
@@ -121,7 +127,7 @@ public class AggregatingStateDescriptor<IN, ACC, OUT> extends StateDescriptor<Ag
 		}
 		else if (o != null && getClass() == o.getClass()) {
 			AggregatingStateDescriptor<?, ?, ?> that = (AggregatingStateDescriptor<?, ?, ?>) o;
-			return serializer.equals(that.serializer) && name.equals(that.name);
+			return name.equals(that.name) && simpleStateDescrEquals(that);
 		}
 		else {
 			return false;
@@ -130,7 +136,7 @@ public class AggregatingStateDescriptor<IN, ACC, OUT> extends StateDescriptor<Ag
 
 	@Override
 	public int hashCode() {
-		int result = serializer.hashCode();
+		int result = simpleStateDescrHashCode();
 		result = 31 * result + name.hashCode();
 		return result;
 	}
@@ -138,8 +144,8 @@ public class AggregatingStateDescriptor<IN, ACC, OUT> extends StateDescriptor<Ag
 	@Override
 	public String toString() {
 		return "AggregatingStateDescriptor{" +
-				"serializer=" + serializer +
-				", aggFunction=" + aggFunction +
+				"aggFunction=" + aggFunction +
+				", " + simpleStateDescrToString() +
 				'}';
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/SimpleStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/SimpleStateDescriptor.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Base class for the descriptors of simple states. Simple state have one value
+ * that they store for a key. The counterpart to simple states are states that have composite values.
+ *
+ * @param <T> The type of the value in the state.
+ * @param <S> The type of the created state.
+ */
+@PublicEvolving
+public abstract class SimpleStateDescriptor<T, S extends State> extends StateDescriptor<S> {
+
+	private static final long serialVersionUID = 1L;
+
+	/** The serializer for the type. May be eagerly initialized in the constructor,
+	 * or lazily once the type is serialized or an ExecutionConfig is provided. */
+	private TypeSerializer<T> typeSerializer;
+
+	/** The type information describing the value type. Only used to lazily create the serializer
+	 * and dropped during serialization */
+	private transient TypeInformation<T> typeInfo;
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Create a new {@code SimpleStateDescriptor} with the given name and the given type serializer.
+	 *
+	 * @param name The name of the {@code SimpleStateDescriptor}.
+	 * @param serializer The type serializer for the values in the state.
+	 */
+	protected SimpleStateDescriptor(String name, TypeSerializer<T> serializer) {
+		super(name);
+		this.typeSerializer = checkNotNull(serializer, "serializer must not be null");
+	}
+
+	/**
+	 * Create a new {@code SimpleStateDescriptor} with the given name and the given type information.
+	 *
+	 * @param name The name of the {@code SimpleStateDescriptor}.
+	 * @param typeInfo The type information for the values in the state.
+	 */
+	protected SimpleStateDescriptor(String name, TypeInformation<T> typeInfo) {
+		super(name);
+		this.typeInfo = checkNotNull(typeInfo, "type information must not be null");
+	}
+
+	/**
+	 * Create a new {@code StateDescriptor} with the given name and the given type information.
+	 *
+	 * <p>If this constructor fails (because it is not possible to describe the type via a class),
+	 * consider using the {@link #SimpleStateDescriptor(String, TypeInformation)} constructor.
+	 *
+	 * @param name The name of the {@code StateDescriptor}.
+	 * @param type The class of the type of values in the state.
+	 */
+	protected SimpleStateDescriptor(String name, Class<T> type) {
+		super(name);
+
+		checkNotNull(type, "type class must not be null");
+
+		try {
+			this.typeInfo = TypeExtractor.createTypeInfo(type);
+		} catch (Exception e) {
+			throw new IllegalArgumentException("Cannot create full type information based on the given class. " +
+					"If the type has generics, Flink needs to capture the generics. Please use constructor " +
+					"StateDescriptor(String name, TypeInformation<T> typeInfo) instead. You can create the" +
+					"TypeInformation via the 'TypeInformation.of(TypeHint)' method.", e);
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Serializers
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Returns the {@link TypeSerializer} that can be used to serialize the value in the state.
+	 * Note that the serializer may initialized lazily and is only guaranteed to exist after
+	 * calling {@link #initializeSerializerUnlessSet(ExecutionConfig)}.
+	 */
+	public TypeSerializer<T> getSerializer() {
+		checkState(typeSerializer != null, "serializer not yet initialized.");
+		return typeSerializer;
+	}
+
+	@Override
+	public boolean isSerializerInitialized() {
+		return typeSerializer != null;
+	}
+
+	@Override
+	public void initializeSerializerUnlessSet(ExecutionConfig executionConfig) {
+		if (typeSerializer == null) {
+			checkState(typeInfo != null, "Cannot initialize serializer after TypeInformation was dropped during serialization");
+			typeSerializer = typeInfo.createSerializer(executionConfig);
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  equals() / hashCode() / toString() helpers
+	// ------------------------------------------------------------------------
+
+	protected int simpleStateDescrHashCode() {
+		return typeSerializer != null ? typeSerializer.hashCode() : 123;
+	}
+
+	protected boolean simpleStateDescrEquals(SimpleStateDescriptor<?, ?> other) {
+		return this.typeSerializer == null ? other.typeSerializer == null :
+				(other.typeSerializer != null && this.typeSerializer.equals(other.typeSerializer));
+	}
+
+	protected String simpleStateDescrToString() {
+		return "serializer=" + String.valueOf(typeSerializer); 
+	}
+
+	// ------------------------------------------------------------------------
+	//  Serialization
+	// ------------------------------------------------------------------------
+
+	private void writeObject(final ObjectOutputStream out) throws IOException {
+		// make sure we have a serializer before the type information gets lost
+		// TODO this is the source of loss of type tags in some user programs that create
+		// TODO  the type descriptors on the client side
+		initializeSerializerUnlessSet(new ExecutionConfig());
+
+		// write all the non-transient fields
+		out.defaultWriteObject();
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/State.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/State.java
@@ -21,12 +21,17 @@ package org.apache.flink.api.common.state;
 import org.apache.flink.annotation.PublicEvolving;
 
 /**
- * Interface that different types of partitioned state must implement.
+ * Base interface for all types of <i>keyed state</i> must implement. Sub-classes of this
+ * interface define the specific type and behavior of the state, for example
+ * {@link ValueState} or {@link ListState}.
  *
- * <p>The state is only accessible by functions applied on a KeyedDataStream. The key is
- * automatically supplied by the system, so the function always sees the value mapped to the
+ * <p>Keyed  state is only accessible by functions applied on a {@code KeyedDataStream}, which
+ * is the result of a {@code DataStream.keyBy()} operation.
+ * 
+ * <p>The key is automatically supplied by the system, so the function always sees the value mapped to the
  * key of the current element. That way, the system can handle stream and state partitioning
- * consistently together.
+ * consistently together, making state accesses local and allowing the system to transparently
+ * re-shard the state when changing the parallelism of the operation that works with the state. 
  */
 @PublicEvolving
 public interface State {

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
@@ -20,34 +20,29 @@ package org.apache.flink.api.common.state;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.typeutils.TypeExtractor;
-import org.apache.flink.core.memory.DataInputViewStreamWrapper;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.util.Preconditions;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
 import static java.util.Objects.requireNonNull;
 
 /**
- * Base class for state descriptors. A {@code StateDescriptor} is used for creating partitioned
- * {@link State} in stateful operations. This contains the name and can create an actual state
- * object given a {@link StateBackend} using {@link #bind(StateBackend)}.
- *
+ * Base class for state descriptors. A {@code StateDescriptor} is used for creating
+ * {@link State keyed state} in stateful operations. The descriptor contains the name of the state,
+ * the serializer to persist the state type, and the configuration that defines the state
+ * as queryable.
+ * 
+ * <h3>Implementation notes</h3>
+ * 
+ * The actual state object is created given a {@link StateBackend} using the 
+ * {@link StateDescriptor#bind(StateBackend)} method.
+ * 
  * <p>Subclasses must correctly implement {@link #equals(Object)} and {@link #hashCode()}.
  *
  * @param <S> The type of the State objects created from this {@code StateDescriptor}.
- * @param <T> The type of the value of the state object described by this state descriptor.
  */
 @PublicEvolving
-public abstract class StateDescriptor<S extends State, T> implements Serializable {
+public abstract class StateDescriptor<S extends State> implements Serializable {
 
 	/**
 	 * An enumeration of the types of supported states. Used to identify the state type
@@ -65,19 +60,8 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	/** Name that uniquely identifies state created from this StateDescriptor. */
 	protected final String name;
 
-	/** The serializer for the type. May be eagerly initialized in the constructor,
-	 * or lazily once the type is serialized or an ExecutionConfig is provided. */
-	protected TypeSerializer<T> serializer;
-
 	/** Name for queries against state created from this StateDescriptor. */
 	private String queryableStateName;
-
-	/** The default value returned by the state when no other value is bound to a key */
-	protected transient T defaultValue;
-
-	/** The type information describing the value type. Only used to lazily create the serializer
-	 * and dropped during serialization */
-	private transient TypeInformation<T> typeInfo;
 
 	// ------------------------------------------------------------------------
 
@@ -85,54 +69,13 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	 * Create a new {@code StateDescriptor} with the given name and the given type serializer.
 	 *
 	 * @param name The name of the {@code StateDescriptor}.
-	 * @param serializer The type serializer for the values in the state.
-	 * @param defaultValue The default value that will be set when requesting state without setting
-	 *                     a value before.
 	 */
-	protected StateDescriptor(String name, TypeSerializer<T> serializer, T defaultValue) {
+	protected StateDescriptor(String name) {
 		this.name = requireNonNull(name, "name must not be null");
-		this.serializer = requireNonNull(serializer, "serializer must not be null");
-		this.defaultValue = defaultValue;
 	}
 
-	/**
-	 * Create a new {@code StateDescriptor} with the given name and the given type information.
-	 *
-	 * @param name The name of the {@code StateDescriptor}.
-	 * @param typeInfo The type information for the values in the state.
-	 * @param defaultValue The default value that will be set when requesting state without setting
-	 *                     a value before.   
-	 */
-	protected StateDescriptor(String name, TypeInformation<T> typeInfo, T defaultValue) {
-		this.name = requireNonNull(name, "name must not be null");
-		this.typeInfo = requireNonNull(typeInfo, "type information must not be null");
-		this.defaultValue = defaultValue;
-	}
-
-	/**
-	 * Create a new {@code StateDescriptor} with the given name and the given type information.
-	 *
-	 * <p>If this constructor fails (because it is not possible to describe the type via a class),
-	 * consider using the {@link #StateDescriptor(String, TypeInformation, Object)} constructor.
-	 *
-	 * @param name The name of the {@code StateDescriptor}.
-	 * @param type The class of the type of values in the state.
-	 * @param defaultValue The default value that will be set when requesting state without setting
-	 *                     a value before.   
-	 */
-	protected StateDescriptor(String name, Class<T> type, T defaultValue) {
-		this.name = requireNonNull(name, "name must not be null");
-		requireNonNull(type, "type class must not be null");
-
-		try {
-			this.typeInfo = TypeExtractor.createTypeInfo(type);
-		} catch (Exception e) {
-			throw new RuntimeException("Cannot create full type information based on the given class. If the type has generics, please", e);
-		}
-
-		this.defaultValue = defaultValue;
-	}
-
+	// ------------------------------------------------------------------------
+	//  Core State Descriptor Methods 
 	// ------------------------------------------------------------------------
 
 	/**
@@ -143,32 +86,21 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	}
 
 	/**
-	 * Returns the default value.
+	 * Gets the type of the state represented by this descriptor.
+	 * @return The state's type
 	 */
-	public T getDefaultValue() {
-		if (defaultValue != null) {
-			if (serializer != null) {
-				return serializer.copy(defaultValue);
-			} else {
-				throw new IllegalStateException("Serializer not yet initialized.");
-			}
-		} else {
-			return null;
-		}
-	}
+	public abstract Type getType();
 
 	/**
-	 * Returns the {@link TypeSerializer} that can be used to serialize the value in the state.
-	 * Note that the serializer may initialized lazily and is only guaranteed to exist after
-	 * calling {@link #initializeSerializerUnlessSet(ExecutionConfig)}.
+	 * Creates a new {@link State} on the given {@link StateBackend}.
+	 *
+	 * @param stateBackend The {@code StateBackend} on which to create the {@link State}.
 	 */
-	public TypeSerializer<T> getSerializer() {
-		if (serializer != null) {
-			return serializer;
-		} else {
-			throw new IllegalStateException("Serializer not yet initialized.");
-		}
-	}
+	public abstract S bind(StateBackend stateBackend) throws Exception;
+
+	// ------------------------------------------------------------------------
+	//  Queryable State Options
+	// ------------------------------------------------------------------------
 
 	/**
 	 * Sets the name for queries of state created from this descriptor.
@@ -207,13 +139,8 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 		return queryableStateName != null;
 	}
 
-	/**
-	 * Creates a new {@link State} on the given {@link StateBackend}.
-	 *
-	 * @param stateBackend The {@code StateBackend} on which to create the {@link State}.
-	 */
-	public abstract S bind(StateBackend stateBackend) throws Exception;
-
+	// ------------------------------------------------------------------------
+	//  Serializer initialization
 	// ------------------------------------------------------------------------
 
 	/**
@@ -223,41 +150,14 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	 *
 	 * @return True if the serializers have been initialized, false otherwise.
 	 */
-	public boolean isSerializerInitialized() {
-		return serializer != null;
-	}
+	public abstract boolean isSerializerInitialized();
 
 	/**
 	 * Initializes the serializer, unless it has been initialized before.
 	 *
 	 * @param executionConfig The execution config to use when creating the serializer.
 	 */
-	public void initializeSerializerUnlessSet(ExecutionConfig executionConfig) {
-		if (serializer == null) {
-			if (typeInfo != null) {
-				serializer = typeInfo.createSerializer(executionConfig);
-			} else {
-				throw new IllegalStateException(
-						"Cannot initialize serializer after TypeInformation was dropped during serialization");
-			}
-		}
-	}
-
-	/**
-	 * This method should be called by subclasses prior to serialization. Because the TypeInformation is
-	 * not always serializable, it is 'transient' and dropped during serialization. Hence, the descriptor
-	 * needs to make sure that the serializer is created before the TypeInformation is dropped. 
-	 */
-	private void ensureSerializerCreated() {
-		if (serializer == null) {
-			if (typeInfo != null) {
-				serializer = typeInfo.createSerializer(new ExecutionConfig());
-			} else {
-				throw new IllegalStateException(
-						"Cannot initialize serializer after TypeInformation was dropped during serialization");
-			}
-		}
-	}
+	public abstract void initializeSerializerUnlessSet(ExecutionConfig executionConfig);
 
 	// ------------------------------------------------------------------------
 	//  Standard Utils
@@ -270,79 +170,5 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	public abstract boolean equals(Object o);
 
 	@Override
-	public String toString() {
-		return getClass().getSimpleName() +
-				"{name=" + name +
-				", defaultValue=" + defaultValue +
-				", serializer=" + serializer +
-				(isQueryable() ? ", queryableStateName=" + queryableStateName + "" : "") +
-				'}';
-	}
-
-	public abstract Type getType();
-
-	// ------------------------------------------------------------------------
-	//  Serialization
-	// ------------------------------------------------------------------------
-
-	private void writeObject(final ObjectOutputStream out) throws IOException {
-		// make sure we have a serializer before the type information gets lost
-		ensureSerializerCreated();
-
-		// write all the non-transient fields
-		out.defaultWriteObject();
-
-		// write the non-serializable default value field
-		if (defaultValue == null) {
-			// we don't have a default value
-			out.writeBoolean(false);
-		} else {
-			// we have a default value
-			out.writeBoolean(true);
-
-			byte[] serializedDefaultValue;
-			try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-					DataOutputViewStreamWrapper outView = new DataOutputViewStreamWrapper(baos))
-			{
-				TypeSerializer<T> duplicateSerializer = serializer.duplicate();
-				duplicateSerializer.serialize(defaultValue, outView);
-
-				outView.flush();
-				serializedDefaultValue = baos.toByteArray();
-			}
-			catch (Exception e) {
-				throw new IOException("Unable to serialize default value of type " +
-						defaultValue.getClass().getSimpleName() + ".", e);
-			}
-
-			out.writeInt(serializedDefaultValue.length);
-			out.write(serializedDefaultValue);
-		}
-	}
-
-	private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
-		// read the non-transient fields
-		in.defaultReadObject();
-
-		// read the default value field
-		boolean hasDefaultValue = in.readBoolean();
-		if (hasDefaultValue) {
-			int size = in.readInt();
-
-			byte[] buffer = new byte[size];
-
-			in.readFully(buffer);
-
-			try (ByteArrayInputStream bais = new ByteArrayInputStream(buffer);
-					DataInputViewStreamWrapper inView = new DataInputViewStreamWrapper(bais))
-			{
-				defaultValue = serializer.deserialize(inView);
-			}
-			catch (Exception e) {
-				throw new IOException("Unable to deserialize default value.", e);
-			}
-		} else {
-			defaultValue = null;
-		}
-	}
+	public abstract String toString();
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ValueStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ValueStateDescriptor.java
@@ -21,9 +21,17 @@ package org.apache.flink.api.common.state;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 /**
- * {@link StateDescriptor} for {@link ValueState}. This can be used to create partitioned
+ * A {@link StateDescriptor} for {@link ValueState}. This can be used to create keyed
  * value state using
  * {@link org.apache.flink.api.common.functions.RuntimeContext#getState(ValueStateDescriptor)}.
  *
@@ -33,9 +41,14 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
  * @param <T> The type of the values that the value state can hold.
  */
 @PublicEvolving
-public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
+public class ValueStateDescriptor<T> extends SimpleStateDescriptor<T, ValueState<T>> {
 	private static final long serialVersionUID = 1L;
-	
+
+	/** The default value returned by the state when no other value is bound to a key */
+	protected transient T defaultValue;
+
+	// ------------------------------------------------------------------------
+
 	/**
 	 * Creates a new {@code ValueStateDescriptor} with the given name, type, and default value.
 	 * 
@@ -52,7 +65,9 @@ public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
 	 */
 	@Deprecated
 	public ValueStateDescriptor(String name, Class<T> typeClass, T defaultValue) {
-		super(name, typeClass, defaultValue);
+		super(name, typeClass);
+
+		this.defaultValue = defaultValue;
 	}
 
 	/**
@@ -68,7 +83,9 @@ public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
 	 */
 	@Deprecated
 	public ValueStateDescriptor(String name, TypeInformation<T> typeInfo, T defaultValue) {
-		super(name, typeInfo, defaultValue);
+		super(name, typeInfo);
+
+		this.defaultValue = defaultValue;
 	}
 
 	/**
@@ -85,7 +102,9 @@ public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
 	 */
 	@Deprecated
 	public ValueStateDescriptor(String name, TypeSerializer<T> typeSerializer, T defaultValue) {
-		super(name, typeSerializer, defaultValue);
+		super(name, typeSerializer);
+
+		this.defaultValue = defaultValue;
 	}
 
 	/**
@@ -98,7 +117,7 @@ public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
 	 * @param typeClass The type of the values in the state.
 	 */
 	public ValueStateDescriptor(String name, Class<T> typeClass) {
-		super(name, typeClass, null);
+		super(name, typeClass);
 	}
 
 	/**
@@ -108,7 +127,7 @@ public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
 	 * @param typeInfo The type of the values in the state.
 	 */
 	public ValueStateDescriptor(String name, TypeInformation<T> typeInfo) {
-		super(name, typeInfo, null);
+		super(name, typeInfo);
 	}
 
 	/**
@@ -118,15 +137,38 @@ public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
 	 * @param typeSerializer The type serializer of the values in the state.
 	 */
 	public ValueStateDescriptor(String name, TypeSerializer<T> typeSerializer) {
-		super(name, typeSerializer, null);
+		super(name, typeSerializer);
 	}
 
 	// ------------------------------------------------------------------------
-	
+	//  Value State Descriptor
+	// ------------------------------------------------------------------------
+
+	@Override
+	public Type getType() {
+		return Type.VALUE;
+	}
+
 	@Override
 	public ValueState<T> bind(StateBackend stateBackend) throws Exception {
 		return stateBackend.createValueState(this);
 	}
+
+	/**
+	 * Returns the default value.
+	 */
+	public T getDefaultValue() {
+		if (defaultValue == null) {
+			return null;
+		}
+		else {
+			return getSerializer().copy(defaultValue);
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Standard Utils
+	// ------------------------------------------------------------------------
 
 	@Override
 	public boolean equals(Object o) {
@@ -138,14 +180,13 @@ public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
 		}
 
 		ValueStateDescriptor<?> that = (ValueStateDescriptor<?>) o;
-
-		return serializer.equals(that.serializer) && name.equals(that.name);
+		return name.equals(that.name) && simpleStateDescrEquals(that);
 
 	}
 
 	@Override
 	public int hashCode() {
-		int result = serializer.hashCode();
+		int result = simpleStateDescrHashCode();
 		result = 31 * result + name.hashCode();
 		return result;
 	}
@@ -155,12 +196,71 @@ public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
 		return "ValueStateDescriptor{" +
 				"name=" + name +
 				", defaultValue=" + defaultValue +
-				", serializer=" + serializer +
+				", " + simpleStateDescrToString() +
 				'}';
 	}
 
-	@Override
-	public Type getType() {
-		return Type.VALUE;
+	// ------------------------------------------------------------------------
+	//  Serialization
+	// ------------------------------------------------------------------------
+
+	private void writeObject(final ObjectOutputStream out) throws IOException {
+		out.defaultWriteObject();
+
+		// write the non-serializable default value field
+		if (defaultValue == null) {
+			// we don't have a default value
+			out.writeBoolean(false);
+		} else {
+			// we have a default value
+			out.writeBoolean(true);
+
+			byte[] serializedDefaultValue;
+			try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+				DataOutputViewStreamWrapper outView = new DataOutputViewStreamWrapper(baos))
+			{
+				// we duplicate the type serializer here, because the serializers may be asynchronously
+				// serialized into asynchronous snapshots
+				// Note: as of Flink 1.2, only the serializers are written, but not the entire state
+				// descriptors any more, so we may be safe do drop this?
+				TypeSerializer<T> duplicateSerializer = getSerializer().duplicate();
+				duplicateSerializer.serialize(defaultValue, outView);
+
+				outView.flush();
+				serializedDefaultValue = baos.toByteArray();
+			}
+			catch (Exception e) {
+				throw new IOException("Unable to serialize default value of type " +
+					defaultValue.getClass().getSimpleName() + ".", e);
+			}
+
+			out.writeInt(serializedDefaultValue.length);
+			out.write(serializedDefaultValue);
+		}
+	}
+
+	private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+		in.defaultReadObject();
+		
+		// read the default value field
+		boolean hasDefaultValue = in.readBoolean();
+		if (hasDefaultValue) {
+			int size = in.readInt();
+
+			byte[] buffer = new byte[size];
+
+			in.readFully(buffer);
+
+			try (ByteArrayInputStream bais = new ByteArrayInputStream(buffer);
+				DataInputViewStreamWrapper inView = new DataInputViewStreamWrapper(bais))
+			{
+				defaultValue = getSerializer().deserialize(inView);
+			}
+			catch (Exception e) {
+				throw new IOException("Unable to deserialize default value.", e);
+			}
+		} else {
+			defaultValue = null;
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/FoldingStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/FoldingStateDescriptor.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.migration.api.common.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.FoldFunction;
+import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.api.common.state.FoldingState;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Migration class present only to support resuming old savepoints that contained java-serialized data.
+ */
+@Internal
+@Deprecated
+public class FoldingStateDescriptor<T, ACC> extends org.apache.flink.migration.api.common.state.StateDescriptor<FoldingState<T, ACC>, ACC> {
+	private static final long serialVersionUID = 1L;
+
+
+	private final FoldFunction<T, ACC> foldFunction;
+
+	/**
+	 * Creates a new {@code FoldingStateDescriptor} with the given name, type, and initial value.
+	 *
+	 * <p>If this constructor fails (because it is not possible to describe the type via a class),
+	 * consider using the {@link #FoldingStateDescriptor(String, ACC, FoldFunction, TypeInformation)} constructor.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param initialValue The initial value of the fold.
+	 * @param foldFunction The {@code FoldFunction} used to aggregate the state.
+	 * @param typeClass The type of the values in the state.
+	 */
+	public FoldingStateDescriptor(String name, ACC initialValue, FoldFunction<T, ACC> foldFunction, Class<ACC> typeClass) {
+		super(name, typeClass, initialValue);
+		this.foldFunction = requireNonNull(foldFunction);
+
+		if (foldFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("FoldFunction of FoldingState can not be a RichFunction.");
+		}
+	}
+
+	/**
+	 * Creates a new {@code FoldingStateDescriptor} with the given name and default value.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param initialValue The initial value of the fold.
+	 * @param foldFunction The {@code FoldFunction} used to aggregate the state.
+	 * @param typeInfo The type of the values in the state.
+	 */
+	public FoldingStateDescriptor(String name, ACC initialValue, FoldFunction<T, ACC> foldFunction, TypeInformation<ACC> typeInfo) {
+		super(name, typeInfo, initialValue);
+		this.foldFunction = requireNonNull(foldFunction);
+
+		if (foldFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("FoldFunction of FoldingState can not be a RichFunction.");
+		}
+	}
+
+	/**
+	 * Creates a new {@code ValueStateDescriptor} with the given name and default value.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param initialValue The initial value of the fold.
+	 * @param foldFunction The {@code FoldFunction} used to aggregate the state.
+	 * @param typeSerializer The type serializer of the values in the state.
+	 */
+	public FoldingStateDescriptor(String name, ACC initialValue, FoldFunction<T, ACC> foldFunction, TypeSerializer<ACC> typeSerializer) {
+		super(name, typeSerializer, initialValue);
+		this.foldFunction = requireNonNull(foldFunction);
+
+		if (foldFunction instanceof RichFunction) {
+			throw new UnsupportedOperationException("FoldFunction of FoldingState can not be a RichFunction.");
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public FoldingState<T, ACC> bind(StateBackend stateBackend) throws Exception {
+		return stateBackend.createFoldingState(this);
+	}
+
+	/**
+	 * Returns the fold function to be used for the folding state.
+	 */
+	public FoldFunction<T, ACC> getFoldFunction() {
+		return foldFunction;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		FoldingStateDescriptor<?, ?> that = (FoldingStateDescriptor<?, ?>) o;
+
+		return serializer.equals(that.serializer) && name.equals(that.name);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = serializer.hashCode();
+		result = 31 * result + name.hashCode();
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "FoldingStateDescriptor{" +
+				"serializer=" + serializer +
+				", initialValue=" + defaultValue +
+				", foldFunction=" + foldFunction +
+				'}';
+	}
+
+	@Override
+	public org.apache.flink.api.common.state.StateDescriptor.Type getType() {
+		return org.apache.flink.api.common.state.StateDescriptor.Type.FOLDING;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/StateBackend.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.migration.api.common.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.FoldingState;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ValueState;
+
+/**
+ * Migration class present only to support resuming old savepoints that contained java-serialized data.
+ */
+@Internal
+@Deprecated
+public interface StateBackend {
+
+	/**
+	 * Creates and returns a new {@link ValueState}.
+	 * @param stateDesc The {@code StateDescriptor} that contains the name of the state.
+	 *
+	 * @param <T> The type of the value that the {@code ValueState} can store.
+	 */
+	<T> ValueState<T> createValueState(ValueStateDescriptor<T> stateDesc) throws Exception;
+
+	/**
+	 * Creates and returns a new {@link ListState}.
+	 * @param stateDesc The {@code StateDescriptor} that contains the name of the state.
+	 *
+	 * @param <T> The type of the values that the {@code ListState} can store.
+	 */
+	<T> ListState<T> createListState(ListStateDescriptor<T> stateDesc) throws Exception;
+
+	/**
+	 * Creates and returns a new {@link ReducingState}.
+	 * @param stateDesc The {@code StateDescriptor} that contains the name of the state.
+	 *
+	 * @param <T> The type of the values that the {@code ListState} can store.
+	 */
+	<T> ReducingState<T> createReducingState(ReducingStateDescriptor<T> stateDesc) throws Exception;
+
+	/**
+	 * Creates and returns a new {@link FoldingState}.
+	 * @param stateDesc The {@code StateDescriptor} that contains the name of the state.
+	 *
+	 * @param <T> Type of the values folded into the state
+	 * @param <ACC> Type of the value in the state
+	 */
+	<T, ACC> FoldingState<T, ACC> createFoldingState(FoldingStateDescriptor<T, ACC> stateDesc) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/StateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/StateDescriptor.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.migration.api.common.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.util.Preconditions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Migration class present only to support resuming old savepoints that contained java-serialized data.
+ */
+@Internal
+@Deprecated
+public abstract class StateDescriptor<S extends State, T> implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/** Name that uniquely identifies state created from this StateDescriptor. */
+	protected final String name;
+
+	/** The serializer for the type. May be eagerly initialized in the constructor,
+	 * or lazily once the type is serialized or an ExecutionConfig is provided. */
+	protected TypeSerializer<T> serializer;
+
+	/** Name for queries against state created from this StateDescriptor. */
+	private String queryableStateName;
+
+	/** The default value returned by the state when no other value is bound to a key */
+	protected transient T defaultValue;
+
+	/** The type information describing the value type. Only used to lazily create the serializer
+	 * and dropped during serialization */
+	private transient TypeInformation<T> typeInfo;
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Create a new {@code StateDescriptor} with the given name and the given type serializer.
+	 *
+	 * @param name The name of the {@code StateDescriptor}.
+	 * @param serializer The type serializer for the values in the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting
+	 *                     a value before.
+	 */
+	protected StateDescriptor(String name, TypeSerializer<T> serializer, T defaultValue) {
+		this.name = requireNonNull(name, "name must not be null");
+		this.serializer = requireNonNull(serializer, "serializer must not be null");
+		this.defaultValue = defaultValue;
+	}
+
+	/**
+	 * Create a new {@code StateDescriptor} with the given name and the given type information.
+	 *
+	 * @param name The name of the {@code StateDescriptor}.
+	 * @param typeInfo The type information for the values in the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting
+	 *                     a value before.
+	 */
+	protected StateDescriptor(String name, TypeInformation<T> typeInfo, T defaultValue) {
+		this.name = requireNonNull(name, "name must not be null");
+		this.typeInfo = requireNonNull(typeInfo, "type information must not be null");
+		this.defaultValue = defaultValue;
+	}
+
+	/**
+	 * Create a new {@code StateDescriptor} with the given name and the given type information.
+	 *
+	 * <p>If this constructor fails (because it is not possible to describe the type via a class),
+	 * consider using the {@link #StateDescriptor(String, TypeInformation, Object)} constructor.
+	 *
+	 * @param name The name of the {@code StateDescriptor}.
+	 * @param type The class of the type of values in the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting
+	 *                     a value before.
+	 */
+	protected StateDescriptor(String name, Class<T> type, T defaultValue) {
+		this.name = requireNonNull(name, "name must not be null");
+		requireNonNull(type, "type class must not be null");
+
+		try {
+			this.typeInfo = TypeExtractor.createTypeInfo(type);
+		} catch (Exception e) {
+			throw new RuntimeException("Cannot create full type information based on the given class. If the type has generics, please", e);
+		}
+
+		this.defaultValue = defaultValue;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Returns the name of this {@code StateDescriptor}.
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Returns the default value.
+	 */
+	public T getDefaultValue() {
+		if (defaultValue != null) {
+			if (serializer != null) {
+				return serializer.copy(defaultValue);
+			} else {
+				throw new IllegalStateException("Serializer not yet initialized.");
+			}
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns the {@link TypeSerializer} that can be used to serialize the value in the state.
+	 * Note that the serializer may initialized lazily and is only guaranteed to exist after
+	 * calling {@link #initializeSerializerUnlessSet(ExecutionConfig)}.
+	 */
+	public TypeSerializer<T> getSerializer() {
+		if (serializer != null) {
+			return serializer;
+		} else {
+			throw new IllegalStateException("Serializer not yet initialized.");
+		}
+	}
+
+	/**
+	 * Sets the name for queries of state created from this descriptor.
+	 *
+	 * <p>If a name is set, the created state will be published for queries
+	 * during runtime. The name needs to be unique per job. If there is another
+	 * state instance published under the same name, the job will fail during runtime.
+	 *
+	 * @param queryableStateName State name for queries (unique name per job)
+	 * @throws IllegalStateException If queryable state name already set
+	 */
+	public void setQueryable(String queryableStateName) {
+		if (this.queryableStateName == null) {
+			this.queryableStateName = Preconditions.checkNotNull(queryableStateName, "Registration name");
+		} else {
+			throw new IllegalStateException("Queryable state name already set");
+		}
+	}
+
+	/**
+	 * Returns the queryable state name.
+	 *
+	 * @return Queryable state name or <code>null</code> if not set.
+	 */
+	public String getQueryableStateName() {
+		return queryableStateName;
+	}
+
+	/**
+	 * Returns whether the state created from this descriptor is queryable.
+	 *
+	 * @return <code>true</code> if state is queryable, <code>false</code>
+	 * otherwise.
+	 */
+	public boolean isQueryable() {
+		return queryableStateName != null;
+	}
+
+	/**
+	 * Creates a new {@link State} on the given {@link StateBackend}.
+	 *
+	 * @param stateBackend The {@code StateBackend} on which to create the {@link State}.
+	 */
+	public abstract S bind(StateBackend stateBackend) throws Exception;
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Checks whether the serializer has been initialized. Serializer initialization is lazy,
+	 * to allow parametrization of serializers with an {@link ExecutionConfig} via
+	 * {@link #initializeSerializerUnlessSet(ExecutionConfig)}.
+	 *
+	 * @return True if the serializers have been initialized, false otherwise.
+	 */
+	public boolean isSerializerInitialized() {
+		return serializer != null;
+	}
+
+	/**
+	 * Initializes the serializer, unless it has been initialized before.
+	 *
+	 * @param executionConfig The execution config to use when creating the serializer.
+	 */
+	public void initializeSerializerUnlessSet(ExecutionConfig executionConfig) {
+		if (serializer == null) {
+			if (typeInfo != null) {
+				serializer = typeInfo.createSerializer(executionConfig);
+			} else {
+				throw new IllegalStateException(
+						"Cannot initialize serializer after TypeInformation was dropped during serialization");
+			}
+		}
+	}
+
+	/**
+	 * This method should be called by subclasses prior to serialization. Because the TypeInformation is
+	 * not always serializable, it is 'transient' and dropped during serialization. Hence, the descriptor
+	 * needs to make sure that the serializer is created before the TypeInformation is dropped.
+	 */
+	private void ensureSerializerCreated() {
+		if (serializer == null) {
+			if (typeInfo != null) {
+				serializer = typeInfo.createSerializer(new ExecutionConfig());
+			} else {
+				throw new IllegalStateException(
+						"Cannot initialize serializer after TypeInformation was dropped during serialization");
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Standard Utils
+	// ------------------------------------------------------------------------
+
+	@Override
+	public abstract int hashCode();
+
+	@Override
+	public abstract boolean equals(Object o);
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() +
+				"{name=" + name +
+				", defaultValue=" + defaultValue +
+				", serializer=" + serializer +
+				(isQueryable() ? ", queryableStateName=" + queryableStateName + "" : "") +
+				'}';
+	}
+
+	public abstract org.apache.flink.api.common.state.StateDescriptor.Type getType();
+
+	// ------------------------------------------------------------------------
+	//  Serialization
+	// ------------------------------------------------------------------------
+
+	private void writeObject(final ObjectOutputStream out) throws IOException {
+		// make sure we have a serializer before the type information gets lost
+		ensureSerializerCreated();
+
+		// write all the non-transient fields
+		out.defaultWriteObject();
+
+		// write the non-serializable default value field
+		if (defaultValue == null) {
+			// we don't have a default value
+			out.writeBoolean(false);
+		} else {
+			// we have a default value
+			out.writeBoolean(true);
+
+			byte[] serializedDefaultValue;
+			try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+				DataOutputViewStreamWrapper outView = new DataOutputViewStreamWrapper(baos))
+			{
+				TypeSerializer<T> duplicateSerializer = serializer.duplicate();
+				duplicateSerializer.serialize(defaultValue, outView);
+
+				outView.flush();
+				serializedDefaultValue = baos.toByteArray();
+			}
+			catch (Exception e) {
+				throw new IOException("Unable to serialize default value of type " +
+						defaultValue.getClass().getSimpleName() + ".", e);
+			}
+
+			out.writeInt(serializedDefaultValue.length);
+			out.write(serializedDefaultValue);
+		}
+	}
+
+	private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+		// read the non-transient fields
+		in.defaultReadObject();
+
+		// read the default value field
+		boolean hasDefaultValue = in.readBoolean();
+		if (hasDefaultValue) {
+			int size = in.readInt();
+
+			byte[] buffer = new byte[size];
+
+			in.readFully(buffer);
+
+			try (ByteArrayInputStream bais = new ByteArrayInputStream(buffer);
+				DataInputViewStreamWrapper inView = new DataInputViewStreamWrapper(bais))
+			{
+				defaultValue = serializer.deserialize(inView);
+			}
+			catch (Exception e) {
+				throw new IOException("Unable to deserialize default value.", e);
+			}
+		} else {
+			defaultValue = null;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/ValueStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/ValueStateDescriptor.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.migration.api.common.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+/**
+ * Migration class present only to support resuming old savepoints that contained java-serialized data.
+ */
+@Internal
+@Deprecated
+public class ValueStateDescriptor<T> extends StateDescriptor<ValueState<T>, T> {
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Creates a new {@code ValueStateDescriptor} with the given name, type, and default value.
+	 *
+	 * <p>If this constructor fails (because it is not possible to describe the type via a class),
+	 * consider using the {@link #ValueStateDescriptor(String, TypeInformation, Object)} constructor.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param typeClass The type of the values in the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting
+	 *                     a value before.
+	 */
+	public ValueStateDescriptor(String name, Class<T> typeClass, T defaultValue) {
+		super(name, typeClass, defaultValue);
+	}
+
+	/**
+	 * Creates a new {@code ValueStateDescriptor} with the given name and default value.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param typeInfo The type of the values in the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting
+	 *                     a value before.
+	 */
+	public ValueStateDescriptor(String name, TypeInformation<T> typeInfo, T defaultValue) {
+		super(name, typeInfo, defaultValue);
+	}
+
+	/**
+	 * Creates a new {@code ValueStateDescriptor} with the given name, default value, and the specific
+	 * serializer.
+	 *
+	 * @param name The (unique) name for the state.
+	 * @param typeSerializer The type serializer of the values in the state.
+	 * @param defaultValue The default value that will be set when requesting state without setting
+	 *                     a value before.
+	 */
+	public ValueStateDescriptor(String name, TypeSerializer<T> typeSerializer, T defaultValue) {
+		super(name, typeSerializer, defaultValue);
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public ValueState<T> bind(StateBackend stateBackend) throws Exception {
+		return stateBackend.createValueState(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		ValueStateDescriptor<?> that = (ValueStateDescriptor<?>) o;
+
+		return serializer.equals(that.serializer) && name.equals(that.name);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = serializer.hashCode();
+		result = 31 * result + name.hashCode();
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "ValueStateDescriptor{" +
+				"name=" + name +
+				", defaultValue=" + defaultValue +
+				", serializer=" + serializer +
+				'}';
+	}
+
+	@Override
+	public org.apache.flink.api.common.state.StateDescriptor.Type getType() {
+		return org.apache.flink.api.common.state.StateDescriptor.Type.VALUE;
+	}
+}
+

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/KvStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/KvStateSnapshot.java
@@ -19,7 +19,7 @@
 package org.apache.flink.migration.runtime.state;
 
 import org.apache.flink.api.common.state.State;
-import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.migration.api.common.state.StateDescriptor;
 
 @Deprecated
 public interface KvStateSnapshot<K, N, S extends State, SD extends StateDescriptor<S, ?>>

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/AbstractFsStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/AbstractFsStateSnapshot.java
@@ -19,9 +19,9 @@
 package org.apache.flink.migration.runtime.state.filesystem;
 
 import org.apache.flink.api.common.state.State;
-import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.migration.api.common.state.StateDescriptor;
 import org.apache.flink.migration.runtime.state.KvStateSnapshot;
 
 import java.io.IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsFoldingState.java
@@ -19,9 +19,9 @@
 package org.apache.flink.migration.runtime.state.filesystem;
 
 import org.apache.flink.api.common.state.FoldingState;
-import org.apache.flink.api.common.state.FoldingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.migration.api.common.state.FoldingStateDescriptor;
 
 @Deprecated
 public class FsFoldingState<K, N, T, ACC> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsListState.java
@@ -19,9 +19,9 @@
 package org.apache.flink.migration.runtime.state.filesystem;
 
 import org.apache.flink.api.common.state.ListState;
-import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.migration.api.common.state.ListStateDescriptor;
 
 import java.util.ArrayList;
 

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsReducingState.java
@@ -19,9 +19,9 @@
 package org.apache.flink.migration.runtime.state.filesystem;
 
 import org.apache.flink.api.common.state.ReducingState;
-import org.apache.flink.api.common.state.ReducingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.migration.api.common.state.ReducingStateDescriptor;
 
 @Deprecated
 public class FsReducingState<K, N, V> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsValueState.java
@@ -19,9 +19,9 @@
 package org.apache.flink.migration.runtime.state.filesystem;
 
 import org.apache.flink.api.common.state.ValueState;
-import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.migration.api.common.state.ValueStateDescriptor;
 
 @Deprecated
 public class FsValueState<K, N, V> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/AbstractMemStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/AbstractMemStateSnapshot.java
@@ -19,8 +19,8 @@
 package org.apache.flink.migration.runtime.state.memory;
 
 import org.apache.flink.api.common.state.State;
-import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.migration.api.common.state.StateDescriptor;
 import org.apache.flink.migration.runtime.state.KvStateSnapshot;
 import org.apache.flink.runtime.util.DataInputDeserializer;
 

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemFoldingState.java
@@ -19,8 +19,8 @@
 package org.apache.flink.migration.runtime.state.memory;
 
 import org.apache.flink.api.common.state.FoldingState;
-import org.apache.flink.api.common.state.FoldingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.migration.api.common.state.FoldingStateDescriptor;
 
 @Deprecated
 public class MemFoldingState<K, N, T, ACC> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemListState.java
@@ -19,8 +19,8 @@
 package org.apache.flink.migration.runtime.state.memory;
 
 import org.apache.flink.api.common.state.ListState;
-import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.migration.api.common.state.ListStateDescriptor;
 
 import java.util.ArrayList;
 

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemReducingState.java
@@ -19,8 +19,8 @@
 package org.apache.flink.migration.runtime.state.memory;
 
 import org.apache.flink.api.common.state.ReducingState;
-import org.apache.flink.api.common.state.ReducingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.migration.api.common.state.ReducingStateDescriptor;
 
 /**
  * Heap-backed partitioned {@link ReducingState} that is

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemValueState.java
@@ -19,8 +19,8 @@
 package org.apache.flink.migration.runtime.state.memory;
 
 import org.apache.flink.api.common.state.ValueState;
-import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.migration.api.common.state.ValueStateDescriptor;
 
 /**
  * Heap-backed key/value state that is snapshotted into a serialized memory copy.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -242,7 +242,7 @@ public abstract class AbstractKeyedStateBackend<K>
 	@Override
 	public <N, S extends State, V> S getOrCreateKeyedState(
 			final TypeSerializer<N> namespaceSerializer,
-			StateDescriptor<S, V> stateDescriptor) throws Exception {
+			StateDescriptor<S> stateDescriptor) throws Exception {
 
 		checkNotNull(namespaceSerializer, "Namespace serializer");
 
@@ -323,7 +323,7 @@ public abstract class AbstractKeyedStateBackend<K>
 	public <N, S extends State> S getPartitionedState(
 			final N namespace,
 			final TypeSerializer<N> namespaceSerializer,
-			final StateDescriptor<S, ?> stateDescriptor) throws Exception {
+			final StateDescriptor<S> stateDescriptor) throws Exception {
 
 		checkNotNull(namespace, "Namespace");
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultKeyedStateStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultKeyedStateStore.java
@@ -93,7 +93,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
 		}
 	}
 
-	private <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) throws Exception {
+	private <S extends State> S getPartitionedState(StateDescriptor<S> stateDescriptor) throws Exception {
 		return keyedStateBackend.getPartitionedState(
 				VoidNamespace.INSTANCE,
 				VoidNamespaceSerializer.INSTANCE,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -75,7 +75,7 @@ public interface KeyedStateBackend<K> {
 	 */
 	<N, S extends State, T> S getOrCreateKeyedState(
 			TypeSerializer<N> namespaceSerializer,
-			StateDescriptor<S, T> stateDescriptor) throws Exception;
+			StateDescriptor<S> stateDescriptor) throws Exception;
 
 	/**
 	 * Creates or retrieves a partitioned state backed by this state backend.
@@ -96,7 +96,7 @@ public interface KeyedStateBackend<K> {
 	<N, S extends State> S getPartitionedState(
 			N namespace,
 			TypeSerializer<N> namespaceSerializer,
-			StateDescriptor<S, ?> stateDescriptor) throws Exception;
+			StateDescriptor<S> stateDescriptor) throws Exception;
 
 	/**
 	 * Closes the backend and releases all resources.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapMergingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapMergingState.java
@@ -19,8 +19,8 @@
 package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.api.common.state.MergingState;
+import org.apache.flink.api.common.state.SimpleStateDescriptor;
 import org.apache.flink.api.common.state.State;
-import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.internal.InternalMergingState;
@@ -40,7 +40,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * @param <S> The type of State
  * @param <SD> The type of StateDescriptor for the State S
  */
-public abstract class AbstractHeapMergingState<K, N, IN, OUT, SV, S extends State, SD extends StateDescriptor<S, ?>>
+public abstract class AbstractHeapMergingState<K, N, IN, OUT, SV, S extends State, SD extends SimpleStateDescriptor<?, S>>
 		extends AbstractHeapState<K, N, SV, S, SD>
 		implements InternalMergingState<N, IN, OUT> {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapState.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.SimpleStateDescriptor;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -43,7 +44,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @param <S> The type of State
  * @param <SD> The type of StateDescriptor for the State S
  */
-public abstract class AbstractHeapState<K, N, SV, S extends State, SD extends StateDescriptor<S, ?>>
+public abstract class AbstractHeapState<K, N, SV, S extends State, SD extends SimpleStateDescriptor<?, S>>
 		implements InternalKvState<N> {
 
 	/** Map containing the actual key/value pairs */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
@@ -119,7 +119,7 @@ public class HeapFoldingState<K, N, T, ACC>
 
 			if (currentValue == null) {
 				keyedMap.put(backend.<K>getCurrentKey(),
-						foldFunction.fold(stateDesc.getDefaultValue(), value));
+						foldFunction.fold(stateDesc.getInitialValue(), value));
 			} else {
 				keyedMap.put(backend.<K>getCurrentKey(), foldFunction.fold(currentValue, value));
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.state.AggregatingStateDescriptor;
 import org.apache.flink.api.common.state.FoldingStateDescriptor;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.SimpleStateDescriptor;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -111,7 +112,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 	@SuppressWarnings("unchecked")
 	private <N, V> StateTable<K, N, V> tryRegisterStateTable(
-			TypeSerializer<N> namespaceSerializer, StateDescriptor<?, V> stateDesc) {
+			TypeSerializer<N> namespaceSerializer, SimpleStateDescriptor<V, ?> stateDesc) {
 
 		String name = stateDesc.getName();
 		StateTable<K, N, V> stateTable = (StateTable<K, N, V>) stateTables.get(name);
@@ -158,7 +159,8 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		StateTable<K, N, ArrayList<T>> stateTable = (StateTable<K, N, ArrayList<T>>) stateTables.get(name);
 
 		RegisteredBackendStateMetaInfo<N, ArrayList<T>> newMetaInfo =
-				new RegisteredBackendStateMetaInfo<>(stateDesc.getType(), name, namespaceSerializer, new ArrayListSerializer<>(stateDesc.getSerializer()));
+				new RegisteredBackendStateMetaInfo<>(stateDesc.getType(), name, namespaceSerializer, 
+						new ArrayListSerializer<>(stateDesc.getSerializer()));
 
 		stateTable = tryRegisterStateTable(stateTable, newMetaInfo);
 		return new HeapListState<>(this, stateDesc, stateTable, keySerializer, namespaceSerializer);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/MigrationV0ToV1Test.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/MigrationV0ToV1Test.java
@@ -18,12 +18,13 @@
 
 package org.apache.flink.runtime.checkpoint.savepoint;
 
-import org.apache.flink.api.common.state.ValueStateDescriptor;
+
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.migration.api.common.state.ValueStateDescriptor;
 import org.apache.flink.migration.runtime.checkpoint.savepoint.SavepointV0;
 import org.apache.flink.migration.runtime.checkpoint.savepoint.SavepointV0Serializer;
 import org.apache.flink.migration.runtime.state.KvStateSnapshot;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/AbstractQueryableStateOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/AbstractQueryableStateOperator.java
@@ -37,7 +37,7 @@ abstract class AbstractQueryableStateOperator<S extends State, IN>
 		implements OneInputStreamOperator<IN, IN> {
 
 	/** State descriptor for the queryable state instance. */
-	protected final StateDescriptor<? extends S, ?> stateDescriptor;
+	protected final StateDescriptor<? extends S> stateDescriptor;
 
 	/**
 	 * Name under which the queryable state is registered.
@@ -53,7 +53,7 @@ abstract class AbstractQueryableStateOperator<S extends State, IN>
 
 	public AbstractQueryableStateOperator(
 			String registrationName,
-			StateDescriptor<? extends S, ?> stateDescriptor) {
+			StateDescriptor<? extends S> stateDescriptor) {
 
 		this.registrationName = Preconditions.checkNotNull(registrationName, "Registration name");
 		this.stateDescriptor = Preconditions.checkNotNull(stateDescriptor, "State descriptor");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableAppendingStateOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableAppendingStateOperator.java
@@ -33,7 +33,7 @@ public class QueryableAppendingStateOperator<IN> extends AbstractQueryableStateO
 
 	public QueryableAppendingStateOperator(
 			String registrationName,
-			StateDescriptor<? extends AppendingState<IN, ?>, ?> stateDescriptor) {
+			StateDescriptor<? extends AppendingState<IN, ?>> stateDescriptor) {
 
 		super(registrationName, stateDescriptor);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableValueStateOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/QueryableValueStateOperator.java
@@ -33,7 +33,7 @@ public class QueryableValueStateOperator<IN> extends AbstractQueryableStateOpera
 
 	public QueryableValueStateOperator(
 			String registrationName,
-			StateDescriptor<ValueState<IN>, IN> stateDescriptor) {
+			StateDescriptor<ValueState<IN>> stateDescriptor) {
 
 		super(registrationName, stateDescriptor);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -538,14 +538,14 @@ public abstract class AbstractStreamOperator<OUT>
 	 * @throws IllegalStateException Thrown, if the key/value state was already initialized.
 	 * @throws Exception Thrown, if the state backend cannot create the key/value state.
 	 */
-	protected <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) throws Exception {
+	protected <S extends State> S getPartitionedState(StateDescriptor<S> stateDescriptor) throws Exception {
 		return getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
 	}
 
 
 	protected <N, S extends State, T> S getOrCreateKeyedState(
 			TypeSerializer<N> namespaceSerializer,
-			StateDescriptor<S, T> stateDescriptor) throws Exception {
+			StateDescriptor<S> stateDescriptor) throws Exception {
 
 		if (keyedStateStore != null) {
 			return keyedStateBackend.getOrCreateKeyedState(namespaceSerializer, stateDescriptor);
@@ -570,7 +570,7 @@ public abstract class AbstractStreamOperator<OUT>
 	protected <S extends State, N> S getPartitionedState(
 			N namespace,
 			TypeSerializer<N> namespaceSerializer,
-			StateDescriptor<S, ?> stateDescriptor) throws Exception {
+			StateDescriptor<S> stateDescriptor) throws Exception {
 
 		if (keyedStateStore != null) {
 			return keyedStateBackend.getPartitionedState(namespace, namespaceSerializer, stateDescriptor);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -137,7 +137,7 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
 		return keyedStateStore.getFoldingState(stateProperties);
 	}
 
-	private KeyedStateStore checkPreconditionsAndGetKeyedStateStore(StateDescriptor<?, ?> stateDescriptor) {
+	private KeyedStateStore checkPreconditionsAndGetKeyedStateStore(StateDescriptor<?> stateDescriptor) {
 		Preconditions.checkNotNull(stateDescriptor, "The state properties must not be null");
 		KeyedStateStore keyedStateStore = operator.getKeyedStateStore();
 		Preconditions.checkNotNull(keyedStateStore, "Keyed state can only be used on a 'keyed stream', i.e., after a 'keyBy()' operation.");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
@@ -184,7 +184,7 @@ public abstract class Trigger<T, W extends Window> implements Serializable {
 		 * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
 		 *                                       function (function is not part os a KeyedStream).
 		 */
-		<S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor);
+		<S extends State> S getPartitionedState(StateDescriptor<S> stateDescriptor);
 	
 		/**
 		 * Retrieves a {@link ValueState} object that can be used to interact with
@@ -231,6 +231,6 @@ public abstract class Trigger<T, W extends Window> implements Serializable {
 	 * {@link Trigger#onMerge(Window, OnMergeContext)}.
 	 */
 	public interface OnMergeContext extends TriggerContext {
-		<S extends MergingState<?, ?>> void mergePartitionedState(StateDescriptor<S, ?> stateDescriptor);
+		<S extends MergingState<?, ?>> void mergePartitionedState(StateDescriptor<S> stateDescriptor);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
@@ -67,7 +67,7 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window>
 
 	private final Evictor<? super IN, ? super W> evictor;
 
-	private final StateDescriptor<? extends ListState<StreamRecord<IN>>, ?> evictingWindowStateDescriptor;
+	private final StateDescriptor<? extends ListState<StreamRecord<IN>>> evictingWindowStateDescriptor;
 
 	// ------------------------------------------------------------------------
 	// the fields below are instantiated once the operator runs in the runtime
@@ -82,7 +82,7 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window>
 			TypeSerializer<W> windowSerializer,
 			KeySelector<IN, K> keySelector,
 			TypeSerializer<K> keySerializer,
-			StateDescriptor<? extends ListState<StreamRecord<IN>>, ?> windowStateDescriptor,
+			StateDescriptor<? extends ListState<StreamRecord<IN>>> windowStateDescriptor,
 			InternalWindowFunction<Iterable<IN>, OUT, K, W> windowFunction,
 			Trigger<? super IN, ? super W> trigger,
 			Evictor<? super IN, ? super W> evictor,
@@ -426,7 +426,7 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window>
 	@Override
 	@VisibleForTesting
 	@SuppressWarnings("unchecked, rawtypes")
-	public StateDescriptor<? extends AppendingState<IN, Iterable<IN>>, ?> getStateDescriptor() {
-		return (StateDescriptor<? extends AppendingState<IN, Iterable<IN>>, ?>) evictingWindowStateDescriptor;
+	public StateDescriptor<? extends AppendingState<IN, Iterable<IN>>> getStateDescriptor() {
+		return (StateDescriptor<? extends AppendingState<IN, Iterable<IN>>>) evictingWindowStateDescriptor;
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateDescriptorPassingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateDescriptorPassingTest.java
@@ -23,6 +23,7 @@ import com.esotericsoftware.kryo.serializers.JavaSerializer;
 
 import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.SimpleStateDescriptor;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -200,10 +201,10 @@ public class StateDescriptorPassingTest {
 	private void validateStateDescriptorConfigured(SingleOutputStreamOperator<?> result) {
 		OneInputTransformation<?, ?> transform = (OneInputTransformation<?, ?>) result.getTransformation();
 		WindowOperator<?, ?, ?, ?, ?> op = (WindowOperator<?, ?, ?, ?, ?>) transform.getOperator();
-		StateDescriptor<?, ?> descr = op.getStateDescriptor();
+		StateDescriptor<?> descr = op.getStateDescriptor();
 
 		// this would be the first statement to fail if state descriptors were not properly initialized
-		TypeSerializer<?> serializer = descr.getSerializer();
+		TypeSerializer<?> serializer = ((SimpleStateDescriptor<?, ?>) descr).getSerializer();
 		assertTrue(serializer instanceof KryoSerializer);
 
 		Kryo kryo = ((KryoSerializer<?>) serializer).getKryo();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TriggerTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TriggerTestHarness.java
@@ -321,7 +321,7 @@ public class TriggerTestHarness<T, W extends Window> {
 		}
 
 		@Override
-		public <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) {
+		public <S extends State> S getPartitionedState(StateDescriptor<S> stateDescriptor) {
 			try {
 				return stateBackend.getPartitionedState(window, windowSerializer, stateDescriptor);
 			} catch (Exception e) {
@@ -359,7 +359,7 @@ public class TriggerTestHarness<T, W extends Window> {
 		}
 
 		@Override
-		public <S extends MergingState<?, ?>> void mergePartitionedState(StateDescriptor<S, ?> stateDescriptor) {
+		public <S extends MergingState<?, ?>> void mergePartitionedState(StateDescriptor<S> stateDescriptor) {
 			try {
 				S rawState = stateBackend.getOrCreateKeyedState(windowSerializer, stateDescriptor);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorContractTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorContractTest.java
@@ -2301,7 +2301,7 @@ public class WindowOperatorContractTest extends TestLogger {
 			WindowAssigner<Integer, W> assigner,
 			Trigger<Integer, W> trigger,
 			long allowedLatenss,
-			StateDescriptor<? extends AppendingState<Integer, ACC>, ?> stateDescriptor,
+			StateDescriptor<? extends AppendingState<Integer, ACC>> stateDescriptor,
 			InternalWindowFunction<ACC, OUT, Integer, W> windowFunction) throws Exception {
 
 		KeySelector<Integer, Integer> keySelector = new KeySelector<Integer, Integer>() {


### PR DESCRIPTION
This is a refactored version of #2768 

This pull request splits the `StateDescriptor`:

  - Basic `StateDescriptor`: This only contains only the information
  - The `SimpleStateDescriptor` is the base of all currently used states and holds the information about a single serializer, for the state type.
  - This prepares for a future `CompositeStateDescriptor` that would have multiple serializers, such as for the upcoming `MapState`.

This is technically not API-breaking, since it only touches methods with `@PublicEvolving` annotations.
We should think carefully, though, because this may affect all users that use the state API on `RuntimeContext` and on the `TriggerContext` (in custom windows).
