### PR TITLE
[FLINK-5718] [core] TaskManagers exit the JVM on fatal exceptions.

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -86,7 +86,7 @@ The default fraction for managed memory can be adjusted using the `taskmanager.m
 
 - `taskmanager.memory.segment-size`: The size of memory buffers used by the memory manager and the network stack in bytes (DEFAULT: 32768 (= 32 KiBytes)).
 
-- `taskmanager.memory.preallocate`: Can be either of `true` or `false`. Specifies whether task managers should allocate all managed memory when starting up. (DEFAULT: false). When `taskmanager.memory.off-heap` is set to `true`, then it is advised that this configuration is also set to `true`.  If this configuration is set to `false` cleaning up of the allocated offheap memory happens only when the configured JVM parameter MaxDirectMemorySize is reached by triggering a full GC.
+- `taskmanager.memory.preallocate`: Can be either of `true` or `false`. Specifies whether task managers should allocate all managed memory when starting up. (DEFAULT: false). When `taskmanager.memory.off-heap` is set to `true`, then it is advised that this configuration is also set to `true`.  If this configuration is set to `false` cleaning up of the allocated offheap memory happens only when the configured JVM parameter MaxDirectMemorySize is reached by triggering a full GC. **Note:** For streaming setups, we highly recommend to set this value to `false` as the core state backends currently do not use the managed memory.
 
 ### Memory and Performance Debugging
 
@@ -264,6 +264,8 @@ The following parameters configure Flink's JobManager and TaskManagers.
 - `taskmanager.max-registration-pause`: The maximum registration pause between two consecutive registration attempts. The max registration pause requires a time unit specifier (ms/s/min/h/d) (e.g. "5 s"). (DEFAULT: **30 s**)
 
 - `taskmanager.refused-registration-pause`: The pause after a registration has been refused by the job manager before retrying to connect. The refused registration pause requires a time unit specifier (ms/s/min/h/d) (e.g. "5 s"). (DEFAULT: **10 s**)
+
+- `taskmanager.jvm-exit-on-oom`: Indicates that the TaskManager should immediately terminate the JVM if the task thread throws an `OutOfMemoryError` (DEFAULT: **false**).
 
 - `blob.fetch.retries`: The number of retries for the TaskManager to download BLOBs (such as JAR files) from the JobManager (DEFAULT: **50**).
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -33,6 +33,11 @@ public class TaskManagerOptions {
 	// ------------------------------------------------------------------------
 
 	// @TODO Migrate 'taskmanager.*' config options from ConfigConstants
+	
+	/** Whether to kill the TaskManager when the task thread throws an OutOfMemoryError */
+	public static final ConfigOption<Boolean> KILL_ON_OUT_OF_MEMORY =
+			key("taskmanager.jvm-exit-on-oom")
+			.defaultValue(false);
 
 	// ------------------------------------------------------------------------
 	//  Network Options

--- a/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
@@ -33,8 +33,13 @@ import java.io.StringWriter;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
+/**
+ * A collection of utility functions for dealing with exceptions and exception workflows.
+ */
 @Internal
 public final class ExceptionUtils {
+
+	/** The stringified representation of a null exception reference */ 
 	public static final String STRINGIFIED_NULL_EXCEPTION = "(null)";
 
 	/**
@@ -61,6 +66,38 @@ public final class ExceptionUtils {
 		catch (Throwable t) {
 			return e.getClass().getName() + " (error while printing stack trace)";
 		}
+	}
+
+	/**
+	 * Checks whether the given exception indicates a situation that may leave the
+	 * JVM in a corrupted state, meaning a state where continued normal operation can only be
+	 * guaranteed via clean process restart.
+	 *
+	 * <p>Currently considered fatal exceptions are Virtual Machine errors indicating
+	 * that the JVM is corrupted, like {@link InternalError}, {@link UnknownError},
+	 * and {@link java.util.zip.ZipError} (a special case of InternalError).
+	 *
+	 * @param t The exception to check.
+	 * @return True, if the exception is considered fatal to the JVM, false otherwise.
+	 */
+	public static boolean isJvmFatalError(Throwable t) {
+		return (t instanceof InternalError) || (t instanceof UnknownError);
+	}
+
+	/**
+	 * Checks whether the given exception indicates a situation that may leave the
+	 * JVM in a corrupted state, or an out-of-memory error.
+	 * 
+	 * <p>See {@link ExceptionUtils#isJvmFatalError(Throwable)} for a list of fatal JVM errors.
+	 * This method additionally classifies the {@link OutOfMemoryError} as fatal, because it
+	 * may occur in any thread (not the one that allocated the majority of the memory) and thus
+	 * is often not recoverable by destroying the particular thread that threw the exception.
+	 * 
+	 * @param t The exception to check.
+	 * @return True, if the exception is fatal to the JVM or and OutOfMemoryError, false otherwise.
+	 */
+	public static boolean isJvmFatalOrOutOfMemoryError(Throwable t) {
+		return isJvmFatalError(t) || t instanceof OutOfMemoryError;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManagerRuntimeInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManagerRuntimeInfo.java
@@ -38,4 +38,12 @@ public interface TaskManagerRuntimeInfo {
 	 * @return The list of temporary file directories.
 	 */
 	String[] getTmpDirectories();
+
+	/**
+	 * Checks whether the TaskManager should exit the JVM when the task thread throws
+	 * an OutOfMemoryError.
+	 * 
+	 * @return True to terminate the JVM on an OutOfMemoryError, false otherwise.
+	 */
+	boolean shouldExitJvmOnOutOfMemoryError();
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
@@ -40,7 +40,6 @@ import org.apache.flink.runtime.io.network.LocalConnectionManager;
 import org.apache.flink.runtime.io.network.NetworkEnvironment;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
-import org.apache.flink.runtime.io.network.netty.NettyConfig;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.jobmanager.JobManager;
 import org.apache.flink.runtime.jobmanager.MemoryArchivist;
@@ -109,7 +108,8 @@ public class TaskManagerComponentsStartupShutdownTest {
 				Time.seconds(30),
 				Time.seconds(10),
 				1000000, // cleanup interval
-				config);
+				config,
+				false); // exit-jvm-on-fatal-error
 
 			final NetworkEnvironmentConfiguration netConf = new NetworkEnvironmentConfiguration(
 					32, BUFFER_SIZE, MemoryType.HEAP, IOManager.IOMode.SYNC, 0, 0, null);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
@@ -295,6 +295,15 @@ public abstract class TestJvmProcess {
 		}
 	}
 
+	public void waitFor() throws InterruptedException {
+		Process process = this.process;
+		if (process != null) {
+			process.waitFor();
+		} else {
+			throw new IllegalStateException("process not started");
+		}
+	}
+
 	// ---------------------------------------------------------------------------------------------
 	// File based synchronization utilities
 	// ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.io.InputSplit;
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.SubtaskState;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.execution.librarycache.FallbackLibraryCacheManager;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
+import org.apache.flink.runtime.filecache.FileCache;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.io.network.NetworkEnvironment;
+import org.apache.flink.runtime.io.network.netty.PartitionProducerStateChecker;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.operators.testutils.UnregisteredTaskMetricsGroup;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.taskexecutor.TaskManagerConfiguration;
+import org.apache.flink.runtime.taskmanager.CheckpointResponder;
+import org.apache.flink.runtime.taskmanager.Task;
+import org.apache.flink.runtime.taskmanager.TaskActions;
+import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.runtime.taskmanager.TaskManagerActions;
+import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
+import org.apache.flink.runtime.testutils.TestJvmProcess;
+import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.SerializedValue;
+
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test that verifies the behavior of blocking shutdown hooks and of the
+ * {@link JvmShutdownSafeguard} that guards against it.
+ */
+public class JvmExitOnFatalErrorTest {
+
+	@Test
+	public void testExitJvmOnOutOfMemory() throws Exception {
+		// this test works only on linux
+		assumeTrue(OperatingSystem.isLinux());
+
+		// this test leaves remaining processes if not executed with Java 8
+		CommonTestUtils.assumeJava8();
+
+		// to check what went wrong (when the test hangs) uncomment this line 
+//		ProcessEntryPoint.main(new String[0]);
+
+		final KillOnFatalErrorProcess testProcess = new KillOnFatalErrorProcess();
+
+		try {
+			testProcess.startProcess();
+			testProcess.waitFor();
+		}
+		finally {
+			testProcess.destroy();
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Blocking Process Implementation
+	// ------------------------------------------------------------------------
+
+	private static final class KillOnFatalErrorProcess extends TestJvmProcess {
+
+		public KillOnFatalErrorProcess() throws Exception {}
+
+		@Override
+		public String getName() {
+			return "KillOnFatalErrorProcess";
+		}
+
+		@Override
+		public String[] getJvmArgs() {
+			return new String[0];
+		}
+
+		@Override
+		public String getEntryPointClassName() {
+			return ProcessEntryPoint.class.getName();
+		}
+	} 
+
+	// ------------------------------------------------------------------------
+
+	public static final class ProcessEntryPoint {
+
+		public static void main(String[] args) throws Exception {
+
+			System.err.println("creating task");
+
+			// we suppress process exits via errors here to not
+			// have a test that exits accidentally due to a programming error 
+			try {
+				final Configuration taskManagerConfig = new Configuration();
+				taskManagerConfig.setBoolean(TaskManagerOptions.KILL_ON_OUT_OF_MEMORY, true);
+
+				final JobID jid = new JobID();
+				final JobVertexID jobVertexId = new JobVertexID();
+				final ExecutionAttemptID executionAttemptID = new ExecutionAttemptID();
+				final AllocationID slotAllocationId = new AllocationID();
+
+				final SerializedValue<ExecutionConfig> execConfig = new SerializedValue<>(new ExecutionConfig());
+
+				final JobInformation jobInformation = new JobInformation(
+						jid, "Test Job", execConfig, new Configuration(),
+						Collections.<BlobKey>emptyList(), Collections.<URL>emptyList());
+
+				final TaskInformation taskInformation = new TaskInformation(
+						jobVertexId, "Test Task", 1, 1, OomInvokable.class.getName(), new Configuration());
+
+				final MemoryManager memoryManager = new MemoryManager(1024 * 1024, 1);
+				final IOManager ioManager = new IOManagerAsync();
+
+				final NetworkEnvironment networkEnvironment = mock(NetworkEnvironment.class);
+				when(networkEnvironment.createKvStateTaskRegistry(jid, jobVertexId)).thenReturn(mock(TaskKvStateRegistry.class));
+
+				final TaskManagerRuntimeInfo tmInfo = TaskManagerConfiguration.fromConfiguration(taskManagerConfig);
+
+				final Executor executor = Executors.newCachedThreadPool();
+
+				Task task = new Task(
+						jobInformation,
+						taskInformation,
+						executionAttemptID,
+						slotAllocationId,
+						0,       // subtaskIndex
+						0,       // attemptNumber
+						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
+						Collections.<InputGateDeploymentDescriptor>emptyList(),
+						0,       // targetSlotNumber
+						null,    // taskStateHandles,
+						memoryManager,
+						ioManager,
+						networkEnvironment,
+						new BroadcastVariableManager(),
+						new NoOpTaskManagerActions(),
+						new NoOpInputSplitProvider(),
+						new NoOpCheckpointResponder(),
+						new FallbackLibraryCacheManager(),
+						new FileCache(tmInfo.getTmpDirectories()),
+						tmInfo,
+						new UnregisteredTaskMetricsGroup(),
+						new NoOpResultPartitionConsumableNotifier(),
+						new NoOpPartitionProducerStateChecker(),
+						executor);
+
+				System.err.println("starting task thread");
+
+				task.startTaskThread();
+			}
+			catch (Throwable t) {
+				System.err.println("ERROR STARTING TASK");
+				t.printStackTrace();
+			}
+
+			System.err.println("parking the main thread");
+			CommonTestUtils.blockForeverNonInterruptibly();
+		}
+
+		public static final class OomInvokable extends AbstractInvokable {
+
+			@Override
+			public void invoke() throws Exception {
+				throw new OutOfMemoryError();
+			}
+		}
+
+		private static final class NoOpTaskManagerActions implements TaskManagerActions {
+
+			@Override
+			public void notifyFinalState(ExecutionAttemptID executionAttemptID) {}
+
+			@Override
+			public void notifyFatalError(String message, Throwable cause) {}
+
+			@Override
+			public void failTask(ExecutionAttemptID executionAttemptID, Throwable cause) {}
+
+			@Override
+			public void updateTaskExecutionState(TaskExecutionState taskExecutionState) {}
+		}
+
+		private static final class NoOpInputSplitProvider implements InputSplitProvider {
+
+			@Override
+			public InputSplit getNextInputSplit(ClassLoader userCodeClassLoader) {
+				return null;
+			}
+		}
+
+		private static final class NoOpCheckpointResponder implements CheckpointResponder {
+
+			@Override
+			public void acknowledgeCheckpoint(JobID j, ExecutionAttemptID e, CheckpointMetaData c, SubtaskState s) {}
+
+			@Override
+			public void declineCheckpoint(JobID j, ExecutionAttemptID e, long l, Throwable t) {}
+		}
+
+		private static final class NoOpResultPartitionConsumableNotifier implements ResultPartitionConsumableNotifier {
+
+			@Override
+			public void notifyPartitionConsumable(JobID j, ResultPartitionID p, TaskActions t) {}
+		}
+
+		private static final class NoOpPartitionProducerStateChecker implements PartitionProducerStateChecker {
+
+			@Override
+			public Future<ExecutionState> requestPartitionProducerState(
+					JobID jobId, IntermediateDataSetID intermediateDataSetId, ResultPartitionID r) {
+				return null;
+			}
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/TestingTaskManagerRuntimeInfo.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/TestingTaskManagerRuntimeInfo.java
@@ -59,4 +59,10 @@ public class TestingTaskManagerRuntimeInfo implements TaskManagerRuntimeInfo {
 	public String[] getTmpDirectories() {
 		return tmpDirectories;
 	}
+
+	@Override
+	public boolean shouldExitJvmOnOutOfMemoryError() {
+		// never kill the JVM in tests
+		return false;
+	}
 }

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
@@ -97,6 +97,27 @@ public class CommonTestUtils {
 	}
 
 	/**
+	 * Permanently blocks the current thread. The thread cannot be woken
+	 * up via {@link Thread#interrupt()}.
+	 */
+	public static void blockForeverNonInterruptibly() {
+		final Object lock = new Object();
+		//noinspection InfiniteLoopStatement
+		while (true) {
+			try {
+				//noinspection SynchronizationOnLocalVariableOrMethodParameter
+				synchronized (lock) {
+					lock.wait();
+				}
+			} catch (InterruptedException ignored) {}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Preconditions on the test environment
+	// ------------------------------------------------------------------------
+
+	/**
 	 * Checks whether this code runs in a Java 8 (Java 1.8) JVM. If not, this throws a
 	 * {@link AssumptionViolatedException}, which causes JUnit to skip the test that
 	 * called this method.
@@ -116,6 +137,10 @@ public class CommonTestUtils {
 			fail("Cannot determine Java version: " + e.getMessage());
 		}
 	}
+
+	// ------------------------------------------------------------------------
+	//  Manipulation of environment
+	// ------------------------------------------------------------------------
 
 	public static void setEnv(Map<String, String> newenv) {
 		setEnv(newenv, true);


### PR DESCRIPTION
*This adds a feature requested by a user for production stability.*

Certain exceptions should not be attempted to be handled by the TaskManager, because they indicate that the JVM is corrupt. When the task throws such an exception, the TaskManager simply forcefully and immediately exits the JVM.

Optionally, the `OutOfMemoryError` can also be set to cause such immediate JVM termination, via the `taskmanager.jvm-exit-on-oom` config option.


### Tests

This adds a test that tests the option and the actual process kill (via a spawned test process). 

### Documentation

This adds the `taskmanager.jvm-exit-on-oom` to the `setup/config.md` docs.