### PR TITLE
[FLINK-5838] [scripts] Print shell script usage

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -25,6 +25,11 @@ EXECUTIONMODE=$2
 HOST=$3 # optional when starting multiple instances
 WEBUIPORT=$4 # optional when starting multiple instances
 
+if [[ $STARTSTOP != "start" ]] && [[ $STARTSTOP != "stop" ]] && [[ $STARTSTOP != "stop-all" ]]; then
+  echo $USAGE
+  exit 1
+fi
+
 bin=`dirname "$0"`
 bin=`cd "$bin"; pwd`
 

--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -25,7 +25,7 @@ EXECUTIONMODE=$2
 HOST=$3 # optional when starting multiple instances
 WEBUIPORT=$4 # optional when starting multiple instances
 
-if [[ $STARTSTOP != "start" ]] && [[ $STARTSTOP != "stop" ]] && [[ $STARTSTOP != "stop-all" ]]; then
+if [[ $STARTSTOP != "start" ]] && [[ $STARTSTOP != "start-foreground" ]] && [[ $STARTSTOP != "stop" ]] && [[ $STARTSTOP != "stop-all" ]]; then
   echo $USAGE
   exit 1
 fi

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -22,6 +22,11 @@ USAGE="Usage: taskmanager.sh start|start-foreground|stop|stop-all)"
 
 STARTSTOP=$1
 
+if [[ $STARTSTOP != "start" ]] && [[ $STARTSTOP != "stop" ]] && [[ $STARTSTOP != "stop-all" ]]; then
+  echo $USAGE
+  exit 1
+fi
+
 bin=`dirname "$0"`
 bin=`cd "$bin"; pwd`
 

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -22,7 +22,7 @@ USAGE="Usage: taskmanager.sh start|start-foreground|stop|stop-all)"
 
 STARTSTOP=$1
 
-if [[ $STARTSTOP != "start" ]] && [[ $STARTSTOP != "stop" ]] && [[ $STARTSTOP != "stop-all" ]]; then
+if [[ $STARTSTOP != "start" ]] && [[ $STARTSTOP != "start-foreground" ]] && [[ $STARTSTOP != "stop" ]] && [[ $STARTSTOP != "stop-all" ]]; then
   echo $USAGE
   exit 1
 fi

--- a/flink-dist/src/main/flink-bin/bin/zookeeper.sh
+++ b/flink-dist/src/main/flink-bin/bin/zookeeper.sh
@@ -23,6 +23,11 @@ USAGE="Usage: zookeeper.sh ((start|start-foreground) peer-id)|stop|stop-all"
 STARTSTOP=$1
 PEER_ID=$2
 
+if [[ $STARTSTOP != "start" ]] && [[ $STARTSTOP != "stop" ]] && [[ $STARTSTOP != "stop-all" ]]; then
+  echo $USAGE
+  exit 1
+fi
+
 bin=`dirname "$0"`
 bin=`cd "$bin"; pwd`
 

--- a/flink-dist/src/main/flink-bin/bin/zookeeper.sh
+++ b/flink-dist/src/main/flink-bin/bin/zookeeper.sh
@@ -23,7 +23,7 @@ USAGE="Usage: zookeeper.sh ((start|start-foreground) peer-id)|stop|stop-all"
 STARTSTOP=$1
 PEER_ID=$2
 
-if [[ $STARTSTOP != "start" ]] && [[ $STARTSTOP != "stop" ]] && [[ $STARTSTOP != "stop-all" ]]; then
+if [[ $STARTSTOP != "start" ]] && [[ $STARTSTOP != "start-foreground" ]] && [[ $STARTSTOP != "stop" ]] && [[ $STARTSTOP != "stop-all" ]]; then
   echo $USAGE
   exit 1
 fi


### PR DESCRIPTION
If jobmanager.sh, taskmanager.sh, or zookeeper.sh are called without arguments then argument list for the call to flink-daemon.sh is misaligned and the usage for flink-daemon displayed to the user.

Adds a check to each script to check for a valid action and otherwise displays the proper usage string.

Note: this PR conflicts with the PR for FLINK-4326 which adds a "start-foreground" action.