### PR TITLE
[FLINK-5830] [Distributed Coordination] [FLIP-6] Handle OutOfMemory error during process async message in akka rpc actor

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
@@ -113,6 +113,19 @@ public final class ExceptionUtils {
 	}
 
 	/**
+	 * Rethrows the given {@code Throwable}, if it represents an error that is fatal to the JVM
+	 * or an out-of-memory error. See {@link ExceptionUtils#isJvmFatalError(Throwable)} for a
+	 * definition of fatal errors.
+	 *
+	 * @param t The Throwable to check and rethrow.
+	 */
+	public static void rethrowIfFatalErrorOrOOM(Throwable t) {
+		if (isJvmFatalError(t) || t instanceof OutOfMemoryError) {
+			throw (Error) t;
+		}
+	}
+
+	/**
 	 * Adds a new exception as a {@link Throwable#addSuppressed(Throwable) suppressed exception}
 	 * to a prior exception, or returns the new exception, if no prior exception exists.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.rpc.akka.messages.RpcInvocation;
 import org.apache.flink.runtime.rpc.akka.messages.RunAsync;
 
 import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
+import org.apache.flink.util.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -271,12 +272,9 @@ class AkkaRpcActor<C extends RpcGateway, T extends RpcEndpoint<C>> extends Untyp
 			// run immediately
 			try {
 				runAsync.getRunnable().run();
-			} catch (final OutOfMemoryError e) {
-				LOG.error("OutOfMemory error while executing runnable in main thread.", e);
-				// uncaught fatal error from thread resulting in shutting down ActorSystem and exiting task manager process
-				throw e;
-			}catch (final Throwable e) {
-				LOG.error("Caught exception while executing runnable in main thread.", e);
+			} catch (Throwable t) {
+				LOG.error("Caught exception while executing runnable in main thread.", t);
+				ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
 			}
 		}
 		else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
@@ -271,7 +271,11 @@ class AkkaRpcActor<C extends RpcGateway, T extends RpcEndpoint<C>> extends Untyp
 			// run immediately
 			try {
 				runAsync.getRunnable().run();
-			} catch (final Throwable e) {
+			} catch (final OutOfMemoryError e) {
+				LOG.error("OutOfMemory error while executing runnable in main thread.", e);
+				// uncaught fatal error from thread resulting in shutting down ActorSystem and exiting task manager process
+				throw e;
+			}catch (final Throwable e) {
 				LOG.error("Caught exception while executing runnable in main thread.", e);
 			}
 		}


### PR DESCRIPTION
If caught OOM error during process async messages in `AkkaRpcActor`, it will bring ambiguous behavior and may lost rpc messages. If the message is for notifying final state in `TaskExecutor`, it will result in `JobMaster` can not receive final state any more during process failing job, and may cause job stuck in final.

The solution is to catch this special error in `AkkaRpcActor` and throw it, then it will result in shutting down `ActorSystem` and exiting `TaskExecutor` process. So the `JobMaster` can be aware of that and make the job restart if necessary.

BTW, the `mvn clean verify` is successful in my machine.