### PR TITLE
[FLINK-5811] [tests] Harden YarnClusterDescriptorTest

### DIFF
--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,6 +31,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 
+import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
 
 public class YarnClusterDescriptorTest {
@@ -64,8 +64,13 @@ public class YarnClusterDescriptorTest {
 
 		try {
 			clusterDescriptor.deploy();
-		} catch (Exception e) {
-			Assert.assertTrue(e.getCause() instanceof IllegalConfigurationException);
+
+			fail("The deploy call should have failed.");
+		} catch (RuntimeException e) {
+			// we expect the cause to be an IllegalConfigurationException
+			if (!(e.getCause() instanceof IllegalConfigurationException)) {
+				throw e;
+			}
 		}
 	}
 
@@ -88,9 +93,13 @@ public class YarnClusterDescriptorTest {
 
 		try {
 			clusterDescriptor.deploy();
-		} catch (Exception e) {
-			e.printStackTrace();
-			Assert.assertTrue(e.getCause() instanceof IllegalConfigurationException);
+
+			fail("The deploy call should have failed.");
+		} catch (RuntimeException e) {
+			// we expect the cause to be an IllegalConfigurationException
+			if (!(e.getCause() instanceof IllegalConfigurationException)) {
+				throw e;
+			}
 		}
 	}
 


### PR DESCRIPTION
Add fail call after method which is supposed to fail. Remove stack trace printing
to stdout.
