### PR TITLE
[FLINK-5090] [network] Add metrics for details about inbound/outbound network queues

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -640,7 +640,7 @@ Thus, in order to infer the metric identifier:
       <td>The number of allocated memory segments.</td>
     </tr>
     <tr>
-      <th rowspan="4">Task</th>
+      <th rowspan="8">Task</th>
       <td rowspan="4">buffers</td>
       <td>inputQueueLength</td>
       <td>The number of queued input buffers.</td>
@@ -656,6 +656,24 @@ Thus, in order to infer the metric identifier:
     <tr>
       <td>outPoolUsage</td>
       <td>An estimate of the output buffers usage.</td>
+    </tr>
+    <tr>
+      <td rowspan="4">Network.&lt;Input|Output&gt;.&lt;gate&gt;<br />
+        <strong>(only available if <tt>taskmanager.net.detailed-metrics</tt> config option is set)</strong></td>
+      <td>total-queue-len</td>
+      <td>Total number of queued buffers in all input/output channels.</td>
+    </tr>
+    <tr>
+      <td>min-queue-len</td>
+      <td>Minimum number of queued buffers in all input/output channels.</td>
+    </tr>
+    <tr>
+      <td>max-queue-len</td>
+      <td>Maximum number of queued buffers in all input/output channels.</td>
+    </tr>
+    <tr>
+      <td>avg-queue-len</td>
+      <td>Average number of queued buffers in all input/output channels.</td>
     </tr>
   </tbody>
 </table>

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -660,19 +660,19 @@ Thus, in order to infer the metric identifier:
     <tr>
       <td rowspan="4">Network.&lt;Input|Output&gt;.&lt;gate&gt;<br />
         <strong>(only available if <tt>taskmanager.net.detailed-metrics</tt> config option is set)</strong></td>
-      <td>total-queue-len</td>
+      <td>totalQueueLen</td>
       <td>Total number of queued buffers in all input/output channels.</td>
     </tr>
     <tr>
-      <td>min-queue-len</td>
+      <td>minQueueLen</td>
       <td>Minimum number of queued buffers in all input/output channels.</td>
     </tr>
     <tr>
-      <td>max-queue-len</td>
+      <td>maxQueueLen</td>
       <td>Maximum number of queued buffers in all input/output channels.</td>
     </tr>
     <tr>
