### PR TITLE
[FLINK-5701] [kafka] FlinkKafkaProducer should check asyncException on checkpoints

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBase.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.state.OperatorStateStore;
 import org.apache.flink.api.java.ClosureCleaner;
@@ -387,5 +388,12 @@ public abstract class FlinkKafkaProducerBase<IN> extends RichSinkFunction<IN> im
 		Properties props = new Properties();
 		props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
 		return props;
+	}
+
+	@VisibleForTesting
+	protected long numPendingRecords() {
+		synchronized (pendingRecordsLock) {
+			return pendingRecords;
+		}
 	}
 }

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBaseTest.java
@@ -24,31 +24,31 @@ import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.connectors.kafka.partitioner.KafkaPartitioner;
 import org.apache.flink.streaming.connectors.kafka.testutils.FakeStandardProducerConfig;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.Metric;
-import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -62,7 +62,7 @@ public class FlinkKafkaProducerBaseTest {
 		// no bootstrap servers set in props
 		Properties props = new Properties();
 		// should throw IllegalArgumentException
-		new DummyFlinkKafkaProducer<>(props, null);
+		new DummyFlinkKafkaProducer<>(props, null, mock(KafkaProducer.class));
 	}
 
 	/**
@@ -73,7 +73,7 @@ public class FlinkKafkaProducerBaseTest {
 		Properties props = new Properties();
 		props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:12345");
 		// should set missing key value deserializers
-		new DummyFlinkKafkaProducer<>(props, null);
+		new DummyFlinkKafkaProducer<>(props, null, mock(KafkaProducer.class));
 
 		assertTrue(props.containsKey(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG));
 		assertTrue(props.containsKey(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG));
@@ -87,46 +87,51 @@ public class FlinkKafkaProducerBaseTest {
 	@Test
 	public void testPartitionerOpenedWithDeterminatePartitionList() throws Exception {
 		KafkaPartitioner mockPartitioner = mock(KafkaPartitioner.class);
+
 		RuntimeContext mockRuntimeContext = mock(RuntimeContext.class);
 		when(mockRuntimeContext.getIndexOfThisSubtask()).thenReturn(0);
 		when(mockRuntimeContext.getNumberOfParallelSubtasks()).thenReturn(1);
+		
+		// out-of-order list of 4 partitions
+		List<PartitionInfo> mockPartitionsList = new ArrayList<>(4);
+		mockPartitionsList.add(new PartitionInfo(DummyFlinkKafkaProducer.DUMMY_TOPIC, 3, null, null, null));
+		mockPartitionsList.add(new PartitionInfo(DummyFlinkKafkaProducer.DUMMY_TOPIC, 1, null, null, null));
+		mockPartitionsList.add(new PartitionInfo(DummyFlinkKafkaProducer.DUMMY_TOPIC, 0, null, null, null));
+		mockPartitionsList.add(new PartitionInfo(DummyFlinkKafkaProducer.DUMMY_TOPIC, 2, null, null, null));
+		
+		KafkaProducer mockProducer = mock(KafkaProducer.class);
+		when(mockProducer.partitionsFor(anyString())).thenReturn(mockPartitionsList);
+		when(mockProducer.metrics()).thenReturn(null);
 
 		DummyFlinkKafkaProducer producer = new DummyFlinkKafkaProducer(
-			FakeStandardProducerConfig.get(), mockPartitioner);
+			FakeStandardProducerConfig.get(), mockPartitioner, mockProducer);
 		producer.setRuntimeContext(mockRuntimeContext);
 
 		producer.open(new Configuration());
 
-		// the internal mock KafkaProducer will return an out-of-order list of 4 partitions,
-		// which should be sorted before provided to the custom partitioner's open() method
+		// the out-of-order partitions list should be sorted before provided to the custom partitioner's open() method
 		int[] correctPartitionList = {0, 1, 2, 3};
 		verify(mockPartitioner).open(0, 1, correctPartitionList);
 	}
-
 
 	/**
 	 * Test ensuring that if an invoke call happens right after an async exception is caught, it should be rethrown
 	 */
 	@Test
 	public void testAsyncErrorRethrownOnInvoke() throws Throwable {
-		final OneShotLatch inputLatch = new OneShotLatch();
-
-		final DummyFlinkKafkaProducer<String> producer =
-			new DummyFlinkKafkaProducer<>(FakeStandardProducerConfig.get(), null, inputLatch, 1, new AtomicBoolean(true));
+		KafkaProducer mockProducer = mock(KafkaProducer.class);
+		final DummyFlinkKafkaProducer<String> producer = new DummyFlinkKafkaProducer<>(
+			FakeStandardProducerConfig.get(), null, mockProducer);
 
 		OneInputStreamOperatorTestHarness<String, Object> testHarness =
 			new OneInputStreamOperatorTestHarness<>(new StreamSink(producer));
 
 		testHarness.open();
 
-		List<Callback> pending = producer.getProducerInstance().getPending();
-
 		testHarness.processElement(new StreamRecord<>("msg-1"));
 
-		inputLatch.await();
-
 		// let the message request return an async exception
-		pending.get(0).onCompletion(null, new Exception("artificial async exception"));
+		producer.getPendingCallbacks().get(0).onCompletion(null, new Exception("artificial async exception"));
 
 		try {
 			testHarness.processElement(new StreamRecord<>("msg-2"));
@@ -144,24 +149,19 @@ public class FlinkKafkaProducerBaseTest {
 	 */
 	@Test
 	public void testAsyncErrorRethrownOnCheckpoint() throws Throwable {
-		final OneShotLatch inputLatch = new OneShotLatch();
-
-		final DummyFlinkKafkaProducer<String> producer =
-			new DummyFlinkKafkaProducer<>(FakeStandardProducerConfig.get(), null, inputLatch, 1, new AtomicBoolean(true));
+		KafkaProducer mockProducer = mock(KafkaProducer.class);
+		final DummyFlinkKafkaProducer<String> producer = new DummyFlinkKafkaProducer<>(
+			FakeStandardProducerConfig.get(), null, mockProducer);
 
 		OneInputStreamOperatorTestHarness<String, Object> testHarness =
 			new OneInputStreamOperatorTestHarness<>(new StreamSink(producer));
 
 		testHarness.open();
 
-		List<Callback> pending = producer.getProducerInstance().getPending();
-
 		testHarness.processElement(new StreamRecord<>("msg-1"));
 
-		inputLatch.await();
-
 		// let the message request return an async exception
-		pending.get(0).onCompletion(null, new Exception("artificial async exception"));
+		producer.getPendingCallbacks().get(0).onCompletion(null, new Exception("artificial async exception"));
 
 		try {
 			testHarness.snapshot(123L, 123L);
@@ -177,13 +177,15 @@ public class FlinkKafkaProducerBaseTest {
 	/**
 	 * Test ensuring that if an async exception is caught for one of the flushed requests on checkpoint,
 	 * it should be rethrown; we set a timeout because the test will not finish if the logic is broken.
+	 *
+	 * Note that this test does not test the snapshot method is blocked correctly when there are pending recorrds.
+	 * The test for that is covered in testAtLeastOnceProducer.
 	 */
-	@Test(timeout=500)
+	@Test(timeout=5000)
 	public void testAsyncErrorRethrownOnCheckpointAfterFlush() throws Throwable {
-		final OneShotLatch inputLatch = new OneShotLatch();
-
-		final DummyFlinkKafkaProducer<String> producer =
-			new DummyFlinkKafkaProducer<>(FakeStandardProducerConfig.get(), null, inputLatch, 3, new AtomicBoolean(true));
+		KafkaProducer mockProducer = mock(KafkaProducer.class);
+		final DummyFlinkKafkaProducer<String> producer = new DummyFlinkKafkaProducer<>(
+			FakeStandardProducerConfig.get(), null, mockProducer);
 		producer.setFlushOnCheckpoint(true);
 
 		final OneInputStreamOperatorTestHarness<String, Object> testHarness =
@@ -191,15 +193,14 @@ public class FlinkKafkaProducerBaseTest {
 
 		testHarness.open();
 
-		List<Callback> pending = producer.getProducerInstance().getPending();
-
 		testHarness.processElement(new StreamRecord<>("msg-1"));
 		testHarness.processElement(new StreamRecord<>("msg-2"));
 		testHarness.processElement(new StreamRecord<>("msg-3"));
-		inputLatch.await();
+
+		verify(mockProducer, times(3)).send(any(ProducerRecord.class), any(Callback.class));
 
 		// only let the first callback succeed for now
-		pending.get(0).onCompletion(null, null);
+		producer.getPendingCallbacks().get(0).onCompletion(null, null);
 
 		final Tuple1<Throwable> asyncError = new Tuple1<>(null);
 		Thread snapshotThread = new Thread(new Runnable() {
@@ -216,8 +217,8 @@ public class FlinkKafkaProducerBaseTest {
 		snapshotThread.start();
 
 		// let the 2nd message fail with an async exception
-		pending.get(1).onCompletion(null, new Exception("artificial async failure for 2nd message"));
-		pending.get(2).onCompletion(null, null);
+		producer.getPendingCallbacks().get(1).onCompletion(null, new Exception("artificial async failure for 2nd message"));
+		producer.getPendingCallbacks().get(2).onCompletion(null, null);
 
 		snapshotThread.join();
 
@@ -229,62 +230,66 @@ public class FlinkKafkaProducerBaseTest {
 	 * Test ensuring that the producer is not dropping buffered records;
 	 * we set a timeout because the test will not finish if the logic is broken
 	 */
-	@Test(timeout=5000)
+	@Test(timeout=10000)
 	public void testAtLeastOnceProducer() throws Throwable {
-		final OneShotLatch inputLatch = new OneShotLatch();
 
-		final AtomicBoolean snapshottingFinished = new AtomicBoolean(false);
+		KafkaProducer mockProducer = mock(KafkaProducer.class);
 		final DummyFlinkKafkaProducer<String> producer = new DummyFlinkKafkaProducer<>(
-			FakeStandardProducerConfig.get(), null, inputLatch, 100, snapshottingFinished);
+			FakeStandardProducerConfig.get(), null, mockProducer);
 		producer.setFlushOnCheckpoint(true);
 
-		OneInputStreamOperatorTestHarness<String, Object> testHarness =
+		final OneInputStreamOperatorTestHarness<String, Object> testHarness =
 			new OneInputStreamOperatorTestHarness<>(new StreamSink(producer));
 
 		testHarness.open();
 
-		for (int i = 0; i < 100; i++) {
-			testHarness.processElement(new StreamRecord<>("msg-" + i));
-		}
+		testHarness.processElement(new StreamRecord<>("msg-1"));
+		testHarness.processElement(new StreamRecord<>("msg-2"));
+		testHarness.processElement(new StreamRecord<>("msg-3"));
 
-		// start a thread confirming all pending records
+		verify(mockProducer, times(3)).send(any(ProducerRecord.class), any(Callback.class));
+		Assert.assertEquals(3, producer.getPendingSize());
+
+		// start a thread to perform checkpointing
 		final Tuple1<Throwable> runnableError = new Tuple1<>(null);
+		final OneShotLatch snapshotReturnedLatch = new OneShotLatch();
 
-		Runnable confirmer = new Runnable() {
+		Thread snapshotThread = new Thread(new Runnable() {
 			@Override
 			public void run() {
 				try {
-					MockProducer mp = producer.getProducerInstance();
-					List<Callback> pending = mp.getPending();
-
-					// wait until all records have been added to producer
-					inputLatch.await();
-
-					// we now check that no records have been confirmed yet
-					Assert.assertEquals(100, pending.size());
-
-					Assert.assertFalse("Snapshot method returned before all records were confirmed",
-						snapshottingFinished.get());
-
-					// now confirm all checkpoints
-					for (Callback c: pending) {
-						c.onCompletion(null, null);
-					}
-					pending.clear();
-				} catch(Throwable t) {
-					runnableError.f0 = t;
+					// this should block until all records are flushed
+					testHarness.snapshot(123L, 123L);
+				} catch (Throwable e) {
+					runnableError.f0 = e;
+				} finally {
+					snapshotReturnedLatch.trigger();
 				}
 			}
-		};
-		Thread callbackThread = new Thread(confirmer);
-		callbackThread.start();
+		});
+		snapshotThread.start();
 
-		// this will block if flushOnCheckpoint is enabled
-		// it should not block forever, because the callback thread is confirming completion for all records
-		testHarness.snapshot(0, 0);
+		// being extra safe that the snapshot is correctly blocked
+		try {
+			snapshotReturnedLatch.await(3, TimeUnit.SECONDS);
+		} catch (TimeoutException expected) {
+			//
+		}
+		Assert.assertTrue("Snapshot returned before all records were flushed", !snapshotReturnedLatch.isTriggered());
 
-		// since flushOnCheckpoint is enabled, the snapshot method should block until there are no more pending records
-		Assert.assertEquals(0, producer.getProducerInstance().getPending().size());
+		producer.getPendingCallbacks().get(0).onCompletion(null, null);
+		Assert.assertTrue("Snapshot returned before all records were flushed", !snapshotReturnedLatch.isTriggered());
+		Assert.assertEquals(2, producer.getPendingSize());
+
+		producer.getPendingCallbacks().get(1).onCompletion(null, null);
+		Assert.assertTrue("Snapshot returned before all records were flushed", !snapshotReturnedLatch.isTriggered());
+		Assert.assertEquals(1, producer.getPendingSize());
+
+		producer.getPendingCallbacks().get(2).onCompletion(null, null);
+		Assert.assertEquals(0, producer.getPendingSize());
+
+		snapshotReturnedLatch.await();
+		snapshotThread.join();
 
 		if (runnableError.f0 != null) {
 			throw runnableError.f0;
@@ -300,10 +305,10 @@ public class FlinkKafkaProducerBaseTest {
 	 */
 	@Test(timeout=5000)
 	public void testDoesNotWaitForPendingRecordsIfFlushingDisabled() throws Throwable {
-		final OneShotLatch inputLatch = new OneShotLatch();
 
+		KafkaProducer mockProducer = mock(KafkaProducer.class);
 		final DummyFlinkKafkaProducer<String> producer = new DummyFlinkKafkaProducer<>(
-			FakeStandardProducerConfig.get(), null, inputLatch, 100, new AtomicBoolean(false));
+			FakeStandardProducerConfig.get(), null, mockProducer);
 		producer.setFlushOnCheckpoint(false);
 
 		final OneInputStreamOperatorTestHarness<String, Object> testHarness =
@@ -311,39 +316,13 @@ public class FlinkKafkaProducerBaseTest {
 
 		testHarness.open();
 
-		List<Callback> pending = producer.getProducerInstance().getPending();
-
-		for (int i = 0; i < 100; i++) {
-			testHarness.processElement(new StreamRecord<>("msg-" + i));
-		}
-
-		inputLatch.await();
+		testHarness.processElement(new StreamRecord<>("msg"));
 
 		// make sure that all callbacks have not been completed
-		Assert.assertEquals(100, pending.size());
+		verify(mockProducer, times(1)).send(any(ProducerRecord.class), any(Callback.class));
 
-		// use a separate thread to continuously monitor whether snapshotting has returned
-		final Tuple1<Throwable> runnableError = new Tuple1<>(null);
-		Thread snapshotThread = new Thread(new Runnable() {
-			@Override
-			public void run() {
-				try {
-					testHarness.snapshot(123L, 123L);
-				} catch (Exception e) {
-					runnableError.f0 = e;
-				}
-			}
-		});
-
-		snapshotThread.start();
-
-		// the snapshot should return and the thread finishes,
-		// even if there are still pending records
-		snapshotThread.join();
-
-		if (runnableError.f0 != null) {
-			throw runnableError.f0;
-		}
+		// should return even if there are pending records
+		testHarness.snapshot(123L, 123L);
 
 		testHarness.close();
 	}
@@ -352,110 +331,52 @@ public class FlinkKafkaProducerBaseTest {
 
 	private static class DummyFlinkKafkaProducer<T> extends FlinkKafkaProducerBase<T> {
 		private static final long serialVersionUID = 1L;
+		
+		private final static String DUMMY_TOPIC = "dummy-topic";
 
-		private final OneShotLatch inputLatch;
-		private final int numInputRecordsTriggerLatch;
-
-		private transient MockProducer prod;
-		private AtomicBoolean snapshottingFinished;
+		private final KafkaProducer mockProducer;
+		private final List<Callback> pendingCallbacks = new ArrayList<>();
 
 		@SuppressWarnings("unchecked")
 		public DummyFlinkKafkaProducer(
 				Properties producerConfig,
 				KafkaPartitioner partitioner,
-				OneShotLatch inputLatch,
-				int numInputRecordsTriggerLatch,
-				AtomicBoolean snapshottingFinished) {
-			super("dummy-topic", (KeyedSerializationSchema< T >) mock(KeyedSerializationSchema.class), producerConfig, partitioner);
-			this.snapshottingFinished = snapshottingFinished;
-			this.inputLatch = inputLatch;
-			this.numInputRecordsTriggerLatch = numInputRecordsTriggerLatch;
+				KafkaProducer mockProducer) {
+			super(DUMMY_TOPIC, (KeyedSerializationSchema< T >) mock(KeyedSerializationSchema.class), producerConfig, partitioner);
+			this.mockProducer = mockProducer;
+
+			when(mockProducer.send(any(ProducerRecord.class), any(Callback.class))).thenAnswer(new Answer<Object>() {
+				@Override
+				public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+					pendingCallbacks.add(invocationOnMock.getArgumentAt(1, Callback.class));
+					return null;
+				}
+			});
 		}
 
-		// constructor variant for test irrelated to snapshotting
-		@SuppressWarnings("unchecked")
-		public DummyFlinkKafkaProducer(
-				Properties producerConfig,
-				KafkaPartitioner partitioner) {
-			this(producerConfig, partitioner, new OneShotLatch(), 10, new AtomicBoolean(true));
+		public long getPendingSize() {
+			if (flushOnCheckpoint) {
+				return numPendingRecords();
+			} else {
+				// when flushing is disabled, the implementation does not
+				// maintain the current number of pending records to reduce
+				// the extra locking overhead required to do so
+				throw new UnsupportedOperationException("getPendingSize not supported when flushing is disabled");
+			}
+		}
+
+		public List<Callback> getPendingCallbacks() {
+			return pendingCallbacks;
 		}
 
 		@Override
 		protected <K, V> KafkaProducer<K, V> getKafkaProducer(Properties props) {
-			this.prod = new MockProducer(inputLatch, numInputRecordsTriggerLatch);
-			return this.prod;
-		}
-
-		@Override
-		public void snapshotState(FunctionSnapshotContext ctx) throws Exception {
-			// call the actual snapshot state
-			super.snapshotState(ctx);
-			// notify test that snapshotting has been done
-			snapshottingFinished.set(true);
+			return mockProducer;
 		}
 
 		@Override
 		protected void flush() {
-			this.prod.flush();
-		}
-
-		public MockProducer getProducerInstance() {
-			return this.prod;
-		}
-	}
-
-	/** A mock Kafka producer that accepts a one-shot latch to trigger once an initial number of records are processed. */
-	private static class MockProducer<K, V> extends KafkaProducer<K, V> {
-		List<Callback> pendingCallbacks = new ArrayList<>();
-
-		private final OneShotLatch inputLatch;
-		private final int numInputRecordsTriggerLatch;
-
-		public MockProducer(OneShotLatch inputLatch, int numInputRecordsTriggerLatch) {
-			super(FakeStandardProducerConfig.get());
-			this.inputLatch = inputLatch;
-			this.numInputRecordsTriggerLatch = numInputRecordsTriggerLatch;
-		}
-
-		@Override
-		public Future<RecordMetadata> send(ProducerRecord<K, V> record) {
-			throw new UnsupportedOperationException("Unexpected");
-		}
-
-		@Override
-		public Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback) {
-			pendingCallbacks.add(callback);
-
-			if (pendingCallbacks.size() == numInputRecordsTriggerLatch) {
-				inputLatch.trigger();
-			}
-
-			return null;
-		}
-
-		@Override
-		public List<PartitionInfo> partitionsFor(String topic) {
-			List<PartitionInfo> list = new ArrayList<>();
-			// deliberately return an out-of-order partition list
-			list.add(new PartitionInfo(topic, 3, null, null, null));
-			list.add(new PartitionInfo(topic, 1, null, null, null));
-			list.add(new PartitionInfo(topic, 0, null, null, null));
-			list.add(new PartitionInfo(topic, 2, null, null, null));
-			return list;
-		}
-
-		@Override
-		public Map<MetricName, ? extends Metric> metrics() {
-			return null;
-		}
-
-
-		public List<Callback> getPending() {
-			return this.pendingCallbacks;
-		}
-
-		public void flush() {
-			while (pendingCallbacks.size() > 0) {
+			while (numPendingRecords() > 0) {
 				try {
 					Thread.sleep(10);
 				} catch (InterruptedException e) {


### PR DESCRIPTION
Prior to this change, at-least-once is violated for the FlinkKafkaProducer because we were not failing checkpoints if there were async exceptions from the Kafka producer.

With this PR, on `snapshotState()`, we fail if there previously were async exceptions. We also fail if the flushed records on checkpoint resulted in exceptions.

This PR also improves the tests in `FlinkKafkaProducerBaseTest` to use one-shot latches instead of sleeping for more stable tests. It also removes the test `testAtLeastOnceProducerFailsIfFlushingDisabled()`. My reasoning is that essentially, you _might_ still have at-least-once even if flushing is disabled (i.e. always no pending records to flush on checkpoint), so I don't see the necessity in having that test. I'm open to discussing the removal of that test and adding it back if others think it's necessary.