### PR TITLE
[Flink-5724] Error in documentation zipping elements

### DIFF
--- a/docs/dev/batch/zip_elements_guide.md
+++ b/docs/dev/batch/zip_elements_guide.md
@@ -64,7 +64,7 @@ env.execute()
 {% endhighlight %}
 </div>
 
-<div data-lang="scala" markdown="1">
+<div data-lang="python" markdown="1">
 {% highlight python %}
 from flink.plan.Environment import get_environment
 


### PR DESCRIPTION
Because the Scala tab is defined twice, it is not possible to open
the Python tab.

Please look at the documentation page itself:
https://ci.apache.org/projects/flink/flink-docs-release-1.3/dev/batch/zip_elements_guide.html

I believe it is a copy-paste error (which also happens to me too often ;)


Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
