### PR TITLE
FLINK-5731 Spilt up tests into three disjoint groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,21 +19,30 @@ matrix:
       env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis -Dmaven.javadoc.skip=true"
     - jdk: "oraclejdk8"
       env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis -Dmaven.javadoc.skip=true"
+    - jdk: "oraclejdk8"
+      env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-c,include-kinesis -Dmaven.javadoc.skip=true"
 
     - jdk: "oraclejdk8"
       env: PROFILE="-Dhadoop.version=2.6.3 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis -Dmaven.javadoc.skip=true"
     - jdk: "oraclejdk8"
       env: PROFILE="-Dhadoop.version=2.6.3 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis -Dmaven.javadoc.skip=true"
+    - jdk: "oraclejdk8"
+      env: PROFILE="-Dhadoop.version=2.6.3 -Pinclude-yarn-tests,flink-fast-tests-c,include-kinesis -Dmaven.javadoc.skip=true"
 
     - jdk: "openjdk7"
       env: PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis"
     - jdk: "openjdk7"
       env: PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis"
+    - jdk: "openjdk7"
+      env: PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-c,include-kinesis"
 
     - jdk: "oraclejdk7"
       env: PROFILE="-Dhadoop.version=2.3.0 -Pflink-fast-tests-a,include-kinesis"
     - jdk: "oraclejdk7"
       env: PROFILE="-Dhadoop.version=2.3.0 -Pflink-fast-tests-b,include-kinesis"
+    - jdk: "oraclejdk7"
+      env: PROFILE="-Dhadoop.version=2.3.0 -Pflink-fast-tests-c,include-kinesis"
+
 
 
 git:

--- a/pom.xml
+++ b/pom.xml
@@ -767,13 +767,22 @@ under the License.
 		<profile>
 			<id>flink-fast-tests-a</id>
 			<properties>
-				<flink-fast-tests-pattern>%regex[.*/[A-M].*]</flink-fast-tests-pattern>
+				<!-- Allow A-I by forbidding J-Z -->
+				<flink-fast-tests-pattern>%regex[.*/[J-Z].*]</flink-fast-tests-pattern>
 			</properties>
 		</profile>
 		<profile>
 			<id>flink-fast-tests-b</id>
 			<properties>
-				<flink-fast-tests-pattern>%regex[.*/[N-Z].*]</flink-fast-tests-pattern>
+				<!-- Allow J-R, forbid A-I and S - Z -->
+				<flink-fast-tests-pattern>%regex[.*/[A-IS-Z].*]</flink-fast-tests-pattern>
+			</properties>
+		</profile>
+		<profile>
+			<id>flink-fast-tests-c</id>
+			<properties>
+				<!-- Allow S-Z, forbid A-R -->
+				<flink-fast-tests-pattern>%regex[.*/[A-R].*]</flink-fast-tests-pattern>
 			</properties>
 		</profile>
 	</profiles>


### PR DESCRIPTION
We were running into build timeouts again recently on travis.
That's why I've split the tests into three groups (instead of two).

This means we'll have 12 test jobs (5 run concurrently)

![image](https://cloud.githubusercontent.com/assets/89049/23065154/535d482e-f514-11e6-904a-96b124a53863.png)

I'm not sure if we want to merge this or not. It gives us only 10 more minutes on the slowest builds, so we'll run into the issue again at some point.
