### PR TITLE
[FLINK-5812] [core] Cleanups in the FileSystem class

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -154,7 +154,7 @@ under the License.
 					<parameter>
 						<excludes combine.children="append">
 							<exclude>org.apache.flink.api.common.ExecutionConfig#CONFIG_KEY</exclude>
-							<exclude>org.apache.flink.core.fs.FileSystem$FSKey</exclude>
+							<exclude>org.apache.flink.core.fs.FileSystem\$FSKey</exclude>
 							<exclude>org.apache.flink.api.java.typeutils.WritableTypeInfo</exclude>
 							<!-- Breaking changes between 1.1 and 1.2. 
 							We ignore these changes because these are low-level, internal runtime configuration parameters -->

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
@@ -104,7 +104,7 @@ public abstract class FileOutputFormat<IT> extends RichOutputFormat<IT> implemen
 	protected Path outputFilePath;
 	
 	/**
-	 * The write mode of the output.	
+	 * The write mode of the output.
 	 */
 	private WriteMode writeMode;
 	
@@ -249,7 +249,7 @@ public abstract class FileOutputFormat<IT> extends RichOutputFormat<IT> implemen
 		this.actualFilePath = (numTasks > 1 || outputDirectoryMode == OutputDirectoryMode.ALWAYS) ? p.suffix("/" + getDirectoryFileName(taskNumber)) : p;
 
 		// create output file
