### PR TITLE
[FLINK-5793] [runtime] fix running slot may not be add to AllocatedMap in SlotPool bug

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotPool.java
@@ -436,7 +436,9 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 					LOG.debug("Fulfilling pending request [{}] early with returned slot [{}]",
 							pendingRequest.allocationID(), taskManagerSlot.getSlotAllocationId());
 
-					pendingRequest.future().complete(createSimpleSlot(taskManagerSlot, Locality.UNKNOWN));
+					SimpleSlot newSlot = createSimpleSlot(taskManagerSlot, Locality.UNKNOWN);
+					allocatedSlots.add(newSlot);
+					pendingRequest.future().complete(newSlot);
 				}
 				else {
 					LOG.debug("Adding returned slot [{}] to available slots", taskManagerSlot.getSlotAllocationId());
@@ -624,6 +626,15 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 			result.setLocality(locality);
 		}
 		return result;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Methods for tests
+	// ------------------------------------------------------------------------
+
+	@VisibleForTesting
+	AllocatedSlots getAllocatedSlots() {
+		return allocatedSlots;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SlotPoolTest.java
@@ -115,6 +115,7 @@ public class SlotPoolTest extends TestLogger {
 		assertEquals(resourceID, slot.getTaskManagerID());
 		assertEquals(jobId, slot.getJobID());
 		assertEquals(slotPool.getSlotOwner(), slot.getOwner());
+		assertEquals(slotPool.getAllocatedSlots().get(slot.getAllocatedSlot().getSlotAllocationId()), slot);
 	}
 
 	@Test
@@ -153,6 +154,7 @@ public class SlotPoolTest extends TestLogger {
 		assertTrue(slot2.isAlive());
 		assertEquals(slot1.getTaskManagerID(), slot2.getTaskManagerID());
 		assertEquals(slot1.getSlotNumber(), slot2.getSlotNumber());
+		assertEquals(slotPool.getAllocatedSlots().get(slot1.getAllocatedSlot().getSlotAllocationId()), slot2);
 	}
 
 	@Test


### PR DESCRIPTION
This pr is for jira #[5793](https://issues.apache.org/jira/browse/FLINK-5793)

In SlotPool, when a slot is returned by a finished task, it will try to find a 
pending request mataching it. If found, will give the slot to the request, but
not add the slot to AllocatedMap.