### PR TITLE
[FLINK-5798] [rpc] Let the RpcService provide a ScheduledExecutorService

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/ScheduledExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/ScheduledExecutor.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Extension for the {@link Executor} interface which is enriched by method for scheduling tasks
+ * in the future.
+ */
+public interface ScheduledExecutor extends Executor {
+
+	/**
+	 * Executes the given command after the given delay.
+	 *
+	 * @param command the task to execute in the future
+	 * @param delay the time from now to delay the execution
+	 * @param unit the time unit of the delay parameter
+	 * @return a ScheduledFuture representing the completion of the scheduled task
+	 */
+	ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit);
+
+	/**
+	 * Executes the given callable after the given delay. The result of the callable is returned
+	 * as a {@link ScheduledFuture}.
+	 *
+	 * @param callable the callable to execute
+	 * @param delay the time from now to delay the execution
+	 * @param unit the time unit of the delay parameter
+	 * @param <V> result type of the callable
+	 * @return a ScheduledFuture which holds the future value of the given callable
+	 */
+	<V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit);
+
+	/**
+	 * Executes the given command periodically. The first execution is started after the
+	 * {@code initialDelay}, the second execution is started after {@code initialDelay + period},
+	 * the third after {@code initialDelay + 2*period} and so on.
+	 * The task is executed until either an execution fails, or the returned {@link ScheduledFuture}
+	 * is cancelled.
+	 *
+	 * @param command the task to be executed periodically
+	 * @param initialDelay the time from now until the first execution is triggered
+	 * @param period the time after which the next execution is triggered
+	 * @param unit the time unit of the delay and period parameter
+	 * @return a ScheduledFuture representing the periodic task. This future never completes
+	 * unless an execution of the given task fails or if the future is cancelled
+	 */
+	ScheduledFuture<?> scheduleAtFixedRate(
+		Runnable command,
+		long initialDelay,
+		long period,
+		TimeUnit unit);
+
+	/**
+	 * Executed the given command repeatedly with the given delay between the end of an execution
+	 * and the start of the next execution.
+	 * The task is executed repeatedly until either an exception occurs or if the returned
+	 * {@link ScheduledFuture} is cancelled.
+	 *
+	 * @param command the task to execute repeatedly
+	 * @param initialDelay the time from now until the first execution is triggered
+	 * @param delay the time between the end of the current and the start of the next execution
+	 * @param unit the time unit of the initial delay and the delay parameter
+	 * @return a ScheduledFuture representing the repeatedly executed task. This future never
+	 * completes unless th exectuion of the given task fails or if the future is cancelled
+	 */
+	ScheduledFuture<?> scheduleWithFixedDelay(
+		Runnable command,
+		long initialDelay,
+		long delay,
+		TimeUnit unit);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/ScheduledExecutorServiceAdapter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/ScheduledExecutorServiceAdapter.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.util.Preconditions;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Adapter class for a {@link ScheduledExecutorService} which shall be used as a
+ * {@link ScheduledExecutor}.
+ */
+public class ScheduledExecutorServiceAdapter implements ScheduledExecutor {
+
+	private final ScheduledExecutorService scheduledExecutorService;
+
+	public ScheduledExecutorServiceAdapter(ScheduledExecutorService scheduledExecutorService) {
+		this.scheduledExecutorService = Preconditions.checkNotNull(scheduledExecutorService);
+	}
+
+	@Override
+	public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+		return scheduledExecutorService.schedule(command, delay, unit);
+	}
+
+	@Override
+	public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+		return scheduledExecutorService.schedule(callable, delay, unit);
+	}
+
+	@Override
+	public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+		return scheduledExecutorService.scheduleAtFixedRate(command, initialDelay, period, unit);
+	}
+
+	@Override
+	public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+		return scheduledExecutorService.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+	}
+
+	@Override
+	public void execute(Runnable command) {
+		scheduledExecutorService.execute(command);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
@@ -19,11 +19,11 @@
 package org.apache.flink.runtime.rpc;
 
 import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -99,7 +99,7 @@ public interface RpcService {
 	Executor getExecutor();
 
 	/**
-	 * Gets a scheduled executor service from the RPC service. This executor can be used to schedule
+	 * Gets a scheduled executor from the RPC service. This executor can be used to schedule
 	 * tasks to be executed in the future.
 	 *
 	 * <p><b>IMPORTANT:</b> This executor does not isolate the method invocations against
@@ -108,9 +108,9 @@ public interface RpcService {
 	 * {@link RpcEndpoint#getMainThreadExecutor() MainThreadExecutionContext} of that
 	 * {@code RpcEndpoint}.
 	 *
-	 * @return The RPC service provided scheduled executor service
+	 * @return The RPC service provided scheduled executor
 	 */
-	ScheduledExecutorService getScheduledExecutorService();
+	ScheduledExecutor getScheduledExecutor();
 
 	/**
 	 * Execute the runnable in the execution context of this RPC Service, as returned by

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -96,6 +97,20 @@ public interface RpcService {
 	 * @return The execution context provided by the RPC service
 	 */
 	Executor getExecutor();
+
+	/**
+	 * Gets a scheduled executor service from the RPC service. This executor can be used to schedule
+	 * tasks to be executed in the future.
+	 *
+	 * <p><b>IMPORTANT:</b> This executor does not isolate the method invocations against
+	 * any concurrent invocations and is therefore not suitable to run completion methods of futures
+	 * that modify state of an {@link RpcEndpoint}. For such operations, one needs to use the
+	 * {@link RpcEndpoint#getMainThreadExecutor() MainThreadExecutionContext} of that
+	 * {@code RpcEndpoint}.
+	 *
+	 * @return The RPC service provided scheduled executor service
+	 */
+	ScheduledExecutorService getScheduledExecutorService();
 
 	/**
 	 * Execute the runnable in the execution context of this RPC Service, as returned by

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -23,6 +23,7 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSelection;
 import akka.actor.ActorSystem;
 import akka.actor.Address;
+import akka.actor.Cancellable;
 import akka.actor.Identify;
 import akka.actor.PoisonPill;
 import akka.actor.Props;
@@ -43,18 +44,27 @@ import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.StartStoppable;
 import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
+import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import scala.concurrent.duration.FiniteDuration;
 
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Delayed;
 import java.util.concurrent.Executor;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableScheduledFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -81,6 +91,8 @@ public class AkkaRpcService implements RpcService {
 
 	private final String address;
 
+	private final ScheduledExecutorService internalScheduledExecutorService;
+
 	private volatile boolean stopped;
 
 	public AkkaRpcService(final ActorSystem actorSystem, final Time timeout) {
@@ -101,6 +113,8 @@ public class AkkaRpcService implements RpcService {
 		} else {
 			address = "";
 		}
+
+		internalScheduledExecutorService = new InternalScheduledExecutorService(actorSystem);
 	}
 
 	@Override
@@ -260,6 +274,12 @@ public class AkkaRpcService implements RpcService {
 	}
 
 	@Override
+	public ScheduledExecutorService getScheduledExecutorService() {
+
+		return internalScheduledExecutorService;
+	}
+
+	@Override
 	public void scheduleRunnable(Runnable runnable, long delay, TimeUnit unit) {
 		checkNotNull(runnable, "runnable");
 		checkNotNull(unit, "unit");
@@ -278,5 +298,199 @@ public class AkkaRpcService implements RpcService {
 		scala.concurrent.Future<T> scalaFuture = Futures.future(callable, actorSystem.dispatcher());
 
 		return new FlinkFuture<>(scalaFuture);
+	}
+
+	/**
+	 * Helper class to expose the internal scheduling logic via a {@link ScheduledExecutorService}.
+	 */
+	private static final class InternalScheduledExecutorService extends AbstractExecutorService implements ScheduledExecutorService {
+
+		private final ActorSystem actorSystem;
+
+		private InternalScheduledExecutorService(ActorSystem actorSystem) {
+			this.actorSystem = Preconditions.checkNotNull(actorSystem, "rpcService");
+		}
+
+		@Override
+		@Nonnull
+		public ScheduledFuture<?> schedule(@Nonnull Runnable command, long delay, @Nonnull TimeUnit unit) {
+			ScheduledFutureTask<Void> scheduledFutureTask = new ScheduledFutureTask<>(command, unit.toNanos(delay), 0L);
+
+			Cancellable cancellable = internalSchedule(scheduledFutureTask, delay, unit);
+
+			scheduledFutureTask.setCancellable(cancellable);
+
+			return scheduledFutureTask;
+		}
+
+		@Override
+		@Nonnull
+		public <V> ScheduledFuture<V> schedule(@Nonnull Callable<V> callable, long delay, @Nonnull TimeUnit unit) {
+			ScheduledFutureTask<V> scheduledFutureTask = new ScheduledFutureTask<>(callable, unit.toNanos(delay), 0L);
+
+			Cancellable cancellable = internalSchedule(scheduledFutureTask, delay, unit);
+
+			scheduledFutureTask.setCancellable(cancellable);
+
+			return scheduledFutureTask;
+		}
+
+		@Override
+		@Nonnull
+		public ScheduledFuture<?> scheduleAtFixedRate(@Nonnull Runnable command, long initialDelay, long period, @Nonnull TimeUnit unit) {
+			ScheduledFutureTask<Void> scheduledFutureTask = new ScheduledFutureTask<>(
+				command,
+				triggerTime(unit.toNanos(initialDelay)),
+				unit.toNanos(period));
+
+			Cancellable cancellable = actorSystem.scheduler().schedule(
+				new FiniteDuration(initialDelay, unit),
+				new FiniteDuration(period, unit),
+				scheduledFutureTask,
+				actorSystem.dispatcher());
+
+			scheduledFutureTask.setCancellable(cancellable);
+
+			return scheduledFutureTask;
+		}
+
+		@Override
+		@Nonnull
+		public ScheduledFuture<?> scheduleWithFixedDelay(@Nonnull Runnable command, long initialDelay, long delay, @Nonnull TimeUnit unit) {
+			ScheduledFutureTask<Void> scheduledFutureTask = new ScheduledFutureTask<>(
+				command,
+				triggerTime(unit.toNanos(initialDelay)),
+				unit.toNanos(-delay));
+
+			Cancellable cancellable = internalSchedule(scheduledFutureTask, initialDelay, unit);
+
+			scheduledFutureTask.setCancellable(cancellable);
+
+			return scheduledFutureTask;
+		}
+
+		@Override
+		public void shutdown() {
+			throw new UnsupportedOperationException("The " + getClass().getSimpleName() +
+				" belongs to a " + AkkaRpcService.class.getSimpleName() +
+				". Consequently, you should never try to shut id down.");
+		}
+
+		@Override
+		@Nonnull
+		public List<Runnable> shutdownNow() {
+			throw new UnsupportedOperationException("The " + getClass().getSimpleName() +
+				" belongs to a " + AkkaRpcService.class.getSimpleName() +
+				". Consequently, you should never try to shut id down.");
+		}
+
+		@Override
+		public boolean isShutdown() {
+			return actorSystem.isTerminated();
+		}
+
+		@Override
+		public boolean isTerminated() {
+			return actorSystem.isTerminated();
+		}
+
+		@Override
+		public boolean awaitTermination(long timeout, @Nonnull TimeUnit unit) {
+			throw new UnsupportedOperationException("The " + getClass().getSimpleName() +
+				" belongs to a " + AkkaRpcService.class.getSimpleName() +
+				". Consequently you should never await its termination.");
+		}
+
+		@Override
+		public void execute(@Nonnull Runnable command) {
+			actorSystem.dispatcher().execute(command);
+		}
+
+		private Cancellable internalSchedule(Runnable runnable, long delay, TimeUnit unit) {
+			return actorSystem.scheduler().scheduleOnce(
+				new FiniteDuration(delay, unit),
+				runnable,
+				actorSystem.dispatcher());
+		}
+
+		private long now() {
+			return System.nanoTime();
+		}
+
+		private long triggerTime(long delay) {
+			return now() + delay;
+		}
+
+		private final class ScheduledFutureTask<V> extends FutureTask<V> implements RunnableScheduledFuture<V> {
+
+			private long time;
+
+			private final long period;
+
+			private volatile Cancellable cancellable;
+
+			ScheduledFutureTask(Callable<V> callable, long time, long period) {
+				super(callable);
+				this.time = time;
+				this.period = period;
+			}
+
+			ScheduledFutureTask(Runnable runnable, long time, long period) {
+				super(runnable, null);
+				this.time = time;
+				this.period = period;
+			}
+
+			public void setCancellable(Cancellable newCancellable) {
+				this.cancellable = newCancellable;
+			}
+
+			@Override
+			public void run() {
+				if (!isPeriodic()) {
+					super.run();
+				} else if (runAndReset()){
+					if (period > 0L) {
+						time += period;
+					} else {
+						cancellable = internalSchedule(this, -period, TimeUnit.NANOSECONDS);
+
+						// check whether we have been cancelled concurrently
+						if (isCancelled()) {
+							cancellable.cancel();
+						} else {
+							time = triggerTime(-period);
+						}
+					}
+				}
+			}
+
+			@Override
+			public boolean cancel(boolean mayInterruptIfRunning) {
+				boolean result = super.cancel(mayInterruptIfRunning);
+
+				return result && cancellable.cancel();
+			}
+
+			@Override
+			public long getDelay(@Nonnull  TimeUnit unit) {
+				return unit.convert(time - now(), TimeUnit.NANOSECONDS);
+			}
+
+			@Override
+			public int compareTo(@Nonnull Delayed o) {
+				if (o == this) {
+					return 0;
+				}
+
+				long diff = getDelay(TimeUnit.NANOSECONDS) - o.getDelay(TimeUnit.NANOSECONDS);
+				return (diff < 0L) ? -1 : (diff > 0L) ? 1 : 0;
+			}
+
+			@Override
+			public boolean isPeriodic() {
+				return period != 0L;
+			}
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingSerialRpcService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingSerialRpcService.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.concurrent.CompletableFuture;
 import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.util.DirectExecutorService;
 import org.apache.flink.util.Preconditions;
@@ -53,11 +55,15 @@ public class TestingSerialRpcService implements RpcService {
 	private final ConcurrentHashMap<String, RpcGateway> registeredConnections;
 	private final CompletableFuture<Void> terminationFuture;
 
+	private final ScheduledExecutor scheduledExecutorServiceAdapter;
+
 	public TestingSerialRpcService() {
 		executorService = new DirectExecutorService();
 		scheduledExecutorService = new ScheduledThreadPoolExecutor(1);
 		this.registeredConnections = new ConcurrentHashMap<>(16);
 		this.terminationFuture = new FlinkCompletableFuture<>();
+
+		this.scheduledExecutorServiceAdapter = new ScheduledExecutorServiceAdapter(scheduledExecutorService);
 	}
 
 	@Override
@@ -91,9 +97,8 @@ public class TestingSerialRpcService implements RpcService {
 		return executorService;
 	}
 
-	@Override
-	public ScheduledExecutorService getScheduledExecutorService() {
-		return scheduledExecutorService;
+	public ScheduledExecutor getScheduledExecutor() {
+		return scheduledExecutorServiceAdapter;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.concurrent.impl.FlinkFuture;
 import org.apache.flink.util.TestLogger;
 
@@ -32,7 +33,6 @@ import org.junit.Test;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -160,11 +160,11 @@ public class AkkaRpcServiceTest extends TestLogger {
 	 */
 	@Test(timeout = 1000)
 	public void testScheduledExecutorServiceSimpleSchedule() throws ExecutionException, InterruptedException {
-		ScheduledExecutorService scheduledExecutorService = akkaRpcService.getScheduledExecutorService();
+		ScheduledExecutor scheduledExecutor = akkaRpcService.getScheduledExecutor();
 
 		final OneShotLatch latch = new OneShotLatch();
 
-		ScheduledFuture<?> future = scheduledExecutorService.schedule(
+		ScheduledFuture<?> future = scheduledExecutor.schedule(
 			new Runnable() {
 				@Override
 				public void run() {
@@ -186,7 +186,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 	 */
 	@Test(timeout = 1000)
 	public void testScheduledExecutorServicePeriodicSchedule() throws ExecutionException, InterruptedException {
-		ScheduledExecutorService scheduledExecutorService = akkaRpcService.getScheduledExecutorService();
+		ScheduledExecutor scheduledExecutor = akkaRpcService.getScheduledExecutor();
 
 		final int tries = 4;
 		final long delay = 10L;
@@ -194,7 +194,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 
 		long currentTime = System.nanoTime();
 
-		ScheduledFuture<?> future = scheduledExecutorService.scheduleAtFixedRate(
+		ScheduledFuture<?> future = scheduledExecutor.scheduleAtFixedRate(
 			new Runnable() {
 				@Override
 				public void run() {
@@ -226,7 +226,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 	 */
 	@Test(timeout = 1000)
 	public void testScheduledExecutorServiceWithFixedDelaySchedule() throws ExecutionException, InterruptedException {
-		ScheduledExecutorService scheduledExecutorService = akkaRpcService.getScheduledExecutorService();
+		ScheduledExecutor scheduledExecutor = akkaRpcService.getScheduledExecutor();
 
 		final int tries = 4;
 		final long delay = 10L;
@@ -234,7 +234,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 
 		long currentTime = System.nanoTime();
 
-		ScheduledFuture<?> future = scheduledExecutorService.scheduleWithFixedDelay(
+		ScheduledFuture<?> future = scheduledExecutor.scheduleWithFixedDelay(
 			new Runnable() {
 				@Override
 				public void run() {
@@ -265,7 +265,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 	 */
 	@Test
 	public void testScheduledExecutorServiceCancelWithFixedDelay() throws InterruptedException {
-		ScheduledExecutorService scheduledExecutorService = akkaRpcService.getScheduledExecutorService();
+		ScheduledExecutor scheduledExecutor = akkaRpcService.getScheduledExecutor();
 
 		long delay = 10L;
 
@@ -273,7 +273,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 		final OneShotLatch latch = new OneShotLatch();
 		final OneShotLatch shouldNotBeTriggeredLatch = new OneShotLatch();
 
-		ScheduledFuture<?> future = scheduledExecutorService.scheduleWithFixedDelay(
+		ScheduledFuture<?> future = scheduledExecutor.scheduleWithFixedDelay(
 			new Runnable() {
 				@Override
 				public void run() {
@@ -306,39 +306,6 @@ public class AkkaRpcServiceTest extends TestLogger {
 			shouldNotBeTriggeredLatch.await(5 * delay, TimeUnit.MILLISECONDS);
 			fail("The shouldNotBeTriggeredLatch should never be triggered.");
 		} catch (TimeoutException e) {
-			// expected
-		}
-	}
-
-	/**
-	 * Tests that the shutdown of the RPC service's scheduled executor service fails with an
-	 * {@link UnsupportedOperationException}.
-	 */
-	@Test
-	public void testScheduledExecutorServiceShutdownFails() throws InterruptedException {
-		ScheduledExecutorService scheduledExecutorService = akkaRpcService.getScheduledExecutorService();
-
-		try {
-			scheduledExecutorService.shutdown();
-
-			fail("We should not be able to shutdown the RPC's scheduled executor service.");
-		} catch (UnsupportedOperationException e) {
-			// expected
-		}
-
-		try {
-			scheduledExecutorService.shutdownNow();
-
-			fail("We should not be able to shutdown the RPC's scheduled executor service.");
-		} catch (UnsupportedOperationException e) {
-			// expected
-		}
-
-		try {
-			scheduledExecutorService.awaitTermination(1, TimeUnit.MILLISECONDS);
-
-			fail("We should not be able to await the termination of the RPC's scheduled executor service.");
-		} catch (UnsupportedOperationException e) {
 			// expected
 		}
 	}


### PR DESCRIPTION
This PR adds the getScheduledExecutorService method to the RpcService interface. So
henceforth all RpcService implementations have to provide a ScheduledExecutorService
implementation.

Currently, we only support the AkkaRpcService. The AkkaRpcService returns a
ScheduledExecutorService proxy which forwards the schedule calls to the ActorSystem's
internal scheduler.
