### PR TITLE
[FLINK-5524] [table] Support early out for code generated AND/OR condition

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -286,42 +286,51 @@ object ScalarOperators {
       // Unknown && False -> False
       // Unknown && Unknown -> Unknown
       s"""
-        |${left.code}
-        |${right.code}
-        |boolean $resultTerm;
-        |boolean $nullTerm;
-        |if (!${left.nullTerm} && !${right.nullTerm}) {
-        |  $resultTerm = ${left.resultTerm} && ${right.resultTerm};
-        |  $nullTerm = false;
-        |}
-        |else if (!${left.nullTerm} && ${left.resultTerm} && ${right.nullTerm}) {
-        |  $resultTerm = false;
-        |  $nullTerm = true;
-        |}
-        |else if (!${left.nullTerm} && !${left.resultTerm} && ${right.nullTerm}) {
-        |  $resultTerm = false;
-        |  $nullTerm = false;
-        |}
-        |else if (${left.nullTerm} && !${right.nullTerm} && ${right.resultTerm}) {
-        |  $resultTerm = false;
-        |  $nullTerm = true;
-        |}
-        |else if (${left.nullTerm} && !${right.nullTerm} && !${right.resultTerm}) {
-        |  $resultTerm = false;
-        |  $nullTerm = false;
-        |}
-        |else {
-        |  $resultTerm = false;
-        |  $nullTerm = true;
-        |}
-        |""".stripMargin
+         |${left.code}
+         |
+         |boolean $resultTerm = false;
+         |boolean $nullTerm = false;
+         |if (!${left.nullTerm} && !${left.resultTerm}) {
+         |  // left expr is false, skip right expr
+         |} else {
+         |  ${right.code}
+         |
+         |  if (!${left.nullTerm} && !${right.nullTerm}) {
+         |    $resultTerm = ${left.resultTerm} && ${right.resultTerm};
+         |    $nullTerm = false;
+         |  }
+         |  else if (!${left.nullTerm} && ${left.resultTerm} && ${right.nullTerm}) {
+         |    $resultTerm = false;
+         |    $nullTerm = true;
+         |  }
+         |  else if (!${left.nullTerm} && !${left.resultTerm} && ${right.nullTerm}) {
+         |    $resultTerm = false;
+         |    $nullTerm = false;
+         |  }
+         |  else if (${left.nullTerm} && !${right.nullTerm} && ${right.resultTerm}) {
+         |    $resultTerm = false;
+         |    $nullTerm = true;
+         |  }
+         |  else if (${left.nullTerm} && !${right.nullTerm} && !${right.resultTerm}) {
+         |    $resultTerm = false;
+         |    $nullTerm = false;
+         |  }
+         |  else {
+         |    $resultTerm = false;
+         |    $nullTerm = true;
+         |  }
+         |}
+       """.stripMargin
     }
     else {
       s"""
-        |${left.code}
-        |${right.code}
-        |boolean $resultTerm = ${left.resultTerm} && ${right.resultTerm};
-        |""".stripMargin
+         |${left.code}
+         |boolean $resultTerm = false;
+         |if (${left.resultTerm}) {
+         |  ${right.code}
+         |  $resultTerm = ${right.resultTerm};
+         |}
+         |""".stripMargin
     }
 
     GeneratedExpression(resultTerm, nullTerm, operatorCode, BOOLEAN_TYPE_INFO)
