### PR TITLE
[FLINK-5645] Store accumulators/metrics for canceled/failed tasks

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IOMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IOMetrics.java
@@ -54,9 +54,16 @@ public class IOMetrics implements Serializable {
 	}
 
 	public IOMetrics(
-			int numBytesInLocal, int numBytesInRemote, int numBytesOut, int numRecordsIn, int numRecordsOut,
-			double numBytesInLocalPerSecond, double numBytesInRemotePerSecond, double numBytesOutPerSecond,
-			double numRecordsInPerSecond, double numRecordsOutPerSecond) {
+			int numBytesInLocal,
+			int numBytesInRemote,
+			int numBytesOut,
+			int numRecordsIn,
+			int numRecordsOut,
+			double numBytesInLocalPerSecond,
+			double numBytesInRemotePerSecond,
+			double numBytesOutPerSecond,
+			double numRecordsInPerSecond,
+			double numRecordsOutPerSecond) {
 		this.numBytesInLocal = numBytesInLocal;
 		this.numBytesInRemote = numBytesInRemote;
 		this.numBytesOut = numBytesOut;


### PR DESCRIPTION
This PR modified the Execution/ExecutionGraph to store transmitted io-metrics/accumulators for canceled/failed tasks. Previously these were only stored for finished tasks. For other tasks they were simply discarded.