### PR TITLE
[FLINK-5739] [client] fix NullPointerException in CliFrontend

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -842,6 +842,12 @@ public class CliFrontend {
 			program.deleteExtractedLibraries();
 		}
 
+		if (null == result) {
+			logAndSysout("No JobSubmissionResult returned, please make sure you called " +
+				"ExecutionEnvironment.execute()");
+			return 1;
+		}
+
 		if (result.isJobExecutionResult()) {
 			logAndSysout("Program execution finished");
 			JobExecutionResult execResult = result.getJobExecutionResult();

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -172,7 +172,8 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
 	
 	public JobGraph compileJobGraph(OptimizedPlan program, JobID jobId) {
 		if (program == null) {
-			throw new NullPointerException();
+			throw new NullPointerException("Program is null, did you called " +
+				"ExecutionEnvironment.execute()");
 		}
 		
 		if (jobId == null) {


### PR DESCRIPTION
Type: Bug
Priority: Major
Problem Definition: CliFrontEnd throws a NullPointerException
Design:
see https://issues.apache.org/jira/browse/FLINK-5739
Client will throw a NullPointerException if users forgot to call method "execute()".
Users may be confused by this NullPointerException. This patch adds a message here, and makes the NullPointerException meaningful.
Impact Analysis:
Only the client and messages are affected.
Test:
mvn clean verify has been done.