### PR TITLE
[FLINK-5553] keep the original throwable in PartitionRequestClientHandler

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
@@ -389,7 +389,8 @@ public class ClientTransportErrorHandlingTest {
 		return new EmbeddedChannel(protocol.getClientChannelHandlers());
 	}
 
-	private RemoteInputChannel addInputChannel(PartitionRequestClientHandler clientHandler) {
+	private RemoteInputChannel addInputChannel(PartitionRequestClientHandler clientHandler)
+		throws IOException {
 		RemoteInputChannel rich = createRemoteInputChannel();
 		clientHandler.addInputChannel(rich);
 


### PR DESCRIPTION
This way, when checking for a previous error in any input channel, we can throw a meaningful exception instead of the inspecific `IllegalStateException("There has been an error in the channel.")` before.

Note that the original `Throwable` (from an existing channel) may or may not(!) have been printed by the `InputGate` yet. Any new input channel, however, did not get the `Throwable` and must fail through the (now enhanced) fallback mechanism.