### PR TITLE
[FLINK-5253] Remove special treatment of "dynamic properties"

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
@@ -200,7 +200,7 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 			return;
 		}
 
-		Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
+		Configuration dynamicProperties = BootstrapTools.retrieveDynamicProperties(cmd);
 		Configuration configuration = GlobalConfiguration.loadConfigurationWithDynamicProperties(dynamicProperties);
 
 		MesosJobClusterEntrypoint clusterEntrypoint = new MesosJobClusterEntrypoint(configuration, dynamicProperties);

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
@@ -174,7 +174,7 @@ public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
 			return;
 		}
 
-		Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
+		Configuration dynamicProperties = BootstrapTools.retrieveDynamicProperties(cmd);
 		Configuration configuration = GlobalConfiguration.loadConfigurationWithDynamicProperties(dynamicProperties);
 
 		MesosSessionClusterEntrypoint clusterEntrypoint = new MesosSessionClusterEntrypoint(configuration, dynamicProperties);

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -72,7 +72,7 @@ public class MesosTaskExecutorRunner {
 
 		final Configuration configuration;
 		try {
-			Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
+			Configuration dynamicProperties = BootstrapTools.retrieveDynamicProperties(cmd);
 			LOG.debug("Mesos dynamic properties: {}", dynamicProperties);
 
 			configuration = GlobalConfiguration.loadConfigurationWithDynamicProperties(dynamicProperties);

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
@@ -151,7 +151,7 @@ public class MesosApplicationMasterRunner {
 			CommandLineParser parser = new PosixParser();
 			CommandLine cmd = parser.parse(ALL_OPTIONS, args);
 
-			final Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
+			final Configuration dynamicProperties = BootstrapTools.retrieveDynamicProperties(cmd);
 			final Configuration config = GlobalConfiguration.loadConfigurationWithDynamicProperties(dynamicProperties);
 
 			// configure the default filesystem

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerRunner.java
@@ -72,7 +72,7 @@ public class MesosTaskManagerRunner {
 
 		final Configuration configuration;
 		try {
-			final Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
+			final Configuration dynamicProperties = BootstrapTools.retrieveDynamicProperties(cmd);
 			LOG.debug("Mesos dynamic properties: {}", dynamicProperties);
 
 			configuration = GlobalConfiguration.loadConfigurationWithDynamicProperties(dynamicProperties);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -329,24 +329,33 @@ public class BootstrapTools {
 	/**
 	 * Parse the dynamic properties (passed on the command line).
 	 */
-	public static Configuration parseDynamicProperties(CommandLine cmd) {
-		final Configuration config = new Configuration();
-
+	public static Configuration retrieveDynamicProperties(CommandLine cmd) {
 		String[] values = cmd.getOptionValues(DYNAMIC_PROPERTIES_OPT);
+		return parseDynamicProperties(values);
+	}
+
+	public static Configuration retrieveDynamicProperties(CommandLine cmd, Option dynamicPropertiesOption) {
+		String[] values = cmd.getOptionValues(dynamicPropertiesOption.getOpt());
+		return parseDynamicProperties(values);
+	}
+
+	private static Configuration parseDynamicProperties(String[] values) {
+		final Configuration configuration = new Configuration();
+
 		if(values != null) {
 			for(String value : values) {
 				String[] pair = value.split("=", 2);
 				if(pair.length == 1) {
-					config.setString(pair[0], Boolean.TRUE.toString());
+					configuration.setString(pair[0], Boolean.TRUE.toString());
 				}
 				else if(pair.length == 2) {
-					config.setString(pair[0], pair[1]);
+					configuration.setString(pair[0], pair[1]);
 				}
 			}
 		}
-
-		return config;
+		return configuration;
 	}
+
 
 	/**
 	 * Generates the shell command to start a task manager.

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -42,7 +42,6 @@ import org.mockito.Mockito;
 
 import java.io.File;
 import java.net.InetSocketAddress;
-import java.util.Map;
 
 /**
  * Tests for the FlinkYarnSessionCli.
@@ -65,7 +64,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		CommandLineParser parser = new DefaultParser();
 		CommandLine cmd = parser.parse(options, new String[]{"run", "-j", "fake.jar", "-n", "15",
-				"-D", "akka.ask.timeout=5 min", "-D", "env.java.opts=-DappName=foobar"});
+			"-D", "akka.ask.timeout=5 min", "-D", "env.java.opts=-DappName=foobar"});
 
 		AbstractYarnClusterDescriptor flinkYarnDescriptor = cli.createDescriptor(
 			new Configuration(),
@@ -75,11 +74,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		Assert.assertNotNull(flinkYarnDescriptor);
 
-		Map<String, String> dynProperties =
-			FlinkYarnSessionCli.getDynamicProperties(flinkYarnDescriptor.getDynamicPropertiesEncoded());
-		Assert.assertEquals(2, dynProperties.size());
-		Assert.assertEquals("5 min", dynProperties.get("akka.ask.timeout"));
-		Assert.assertEquals("-DappName=foobar", dynProperties.get("env.java.opts"));
+		Configuration configuration = flinkYarnDescriptor.getFlinkConfiguration();
+		Assert.assertEquals("5 min", configuration.getString("akka.ask.timeout", ""));
+		Assert.assertEquals("-DappName=foobar", configuration.getString("env.java.opts", ""));
 	}
 
 	@Test

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -92,7 +92,6 @@ import java.util.Set;
 import static org.apache.flink.configuration.ConfigConstants.ENV_FLINK_LIB_DIR;
 import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.CONFIG_FILE_LOG4J_NAME;
 import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.CONFIG_FILE_LOGBACK_NAME;
-import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.getDynamicProperties;
 
 /**
  * The descriptor with deployment information for spawning or resuming a {@link YarnClusterClient}.
@@ -120,8 +119,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	private String configurationDirectory;
 
 	private Path flinkJarPath;
-
-	private String dynamicPropertiesEncoded;
 
 	/** Lazily initialized list of files to ship. */
 	protected List<File> shipFiles = new LinkedList<>();
@@ -190,10 +187,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		}
 	}
 
-	public void setDynamicPropertiesEncoded(String dynamicPropertiesEncoded) {
-		this.dynamicPropertiesEncoded = dynamicPropertiesEncoded;
-	}
-
 	/**
 	 * Returns true if the descriptor has the job jars to include in the classpath.
 	 */
@@ -228,10 +221,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 					+ " Currently only file:/// URLs are supported.");
 			}
 		}
-	}
-
-	public String getDynamicPropertiesEncoded() {
-		return this.dynamicPropertiesEncoded;
 	}
 
 	private void isReadyForDeployment(ClusterSpecification clusterSpecification) throws YarnDeploymentException {
@@ -414,12 +403,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		// ------------------ Check if the specified queue exists --------------------
 
 		checkYarnQueues(yarnClient);
-
-		// ------------------ Add dynamic properties to local flinkConfiguraton ------
-		Map<String, String> dynProperties = getDynamicProperties(dynamicPropertiesEncoded);
-		for (Map.Entry<String, String> dynProperty : dynProperties.entrySet()) {
-			flinkConfiguration.setString(dynProperty.getKey(), dynProperty.getValue());
-		}
 
 		// ------------------ Check if the YARN ClusterClient has the requested resources --------------
 
@@ -885,10 +868,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		if (remoteYarnSiteXmlPath != null && remoteKrb5Path != null) {
 			appMasterEnv.put(YarnConfigKeys.ENV_YARN_SITE_XML_PATH, remoteYarnSiteXmlPath.toString());
 			appMasterEnv.put(YarnConfigKeys.ENV_KRB5_PATH, remoteKrb5Path.toString());
-		}
-
-		if (dynamicPropertiesEncoded != null) {
-			appMasterEnv.put(YarnConfigKeys.ENV_DYNAMIC_PROPERTIES, dynamicPropertiesEncoded);
 		}
 
 		// set classpath from YARN configuration

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -46,7 +46,6 @@ import org.apache.flink.runtime.util.SignalHandler;
 import org.apache.flink.runtime.webmonitor.WebMonitor;
 import org.apache.flink.runtime.webmonitor.retriever.impl.AkkaJobManagerRetriever;
 import org.apache.flink.runtime.webmonitor.retriever.impl.AkkaQueryServiceRetriever;
-import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
 import akka.actor.ActorRef;
@@ -156,12 +155,7 @@ public class YarnApplicationMasterRunner {
 			LOG.info("YARN daemon is running as: {} Yarn client user obtainer: {}",
 					currentUser.getShortUserName(), yarnClientUsername);
 
-			// Flink configuration
-			final Map<String, String> dynamicProperties =
-				FlinkYarnSessionCli.getDynamicProperties(ENV.get(YarnConfigKeys.ENV_DYNAMIC_PROPERTIES));
-			LOG.debug("YARN dynamic properties: {}", dynamicProperties);
-
-			final Configuration flinkConfig = createConfiguration(currDir, dynamicProperties);
+			final Configuration flinkConfig = createConfiguration(currDir);
 
 			// set keytab principal and replace path with the local path of the shipped keytab file in NodeManager
 			if (keytabPath != null && remoteKeytabPrincipal != null) {
@@ -492,20 +486,13 @@ public class YarnApplicationMasterRunner {
 	 * Reads the global configuration from the given directory and adds the given parameters to it.
 	 *
 	 * @param baseDirectory directory to load the configuration from
-	 * @param additional additional parameters to be included in the configuration
-	 *
 	 * @return The configuration to be used by the TaskManagers.
 	 */
 	@SuppressWarnings("deprecation")
-	private static Configuration createConfiguration(String baseDirectory, Map<String, String> additional) {
+	private static Configuration createConfiguration(String baseDirectory) {
 		LOG.info("Loading config from directory " + baseDirectory);
 
 		Configuration configuration = GlobalConfiguration.loadConfiguration(baseDirectory);
-
-		// add dynamic properties to JobManager configuration.
-		for (Map.Entry<String, String> property : additional.entrySet()) {
-			configuration.setString(property.getKey(), property.getValue());
-		}
 
 		// override zookeeper namespace with user cli argument (if provided)
 		String cliZKNamespace = ENV.get(YarnConfigKeys.ENV_ZOOKEEPER_NAMESPACE);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
@@ -34,7 +34,6 @@ public class YarnConfigKeys {
 	public static final String ENV_CLIENT_SHIP_FILES = "_CLIENT_SHIP_FILES";
 	public static final String ENV_SLOTS = "_SLOTS";
 	public static final String ENV_DETACHED = "_DETACHED";
-	public static final String ENV_DYNAMIC_PROPERTIES = "_DYNAMIC_PROPERTIES";
 
 	public static final String ENV_FLINK_CLASSPATH = "_FLINK_CLASSPATH";
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -32,7 +32,6 @@ import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.yarn.Utils;
 import org.apache.flink.yarn.YarnConfigKeys;
-import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -81,9 +80,6 @@ public class YarnEntrypointUtils {
 
 		final String zooKeeperNamespace = env.get(YarnConfigKeys.ENV_ZOOKEEPER_NAMESPACE);
 
-		final Map<String, String> dynamicProperties = FlinkYarnSessionCli.getDynamicProperties(
-			env.get(YarnConfigKeys.ENV_DYNAMIC_PROPERTIES));
-
 		final String hostname = env.get(ApplicationConstants.Environment.NM_HOST.key());
 		Preconditions.checkState(
 			hostname != null,
@@ -96,10 +92,6 @@ public class YarnEntrypointUtils {
 //		final String portRange = configuration.getString(
 //			ConfigConstants.YARN_APPLICATION_MASTER_PORT,
 //			ConfigConstants.DEFAULT_YARN_JOB_MANAGER_PORT);
-
-		for (Map.Entry<String, String> property : dynamicProperties.entrySet()) {
-			configuration.setString(property.getKey(), property.getValue());
-		}
 
 		if (zooKeeperNamespace != null) {
 			configuration.setString(HighAvailabilityOptions.HA_CLUSTER_ID, zooKeeperNamespace);


### PR DESCRIPTION
This PR removes special treatment of 'dynamic properties' (aka special way of encoding them as environment variable). Instead, these properties are appended to _flink-conf.yaml_ file.

Link to the issue: https://issues.apache.org/jira/browse/FLINK-5253