### PR TITLE
[FLINK-5616] [tests] Harden YarnIntraNonHaMasterServicesTest.testClosingReportsToLeader

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/leaderelection/SingleLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/leaderelection/SingleLeaderElectionService.java
@@ -92,6 +92,8 @@ public class SingleLeaderElectionService implements LeaderElectionService {
 		this.notificationExecutor = checkNotNull(notificationsDispatcher);
 		this.leaderId = checkNotNull(leaderId);
 		this.listeners = new HashSet<>();
+
+		shutdown = false;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/highavailability/YarnIntraNonHaMasterServicesTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/highavailability/YarnIntraNonHaMasterServicesTest.java
@@ -22,8 +22,11 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.util.StringUtils;
 
+import org.apache.flink.util.TestLogger;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 
 import org.junit.AfterClass;
@@ -41,13 +44,14 @@ import java.util.Random;
 import java.util.UUID;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class YarnIntraNonHaMasterServicesTest {
+public class YarnIntraNonHaMasterServicesTest extends TestLogger {
 
 	private static final Random RND = new Random();
 
@@ -106,18 +110,26 @@ public class YarnIntraNonHaMasterServicesTest {
 		services.close();
 	}
 
-	@Test
+	@Test(timeout=5000)
 	public void testClosingReportsToLeader() throws Exception {
 		final Configuration flinkConfig = new Configuration();
 
 		try (YarnHighAvailabilityServices services = new YarnIntraNonHaMasterServices(flinkConfig, hadoopConfig)) {
 			final LeaderElectionService elector = services.getResourceManagerLeaderElectionService();
+			final LeaderRetrievalService retrieval = services.getResourceManagerLeaderRetriever();
 			final LeaderContender contender = mockContender(elector);
+			final LeaderRetrievalListener listener = mock(LeaderRetrievalListener.class);
 
 			elector.start(contender);
+			retrieval.start(listener);
+
+			// wait until the contender has become the leader
+			verify(listener).notifyLeaderAddress(anyString(), any(UUID.class));
+
+			// now we can close the election service
 			services.close();
 
-			verify(contender, timeout(100).times(1)).handleError(any(Exception.class));
+			verify(contender, times(1)).handleError(any(Exception.class));
 		}
 	}
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/highavailability/YarnIntraNonHaMasterServicesTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/highavailability/YarnIntraNonHaMasterServicesTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -110,7 +110,7 @@ public class YarnIntraNonHaMasterServicesTest extends TestLogger {
 		services.close();
 	}
 
-	@Test(timeout=5000)
+	@Test
 	public void testClosingReportsToLeader() throws Exception {
 		final Configuration flinkConfig = new Configuration();
 
@@ -124,12 +124,12 @@ public class YarnIntraNonHaMasterServicesTest extends TestLogger {
 			retrieval.start(listener);
 
 			// wait until the contender has become the leader
-			verify(listener).notifyLeaderAddress(anyString(), any(UUID.class));
+			verify(listener, timeout(1000L).times(1)).notifyLeaderAddress(anyString(), any(UUID.class));
 
 			// now we can close the election service
 			services.close();
 
-			verify(contender, times(1)).handleError(any(Exception.class));
+			verify(contender, timeout(1000L).times(1)).handleError(any(Exception.class));
 		}
 	}
 


### PR DESCRIPTION
**Updated description**:

Prevent the race condition between shutting down the leader election service and the
contender becoming the leader by waiting on a LeaderRetrievalListener. The problem
was that if the service has been shut down before the contender has become the leader,
then the contender would not be notified about the shut down via the handleError method.