### PR TITLE
[FLINK-5672] add special cases for a local setup in cluster start/stop scripts

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -388,6 +388,33 @@ readSlaves() {
     done < "$SLAVES_FILE"
 }
 
+# starts or stops TMs on all slaves
+# TMSlaves start|stop
+TMSlaves() {
+    CMD=$1
+
+    readSlaves
+
+    if [ ${SLAVES_ALL_LOCALHOST} = true ] ; then
+        # all-local setup
+        for slave in ${SLAVES[@]}; do
+            "${FLINK_BIN_DIR}"/taskmanager.sh "${CMD}"
+        done
+    else
+        # non-local setup
+        # Stop TaskManager instance(s) using pdsh (Parallel Distributed Shell) when available
+        command -v pdsh >/dev/null 2>&1
+        if [[ $? -ne 0 ]]; then
+            for slave in ${SLAVES[@]}; do
+                ssh -n $FLINK_SSH_OPTS $slave -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" \"${CMD}\" &"
+            done
+        else
+            PDSH_SSH_ARGS="" PDSH_SSH_ARGS_APPEND=$FLINK_SSH_OPTS pdsh -w $(IFS=, ; echo "${SLAVES[*]}") \
+                "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" \"${CMD}\""
+        fi
+    fi
+}
+
 useOffHeapMemory() {
     [[ "`echo ${FLINK_TM_OFFHEAP} | tr '[:upper:]' '[:lower:]'`" == "true" ]]
 }

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -374,12 +374,16 @@ readSlaves() {
 
     SLAVES=()
 
+    SLAVES_ALL_LOCALHOST=true
     GOON=true
     while $GOON; do
         read line || GOON=false
         HOST=$( extractHostName $line)
-        if [ -n "$HOST" ]; then
+        if [ -n "$HOST" ] ; then
             SLAVES+=(${HOST})
+            if [ "${HOST}" != "localhost" ] ; then
+                SLAVES_ALL_LOCALHOST=false
+            fi
         fi
     done < "$SLAVES_FILE"
 }

--- a/flink-dist/src/main/flink-bin/bin/start-cluster.sh
+++ b/flink-dist/src/main/flink-bin/bin/start-cluster.sh
@@ -49,23 +49,5 @@ else
 fi
 shopt -u nocasematch
 
-# Start TaskManager instance(s) using pdsh (Parallel Distributed Shell) when available
-readSlaves
-
-if [ ${SLAVES_ALL_LOCALHOST} = true ] ; then
-    # all-local setup
-    for slave in ${SLAVES[@]}; do
-        "${FLINK_BIN_DIR}"/taskmanager.sh start
-    done
-else
-    # non-local setup
-    command -v pdsh >/dev/null 2>&1
-    if [[ $? -ne 0 ]]; then
-        for slave in ${SLAVES[@]}; do
-            ssh -n $FLINK_SSH_OPTS $slave -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" start &"
-        done
-    else
-        PDSH_SSH_ARGS="" PDSH_SSH_ARGS_APPEND="${FLINK_SSH_OPTS}" pdsh -w $(IFS=, ; echo "${SLAVES[*]}") \
-            "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" start"
-    fi
-fi
+# Start TaskManager instance(s)
+TMSlaves start

--- a/flink-dist/src/main/flink-bin/bin/start-cluster.sh
+++ b/flink-dist/src/main/flink-bin/bin/start-cluster.sh
@@ -52,16 +52,7 @@ shopt -u nocasematch
 # Start TaskManager instance(s) using pdsh (Parallel Distributed Shell) when available
 readSlaves
 
-# all-local setup?
-all_localhost=1
-for slave in ${SLAVES[@]}; do
-    if [[ "$slave" != "localhost" ]]; then
-        all_localhost=0
-        break
-    fi
-done
-
-if [[ ${all_localhost} -eq 1 ]]; then
+if [ ${SLAVES_ALL_LOCALHOST} = true ] ; then
     # all-local setup
     for slave in ${SLAVES[@]}; do
         "${FLINK_BIN_DIR}"/taskmanager.sh start

--- a/flink-dist/src/main/flink-bin/bin/stop-cluster.sh
+++ b/flink-dist/src/main/flink-bin/bin/stop-cluster.sh
@@ -25,21 +25,13 @@ bin=`cd "$bin"; pwd`
 # Stop TaskManager instance(s) using pdsh (Parallel Distributed Shell) when available
 readSlaves
 
-# all-local setup?
-all_localhost=1
-for slave in ${SLAVES[@]}; do
-    if [[ "$slave" != "localhost" ]]; then
-        all_localhost=0
-        break
-    fi
-done
-
-if [[ ${all_localhost} -eq 1 ]]; then
+if [ ${SLAVES_ALL_LOCALHOST} = true ] ; then
     # all-local setup
     for slave in ${SLAVES[@]}; do
         "${FLINK_BIN_DIR}"/taskmanager.sh stop
     done
 else
+    # non-local setup
     command -v pdsh >/dev/null 2>&1
     if [[ $? -ne 0 ]]; then
         for slave in ${SLAVES[@]}; do

--- a/flink-dist/src/main/flink-bin/bin/stop-cluster.sh
+++ b/flink-dist/src/main/flink-bin/bin/stop-cluster.sh
@@ -22,26 +22,8 @@ bin=`cd "$bin"; pwd`
 
 . "$bin"/config.sh
 
-# Stop TaskManager instance(s) using pdsh (Parallel Distributed Shell) when available
-readSlaves
-
-if [ ${SLAVES_ALL_LOCALHOST} = true ] ; then
-    # all-local setup
-    for slave in ${SLAVES[@]}; do
-        "${FLINK_BIN_DIR}"/taskmanager.sh stop
-    done
-else
-    # non-local setup
-    command -v pdsh >/dev/null 2>&1
-    if [[ $? -ne 0 ]]; then
-        for slave in ${SLAVES[@]}; do
-            ssh -n $FLINK_SSH_OPTS $slave -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" stop &"
-        done
-    else
-        PDSH_SSH_ARGS="" PDSH_SSH_ARGS_APPEND=$FLINK_SSH_OPTS pdsh -w $(IFS=, ; echo "${SLAVES[*]}") \
-            "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" stop"
-    fi
-fi
+# Stop TaskManager instance(s)
+TMSlaves stop
 
 # Stop JobManager instance(s)
 shopt -s nocasematch


### PR DESCRIPTION
With this PR, if all slaves refer to `"localhost"` we run the daemons from the script itself instead of using ssh which may not be available. This can be seen as a first step in removing the local mode alltogether.
