### PR TITLE
[FLINK-5705] [WebMonitor] request/response use UTF-8 explicitly

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/HttpRequestHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/HttpRequestHandler.java
@@ -107,8 +107,8 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<HttpObject> 
 				else if (currentRequest.getMethod() == HttpMethod.POST) {
 					// POST comes in multiple objects. First the request, then the contents
 					// keep the request and path for the remaining objects of the POST request
-					currentRequestPath = new QueryStringDecoder(currentRequest.getUri()).path();
-					currentDecoder = new HttpPostRequestDecoder(DATA_FACTORY, currentRequest);
+					currentRequestPath = new QueryStringDecoder(currentRequest.getUri(), ENCODING).path();
+					currentDecoder = new HttpPostRequestDecoder(DATA_FACTORY, currentRequest, ENCODING);
 				}
 				else {
 					throw new IOException("Unsupported HTTP method: " + currentRequest.getMethod().name());

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/RuntimeMonitorHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/RuntimeMonitorHandler.java
@@ -32,6 +32,7 @@ import io.netty.handler.codec.http.router.Routed;
 
 import java.net.URLDecoder;
 import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.webmonitor.files.MimeTypes;
 import org.apache.flink.runtime.webmonitor.handlers.RequestHandler;
 import org.apache.flink.util.ExceptionUtils;
 
@@ -116,6 +117,8 @@ public class RuntimeMonitorHandler extends RuntimeMonitorHandlerBase {
 		}
 
 		response.headers().set(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
+		// Content-Encoding:utf-8
+		response.headers().set(HttpHeaders.Names.CONTENT_ENCODING, ENCODING.name());
 
 		KeepAliveWrite.flush(ctx, routed.request(), response);
 	}


### PR DESCRIPTION
QueryStringDecoder and HttpPostRequestDecoder use UTF-8 defined in flink.
Response set content-encoding header with utf-8

- [X] General
  - The pull request references the related JIRA issue ("[FLINK-5705] webmonitor request/response use UTF-8 explicitly")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [X] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [X] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
