### PR TITLE
[FLINK-5814] fix packaging flink-dist in unclean source directory

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -275,7 +275,7 @@ under the License.
 								<configuration>
 									<executable>ln</executable>
 									<arguments>
-										<argument>-sf</argument>
+										<argument>-sfn</argument>
 										<argument>${project.basedir}/target/flink-${project.version}-bin/flink-${project.version}</argument>
 										<argument>${project.basedir}/../build-target</argument>
 									</arguments>


### PR DESCRIPTION
If `<flink-dir>/build-target` already existed, running `mvn package` for
flink-dist would create a symbolic link inside `<flink-dir>/build-target`
instead of replacing that symlink. This commit fixes this behaviour of `ln -sf`
by adding the `--no-dereference` parameter.
