### PR TITLE
[FLINK-5070] [types] Unable to use Scala's BeanProperty with classes

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -1711,9 +1711,6 @@ public class TypeExtractor {
 					// return type is same as field type (or the generic variant of it)
 					(m.getGenericReturnType().equals( fieldType ) || (fieldTypeWrapper != null && m.getReturnType().equals( fieldTypeWrapper )) || (fieldTypeGeneric != null && m.getGenericReturnType().equals(fieldTypeGeneric)) )
 				) {
-					if(hasGetter) {
-						throw new IllegalStateException("Detected more than one getter");
-					}
 					hasGetter = true;
 				}
 				// check for setters (<FieldName>_$eq for scala)
@@ -1723,9 +1720,6 @@ public class TypeExtractor {
 					// return type is void.
 					m.getReturnType().equals(Void.TYPE)
 				) {
-					if(hasSetter) {
-						throw new IllegalStateException("Detected more than one setter");
-					}
 					hasSetter = true;
 				}
 			}
@@ -1733,10 +1727,10 @@ public class TypeExtractor {
 				return true;
 			} else {
 				if(!hasGetter) {
-					LOG.debug(clazz+" does not contain a getter for field "+f.getName() );
+					LOG.info(clazz+" does not contain a getter for field "+f.getName() );
 				}
 				if(!hasSetter) {
-					LOG.debug(clazz+" does not contain a setter for field "+f.getName() );
+					LOG.info(clazz+" does not contain a setter for field "+f.getName() );
 				}
 				return false;
 			}
@@ -1771,7 +1765,7 @@ public class TypeExtractor {
 		for (Field field : fields) {
 			Type fieldType = field.getGenericType();
 			if(!isValidPojoField(field, clazz, typeHierarchy)) {
-				LOG.info(clazz + " is not a valid POJO type");
+				LOG.info(clazz + " is not a valid POJO type because not all fields are valid POJO fields.");
 				return null;
 			}
 			try {

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TypeExtractionTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TypeExtractionTest.scala
@@ -20,13 +20,15 @@ package org.apache.flink.api.scala.typeutils
 
 import org.apache.flink.api.common.io.FileInputFormat
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
-import org.apache.flink.api.java.typeutils.ResultTypeQueryable
+import org.apache.flink.api.java.typeutils.{PojoTypeInfo, ResultTypeQueryable}
 import org.apache.flink.api.scala._
-import org.apache.flink.api.scala.typeutils.TypeExtractionTest.CustomTypeInputFormat
+import org.apache.flink.api.scala.typeutils.TypeExtractionTest.{CustomBeanClass, CustomTypeInputFormat}
 import org.apache.flink.util.TestLogger
-import org.junit.Assert.assertEquals
+import org.junit.Assert._
 import org.junit.Test
 import org.scalatest.junit.JUnitSuiteLike
+
+import scala.beans.BeanProperty
 
 
 class TypeExtractionTest extends TestLogger with JUnitSuiteLike {
@@ -34,8 +36,18 @@ class TypeExtractionTest extends TestLogger with JUnitSuiteLike {
   @Test
   def testResultTypeQueryable(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
-    val productedType = env.createInput(new CustomTypeInputFormat).getType()
-    assertEquals(productedType, BasicTypeInfo.LONG_TYPE_INFO)
+    val producedType = env.createInput(new CustomTypeInputFormat).getType()
+    assertEquals(producedType, BasicTypeInfo.LONG_TYPE_INFO)
+  }
+
+  @Test
+  def testBeanPropertyClass(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val producedType = env.fromElements(new CustomBeanClass()).getType()
+    assertTrue(producedType.isInstanceOf[PojoTypeInfo[_]])
+    val pojoTypeInfo = producedType.asInstanceOf[PojoTypeInfo[_]]
+    assertEquals(pojoTypeInfo.getTypeAt(0), BasicTypeInfo.INT_TYPE_INFO)
+    assertEquals(pojoTypeInfo.getTypeAt(1), BasicTypeInfo.LONG_TYPE_INFO)
   }
 
 }
@@ -49,5 +61,11 @@ object TypeExtractionTest {
     override def reachedEnd(): Boolean = throw new UnsupportedOperationException()
 
     override def nextRecord(reuse: String): String = throw new UnsupportedOperationException()
+  }
+
+  class CustomBeanClass(
+      @BeanProperty var prop: Int,
+      var prop2: Long) {
+    def this() = this(0, 0L)
   }
 }


### PR DESCRIPTION
This PR fixes issues with `@BeanProperty` annotation. The problem is that `var` generates Scala-style getters/setters and the annotation generates Java-style getters/setters. Right now Flink only supports one style in a POJO. I don't know why we have this restriction. I removed them.