### PR TITLE
[FLINK-5586] [table] Extend TableProgramsClusterTestBase for object reuse mode

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/Row.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Row.java
@@ -139,4 +139,18 @@ public class Row implements Serializable{
 		}
 		return row;
 	}
+
+	/**
+	 * Creates a new Row which copied from another row.
+	 *
+	 * @param row The row being copied.
+	 * @return The cloned new Row
+	 */
+	public static Row copy(Row row) {
+		Row ret = new Row(row.getArity());
+		for (int i = 0; i < row.getArity(); ++i) {
+			ret.setField(i, row.getField(i));
+		}
+		return ret;
+	}
 }

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/batch/sql/GroupingSetsITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/batch/sql/GroupingSetsITCase.java
@@ -50,8 +50,8 @@ public class GroupingSetsITCase extends TableProgramsClusterTestBase {
 	private final static String TABLE_WITH_NULLS_NAME = "MyTableWithNulls";
 	private BatchTableEnvironment tableEnv;
 
-	public GroupingSetsITCase(TableConfigMode tableConfigMode) {
-		super(tableConfigMode);
+	public GroupingSetsITCase(TestExecutionMode mode, TableConfigMode tableConfigMode) {
+		super(mode, tableConfigMode);
 	}
 
 	@Before

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/SortITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/SortITCase.scala
@@ -25,6 +25,7 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.scala.batch.utils.SortTestUtils._
 import org.apache.flink.table.api.scala.batch.utils.TableProgramsClusterTestBase
 import org.apache.flink.table.api.scala.batch.utils.TableProgramsTestBase.TableConfigMode
+import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
 import org.apache.flink.test.util.TestBaseUtils
 import org.apache.flink.types.Row
 import org.junit._
@@ -32,9 +33,11 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 @RunWith(classOf[Parameterized])
-class SortITCase(configMode: TableConfigMode) extends TableProgramsClusterTestBase(configMode) {
+class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
+    extends TableProgramsClusterTestBase(mode, configMode) {
 
   private def getExecutionEnvironment = {
     val env = ExecutionEnvironment.getExecutionEnvironment
@@ -56,7 +59,12 @@ class SortITCase(configMode: TableConfigMode) extends TableProgramsClusterTestBa
 
     val expected = sortExpectedly(tupleDataSetStrings)
     // squash all rows inside a partition into one element
-    val results = t.toDataSet[Row].mapPartition(rows => Seq(rows.toSeq)).collect()
+    val results = t.toDataSet[Row].mapPartition(rows => {
+      // the rows need to be copied in object reuse mode
+      val copied = new mutable.ArrayBuffer[Row]
+      rows.foreach(r => copied += Row.copy(r))
+      Seq(copied)
+    }).collect()
 
     val result = results
         .filterNot(_.isEmpty)
@@ -79,7 +87,12 @@ class SortITCase(configMode: TableConfigMode) extends TableProgramsClusterTestBa
 
     val expected = sortExpectedly(tupleDataSetStrings)
     // squash all rows inside a partition into one element
-    val results = t.toDataSet[Row].mapPartition(rows => Seq(rows.toSeq)).collect()
+    val results = t.toDataSet[Row].mapPartition(rows => {
+      // the rows need to be copied in object reuse mode
+      val copied = new mutable.ArrayBuffer[Row]
+      rows.foreach(r => copied += Row.copy(r))
+      Seq(copied)
+    }).collect()
 
     val result = results
         .filterNot(_.isEmpty)
@@ -102,7 +115,12 @@ class SortITCase(configMode: TableConfigMode) extends TableProgramsClusterTestBa
 
     val expected = sortExpectedly(tupleDataSetStrings)
     // squash all rows inside a partition into one element
-    val results = t.toDataSet[Row].mapPartition(rows => Seq(rows.toSeq)).collect()
+    val results = t.toDataSet[Row].mapPartition(rows => {
+      // the rows need to be copied in object reuse mode
+      val copied = new mutable.ArrayBuffer[Row]
+      rows.foreach(r => copied += Row.copy(r))
+      Seq(copied)
+    }).collect()
 
     def rowOrdering = Ordering.by((r : Row) => {
       // ordering for this tuple will fall into the previous defined tupleOrdering,
@@ -131,7 +149,12 @@ class SortITCase(configMode: TableConfigMode) extends TableProgramsClusterTestBa
 
     val expected = sortExpectedly(tupleDataSetStrings, 3, 21)
     // squash all rows inside a partition into one element
-    val results = t.toDataSet[Row].mapPartition(rows => Seq(rows.toSeq)).collect()
+    val results = t.toDataSet[Row].mapPartition(rows => {
+      // the rows need to be copied in object reuse mode
+      val copied = new mutable.ArrayBuffer[Row]
+      rows.foreach(r => copied += Row.copy(r))
+      Seq(copied)
+    }).collect()
 
     val result = results
         .filterNot(_.isEmpty)
@@ -154,7 +177,12 @@ class SortITCase(configMode: TableConfigMode) extends TableProgramsClusterTestBa
 
     val expected = sortExpectedly(tupleDataSetStrings, 3, 8)
     // squash all rows inside a partition into one element
-    val results = t.toDataSet[Row].mapPartition(rows => Seq(rows.toSeq)).collect()
+    val results = t.toDataSet[Row].mapPartition(rows => {
+      // the rows need to be copied in object reuse mode
+      val copied = new mutable.ArrayBuffer[Row]
+      rows.foreach(r => copied += Row.copy(r))
+      Seq(copied)
+    }).collect()
 
     val result = results
         .filterNot(_.isEmpty)
@@ -177,7 +205,12 @@ class SortITCase(configMode: TableConfigMode) extends TableProgramsClusterTestBa
 
     val expected = sortExpectedly(tupleDataSetStrings, 0, 5)
     // squash all rows inside a partition into one element
-    val results = t.toDataSet[Row].mapPartition(rows => Seq(rows.toSeq)).collect()
+    val results = t.toDataSet[Row].mapPartition(rows => {
+      // the rows need to be copied in object reuse mode
+      val copied = new mutable.ArrayBuffer[Row]
+      rows.foreach(r => copied += Row.copy(r))
+      Seq(copied)
+    }).collect()
 
     implicit def rowOrdering = Ordering.by((r : Row) => r.getField(0).asInstanceOf[Int])
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/utils/TableProgramsClusterTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/utils/TableProgramsClusterTestBase.scala
@@ -18,8 +18,13 @@
 
 package org.apache.flink.table.api.scala.batch.utils
 
+import java.util
+
 import org.apache.flink.table.api.scala.batch.utils.TableProgramsTestBase.TableConfigMode
 import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
+import org.junit.runners.Parameterized
+
+import scala.collection.JavaConversions._
 
 /**
   * This test base provides full cluster-like integration tests for batch programs. Only runtime
@@ -27,6 +32,19 @@ import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
   * (e.g. [[org.apache.flink.table.runtime.dataset.DataSetWindowAggregateITCase]])
   */
 class TableProgramsClusterTestBase(
+    executionMode: TestExecutionMode,
     tableConfigMode: TableConfigMode)
-  extends TableProgramsTestBase(TestExecutionMode.CLUSTER, tableConfigMode) {
+    extends TableProgramsTestBase(executionMode, tableConfigMode) {
+}
+
+object TableProgramsClusterTestBase {
+
+  @Parameterized.Parameters(name = "Execution mode = {0}, Table config = {1}")
+  def parameters(): util.Collection[Array[java.lang.Object]] = {
+    Seq[Array[AnyRef]](
+      Array(TestExecutionMode.CLUSTER, TableProgramsTestBase.DEFAULT),
+      Array(TestExecutionMode.CLUSTER_OBJECT_REUSE, TableProgramsTestBase.DEFAULT)
+    )
+  }
+
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/utils/TableProgramsCollectionTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/utils/TableProgramsCollectionTestBase.scala
@@ -18,8 +18,13 @@
 
 package org.apache.flink.table.api.scala.batch.utils
 
+import java.util
+
 import org.apache.flink.table.api.scala.batch.utils.TableProgramsTestBase.TableConfigMode
 import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
+import org.junit.runners.Parameterized
+
+import scala.collection.JavaConversions._
 
 /**
   * This test base provides lightweight integration tests for batch programs. However, it does
@@ -27,6 +32,15 @@ import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
   * use [[TableProgramsClusterTestBase]].
   */
 class TableProgramsCollectionTestBase(
-  tableConfigMode: TableConfigMode)
-  extends TableProgramsTestBase(TestExecutionMode.COLLECTION, tableConfigMode) {
+    tableConfigMode: TableConfigMode)
+    extends TableProgramsTestBase(TestExecutionMode.COLLECTION, tableConfigMode) {
+}
+
+object TableProgramsCollectionTestBase {
+
+  @Parameterized.Parameters(name = "Table config = {0}")
+  def parameters(): util.Collection[Array[java.lang.Object]] = {
+    Seq[Array[AnyRef]](Array(TableProgramsTestBase.DEFAULT))
+  }
+
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/utils/TableProgramsTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/utils/TableProgramsTestBase.scala
@@ -18,15 +18,10 @@
 
 package org.apache.flink.table.api.scala.batch.utils
 
-import java.util
-
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.api.scala.batch.utils.TableProgramsTestBase.{NO_NULL, TableConfigMode}
 import org.apache.flink.test.util.MultipleProgramsTestBase
 import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
-import org.junit.runners.Parameterized
-
-import scala.collection.JavaConversions._
 
 class TableProgramsTestBase(
     mode: TestExecutionMode,
@@ -50,8 +45,4 @@ object TableProgramsTestBase {
   val DEFAULT = TableConfigMode(nullCheck = true)
   val NO_NULL = TableConfigMode(nullCheck = false)
 
-  @Parameterized.Parameters(name = "Table config = {0}")
-  def parameters(): util.Collection[Array[java.lang.Object]] = {
-    Seq[Array[AnyRef]](Array(DEFAULT))
-  }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/dataset/DataSetCalcITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/dataset/DataSetCalcITCase.scala
@@ -26,6 +26,7 @@ import org.apache.flink.table.api.scala.batch.utils.TableProgramsClusterTestBase
 import org.apache.flink.table.api.scala.batch.utils.TableProgramsTestBase.TableConfigMode
 import org.apache.flink.table.expressions.utils.{RichFunc1, RichFunc2, RichFunc3}
 import org.apache.flink.table.utils._
+import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
 import org.apache.flink.test.util.TestBaseUtils
 import org.apache.flink.types.Row
 import org.junit.Test
@@ -36,8 +37,9 @@ import scala.collection.JavaConverters._
 
 @RunWith(classOf[Parameterized])
 class DataSetCalcITCase(
-  configMode: TableConfigMode)
-  extends TableProgramsClusterTestBase(configMode) {
+    mode: TestExecutionMode,
+    configMode: TableConfigMode)
+  extends TableProgramsClusterTestBase(mode, configMode) {
 
   @Test
   def testUserDefinedScalarFunctionWithParameter(): Unit = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/dataset/DataSetUserDefinedFunctionITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/dataset/DataSetUserDefinedFunctionITCase.scala
@@ -28,6 +28,7 @@ import org.apache.flink.table.api.scala.batch.utils.TableProgramsTestBase.TableC
 import org.apache.flink.table.api.scala.batch.utils.TableProgramsClusterTestBase
 import org.apache.flink.table.expressions.utils.{Func13, RichFunc2}
 import org.apache.flink.table.utils._
+import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
 import org.apache.flink.test.util.TestBaseUtils
 import org.apache.flink.types.Row
 import org.junit.Test
@@ -39,8 +40,9 @@ import scala.collection.mutable
 
 @RunWith(classOf[Parameterized])
 class DataSetUserDefinedFunctionITCase(
-  configMode: TableConfigMode)
-  extends TableProgramsClusterTestBase(configMode) {
+    mode: TestExecutionMode,
+    configMode: TableConfigMode)
+    extends TableProgramsClusterTestBase(mode, configMode) {
 
   @Test
   def testCrossJoin(): Unit = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/dataset/DataSetWindowAggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/dataset/DataSetWindowAggregateITCase.scala
@@ -29,12 +29,15 @@ import org.junit._
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.apache.flink.table.api.ValidationException
+import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
 
 import scala.collection.JavaConverters._
 
 @RunWith(classOf[Parameterized])
-class DataSetWindowAggregateITCase(configMode: TableConfigMode)
-  extends TableProgramsClusterTestBase(configMode) {
+class DataSetWindowAggregateITCase(
+    mode: TestExecutionMode,
+    configMode: TableConfigMode)
+    extends TableProgramsClusterTestBase(mode, configMode) {
 
   val data = List(
     (1L, 1, "Hi"),

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MultipleProgramsTestBase.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MultipleProgramsTestBase.java
@@ -62,7 +62,8 @@ public class MultipleProgramsTestBase extends TestBaseUtils {
 	 */
 	public enum TestExecutionMode {
 		CLUSTER,
-		COLLECTION
+		CLUSTER_OBJECT_REUSE,
+		COLLECTION,
 	}
 	
 	// ------------------------------------------------------------------------
@@ -85,12 +86,13 @@ public class MultipleProgramsTestBase extends TestBaseUtils {
 		
 		switch(mode){
 			case CLUSTER:
-				TestEnvironment clusterEnv = new TestEnvironment(cluster, 4);
-				clusterEnv.setAsContext();
+				new TestEnvironment(cluster, 4).setAsContext();
+				break;
+			case CLUSTER_OBJECT_REUSE:
+				new TestEnvironment(cluster, 4, true).setAsContext();
 				break;
 			case COLLECTION:
-				CollectionTestEnvironment collectionEnv = new CollectionTestEnvironment();
-				collectionEnv.setAsContext();
+				new CollectionTestEnvironment().setAsContext();
 				break;
 		}
 	}


### PR DESCRIPTION
Make all cluster-based ITCases verified in object reuse mode. This only includes batch table tests now.