@@ -345,40 +354,49 @@ object ScalarOperators {
       // Unknown && Unknown -> Unknown
       s"""
         |${left.code}
-        |${right.code}
-        |boolean $resultTerm;
-        |boolean $nullTerm;
-        |if (!${left.nullTerm} && !${right.nullTerm}) {
-        |  $resultTerm = ${left.resultTerm} || ${right.resultTerm};
-        |  $nullTerm = false;
-        |}
-        |else if (!${left.nullTerm} && ${left.resultTerm} && ${right.nullTerm}) {
-        |  $resultTerm = true;
-        |  $nullTerm = false;
-        |}
-        |else if (!${left.nullTerm} && !${left.resultTerm} && ${right.nullTerm}) {
-        |  $resultTerm = false;
-        |  $nullTerm = true;
-        |}
-        |else if (${left.nullTerm} && !${right.nullTerm} && ${right.resultTerm}) {
-        |  $resultTerm = true;
-        |  $nullTerm = false;
-        |}
-        |else if (${left.nullTerm} && !${right.nullTerm} && !${right.resultTerm}) {
-        |  $resultTerm = false;
-        |  $nullTerm = true;
-        |}
-        |else {
-        |  $resultTerm = false;
-        |  $nullTerm = true;
+        |
+        |boolean $resultTerm = true;
+        |boolean $nullTerm = false;
+        |if (!${left.nullTerm} && ${left.resultTerm}) {
+        |  // left expr is true, skip right expr
+        |} else {
+        |  ${right.code}
+        |
+        |  if (!${left.nullTerm} && !${right.nullTerm}) {
+        |    $resultTerm = ${left.resultTerm} || ${right.resultTerm};
+        |    $nullTerm = false;
+        |  }
+        |  else if (!${left.nullTerm} && ${left.resultTerm} && ${right.nullTerm}) {
+        |    $resultTerm = true;
+        |    $nullTerm = false;
+        |  }
+        |  else if (!${left.nullTerm} && !${left.resultTerm} && ${right.nullTerm}) {
+        |    $resultTerm = false;
+        |    $nullTerm = true;
+        |  }
+        |  else if (${left.nullTerm} && !${right.nullTerm} && ${right.resultTerm}) {
+        |    $resultTerm = true;
+        |    $nullTerm = false;
+        |  }
+        |  else if (${left.nullTerm} && !${right.nullTerm} && !${right.resultTerm}) {
+        |    $resultTerm = false;
+        |    $nullTerm = true;
+        |  }
+        |  else {
+        |    $resultTerm = false;
+        |    $nullTerm = true;
+        |  }
         |}
         |""".stripMargin
     }
     else {
       s"""
-        |${left.code}
-        |${right.code}
-        |boolean $resultTerm = ${left.resultTerm} || ${right.resultTerm};
+         |${left.code}
+         |boolean $resultTerm = true;
+         |if (!${left.resultTerm}) {
+         |  ${right.code}
+         |  $resultTerm = ${right.resultTerm};
+         |}
         |""".stripMargin
     }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -347,11 +347,11 @@ object ScalarOperators {
     val operatorCode = if (nullCheck) {
       // Three-valued logic:
       // no Unknown -> Two-valued logic
-      // True && Unknown -> True
-      // False && Unknown -> Unknown
-      // Unknown && True -> True
-      // Unknown && False -> Unknown
-      // Unknown && Unknown -> Unknown
+      // True || Unknown -> True
+      // False || Unknown -> Unknown
+      // Unknown || True -> True
+      // Unknown || False -> Unknown
+      // Unknown || Unknown -> Unknown
       s"""
         |${left.code}
         |

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/CalcITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/CalcITCase.scala
@@ -31,7 +31,6 @@ import org.apache.flink.table.expressions.Literal
 import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.test.util.TestBaseUtils
 import org.apache.flink.types.Row
-import org.junit.Assert.assertEquals
 import org.junit._
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/CalcITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/CalcITCase.scala
@@ -217,21 +217,6 @@ class CalcITCase(
   }
 
   @Test
-  def testConjunctivePredicate(): Unit = {
-    val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
-
-    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-
-    val filterDs = ds.filter('a < 15 && 'b > 4)
-    val expected = List(
-      "11,5,Comment#5", "12,5,Comment#6",
-      "13,5,Comment#7", "14,5,Comment#8").mkString("\n")
-    val results = filterDs.collect()
-    TestBaseUtils.compareResultAsText(results.asJava, expected)
-  }
-
-  @Test
   def testConsecutiveFilters(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/CalcITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/CalcITCase.scala
@@ -218,28 +218,6 @@ class CalcITCase(
   }
 
   @Test
-  def testDisjunctivePredicateEarlyOut(): Unit = {
-    val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
-
-    {
-      val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-      val results = ds.filter('a < 100 || shouldNotExecuteFunc('c)).collect()
-      assertEquals(21, results.length)
-    }
-    {
-      val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-      val results = ds.filter('a < 12 || 'b > 4 || shouldNotExecuteFunc('c)).collect()
-      assertEquals(21, results.length)
-    }
-    {
-      val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-      val results = ds.filter(('a < 100 && 'b < 7) || shouldNotExecuteFunc('c)).collect()
-      assertEquals(21, results.length)
-    }
-  }
-
-  @Test
   def testConjunctivePredicate(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
@@ -252,28 +230,6 @@ class CalcITCase(
       "13,5,Comment#7", "14,5,Comment#8").mkString("\n")
     val results = filterDs.collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
-  }
-
-  @Test
-  def testConjunctivePredicateEarlyOut(): Unit = {
-    val env = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env, config)
-
-    {
-      val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-      val results = ds.filter('a > 100 && shouldNotExecuteFunc('c)).collect()
-      assertEquals(0, results.length)
-    }
-    {
-      val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-      val results = ds.filter('a > 10 && 'b < 4 && shouldNotExecuteFunc('c)).collect()
-      assertEquals(0, results.length)
-    }
-    {
-      val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-      val results = ds.filter(('a > 100 || 'b > 10) && shouldNotExecuteFunc('c)).collect()
-      assertEquals(0, results.length)
-    }
   }
 
   @Test
@@ -438,10 +394,4 @@ object HashCode extends ScalarFunction {
 
 object OldHashCode extends ScalarFunction {
   def eval(s: String): Int = -1
-}
-
-object shouldNotExecuteFunc extends ScalarFunction {
-  def eval(s: String): Boolean = {
-    throw new Exception("This func should never be executed")
-  }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/UserDefinedScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/UserDefinedScalarFunctions.scala
@@ -124,6 +124,12 @@ object Func12 extends ScalarFunction {
   }
 }
 
+object ShouldNotExecuteFunc extends ScalarFunction {
+  def eval(s: String): Boolean = {
+    throw new Exception("This func should never be executed")
+  }
+}
+
 class RichFunc0 extends ScalarFunction {
   var openCalled = false
   var closeCalled = false


### PR DESCRIPTION
For condition like a AND b, if the result of a is false, we can save b from execution.

For condition like a OR b, if the result of a is true, we can also save b from execution.