### PR TITLE
[FLINK-5791] [runtime] [FLIP-6] Slots should be strictly matched according to resource profile when allocating for yarn mode

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -168,6 +168,11 @@ public final class ConfigConstants {
 	public static final String LIBRARY_CACHE_MANAGER_CLEANUP_INTERVAL = "library-cache-manager.cleanup.interval";
 
 	/**
+     * The config parameter defining the task manager resource profile.
+	 */
+	public static final String TASK_MANAGER_RESOURCE_PROFILE_KEY = "taskmanager.resourceProfile";
+
+	/**
 	 * The config parameter defining the task manager's hostname.
 	 */
 	public static final String TASK_MANAGER_HOSTNAME_KEY = "taskmanager.hostname";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -38,6 +38,9 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 
 	public static final ResourceProfile UNKNOWN = new ResourceProfile(-1.0, -1L);
 
+	// A universal resource profile which can match any one
+	public static final ResourceProfile UNIVERSAL = new ResourceProfile(0, 0L);
+
 	// ------------------------------------------------------------------------
 
 	/** How many cpu cores are needed, use double so we can specify cpu like 0.1 */
@@ -119,6 +122,9 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 		}
 		else if (obj != null && obj.getClass() == ResourceProfile.class) {
 			ResourceProfile that = (ResourceProfile) obj;
+			if (this == ResourceProfile.UNIVERSAL || that == ResourceProfile.UNIVERSAL) {
+				return true;
+			}
 			return this.cpuCores == that.cpuCores && this.memoryInMB == that.memoryInMB; 
 		}
 		else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -199,8 +199,9 @@ public class TaskManagerServices {
 
 		final List<ResourceProfile> resourceProfiles = taskManagerServicesConfiguration.getResourceProfiles();
 
+		// for standalone, there are no resource pofile in the configuration, the size is zero
 		for (int i = resourceProfiles.size(); i < taskManagerServicesConfiguration.getNumberOfSlots(); i++) {
-			resourceProfiles.add(new ResourceProfile(1.0, 42L));
+			resourceProfiles.add(ResourceProfile.UNIVERSAL);
 		}
 
 		final TimerService<AllocationID> timerService = new TimerService<>(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -52,7 +52,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
@@ -198,9 +197,9 @@ public class TaskManagerServices {
 
 		final FileCache fileCache = new FileCache(taskManagerServicesConfiguration.getTmpDirPaths());
 
-		final List<ResourceProfile> resourceProfiles = new ArrayList<>(taskManagerServicesConfiguration.getNumberOfSlots());
+		final List<ResourceProfile> resourceProfiles = taskManagerServicesConfiguration.getResourceProfiles();
 
-		for (int i = 0; i < taskManagerServicesConfiguration.getNumberOfSlots(); i++) {
+		for (int i = resourceProfiles.size(); i < taskManagerServicesConfiguration.getNumberOfSlots(); i++) {
 			resourceProfiles.add(new ResourceProfile(1.0, 42L));
 		}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkApplicationMasterRunner.java
@@ -37,7 +37,6 @@ import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerConfiguration;
-import org.apache.flink.runtime.resourcemanager.slotmanager.DefaultSlotManager;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -45,6 +44,7 @@ import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;
+import org.apache.flink.yarn.slotmanager.SMRFSlotManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.concurrent.duration.FiniteDuration;
@@ -187,7 +187,7 @@ public class YarnFlinkApplicationMasterRunner extends AbstractYarnFlinkApplicati
 
 	private ResourceManager<?> createResourceManager(Configuration config) throws Exception {
 		final ResourceManagerConfiguration resourceManagerConfiguration = ResourceManagerConfiguration.fromConfiguration(config);
-		final SlotManagerFactory slotManagerFactory = new DefaultSlotManager.Factory();
+		final SlotManagerFactory slotManagerFactory = new SMRFSlotManager.Factory();
 		final JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(haServices);
 
 		return new YarnResourceManager(config,

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/slotmanager/SMRFSlotManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/slotmanager/SMRFSlotManager.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn.slotmanager;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceSlot;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerServices;
+import org.apache.flink.runtime.resourcemanager.SlotRequest;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerFactory;
+
+import java.util.Map;
+
+/**
+ * A strictly matching and release fast slot manager.
+ * It answers requests with slots whose resource strictly match the resource requested,
+ * and if all slots on a task executor are free by job master,
+ * will release the task executor fast instead of keeping them for later use(TODO).
+ */
+public class SMRFSlotManager extends SlotManager {
+
+	public SMRFSlotManager(ResourceManagerServices rmServices) {
+		super(rmServices);
+	}
+
+	@Override
+	protected ResourceSlot chooseSlotToUse(SlotRequest request, Map<SlotID, ResourceSlot> freeSlots) {
+		for (ResourceSlot slot : freeSlots.values()) {
+			if (request.getResourceProfile().equals(slot.getResourceProfile())) {
+				return slot;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	protected SlotRequest chooseRequestToFulfill(ResourceSlot offeredSlot, Map<AllocationID, SlotRequest> pendingRequests) {
+		for (SlotRequest request : pendingRequests.values()) {
+			if (request.getResourceProfile().equals(offeredSlot.getResourceProfile())) {
+				return request;
+			}
+		}
+		return null;
+	}
+
+	// ------------------------------------------------------------------------
+
+	public static class Factory implements SlotManagerFactory {
+
+		@Override
+		public SlotManager create(ResourceManagerServices rmServices) {
+			return new SMRFSlotManager(rmServices);
+		}
+	}
+
+}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.heartbeat.HeartbeatManagerImpl;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerConfiguration;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerFactory;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.TestingSerialRpcService;
+import org.apache.flink.util.TestLogger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class YarnResourceManagerTest extends TestLogger {
+
+	private YarnResourceManager yarnResourceManager;
+
+	@Before
+	public void setup() {
+		Configuration conf = new Configuration();
+		ResourceManagerConfiguration rmConfig =
+				new ResourceManagerConfiguration(Time.seconds(1), Time.seconds(10));
+		yarnResourceManager = new YarnResourceManager(conf, null, new TestingSerialRpcService(), rmConfig,
+				mock(HighAvailabilityServices.class), mock(SlotManagerFactory.class),
+				mock(MetricRegistry.class),	 mock(JobLeaderIdService.class),
+                mock(FatalErrorHandler.class));
+	}
+
+	@After
+	public void teardown() {
+	}
+
+	@Test
+	public void testGeneratePriority() throws Exception {
+		ResourceProfile resourceProfile = new ResourceProfile(1, 1024);
+		int priority = yarnResourceManager.generatePriority(resourceProfile);
+		assertEquals(priority, 0);
+
+        ResourceProfile resourceProfile2 = new ResourceProfile(2, 100);
+		priority = yarnResourceManager.generatePriority(resourceProfile2);
+		assertEquals(priority, 1);
+
+		priority = yarnResourceManager.generatePriority(resourceProfile);
+		assertEquals(priority, 0);
+	}
+
+	@Test
+	public void testGetResourceProfile() throws Exception {
+		ResourceProfile resourceProfile = new ResourceProfile(1, 1024);
+		int priority = yarnResourceManager.generatePriority(resourceProfile);
+		assertEquals(priority, 0);
+
+        ResourceProfile resourceProfile2 = new ResourceProfile(2, 100);
+		priority = yarnResourceManager.generatePriority(resourceProfile2);
+		assertEquals(priority, 1);
+
+		ResourceProfile profile = yarnResourceManager.getResourceProfile(0);
+		assertEquals(profile, resourceProfile);
+
+		profile = yarnResourceManager.getResourceProfile(2);
+		assertEquals(profile, null);
+	}
+
+}


### PR DESCRIPTION
This pr is for jira #[5791](https://issues.apache.org/jira/browse/FLINK-5791).

It has following changes:
1. Yarn RM will pass the real ResourceProfile to TM for initializing the slots.
2. Add a SMRFSlotManager for allocating slots only resource strictly equal.