### PR TITLE
[FLINK-5618][docs] createSerializer must actually get a non-null ExecutionConfig

### DIFF
--- a/docs/dev/stream/queryable_state.md
+++ b/docs/dev/stream/queryable_state.md
@@ -214,9 +214,9 @@ config.setInteger(ConfigConstants.JOB_MANAGER_IPC_PORT_KEY, queryPort);
 QueryableStateClient client = new QueryableStateClient(config);
 
 final TypeSerializer<Long> keySerializer =
-        TypeInformation.of(new TypeHint<Long>() {}).createSerializer(null);
+        TypeInformation.of(new TypeHint<Long>() {}).createSerializer(new ExecutionConfig());
 final TypeSerializer<Tuple2<Long, Long>> valueSerializer =
-        TypeInformation.of(new TypeHint<Tuple2<Long, Long>>() {}).createSerializer(null);
+        TypeInformation.of(new TypeHint<Tuple2<Long, Long>>() {}).createSerializer(new ExecutionConfig());
 
 final byte[] serializedKey =
         KvStateRequestSerializer.serializeKeyAndNamespace(


### PR DESCRIPTION
providing `null` fails with a NPE