### PR TITLE
[FLINK-5745] set an uncaught exception handler for netty threads

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -30,6 +30,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.ssl.SslHandler;
+import org.apache.flink.runtime.util.FatalExitExceptionHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +45,10 @@ import static org.apache.flink.util.Preconditions.checkState;
 
 class NettyServer {
 
-	private static final ThreadFactoryBuilder THREAD_FACTORY_BUILDER = new ThreadFactoryBuilder().setDaemon(true);
+	private static final ThreadFactoryBuilder THREAD_FACTORY_BUILDER =
+		new ThreadFactoryBuilder()
+			.setDaemon(true)
+			.setUncaughtExceptionHandler(FatalExitExceptionHandler.INSTANCE);
 
 	private static final Logger LOG = LoggerFactory.getLogger(NettyServer.class);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ExecutorThreadFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ExecutorThreadFactory.java
@@ -22,9 +22,6 @@ import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -116,16 +113,4 @@ public class ExecutorThreadFactory implements ThreadFactory {
 
 	// --------------------------------------------------------------------------------------------
 
-	private static final class FatalExitExceptionHandler implements UncaughtExceptionHandler {
-
-		private static final Logger LOG = LoggerFactory.getLogger(FatalExitExceptionHandler.class);
-
-		static final FatalExitExceptionHandler INSTANCE = new FatalExitExceptionHandler(); 
-
-		@Override
-		public void uncaughtException(Thread t, Throwable e) {
-			LOG.error("FATAL: Thread '" + t.getName() + "' produced an uncaught exception. Stopping the process...", e);
-			System.exit(-17);
-		}
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/FatalExitExceptionHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/FatalExitExceptionHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handler for uncaught exceptions that will log the exception and kill the process afterwards.
+ *
+ * <p>This guarantees that critical exceptions are not accidentally lost and leave the system
+ * running in an inconsistent state.
+ */
+public final class FatalExitExceptionHandler implements Thread.UncaughtExceptionHandler {
+
+	private static final Logger LOG = LoggerFactory.getLogger(FatalExitExceptionHandler.class);
+
+	public static final FatalExitExceptionHandler INSTANCE = new FatalExitExceptionHandler();
+
+	@Override
+	public void uncaughtException(Thread t, Throwable e) {
+		LOG.error("FATAL: Thread '" + t.getName() +
+			"' produced an uncaught exception. Stopping the process...", e);
+		System.exit(-17);
+	}
+}


### PR DESCRIPTION
This adds a JVM-terminating handler that logs errors from uncaught exceptions
and terminates the process so that critical exceptions are not accidentally
lost and leave the system running in an inconsistent state.

It borrows and re-uses code from @StephanEwen from this PR:
https://github.com/apache/flink/pull/3290