### PR TITLE
[FLINK-5852] Move handler JSON generation code into static methods

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ArchivedExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ArchivedExecutionConfig.java
@@ -54,6 +54,19 @@ public class ArchivedExecutionConfig implements Serializable {
 		}
 	}
 
+	public ArchivedExecutionConfig(
+			String executionMode,
+			String restartStrategyDescription,
+			int parallelism,
+			boolean objectReuseEnabled,
+			Map<String, String> globalJobParameters) {
+		this.executionMode = executionMode;
+		this.restartStrategyDescription = restartStrategyDescription;
+		this.parallelism = parallelism;
+		this.objectReuseEnabled = objectReuseEnabled;
+		this.globalJobParameters = globalJobParameters;
+	}
+
 	public String getExecutionMode() {
 		return executionMode;
 	}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandler.java
@@ -28,6 +28,7 @@ import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 
@@ -73,20 +74,20 @@ public class CurrentJobsOverviewHandler extends AbstractJsonRequestHandler {
 				if (includeRunningJobs && includeFinishedJobs) {
 					gen.writeArrayFieldStart("running");
 					for (JobDetails detail : result.getRunningJobs()) {
-						generateSingleJobDetails(detail, gen, now);
+						writeJobDetailOverviewAsJson(detail, gen, now);
 					}
 					gen.writeEndArray();
 	
 					gen.writeArrayFieldStart("finished");
 					for (JobDetails detail : result.getFinishedJobs()) {
-						generateSingleJobDetails(detail, gen, now);
+						writeJobDetailOverviewAsJson(detail, gen, now);
 					}
 					gen.writeEndArray();
 				}
 				else {
 					gen.writeArrayFieldStart("jobs");
 					for (JobDetails detail : includeRunningJobs ? result.getRunningJobs() : result.getFinishedJobs()) {
-						generateSingleJobDetails(detail, gen, now);
+						writeJobDetailOverviewAsJson(detail, gen, now);
 					}
 					gen.writeEndArray();
 				}
@@ -104,7 +105,7 @@ public class CurrentJobsOverviewHandler extends AbstractJsonRequestHandler {
 		}
 	}
 