-		this.stream = fs.create(this.actualFilePath, writeMode == WriteMode.OVERWRITE);
+		this.stream = fs.create(this.actualFilePath, writeMode);
 		
 		// at this point, the file creation must have succeeded, or an exception has been thrown
 		this.fileCreated = true;

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystemSafetyNet.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystemSafetyNet.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.IOUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * The FileSystemSafetyNet can be used to guard a thread against {@link FileSystem} stream resource leaks.
+ * When activated for a thread, it tracks all streams that are opened by FileSystems that the thread
+ * obtains. The safety net has a global cleanup hook that will close all streams that were
+ * not properly closed.
+ * 
+ * <p>The main thread of each Flink task, as well as the checkpointing thread are automatically guarded
+ * by this safety net.
+ * 
+ * <p><b>Important:</b> This safety net works only for streams created by Flink's FileSystem abstraction,
+ * i.e., for {@code FileSystem} instances obtained via {@link FileSystem#get(URI)} or through
+ * {@link Path#getFileSystem()}.
+ * 
+ * <p><b>Important:</b> When a guarded thread obtains a {@code FileSystem} or a stream and passes them
+ * to another thread, the safety net will close those resources once the former thread finishes.
+ * 
+ * <p>The safety net can be used as follows:
+ * <pre>{@code
+ * 
+ * class GuardedThread extends Thread {
+ * 
+ *     public void run() {
+ *         FileSystemSafetyNet.initializeSafetyNetForThread();
+ *         try {
+ *             // do some heavy stuff where you are unsure whether it closes all streams
+ *             // like some untrusted user code or library code
+ *         }
+ *         finally {
+ *             FileSystemSafetyNet.closeSafetyNetAndGuardedResourcesForThread();
+ *         }
+ *     }
+ * }
+ * }</pre>
+ */
+@Internal
+public class FileSystemSafetyNet {
+
+	private static final Logger LOG = LoggerFactory.getLogger(FileSystemSafetyNet.class);
+
+	/** The map from thread to the safety net registry for that thread */
+	private static final ThreadLocal<SafetyNetCloseableRegistry> REGISTRIES = new ThreadLocal<>();
+
+	// ------------------------------------------------------------------------
+	//  Activating / Deactivating
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Activates the safety net for a thread. {@link FileSystem} instances obtained by the thread
+	 * that called this method will be guarded, meaning that their created streams are tracked and can
+	 * be closed via the safety net closing hook.
+	 * 
+	 * <p>This method should be called at the beginning of a thread that should be guarded.
+	 * 
+	 * @throws IllegalStateException Thrown, if a safety net was already registered for the thread.
+	 */
+	@Internal
+	public static void initializeSafetyNetForThread() {
+		SafetyNetCloseableRegistry oldRegistry = REGISTRIES.get();
+
+		checkState(null == oldRegistry, "Found an existing FileSystem safety net for this thread: %s " +
+				"This may indicate an accidental repeated initialization, or a leak of the" +
+				"(Inheritable)ThreadLocal through a ThreadPool.", oldRegistry);
+
+		SafetyNetCloseableRegistry newRegistry = new SafetyNetCloseableRegistry();
+		REGISTRIES.set(newRegistry);
+		LOG.info("Created new CloseableRegistry {} for {}", newRegistry, Thread.currentThread().getName());
+	}
+
+	/**
+	 * Closes the safety net for a thread. This closes all remaining unclosed streams that were opened
+	 * by safety-net-guarded file systems. After this method was called, no streams can be opened any more
+	 * from any FileSystem instance that was obtained while the thread was guarded by the safety net.
+	 * 
+	 * <p>This method should be called at the very end of a guarded thread.
+	 */
+	@Internal
+	public static void closeSafetyNetAndGuardedResourcesForThread() {
+		SafetyNetCloseableRegistry registry = REGISTRIES.get();
+		if (null != registry) {
+			LOG.info("Ensuring all FileSystem streams are closed for {}", Thread.currentThread().getName());
+			REGISTRIES.remove();
+			IOUtils.closeQuietly(registry);
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utilities
+	// ------------------------------------------------------------------------
+
+	static FileSystem wrapWithSafetyNetWhenActivated(FileSystem fs) {
+		SafetyNetCloseableRegistry reg = REGISTRIES.get();
+		return reg != null ? new SafetyNetWrapperFileSystem(fs, reg) : fs;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
@@ -29,8 +29,8 @@ import java.net.URI;
  * {@link ClosingFSDataInputStream} or {@link ClosingFSDataOutputStream} and (ii) registers them to
  * a {@link SafetyNetCloseableRegistry}.
  *
- * Streams obtained by this are therefore managed by the {@link SafetyNetCloseableRegistry} to prevent resource leaks
- * from unclosed streams.
+ * <p>Streams obtained by this are therefore managed by the {@link SafetyNetCloseableRegistry} to
+ * prevent resource leaks from unclosed streams.
  */
 public class SafetyNetWrapperFileSystem extends FileSystem implements WrappingProxy<FileSystem> {
 
@@ -118,7 +118,7 @@ public class SafetyNetWrapperFileSystem extends FileSystem implements WrappingPr
 	}
 
 	@Override
-	public FSDataOutputStream create(Path f, boolean overwrite) throws IOException {
+	public FSDataOutputStream create(Path f, WriteMode overwrite) throws IOException {
 		FSDataOutputStream innerStream = unsafeFileSystem.create(f, overwrite);
 		return ClosingFSDataOutputStream.wrapSafe(innerStream, registry, String.valueOf(f));
 	}

--- a/flink-core/src/main/java/org/apache/flink/util/AbstractCloseableRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/util/AbstractCloseableRegistry.java
@@ -105,10 +105,6 @@ public abstract class AbstractCloseableRegistry<C extends Closeable, T> implemen
 		return closeableToRef;
 	}
 
-	// ------------------------------------------------------------------------
-	//  
-	// ------------------------------------------------------------------------
-
 	protected abstract void doUnRegister(C closeable, Map<Closeable, T> closeableMap);
 
 	protected abstract void doRegister(C closeable, Map<Closeable, T> closeableMap) throws IOException;

--- a/flink-core/src/main/java/org/apache/flink/util/AbstractCloseableRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/util/AbstractCloseableRegistry.java
@@ -25,10 +25,10 @@ import java.util.Map;
 /**
  * This is the abstract base class for registries that allow to register instances of {@link Closeable}, which are all
  * closed if this registry is closed.
- * <p>
- * Registering to an already closed registry will throw an exception and close the provided {@link Closeable}
- * <p>
- * All methods in this class are thread-safe.
+ * 
+ * <p>Registering to an already closed registry will throw an exception and close the provided {@link Closeable}
+ * 
+ * <p>All methods in this class are thread-safe.
  *
  * @param <C> Type of the closeable this registers
  * @param <T> Type for potential meta data associated with the registering closeables
@@ -48,7 +48,7 @@ public abstract class AbstractCloseableRegistry<C extends Closeable, T> implemen
 	 * {@link IllegalStateException} and closes the passed {@link Closeable}.
 	 *
 	 * @param closeable Closeable tor register
-	 * @return true if the the Closeable was newly added to the registry
+	 * 
 	 * @throws IOException exception when the registry was closed before
 	 */
 	public final void registerClosable(C closeable) throws IOException {
@@ -71,7 +71,6 @@ public abstract class AbstractCloseableRegistry<C extends Closeable, T> implemen
 	 * Removes a {@link Closeable} from the registry.
 	 *
 	 * @param closeable instance to remove from the registry.
-	 * @return true, if the instance was actually registered and now removed
 	 */
 	public final void unregisterClosable(C closeable) {
 
@@ -105,6 +104,10 @@ public abstract class AbstractCloseableRegistry<C extends Closeable, T> implemen
 	protected final Object getSynchronizationLock() {
 		return closeableToRef;
 	}
+
+	// ------------------------------------------------------------------------
+	//  
+	// ------------------------------------------------------------------------
 
 	protected abstract void doUnRegister(C closeable, Map<Closeable, T> closeableMap);
 

--- a/flink-core/src/test/java/org/apache/flink/core/fs/SafetyNetCloseableRegistryTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/SafetyNetCloseableRegistryTest.java
@@ -77,7 +77,7 @@ public class SafetyNetCloseableRegistryTest {
 					FileSystem fs1 = FileSystem.getLocalFileSystem();
 					// ensure no safety net in place
 					Assert.assertFalse(fs1 instanceof SafetyNetWrapperFileSystem);
-					FileSystem.createAndSetFileSystemCloseableRegistryForThread();
+					FileSystemSafetyNet.initializeSafetyNetForThread();
 					fs1 = FileSystem.getLocalFileSystem();
 					// ensure safety net is in place now
 					Assert.assertTrue(fs1 instanceof SafetyNetWrapperFileSystem);
@@ -91,11 +91,11 @@ public class SafetyNetCloseableRegistryTest {
 								FileSystem fs2 = FileSystem.getLocalFileSystem();
 								// ensure the safety net does not leak here
 								Assert.assertFalse(fs2 instanceof SafetyNetWrapperFileSystem);
-								FileSystem.createAndSetFileSystemCloseableRegistryForThread();
+								FileSystemSafetyNet.initializeSafetyNetForThread();
 								fs2 = FileSystem.getLocalFileSystem();
 								// ensure we can bring another safety net in place
 								Assert.assertTrue(fs2 instanceof SafetyNetWrapperFileSystem);
-								FileSystem.closeAndDisposeFileSystemCloseableRegistryForThread();
+								FileSystemSafetyNet.closeSafetyNetAndGuardedResourcesForThread();
 								fs2 = FileSystem.getLocalFileSystem();
 								// and that we can remove it again
 								Assert.assertFalse(fs2 instanceof SafetyNetWrapperFileSystem);
@@ -107,7 +107,7 @@ public class SafetyNetCloseableRegistryTest {
 
 						//ensure stream is still open and was never closed by any interferences
 						stream.write(42);
-						FileSystem.closeAndDisposeFileSystemCloseableRegistryForThread();
+						FileSystemSafetyNet.closeSafetyNetAndGuardedResourcesForThread();
 
 						// ensure leaking stream was closed
 						try {

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -275,7 +275,7 @@ under the License.
 								<configuration>
 									<executable>ln</executable>
 									<arguments>
-										<argument>-sf</argument>
+										<argument>-sfn</argument>
 										<argument>${project.basedir}/target/flink-${project.version}-bin/flink-${project.version}</argument>
 										<argument>${project.basedir}/../build-target</argument>
 									</arguments>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
@@ -417,9 +417,9 @@ public final class HadoopFileSystem extends FileSystem implements HadoopFileSyst
 
 
 	@Override
-	public HadoopDataOutputStream create(final Path f, final boolean overwrite) throws IOException {
+	public HadoopDataOutputStream create(final Path f, final WriteMode overwrite) throws IOException {
 		final org.apache.hadoop.fs.FSDataOutputStream fsDataOutputStream = this.fs
-			.create(new org.apache.hadoop.fs.Path(f.toString()), overwrite);
+			.create(new org.apache.hadoop.fs.Path(f.toString()), overwrite == WriteMode.OVERWRITE);
 		return new HadoopDataOutputStream(fsDataOutputStream);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/fs/maprfs/MapRFileSystem.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/fs/maprfs/MapRFileSystem.java
@@ -327,11 +327,11 @@ public final class MapRFileSystem extends FileSystem {
 	}
 
 	@Override
-	public FSDataOutputStream create(final Path f, final boolean overwrite)
+	public FSDataOutputStream create(final Path f, final WriteMode overwrite)
 			throws IOException {
 
 		final org.apache.hadoop.fs.FSDataOutputStream fdos = this.fs.create(
-				new org.apache.hadoop.fs.Path(f.toString()), overwrite);
+				new org.apache.hadoop.fs.Path(f.toString()), overwrite == WriteMode.OVERWRITE);
 
 		return new HadoopDataOutputStream(fdos);
 	}


### PR DESCRIPTION
The FileSystem class is overloaded and has methods that are not well supported.

This pull request does the following cleanups:

Commit 1:
  - Use the `WriteMode` to indicate overwriting behavior. Right now, the `FileSystem` class defines that enum and never uses it. It feels weird.
  - Remove the method `FsDataOutputStream create(path, overwrite, blocksize, replication, ...)`, which is not really supported across file system implementations. For HDFS, the behavior should be set via the configuration anyways.

Commit 2:
  - Pull the safety net into a separate class
  - Extend the docs of the safety net.

All changes have to be made in a non-API-breaking fashion.