### PR TITLE
Multithreaded `DataSet#flatMap` function

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -522,7 +522,7 @@ public class DataStream<T> {
 		TypeInformation<R> outType = TypeExtractor.getFlatMapReturnTypes(clean(flatMapper),
 				getType(), Utils.getCallLocationName(), true);
 
-		return transform("Flat Map", outType,
+		return transform("Multi Threaded Flat Map", outType,
 				new MultiThreadedStreamFlatMap<>(clean(flatMapper), parallelism));
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -17,21 +17,13 @@
 
 package org.apache.flink.streaming.api.datastream;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.functions.FilterFunction;
-import org.apache.flink.api.common.functions.FlatMapFunction;
-import org.apache.flink.api.common.functions.MapFunction;
-import org.apache.flink.api.common.functions.Partitioner;
-import org.apache.flink.api.common.functions.RichFilterFunction;
-import org.apache.flink.api.common.functions.RichFlatMapFunction;
-import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.functions.*;
 import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.api.common.operators.Keys;
 import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -39,7 +31,6 @@ import org.apache.flink.api.java.Utils;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.io.CsvOutputFormat;
 import org.apache.flink.api.java.io.TextOutputFormat;
-import org.apache.flink.api.common.operators.Keys;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
@@ -50,28 +41,20 @@ import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
-import org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor;
-import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
 import org.apache.flink.streaming.api.functions.TimestampExtractor;
 import org.apache.flink.streaming.api.functions.sink.OutputFormatSinkFunction;
 import org.apache.flink.streaming.api.functions.sink.PrintSinkFunction;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.sink.SocketClientSink;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-import org.apache.flink.streaming.api.operators.StreamFilter;
-import org.apache.flink.streaming.api.operators.StreamFlatMap;
-import org.apache.flink.streaming.api.operators.StreamMap;
-import org.apache.flink.streaming.api.operators.StreamSink;
+import org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor;
+import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
+import org.apache.flink.streaming.api.operators.*;
+import org.apache.flink.streaming.api.operators.multithreaded.MultiThreadedStreamFlatMap;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.streaming.api.transformations.StreamTransformation;
 import org.apache.flink.streaming.api.transformations.UnionTransformation;
-import org.apache.flink.streaming.api.windowing.assigners.GlobalWindows;
-import org.apache.flink.streaming.api.windowing.assigners.SlidingProcessingTimeWindows;
-import org.apache.flink.streaming.api.windowing.assigners.SlidingEventTimeWindows;
-import org.apache.flink.streaming.api.windowing.assigners.TumblingProcessingTimeWindows;
-import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
-import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+import org.apache.flink.streaming.api.windowing.assigners.*;
 import org.apache.flink.streaming.api.windowing.evictors.CountEvictor;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.CountTrigger;
@@ -82,17 +65,13 @@ import org.apache.flink.streaming.api.windowing.windows.Window;
 import org.apache.flink.streaming.runtime.operators.ExtractTimestampsOperator;
 import org.apache.flink.streaming.runtime.operators.TimestampsAndPeriodicWatermarksOperator;
 import org.apache.flink.streaming.runtime.operators.TimestampsAndPunctuatedWatermarksOperator;
-import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
-import org.apache.flink.streaming.runtime.partitioner.CustomPartitionerWrapper;
-import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
-import org.apache.flink.streaming.runtime.partitioner.RescalePartitioner;
-import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
-import org.apache.flink.streaming.runtime.partitioner.GlobalPartitioner;
-import org.apache.flink.streaming.runtime.partitioner.ShufflePartitioner;
-import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
+import org.apache.flink.streaming.runtime.partitioner.*;
 import org.apache.flink.streaming.util.keys.KeySelectorUtil;
 import org.apache.flink.streaming.util.serialization.SerializationSchema;
 import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A DataStream represents a stream of elements of the same type. A DataStream
@@ -543,7 +522,8 @@ public class DataStream<T> {
 		TypeInformation<R> outType = TypeExtractor.getFlatMapReturnTypes(clean(flatMapper),
 				getType(), Utils.getCallLocationName(), true);
 
-		return transform("Flat Map", outType, new StreamFlatMap<>(clean(flatMapper), parallelism));
+		return transform("Flat Map", outType,
+				new MultiThreadedStreamFlatMap<>(clean(flatMapper), parallelism));
 	}
 
 	/**
@@ -563,7 +543,10 @@ public class DataStream<T> {
 	 * @return The transformed {@link DataStream}.
 	 */
 	public <R> SingleOutputStreamOperator<R> flatMap(FlatMapFunction<T, R> flatMapper) {
-		return flatMap(flatMapper, 0);
+		TypeInformation<R> outType = TypeExtractor.getFlatMapReturnTypes(clean(flatMapper),
+				getType(), Utils.getCallLocationName(), true);
+
+		return transform("Flat Map", outType, new StreamFlatMap(clean(flatMapper)));
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamFlatMap.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamFlatMap.java
@@ -42,6 +42,11 @@ public class StreamFlatMap<IN, OUT>
 	}
 
 	@Override
+	public void close() throws Exception {
+		super.close();
+	}
+
+	@Override
 	public void processElement(StreamRecord<IN> element) throws Exception {
 		collector.setTimestamp(element);
 		userFunction.flatMap(element.getValue(), collector);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamFlatMap.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamFlatMap.java
@@ -19,6 +19,9 @@ package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.Preconditions;
 
@@ -55,6 +58,10 @@ public class StreamFlatMap<IN, OUT>
 		this(flatMapper, 0);
 	}
 
+    // ------------------------------------------------------------------------
+    //  operator life cycle
+    // ------------------------------------------------------------------------
+
 	@Override
 	public void open() throws Exception {
 		super.open();
@@ -82,6 +89,27 @@ public class StreamFlatMap<IN, OUT>
             new ProcessElementTask(userFunction, element, new TimestampedCollector<>(output)).processElement();
     }
 
+    // ------------------------------------------------------------------------
+    //  Checkpoint and recovery
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void snapshotState(StateSnapshotContext context) throws Exception {
+        super.snapshotState(context);
+    }
+
+    @Override
+    public void restoreState(FSDataInputStream in) throws Exception {
+        super.restoreState(in);
+    }
+
+    @Override
+    public void notifyOfCompletedCheckpoint(long checkpointId) throws Exception {
+        super.notifyOfCompletedCheckpoint(checkpointId);
+    }
+    // ------------------------------------------------------------------------
+    //  Utilities
+    // ------------------------------------------------------------------------
     private boolean canBeParallelized() {
         return parallelism > 0;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamFlatMap.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamFlatMap.java
@@ -18,9 +18,11 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
 import org.apache.flink.core.fs.FSDataInputStream;
-import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.Preconditions;
@@ -31,7 +33,7 @@ import java.util.concurrent.*;
 @Internal
 public class StreamFlatMap<IN, OUT>
 		extends AbstractUdfStreamOperator<OUT, FlatMapFunction<IN, OUT>>
-		implements OneInputStreamOperator<IN, OUT> {
+		implements OneInputStreamOperator<IN, OUT>, InputTypeConfigurable {
 
 	private static final long serialVersionUID = 1L;
 
@@ -107,6 +109,16 @@ public class StreamFlatMap<IN, OUT>
     public void notifyOfCompletedCheckpoint(long checkpointId) throws Exception {
         super.notifyOfCompletedCheckpoint(checkpointId);
     }
+
+    // ------------------------------------------------------------------------
+    //  Serialization
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void setInputType(TypeInformation<?> type, ExecutionConfig executionConfig) {
+
+    }
+
     // ------------------------------------------------------------------------
     //  Utilities
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamFlatMap.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamFlatMap.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.multithreaded.MultiThreadedTimestampedCollector;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.Preconditions;
 
@@ -86,7 +87,7 @@ public class StreamFlatMap<IN, OUT>
 	@Override
 	public void processElement(final StreamRecord<IN> element) throws Exception {
         if(canBeParallelized())
-            tasks.add(new ProcessElementTask(userFunction, element, new TimestampedCollector<>(output)));
+            tasks.add(new ProcessElementTask(userFunction, element, new MultiThreadedTimestampedCollector<>(output)));
         else
             new ProcessElementTask(userFunction, element, new TimestampedCollector<>(output)).processElement();
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimestampedCollector.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimestampedCollector.java
@@ -34,9 +34,9 @@ import org.apache.flink.util.Collector;
 @Internal
 public class TimestampedCollector<T> implements Collector<T> {
 	
-	private final Output<StreamRecord<T>> output;
+	protected final Output<StreamRecord<T>> output;
 
-	private final StreamRecord<T> reuse;
+	protected final StreamRecord<T> reuse;
 
 	/**
 	 * Creates a new {@link TimestampedCollector} that wraps the given {@link Output}.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/multithreaded/MultiThreadedStreamFlatMap.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/multithreaded/MultiThreadedStreamFlatMap.java
@@ -54,7 +54,7 @@ public class MultiThreadedStreamFlatMap<IN, OUT>
     public MultiThreadedStreamFlatMap(FlatMapFunction<IN, OUT> flatMapper, int parallelism) {
         super(flatMapper);
 
-        Preconditions.checkArgument(parallelism >= 0 ? true : false, "Invalid parallelism!");
+        Preconditions.checkArgument(parallelism > 0 ? true : false, "Invalid parallelism!");
 
         this.parallelism = parallelism;
         tasks = new ArrayList<>();
@@ -123,7 +123,7 @@ public class MultiThreadedStreamFlatMap<IN, OUT>
     }
 
     private void createExecutorService() {
-        executorService = Executors.newFixedThreadPool(parallelism > 0 ? parallelism : 1);
+        executorService = Executors.newFixedThreadPool(parallelism);
     }
 
     private void closeExecutor() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/multithreaded/MultiThreadedStreamFlatMap.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/multithreaded/MultiThreadedStreamFlatMap.java
@@ -49,6 +49,7 @@ public class MultiThreadedStreamFlatMap<IN, OUT>
     private int parallelism;
     private ExecutorService executorService;
     private List<Callable<Void>> tasks;
+    private Object lock;
 
     public MultiThreadedStreamFlatMap(FlatMapFunction<IN, OUT> flatMapper, int parallelism) {
         super(flatMapper);
@@ -57,6 +58,7 @@ public class MultiThreadedStreamFlatMap<IN, OUT>
 
         this.parallelism = parallelism;
         tasks = new ArrayList<>();
+        lock = new Object();
 
         chainingStrategy = ChainingStrategy.ALWAYS;
     }
@@ -82,7 +84,7 @@ public class MultiThreadedStreamFlatMap<IN, OUT>
 
     @Override
     public void processElement(final StreamRecord<IN> element) throws Exception {
-        tasks.add(new ProcessElementTask(userFunction, element, new MultiThreadedTimestampedCollector<>(output)));
+        tasks.add(new ProcessElementTask(userFunction, element, new MultiThreadedTimestampedCollector<>(output, lock)));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/multithreaded/MultiThreadedStreamFlatMap.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/multithreaded/MultiThreadedStreamFlatMap.java
@@ -57,8 +57,7 @@ public class MultiThreadedStreamFlatMap<IN, OUT>
     private List<Callable<StreamRecord<IN>>> tasks;
 
     private transient Object lock;
-
-    private transient TypeSerializer<IN> serializer;
+    
     private transient StreamElementSerializer<IN> inStreamElementSerializer;
     private transient ListState<StreamElement> states;
     private List<StreamElement> elementsToBeProcessedBuffer;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/multithreaded/MultiThreadedStreamFlatMap.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/multithreaded/MultiThreadedStreamFlatMap.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.multithreaded;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+@Internal
+public class MultiThreadedStreamFlatMap<IN, OUT>
+        extends AbstractUdfStreamOperator<OUT, FlatMapFunction<IN, OUT>>
+        implements OneInputStreamOperator<IN, OUT>, InputTypeConfigurable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final long TERMINATION_TIMEOUT = 5000L;
+
+    private int parallelism;
+    private ExecutorService executorService;
+    private List<Callable<Void>> tasks;
+
+    public MultiThreadedStreamFlatMap(FlatMapFunction<IN, OUT> flatMapper, int parallelism) {
+        super(flatMapper);
+
+        Preconditions.checkArgument(parallelism >= 0 ? true : false, "Invalid parallelism!");
+
+        this.parallelism = parallelism;
+        tasks = new ArrayList<>();
+
+        chainingStrategy = ChainingStrategy.ALWAYS;
+    }
+
+    // ------------------------------------------------------------------------
+    //  operator life cycle
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        createExecutorService();
+    }
+
+    @Override
+    public void close() throws Exception {
+        invokeAllTasks();
+
+        closeExecutor();
+
+        super.close();
+    }
+
+    @Override
+    public void processElement(final StreamRecord<IN> element) throws Exception {
+        tasks.add(new ProcessElementTask(userFunction, element, new MultiThreadedTimestampedCollector<>(output)));
+    }
+
+    // ------------------------------------------------------------------------
+    //  Checkpoint and recovery
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void snapshotState(StateSnapshotContext context) throws Exception {
+        super.snapshotState(context);
+    }
+
+    @Override
+    public void restoreState(FSDataInputStream in) throws Exception {
+        super.restoreState(in);
+    }
+
+    @Override
+    public void notifyOfCompletedCheckpoint(long checkpointId) throws Exception {
+        super.notifyOfCompletedCheckpoint(checkpointId);
+    }
+
+    // ------------------------------------------------------------------------
+    //  Serialization
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void setInputType(TypeInformation<?> type, ExecutionConfig executionConfig) {
+
+    }
+
+    // ------------------------------------------------------------------------
+    //  Utilities
+    // ------------------------------------------------------------------------
+    private void invokeAllTasks() throws InterruptedException {
+        executorService.invokeAll(tasks);
+    }
+
+    private void createExecutorService() {
+        executorService = Executors.newFixedThreadPool(parallelism > 0 ? parallelism : 1);
+    }
+
+    private void closeExecutor() {
+        executorService.shutdown();
+
+        try {
+            if (!executorService.awaitTermination(TERMINATION_TIMEOUT, TimeUnit.MILLISECONDS))
+                executorService.shutdownNow();
+        } catch (InterruptedException interrupted) {
+            executorService.shutdownNow();
+        }
+    }
+
+    private class ProcessElementTask<IN, OUT> implements Callable {
+        private FlatMapFunction<IN, OUT> userFunction;
+        private StreamRecord<IN> element;
+        private TimestampedCollector<OUT> collector;
+
+        public ProcessElementTask(FlatMapFunction<IN, OUT> userFunction,  StreamRecord<IN> element,
+                                  TimestampedCollector<OUT> collector) {
+            this.userFunction = userFunction;
+            this.element = element;
+            this.collector = collector;
+        }
+
+        @Override
+        public Void call() throws Exception {
+            processElement();
+            return null;
+        }
+
+        public void processElement() throws Exception {
+            collector.setTimestamp(element);
+            userFunction.flatMap(element.getValue(), collector);
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/multithreaded/MultiThreadedStreamFlatMap.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/multithreaded/MultiThreadedStreamFlatMap.java
@@ -49,7 +49,7 @@ public class MultiThreadedStreamFlatMap<IN, OUT>
     private int parallelism;
     private ExecutorService executorService;
     private List<Callable<Void>> tasks;
-    private Object lock;
+    private transient Object lock;
 
     public MultiThreadedStreamFlatMap(FlatMapFunction<IN, OUT> flatMapper, int parallelism) {
         super(flatMapper);
@@ -112,7 +112,6 @@ public class MultiThreadedStreamFlatMap<IN, OUT>
 
     @Override
     public void setInputType(TypeInformation<?> type, ExecutionConfig executionConfig) {
-
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/multithreaded/MultiThreadedTimestampedCollector.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/multithreaded/MultiThreadedTimestampedCollector.java
@@ -1,0 +1,37 @@
+package org.apache.flink.streaming.api.operators.multithreaded;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Collector;
+
+/**
+ * A multi-threaded wrapper around an {@link Output} for user functions that expect a {@link Collector}.
+ * Before giving the {@link MultiThreadedTimestampedCollector} to a user function you must set
+ * the timestamp that should be attached to emitted elements. Most operators
+ * would set the timestamp of the incoming
+ * {@link org.apache.flink.streaming.runtime.streamrecord.StreamRecord} here.
+ *
+ * @param <T> The type of the elements that can be emitted.
+ */
+@Internal
+public class MultiThreadedTimestampedCollector<T> extends TimestampedCollector<T> {
+    private Object lock = new Object();
+
+    /**
+     * Creates a new {@link MultiThreadedTimestampedCollector} that wraps the given {@link Output}.
+     *
+     * @param output
+     */
+    public MultiThreadedTimestampedCollector(Output<StreamRecord<T>> output) {
+        super(output);
+    }
+
+    @Override
+    public void collect(T record) {
+        synchronized (lock) {
+            output.collect(reuse.replace(record));
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/multithreaded/MultiThreadedTimestampedCollector.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/multithreaded/MultiThreadedTimestampedCollector.java
@@ -17,15 +17,16 @@ import org.apache.flink.util.Collector;
  */
 @Internal
 public class MultiThreadedTimestampedCollector<T> extends TimestampedCollector<T> {
-    private Object lock = new Object();
+    private Object lock;
 
     /**
      * Creates a new {@link MultiThreadedTimestampedCollector} that wraps the given {@link Output}.
      *
      * @param output
      */
-    public MultiThreadedTimestampedCollector(Output<StreamRecord<T>> output) {
+    public MultiThreadedTimestampedCollector(Output<StreamRecord<T>> output, Object lock) {
         super(output);
+        this.lock = lock;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
@@ -51,7 +51,7 @@ public class OneInputTransformation<IN, OUT> extends StreamTransformation<OUT> {
 	 *
 	 * @param input The input {@code StreamTransformation}
 	 * @param name The name of the {@code StreamTransformation}, this will be shown in Visualizations and the Log
-	 * @param operator The {@code TwoInputStreamOperator}
+	 * @param operator The {@code OneInputStreamOperator}
 	 * @param outputType The type of the elements produced by this {@code OneInputTransformation}
 	 * @param parallelism The parallelism of this {@code OneInputTransformation}
 	 */
@@ -81,7 +81,7 @@ public class OneInputTransformation<IN, OUT> extends StreamTransformation<OUT> {
 	}
 
 	/**
-	 * Returns the {@code TwoInputStreamOperator} of this Transformation.
+	 * Returns the {@code OneInputStreamOperator} of this Transformation.
 	 */
 	public OneInputStreamOperator<IN, OUT> getOperator() {
 		return operator;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamFlatMapTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamFlatMapTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.flink.streaming.api.operators;
 
-import java.util.concurrent.ConcurrentLinkedQueue;
-
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.configuration.Configuration;
@@ -29,6 +27,8 @@ import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.util.Collector;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Tests for {@link StreamMap}. These test that:

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamFlatMapTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamFlatMapTest.java
@@ -75,6 +75,8 @@ public class StreamFlatMapTest {
 		testHarness.processElement(new StreamRecord<Integer>(7, initialTime + 7));
 		testHarness.processElement(new StreamRecord<Integer>(8, initialTime + 8));
 
+		testHarness.close();
+
 		expectedOutput.add(new StreamRecord<Integer>(2, initialTime + 2));
 		expectedOutput.add(new StreamRecord<Integer>(4, initialTime + 2));
 		expectedOutput.add(new Watermark(initialTime + 2));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoStreamFlatMapTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoStreamFlatMapTest.java
@@ -17,11 +17,6 @@
 
 package org.apache.flink.streaming.api.operators.co;
 
-import static org.junit.Assert.fail;
-
-import java.io.Serializable;
-import java.util.concurrent.ConcurrentLinkedQueue;
-
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.co.CoFlatMapFunction;
 import org.apache.flink.streaming.api.functions.co.RichCoFlatMapFunction;
@@ -32,6 +27,9 @@ import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
 import org.apache.flink.util.Collector;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Tests for {@link CoStreamFlatMap}. These test that:

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
@@ -62,9 +62,9 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 	public OneInputStreamOperatorTestHarness(
 			OneInputStreamOperator<IN, OUT> operator,
 			int maxParallelism,
-			int numTubtasks,
+			int numSubtasks,
 			int subtaskIndex) throws Exception {
-		super(operator, maxParallelism, numTubtasks, subtaskIndex);
+		super(operator, maxParallelism, numSubtasks, subtaskIndex);
 
 		this.oneInputOperator = operator;
 	}
@@ -72,10 +72,10 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 	public OneInputStreamOperatorTestHarness(
 		OneInputStreamOperator<IN, OUT> operator,
 		int maxParallelism,
-		int numTubtasks,
+		int numSubtasks,
 		int subtaskIndex,
 		Environment environment) throws Exception {
-		super(operator, maxParallelism, numTubtasks, subtaskIndex, environment);
+		super(operator, maxParallelism, numSubtasks, subtaskIndex, environment);
 
 		this.oneInputOperator = operator;
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestHarnessUtil.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestHarnessUtil.java
@@ -61,6 +61,23 @@ public class TestHarnessUtil {
 
 	}
 
+	public static void assertOutputEqualsWithoutOrder(String message, Queue<Object> expected, Queue<Object> actual) {
+		Object[] expectedObjectArray = expected.toArray();
+		String[] expectedStringArray = new String[expectedObjectArray.length];
+
+		for(int i = 0; i < expectedObjectArray.length; i ++) { expectedStringArray[i] = expectedObjectArray[i].toString(); }
+
+		Object[] actualObjectArray = actual.toArray();
+		String[] actualStringArray = new String[actual.size()];
+
+		for(int i = 0; i < actualObjectArray.length; i ++) { actualStringArray[i] = actualObjectArray[i].toString(); }
+
+		Arrays.sort(expectedStringArray);
+		Arrays.sort(actualStringArray);
+
+		Assert.assertArrayEquals(message, expectedStringArray, actualStringArray);
+	}
+
 	/**
 	 * Compare the two queues containing operator/task output by converting them to an array first.
 	 */


### PR DESCRIPTION
# Mutli-Threaded FlatMap

## Overview

The DataStream#flatMap function takes a FlatMapFunction interface that has a method named flatMap that gets called by the DataStream#flatMap.

The FlatMapFunction#flatMap method takes an element (DataStream record) and do some transformation on that element for example if the element is a string, the flatMap function can implement the logic for splitting the element by space or converting to upper case.

The current implementation of the DataStream#flatMap uses a single thread to transform the element from one form to another. The idea of this change is to introduce a new API method the DataStream#flatMap that takes the parallelism value for transforming the input elements.

## Implementation Details

The following diagram shows the multithreaded `flatMap` function. Assume in the following diagram the parallelism (maximum thread pool) is set to `3` (3 threads can run transformations on the input element)

Briefly, when the `flatMap` function receives an element it pushes it to a _buffer_ then spawns a thread per element to do the transformation then write back to the _output_.

The _output_ is thread-safe and only 1 thread can write at a time. It uses an `Object` as a lock state to the output.

The _buffer_ is used to accumulate elements so that when the _snapshot_ job runs and the element transformation is not yet finished, the _buffer_ writes all its elements serialized into an _output stream_. When a _restore_ is called it deserialize the elements of the buffer and try run the transformation again because their output state was not taken into consideration when the snapshot job ran.

![multithreaded flatmap](https://cloud.githubusercontent.com/assets/1228432/23085859/699a2926-f56a-11e6-9146-1be213caaaa7.png)

