### PR TITLE
[FLINK-5854] [core] Add base Flink Exception classes

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/DynamicCodeLoadingException.java
+++ b/flink-core/src/main/java/org/apache/flink/util/DynamicCodeLoadingException.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.apache.flink.annotation.Public;
+
+/**
+ * An exception that is thrown if the dynamic instantiation of code fails.
+ * 
+ * <p>This exception is supposed to "sum up" the zoo of exceptions typically thrown around
+ * dynamic code loading and instantiations:
+ * 
+ * <pre>{@code
+ * try {
+ *     Class.forName(classname).asSubclass(TheType.class).newInstance();
+ * }
+ * catch (ClassNotFoundException | ClassCastException | InstantiationException | IllegalAccessException e) {
+ *     throw new DynamicCodeLoadingException(e);
+ * }
+ * }</pre>
+ */
+@Public
+public class DynamicCodeLoadingException extends FlinkException {
+
+	private static final long serialVersionUID = -25138443817255490L;
+
+	/**
+	 * Creates a new exception with the given message and cause
+	 *
+	 * @param message The exception message
+	 * @param cause The exception that caused this exception
+	 */
+	public DynamicCodeLoadingException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/util/FlinkException.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FlinkException.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.apache.flink.annotation.Public;
+
+/**
+ * Base class of all Flink-specific checked exceptions.
+ */
+@Public
+public class FlinkException extends Exception {
+
+	private static final long serialVersionUID = 450688772469004724L;
+
+	/**
+	 * Creates a new exception with a null message and null cause. 
+	 */
+	public FlinkException() {
+		super();
+	}
+
+	/**
+	 * Creates a new Exception with the given message and null as the cause.
+	 * 
+	 * @param message The exception message
+	 */
+	public FlinkException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Creates a new exception with a null message and the given cause.
+	 * 
+	 * @param cause The exception that caused this exception
+	 */
+	public FlinkException(Throwable cause) {
+		super(cause);
+	}
+
+	/**
+	 * Creates a new exception with the given message and cause
+	 * 
+	 * @param message The exception message
+	 * @param cause The exception that caused this exception
+	 */
+	public FlinkException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/util/FlinkRuntimeException.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FlinkRuntimeException.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.apache.flink.annotation.Public;
+
+/**
+ * Base class of all Flink-specific unchecked exceptions.
+ */
+@Public
+public class FlinkRuntimeException extends RuntimeException {
+
+	private static final long serialVersionUID = 193141189399279147L;
+
+	/**
+	 * Creates a new exception with a null message and null cause. 
+	 */
+	public FlinkRuntimeException() {
+		super();
+	}
+
+	/**
+	 * Creates a new Exception with the given message and null as the cause.
+	 * 
+	 * @param message The exception message
+	 */
+	public FlinkRuntimeException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Creates a new exception with a null message and the given cause.
+	 * 
+	 * @param cause The exception that caused this exception
+	 */
+	public FlinkRuntimeException(Throwable cause) {
+		super(cause);
+	}
+
+	/**
+	 * Creates a new exception with the given message and cause
+	 * 
+	 * @param message The exception message
+	 * @param cause The exception that caused this exception
+	 */
+	public FlinkRuntimeException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}


### PR DESCRIPTION
This pull request adds two exception base classes: `FlinkException` and `FlinkRuntimeException`.
They are useful in improving the way certain parts of the code handle exceptions.

  - `FlinkException` is a base class for checked exceptions that indicate that something related to using Flink went wrong. It is helpful, because letting a method throw `FlinkException` rather than `Exception` already helps to not include all of Java's runtime exceptions, which indicate programming errors, rather than situations that should be recovered.
  - `FlinkRuntimeException` as a Flink-specific subclass of `RuntimeException` comes in handy in places where no exceptions were declared, for example when reusing an interface that does not declare exceptions.

**Important: This does not mean we should just declare `FlinkException` everywhere and throw and catch `FlinkException` and `FlinkRuntimeException` arbitrarily. Exception handling remains a careful and conscious task.**

This also adds the `DynamicCodeLoadingException` subclass of `FlinkException` as an example.