-	private static void generateSingleJobDetails(JobDetails details, JsonGenerator gen, long now) throws Exception {
+	public static void writeJobDetailOverviewAsJson(JobDetails details, JsonGenerator gen, long now) throws IOException {
 		gen.writeStartObject();
 
 		gen.writeStringField("jid", details.getJobId().toString());

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/DashboardConfigHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/DashboardConfigHandler.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 import java.util.TimeZone;
@@ -36,29 +37,8 @@ public class DashboardConfigHandler extends AbstractJsonRequestHandler {
 	private final String configString;
 	
 	public DashboardConfigHandler(long refreshInterval) {
-		TimeZone timeZome = TimeZone.getDefault();
-		String timeZoneName = timeZome.getDisplayName();
-		long timeZoneOffset= timeZome.getRawOffset();
-
 		try {
-			StringWriter writer = new StringWriter();
-			JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
-	
-			gen.writeStartObject();
-			gen.writeNumberField("refresh-interval", refreshInterval);
-			gen.writeNumberField("timezone-offset", timeZoneOffset);
-			gen.writeStringField("timezone-name", timeZoneName);
-			gen.writeStringField("flink-version", EnvironmentInformation.getVersion());
-
-			EnvironmentInformation.RevisionInformation revision = EnvironmentInformation.getRevisionInformation();
-			if (revision != null) {
-				gen.writeStringField("flink-revision", revision.commitId + " @ " + revision.commitDate);
-			}
-
-			gen.writeEndObject();
-	
-			gen.close();
-			this.configString = writer.toString();
+			this.configString = createConfigJson(refreshInterval);
 		}
 		catch (Exception e) {
 			// should never happen
@@ -69,5 +49,31 @@ public class DashboardConfigHandler extends AbstractJsonRequestHandler {
 	@Override
 	public String handleJsonRequest(Map<String, String> pathParams, Map<String, String> queryParams, ActorGateway jobManager) throws Exception {
 		return this.configString;
+	}
+
+	public static String createConfigJson(long refreshInterval) throws IOException {
+		StringWriter writer = new StringWriter();
+		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
+	
+		TimeZone timeZone = TimeZone.getDefault();
+		String timeZoneName = timeZone.getDisplayName();
+		long timeZoneOffset = timeZone.getRawOffset();
+
+		gen.writeStartObject();
+		gen.writeNumberField("refresh-interval", refreshInterval);
+		gen.writeNumberField("timezone-offset", timeZoneOffset);
+		gen.writeStringField("timezone-name", timeZoneName);
+		gen.writeStringField("flink-version", EnvironmentInformation.getVersion());
+
+		EnvironmentInformation.RevisionInformation revision = EnvironmentInformation.getRevisionInformation();
+		if (revision != null) {
+			gen.writeStringField("flink-revision", revision.commitId + " @ " + revision.commitDate);
+		}
+
+		gen.writeEndObject();
+
+		gen.close();
+
+		return writer.toString();
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandler.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 
@@ -37,10 +38,14 @@ public class JobAccumulatorsHandler extends AbstractExecutionGraphRequestHandler
 
 	@Override
 	public String handleRequest(AccessExecutionGraph graph, Map<String, String> params) throws Exception {
-		StringifiedAccumulatorResult[] allAccumulators = graph.getAccumulatorResultsStringified();
-		
+		return createJobAccumulatorsJson(graph);
+	}
+
+	public static String createJobAccumulatorsJson(AccessExecutionGraph graph) throws IOException {
 		StringWriter writer = new StringWriter();
 		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
+
+		StringifiedAccumulatorResult[] allAccumulators = graph.getAccumulatorResultsStringified();
 
 		gen.writeStartObject();
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandler.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.webmonitor.handlers;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 
@@ -37,7 +38,10 @@ public class JobConfigHandler extends AbstractExecutionGraphRequestHandler {
 
 	@Override
 	public String handleRequest(AccessExecutionGraph graph, Map<String, String> params) throws Exception {
+		return createJobConfigJson(graph);
+	}
 
+	public static String createJobConfigJson(AccessExecutionGraph graph) throws IOException {
 		StringWriter writer = new StringWriter();
 		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandler.java
@@ -25,13 +25,13 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
-import org.apache.flink.runtime.executiongraph.IOMetrics;
 import org.apache.flink.runtime.jobgraph.JobStatus;
-import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
-import org.apache.flink.runtime.webmonitor.metrics.MetricStore;
+import org.apache.flink.runtime.webmonitor.utils.MutableIOMetrics;
 
+import javax.annotation.Nullable;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 
@@ -56,6 +56,10 @@ public class JobDetailsHandler extends AbstractExecutionGraphRequestHandler {
 
 	@Override
 	public String handleRequest(AccessExecutionGraph graph, Map<String, String> params) throws Exception {
+		return createJobDetailsJson(graph, fetcher);
+	}
+
+	public static String createJobDetailsJson(AccessExecutionGraph graph, @Nullable MetricFetcher fetcher) throws IOException {
 		final StringWriter writer = new StringWriter();
 		final JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
 
@@ -145,37 +149,20 @@ public class JobDetailsHandler extends AbstractExecutionGraphRequestHandler {
 			}
 			gen.writeEndObject();
 			
-			long numBytesIn = 0;
-			long numBytesOut = 0;
-			long numRecordsIn = 0;
-			long numRecordsOut = 0;
+			MutableIOMetrics counts = new MutableIOMetrics();
 
 			for (AccessExecutionVertex vertex : ejv.getTaskVertices()) {
-				IOMetrics ioMetrics = vertex.getCurrentExecutionAttempt().getIOMetrics();
-
-				if (ioMetrics != null) { // execAttempt is already finished, use final metrics stored in ExecutionGraph
-					numBytesIn += ioMetrics.getNumBytesInLocal() + ioMetrics.getNumBytesInRemote();
-					numBytesOut += ioMetrics.getNumBytesOut();
-					numRecordsIn += ioMetrics.getNumRecordsIn();
-					numRecordsOut += ioMetrics.getNumRecordsOut();
-				} else { // execAttempt is still running, use MetricQueryService instead
-					fetcher.update();
-					MetricStore.SubtaskMetricStore metrics = fetcher.getMetricStore().getSubtaskMetricStore(graph.getJobID().toString(), ejv.getJobVertexId().toString(), vertex.getParallelSubtaskIndex());
-					if (metrics != null) {
-						numBytesIn += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_IN_LOCAL, "0")) + Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_IN_REMOTE, "0"));
-						numBytesOut += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_OUT, "0"));
-						numRecordsIn += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_RECORDS_IN, "0"));
-						numRecordsOut += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_RECORDS_OUT, "0"));
-					}
-				}
+				MutableIOMetrics.addIOMetrics(
+					counts,
+					vertex.getCurrentExecutionAttempt().getState(),
+					vertex.getCurrentExecutionAttempt().getIOMetrics(),
+					fetcher,
+					graph.getJobID().toString(),
+					ejv.getJobVertexId().toString(),
+					vertex.getParallelSubtaskIndex());
 			}
 
-			gen.writeObjectFieldStart("metrics");
-			gen.writeNumberField("read-bytes", numBytesIn);
-			gen.writeNumberField("write-bytes", numBytesOut);
-			gen.writeNumberField("read-records", numRecordsIn);
-			gen.writeNumberField("write-records", numRecordsOut);
-			gen.writeEndObject();
+			MutableIOMetrics.writeIOMetrics(gen, counts);
 			
 			gen.writeEndObject();
 		}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandler.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.util.ExceptionUtils;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 
@@ -33,7 +34,7 @@ import java.util.Map;
  */
 public class JobExceptionsHandler extends AbstractExecutionGraphRequestHandler {
 
-	private static final int MAX_NUMBER_EXCEPTION_TO_REPORT = 20;
+	public static final int MAX_NUMBER_EXCEPTION_TO_REPORT = 20;
 	
 	public JobExceptionsHandler(ExecutionGraphHolder executionGraphHolder) {
 		super(executionGraphHolder);
@@ -41,6 +42,10 @@ public class JobExceptionsHandler extends AbstractExecutionGraphRequestHandler {
 
 	@Override
 	public String handleRequest(AccessExecutionGraph graph, Map<String, String> params) throws Exception {
+		return createJobExceptionsJson(graph);
+	}
+
+	public static String createJobExceptionsJson(AccessExecutionGraph graph) throws IOException {
 		StringWriter writer = new StringWriter();
 		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
 
@@ -48,7 +53,7 @@ public class JobExceptionsHandler extends AbstractExecutionGraphRequestHandler {
 		
 		// most important is the root failure cause
 		String rootException = graph.getFailureCauseAsString();
-		if (rootException != null) {
+		if (rootException != null && !rootException.equals(ExceptionUtils.STRINGIFIED_NULL_EXCEPTION)) {
 			gen.writeStringField("root-exception", rootException);
 		}
 
@@ -60,7 +65,7 @@ public class JobExceptionsHandler extends AbstractExecutionGraphRequestHandler {
 		
 		for (AccessExecutionVertex task : graph.getAllExecutionVertices()) {
 			String t = task.getFailureCauseAsString();
-			if (!t.equals(ExceptionUtils.STRINGIFIED_NULL_EXCEPTION)) {
+			if (t != null && !t.equals(ExceptionUtils.STRINGIFIED_NULL_EXCEPTION)) {
 				if (numExceptionsSoFar >= MAX_NUMBER_EXCEPTION_TO_REPORT) {
 					truncated = true;
 					break;

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandler.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 
@@ -36,10 +37,14 @@ public class JobVertexAccumulatorsHandler extends AbstractJobVertexRequestHandle
 
 	@Override
 	public String handleRequest(AccessExecutionJobVertex jobVertex, Map<String, String> params) throws Exception {
-		StringifiedAccumulatorResult[] accs = jobVertex.getAggregatedUserAccumulatorsStringified();
-		
+		return createVertexAccumulatorsJson(jobVertex);
+	}
+
+	public static String createVertexAccumulatorsJson(AccessExecutionJobVertex jobVertex) throws IOException {
 		StringWriter writer = new StringWriter();
 		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
+
+		StringifiedAccumulatorResult[] accs = jobVertex.getAggregatedUserAccumulatorsStringified();
 
 		gen.writeStartObject();
 		gen.writeStringField("id", jobVertex.getJobVertexId().toString());

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandler.java
@@ -23,13 +23,13 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
-import org.apache.flink.runtime.executiongraph.IOMetrics;
-import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
-import org.apache.flink.runtime.webmonitor.metrics.MetricStore;
+import org.apache.flink.runtime.webmonitor.utils.MutableIOMetrics;
 
+import javax.annotation.Nullable;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 
@@ -48,6 +48,13 @@ public class JobVertexDetailsHandler extends AbstractJobVertexRequestHandler {
 
 	@Override
 	public String handleRequest(AccessExecutionJobVertex jobVertex, Map<String, String> params) throws Exception {
+		return createVertexDetailsJson(jobVertex, params.get("jobid"), fetcher);
+	}
+
+	public static String createVertexDetailsJson(
+			AccessExecutionJobVertex jobVertex,
+			String jobID,
+			@Nullable MetricFetcher fetcher) throws IOException {
 		final long now = System.currentTimeMillis();
 		
 		StringWriter writer = new StringWriter();
@@ -84,35 +91,19 @@ public class JobVertexDetailsHandler extends AbstractJobVertexRequestHandler {
 			gen.writeNumberField("end-time", endTime);
 			gen.writeNumberField("duration", duration);
 
-			IOMetrics ioMetrics = vertex.getCurrentExecutionAttempt().getIOMetrics();
+			MutableIOMetrics counts = new MutableIOMetrics();
 
-			long numBytesIn = 0;
-			long numBytesOut = 0;
-			long numRecordsIn = 0;
-			long numRecordsOut = 0;
+			MutableIOMetrics.addIOMetrics(
+				counts,
+				status,
+				vertex.getCurrentExecutionAttempt().getIOMetrics(),
+				fetcher,
+				jobID,
+				jobVertex.getJobVertexId().toString(),
+				vertex.getParallelSubtaskIndex()
+			);
 
-			if (ioMetrics != null) { // execAttempt is already finished, use final metrics stored in ExecutionGraph
-				numBytesIn = ioMetrics.getNumBytesInLocal() + ioMetrics.getNumBytesInRemote();
-				numBytesOut = ioMetrics.getNumBytesOut();
-				numRecordsIn = ioMetrics.getNumRecordsIn();
-				numRecordsOut = ioMetrics.getNumRecordsOut();
-			} else { // execAttempt is still running, use MetricQueryService instead
-				fetcher.update();
-				MetricStore.SubtaskMetricStore metrics = fetcher.getMetricStore().getSubtaskMetricStore(params.get("jobid"), jobVertex.getJobVertexId().toString(), vertex.getParallelSubtaskIndex());
-				if (metrics != null) {
-					numBytesIn += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_IN_LOCAL, "0")) + Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_IN_REMOTE, "0"));
-					numBytesOut += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_OUT, "0"));
-					numRecordsIn += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_RECORDS_IN, "0"));
-					numRecordsOut += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_RECORDS_OUT, "0"));
-				}
-			}
-
-			gen.writeObjectFieldStart("metrics");
-			gen.writeNumberField("read-bytes", numBytesIn);
-			gen.writeNumberField("write-bytes", numBytesOut);
-			gen.writeNumberField("read-records", numRecordsIn);
-			gen.writeNumberField("write-records", numRecordsOut);
-			gen.writeEndObject();
+			MutableIOMetrics.writeIOMetrics(gen, counts);
 			
 			gen.writeEndObject();
 			

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexTaskManagersHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexTaskManagersHandler.java
@@ -23,19 +23,18 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
-import org.apache.flink.runtime.executiongraph.IOMetrics;
-import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
-import org.apache.flink.runtime.webmonitor.metrics.MetricStore;
+import org.apache.flink.runtime.webmonitor.utils.MutableIOMetrics;
 
+import javax.annotation.Nullable;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 /**
  * A request handler that provides the details of a job vertex, including id, name, and the
@@ -52,6 +51,16 @@ public class JobVertexTaskManagersHandler extends AbstractJobVertexRequestHandle
 
 	@Override
 	public String handleRequest(AccessExecutionJobVertex jobVertex, Map<String, String> params) throws Exception {
+		return createVertexDetailsByTaskManagerJson(jobVertex, params.get("jobid"), fetcher);
+	}
+
+	public static String createVertexDetailsByTaskManagerJson(
+			AccessExecutionJobVertex jobVertex,
+			String jobID,
+			@Nullable MetricFetcher fetcher) throws IOException {
+		StringWriter writer = new StringWriter();
+		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
+
 		// Build a map that groups tasks by TaskManager
 		Map<String, List<AccessExecutionVertex>> taskManagerVertices = new HashMap<>();
 
@@ -72,8 +81,6 @@ public class JobVertexTaskManagersHandler extends AbstractJobVertexRequestHandle
 		// Build JSON response
 		final long now = System.currentTimeMillis();
 
-		StringWriter writer = new StringWriter();
-		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
 
 		gen.writeStartObject();
 
@@ -82,7 +89,7 @@ public class JobVertexTaskManagersHandler extends AbstractJobVertexRequestHandle
 		gen.writeNumberField("now", now);
 
 		gen.writeArrayFieldStart("taskmanagers");
-		for (Entry<String, List<AccessExecutionVertex>> entry : taskManagerVertices.entrySet()) {
+		for (Map.Entry<String, List<AccessExecutionVertex>> entry : taskManagerVertices.entrySet()) {
 			String host = entry.getKey();
 			List<AccessExecutionVertex> taskVertices = entry.getValue();
 
@@ -92,10 +99,7 @@ public class JobVertexTaskManagersHandler extends AbstractJobVertexRequestHandle
 			long endTime = 0;
 			boolean allFinished = true;
 
-			long numBytesIn = 0;
-			long numBytesOut = 0;
-			long numRecordsIn = 0;
-			long numRecordsOut = 0;
+			MutableIOMetrics counts = new MutableIOMetrics();
 
 			for (AccessExecutionVertex vertex : taskVertices) {
 				final ExecutionState state = vertex.getExecutionState();
@@ -110,23 +114,14 @@ public class JobVertexTaskManagersHandler extends AbstractJobVertexRequestHandle
 				allFinished &= state.isTerminal();
 				endTime = Math.max(endTime, vertex.getStateTimestamp(state));
 
-				IOMetrics ioMetrics = vertex.getCurrentExecutionAttempt().getIOMetrics();
-
-				if (ioMetrics != null) { // execAttempt is already finished, use final metrics stored in ExecutionGraph
-					numBytesIn += ioMetrics.getNumBytesInLocal() + ioMetrics.getNumBytesInRemote();
-					numBytesOut += ioMetrics.getNumBytesOut();
-					numRecordsIn += ioMetrics.getNumRecordsIn();
-					numRecordsOut += ioMetrics.getNumRecordsOut();
-				} else { // execAttempt is still running, use MetricQueryService instead
-					fetcher.update();
-					MetricStore.SubtaskMetricStore metrics = fetcher.getMetricStore().getSubtaskMetricStore(params.get("jobid"), params.get("vertexid"), vertex.getParallelSubtaskIndex());
-					if (metrics != null) {
-						numBytesIn += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_IN_LOCAL, "0")) + Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_IN_REMOTE, "0"));
-						numBytesOut += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_OUT, "0"));
-						numRecordsIn += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_RECORDS_IN, "0"));
-						numRecordsOut += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_RECORDS_OUT, "0"));
-					}
-				}
+				MutableIOMetrics.addIOMetrics(
+					counts,
+					vertex.getExecutionState(),
+					vertex.getCurrentExecutionAttempt().getIOMetrics(),
+					fetcher,
+					jobID,
+					jobVertex.getJobVertexId().toString(),
+					vertex.getParallelSubtaskIndex());
 			}
 
 			long duration;
@@ -157,12 +152,7 @@ public class JobVertexTaskManagersHandler extends AbstractJobVertexRequestHandle
 			gen.writeNumberField("end-time", endTime);
 			gen.writeNumberField("duration", duration);
 
-			gen.writeObjectFieldStart("metrics");
-			gen.writeNumberField("read-bytes", numBytesIn);
-			gen.writeNumberField("write-bytes", numBytesOut);
-			gen.writeNumberField("read-records", numRecordsIn);
-			gen.writeNumberField("write-records", numRecordsOut);
-			gen.writeEndObject();
+			MutableIOMetrics.writeIOMetrics(gen, counts);
 
 			gen.writeObjectFieldStart("status-counts");
 			for (ExecutionState state : ExecutionState.values()) {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandler.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.executiongraph.AccessExecution;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 
@@ -38,10 +39,14 @@ public class SubtaskExecutionAttemptAccumulatorsHandler extends AbstractSubtaskA
 
 	@Override
 	public String handleRequest(AccessExecution execAttempt, Map<String, String> params) throws Exception {
-		final StringifiedAccumulatorResult[] accs = execAttempt.getUserAccumulatorsStringified();
+		return createAttemptAccumulatorsJson(execAttempt);
+	}
 		
+	public static String createAttemptAccumulatorsJson(AccessExecution execAttempt) throws IOException {
 		StringWriter writer = new StringWriter();
 		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
+		
+		final StringifiedAccumulatorResult[] accs = execAttempt.getUserAccumulatorsStringified();
 
 		gen.writeStartObject();
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandler.java
@@ -22,13 +22,13 @@ import com.fasterxml.jackson.core.JsonGenerator;
 
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecution;
-import org.apache.flink.runtime.executiongraph.IOMetrics;
-import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
-import org.apache.flink.runtime.webmonitor.metrics.MetricStore;
+import org.apache.flink.runtime.webmonitor.utils.MutableIOMetrics;
 
+import javax.annotation.Nullable;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 
@@ -46,6 +46,17 @@ public class SubtaskExecutionAttemptDetailsHandler extends AbstractSubtaskAttemp
 
 	@Override
 	public String handleRequest(AccessExecution execAttempt, Map<String, String> params) throws Exception {
+		return createAttemptDetailsJson(execAttempt, params.get("jobid"), params.get("vertexid"), fetcher);
+	}
+
+	public static String createAttemptDetailsJson(
+			AccessExecution execAttempt,
+			String jobID,
+			String vertexID,
+			@Nullable MetricFetcher fetcher) throws IOException {
+		StringWriter writer = new StringWriter();
+		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
+
 		final ExecutionState status = execAttempt.getState();
 		final long now = System.currentTimeMillis();
 
@@ -59,9 +70,6 @@ public class SubtaskExecutionAttemptDetailsHandler extends AbstractSubtaskAttemp
 		long endTime = status.isTerminal() ? execAttempt.getStateTimestamp(status) : -1;
 		long duration = startTime > 0 ? ((endTime > 0 ? endTime : now) - startTime) : -1;
 
-		StringWriter writer = new StringWriter();
-		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
-
 		gen.writeStartObject();
 		gen.writeNumberField("subtask", execAttempt.getParallelSubtaskIndex());
 		gen.writeStringField("status", status.name());
@@ -71,35 +79,19 @@ public class SubtaskExecutionAttemptDetailsHandler extends AbstractSubtaskAttemp
 		gen.writeNumberField("end-time", endTime);
 		gen.writeNumberField("duration", duration);
 
-		IOMetrics ioMetrics = execAttempt.getIOMetrics();
+		MutableIOMetrics counts = new MutableIOMetrics();
 
-		long numBytesIn = 0;
-		long numBytesOut = 0;
-		long numRecordsIn = 0;
-		long numRecordsOut = 0;
+		MutableIOMetrics.addIOMetrics(
+			counts,
+			execAttempt.getState(),
+			execAttempt.getIOMetrics(),
+			fetcher,
+			jobID,
+			vertexID,
+			execAttempt.getParallelSubtaskIndex()
+		);
 		
-		if (ioMetrics != null) { // execAttempt is already finished, use final metrics stored in ExecutionGraph
-			numBytesIn = ioMetrics.getNumBytesInLocal() + ioMetrics.getNumBytesInRemote();
-			numBytesOut = ioMetrics.getNumBytesOut();
-			numRecordsIn = ioMetrics.getNumRecordsIn();
-			numRecordsOut = ioMetrics.getNumRecordsOut();
-		} else { // execAttempt is still running, use MetricQueryService instead
-			fetcher.update();
-			MetricStore.SubtaskMetricStore metrics = fetcher.getMetricStore().getSubtaskMetricStore(params.get("jobid"), params.get("vertexid"), execAttempt.getParallelSubtaskIndex());
-			if (metrics != null) {
-				numBytesIn = Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_IN_LOCAL, "0")) + Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_IN_REMOTE, "0"));
-				numBytesOut = Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_OUT, "0"));
-				numRecordsIn = Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_RECORDS_IN, "0"));
-				numRecordsOut = Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_RECORDS_OUT, "0"));
-			}
-		}
-		
-		gen.writeObjectFieldStart("metrics");
-		gen.writeNumberField("read-bytes", numBytesIn);
-		gen.writeNumberField("write-bytes", numBytesOut);
-		gen.writeNumberField("read-records", numRecordsIn);
-		gen.writeNumberField("write-records", numRecordsOut);
-		gen.writeEndObject();
+		MutableIOMetrics.writeIOMetrics(gen, counts);
 
 		gen.writeEndObject();
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandler.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 
@@ -40,6 +41,10 @@ public class SubtasksAllAccumulatorsHandler extends AbstractJobVertexRequestHand
 
 	@Override
 	public String handleRequest(AccessExecutionJobVertex jobVertex, Map<String, String> params) throws Exception {
+		return createSubtasksAccumulatorsJson(jobVertex);
+	}
+
+	public static String createSubtasksAccumulatorsJson(AccessExecutionJobVertex jobVertex) throws IOException {
 		StringWriter writer = new StringWriter();
 		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandler.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 
@@ -42,6 +43,10 @@ public class SubtasksTimesHandler extends AbstractJobVertexRequestHandler {
 
 	@Override
 	public String handleRequest(AccessExecutionJobVertex jobVertex, Map<String, String> params) throws Exception {
+		return createSubtaskTimesJson(jobVertex);
+	}
+
+	public static String createSubtaskTimesJson(AccessExecutionJobVertex jobVertex) throws IOException {
 		final long now = System.currentTimeMillis();
 
 		StringWriter writer = new StringWriter();

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandler.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.handlers.AbstractExecutionGraphRequestHandler;
 import org.apache.flink.runtime.webmonitor.handlers.JsonFactory;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 
@@ -40,8 +41,11 @@ public class CheckpointConfigHandler extends AbstractExecutionGraphRequestHandle
 
 	@Override
 	public String handleRequest(AccessExecutionGraph graph, Map<String, String> params) throws Exception {
-		StringWriter writer = new StringWriter();
+		return createCheckpointConfigJson(graph);
+	}
 
+	private static String createCheckpointConfigJson(AccessExecutionGraph graph) throws IOException {
+		StringWriter writer = new StringWriter();
 		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
 		JobSnapshottingSettings settings = graph.getJobSnapshottingSettings();
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsHandler.java
@@ -70,10 +70,10 @@ public class CheckpointStatsDetailsHandler extends AbstractExecutionGraphRequest
 			}
 		}
 
-		return writeResponse(checkpoint);
+		return createCheckpointDetailsJson(checkpoint);
 	}
 
-	private String writeResponse(AbstractCheckpointStats checkpoint) throws IOException {
+	public static String createCheckpointDetailsJson(AbstractCheckpointStats checkpoint) throws IOException {
 		StringWriter writer = new StringWriter();
 		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
 		gen.writeStartObject();

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsSubtasksHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsSubtasksHandler.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 
+import static org.apache.flink.runtime.webmonitor.handlers.checkpoints.CheckpointStatsHandler.writeMinMaxAvg;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -88,19 +89,19 @@ public class CheckpointStatsDetailsSubtasksHandler extends AbstractExecutionGrap
 			}
 		}
 
-		return writeResponse(checkpoint, vertexId);
-	}
-
-	private String writeResponse(AbstractCheckpointStats checkpoint, JobVertexID vertexId) throws IOException {
-		StringWriter writer = new StringWriter();
-		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
-		gen.writeStartObject();
-
 		TaskStateStats taskStats = checkpoint.getTaskStateStats(vertexId);
 		if (taskStats == null) {
 			return "{}";
 		}
+		
+		return createSubtaskCheckpointDetailsJson(checkpoint, taskStats);
+	}
 
+	private static String createSubtaskCheckpointDetailsJson(AbstractCheckpointStats checkpoint, TaskStateStats taskStats) throws IOException {
+		StringWriter writer = new StringWriter();
+		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
+
+		gen.writeStartObject();
 		// Overview
 		gen.writeNumberField("id", checkpoint.getCheckpointId());
 		gen.writeStringField("status", checkpoint.getStatus().toString());
@@ -179,12 +180,6 @@ public class CheckpointStatsDetailsSubtasksHandler extends AbstractExecutionGrap
 		gen.close();
 
 		return writer.toString();
-	}
-
-	private void writeMinMaxAvg(JsonGenerator gen, MinMaxAvgStats minMaxAvg) throws IOException {
-		gen.writeNumberField("min", minMaxAvg.getMinimum());
-		gen.writeNumberField("max", minMaxAvg.getMaximum());
-		gen.writeNumberField("avg", minMaxAvg.getAverage());
 	}
 
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandler.java
@@ -50,6 +50,10 @@ public class CheckpointStatsHandler extends AbstractExecutionGraphRequestHandler
 
 	@Override
 	public String handleRequest(AccessExecutionGraph graph, Map<String, String> params) throws Exception {
+		return createCheckpointStatsJson(graph);
+	}
+
+	private static String createCheckpointStatsJson(AccessExecutionGraph graph) throws IOException {
 		StringWriter writer = new StringWriter();
 		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);
 
@@ -85,7 +89,7 @@ public class CheckpointStatsHandler extends AbstractExecutionGraphRequestHandler
 		return writer.toString();
 	}
 
-	private void writeCounts(JsonGenerator gen, CheckpointStatsCounts counts) throws IOException {
+	private static void writeCounts(JsonGenerator gen, CheckpointStatsCounts counts) throws IOException {
 		gen.writeObjectFieldStart("counts");
 		gen.writeNumberField("restored", counts.getNumberOfRestoredCheckpoints());
 		gen.writeNumberField("total", counts.getTotalNumberOfCheckpoints());
@@ -95,7 +99,7 @@ public class CheckpointStatsHandler extends AbstractExecutionGraphRequestHandler
 		gen.writeEndObject();
 	}
 
-	private void writeSummary(
+	private static void writeSummary(
 		JsonGenerator gen,
 		CompletedCheckpointStatsSummary summary) throws IOException {
 		gen.writeObjectFieldStart("summary");
@@ -113,13 +117,13 @@ public class CheckpointStatsHandler extends AbstractExecutionGraphRequestHandler
 		gen.writeEndObject();
 	}
 
-	private void writeMinMaxAvg(JsonGenerator gen, MinMaxAvgStats minMaxAvg) throws IOException {
+	static void writeMinMaxAvg(JsonGenerator gen, MinMaxAvgStats minMaxAvg) throws IOException {
 		gen.writeNumberField("min", minMaxAvg.getMinimum());
 		gen.writeNumberField("max", minMaxAvg.getMaximum());
 		gen.writeNumberField("avg", minMaxAvg.getAverage());
 	}
 
-	private void writeLatestCheckpoints(
+	private static void writeLatestCheckpoints(
 		JsonGenerator gen,
 		@Nullable CompletedCheckpointStats completed,
 		@Nullable CompletedCheckpointStats savepoint,
@@ -181,7 +185,7 @@ public class CheckpointStatsHandler extends AbstractExecutionGraphRequestHandler
 		gen.writeEndObject();
 	}
 
-	private void writeCheckpoint(JsonGenerator gen, AbstractCheckpointStats checkpoint) throws IOException {
+	private static void writeCheckpoint(JsonGenerator gen, AbstractCheckpointStats checkpoint) throws IOException {
 		gen.writeNumberField("id", checkpoint.getCheckpointId());
 		gen.writeNumberField("trigger_timestamp", checkpoint.getTriggerTimestamp());
 		gen.writeNumberField("latest_ack_timestamp", checkpoint.getLatestAckTimestamp());
@@ -191,7 +195,7 @@ public class CheckpointStatsHandler extends AbstractExecutionGraphRequestHandler
 
 	}
 
-	private void writeHistory(JsonGenerator gen, CheckpointStatsHistory history) throws IOException {
+	private static void writeHistory(JsonGenerator gen, CheckpointStatsHistory history) throws IOException {
 		gen.writeArrayFieldStart("history");
 		for (AbstractCheckpointStats checkpoint : history.getCheckpoints()) {
 			gen.writeStartObject();

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/MutableIOMetrics.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/MutableIOMetrics.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.utils;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
+import org.apache.flink.runtime.webmonitor.metrics.MetricStore;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+public class MutableIOMetrics extends IOMetrics {
+
+	private static final long serialVersionUID = -5460777634971381737L;
+
+	public MutableIOMetrics() {
+		super(0, 0, 0, 0, 0, 0.0D, 0.0D, 0.0D, 0.0D, 0.0D);
+	}
+
+	public void addNumBytesInLocal(long toAdd) {
+		this.numBytesInLocal += toAdd;
+	}
+
+	public void addNumBytesInRemote(long toAdd) {
+		this.numBytesInRemote += toAdd;
+	}
+
+	public void addNumBytesOut(long toAdd) {
+		this.numBytesOut += toAdd;
+	}
+
+	public void addNumRecordsIn(long toAdd) {
+		this.numRecordsIn += toAdd;
+	}
+
+	public void addNumRecordsOut(long toAdd) {
+		this.numRecordsOut += toAdd;
+	}
+
+	public static void addIOMetrics(MutableIOMetrics summedMetrics, ExecutionState state, @Nullable IOMetrics ioMetrics, @Nullable MetricFetcher fetcher, String jobID, String taskID, int subtaskIndex) {
+		if (state.isTerminal()) {
+			if (ioMetrics != null) { // execAttempt is already finished, use final metrics stored in ExecutionGraph
+				summedMetrics.addNumBytesInLocal(ioMetrics.getNumBytesInLocal());
+				summedMetrics.addNumBytesInRemote(ioMetrics.getNumBytesInRemote());
+				summedMetrics.addNumBytesOut(ioMetrics.getNumBytesOut());
+				summedMetrics.addNumRecordsIn(ioMetrics.getNumRecordsIn());
+				summedMetrics.addNumRecordsOut(ioMetrics.getNumRecordsOut());
+			}
+		} else { // execAttempt is still running, use MetricQueryService instead
+			if (fetcher != null) {
+				fetcher.update();
+				MetricStore.SubtaskMetricStore metrics = fetcher.getMetricStore().getSubtaskMetricStore(jobID, taskID, subtaskIndex);
+				if (metrics != null) {
+					summedMetrics.addNumBytesInLocal(Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_IN_LOCAL, "0")));
+					summedMetrics.addNumBytesInRemote(Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_IN_REMOTE, "0")));
+					summedMetrics.addNumBytesOut(Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_OUT, "0")));
+					summedMetrics.addNumRecordsIn(Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_RECORDS_IN, "0")));
+					summedMetrics.addNumRecordsOut(Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_RECORDS_OUT, "0")));
+				}
+			}
+		}
+	}
+
+	public static void writeIOMetrics(JsonGenerator gen, IOMetrics metrics) throws IOException {
+		gen.writeObjectFieldStart("metrics");
+		gen.writeNumberField("read-bytes", metrics.getNumBytesInLocal() + metrics.getNumBytesInRemote());
+		gen.writeNumberField("write-bytes", metrics.getNumBytesOut());
+		gen.writeNumberField("read-records", metrics.getNumRecordsIn());
+		gen.writeNumberField("write-records", metrics.getNumRecordsOut());
+		gen.writeEndObject();
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandlerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
+import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.StringWriter;
+
+public class CurrentJobsOverviewHandlerTest {
+	@Test
+	public void testJsonGeneration() throws Exception {
+		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
+		JobDetails expectedDetails = WebMonitorUtils.createDetailsForJob(originalJob);
+		StringWriter writer = new StringWriter();
+		try (JsonGenerator gen = ArchivedJobGenerationUtils.jacksonFactory.createGenerator(writer)) {
+			CurrentJobsOverviewHandler.writeJobDetailOverviewAsJson(expectedDetails, gen, 0);
+		}
+		String answer = writer.toString();
+
+		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(answer);
+
+		Assert.assertEquals(expectedDetails.getJobId().toString(), result.get("jid").asText());
+		Assert.assertEquals(expectedDetails.getJobName(), result.get("name").asText());
+		Assert.assertEquals(expectedDetails.getStatus().name(), result.get("state").asText());
+
+		Assert.assertEquals(expectedDetails.getStartTime(), result.get("start-time").asLong());
+		Assert.assertEquals(expectedDetails.getEndTime(), result.get("end-time").asLong());
+		Assert.assertEquals(expectedDetails.getEndTime() - expectedDetails.getStartTime(), result.get("duration").asLong());
+		Assert.assertEquals(expectedDetails.getLastUpdateTime(), result.get("last-modification").asLong());
+
+		JsonNode tasks = result.get("tasks");
+		Assert.assertEquals(expectedDetails.getNumTasks(), tasks.get("total").asInt());
+		int[] tasksPerState = expectedDetails.getNumVerticesPerExecutionState();
+		Assert.assertEquals(
+			tasksPerState[ExecutionState.CREATED.ordinal()] + tasksPerState[ExecutionState.SCHEDULED.ordinal()] + tasksPerState[ExecutionState.DEPLOYING.ordinal()],
+			tasks.get("pending").asInt());
+		Assert.assertEquals(tasksPerState[ExecutionState.RUNNING.ordinal()], tasks.get("running").asInt());
+		Assert.assertEquals(tasksPerState[ExecutionState.FINISHED.ordinal()], tasks.get("finished").asInt());
+		Assert.assertEquals(tasksPerState[ExecutionState.CANCELING.ordinal()], tasks.get("canceling").asInt());
+		Assert.assertEquals(tasksPerState[ExecutionState.CANCELED.ordinal()], tasks.get("canceled").asInt());
+		Assert.assertEquals(tasksPerState[ExecutionState.FAILED.ordinal()], tasks.get("failed").asInt());
+
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/DashboardConfigHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/DashboardConfigHandlerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.runtime.util.EnvironmentInformation;
+import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
+import org.junit.Test;
+
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+public class DashboardConfigHandlerTest {
+	@Test
+	public void testJsonGeneration() throws Exception {
+		long refreshInterval = 12345;
+		TimeZone timeZone = TimeZone.getDefault();
+		EnvironmentInformation.RevisionInformation revision = EnvironmentInformation.getRevisionInformation();
+
+		String json = DashboardConfigHandler.createConfigJson(refreshInterval);
+
+		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
+
+		assertEquals(refreshInterval, result.get("refresh-interval").asLong());
+		assertEquals(timeZone.getDisplayName(), result.get("timezone-name").asText());
+		assertEquals(timeZone.getRawOffset(), result.get("timezone-offset").asLong());
+		assertEquals(EnvironmentInformation.getVersion(), result.get("flink-version").asText());
+		assertEquals(revision.commitId + " @ " + revision.commitDate, result.get("flink-revision").asText());
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandlerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JobAccumulatorsHandlerTest {
+	@Test
+	public void testJsonGeneration() throws Exception {
+		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
+		String json = JobAccumulatorsHandler.createJobAccumulatorsJson(originalJob);
+
+		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
+
+		ArrayNode accs = (ArrayNode) result.get("job-accumulators");
+		assertEquals(0, accs.size());
+
+		assertTrue(originalJob.getAccumulatorResultsStringified().length > 0);
+		ArchivedJobGenerationUtils.compareStringifiedAccumulators(
+			originalJob.getAccumulatorResultsStringified(),
+			(ArrayNode) result.get("user-task-accumulators"));
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandlerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.api.common.ArchivedExecutionConfig;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JobConfigHandlerTest {
+	@Test
+	public void testJsonGeneration() throws Exception {
+		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
+		String answer = JobConfigHandler.createJobConfigJson(originalJob);
+
+		JsonNode job = ArchivedJobGenerationUtils.mapper.readTree(answer);
+		
+		Assert.assertEquals(originalJob.getJobID().toString(), job.get("jid").asText());
+		Assert.assertEquals(originalJob.getJobName(), job.get("name").asText());
+		
+		ArchivedExecutionConfig originalConfig = originalJob.getArchivedExecutionConfig();
+		JsonNode config = job.get("execution-config");
+		
+		Assert.assertEquals(originalConfig.getExecutionMode(), config.get("execution-mode").asText());
+		Assert.assertEquals(originalConfig.getRestartStrategyDescription(), config.get("restart-strategy").asText());
+		Assert.assertEquals(originalConfig.getParallelism(), config.get("job-parallelism").asInt());
+		Assert.assertEquals(originalConfig.getObjectReuseEnabled(), config.get("object-reuse-mode").asBoolean());
+		
+		Map<String, String> originalUserConfig = originalConfig.getGlobalJobParameters();
+		JsonNode userConfig = config.get("user-config");
+		
+		for (Map.Entry<String, String> originalEntry : originalUserConfig.entrySet()) {
+			Assert.assertEquals(originalEntry.getValue(), userConfig.get(originalEntry.getKey()).asText());
+		}
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandlerTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class JobDetailsHandlerTest {
+	@Test
+	public void testJsonGeneration() throws Exception {
+		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
+		String json = JobDetailsHandler.createJobDetailsJson(originalJob, null);
+
+		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
+
+		assertEquals(originalJob.getJobID().toString(), result.get("jid").asText());
+		assertEquals(originalJob.getJobName(), result.get("name").asText());
+		assertEquals(originalJob.isStoppable(), result.get("isStoppable").asBoolean());
+		assertEquals(originalJob.getState().name(), result.get("state").asText());
+
+		assertEquals(originalJob.getStatusTimestamp(JobStatus.CREATED), result.get("start-time").asLong());
+		assertEquals(originalJob.getStatusTimestamp(originalJob.getState()), result.get("end-time").asLong());
+		assertEquals(
+			originalJob.getStatusTimestamp(originalJob.getState()) - originalJob.getStatusTimestamp(JobStatus.CREATED),
+			result.get("duration").asLong()
+		);
+
+		JsonNode timestamps = result.get("timestamps");
+		for (JobStatus status : JobStatus.values()) {
+			assertEquals(originalJob.getStatusTimestamp(status), timestamps.get(status.name()).asLong());
+		}
+
+		ArrayNode tasks = (ArrayNode) result.get("vertices");
+		int x = 0;
+		for (AccessExecutionJobVertex expectedTask : originalJob.getVerticesTopologically()) {
+			JsonNode task = tasks.get(x);
+
+			assertEquals(expectedTask.getJobVertexId().toString(), task.get("id").asText());
+			assertEquals(expectedTask.getName(), task.get("name").asText());
+			assertEquals(expectedTask.getParallelism(), task.get("parallelism").asInt());
+			assertEquals(expectedTask.getAggregateState().name(), task.get("status").asText());
+
+			assertEquals(3, task.get("start-time").asLong());
+			assertEquals(5, task.get("end-time").asLong());
+			assertEquals(2, task.get("duration").asLong());
+
+			JsonNode subtasksPerState = task.get("tasks");
+			assertEquals(0, subtasksPerState.get(ExecutionState.CREATED.name()).asInt());
+			assertEquals(0, subtasksPerState.get(ExecutionState.SCHEDULED.name()).asInt());
+			assertEquals(0, subtasksPerState.get(ExecutionState.DEPLOYING.name()).asInt());
+			assertEquals(0, subtasksPerState.get(ExecutionState.RUNNING.name()).asInt());
+			assertEquals(1, subtasksPerState.get(ExecutionState.FINISHED.name()).asInt());
+			assertEquals(0, subtasksPerState.get(ExecutionState.CANCELING.name()).asInt());
+			assertEquals(0, subtasksPerState.get(ExecutionState.CANCELED.name()).asInt());
+			assertEquals(0, subtasksPerState.get(ExecutionState.FAILED.name()).asInt());
+
+			long expectedNumBytesIn = 0;
+			long expectedNumBytesOut = 0;
+			long expectedNumRecordsIn = 0;
+			long expectedNumRecordsOut = 0;
+
+			for (AccessExecutionVertex vertex : expectedTask.getTaskVertices()) {
+				IOMetrics ioMetrics = vertex.getCurrentExecutionAttempt().getIOMetrics();
+
+				expectedNumBytesIn += ioMetrics.getNumBytesInLocal() + ioMetrics.getNumBytesInRemote();
+				expectedNumBytesOut += ioMetrics.getNumBytesOut();
+				expectedNumRecordsIn += ioMetrics.getNumRecordsIn();
+				expectedNumRecordsOut += ioMetrics.getNumRecordsOut();
+			}
+
+			JsonNode metrics = task.get("metrics");
+
+			assertEquals(expectedNumBytesIn, metrics.get("read-bytes").asLong());
+			assertEquals(expectedNumBytesOut, metrics.get("write-bytes").asLong());
+			assertEquals(expectedNumRecordsIn, metrics.get("read-records").asLong());
+			assertEquals(expectedNumRecordsOut, metrics.get("write-records").asLong());
+
+			x++;
+		}
+		assertEquals(1, tasks.size());
+
+		JsonNode statusCounts = result.get("status-counts");
+		assertEquals(0, statusCounts.get(ExecutionState.CREATED.name()).asInt());
+		assertEquals(0, statusCounts.get(ExecutionState.SCHEDULED.name()).asInt());
+		assertEquals(0, statusCounts.get(ExecutionState.DEPLOYING.name()).asInt());
+		assertEquals(1, statusCounts.get(ExecutionState.RUNNING.name()).asInt());
+		assertEquals(0, statusCounts.get(ExecutionState.FINISHED.name()).asInt());
+		assertEquals(0, statusCounts.get(ExecutionState.CANCELING.name()).asInt());
+		assertEquals(0, statusCounts.get(ExecutionState.CANCELED.name()).asInt());
+		assertEquals(0, statusCounts.get(ExecutionState.FAILED.name()).asInt());
+
+		assertEquals(ArchivedJobGenerationUtils.mapper.readTree(originalJob.getJsonPlan()), result.get("plan"));
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandlerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
+import org.apache.flink.util.ExceptionUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class JobExceptionsHandlerTest {
+	@Test
+	public void testJsonGeneration() throws Exception {
+		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
+		String json = JobExceptionsHandler.createJobExceptionsJson(originalJob);
+
+		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
+
+		assertEquals(originalJob.getFailureCauseAsString(), result.get("root-exception").asText());
+
+		ArrayNode exceptions = (ArrayNode) result.get("all-exceptions");
+
+		int x = 0;
+		for (AccessExecutionVertex expectedSubtask : originalJob.getAllExecutionVertices()) {
+			if (!expectedSubtask.getFailureCauseAsString().equals(ExceptionUtils.STRINGIFIED_NULL_EXCEPTION)) {
+				JsonNode exception = exceptions.get(x);
+
+				assertEquals(expectedSubtask.getFailureCauseAsString(), exception.get("exception").asText());
+				assertEquals(expectedSubtask.getTaskNameWithSubtaskIndex(), exception.get("task").asText());
+
+				TaskManagerLocation location = expectedSubtask.getCurrentAssignedResourceLocation();
+				String expectedLocationString = location.getFQDNHostname() + ':' + location.dataPort();
+				assertEquals(expectedLocationString, exception.get("location").asText());
+			}
+			x++;
+		}
+		assertEquals(x > JobExceptionsHandler.MAX_NUMBER_EXCEPTION_TO_REPORT, result.get("truncated").asBoolean());
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandlerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class JobVertexAccumulatorsHandlerTest {
+	@Test
+	public void testJsonGeneration() throws Exception {
+		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
+		String json = JobVertexAccumulatorsHandler.createVertexAccumulatorsJson(originalTask);
+
+		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
+
+		assertEquals(originalTask.getJobVertexId().toString(), result.get("id").asText());
+
+		ArrayNode accs = (ArrayNode) result.get("user-accumulators");
+		StringifiedAccumulatorResult[] expectedAccs = originalTask.getAggregatedUserAccumulatorsStringified();
+
+		ArchivedJobGenerationUtils.compareStringifiedAccumulators(expectedAccs, accs);
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandlerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JobVertexDetailsHandlerTest {
+	@Test
+	public void testJsonGeneration() throws Exception {
+		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
+		String json = JobVertexDetailsHandler.createVertexDetailsJson(
+			originalTask, ArchivedJobGenerationUtils.getTestJob().getJobID().toString(), null);
+
+		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
+
+		assertEquals(originalTask.getJobVertexId().toString(), result.get("id").asText());
+		assertEquals(originalTask.getName(), result.get("name").asText());
+		assertEquals(originalTask.getParallelism(), result.get("parallelism").asInt());
+		assertTrue(result.get("now").asLong() > 0);
+
+		ArrayNode subtasks = (ArrayNode) result.get("subtasks");
+
+		assertEquals(originalTask.getTaskVertices().length, subtasks.size());
+		for (int x = 0; x < originalTask.getTaskVertices().length; x++) {
+			AccessExecutionVertex expectedSubtask = originalTask.getTaskVertices()[x];
+			JsonNode subtask = subtasks.get(x);
+
+			assertEquals(x, subtask.get("subtask").asInt());
+			assertEquals(expectedSubtask.getExecutionState().name(), subtask.get("status").asText());
+			assertEquals(expectedSubtask.getCurrentExecutionAttempt().getAttemptNumber(), subtask.get("attempt").asInt());
+
+			TaskManagerLocation location = expectedSubtask.getCurrentAssignedResourceLocation();
+			String expectedLocationString = location.getHostname() + ":" + location.dataPort();
+			assertEquals(expectedLocationString, subtask.get("host").asText());
+			long start = expectedSubtask.getStateTimestamp(ExecutionState.DEPLOYING);
+			assertEquals(start, subtask.get("start-time").asLong());
+			long end = expectedSubtask.getStateTimestamp(ExecutionState.FINISHED);
+			assertEquals(end, subtask.get("end-time").asLong());
+			assertEquals(end - start, subtask.get("duration").asLong());
+
+			ArchivedJobGenerationUtils.compareIoMetrics(expectedSubtask.getCurrentExecutionAttempt().getIOMetrics(), subtask.get("metrics"));
+		}
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexTaskManagersHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexTaskManagersHandlerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JobVertexTaskManagersHandlerTest {
+	@Test
+	public void testJsonGeneration() throws Exception {
+		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
+		AccessExecutionVertex originalSubtask = ArchivedJobGenerationUtils.getTestSubtask();
+		String json = JobVertexTaskManagersHandler.createVertexDetailsByTaskManagerJson(
+			originalTask, ArchivedJobGenerationUtils.getTestJob().getJobID().toString(), null);
+
+		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
+
+		assertEquals(originalTask.getJobVertexId().toString(), result.get("id").asText());
+		assertEquals(originalTask.getName(), result.get("name").asText());
+		assertTrue(result.get("now").asLong() > 0);
+
+		ArrayNode taskmanagers = (ArrayNode) result.get("taskmanagers");
+
+		JsonNode taskManager = taskmanagers.get(0);
+
+		TaskManagerLocation location = originalSubtask.getCurrentAssignedResourceLocation();
+		String expectedLocationString = location.getHostname() + ':' + location.dataPort();
+		assertEquals(expectedLocationString, taskManager.get("host").asText());
+		assertEquals(ExecutionState.FINISHED.name(), taskManager.get("status").asText());
+
+		assertEquals(3, taskManager.get("start-time").asLong());
+		assertEquals(5, taskManager.get("end-time").asLong());
+		assertEquals(2, taskManager.get("duration").asLong());
+
+		JsonNode statusCounts = taskManager.get("status-counts");
+		assertEquals(0, statusCounts.get(ExecutionState.CREATED.name()).asInt());
+		assertEquals(0, statusCounts.get(ExecutionState.SCHEDULED.name()).asInt());
+		assertEquals(0, statusCounts.get(ExecutionState.DEPLOYING.name()).asInt());
+		assertEquals(0, statusCounts.get(ExecutionState.RUNNING.name()).asInt());
+		assertEquals(1, statusCounts.get(ExecutionState.FINISHED.name()).asInt());
+		assertEquals(0, statusCounts.get(ExecutionState.CANCELING.name()).asInt());
+		assertEquals(0, statusCounts.get(ExecutionState.CANCELED.name()).asInt());
+		assertEquals(0, statusCounts.get(ExecutionState.FAILED.name()).asInt());
+
+		long expectedNumBytesIn = 0;
+		long expectedNumBytesOut = 0;
+		long expectedNumRecordsIn = 0;
+		long expectedNumRecordsOut = 0;
+
+		for (AccessExecutionVertex vertex : originalTask.getTaskVertices()) {
+			IOMetrics ioMetrics = vertex.getCurrentExecutionAttempt().getIOMetrics();
+
+			expectedNumBytesIn += ioMetrics.getNumBytesInLocal() + ioMetrics.getNumBytesInRemote();
+			expectedNumBytesOut += ioMetrics.getNumBytesOut();
+			expectedNumRecordsIn += ioMetrics.getNumRecordsIn();
+			expectedNumRecordsOut += ioMetrics.getNumRecordsOut();
+		}
+
+		JsonNode metrics = taskManager.get("metrics");
+
+		assertEquals(expectedNumBytesIn, metrics.get("read-bytes").asLong());
+		assertEquals(expectedNumBytesOut, metrics.get("write-bytes").asLong());
+		assertEquals(expectedNumRecordsIn, metrics.get("read-records").asLong());
+		assertEquals(expectedNumRecordsOut, metrics.get("write-records").asLong());
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.flink.runtime.executiongraph.AccessExecution;
+import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SubtaskExecutionAttemptAccumulatorsHandlerTest {
+	@Test
+	public void testJsonGeneration() throws Exception {
+		AccessExecution originalAttempt = ArchivedJobGenerationUtils.getTestAttempt();
+		String json = SubtaskExecutionAttemptAccumulatorsHandler.createAttemptAccumulatorsJson(originalAttempt);
+
+		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
+
+		assertEquals(1, result.get("subtask").asInt());
+		assertEquals(3, result.get("attempt").asInt());
+		assertEquals(originalAttempt.getAttemptId().toString(), result.get("id").asText());
+
+		ArchivedJobGenerationUtils.compareStringifiedAccumulators(originalAttempt.getUserAccumulatorsStringified(), (ArrayNode) result.get("user-accumulators"));
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandlerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecution;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SubtaskExecutionAttemptDetailsHandlerTest {
+	@Test
+	public void testJsonGeneration() throws Exception {
+		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
+		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
+		AccessExecution originalAttempt = ArchivedJobGenerationUtils.getTestAttempt();
+		String json = SubtaskExecutionAttemptDetailsHandler.createAttemptDetailsJson(
+			originalAttempt, originalJob.getJobID().toString(), originalTask.getJobVertexId().toString(), null);
+
+		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
+
+		Assert.assertEquals(originalAttempt.getParallelSubtaskIndex(), result.get("subtask").asInt());
+		Assert.assertEquals(originalAttempt.getState().name(), result.get("status").asText());
+		Assert.assertEquals(originalAttempt.getAttemptNumber(), result.get("attempt").asInt());
+		Assert.assertEquals(originalAttempt.getAssignedResourceLocation().getHostname(), result.get("host").asText());
+		long start = originalAttempt.getStateTimestamp(ExecutionState.DEPLOYING);
+		Assert.assertEquals(start, result.get("start-time").asLong());
+		long end = originalAttempt.getStateTimestamp(ExecutionState.FINISHED);
+		Assert.assertEquals(end, result.get("end-time").asLong());
+		Assert.assertEquals(end - start, result.get("duration").asLong());
+
+		ArchivedJobGenerationUtils.compareIoMetrics(originalAttempt.getIOMetrics(), result.get("metrics"));
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandlerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SubtasksAllAccumulatorsHandlerTest {
+	@Test
+	public void testJsonGeneration() throws Exception {
+		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
+		String json = SubtasksAllAccumulatorsHandler.createSubtasksAccumulatorsJson(originalTask);
+
+		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
+
+		Assert.assertEquals(originalTask.getJobVertexId().toString(), result.get("id").asText());
+		Assert.assertEquals(originalTask.getParallelism(), result.get("parallelism").asInt());
+
+		ArrayNode subtasks = (ArrayNode) result.get("subtasks");
+
+		assertEquals(originalTask.getTaskVertices().length, subtasks.size());
+		for (int x = 0; x < originalTask.getTaskVertices().length; x++) {
+			JsonNode subtask = subtasks.get(x);
+			AccessExecutionVertex expectedSubtask = originalTask.getTaskVertices()[x];
+
+			Assert.assertEquals(x, subtask.get("subtask").asInt());
+			Assert.assertEquals(expectedSubtask.getCurrentExecutionAttempt().getAttemptNumber(), subtask.get("attempt").asInt());
+			Assert.assertEquals(expectedSubtask.getCurrentAssignedResourceLocation().getHostname(), subtask.get("host").asText());
+
+			ArchivedJobGenerationUtils.compareStringifiedAccumulators(
+				expectedSubtask.getCurrentExecutionAttempt().getUserAccumulatorsStringified(),
+				(ArrayNode) subtask.get("user-accumulators"));
+		}
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandlerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecution;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SubtasksTimesHandlerTest {
+	@Test
+	public void testJsonGeneration() throws Exception {
+		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
+		AccessExecution originalAttempt = ArchivedJobGenerationUtils.getTestAttempt();
+		String json = SubtasksTimesHandler.createSubtaskTimesJson(originalTask);
+
+		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
+
+		Assert.assertEquals(originalTask.getJobVertexId().toString(), result.get("id").asText());
+		Assert.assertEquals(originalTask.getName(), result.get("name").asText());
+		Assert.assertTrue(result.get("now").asLong() > 0L);
+
+		ArrayNode subtasks = (ArrayNode) result.get("subtasks");
+
+		JsonNode subtask = subtasks.get(0);
+		Assert.assertEquals(0, subtask.get("subtask").asInt());
+		Assert.assertEquals(originalAttempt.getAssignedResourceLocation().getHostname(), subtask.get("host").asText());
+		Assert.assertEquals(originalAttempt.getStateTimestamp(originalAttempt.getState()) - originalAttempt.getStateTimestamp(ExecutionState.SCHEDULED), subtask.get("duration").asLong());
+
+		JsonNode timestamps = subtask.get("timestamps");
+
+		Assert.assertEquals(originalAttempt.getStateTimestamp(ExecutionState.CREATED), timestamps.get(ExecutionState.CREATED.name()).asLong());
+		Assert.assertEquals(originalAttempt.getStateTimestamp(ExecutionState.SCHEDULED), timestamps.get(ExecutionState.SCHEDULED.name()).asLong());
+		Assert.assertEquals(originalAttempt.getStateTimestamp(ExecutionState.DEPLOYING), timestamps.get(ExecutionState.DEPLOYING.name()).asLong());
+		Assert.assertEquals(originalAttempt.getStateTimestamp(ExecutionState.RUNNING), timestamps.get(ExecutionState.RUNNING.name()).asLong());
+		Assert.assertEquals(originalAttempt.getStateTimestamp(ExecutionState.FINISHED), timestamps.get(ExecutionState.FINISHED.name()).asLong());
+		Assert.assertEquals(originalAttempt.getStateTimestamp(ExecutionState.CANCELING), timestamps.get(ExecutionState.CANCELING.name()).asLong());
+		Assert.assertEquals(originalAttempt.getStateTimestamp(ExecutionState.CANCELED), timestamps.get(ExecutionState.CANCELED.name()).asLong());
+		Assert.assertEquals(originalAttempt.getStateTimestamp(ExecutionState.FAILED), timestamps.get(ExecutionState.FAILED.name()).asLong());
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/ArchivedExecutionBuilder.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/ArchivedExecutionBuilder.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.utils;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MeterView;
+import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ArchivedExecution;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.Preconditions;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class ArchivedExecutionBuilder {
+	private ExecutionAttemptID attemptId;
+	private long[] stateTimestamps;
+	private int attemptNumber;
+	private ExecutionState state;
+	private String failureCause;
+	private TaskManagerLocation assignedResourceLocation;
+	private StringifiedAccumulatorResult[] userAccumulators;
+	private IOMetrics ioMetrics;
+	private int parallelSubtaskIndex;
+
+	public ArchivedExecutionBuilder setAttemptId(ExecutionAttemptID attemptId) {
+		this.attemptId = attemptId;
+		return this;
+	}
+
+	public ArchivedExecutionBuilder setStateTimestamps(long[] stateTimestamps) {
+		Preconditions.checkArgument(stateTimestamps.length == ExecutionState.values().length);
+		this.stateTimestamps = stateTimestamps;
+		return this;
+	}
+
+	public ArchivedExecutionBuilder setAttemptNumber(int attemptNumber) {
+		this.attemptNumber = attemptNumber;
+		return this;
+	}
+
+	public ArchivedExecutionBuilder setState(ExecutionState state) {
+		this.state = state;
+		return this;
+	}
+
+	public ArchivedExecutionBuilder setFailureCause(String failureCause) {
+		this.failureCause = failureCause;
+		return this;
+	}
+
+	public ArchivedExecutionBuilder setAssignedResourceLocation(TaskManagerLocation assignedResourceLocation) {
+		this.assignedResourceLocation = assignedResourceLocation;
+		return this;
+	}
+
+	public ArchivedExecutionBuilder setUserAccumulators(StringifiedAccumulatorResult[] userAccumulators) {
+		this.userAccumulators = userAccumulators;
+		return this;
+	}
+
+	public ArchivedExecutionBuilder setParallelSubtaskIndex(int parallelSubtaskIndex) {
+		this.parallelSubtaskIndex = parallelSubtaskIndex;
+		return this;
+	}
+
+	public ArchivedExecutionBuilder setIOMetrics(IOMetrics ioMetrics) {
+		this.ioMetrics = ioMetrics;
+		return this;
+	}
+
+	public ArchivedExecution build() throws UnknownHostException {
+		return new ArchivedExecution(
+			userAccumulators != null ? userAccumulators : new StringifiedAccumulatorResult[0],
+			ioMetrics != null ? ioMetrics : new TestIOMetrics(),
+			attemptId != null ? attemptId : new ExecutionAttemptID(),
+			attemptNumber,
+			state != null ? state : ExecutionState.FINISHED,
+			failureCause != null ? failureCause : "(null)",
+			assignedResourceLocation != null ? assignedResourceLocation : new TaskManagerLocation(new ResourceID("tm"), InetAddress.getLocalHost(), 1234),
+			parallelSubtaskIndex,
+			stateTimestamps != null ? stateTimestamps : new long[]{1, 2, 3, 4, 5, 5, 5, 5}
+		);
+	}
+
+	private static class TestIOMetrics extends IOMetrics {
+		private static final long serialVersionUID = -5920076211680012555L;
+
+		public TestIOMetrics() {
+			super(
+				new MeterView(new TestCounter(1), 0),
+				new MeterView(new TestCounter(2), 0),
+				new MeterView(new TestCounter(3), 0),
+				new MeterView(new TestCounter(4), 0),
+				new MeterView(new TestCounter(5), 0));
+		}
+	}
+
+	private static class TestCounter implements Counter {
+		private final long count;
+
+		private TestCounter(long count) {
+			this.count = count;
+		}
+
+		@Override
+		public void inc() {
+		}
+
+		@Override
+		public void inc(long n) {
+		}
+
+		@Override
+		public void dec() {
+		}
+
+		@Override
+		public void dec(long n) {
+		}
+
+		@Override
+		public long getCount() {
+			return count;
+		}
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/ArchivedExecutionConfigBuilder.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/ArchivedExecutionConfigBuilder.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.utils;
+
+import org.apache.flink.api.common.ArchivedExecutionConfig;
+import org.apache.flink.api.common.ExecutionMode;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class ArchivedExecutionConfigBuilder {
+	private String executionMode;
+	private String restartStrategyDescription;
+	private int parallelism;
+	private boolean objectReuseEnabled;
+	private Map<String, String> globalJobParameters;
+
+	public ArchivedExecutionConfigBuilder setExecutionMode(String executionMode) {
+		this.executionMode = executionMode;
+		return this;
+	}
+
+	public ArchivedExecutionConfigBuilder setRestartStrategyDescription(String restartStrategyDescription) {
+		this.restartStrategyDescription = restartStrategyDescription;
+		return this;
+	}
+
+	public ArchivedExecutionConfigBuilder setParallelism(int parallelism) {
+		this.parallelism = parallelism;
+		return this;
+	}
+
+	public ArchivedExecutionConfigBuilder setObjectReuseEnabled(boolean objectReuseEnabled) {
+		this.objectReuseEnabled = objectReuseEnabled;
+		return this;
+	}
+
+	public ArchivedExecutionConfigBuilder setGlobalJobParameters(Map<String, String> globalJobParameters) {
+		this.globalJobParameters = globalJobParameters;
+		return this;
+	}
+
+	public ArchivedExecutionConfig build() {
+		return new ArchivedExecutionConfig(
+			executionMode != null ? executionMode : ExecutionMode.PIPELINED.name(),
+			restartStrategyDescription != null ? restartStrategyDescription : "default",
+			parallelism,
+			objectReuseEnabled,
+			globalJobParameters != null ? globalJobParameters : Collections.<String, String>emptyMap()
+		);
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/ArchivedExecutionGraphBuilder.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/ArchivedExecutionGraphBuilder.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.utils;
+
+import org.apache.flink.api.common.ArchivedExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionJobVertex;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.SerializedValue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+public class ArchivedExecutionGraphBuilder {
+
+	private static final Random RANDOM = new Random();
+
+	private JobID jobID;
+	private String jobName;
+	private Map<JobVertexID, ArchivedExecutionJobVertex> tasks;
+	private List<ArchivedExecutionJobVertex> verticesInCreationOrder;
+	private long[] stateTimestamps;
+	private JobStatus state;
+	private String failureCause;
+	private String jsonPlan;
+	private StringifiedAccumulatorResult[] archivedUserAccumulators;
+	private ArchivedExecutionConfig archivedExecutionConfig;
+	private boolean isStoppable;
+	private Map<String, SerializedValue<Object>> serializedUserAccumulators;
+
+	public ArchivedExecutionGraphBuilder setJobID(JobID jobID) {
+		this.jobID = jobID;
+		return this;
+	}
+
+	public ArchivedExecutionGraphBuilder setJobName(String jobName) {
+		this.jobName = jobName;
+		return this;
+	}
+
+	public ArchivedExecutionGraphBuilder setTasks(Map<JobVertexID, ArchivedExecutionJobVertex> tasks) {
+		this.tasks = tasks;
+		return this;
+	}
+
+	public ArchivedExecutionGraphBuilder setVerticesInCreationOrder(List<ArchivedExecutionJobVertex> verticesInCreationOrder) {
+		this.verticesInCreationOrder = verticesInCreationOrder;
+		return this;
+	}
+
+	public ArchivedExecutionGraphBuilder setStateTimestamps(long[] stateTimestamps) {
+		Preconditions.checkArgument(stateTimestamps.length == JobStatus.values().length);
+		this.stateTimestamps = stateTimestamps;
+		return this;
+	}
+
+	public ArchivedExecutionGraphBuilder setState(JobStatus state) {
+		this.state = state;
+		return this;
+	}
+
+	public ArchivedExecutionGraphBuilder setFailureCause(String failureCause) {
+		this.failureCause = failureCause;
+		return this;
+	}
+
+	public ArchivedExecutionGraphBuilder setJsonPlan(String jsonPlan) {
+		this.jsonPlan = jsonPlan;
+		return this;
+	}
+
+	public ArchivedExecutionGraphBuilder setArchivedUserAccumulators(StringifiedAccumulatorResult[] archivedUserAccumulators) {
+		this.archivedUserAccumulators = archivedUserAccumulators;
+		return this;
+	}
+
+	public ArchivedExecutionGraphBuilder setArchivedExecutionConfig(ArchivedExecutionConfig archivedExecutionConfig) {
+		this.archivedExecutionConfig = archivedExecutionConfig;
+		return this;
+	}
+
+	public ArchivedExecutionGraphBuilder setStoppable(boolean stoppable) {
+		isStoppable = stoppable;
+		return this;
+	}
+
+	public ArchivedExecutionGraphBuilder setSerializedUserAccumulators(Map<String, SerializedValue<Object>> serializedUserAccumulators) {
+		this.serializedUserAccumulators = serializedUserAccumulators;
+		return this;
+	}
+
+	public ArchivedExecutionGraph build() {
+		Preconditions.checkNotNull(tasks, "Tasks must not be null.");
+		JobID jobID = this.jobID != null ? this.jobID : new JobID();
+		String jobName = this.jobName != null ? this.jobName : "job_" + RANDOM.nextInt();
+		return new ArchivedExecutionGraph(
+			jobID,
+			jobName,
+			tasks,
+			verticesInCreationOrder != null ? verticesInCreationOrder : new ArrayList<>(tasks.values()),
+			stateTimestamps != null ? stateTimestamps : new long[JobStatus.values().length],
+			state != null ? state : JobStatus.FINISHED,
+			failureCause != null ? failureCause : "(null)",
+			jsonPlan != null ? jsonPlan : "{\"" + JsonUtils.Keys.JOB_ID + "\":\"" + jobID + "\", \"" + JsonUtils.Keys.NAME + "\":\"" + jobName + "\", \"nodes\":[]}",
+			archivedUserAccumulators != null ? archivedUserAccumulators : new StringifiedAccumulatorResult[0],
+			serializedUserAccumulators != null ? serializedUserAccumulators : Collections.<String, SerializedValue<Object>>emptyMap(),
+			archivedExecutionConfig != null ? archivedExecutionConfig : new ArchivedExecutionConfigBuilder().build(),
+			isStoppable,
+			null,
+			null
+		);
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/ArchivedExecutionJobVertexBuilder.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/ArchivedExecutionJobVertexBuilder.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.utils;
+
+import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Random;
+
+public class ArchivedExecutionJobVertexBuilder {
+
+	private static final Random RANDOM = new Random();
+
+	private ArchivedExecutionVertex[] taskVertices;
+	private JobVertexID id;
+	private String name;
+	private int parallelism;
+	private int maxParallelism;
+	private StringifiedAccumulatorResult[] archivedUserAccumulators;
+
+	public ArchivedExecutionJobVertexBuilder setTaskVertices(ArchivedExecutionVertex[] taskVertices) {
+		this.taskVertices = taskVertices;
+		return this;
+	}
+
+	public ArchivedExecutionJobVertexBuilder setId(JobVertexID id) {
+		this.id = id;
+		return this;
+	}
+
+	public ArchivedExecutionJobVertexBuilder setName(String name) {
+		this.name = name;
+		return this;
+	}
+
+	public ArchivedExecutionJobVertexBuilder setParallelism(int parallelism) {
+		this.parallelism = parallelism;
+		return this;
+	}
+
+	public ArchivedExecutionJobVertexBuilder setMaxParallelism(int maxParallelism) {
+		this.maxParallelism = maxParallelism;
+		return this;
+	}
+
+	public ArchivedExecutionJobVertexBuilder setArchivedUserAccumulators(StringifiedAccumulatorResult[] archivedUserAccumulators) {
+		this.archivedUserAccumulators = archivedUserAccumulators;
+		return this;
+	}
+
+	public ArchivedExecutionJobVertex build() {
+		Preconditions.checkNotNull(taskVertices);
+		return new ArchivedExecutionJobVertex(
+			taskVertices,
+			id != null ? id : new JobVertexID(),
+			name != null ? name : "task_" + RANDOM.nextInt(),
+			parallelism,
+			maxParallelism,
+			archivedUserAccumulators != null ? archivedUserAccumulators : new StringifiedAccumulatorResult[0]
+		);
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/ArchivedExecutionVertexBuilder.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/ArchivedExecutionVertexBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.utils;
+
+import org.apache.flink.runtime.executiongraph.ArchivedExecution;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
+import org.apache.flink.runtime.util.EvictingBoundedList;
+import org.apache.flink.util.Preconditions;
+
+import java.util.List;
+import java.util.Random;
+
+public class ArchivedExecutionVertexBuilder {
+
+	private static final Random RANDOM = new Random();
+
+	private int subtaskIndex;
+	private EvictingBoundedList<ArchivedExecution> priorExecutions;
+	private String taskNameWithSubtask;
+	private ArchivedExecution currentExecution;
+
+	public ArchivedExecutionVertexBuilder setSubtaskIndex(int subtaskIndex) {
+		this.subtaskIndex = subtaskIndex;
+		return this;
+	}
+
+	public ArchivedExecutionVertexBuilder setPriorExecutions(List<ArchivedExecution> priorExecutions) {
+		this.priorExecutions = new EvictingBoundedList<>(priorExecutions.size());
+		for (ArchivedExecution execution : priorExecutions) {
+			this.priorExecutions.add(execution);
+		}
+		return this;
+	}
+
+	public ArchivedExecutionVertexBuilder setTaskNameWithSubtask(String taskNameWithSubtask) {
+		this.taskNameWithSubtask = taskNameWithSubtask;
+		return this;
+	}
+
+	public ArchivedExecutionVertexBuilder setCurrentExecution(ArchivedExecution currentExecution) {
+		this.currentExecution = currentExecution;
+		return this;
+	}
+
+	public ArchivedExecutionVertex build() {
+		Preconditions.checkNotNull(currentExecution);
+		return new ArchivedExecutionVertex(
+			subtaskIndex,
+			taskNameWithSubtask != null ? taskNameWithSubtask : "task_" + RANDOM.nextInt() + "_" + subtaskIndex,
+			currentExecution,
+			priorExecutions != null ? priorExecutions : new EvictingBoundedList<ArchivedExecution>(0)
+		);
+	}
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/ArchivedJobGenerationUtils.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/ArchivedJobGenerationUtils.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.utils;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecution;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.executiongraph.ArchivedExecution;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ArchivedJobGenerationUtils {
+	public static final ObjectMapper mapper = new ObjectMapper();
+	public static final JsonFactory jacksonFactory = new JsonFactory()
+		.enable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
+		.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
+
+	private static ArchivedExecutionGraph originalJob;
+	private static ArchivedExecutionJobVertex originalTask;
+	private static ArchivedExecutionVertex originalSubtask;
+	private static ArchivedExecution originalAttempt;
+
+	private static final Object lock = new Object();
+
+	private ArchivedJobGenerationUtils() {
+	}
+
+	public static AccessExecutionGraph getTestJob() throws Exception {
+		synchronized (lock) {
+			if (originalJob == null) {
+				generateArchivedJob();
+			}
+		}
+		return originalJob;
+	}
+
+	public static AccessExecutionJobVertex getTestTask() throws Exception {
+		synchronized (lock) {
+			if (originalJob == null) {
+				generateArchivedJob();
+			}
+		}
+		return originalTask;
+	}
+
+	public static AccessExecutionVertex getTestSubtask() throws Exception {
+		synchronized (lock) {
+			if (originalJob == null) {
+				generateArchivedJob();
+			}
+		}
+		return originalSubtask;
+	}
+
+	public static AccessExecution getTestAttempt() throws Exception {
+		synchronized (lock) {
+			if (originalJob == null) {
+				generateArchivedJob();
+			}
+		}
+		return originalAttempt;
+	}
+
+	private static void generateArchivedJob() throws Exception {
+		// Attempt
+		StringifiedAccumulatorResult acc1 = new StringifiedAccumulatorResult("name1", "type1", "value1");
+		StringifiedAccumulatorResult acc2 = new StringifiedAccumulatorResult("name2", "type2", "value2");
+		TaskManagerLocation location = new TaskManagerLocation(new ResourceID("hello"), InetAddress.getLocalHost(), 1234);
+		originalAttempt = new ArchivedExecutionBuilder()
+			.setStateTimestamps(new long[]{1, 2, 3, 4, 5, 6, 7, 8, 9})
+			.setParallelSubtaskIndex(1)
+			.setAttemptNumber(3)
+			.setAssignedResourceLocation(location)
+			.setUserAccumulators(new StringifiedAccumulatorResult[]{acc1, acc2})
+			.setState(ExecutionState.FINISHED)
+			.setFailureCause("attemptException")
+			.build();
+		// Subtask
+		originalSubtask = new ArchivedExecutionVertexBuilder()
+			.setSubtaskIndex(originalAttempt.getParallelSubtaskIndex())
+			.setTaskNameWithSubtask("hello(1/1)")
+			.setCurrentExecution(originalAttempt)
+			.build();
+		// Task
+		originalTask = new ArchivedExecutionJobVertexBuilder()
+			.setTaskVertices(new ArchivedExecutionVertex[]{originalSubtask})
+			.build();
+		// Job
+		Map<JobVertexID, ArchivedExecutionJobVertex> tasks = new HashMap<>();
+		tasks.put(originalTask.getJobVertexId(), originalTask);
+		originalJob = new ArchivedExecutionGraphBuilder()
+			.setJobID(new JobID())
+			.setTasks(tasks)
+			.setFailureCause("jobException")
+			.setState(JobStatus.FINISHED)
+			.setStateTimestamps(new long[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+			.setArchivedUserAccumulators(new StringifiedAccumulatorResult[]{acc1, acc2})
+			.build();
+	}
+
+	// ========================================================================
+	// utility methods
+	// ========================================================================
+
+	public static void compareStringifiedAccumulators(StringifiedAccumulatorResult[] expectedAccs, ArrayNode writtenAccs) {
+		assertEquals(expectedAccs.length, writtenAccs.size());
+		for (int x = 0; x < expectedAccs.length; x++) {
+			JsonNode acc = writtenAccs.get(x);
+
+			assertEquals(expectedAccs[x].getName(), acc.get(JsonUtils.Keys.NAME).asText());
+			assertEquals(expectedAccs[x].getType(), acc.get(JsonUtils.Keys.TYPE).asText());
+			assertEquals(expectedAccs[x].getValue(), acc.get(JsonUtils.Keys.VALUE).asText());
+		}
+	}
+
+	public static void compareIoMetrics(IOMetrics expectedMetrics, JsonNode writtenMetrics) {
+		assertEquals(expectedMetrics.getNumBytesInTotal(), writtenMetrics.get(JsonUtils.Keys.READ_BYTES).asLong());
+		assertEquals(expectedMetrics.getNumBytesOut(), writtenMetrics.get(JsonUtils.Keys.WRITE_BYTES).asLong());
+		assertEquals(expectedMetrics.getNumRecordsIn(), writtenMetrics.get(JsonUtils.Keys.READ_RECORDS).asLong());
+		assertEquals(expectedMetrics.getNumRecordsOut(), writtenMetrics.get(JsonUtils.Keys.WRITE_RECORDS).asLong());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecution.java
@@ -59,6 +59,21 @@ public class ArchivedExecution implements AccessExecution, Serializable {
 		this.ioMetrics = execution.getIOMetrics();
 	}
 
+	public ArchivedExecution(
+			StringifiedAccumulatorResult[] userAccumulators, IOMetrics ioMetrics,
+			ExecutionAttemptID attemptId, int attemptNumber, ExecutionState state, String failureCause,
+			TaskManagerLocation assignedResourceLocation, int parallelSubtaskIndex, long[] stateTimestamps) {
+		this.userAccumulators = userAccumulators;
+		this.ioMetrics = ioMetrics;
+		this.failureCause = failureCause;
+		this.assignedResourceLocation = assignedResourceLocation;
+		this.attemptNumber = attemptNumber;
+		this.attemptId = attemptId;
+		this.state = state;
+		this.stateTimestamps = stateTimestamps;
+		this.parallelSubtaskIndex = parallelSubtaskIndex;
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//   Accessors
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionJobVertex.java
@@ -54,6 +54,21 @@ public class ArchivedExecutionJobVertex implements AccessExecutionJobVertex, Ser
 		this.maxParallelism = jobVertex.getMaxParallelism();
 	}
 
+	public ArchivedExecutionJobVertex(
+			ArchivedExecutionVertex[] taskVertices,
+			JobVertexID id,
+			String name,
+			int parallelism,
+			int maxParallelism,
+			StringifiedAccumulatorResult[] archivedUserAccumulators) {
+		this.taskVertices = taskVertices;
+		this.id = id;
+		this.name = name;
+		this.parallelism = parallelism;
+		this.maxParallelism = maxParallelism;
+		this.archivedUserAccumulators = archivedUserAccumulators;
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//   Accessors
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
@@ -45,6 +45,15 @@ public class ArchivedExecutionVertex implements AccessExecutionVertex, Serializa
 		this.currentExecution = vertex.getCurrentExecutionAttempt().archive();
 	}
 
+	public ArchivedExecutionVertex(
+			int subTaskIndex, String taskNameWithSubtask,
+			ArchivedExecution currentExecution, EvictingBoundedList<ArchivedExecution> priorExecutions) {
+		this.subTaskIndex = subTaskIndex;
+		this.taskNameWithSubtask = taskNameWithSubtask;
+		this.currentExecution = currentExecution;
+		this.priorExecutions = priorExecutions;
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//   Accessors
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IOMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IOMetrics.java
@@ -26,19 +26,19 @@ import java.io.Serializable;
  */
 public class IOMetrics implements Serializable {
 	private static final long serialVersionUID = -7208093607556457183L;
-	private final long numRecordsIn;
-	private final long numRecordsOut;
+	protected long numRecordsIn;
+	protected long numRecordsOut;
 
-	private final double numRecordsInPerSecond;
-	private final double numRecordsOutPerSecond;
+	protected double numRecordsInPerSecond;
+	protected double numRecordsOutPerSecond;
 
-	private final long numBytesInLocal;
-	private final long numBytesInRemote;
-	private final long numBytesOut;
+	protected long numBytesInLocal;
+	protected long numBytesInRemote;
+	protected long numBytesOut;
 
-	private final double numBytesInLocalPerSecond;
-	private final double numBytesInRemotePerSecond;
-	private final double numBytesOutPerSecond;
+	protected double numBytesInLocalPerSecond;
+	protected double numBytesInRemotePerSecond;
+	protected double numBytesOutPerSecond;
 
 	public IOMetrics(Meter recordsIn, Meter recordsOut, Meter bytesLocalIn, Meter bytesRemoteIn, Meter bytesOut) {
 		this.numRecordsIn = recordsIn.getCount();
@@ -51,6 +51,22 @@ public class IOMetrics implements Serializable {
 		this.numBytesInRemotePerSecond = bytesRemoteIn.getRate();
 		this.numBytesOut = bytesOut.getCount();
 		this.numBytesOutPerSecond = bytesOut.getRate();
+	}
+
+	public IOMetrics(
+			int numBytesInLocal, int numBytesInRemote, int numBytesOut, int numRecordsIn, int numRecordsOut,
+			double numBytesInLocalPerSecond, double numBytesInRemotePerSecond, double numBytesOutPerSecond,
+			double numRecordsInPerSecond, double numRecordsOutPerSecond) {
+		this.numBytesInLocal = numBytesInLocal;
+		this.numBytesInRemote = numBytesInRemote;
+		this.numBytesOut = numBytesOut;
+		this.numRecordsIn = numRecordsIn;
+		this.numRecordsOut = numRecordsOut;
+		this.numBytesInLocalPerSecond = numBytesInLocalPerSecond;
+		this.numBytesInRemotePerSecond = numBytesInRemotePerSecond;
+		this.numBytesOutPerSecond = numBytesOutPerSecond;
+		this.numRecordsInPerSecond = numRecordsInPerSecond;
+		this.numRecordsOutPerSecond = numRecordsOutPerSecond;
 	}
 
 	public long getNumRecordsIn() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -106,9 +106,13 @@ public class ArchivedExecutionGraphTest {
 			new NoRestartStrategy());
 		runtimeGraph.attachJobGraph(vertices);
 
+		List<ExecutionJobVertex> jobVertices = new ArrayList<>();
+		jobVertices.add(runtimeGraph.getJobVertex(v1ID));
+		jobVertices.add(runtimeGraph.getJobVertex(v2ID));
+		
 		CheckpointStatsTracker statsTracker = new CheckpointStatsTracker(
 				0,
-				Collections.<ExecutionJobVertex>emptyList(),
+				jobVertices,
 				mock(JobSnapshottingSettings.class),
 				new UnregisteredMetricsGroup());
 


### PR DESCRIPTION
This PR is part of the History Server implementation. It is opened separately to make the review easier.

The primary change is that the JSON generation of job-specific REST responses was moved from various ```handleRequest``` methods into static methods. This will allow easier re-use. In addition several refactorings have been made and tests were added.

Other changes include:
* ~~added a utility method ```JsonUtils#addIOMetrics``` to aggregate ```IOMetrics```~~
* ~~added a utility method ```JsonUtils#writeIOMetrics``` to write ```IOMetrics```~~
* ~~added a utiltiy method ```JsonUtils#writeMinMaxAvg``` to write ```MinMaxAvgStats``` (checkpointing related)~~
* added utility ```MutableIOMetrics``` class for easier IOMetrics aggregation in handlers
* replaced **job-related** hard-coded JSON keys with static constants, defined in ```JsonUtils#Keys```
* added an additional constructor to the ```ArchivedExecutionConfig``` class for easier generation in tests
* added ```BuilderUtils``` class for easier generation of ```Archived*``` classes in tests
* modified ```IOMetrics``` to allow sub-classing without requiring usage of Meters
* added a test for every introduced static method