### PR TITLE
[FLINK-5818][Security]change checkpoint dir permission to 700

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -47,6 +47,12 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-hadoop2</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 		<!-- standard utilities -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -631,6 +631,8 @@ public abstract class FileSystem {
 	 */
 	public abstract boolean rename(Path src, Path dst) throws IOException;
 
+	public abstract void setPermission(Path f, String perm) throws IOException;
+
 	/**
 	 * Returns true if this is a distributed file system, false otherwise.
 	 *

--- a/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
@@ -129,6 +129,11 @@ public class SafetyNetWrapperFileSystem extends FileSystem implements WrappingPr
 	}
 
 	@Override
+	public void setPermission(Path p, String perm) throws IOException {
+		unsafeFileSystem.setPermission(p, perm);
+	}
+
+	@Override
 	public boolean initOutPathLocalFS(Path outPath, WriteMode writeMode, boolean createDirectory) throws IOException {
 		return unsafeFileSystem.initOutPathLocalFS(outPath, writeMode, createDirectory);
 	}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -34,6 +34,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.OperatingSystem;
 
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +44,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermissions;
 
 /**
  * The class <code>LocalFile</code> provides an implementation of the {@link FileSystem} interface
@@ -262,6 +265,13 @@ public class LocalFileSystem extends FileSystem {
 		final File dstFile = pathToFile(dst);
 
 		return srcFile.renameTo(dstFile);
+	}
+
+	@Override
+	public void setPermission(Path p, String perm) throws IOException {
+		// use Hadoop class to translate numbers into String
+		FsPermission fsPerm = new FsPermission(perm);
+		Files.setPosixFilePermissions(pathToFile(p).toPath(), PosixFilePermissions.fromString(fsPerm.toString()));
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.fs.HadoopFileSystemWrapper;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -450,6 +451,11 @@ public final class HadoopFileSystem extends FileSystem implements HadoopFileSyst
 	public boolean rename(final Path src, final Path dst) throws IOException {
 		return this.fs.rename(new org.apache.hadoop.fs.Path(src.toString()),
 			new org.apache.hadoop.fs.Path(dst.toString()));
+	}
+
+	@Override
+	public void setPermission(Path p, String perm) throws IOException {
+		fs.setPermission(new org.apache.hadoop.fs.Path(p.toString()), new FsPermission(perm));
 	}
 
 	@SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/fs/maprfs/MapRFileSystem.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/fs/maprfs/MapRFileSystem.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.flink.core.fs.BlockLocation;
@@ -370,6 +371,11 @@ public final class MapRFileSystem extends FileSystem {
 
 		return this.fs.rename(new org.apache.hadoop.fs.Path(src.toString()),
 				new org.apache.hadoop.fs.Path(dst.toString()));
+	}
+
+	@Override
+	public void setPermission(Path p, String perm) throws IOException {
+		fs.setPermission(new org.apache.hadoop.fs.Path(p.toString()), new FsPermission(perm));
 	}
 
 	@SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
@@ -104,6 +104,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 
 		filesystem = basePath.getFileSystem();
 		filesystem.mkdirs(dir);
+		filesystem.setPermission(dir, "700"); // set permission for path.
 
 		checkpointDirectory = dir;
 	}


### PR DESCRIPTION
Now checkpoint directory is made w/o specified permission, so it is easy for another user to delete or read files under it, which will cause restore failure or information leak.

It's better to lower it down to 700.

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
![chp-filesystem-session](https://cloud.githubusercontent.com/assets/5276001/23019741/d753e8e0-f47e-11e6-9f2e-2cd35de35ef1.JPG)

# Discussion Details
## Preconditions
1. Every flink job(session or single) can specify a directory storing checkpoint, called `state.backend.fs.checkpointdir`.
2. Different jobs can set same or different directories, which means their checkpoint files can be stored in one same or different directories, with **sub-dir** created with their own job-ids.
3. Jobs can be run by different users, and users has requirement that one could not read chp files written by another user, which will cause information leak.
4. In some condition(which is relatively rare, I think), as @StephanEwen said, users has need to access other users’ chp files for cloning/migrating jobs.
5. The chp files path is like: `hdfs://namenode:port/flink-checkpoints/<job-id>/chk-17/6ba7b810-9dad-11d1-80b4-00c04fd430c8`

## Solutions 
### Solution #1 (would not require changes)
1. Admins control permission of root directory via HDFS ACLs(set it like: user1 can read&write, user2 can only read, …).
2. This has two disadvantages: a) It is a** huge burden for Admins** to set different permissions for large number of users/groups); and b) sub-dirs inherited permissions from root directory, which means **they are basically same**, which make it hard to do fine grained control.
### Solution #2 (this proposal)
1. We don’t care what permission of the root dir is. It can be create while setup or job running, as long as it is available to use.
2. We control every sub-dir created by different jobs(which are submitted by different users, in most cases), and set it to a lower value(like “700”) to prevent it to be read by others.
3. If someone wanna migrate or clone jobs across users(again, this scenario is rare in my view), he should ask admins(normally HDFS admin) to add ACLs(or whatever) for this purpose.
