### PR TITLE
[FLINK-3163] [scripts] Configure Flink for NUMA systems

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -72,6 +72,10 @@ without explicit scheme definition, such as `/user/USERNAME/in.txt`, is going to
 
 ## Advanced Options
 
+### Compute
+
+- `taskmanager.compute.numa`: When enabled a TaskManager is started on each NUMA node for each worker listed in *conf/slaves* (DEFAULT: false)
+
 ### Managed Memory
 
 By default, Flink allocates a fraction of `0.7` of the total memory configured via `taskmanager.heap.mb` for its managed memory. Managed memory helps Flink to run the batch operators efficiently. It prevents `OutOfMemoryException`s because Flink knows how much memory it can use to execute operations. If Flink runs out of managed memory, it utilizes disk space. Using managed memory, some operations can be performed directly on the raw data without having to deserialize the data to convert it into Java objects. All in all, managed memory improves the robustness and speed of the system.

--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -74,7 +74,7 @@ without explicit scheme definition, such as `/user/USERNAME/in.txt`, is going to
 
 ### Compute
 
-- `taskmanager.compute.numa`: When enabled a TaskManager is started on each NUMA node for each worker listed in *conf/slaves* (DEFAULT: false)
+- `taskmanager.compute.numa`: When enabled a TaskManager is started on each NUMA node for each worker listed in *conf/slaves* (DEFAULT: false). Note: only supported when deploying Flink as a standalone cluster.
 
 ### Managed Memory
 

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -96,6 +96,8 @@ KEY_TASKM_MEM_MANAGED_FRACTION="taskmanager.memory.fraction"
 KEY_TASKM_OFFHEAP="taskmanager.memory.off-heap"
 KEY_TASKM_MEM_PRE_ALLOCATE="taskmanager.memory.preallocate"
 
+KEY_TASKM_COMPUTE_NUMA="taskmanager.compute.numa"
+
 KEY_ENV_PID_DIR="env.pid.dir"
 KEY_ENV_LOG_DIR="env.log.dir"
 KEY_ENV_LOG_MAX="env.log.max"
@@ -215,6 +217,17 @@ fi
 # Define FLINK_TM_MEM_PRE_ALLOCATE if it is not already set
 if [ -z "${FLINK_TM_MEM_PRE_ALLOCATE}" ]; then
     FLINK_TM_MEM_PRE_ALLOCATE=$(readFromConfig ${KEY_TASKM_MEM_PRE_ALLOCATE} "false" "${YAML_CONF}")
+fi
+
+# Verify that NUMA tooling is available
+command -v numactl >/dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+    FLINK_TM_COMPUTE_NUMA="false"
+else
+    # Define FLINK_TM_COMPUTE_NUMA if it is not already set
+    if [ -z "${FLINK_TM_COMPUTE_NUMA}" ]; then
+        FLINK_TM_COMPUTE_NUMA=$(readFromConfig ${KEY_TASKM_COMPUTE_NUMA} "false" "${YAML_CONF}")
+    fi
 fi
 
 if [ -z "${MAX_LOG_FILE_NUMBER}" ]; then


### PR DESCRIPTION
Start a TaskManager on each NUMA node on each worker when the new configuration option 'taskmanager.compute.numa' is enabled.

This does not affect the runtime process for the JobManager (or future ResourceManager) as the startup scripts do not provide a simple means of disambiguating masters and slaves. I expect most large clusters to run these master processes on separate machines, and for small clusters the JobManager can run alongside a TaskManager.