### PR TITLE
[FLINK-4813][flink-test-utils] make the hadoop-minikdc dependency optional

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils/pom.xml
@@ -83,6 +83,13 @@ under the License.
 			<artifactId>hadoop-minikdc</artifactId>
 			<version>${minikdc.version}</version>
 			<scope>compile</scope>
+			<!-- Since this requires the maven-bundle-plugin to be present,
+			make it optional.
+			The only class using this dependency is SecureTestEnvironment and if
+			a project is using it, it must now add the hadoop-minikdc dependency
+			on its own as well as include maven-bundle-plugin.
+			-->
+			<optional>true</optional>
 		</dependency>
 
 	</dependencies>

--- a/flink-test-utils-parent/flink-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils/pom.xml
@@ -94,4 +94,20 @@ under the License.
 
 	</dependencies>
 
+	<build>
+		<plugins>
+			<!--
+            https://issues.apache.org/jira/browse/DIRSHARED-134
+            Required to pull the Mini-KDC transitive dependency
+            -->
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>3.0.1</version>
+				<inherited>true</inherited>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/SecureTestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/SecureTestEnvironment.java
@@ -41,34 +41,34 @@ import java.util.Properties;
  *
  * If you use this class in your project, please make sure to add a dependency to
  * <tt>hadoop-minikdc</tt>, e.g. in your <tt>pom.xml</tt>:
- * <pre>
+ * <pre>{@code
  * ...
- * &lt;dependencies>
- *   &lt;dependency>
- *     &lt;groupId>org.apache.hadoop&lt;/groupId>
- *     &lt;artifactId>hadoop-minikdc&lt;/artifactId>
- *     &lt;version>${minikdc.version}&lt;/version>
- *     &lt;scope>compile&lt;/scope>
- *   &lt;/dependency>
+ * <dependencies>
+ *   <dependency>
+ *     <groupId>org.apache.hadoop</groupId>
+ *     <artifactId>hadoop-minikdc</artifactId>
+ *     <version>${minikdc.version}</version>
+ *     <scope>compile</scope>
+ *   </dependency>
  * ...
- * &lt;/dependencies>
+ * </dependencies>
  * ...
  *
- * &lt;build>
- *   &lt;plugins>
- *     &lt;!--
+ * <build>
+ *   <plugins>
+ *     <!--
  *       https://issues.apache.org/jira/browse/DIRSHARED-134
  *       Required to pull the Mini-KDC transitive dependency
  *     -->
- *     &lt;plugin>
- *     &lt;groupId>org.apache.felix&lt;/groupId>
- *     &lt;artifactId>maven-bundle-plugin&lt;/artifactId>
- *     &lt;version>3.0.1&lt;/version>
- *     &lt;inherited>true&lt;/inherited>
- *     &lt;extensions>true&lt;/extensions>
- *   &lt;/plugin>
+ *     <plugin>
+ *     <groupId>org.apache.felix</groupId>
+ *     <artifactId>maven-bundle-plugin</artifactId>
+ *     <version>3.0.1</version>
+ *     <inherited>true</inherited>
+ *     <extensions>true</extensions>
+ *   </plugin>
  * ...
- * </pre>
+ * }</pre>
  */
 public class SecureTestEnvironment {
 

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/SecureTestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/SecureTestEnvironment.java
@@ -37,9 +37,39 @@ import java.util.Properties;
 /**
  * Helper {@link SecureTestEnvironment} to handle MiniKDC lifecycle.
  * This class can be used to start/stop MiniKDC and create secure configurations for MiniDFSCluster
- * and MiniYarn
+ * and MiniYarn.
+ *
+ * If you use this class in your project, please make sure to add a dependency to
+ * <tt>hadoop-minikdc</tt>, e.g. in your <tt>pom.xml</tt>:
+ * <pre>
+ * ...
+ * &lt;dependencies>
+ *   &lt;dependency>
+ *     &lt;groupId>org.apache.hadoop&lt;/groupId>
+ *     &lt;artifactId>hadoop-minikdc&lt;/artifactId>
+ *     &lt;version>${minikdc.version}&lt;/version>
+ *     &lt;scope>compile&lt;/scope>
+ *   &lt;/dependency>
+ * ...
+ * &lt;/dependencies>
+ * ...
+ *
+ * &lt;build>
+ *   &lt;plugins>
+ *     &lt;!--
+ *       https://issues.apache.org/jira/browse/DIRSHARED-134
+ *       Required to pull the Mini-KDC transitive dependency
+ *     -->
+ *     &lt;plugin>
+ *     &lt;groupId>org.apache.felix&lt;/groupId>
+ *     &lt;artifactId>maven-bundle-plugin&lt;/artifactId>
+ *     &lt;version>3.0.1&lt;/version>
+ *     &lt;inherited>true&lt;/inherited>
+ *     &lt;extensions>true&lt;/extensions>
+ *   &lt;/plugin>
+ * ...
+ * </pre>
  */
-
 public class SecureTestEnvironment {
 
 	protected static final Logger LOG = LoggerFactory.getLogger(SecureTestEnvironment.class);

--- a/pom.xml
+++ b/pom.xml
@@ -1113,16 +1113,6 @@ under the License.
 				</executions>
 			</plugin>
 
-			<!-- Pull bundled transitive dependencies (i.e. Mini-KDC).
-			See https://issues.apache.org/jira/browse/DIRSHARED-134 -->
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.0.1</version>
-				<inherited>true</inherited>
-				<extensions>true</extensions>
-			</plugin>
-
 		</plugins>
 
 		<!-- Plugin configurations for plugins activated in sub-projects --> 


### PR DESCRIPTION
This removes the need to add the `maven-bundle-plugin`plugin for most projects using `flink-test-utils`.

Instead, any project using `flink-test-utils` that also requires
`SecureTestEnvironment` must add a dependency to `hadoop-minikdc` itself, e.g. in
`pom.xml`:

```xml
   ...
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-minikdc</artifactId>
       <version>${minikdc.version}</version>
       <scope>compile</scope>
     </dependency>
   ...
   </dependencies>
   ...

   <build>
     <plugins>
       <!--
         https://issues.apache.org/jira/browse/DIRSHARED-134
         Required to pull the Mini-KDC transitive dependency
       -->
       <plugin>
       <groupId>org.apache.felix</groupId>
       <artifactId>maven-bundle-plugin</artifactId>
       <version>3.0.1</version>
       <inherited>true</inherited>
       <extensions>true</extensions>
     </plugin>
   ...
```