-      <td>avg-queue-len</td>
+      <td>avgQueueLen</td>
       <td>Average number of queued buffers in all input/output channels.</td>
     </tr>
   </tbody>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -230,6 +230,12 @@ public final class ConfigConstants {
 	public static final String TASK_MANAGER_NETWORK_NUM_BUFFERS_KEY = "taskmanager.network.numberOfBuffers";
 
 	/**
+	 * Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths
+	 */
+	@PublicEvolving
+	public static final String NETWORK_DETAILED_METRICS_KEY = "taskmanager.net.detailed-metrics";
+
+	/**
 	 * Config parameter defining the size of memory buffers used by the network stack and the memory manager.
 	 */
 	public static final String TASK_MANAGER_MEMORY_SEGMENT_SIZE_KEY = "taskmanager.memory.segment-size";

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -233,7 +233,9 @@ public final class ConfigConstants {
 	 * Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths
 	 */
 	@PublicEvolving
-	public static final String NETWORK_DETAILED_METRICS_KEY = "taskmanager.net.detailed-metrics";
+	public static final ConfigOption<Boolean> NETWORK_DETAILED_METRICS_KEY =
+		key("taskmanager.network.detailed-metrics")
+			.defaultValue(false);
 
 	/**
 	 * Config parameter defining the size of memory buffers used by the network stack and the memory manager.

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -230,14 +230,6 @@ public final class ConfigConstants {
 	public static final String TASK_MANAGER_NETWORK_NUM_BUFFERS_KEY = "taskmanager.network.numberOfBuffers";
 
 	/**
-	 * Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths
-	 */
-	@PublicEvolving
-	public static final ConfigOption<Boolean> NETWORK_DETAILED_METRICS_KEY =
-		key("taskmanager.network.detailed-metrics")
-			.defaultValue(false);
-
-	/**
 	 * Config parameter defining the size of memory buffers used by the network stack and the memory manager.
 	 */
 	public static final String TASK_MANAGER_MEMORY_SEGMENT_SIZE_KEY = "taskmanager.memory.segment-size";

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -71,7 +71,7 @@ public class TaskManagerOptions {
 	 * Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue
 	 * lengths.
 	 */
-	public static final ConfigOption<Boolean> NETWORK_DETAILED_METRICS_KEY =
+	public static final ConfigOption<Boolean> NETWORK_DETAILED_METRICS =
 			key("taskmanager.net.detailed-metrics")
 			.defaultValue(false);
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -67,6 +67,14 @@ public class TaskManagerOptions {
 		key("taskmanager.net.memory.extra-buffers-per-gate")
 			.defaultValue(8);
 
+	/**
+	 * Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue
+	 * lengths.
+	 */
+	public static final ConfigOption<Boolean> NETWORK_DETAILED_METRICS_KEY =
+			key("taskmanager.net.detailed-metrics")
+			.defaultValue(false);
+
 	// ------------------------------------------------------------------------
 	//  Task Options
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -211,7 +211,8 @@ class PipelinedSubpartition extends ResultSubpartition {
 	}
 
 	@Override
-	public int getNumberOfQueuedBuffers() {
-			return buffers.size();
+	public int unsynchronizedGetNumberOfQueuedBuffers() {
+		// since we do not synchronize, the size may actually be lower than 0!
+		return Math.max(buffers.size(), 0);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.taskmanager.TaskActions;
 import org.apache.flink.runtime.taskmanager.TaskManager;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -232,7 +233,7 @@ public class ResultPartition implements BufferPoolOwner {
 		int totalBuffers = 0;
 
 		for (ResultSubpartition subpartition : subpartitions) {
-			totalBuffers += subpartition.getNumberOfQueuedBuffers();
+			totalBuffers += subpartition.unsynchronizedGetNumberOfQueuedBuffers();
 		}
 
 		return totalBuffers;
@@ -444,6 +445,10 @@ public class ResultPartition implements BufferPoolOwner {
 
 		LOG.debug("{}: Received release notification for subpartition {} (reference count now at: {}).",
 				this, subpartitionIndex, pendingReferences);
+	}
+
+	ResultSubpartition[] getAllPartitions() {
+		return subpartitions;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -221,10 +221,20 @@ public class ResultPartition implements BufferPoolOwner {
 		return bufferPool;
 	}
 
+	/**
+	 * Returns the total number of processed network buffers since initialization.
+	 *
+	 * @return overall number of processed network buffers
+	 */
 	public int getTotalNumberOfBuffers() {
 		return totalNumberOfBuffers;
 	}
 
+	/**
+	 * Returns the total size of processed network buffers since initialization.
+	 *
+	 * @return overall size of processed network buffers
+	 */
 	public long getTotalNumberOfBytes() {
 		return totalNumberOfBytes;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionMetrics.java
@@ -155,9 +155,9 @@ public class ResultPartitionMetrics {
 	public static void registerQueueLengthMetrics(MetricGroup group, ResultPartition partition) {
 		ResultPartitionMetrics metrics = new ResultPartitionMetrics(partition);
 
-		group.gauge("total-queue-len", metrics.getTotalQueueLenGauge());
-		group.gauge("min-queue-len", metrics.getMinQueueLenGauge());
-		group.gauge("max-queue-len", metrics.getMaxQueueLenGauge());
-		group.gauge("avg-queue-len", metrics.getAvgQueueLenGauge());
+		group.gauge("totalQueueLen", metrics.getTotalQueueLenGauge());
+		group.gauge("minQueueLen", metrics.getMinQueueLenGauge());
+		group.gauge("maxQueueLen", metrics.getMaxQueueLenGauge());
+		group.gauge("avgQueueLen", metrics.getAvgQueueLenGauge());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionMetrics.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+public class ResultPartitionMetrics {
+
+	private final ResultPartition partition;
+
+	private int lastMin = -1;
+
+	private int lastMax = -1;
+
+	private float lastAvg = -1.0f;
+
+	// ------------------------------------------------------------------------
+
+	private ResultPartitionMetrics(ResultPartition partition) {
+		this.partition = checkNotNull(partition);
+	}
+
+	// ------------------------------------------------------------------------
+
+	// these methods are package private to make access from the nested classes faster 
+
+	int refreshAndGetMin() {
+		int min;
+		if ((min = lastMin) == -1) {
+			refresh();
+			min = lastMin;
+		}
+
+		lastMin = -1;
+		return min;
+	}
+
+	int refreshAndGetMax() {
+		int max;
+		if ((max = lastMax) == -1) {
+			refresh();
+			max = lastMax;
+		}
+
+		lastMax = -1;
+		return max;
+	}
+
+	float refreshAndGetAvg() {
+		float avg;
+		if ((avg = lastAvg) < 0.0f) {
+			refresh();
+			avg = lastAvg;
+		}
+
+		lastAvg = -1.0f;
+		return avg;
+	}
+
+	private void refresh() {
+		int min = Integer.MAX_VALUE;
+		int max = 0;
+
+		for (ResultSubpartition part : partition.getAllPartitions()) {
+			int size = part.unsynchronizedGetNumberOfQueuedBuffers();
+			min = Math.min(min, size);
+			max = Math.max(max, size);
+		}
+
+		this.lastMin = min;
+		this.lastMax = max;
+		this.lastAvg = partition.getTotalNumberOfBuffers() / (float) partition.getNumberOfSubpartitions();
+	}
+
+	// ------------------------------------------------------------------------
+	//  Gauges to access the stats
+	// ------------------------------------------------------------------------
+
+	private Gauge<Integer> getMinQueueLenGauge() {
+		return new Gauge<Integer>() {
+			@Override
+			public Integer getValue() {
+				return refreshAndGetMin();
+			}
+		};
+	}
+
+	private Gauge<Integer> getMaxQueueLenGauge() {
+		return new Gauge<Integer>() {
+			@Override
+			public Integer getValue() {
+				return refreshAndGetMax();
+			}
+		};
+	}
+
+	private Gauge<Float> getAvgQueueLenGauge() {
+		return new Gauge<Float>() {
+			@Override
+			public Float getValue() {
+				return refreshAndGetAvg();
+			}
+		};
+	}
+
+	// ------------------------------------------------------------------------
+	//  Static access
+	// ------------------------------------------------------------------------
+
+	public static void registerQueueLengthMetrics(MetricGroup group, ResultPartition partition) {
+		ResultPartitionMetrics metrics = new ResultPartitionMetrics(partition);
+
+		group.gauge("min-queue-len", metrics.getMinQueueLenGauge());
+		group.gauge("max-queue-len", metrics.getMaxQueueLenGauge());
+		group.gauge("avg-queue-len", metrics.getAvgQueueLenGauge());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionMetrics.java
@@ -77,18 +77,21 @@ public class ResultPartitionMetrics {
 	}
 
 	private void refresh() {
+		long total = 0;
 		int min = Integer.MAX_VALUE;
 		int max = 0;
 
-		for (ResultSubpartition part : partition.getAllPartitions()) {
+		ResultSubpartition[] allPartitions = partition.getAllPartitions();
+		for (ResultSubpartition part : allPartitions) {
 			int size = part.unsynchronizedGetNumberOfQueuedBuffers();
+			total += size;
 			min = Math.min(min, size);
 			max = Math.max(max, size);
 		}
 
 		this.lastMin = min;
 		this.lastMax = max;
-		this.lastAvg = partition.getTotalNumberOfBuffers() / (float) partition.getNumberOfSubpartitions();
+		this.lastAvg = total / (float) allPartitions.length;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -83,6 +83,11 @@ public abstract class ResultSubpartition {
 
 	abstract public boolean isReleased();
 
-	abstract public int getNumberOfQueuedBuffers();
+	/**
+	 * Makes a best effort to get the current size of the queue.
+	 * This method must not acquire locks or interfere with the task and network threads in
+	 * any way.
+	 */
+	abstract public int unsynchronizedGetNumberOfQueuedBuffers();
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -234,8 +234,9 @@ class SpillableSubpartition extends ResultSubpartition {
 	}
 
 	@Override
-	public int getNumberOfQueuedBuffers() {
-		return buffers.size();
+	public int unsynchronizedGetNumberOfQueuedBuffers() {
+		// since we do not synchronize, the size may actually be lower than 0!
+		return Math.max(buffers.size(), 0);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateMetrics.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+public class InputGateMetrics {
+
+	private final SingleInputGate inputGate;
+
+	private long lastTotal = -1;
+
+	private int lastMin = -1;
+
+	private int lastMax = -1;
+
+	private float lastAvg = -1.0f;
+
+	// ------------------------------------------------------------------------
+
+	private InputGateMetrics(SingleInputGate inputGate) {
+		this.inputGate = checkNotNull(inputGate);
+	}
+
+	// ------------------------------------------------------------------------
+
+	// these methods are package private to make access from the nested classes faster 
+
+	long refreshAndGetTotal() {
+		long total;
+		if ((total = lastTotal) == -1) {
+			refresh();
+			total = lastTotal;
+		}
+
+		lastTotal = -1;
+		return total;
+	}
+
+	int refreshAndGetMin() {
+		int min;
+		if ((min = lastMin) == -1) {
+			refresh();
+			min = lastMin;
+		}
+
+		lastMin = -1;
+		return min;
+	}
+
+	int refreshAndGetMax() {
+		int max;
+		if ((max = lastMax) == -1) {
+			refresh();
+			max = lastMax;
+		}
+
+		lastMax = -1;
+		return max;
+	}
+
+	float refreshAndGetAvg() {
+		float avg;
+		if ((avg = lastAvg) < 0.0f) {
+			refresh();
+			avg = lastAvg;
+		}
+
+		lastAvg = -1.0f;
+		return avg;
+	}
+
+	private void refresh() {
+		long total = 0;
+		int min = Integer.MAX_VALUE;
+		int max = 0;
+		int count = 0;
+
+		for (InputChannel channel : inputGate.getInputChannels().values()) {
+			if (channel.getClass() == RemoteInputChannel.class) {
+				RemoteInputChannel rc = (RemoteInputChannel) channel;
+
+				int size = rc.unsynchronizedGetNumberOfQueuedBuffers();
+				total += size;
+				min = Math.min(min, size);
+				max = Math.max(max, size);
+				count++;
+			}
+		}
+
+		this.lastMin = min;
+		this.lastMax = max;
+		this.lastAvg = total / (float) count;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Gauges to access the stats
+	// ------------------------------------------------------------------------
+
+	private Gauge<Long> getTotalQueueLenGauge() {
+		return new Gauge<Long>() {
+			@Override
+			public Long getValue() {
+				return refreshAndGetTotal();
+			}
+		};
+	}
+
+	private Gauge<Integer> getMinQueueLenGauge() {
+		return new Gauge<Integer>() {
+			@Override
+			public Integer getValue() {
+				return refreshAndGetMin();
+			}
+		};
+	}
+
+	private Gauge<Integer> getMaxQueueLenGauge() {
+		return new Gauge<Integer>() {
+			@Override
+			public Integer getValue() {
+				return refreshAndGetMax();
+			}
+		};
+	}
+
+	private Gauge<Float> getAvgQueueLenGauge() {
+		return new Gauge<Float>() {
+			@Override
+			public Float getValue() {
+				return refreshAndGetAvg();
+			}
+		};
+	}
+
+	// ------------------------------------------------------------------------
+	//  Static access
+	// ------------------------------------------------------------------------
+
+	public static void registerQueueLengthMetrics(MetricGroup group, SingleInputGate gate) {
+		InputGateMetrics metrics = new InputGateMetrics(gate);
+
+		group.gauge("total-queue-len", metrics.getTotalQueueLenGauge());
+		group.gauge("min-queue-len", metrics.getMinQueueLenGauge());
+		group.gauge("max-queue-len", metrics.getMaxQueueLenGauge());
+		group.gauge("avg-queue-len", metrics.getAvgQueueLenGauge());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateMetrics.java
@@ -160,9 +160,9 @@ public class InputGateMetrics {
 	public static void registerQueueLengthMetrics(MetricGroup group, SingleInputGate gate) {
 		InputGateMetrics metrics = new InputGateMetrics(gate);
 
-		group.gauge("total-queue-len", metrics.getTotalQueueLenGauge());
-		group.gauge("min-queue-len", metrics.getMinQueueLenGauge());
-		group.gauge("max-queue-len", metrics.getMaxQueueLenGauge());
-		group.gauge("avg-queue-len", metrics.getAvgQueueLenGauge());
+		group.gauge("totalQueueLen", metrics.getTotalQueueLenGauge());
+		group.gauge("minQueueLen", metrics.getMinQueueLenGauge());
+		group.gauge("maxQueueLen", metrics.getMaxQueueLenGauge());
+		group.gauge("avgQueueLen", metrics.getAvgQueueLenGauge());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateMetrics.java
@@ -107,6 +107,7 @@ public class InputGateMetrics {
 			}
 		}
 
+		this.lastTotal = total;
 		this.lastMin = min;
 		this.lastMax = max;
 		this.lastAvg = total / (float) count;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateMetrics.java
@@ -21,19 +21,16 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 
+import java.util.Collection;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
+/**
+ * Collects metrics of an input gate.
+ */
 public class InputGateMetrics {
 
 	private final SingleInputGate inputGate;
-
-	private long lastTotal = -1;
-
-	private int lastMin = -1;
-
-	private int lastMax = -1;
-
-	private float lastAvg = -1.0f;
 
 	// ------------------------------------------------------------------------
 
@@ -45,72 +42,95 @@ public class InputGateMetrics {
 
 	// these methods are package private to make access from the nested classes faster 
 
+	/**
+	 * Iterates over all input channels and collects the total number of queued buffers in a
+	 * best-effort way.
+	 *
+	 * @return total number of queued buffers
+	 */
 	long refreshAndGetTotal() {
-		long total;
-		if ((total = lastTotal) == -1) {
-			refresh();
-			total = lastTotal;
+		long total = 0;
+
+		for (InputChannel channel : inputGate.getInputChannels().values()) {
+			if (channel instanceof RemoteInputChannel) {
+				RemoteInputChannel rc = (RemoteInputChannel) channel;
+
+				total += rc.unsynchronizedGetNumberOfQueuedBuffers();
+			}
 		}
 
-		lastTotal = -1;
 		return total;
 	}
 
+	/**
+	 * Iterates over all input channels and collects the minimum number of queued buffers in a
+	 * channel in a best-effort way.
+	 *
+	 * @return minimum number of queued buffers per channel (<tt>0</tt> if no channels exist)
+	 */
 	int refreshAndGetMin() {
-		int min;
-		if ((min = lastMin) == -1) {
-			refresh();
-			min = lastMin;
+		int min = Integer.MAX_VALUE;
+
+		Collection<InputChannel> channels = inputGate.getInputChannels().values();
+		if (channels.isEmpty()) {
+			// meaningful value when no channels exist:
+			return 0;
 		}
 
-		lastMin = -1;
+		for (InputChannel channel : channels) {
+			if (channel instanceof RemoteInputChannel) {
+				RemoteInputChannel rc = (RemoteInputChannel) channel;
+
+				int size = rc.unsynchronizedGetNumberOfQueuedBuffers();
+				min = Math.min(min, size);
+			}
+		}
+
 		return min;
 	}
 
+	/**
+	 * Iterates over all input channels and collects the maximum number of queued buffers in a
+	 * channel in a best-effort way.
+	 *
+	 * @return maximum number of queued buffers per channel
+	 */
 	int refreshAndGetMax() {
-		int max;
-		if ((max = lastMax) == -1) {
-			refresh();
-			max = lastMax;
+		int max = 0;
+
+		for (InputChannel channel : inputGate.getInputChannels().values()) {
+			if (channel instanceof RemoteInputChannel) {
+				RemoteInputChannel rc = (RemoteInputChannel) channel;
+
+				int size = rc.unsynchronizedGetNumberOfQueuedBuffers();
+				max = Math.max(max, size);
+			}
 		}
 
-		lastMax = -1;
 		return max;
 	}
 
+	/**
+	 * Iterates over all input channels and collects the average number of queued buffers in a
+	 * channel in a best-effort way.
+	 *
+	 * @return average number of queued buffers per channel
+	 */
 	float refreshAndGetAvg() {
-		float avg;
-		if ((avg = lastAvg) < 0.0f) {
-			refresh();
-			avg = lastAvg;
-		}
-
-		lastAvg = -1.0f;
-		return avg;
-	}
-
-	private void refresh() {
 		long total = 0;
-		int min = Integer.MAX_VALUE;
-		int max = 0;
 		int count = 0;
 
 		for (InputChannel channel : inputGate.getInputChannels().values()) {
-			if (channel.getClass() == RemoteInputChannel.class) {
+			if (channel instanceof RemoteInputChannel) {
 				RemoteInputChannel rc = (RemoteInputChannel) channel;
 
 				int size = rc.unsynchronizedGetNumberOfQueuedBuffers();
 				total += size;
-				min = Math.min(min, size);
-				max = Math.max(max, size);
-				count++;
+				++count;
 			}
 		}
 
-		this.lastTotal = total;
-		this.lastMin = min;
-		this.lastMax = max;
-		this.lastAvg = total / (float) count;
+		return total / (float) count;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
-import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -54,7 +53,7 @@ public class RemoteInputChannel extends InputChannel {
 	 * The received buffers. Received buffers are enqueued by the network I/O thread and the queue
 	 * is consumed by the receiving task thread.
 	 */
-	private final Queue<Buffer> receivedBuffers = new ArrayDeque<>();
+	private final ArrayDeque<Buffer> receivedBuffers = new ArrayDeque<>();
 
 	/**
 	 * Flag indicating whether this channel has been released. Either called by the receiving task
@@ -217,6 +216,10 @@ public class RemoteInputChannel extends InputChannel {
 		synchronized (receivedBuffers) {
 			return receivedBuffers.size();
 		}
+	}
+
+	public int unsynchronizedGetNumberOfQueuedBuffers() {
+		return Math.max(0, receivedBuffers.size());
 	}
 
 	public InputChannelID getInputChannelId() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
-import com.google.common.collect.Maps;
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -48,6 +46,7 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Timer;
@@ -188,7 +187,7 @@ public class SingleInputGate implements InputGate {
 		checkArgument(numberOfInputChannels > 0);
 		this.numberOfInputChannels = numberOfInputChannels;
 
-		this.inputChannels = Maps.newHashMapWithExpectedSize(numberOfInputChannels);
+		this.inputChannels = new HashMap<>(numberOfInputChannels);
 		this.channelsWithEndOfPartitionEvents = new BitSet(numberOfInputChannels);
 
 		this.taskActions = checkNotNull(taskActions);
@@ -566,7 +565,6 @@ public class SingleInputGate implements InputGate {
 
 	// ------------------------------------------------------------------------
 
-	@VisibleForTesting
 	Map<IntermediateResultPartitionID, InputChannel> getInputChannels() {
 		return inputChannels;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -390,7 +390,7 @@ public class Task implements Runnable, TaskActions {
 		}
 
 		// register detailed network metrics, if configured
-		if (tmConfig.getBoolean(ConfigConstants.NETWORK_DETAILED_METRICS_KEY, false)) {
+		if (tmConfig.getBoolean(ConfigConstants.NETWORK_DETAILED_METRICS_KEY)) {
 			// output metrics
 			for (int i = 0; i < producedPartitions.length; i++) {
 				ResultPartitionMetrics.registerQueueLengthMetrics(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -74,6 +74,7 @@ import org.apache.flink.util.SerializedValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URL;
@@ -280,7 +281,7 @@ public class Task implements Runnable, TaskActions {
 		LibraryCacheManager libraryCache,
 		FileCache fileCache,
 		TaskManagerRuntimeInfo taskManagerConfig,
-		TaskMetricGroup metricGroup,
+		@Nonnull TaskMetricGroup metricGroup,
 		ResultPartitionConsumableNotifier resultPartitionConsumableNotifier,
 		PartitionProducerStateChecker partitionProducerStateChecker,
 		Executor executor) {
@@ -412,10 +413,8 @@ public class Task implements Runnable, TaskActions {
 		// finally, create the executing thread, but do not start it
 		executingThread = new Thread(TASK_THREADS_GROUP, this, taskNameWithSubtask);
 
-		if (this.metrics != null && this.metrics.getIOMetricGroup() != null) {
-			// add metrics for buffers
-			this.metrics.getIOMetricGroup().initializeBufferMetrics(this);
-		}
+		// add metrics for buffers
+		this.metrics.getIOMetricGroup().initializeBufferMetrics(this);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.cache.DistributedCache;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.FileSystemSafetyNet;
@@ -391,7 +390,7 @@ public class Task implements Runnable, TaskActions {
 		}
 
 		// register detailed network metrics, if configured
-		if (tmConfig.getBoolean(ConfigConstants.NETWORK_DETAILED_METRICS_KEY)) {
+		if (tmConfig.getBoolean(TaskManagerOptions.NETWORK_DETAILED_METRICS_KEY)) {
 			MetricGroup networkGroup = metricGroup.addGroup("Network"); // same as in MetricUtils.instantiateNetworkMetrics()
 			MetricGroup outputGroup = networkGroup.addGroup("Output"); // this is optional
 			MetricGroup inputGroup = networkGroup.addGroup("Input"); // this is optional

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -28,6 +28,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.FileSystemSafetyNet;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
@@ -391,15 +392,19 @@ public class Task implements Runnable, TaskActions {
 
 		// register detailed network metrics, if configured
 		if (tmConfig.getBoolean(ConfigConstants.NETWORK_DETAILED_METRICS_KEY)) {
+			MetricGroup networkGroup = metricGroup.addGroup("Network"); // same as in MetricUtils.instantiateNetworkMetrics()
+			MetricGroup outputGroup = networkGroup.addGroup("Output"); // this is optional
+			MetricGroup inputGroup = networkGroup.addGroup("Input"); // this is optional
+
 			// output metrics
 			for (int i = 0; i < producedPartitions.length; i++) {
 				ResultPartitionMetrics.registerQueueLengthMetrics(
-						metricGroup.addGroup("netout_" + i), producedPartitions[i]);
+					outputGroup.addGroup(i), producedPartitions[i]);
 			}
 
 			for (int i = 0; i < inputGates.length; i++) {
 				InputGateMetrics.registerQueueLengthMetrics(
-						metricGroup.addGroup("netin_" + i), inputGates[i]);
+					inputGroup.addGroup(i), inputGates[i]);
 			}
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -46,6 +46,7 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.jobgraph.tasks.StatefulTask;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.TaskStateHandles;
@@ -157,6 +158,9 @@ public class TaskAsyncCallTest {
 		when(networkEnvironment.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class)))
 				.thenReturn(mock(TaskKvStateRegistry.class));
 
+		TaskMetricGroup taskMetricGroup = mock(TaskMetricGroup.class);
+		when(taskMetricGroup.getIOMetricGroup()).thenReturn(mock(TaskIOMetricGroup.class));
+
 		JobInformation jobInformation = new JobInformation(
 			new JobID(),
 			"Job Name",
@@ -194,7 +198,7 @@ public class TaskAsyncCallTest {
 			libCache,
 			mock(FileCache.class),
 			new TestingTaskManagerRuntimeInfo(),
-			mock(TaskMetricGroup.class),
+			taskMetricGroup,
 			consumableNotifier,
 			partitionProducerStateChecker,
 			executor);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.io.network.netty.PartitionProducerStateChecker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
@@ -68,6 +69,9 @@ public class TaskStopTest {
 		TaskManagerRuntimeInfo tmRuntimeInfo = mock(TaskManagerRuntimeInfo.class);
 		when(tmRuntimeInfo.getConfiguration()).thenReturn(new Configuration());
 
+		TaskMetricGroup taskMetricGroup = mock(TaskMetricGroup.class);
+		when(taskMetricGroup.getIOMetricGroup()).thenReturn(mock(TaskIOMetricGroup.class));
+
 		task = new Task(
 			mock(JobInformation.class),
 			new TaskInformation(
@@ -95,7 +99,7 @@ public class TaskStopTest {
 			mock(LibraryCacheManager.class),
 			mock(FileCache.class),
 			tmRuntimeInfo,
-			mock(TaskMetricGroup.class),
+			taskMetricGroup,
 			mock(ResultPartitionConsumableNotifier.class),
 			mock(PartitionProducerStateChecker.class),
 			mock(Executor.class));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -53,9 +53,9 @@ import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.messages.TaskManagerMessages;
 import org.apache.flink.runtime.messages.TaskMessages;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
-import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
@@ -941,6 +941,9 @@ public class TaskTest extends TestLogger {
 			1,
 			invokable.getName(),
 			new Configuration());
+
+		TaskMetricGroup taskMetricGroup = mock(TaskMetricGroup.class);
+		when(taskMetricGroup.getIOMetricGroup()).thenReturn(mock(TaskIOMetricGroup.class));
 		
 		return new Task(
 			jobInformation,
@@ -963,7 +966,7 @@ public class TaskTest extends TestLogger {
 			libCache,
 			mock(FileCache.class),
 			new TestingTaskManagerRuntimeInfo(taskManagerConfig),
-			mock(TaskMetricGroup.class),
+			taskMetricGroup,
 			consumableNotifier,
 			partitionProducerStateChecker,
 			executor);


### PR DESCRIPTION
These metrics are optimised go go through the channels only once in order to
gather all metrics, i.e. min, max, avg and sum. Whenever a request to either
of those is made, all metrics are refreshed and cached. Requests to the other
metrics will be served from the cache. However, each value will be served only
once from the cache and a second call to retrieve the minimum, for example,
will refresh the cache for all values.

This setup may at first be a bit strange but ensures that the statistics belong
together logically and originate from a common point in time. This is not
necessarily the point in time the metric was requested though.