### PR TITLE
[FLINK-5729][EXAMPLES]add hostname option to be more convenient

### DIFF
--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/socket/SocketWindowWordCount.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/socket/SocketWindowWordCount.java
@@ -35,21 +35,23 @@ import org.apache.flink.util.Collector;
  * <pre>
  * nc -l 12345
  * </pre>
- * and run this example with the port as an argument.
+ * and run this example with the hostname and the port as arguments.
  */
 @SuppressWarnings("serial")
 public class SocketWindowWordCount {
 
 	public static void main(String[] args) throws Exception {
 
-		// the port to connect to
+		// the host and the port to connect to
+		final String hostname;
 		final int port;
 		try {
 			final ParameterTool params = ParameterTool.fromArgs(args);
+			hostname = params.has("hostname") ? params.get("hostname") : "localhost";
 			port = params.getInt("port");
 		} catch (Exception e) {
-			System.err.println("No port specified. Please run 'SocketWindowWordCount --port <port>', " +
-					"where port is the address of the text server");
+			System.err.println("No port specified. Please run 'SocketWindowWordCount --hostname <hostname> --port <port>', " +
+					"where hostname (localhost by default) and port is the address of the text server");
 			System.err.println("To start a simple text server, run 'netcat -l <port>' and type the input text " +
 					"into the command line");
 			return;
@@ -59,7 +61,7 @@ public class SocketWindowWordCount {
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
 		// get input data by connecting to the socket
-		DataStream<String> text = env.socketTextStream("localhost", port, "\n");
+		DataStream<String> text = env.socketTextStream(hostname, port, "\n");
 
 		// parse the data, group it, window it, and aggregate the counts
 		DataStream<WordWithCount> windowCounts = text

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/socket/SocketWindowWordCount.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/socket/SocketWindowWordCount.java
@@ -50,10 +50,11 @@ public class SocketWindowWordCount {
 			hostname = params.has("hostname") ? params.get("hostname") : "localhost";
 			port = params.getInt("port");
 		} catch (Exception e) {
-			System.err.println("No port specified. Please run 'SocketWindowWordCount --hostname <hostname> --port <port>', " +
-					"where hostname (localhost by default) and port is the address of the text server");
-			System.err.println("To start a simple text server, run 'netcat -l <port>' and type the input text " +
-					"into the command line");
+			System.err.println("No port specified. Please run 'SocketWindowWordCount " +
+				"--hostname <hostname> --port <port>', where hostname (localhost by default) " +
+				"and port is the address of the text server");
+			System.err.println("To start a simple text server, run 'netcat -l <port>' and " +
+				"type the input text into the command line");
 			return;
 		}
 

--- a/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/socket/SocketWindowWordCount.scala
+++ b/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/socket/SocketWindowWordCount.scala
@@ -31,20 +31,25 @@ import org.apache.flink.streaming.api.windowing.time.Time
  * <pre>
  * nc -l 12345
  * </pre>
- * and run this example with the port as an argument.
+ * and run this example with the hostname and the port as arguments..
  */
 object SocketWindowWordCount {
 
   /** Main program method */
   def main(args: Array[String]) : Unit = {
-    
-    // the port to connect to
-    val port: Int = try {
-      ParameterTool.fromArgs(args).getInt("port")
+
+    // the host and the port to connect to
+    var hostname: String = "localhost"
+    var port: Int = 0
+
+    try {
+      val params = ParameterTool.fromArgs(args)
+      hostname = if (params.has("hostname")) params.get("hostname") else "localhost"
+      port = params.getInt("port")
     } catch {
       case e: Exception => {
-        System.err.println("No port specified. Please run 'SocketWindowWordCount --port <port>', " +
-          "where port is the address of the text server")
+        System.err.println("No port specified. Please run 'SocketWindowWordCount --hostname <hostname> --port <port>', " +
+          "where hostname (localhost by default) and port is the address of the text server")
         System.err.println("To start a simple text server, run 'netcat -l <port>' " +
           "and type the input text into the command line")
         return
@@ -55,7 +60,7 @@ object SocketWindowWordCount {
     val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
     
     // get input data by connecting to the socket
-    val text = env.socketTextStream("localhost", port, '\n')
+    val text = env.socketTextStream(hostname, port, '\n')
 
     // parse the data, group it, window it, and aggregate the counts 
     val windowCounts = text

--- a/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/socket/SocketWindowWordCount.scala
+++ b/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/socket/SocketWindowWordCount.scala
@@ -48,8 +48,9 @@ object SocketWindowWordCount {
       port = params.getInt("port")
     } catch {
       case e: Exception => {
-        System.err.println("No port specified. Please run 'SocketWindowWordCount --hostname <hostname> --port <port>', " +
-          "where hostname (localhost by default) and port is the address of the text server")
+        System.err.println("No port specified. Please run 'SocketWindowWordCount " +
+          "--hostname <hostname> --port <port>', where hostname (localhost by default) and port " +
+          "is the address of the text server")
         System.err.println("To start a simple text server, run 'netcat -l <port>' " +
           "and type the input text into the command line")
         return


### PR DESCRIPTION
"hostname" option will help users to get data from the right port, otherwise the example would fail easily due to connection refused, especially in yarn-session mode.