### PR TITLE
[FLINK-5487] [elasticsearch] At-least-once ElasticsearchSink

### DIFF
--- a/docs/dev/connectors/elasticsearch.md
+++ b/docs/dev/connectors/elasticsearch.md
@@ -23,6 +23,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+* This will be replaced by the TOC
+{:toc}
+
 This connector provides sinks that can request document actions to an
 [Elasticsearch](https://elastic.co/) Index. To use this connector, add one
 of the following dependencies to your project, depending on the version
@@ -59,14 +62,14 @@ Note that the streaming connectors are currently not part of the binary
 distribution. See [here]({{site.baseurl}}/dev/linking.html) for information
 about how to package the program with the libraries for cluster execution.
 
-#### Installing Elasticsearch
+## Installing Elasticsearch
 
 Instructions for setting up an Elasticsearch cluster can be found
 [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html).
 Make sure to set and remember a cluster name. This must be set when
 creating an `ElasticsearchSink` for requesting document actions against your cluster.
 
-#### Elasticsearch Sink
+## Elasticsearch Sink
 
 The `ElasticsearchSink` uses a `TransportClient` to communicate with an
 Elasticsearch cluster.
@@ -200,15 +203,13 @@ request for each incoming element. Generally, the `ElasticsearchSinkFunction`
 can be used to perform multiple requests of different types (ex.,
 `DeleteRequest`, `UpdateRequest`, etc.). 
 
-Internally, the sink uses a `BulkProcessor` to send action requests to the cluster.
-This will buffer elements before sending them in bulk to the cluster. The behaviour of the
-`BulkProcessor` can be set using these config keys in the provided `Map` configuration:
- * **bulk.flush.max.actions**: Maximum amount of elements to buffer
- * **bulk.flush.max.size.mb**: Maximum amount of data (in megabytes) to buffer
- * **bulk.flush.interval.ms**: Interval at which to flush data regardless of the other two
-  settings in milliseconds
+Internally, each parallel instance of the Flink Elasticsearch Sink uses
+a `BulkProcessor` to send action requests to the cluster.
+This will buffer elements before sending them in bulk to the cluster. The `BulkProcessor`
+executes bulk requests one at a time, i.e. there will be no two concurrent
+flushes of the buffered actions in progress.
 
-#### Communication using Embedded Node (only for Elasticsearch 1.x)
+### Communication using Embedded Node (only for Elasticsearch 1.x)
 
 For Elasticsearch versions 1.x, communication using an embedded node is
 also supported. See [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/current/client.html)
@@ -272,14 +273,106 @@ input.addSink(new ElasticsearchSink(config, new ElasticsearchSinkFunction[String
 The difference is that now we do not need to provide a list of addresses
 of Elasticsearch nodes.
 
-Optionally, the sink can try to re-execute the bulk request when the error
-message matches certain patterns indicating a timeout or a overloaded cluster.
-This behaviour is disabled by default and can be enabled by setting `checkErrorAndRetryBulk(true)`.
+### Handling Failing Elasticsearch Requests
 
+Elasticsearch action requests may fail due to a variety of reasons, including
+temporarily saturated node queue capacity or malformed documents to be indexed.
+The Flink Elasticsearch Sink allows the user to specify how request
+failures are handled, by simply implementing an `ActionRequestFailureHandler` and
+providing it to the constructor.
+
+Below is an example:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+DataStream<String> input = ...;
+
+input.addSink(new ElasticsearchSink<>(
+    config, transportAddresses,
+    new ElasticsearchSinkFunction<String>() {...},
+    new ActionRequestFailureHandler() {
+        @Override
+        boolean onFailure(ActionRequest action, Throwable failure, RequestIndexer indexer) {
+            // this example uses Apache Commons to search for nested exceptions
+            
+            if (ExceptionUtils.indexOfThrowable(failure, EsRejectedExecutionException.class) >= 0) {
+                // full queue; re-add document for indexing
+                indexer.add(action);
+                return false;
+            } else if (ExceptionUtils.indexOfThrowable(failure, ElasticsearchParseException.class) >= 0) {
+                // malformed document; simply drop request without failing sink
+                return false;
+            } else {
+                // for all other failures, fail the sink
+                return true;
+            }
+        }
+}));
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val input: DataStream[String] = ...
+
+input.addSink(new ElasticsearchSink(
+    config, transportAddresses,
+    new ElasticsearchSinkFunction[String] {...},
+    new ActionRequestFailureHandler {
+        override def onFailure(ActionRequest action, Throwable failure, RequestIndexer indexer) {
+            // this example uses Apache Commons to search for nested exceptions
+
+            if (ExceptionUtils.indexOfThrowable(failure, EsRejectedExecutionException.class) >= 0) {
+                // full queue; re-add document for indexing
+                indexer.add(action)
+                return false
+            } else if (ExceptionUtils.indexOfThrowable(failure, ElasticsearchParseException.class) {
+                // malformed document; simply drop request without failing sink
+                return false
+            } else {
+                // for all other failures, fail the sink
+                return true
+            }
+        }
+}))
+{% endhighlight %}
+</div>
+</div>
+
+The above example will let the sink re-add requests that failed due to
+queue capacity saturation and drop requests with malformed documents, without
+failing the sink. For all other failures, the sink will fail. If a `ActionRequestFailureHandler`
+is not provided to the constructor, the sink will fail for any kind of error.
+
+Note that `onFailure` is called for failures that still occur only after the
+`BulkProcessor` internally finishes all backoff retry attempts.
+By default, the `BulkProcessor` retries to a maximum of 8 attempts with
+an exponential backoff. For more information on the behaviour of the
+internal `BulkProcessor` and how to configure it, please see the following section.
+ 
+### Configuring the Internal Bulk Processor
+
+The internal `BulkProcessor` can be further configured for its behaviour
+on how buffered action requests are flushed, by setting the following values in
+the provided `Map<String, String>`:
+
+ * **bulk.flush.max.actions**: Maximum amount of actions to buffer before flushing.
+ * **bulk.flush.max.size.mb**: Maximum size of data (in megabytes) to buffer before flushing.
+ * **bulk.flush.interval.ms**: Interval at which to flush regardless of the amount or size of buffered actions.
+ 
+For versions 2.x and above, configuring how temporary request errors are
+retried is also supported:
+ 
+ * **bulk.flush.backoff.enable**: Whether or not to perform retries with backoff delay for a flush
+ if one or more of its actions failed due to a temporary `EsRejectedExecutionException`.
+ * **bulk.flush.backoff.type**: The type of backoff delay, either `CONSTANT` or `EXPONENTIAL`
+ * **bulk.flush.backoff.delay**: The amount of delay for backoff. For constant backoff, this
+ is simply the delay between each retry. For exponential backoff, this is the initial base delay.
+ * **bulk.flush.backoff.retries**: The amount of backoff retries to attempt.
 
 More information about Elasticsearch can be found [here](https://elastic.co).
 
-#### Packaging the Elasticsearch Connector into an Uber-Jar
+## Packaging the Elasticsearch Connector into an Uber-Jar
 
 For the execution of your Flink program, it is recommended to build a
 so-called uber-jar (executable jar) containing all your dependencies

--- a/docs/dev/connectors/elasticsearch.md
+++ b/docs/dev/connectors/elasticsearch.md
@@ -272,6 +272,11 @@ input.addSink(new ElasticsearchSink(config, new ElasticsearchSinkFunction[String
 The difference is that now we do not need to provide a list of addresses
 of Elasticsearch nodes.
 
+Optionally, the sink can try to re-execute the bulk request when the error
+message matches certain patterns indicating a timeout or a overloaded cluster.
+This behaviour is disabled by default and can be enabled by setting `checkErrorAndRetryBulk(true)`.
+
+
 More information about Elasticsearch can be found [here](https://elastic.co).
 
 #### Packaging the Elasticsearch Connector into an Uber-Jar

--- a/flink-connectors/flink-connector-elasticsearch-base/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch-base/pom.xml
@@ -68,6 +68,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_2.10</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java_2.10</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ActionRequestFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ActionRequestFailureHandler.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch;
+
+import org.elasticsearch.action.ActionRequest;
+
+import java.io.Serializable;
+
+/**
+ * An implementation of {@link ActionRequestFailureHandler} is provided by the user to define how failed
+ * {@link ActionRequest ActionRequests} should be handled, ex. dropping them, reprocessing malformed documents, or
+ * simply requesting them to be sent to Elasticsearch again if the failure is only temporary.
+ *
+ * <p>
+ * Example:
+ *
+ * <pre>{@code
+ *
+ *	private static class ExampleActionRequestFailureHandler implements ActionRequestFailureHandler {
+ *
+ *		@Override
+ *		boolean onFailure(ActionRequest action, Throwable failure, RequestIndexer indexer) {
+ *			// this example uses Apache Commons to search for nested exceptions
+ *
+ *			if (ExceptionUtils.indexOfThrowable(failure, EsRejectedExecutionException.class) >= 0) {
+ *				// full queue; re-add document for indexing
+ *				indexer.add(action);
+ *				return false;
+ *			} else if (ExceptionUtils.indexOfThrowable(failure, ElasticsearchParseException.class) {
+ *				// malformed document; simply drop request without failing sink
+ *				return false;
+ *			} else {
+ *				// for all other failures, fail the sink
+ *				return true;
+ *			}
+ *		}
+ *	}
+ *
+ * }</pre>
+ *
+ * <p>
+ * The above example will let the sink re-add requests that failed due to queue capacity saturation and drop requests
+ * with malformed documents, without failing the sink. For all other failures, the sink will fail.
+ */
+public interface ActionRequestFailureHandler extends Serializable {
+
+	/**
+	 * Handle a failed {@link ActionRequest}.
+	 *
+	 * @param action the {@link ActionRequest} that failed due to the failure
+	 * @param failure the cause of failure
+	 * @param indexer request indexer to re-add the failed action, if intended to do so
+	 * @return the implementation should return {@code true} if the sink should fail due to this failure, and {@code false} otherwise
+	 */
+	boolean onFailure(ActionRequest action, Throwable failure, RequestIndexer indexer);
+
+}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ActionRequestFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ActionRequestFailureHandler.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
 
 /**
  * An implementation of {@link ActionRequestFailureHandler} is provided by the user to define how failed
- * {@link ActionRequest ActionRequests} should be handled, ex. dropping them, reprocessing malformed documents, or
+ * {@link ActionRequest ActionRequests} should be handled, e.g. dropping them, reprocessing malformed documents, or
  * simply requesting them to be sent to Elasticsearch again if the failure is only temporary.
  *
  * <p>

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ActionRequestFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ActionRequestFailureHandler.java
@@ -34,7 +34,7 @@ import java.io.Serializable;
  *	private static class ExampleActionRequestFailureHandler implements ActionRequestFailureHandler {
  *
  *		@Override
- *		void onFailure(ActionRequest action, Throwable failure, RequestIndexer indexer) throws Throwable {
+ *		void onFailure(ActionRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer) throws Throwable {
  *			if (ExceptionUtils.containsThrowable(failure, EsRejectedExecutionException.class)) {
  *				// full queue; re-add document for indexing
  *				indexer.add(action);
@@ -53,6 +53,11 @@ import java.io.Serializable;
  * <p>
  * The above example will let the sink re-add requests that failed due to queue capacity saturation and drop requests
  * with malformed documents, without failing the sink. For all other failures, the sink will fail.
+ *
+ * <p>
+ * Note: For Elasticsearch 1.x, it is not feasible to match the type of the failure because the exact type
+ * could not be retrieved through the older version Java client APIs (thus, the types will be general {@link Exception}s
+ * and only differ in the failure message). In this case, it is recommended to match on the provided REST status code.
  */
 public interface ActionRequestFailureHandler extends Serializable {
 
@@ -61,11 +66,12 @@ public interface ActionRequestFailureHandler extends Serializable {
 	 *
 	 * @param action the {@link ActionRequest} that failed due to the failure
 	 * @param failure the cause of failure
+	 * @param restStatusCode the REST status code of the failure (-1 if none can be retrieved)
 	 * @param indexer request indexer to re-add the failed action, if intended to do so
 	 *
 	 * @throws Throwable if the sink should fail on this failure, the implementation should rethrow
 	 *                   the exception or a custom one
 	 */
-	void onFailure(ActionRequest action, Throwable failure, RequestIndexer indexer) throws Throwable;
+	void onFailure(ActionRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer) throws Throwable;
 
 }

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.connectors.elasticsearch;
 
 import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.client.Client;
 
 import javax.annotation.Nullable;
@@ -51,6 +52,17 @@ public interface ElasticsearchApiCallBridge extends Serializable {
 	 * @return the extracted {@link Throwable} from the response ({@code null} is the response is successful).
 	 */
 	@Nullable Throwable extractFailureCauseFromBulkItemResponse(BulkItemResponse bulkItemResponse);
+
+	/**
+	 * Set backoff-related configurations on the provided {@link BulkProcessor.Builder}.
+	 * The builder will be later on used to instantiate the actual {@link BulkProcessor}.
+	 *
+	 * @param builder the {@link BulkProcessor.Builder} to configure.
+	 * @param flushBackoffPolicy user-provided backoff retry settings ({@code null} if the user disabled backoff retries).
+	 */
+	void configureBulkProcessorBackoff(
+		BulkProcessor.Builder builder,
+		@Nullable ElasticsearchSinkBase.BulkFlushBackoffPolicy flushBackoffPolicy);
 
 	/**
 	 * Perform any necessary state cleanup.

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
@@ -287,7 +287,10 @@ public abstract class ElasticsearchSinkBase<T> extends RichSinkFunction<T> imple
 							if (failure != null) {
 								LOG.error("Failed Elasticsearch item request: {}", itemResponse.getFailureMessage(), failure);
 
-								if (failureHandler.onFailure(request.requests().get(i), failure, requestIndexer)) {
+								try {
+									failureHandler.onFailure(request.requests().get(i), failure, requestIndexer);
+								} catch (Throwable t) {
+									// fail the sink if the failure handler decides to throw an exception
 									failureThrowable.compareAndSet(null, failure);
 								}
 							}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
@@ -190,21 +190,13 @@ public abstract class ElasticsearchSinkBase<T> extends RichSinkFunction<T> imple
 		// otherwise, if they aren't serializable, users will merely get a non-informative error message
 		// "ElasticsearchSinkBase is not serializable"
 
-		try {
-			InstantiationUtil.serializeObject(elasticsearchSinkFunction);
-		} catch (Exception e) {
-			throw new IllegalArgumentException(
-				"The implementation of the provided ElasticsearchSinkFunction is not serializable. " +
-				"The object probably contains or references non serializable fields.");
-		}
+		checkArgument(InstantiationUtil.isSerializable(elasticsearchSinkFunction),
+			"The implementation of the provided ElasticsearchSinkFunction is not serializable. " +
+				"The object probably contains or references non-serializable fields.");
 
-		try {
-			InstantiationUtil.serializeObject(failureHandler);
-		} catch (Exception e) {
-			throw new IllegalArgumentException(
-				"The implementation of the provided ActionRequestFailureHandler is not serializable. " +
-					"The object probably contains or references non serializable fields.");
-		}
+		checkArgument(InstantiationUtil.isSerializable(failureHandler),
+			"The implementation of the provided ActionRequestFailureHandler is not serializable. " +
+				"The object probably contains or references non-serializable fields.");
 
 		// extract and remove bulk processor related configuration from the user-provided config,
 		// so that the resulting user config only contains configuration related to the Elasticsearch client.

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
@@ -298,7 +298,9 @@ public abstract class ElasticsearchSinkBase<T> extends RichSinkFunction<T> imple
 						}
 					}
 
-					numPendingRequests.getAndAdd(-request.numberOfActions());
+					if (flushOnCheckpoint) {
+						numPendingRequests.getAndAdd(-request.numberOfActions());
+					}
 				}
 
 				@Override
@@ -315,7 +317,9 @@ public abstract class ElasticsearchSinkBase<T> extends RichSinkFunction<T> imple
 						failureThrowable.compareAndSet(null, t);
 					}
 
-					numPendingRequests.getAndAdd(-request.numberOfActions());
+					if (flushOnCheckpoint) {
+						numPendingRequests.getAndAdd(-request.numberOfActions());
+					}
 				}
 			}
 		);

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
@@ -109,12 +109,12 @@ public abstract class ElasticsearchSinkBase<T> extends RichSinkFunction<T> imple
 		}
 
 		public void setMaxRetryCount(int maxRetryCount) {
-			checkArgument(maxRetryCount > 0);
+			checkArgument(maxRetryCount >= 0);
 			this.maxRetryCount = maxRetryCount;
 		}
 
 		public void setDelayMillis(long delayMillis) {
-			checkArgument(delayMillis > 0);
+			checkArgument(delayMillis >= 0);
 			this.delayMillis = delayMillis;
 		}
 	}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/NoOpActionRequestFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/NoOpActionRequestFailureHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch.util;
+
+import org.apache.flink.streaming.connectors.elasticsearch.ActionRequestFailureHandler;
+import org.apache.flink.streaming.connectors.elasticsearch.RequestIndexer;
+import org.elasticsearch.action.ActionRequest;
+
+/**
+ * An {@link ActionRequestFailureHandler} that simply fails the sink on any failures.
+ */
+public class NoOpActionRequestFailureHandler implements ActionRequestFailureHandler {
+
+	private static final long serialVersionUID = 737941343410827885L;
+
+	@Override
+	public boolean onFailure(ActionRequest action, Throwable failure, RequestIndexer indexer) {
+		// simply fail the sink
+		return true;
+	}
+
+}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/NoOpFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/NoOpFailureHandler.java
@@ -29,7 +29,7 @@ public class NoOpFailureHandler implements ActionRequestFailureHandler {
 	private static final long serialVersionUID = 737941343410827885L;
 
 	@Override
-	public void onFailure(ActionRequest action, Throwable failure, RequestIndexer indexer) throws Throwable {
+	public void onFailure(ActionRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer) throws Throwable {
 		// simply fail the sink
 		throw failure;
 	}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/NoOpFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/NoOpFailureHandler.java
@@ -24,14 +24,14 @@ import org.elasticsearch.action.ActionRequest;
 /**
  * An {@link ActionRequestFailureHandler} that simply fails the sink on any failures.
  */
-public class NoOpActionRequestFailureHandler implements ActionRequestFailureHandler {
+public class NoOpFailureHandler implements ActionRequestFailureHandler {
 
 	private static final long serialVersionUID = 737941343410827885L;
 
 	@Override
-	public boolean onFailure(ActionRequest action, Throwable failure, RequestIndexer indexer) {
+	public void onFailure(ActionRequest action, Throwable failure, RequestIndexer indexer) throws Throwable {
 		// simply fail the sink
-		return true;
+		throw failure;
 	}
 
 }

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/RetryRejectedExecutionFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/RetryRejectedExecutionFailureHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch.util;
+
+import org.apache.flink.streaming.connectors.elasticsearch.ActionRequestFailureHandler;
+import org.apache.flink.streaming.connectors.elasticsearch.RequestIndexer;
+import org.apache.flink.util.ExceptionUtils;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+
+/**
+ * An {@link ActionRequestFailureHandler} that re-adds requests that failed due to temporary
+ * {@link EsRejectedExecutionException}s (which means that Elasticsearch node queues are currently full),
+ * and fails for all other failures.
+ */
+public class RetryRejectedExecutionFailureHandler implements ActionRequestFailureHandler {
+
+	private static final long serialVersionUID = -7423562912824511906L;
+
+	@Override
+	public void onFailure(ActionRequest action, Throwable failure, RequestIndexer indexer) throws Throwable {
+		if (ExceptionUtils.containsThrowable(failure, EsRejectedExecutionException.class)) {
+			indexer.add(action);
+		} else {
+			// rethrow all other failures
+			throw failure;
+		}
+	}
+
+}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/RetryRejectedExecutionFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/RetryRejectedExecutionFailureHandler.java
@@ -34,7 +34,7 @@ public class RetryRejectedExecutionFailureHandler implements ActionRequestFailur
 	private static final long serialVersionUID = -7423562912824511906L;
 
 	@Override
-	public void onFailure(ActionRequest action, Throwable failure, RequestIndexer indexer) throws Throwable {
+	public void onFailure(ActionRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer) throws Throwable {
 		if (ExceptionUtils.containsThrowable(failure, EsRejectedExecutionException.class)) {
 			indexer.add(action);
 		} else {

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
@@ -1,0 +1,568 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.core.testutils.MultiShotLatch;
+import org.apache.flink.streaming.api.operators.StreamSink;
+import org.apache.flink.streaming.connectors.elasticsearch.util.NoOpFailureHandler;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.Requests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Suite of tests for {@link ElasticsearchSinkBase}.
+ */
+public class ElasticsearchSinkBaseTest {
+
+	/** Tests that any item failure in the listener callbacks is rethrown on an immediately following invoke call. */
+	@Test
+	public void testItemFailureRethrownOnInvoke() throws Throwable {
+		final DummyElasticsearchSink<String> sink = new DummyElasticsearchSink<>(
+			new HashMap<String, String>(), new SimpleSinkFunction<String>(), new NoOpFailureHandler());
+
+		final OneInputStreamOperatorTestHarness<String, Object> testHarness =
+			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
+
+		testHarness.open();
+
+		// setup the next bulk request, and its mock item failures
+		sink.setMockItemFailuresListForNextBulkItemResponses(Collections.singletonList(new Exception("artificial failure for record")));
+		testHarness.processElement(new StreamRecord<>("msg"));
+		verify(sink.getMockBulkProcessor(), times(1)).add(any(ActionRequest.class));
+
+		// manually execute the next bulk request
+		sink.manualBulkRequestWithAllPendingRequests();
+
+		try {
+			testHarness.processElement(new StreamRecord<>("next msg"));
+		} catch (Exception e) {
+			// the invoke should have failed with the failure
+			Assert.assertTrue(e.getCause().getMessage().contains("artificial failure for record"));
+
+			// test succeeded
+			return;
+		}
+
+		Assert.fail();
+	}
+
+	/** Tests that any item failure in the listener callbacks is rethrown on an immediately following checkpoint. */
+	@Test
+	public void testItemFailureRethrownOnCheckpoint() throws Throwable {
+		final DummyElasticsearchSink<String> sink = new DummyElasticsearchSink<>(
+			new HashMap<String, String>(), new SimpleSinkFunction<String>(), new NoOpFailureHandler());
+
+		final OneInputStreamOperatorTestHarness<String, Object> testHarness =
+			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
+
+		testHarness.open();
+
+		// setup the next bulk request, and its mock item failures
+		sink.setMockItemFailuresListForNextBulkItemResponses(Collections.singletonList(new Exception("artificial failure for record")));
+		testHarness.processElement(new StreamRecord<>("msg"));
+		verify(sink.getMockBulkProcessor(), times(1)).add(any(ActionRequest.class));
+
+		// manually execute the next bulk request
+		sink.manualBulkRequestWithAllPendingRequests();
+
+		try {
+			testHarness.snapshot(1L, 1000L);
+		} catch (Exception e) {
+			// the snapshot should have failed with the failure
+			Assert.assertTrue(e.getCause().getCause().getMessage().contains("artificial failure for record"));
+
+			// test succeeded
+			return;
+		}
+
+		Assert.fail();
+	}
+
+	/**
+	 * Tests that any item failure in the listener callbacks due to flushing on an immediately following checkpoint
+	 * is rethrown; we set a timeout because the test will not finish if the logic is broken
+	 */
+	@Test(timeout=5000)
+	public void testItemFailureRethrownOnCheckpointAfterFlush() throws Throwable {
+		final DummyElasticsearchSink<String> sink = new DummyElasticsearchSink<>(
+			new HashMap<String, String>(), new SimpleSinkFunction<String>(), new NoOpFailureHandler());
+
+		final OneInputStreamOperatorTestHarness<String, Object> testHarness =
+			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
+
+		testHarness.open();
+
+		// setup the next bulk request, and its mock item failures
+
+		List<Exception> mockResponsesList = new ArrayList<>(2);
+		mockResponsesList.add(null); // the first request in a bulk will succeed
+		mockResponsesList.add(new Exception("artificial failure for record")); // the second request in a bulk will fail
+		sink.setMockItemFailuresListForNextBulkItemResponses(mockResponsesList);
+
+		testHarness.processElement(new StreamRecord<>("msg-1"));
+		verify(sink.getMockBulkProcessor(), times(1)).add(any(ActionRequest.class));
+
+		// manually execute the next bulk request (1 request only, thus should succeed)
+		sink.manualBulkRequestWithAllPendingRequests();
+
+		CheckedThread snapshotThread = new CheckedThread() {
+			@Override
+			public void go() throws Exception {
+				testHarness.snapshot(1L, 1000L);
+			}
+		};
+		snapshotThread.start();
+
+		// the snapshot should eventually be blocked before snapshot triggers flushing
+		while (snapshotThread.getState() != Thread.State.WAITING) {
+			Thread.sleep(10);
+		}
+
+		// setup the requests to be flushed
+		testHarness.processElement(new StreamRecord<>("msg-2"));
+		testHarness.processElement(new StreamRecord<>("msg-3"));
+		verify(sink.getMockBulkProcessor(), times(3)).add(any(ActionRequest.class));
+
+		// let the snapshot-triggered flush continue (2 records in the bulk, so the 2nd one should fail)
+		sink.continueFlush();
+
+		try {
+			snapshotThread.sync();
+		} catch (Exception e) {
+			// the snapshot should have failed with the failure from the 2nd request
+			Assert.assertTrue(e.getCause().getCause().getMessage().contains("artificial failure for record"));
+
+			// test succeeded
+			return;
+		}
+
+		Assert.fail();
+	}
+
+	/** Tests that any bulk failure in the listener callbacks is rethrown on an immediately following invoke call. */
+	@Test
+	public void testBulkFailureRethrownOnInvoke() throws Throwable {
+		final DummyElasticsearchSink<String> sink = new DummyElasticsearchSink<>(
+			new HashMap<String, String>(), new SimpleSinkFunction<String>(), new NoOpFailureHandler());
+
+		final OneInputStreamOperatorTestHarness<String, Object> testHarness =
+			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
+
+		testHarness.open();
+
+		// setup the next bulk request, and let the whole bulk request fail
+		sink.setFailNextBulkRequestCompletely(new Exception("artificial failure for bulk request"));
+		testHarness.processElement(new StreamRecord<>("msg"));
+		verify(sink.getMockBulkProcessor(), times(1)).add(any(ActionRequest.class));
+
+		// manually execute the next bulk request
+		sink.manualBulkRequestWithAllPendingRequests();
+
+		try {
+			testHarness.processElement(new StreamRecord<>("next msg"));
+		} catch (Exception e) {
+			// the invoke should have failed with the bulk request failure
+			Assert.assertTrue(e.getCause().getMessage().contains("artificial failure for bulk request"));
+
+			// test succeeded
+			return;
+		}
+
+		Assert.fail();
+	}
+
+	/** Tests that any bulk failure in the listener callbacks is rethrown on an immediately following checkpoint. */
+	@Test
+	public void testBulkFailureRethrownOnCheckpoint() throws Throwable {
+		final DummyElasticsearchSink<String> sink = new DummyElasticsearchSink<>(
+			new HashMap<String, String>(), new SimpleSinkFunction<String>(), new NoOpFailureHandler());
+
+		final OneInputStreamOperatorTestHarness<String, Object> testHarness =
+			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
+
+		testHarness.open();
+
+		// setup the next bulk request, and let the whole bulk request fail
+		sink.setFailNextBulkRequestCompletely(new Exception("artificial failure for bulk request"));
+		testHarness.processElement(new StreamRecord<>("msg"));
+		verify(sink.getMockBulkProcessor(), times(1)).add(any(ActionRequest.class));
+
+		// manually execute the next bulk request
+		sink.manualBulkRequestWithAllPendingRequests();
+
+		try {
+			testHarness.snapshot(1L, 1000L);
+		} catch (Exception e) {
+			// the snapshot should have failed with the bulk request failure
+			Assert.assertTrue(e.getCause().getCause().getMessage().contains("artificial failure for bulk request"));
+
+			// test succeeded
+			return;
+		}
+
+		Assert.fail();
+	}
+
+	/**
+	 * Tests that any bulk failure in the listener callbacks due to flushing on an immediately following checkpoint
+	 * is rethrown; we set a timeout because the test will not finish if the logic is broken.
+	 */
+	@Test(timeout=5000)
+	public void testBulkFailureRethrownOnOnCheckpointAfterFlush() throws Throwable {
+		final DummyElasticsearchSink<String> sink = new DummyElasticsearchSink<>(
+			new HashMap<String, String>(), new SimpleSinkFunction<String>(), new NoOpFailureHandler());
+
+		final OneInputStreamOperatorTestHarness<String, Object> testHarness =
+			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
+
+		testHarness.open();
+
+		// setup the next bulk request, and let bulk request succeed
+		sink.setMockItemFailuresListForNextBulkItemResponses(Collections.singletonList((Exception) null));
+		testHarness.processElement(new StreamRecord<>("msg-1"));
+		verify(sink.getMockBulkProcessor(), times(1)).add(any(ActionRequest.class));
+
+		// manually execute the next bulk request
+		sink.manualBulkRequestWithAllPendingRequests();
+
+		CheckedThread snapshotThread = new CheckedThread() {
+			@Override
+			public void go() throws Exception {
+				testHarness.snapshot(1L, 1000L);
+			}
+		};
+		snapshotThread.start();
+
+		// the snapshot should eventually be blocked before snapshot triggers flushing
+		while (snapshotThread.getState() != Thread.State.WAITING) {
+			Thread.sleep(10);
+		}
+
+		// for the snapshot-triggered flush, we let the bulk request fail completely
+		sink.setFailNextBulkRequestCompletely(new Exception("artificial failure for bulk request"));
+
+		// setup the requests to be flushed
+		testHarness.processElement(new StreamRecord<>("msg-2"));
+		testHarness.processElement(new StreamRecord<>("msg-3"));
+		verify(sink.getMockBulkProcessor(), times(3)).add(any(ActionRequest.class));
+
+		// let the snapshot-triggered flush continue (bulk request should fail completely)
+		sink.continueFlush();
+
+		try {
+			snapshotThread.sync();
+		} catch (Exception e) {
+			// the snapshot should have failed with the bulk request failure
+			Assert.assertTrue(e.getCause().getCause().getMessage().contains("artificial failure for bulk request"));
+
+			// test succeeded
+			return;
+		}
+
+		Assert.fail();
+	}
+
+	/**
+	 * Tests that the sink correctly waits for pending requests (including re-added requests) on checkpoints;
+	 * we set a timeout because the test will not finish if the logic is broken
+	 */
+	@Test(timeout=5000)
+	public void testAtLeastOnceSink() throws Throwable {
+		final DummyElasticsearchSink<String> sink = new DummyElasticsearchSink<>(
+				new HashMap<String, String>(),
+				new SimpleSinkFunction<String>(),
+				new DummyRetryFailureHandler()); // use a failure handler that simply re-adds requests
+
+		final OneInputStreamOperatorTestHarness<String, Object> testHarness =
+			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
+
+		testHarness.open();
+
+		// setup the next bulk request, and its mock item failures;
+		// it contains 1 request, which will fail and re-added to the next bulk request
+		sink.setMockItemFailuresListForNextBulkItemResponses(Collections.singletonList(new Exception("artificial failure for record")));
+		testHarness.processElement(new StreamRecord<>("msg"));
+		verify(sink.getMockBulkProcessor(), times(1)).add(any(ActionRequest.class));
+
+		CheckedThread snapshotThread = new CheckedThread() {
+			@Override
+			public void go() throws Exception {
+				testHarness.snapshot(1L, 1000L);
+			}
+		};
+		snapshotThread.start();
+
+		// the snapshot should eventually be blocked before snapshot triggers flushing
+		while (snapshotThread.getState() != Thread.State.WAITING) {
+			Thread.sleep(10);
+		}
+
+		sink.continueFlush();
+
+		// since the previous flush should have resulted in a request re-add from the failure handler,
+		// we should have flushed again, and eventually be blocked before snapshot triggers the 2nd flush
+		while (snapshotThread.getState() != Thread.State.WAITING) {
+			Thread.sleep(10);
+		}
+
+		// current number of pending request should be 1 due to the re-add
+		Assert.assertEquals(1, sink.getNumPendingRequests());
+
+		// this time, let the bulk request succeed, so no-more requests are re-added
+		sink.setMockItemFailuresListForNextBulkItemResponses(Collections.singletonList((Exception) null));
+
+		sink.continueFlush();
+
+		// the snapshot should finish with no exceptions
+		snapshotThread.sync();
+
+		testHarness.close();
+	}
+
+	/**
+	 * This test is meant to assure that testAtLeastOnceSink is valid by testing that if flushing is disabled,
+	 * the snapshot method does indeed finishes without waiting for pending requests;
+	 * we set a timeout because the test will not finish if the logic is broken
+	 */
+	@Test(timeout=5000)
+	public void testDoesNotWaitForPendingRequestsIfFlushingDisabled() throws Exception {
+		final DummyElasticsearchSink<String> sink = new DummyElasticsearchSink<>(
+			new HashMap<String, String>(), new SimpleSinkFunction<String>(), new DummyRetryFailureHandler());
+		sink.disableFlushOnCheckpoint(); // disable flushing
+
+		final OneInputStreamOperatorTestHarness<String, Object> testHarness =
+			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
+
+		testHarness.open();
+
+		// setup the next bulk request, and let bulk request succeed
+		sink.setMockItemFailuresListForNextBulkItemResponses(Collections.singletonList(new Exception("artificial failure for record")));
+		testHarness.processElement(new StreamRecord<>("msg-1"));
+		verify(sink.getMockBulkProcessor(), times(1)).add(any(ActionRequest.class));
+
+		// the snapshot should not block even though we haven't flushed the bulk request
+		testHarness.snapshot(1L, 1000L);
+
+		testHarness.close();
+	}
+
+	private static class DummyElasticsearchSink<T> extends ElasticsearchSinkBase<T> {
+
+		private static final long serialVersionUID = 5051907841570096991L;
+
+		private transient BulkProcessor mockBulkProcessor;
+		private transient BulkRequest nextBulkRequest = new BulkRequest();
+		private transient MultiShotLatch flushLatch = new MultiShotLatch();
+
+		private List<? extends Throwable> mockItemFailuresList;
+		private Throwable nextBulkFailure;
+
+		public DummyElasticsearchSink(
+				Map<String, String> userConfig,
+				ElasticsearchSinkFunction<T> sinkFunction,
+				ActionRequestFailureHandler failureHandler) {
+			super(new DummyElasticsearchApiCallBridge(), userConfig, sinkFunction, failureHandler);
+		}
+
+		/**
+		 * This method is used to mimic a scheduled bulk request; we need to do this
+		 * manually because we are mocking the BulkProcessor
+		 */
+		public void manualBulkRequestWithAllPendingRequests() {
+			flushLatch.trigger(); // let the flush
+			mockBulkProcessor.flush();
+		}
+
+		/**
+		 * On non-manual flushes, i.e. when flush is called in the snapshot method implementation,
+		 * usages need to explicitly call this to allow the flush to continue. This is useful
+		 * to make sure that specific requests get added to the the next bulk request for flushing.
+		 */
+		public void continueFlush() {
+			flushLatch.trigger();
+		}
+
+		/**
+		 * Set the list of mock failures to use for the next bulk of item responses. A {@code null}
+		 * means that the response is successful, failed otherwise.
+		 *
+		 * The list is used with corresponding order to the requests in the bulk, i.e. the first
+		 * request uses the response at index 0, the second requests uses the response at index 1, etc.
+		 */
+		public void setMockItemFailuresListForNextBulkItemResponses(List<? extends Throwable> mockItemFailuresList) {
+			this.mockItemFailuresList = mockItemFailuresList;
+		}
+
+		/**
+		 * Let the next bulk request fail completely with the provided throwable.
+		 * If this is set, the failures list provided with setMockItemFailuresListForNextBulkItemResponses is not respected.
+		 */
+		public void setFailNextBulkRequestCompletely(Throwable failure) {
+			this.nextBulkFailure = failure;
+		}
+
+		public BulkProcessor getMockBulkProcessor() {
+			return mockBulkProcessor;
+		}
+
+		/**
+		 * Override the bulk processor build process to provide a mock implementation,
+		 * but reuse the listener implementation in our mock to test that the listener logic
+		 * works correctly with request flushing logic.
+		 */
+		@Override
+		protected BulkProcessor buildBulkProcessor(final BulkProcessor.Listener listener) {
+			this.mockBulkProcessor = mock(BulkProcessor.class);
+
+			when(mockBulkProcessor.add(any(ActionRequest.class))).thenAnswer(new Answer<Object>() {
+				@Override
+				public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+					// intercept the request and add it to our mock bulk request
+					nextBulkRequest.add(invocationOnMock.getArgumentAt(0, ActionRequest.class));
+
+					return null;
+				}
+			});
+
+			doAnswer(new Answer() {
+				@Override
+				public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+					// wait until we are allowed to continue with the flushing
+					flushLatch.await();
+
+					// create a copy of the accumulated mock requests, so that
+					// re-added requests from the failure handler are included in the next bulk
+					BulkRequest currentBulkRequest = nextBulkRequest;
+					nextBulkRequest = new BulkRequest();
+
+					listener.beforeBulk(123L, currentBulkRequest);
+
+					if (nextBulkFailure == null) {
+						BulkItemResponse[] mockResponses = new BulkItemResponse[currentBulkRequest.requests().size()];
+						for (int i = 0; i < currentBulkRequest.requests().size(); i++) {
+							Throwable mockItemFailure = mockItemFailuresList.get(i);
+
+							if (mockItemFailure == null) {
+								// the mock response for the item is success
+								mockResponses[i] = new BulkItemResponse(i, "opType", mock(ActionResponse.class));
+							} else {
+								// the mock response for the item is failure
+								mockResponses[i] = new BulkItemResponse(i, "opType", new BulkItemResponse.Failure("index", "type", "id", mockItemFailure));
+							}
+						}
+
+						listener.afterBulk(123L, currentBulkRequest, new BulkResponse(mockResponses, 1000L));
+					} else {
+						listener.afterBulk(123L, currentBulkRequest, nextBulkFailure);
+					}
+
+					return null;
+				}
+			}).when(mockBulkProcessor).flush();
+
+			return mockBulkProcessor;
+		}
+	}
+
+	private static class DummyElasticsearchApiCallBridge implements ElasticsearchApiCallBridge {
+
+		private static final long serialVersionUID = -4272760730959041699L;
+
+		@Override
+		public Client createClient(Map<String, String> clientConfig) {
+			return mock(Client.class);
+		}
+
+		@Nullable
+		@Override
+		public Throwable extractFailureCauseFromBulkItemResponse(BulkItemResponse bulkItemResponse) {
+			if (bulkItemResponse.isFailed()) {
+				return new Exception(bulkItemResponse.getFailure().getMessage());
+			} else {
+				return null;
+			}
+		}
+
+		@Override
+		public void configureBulkProcessorBackoff(BulkProcessor.Builder builder, @Nullable ElasticsearchSinkBase.BulkFlushBackoffPolicy flushBackoffPolicy) {
+			// no need for this in the test cases here
+		}
+
+		@Override
+		public void cleanup() {
+			// nothing to cleanup
+		}
+	}
+
+	private static class SimpleSinkFunction<String> implements ElasticsearchSinkFunction<String> {
+
+		private static final long serialVersionUID = -176739293659135148L;
+
+		@Override
+		public void process(String element, RuntimeContext ctx, RequestIndexer indexer) {
+			Map<java.lang.String, Object> json = new HashMap<>();
+			json.put("data", element);
+
+			indexer.add(
+				Requests.indexRequest()
+					.index("index")
+					.type("type")
+					.id("id")
+					.source(json)
+			);
+		}
+	}
+
+	private static class DummyRetryFailureHandler implements ActionRequestFailureHandler {
+
+		private static final long serialVersionUID = 5400023700099200745L;
+
+		@Override
+		public void onFailure(ActionRequest action, Throwable failure, RequestIndexer indexer) throws Throwable {
+			indexer.add(action);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
@@ -561,7 +561,7 @@ public class ElasticsearchSinkBaseTest {
 		private static final long serialVersionUID = 5400023700099200745L;
 
 		@Override
-		public void onFailure(ActionRequest action, Throwable failure, RequestIndexer indexer) throws Throwable {
+		public void onFailure(ActionRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer) throws Throwable {
 			indexer.add(action);
 		}
 	}

--- a/flink-connectors/flink-connector-elasticsearch/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/Elasticsearch1ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/Elasticsearch1ApiCallBridge.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.connectors.elasticsearch;
 
 import org.apache.flink.util.Preconditions;
 import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.Settings;
@@ -27,6 +28,7 @@ import org.elasticsearch.node.Node;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
@@ -116,6 +118,14 @@ public class Elasticsearch1ApiCallBridge implements ElasticsearchApiCallBridge {
 		} else {
 			return new RuntimeException(bulkItemResponse.getFailureMessage());
 		}
+	}
+
+	@Override
+	public void configureBulkProcessorBackoff(
+		BulkProcessor.Builder builder,
+		@Nullable ElasticsearchSinkBase.BulkFlushBackoffPolicy flushBackoffPolicy) {
+		// Elasticsearch 1.x does not support backoff retries for failed bulk requests
+		LOG.warn("Elasticsearch 1.x does not support backoff retries.");
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-elasticsearch/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSink.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.streaming.connectors.elasticsearch;
 
-import org.apache.flink.streaming.connectors.elasticsearch.util.NoOpActionRequestFailureHandler;
+import org.apache.flink.streaming.connectors.elasticsearch.util.NoOpFailureHandler;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.action.index.IndexRequest;
@@ -106,7 +106,7 @@ public class ElasticsearchSink<T> extends ElasticsearchSinkBase<T> {
 	 * @param elasticsearchSinkFunction This is used to generate multiple {@link ActionRequest} from the incoming element
 	 */
 	public ElasticsearchSink(Map<String, String> userConfig, ElasticsearchSinkFunction<T> elasticsearchSinkFunction) {
-		this(userConfig, elasticsearchSinkFunction, new NoOpActionRequestFailureHandler());
+		this(userConfig, elasticsearchSinkFunction, new NoOpFailureHandler());
 	}
 
 	/**
@@ -117,7 +117,7 @@ public class ElasticsearchSink<T> extends ElasticsearchSinkBase<T> {
 	 * @param elasticsearchSinkFunction This is used to generate multiple {@link ActionRequest} from the incoming element
 	 */
 	public ElasticsearchSink(Map<String, String> userConfig, List<TransportAddress> transportAddresses, ElasticsearchSinkFunction<T> elasticsearchSinkFunction) {
-		this(userConfig, transportAddresses, elasticsearchSinkFunction, new NoOpActionRequestFailureHandler());
+		this(userConfig, transportAddresses, elasticsearchSinkFunction, new NoOpFailureHandler());
 	}
 
 	/**

--- a/flink-connectors/flink-connector-elasticsearch/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSink.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.elasticsearch;
 
+import org.apache.flink.streaming.connectors.elasticsearch.util.NoOpActionRequestFailureHandler;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.action.index.IndexRequest;
@@ -105,7 +106,7 @@ public class ElasticsearchSink<T> extends ElasticsearchSinkBase<T> {
 	 * @param elasticsearchSinkFunction This is used to generate multiple {@link ActionRequest} from the incoming element
 	 */
 	public ElasticsearchSink(Map<String, String> userConfig, ElasticsearchSinkFunction<T> elasticsearchSinkFunction) {
-		super(new Elasticsearch1ApiCallBridge(), userConfig, elasticsearchSinkFunction);
+		this(userConfig, elasticsearchSinkFunction, new NoOpActionRequestFailureHandler());
 	}
 
 	/**
@@ -116,6 +117,38 @@ public class ElasticsearchSink<T> extends ElasticsearchSinkBase<T> {
 	 * @param elasticsearchSinkFunction This is used to generate multiple {@link ActionRequest} from the incoming element
 	 */
 	public ElasticsearchSink(Map<String, String> userConfig, List<TransportAddress> transportAddresses, ElasticsearchSinkFunction<T> elasticsearchSinkFunction) {
-		super(new Elasticsearch1ApiCallBridge(transportAddresses), userConfig, elasticsearchSinkFunction);
+		this(userConfig, transportAddresses, elasticsearchSinkFunction, new NoOpActionRequestFailureHandler());
+	}
+
+	/**
+	 * Creates a new {@code ElasticsearchSink} that connects to the cluster using an embedded {@link Node}.
+	 *
+	 * @param userConfig The map of user settings that are used when constructing the embedded {@link Node} and {@link BulkProcessor}
+	 * @param elasticsearchSinkFunction This is used to generate multiple {@link ActionRequest} from the incoming element
+	 * @param failureHandler This is used to handle failed {@link ActionRequest}
+	 */
+	public ElasticsearchSink(
+		Map<String, String> userConfig,
+		ElasticsearchSinkFunction<T> elasticsearchSinkFunction,
+		ActionRequestFailureHandler failureHandler) {
+
+		super(new Elasticsearch1ApiCallBridge(), userConfig, elasticsearchSinkFunction, failureHandler);
+	}
+
+	/**
+	 * Creates a new {@code ElasticsearchSink} that connects to the cluster using a {@link TransportClient}.
+	 *
+	 * @param userConfig The map of user settings that are used when constructing the {@link TransportClient} and {@link BulkProcessor}
+	 * @param transportAddresses The addresses of Elasticsearch nodes to which to connect using a {@link TransportClient}
+	 * @param elasticsearchSinkFunction This is used to generate multiple {@link ActionRequest} from the incoming element
+	 * @param failureHandler This is used to handle failed {@link ActionRequest}
+	 */
+	public ElasticsearchSink(
+		Map<String, String> userConfig,
+		List<TransportAddress> transportAddresses,
+		ElasticsearchSinkFunction<T> elasticsearchSinkFunction,
+		ActionRequestFailureHandler failureHandler) {
+
+		super(new Elasticsearch1ApiCallBridge(transportAddresses), userConfig, elasticsearchSinkFunction, failureHandler);
 	}
 }

--- a/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/ElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/ElasticsearchSink.java
@@ -18,7 +18,7 @@ package org.apache.flink.streaming.connectors.elasticsearch2;
 
 import org.apache.flink.streaming.connectors.elasticsearch.ActionRequestFailureHandler;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
-import org.apache.flink.streaming.connectors.elasticsearch.util.NoOpActionRequestFailureHandler;
+import org.apache.flink.streaming.connectors.elasticsearch.util.NoOpFailureHandler;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.client.transport.TransportClient;
@@ -89,7 +89,7 @@ public class ElasticsearchSink<T> extends ElasticsearchSinkBase<T> {
 		List<InetSocketAddress> transportAddresses,
 		org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkFunction<T> elasticsearchSinkFunction) {
 
-		this(userConfig, transportAddresses, elasticsearchSinkFunction, new NoOpActionRequestFailureHandler());
+		this(userConfig, transportAddresses, elasticsearchSinkFunction, new NoOpFailureHandler());
 	}
 
 	/**

--- a/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/ElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/ElasticsearchSink.java
@@ -16,7 +16,9 @@
  */
 package org.apache.flink.streaming.connectors.elasticsearch2;
 
+import org.apache.flink.streaming.connectors.elasticsearch.ActionRequestFailureHandler;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
+import org.apache.flink.streaming.connectors.elasticsearch.util.NoOpActionRequestFailureHandler;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.client.transport.TransportClient;
@@ -82,9 +84,28 @@ public class ElasticsearchSink<T> extends ElasticsearchSinkBase<T> {
 	 * @param transportAddresses The addresses of Elasticsearch nodes to which to connect using a {@link TransportClient}
 	 * @param elasticsearchSinkFunction This is used to generate multiple {@link ActionRequest} from the incoming element
 	 */
-	public ElasticsearchSink(Map<String, String> userConfig,
-							List<InetSocketAddress> transportAddresses,
-							org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkFunction<T> elasticsearchSinkFunction) {
-		super(new Elasticsearch2ApiCallBridge(transportAddresses), userConfig, elasticsearchSinkFunction);
+	public ElasticsearchSink(
+		Map<String, String> userConfig,
+		List<InetSocketAddress> transportAddresses,
+		org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkFunction<T> elasticsearchSinkFunction) {
+
+		this(userConfig, transportAddresses, elasticsearchSinkFunction, new NoOpActionRequestFailureHandler());
+	}
+
+	/**
+	 * Creates a new {@code ElasticsearchSink} that connects to the cluster using a {@link TransportClient}.
+	 *
+	 * @param userConfig The map of user settings that are used when constructing the {@link TransportClient} and {@link BulkProcessor}
+	 * @param transportAddresses The addresses of Elasticsearch nodes to which to connect using a {@link TransportClient}
+	 * @param elasticsearchSinkFunction This is used to generate multiple {@link ActionRequest} from the incoming element
+	 * @param failureHandler This is used to handle failed {@link ActionRequest}
+	 */
+	public ElasticsearchSink(
+		Map<String, String> userConfig,
+		List<InetSocketAddress> transportAddresses,
+		org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkFunction<T> elasticsearchSinkFunction,
+		ActionRequestFailureHandler failureHandler) {
+
+		super(new Elasticsearch2ApiCallBridge(transportAddresses), userConfig, elasticsearchSinkFunction, failureHandler);
 	}
 }

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/java/org/apache/flink/streaming/connectors/elasticsearch5/ElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/java/org/apache/flink/streaming/connectors/elasticsearch5/ElasticsearchSink.java
@@ -16,8 +16,10 @@
  */
 package org.apache.flink.streaming.connectors.elasticsearch5;
 
+import org.apache.flink.streaming.connectors.elasticsearch.ActionRequestFailureHandler;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkFunction;
+import org.apache.flink.streaming.connectors.elasticsearch.util.NoOpActionRequestFailureHandler;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.client.transport.TransportClient;
@@ -64,13 +66,32 @@ public class ElasticsearchSink<T> extends ElasticsearchSinkBase<T> {
 	/**
 	 * Creates a new {@code ElasticsearchSink} that connects to the cluster using a {@link TransportClient}.
 	 *
-	 * @param userConfig The map of user settings that are used when constructing the {@link TransportClient}
+	 * @param userConfig The map of user settings that are used when constructing the {@link TransportClient} and {@link BulkProcessor}
 	 * @param transportAddresses The addresses of Elasticsearch nodes to which to connect using a {@link TransportClient}
 	 * @param elasticsearchSinkFunction This is used to generate multiple {@link ActionRequest} from the incoming element
 	 */
-	public ElasticsearchSink(Map<String, String> userConfig,
-							List<InetSocketAddress> transportAddresses,
-							ElasticsearchSinkFunction<T> elasticsearchSinkFunction) {
-		super(new Elasticsearch5ApiCallBridge(transportAddresses), userConfig, elasticsearchSinkFunction);
+	public ElasticsearchSink(
+		Map<String, String> userConfig,
+		List<InetSocketAddress> transportAddresses,
+		ElasticsearchSinkFunction<T> elasticsearchSinkFunction) {
+
+		this(userConfig, transportAddresses, elasticsearchSinkFunction, new NoOpActionRequestFailureHandler());
+	}
+
+	/**
+	 * Creates a new {@code ElasticsearchSink} that connects to the cluster using a {@link TransportClient}.
+	 *
+	 * @param userConfig The map of user settings that are used when constructing the {@link TransportClient} and {@link BulkProcessor}
+	 * @param transportAddresses The addresses of Elasticsearch nodes to which to connect using a {@link TransportClient}
+	 * @param elasticsearchSinkFunction This is used to generate multiple {@link ActionRequest} from the incoming element
+	 * @param failureHandler This is used to handle failed {@link ActionRequest}
+	 */
+	public ElasticsearchSink(
+		Map<String, String> userConfig,
+		List<InetSocketAddress> transportAddresses,
+		ElasticsearchSinkFunction<T> elasticsearchSinkFunction,
+		ActionRequestFailureHandler failureHandler) {
+
+		super(new Elasticsearch5ApiCallBridge(transportAddresses), userConfig, elasticsearchSinkFunction, failureHandler);
 	}
 }

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/java/org/apache/flink/streaming/connectors/elasticsearch5/ElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/java/org/apache/flink/streaming/connectors/elasticsearch5/ElasticsearchSink.java
@@ -19,7 +19,7 @@ package org.apache.flink.streaming.connectors.elasticsearch5;
 import org.apache.flink.streaming.connectors.elasticsearch.ActionRequestFailureHandler;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
 import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkFunction;
-import org.apache.flink.streaming.connectors.elasticsearch.util.NoOpActionRequestFailureHandler;
+import org.apache.flink.streaming.connectors.elasticsearch.util.NoOpFailureHandler;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.client.transport.TransportClient;
@@ -75,7 +75,7 @@ public class ElasticsearchSink<T> extends ElasticsearchSinkBase<T> {
 		List<InetSocketAddress> transportAddresses,
 		ElasticsearchSinkFunction<T> elasticsearchSinkFunction) {
 
-		this(userConfig, transportAddresses, elasticsearchSinkFunction, new NoOpActionRequestFailureHandler());
+		this(userConfig, transportAddresses, elasticsearchSinkFunction, new NoOpFailureHandler());
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
@@ -261,6 +261,30 @@ public final class ExceptionUtils {
 		}
 	}
 
+	/**
+	 * Checks whether a throwable chain contains a specific type of exception.
+	 *
+	 * @param throwable the throwable chain to check.
+	 * @param searchType the type of exception to search for in the chain.
+	 * @return True, if the searched type is nested in the throwable, false otherwise.
+	 */
+	public static boolean containsThrowable(Throwable throwable, Class searchType) {
+		if (throwable == null || searchType == null) {
+			return false;
+		}
+
+		Throwable t = throwable;
+		while (t != null) {
+			if (searchType.isAssignableFrom(t.getClass())) {
+				return true;
+			} else {
+				t = t.getCause();
+			}
+		}
+
+		return false;
+	}
+
 	// ------------------------------------------------------------------------
 
 	/** Private constructor to prevent instantiation. */

--- a/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
@@ -325,6 +325,16 @@ public final class InstantiationUtil {
 		oos.writeObject(o);
 	}
 
+	public static boolean isSerializable(Object o) {
+		try {
+			serializeObject(o);
+		} catch (IOException e) {
+			return false;
+		}
+
+		return true;
+	}
+
 	/**
 	 * Clones the given serializable object using Java serialization.
 	 *


### PR DESCRIPTION
This PR adds proper support for an at-least-once `ElasticsearchSink`. This is based on the pluggable error handling strategy functionality added in #3246, so only the last commit is relevant.

Like the Kafka producer, the way it works is that pending requests not yet acknowledged by Elasticsearch needs to be flushed before proceeding with the next record from upstream.
Slight difference is that for the `ElasticsearchSink`, since we're allowing re-adding failed requests back to the internal `BulkProcessor` (as part of #3246), we'll also need to wait for the re-added requests. The docs warn that if requests are re-added, it may lead to longer checkpoints since we need to wait for those too.

Flushing is enabled by default, but we provide a `disableFlushOnCheckpoint` method to switch it off. The docs and Javadoc of the method warns the user how this would affect at-least-once delivery.