### PR TITLE
[FLINK-5751] [docs] Add link check script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ out/
 /docs/ruby2/.bundle
 /docs/ruby2/.rubydeps
 /docs/.jekyll-metadata
-/docs/spider.log
 *.ipr
 *.iws
 tools/flink

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ out/
 /docs/ruby2/.bundle
 /docs/ruby2/.rubydeps
 /docs/.jekyll-metadata
+/docs/spider.log
 *.ipr
 *.iws
 tools/flink

--- a/docs/check_links.sh
+++ b/docs/check_links.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Don't abort on any non-zero exit code
+#set +e
+
+target=${1:-"http://localhost:4000"}
+
+# Crawl the docs, ignoring robots.txt, storing nothing locally
+wget --spider -r -nd -nv -e robots=off -p -o spider.log $target
+
+# Abort for anything other than 0 and 4 ("Network failure")
+status=$?
+if [ $status -ne 0 ] && [ $status -ne 4 ]; then
+    exit $status
+fi
+
+# Fail the build if any broken links are found
+broken_links_str=$(grep -e 'Found [[:digit:]]\+ broken link' spider.log)
+echo -e "$broken_links_str"
+if [ -n "$broken_links_str" ]; then
+    exit 1
+fi

--- a/docs/check_links.sh
+++ b/docs/check_links.sh
@@ -17,13 +17,10 @@
 # limitations under the License.
 ################################################################################
 
-# Don't abort on any non-zero exit code
-#set +e
-
 target=${1:-"http://localhost:4000"}
 
 # Crawl the docs, ignoring robots.txt, storing nothing locally
-wget --spider -r -nd -nv -e robots=off -p -o spider.log $target
+wget --spider -r -nd -nv -e robots=off -p -o spider.log "$target"
 
 # Abort for anything other than 0 and 4 ("Network failure")
 status=$?
@@ -32,8 +29,8 @@ if [ $status -ne 0 ] && [ $status -ne 4 ]; then
 fi
 
 # Fail the build if any broken links are found
-broken_links_str=$(grep -e 'Found [[:digit:]]\+ broken link' spider.log)
-echo -e "$broken_links_str"
+broken_links_str=$(grep -e 'Found [[:digit:]]\+ broken link(s)' spider.log)
 if [ -n "$broken_links_str" ]; then
+	echo "$broken_links_str"
     exit 1
 fi

--- a/docs/check_links.sh
+++ b/docs/check_links.sh
@@ -31,6 +31,6 @@ fi
 # Fail the build if any broken links are found
 broken_links_str=$(grep -e 'Found [[:digit:]]\+ broken link(s)' spider.log)
 if [ -n "$broken_links_str" ]; then
-	echo "$broken_links_str"
+	echo -e "\e[1;31m$broken_links_str\e[0m"
     exit 1
 fi


### PR DESCRIPTION
This is a slightly adjusted script from @patricklucas as posted in FLINK-5751.

I was wondering whether it makes sense to have it inside the repo, the local work flow would be:
```sh
./build_docs.sh -p
./check_links.sh
```

You can overwrite the URL to check like `./check_links.sh https://ci.apache.org/projects/flink/flink-docs-master/`.

@rmetzger @patricklucas Should we include this?