### PR TITLE
[FLINK-5498] [table] Add support for left/right outer joins with non-…

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenUtils.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenUtils.scala
@@ -78,6 +78,10 @@ object CodeGenUtils {
       tpe.getTypeClass.getCanonicalName
   }
 
+  def boxedTypeTermForIterableTypeInfo(tpe: TypeInformation[_]): String = {
+    s"java.util.Iterator<${tpe.getTypeClass.getCanonicalName}>"
+  }
+
   def boxedTypeTermForTypeInfo(tpe: TypeInformation[_]): String = tpe match {
     // From PrimitiveArrayTypeInfo we would get class "int[]", scala reflections
     // does not seem to like this, so we manually give the correct type here.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -420,7 +420,7 @@ class CodeGenerator(
                 //init once
                 if (${iterableInput1Term}.hasNext() && firstCnt==0){
                   needCopy = true;
-                  copy = new java.util.ArrayList<${input2TypeTerm}>();
+                  copy = new java.util.LinkedList<${input2TypeTerm}>();
                 }
                 if(firstCnt > 0){
                   // it1:it2 many to one/many, restart iterator.
@@ -453,7 +453,7 @@ class CodeGenerator(
                 //init once
                 if (${iterableInput2Term}.hasNext() && firstCnt==0){
                   needCopy = true;
-                  copy = new java.util.ArrayList<${input1TypeTerm}>();
+                  copy = new java.util.LinkedList<${input1TypeTerm}>();
                 }
 
                 if(firstCnt > 0){

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.codegen
 import java.math.{BigDecimal => JBigDecimal}
 
 import org.apache.calcite.avatica.util.DateTimeUtils
+import org.apache.calcite.rel.core.JoinRelType
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.SqlOperator
 import org.apache.calcite.sql.`type`.SqlTypeName._
@@ -41,7 +42,7 @@ import org.apache.flink.table.codegen.calls.FunctionGenerator
 import org.apache.flink.table.codegen.calls.ScalarOperators._
 import org.apache.flink.table.functions.{FunctionContext, UserDefinedFunction}
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils
-import org.apache.flink.table.runtime.TableFunctionCollector
+import org.apache.flink.table.runtime.{OuterJoinCoGroupFunction, TableFunctionCollector}
 import org.apache.flink.table.typeutils.TypeCheckUtils._
 import org.apache.flink.types.Row
 
@@ -203,6 +204,16 @@ class CodeGenerator(
   }
 
   /**
+    * @return term of the first iterable input
+    */
+  var iterableInput1Term = "it1"
+
+  /**
+    * @return term of the second iterable input
+    */
+  var iterableInput2Term = "it2"
+
+  /**
     * @return term of the (casted and possibly boxed) first input
     */
   var input1Term = "in1"
@@ -333,6 +344,188 @@ class CodeGenerator(
   }
 
   /**
+    * Generates a concrete [[org.apache.flink.table.runtime.OuterJoinCoGroupFunction]]
+    * processing Iterable inputs and can be passed to Java compiler.
+    * [[CodeGenerator.generateFunction]] is only suitable for those functions which process one or
+    * two input Object(s), so create the new method. This method is not a general use case for
+    * CoGroupFunction generating because it aims to solve outer joins with non-equi conditions.
+    *
+    * It should be noted that current implementation is not memory safe when do a many-to-one outer
+    * join which will copy the opposite side input into an ArrayList buffer. It's a work-around for
+    * now due to the backend limitation of shared iterator instance.
+    *
+    * @param name Class name of the Function. Must not be unique but has to be a valid Java class
+    *             identifier.
+    * @param joinType
+    * @param nonEquiCondition
+    * @param conversion
+    * @param conversionWithNull
+    * @param input1Type
+    * @param input2Type
+    * @param clazz Flink Function to be generated.
+    * @param returnType expected return type
+    * @tparam F Flink Function to be generated.
+    * @tparam T Return type of the Flink Function.
+    * @return instance of GeneratedFunction
+    */
+  def generateOuterJoinCoGroupFunction[F <: Function, T <: Any](
+      name: String,
+      joinType: JoinRelType,
+      nonEquiCondition: GeneratedExpression,
+      conversion: GeneratedExpression,
+      conversionWithNull: GeneratedExpression,
+      input1Type: TypeInformation[T],
+      input2Type: TypeInformation[T],
+      clazz: Class[F],
+      returnType: TypeInformation[T])
+  : GeneratedFunction[F, T] = {
+    if (joinType == JoinRelType.FULL){
+      throw new CodeGenException("Unsupported JoinType.")
+    }
+    if (clazz != classOf[OuterJoinCoGroupFunction[_, _, _]]) {
+      throw new CodeGenException("Unsupported Function.")
+    }
+    val funcName = newName(name)
+    val input1TypeTerm = CodeGenUtils.boxedTypeTermForTypeInfo(input1Type)
+    val input2TypeTerm = CodeGenUtils.boxedTypeTermForTypeInfo(input2Type)
+
+    val iterableInputTypeTerm1 = boxedTypeTermForIterableTypeInfo(input1)
+    val iterableInputTypeTerm2 = boxedTypeTermForIterableTypeInfo(
+      input2.getOrElse(
+        throw new CodeGenException("Input 2 for OuterJoinCoGroupFunction should not be null")))
+
+    // Janino does not support generics, that's why we need manual casting here
+    val samHeader = (s"void coGroup(Iterable _it1, Iterable _it2, org.apache.flink.util.Collector" +
+      s" $collectorTerm)",
+      List(
+        s"$iterableInputTypeTerm1 $iterableInput1Term = ($iterableInputTypeTerm1) _it1.iterator();",
+        s"$iterableInputTypeTerm2 $iterableInput2Term = ($iterableInputTypeTerm2) _it2.iterator();"
+      ),
+      List(
+        s"${input1TypeTerm} ${input1Term} = null;",
+        s"${input2TypeTerm} ${input2Term} = null;"
+      )
+    )
+
+    val partialIterationCodeBlock = if(joinType == JoinRelType.LEFT) {
+      j"""
+            if (null != ${iterableInput1Term}) {
+              long firstCnt = 0;
+              boolean needCopy = false;
+              java.util.List<${input2TypeTerm}> copy = null;
+              while(${iterableInput1Term}.hasNext()){
+                boolean matched = false;
+                ${input1Term} = (${input1TypeTerm})${iterableInput1Term}.next();
+
+                //init once
+                if (${iterableInput1Term}.hasNext() && firstCnt==0){
+                  needCopy = true;
+                  copy = new java.util.ArrayList<${input2TypeTerm}>();
+                }
+                if(firstCnt > 0){
+                  // it1:it2 many to one/many, restart iterator.
+                  // the backend Iterator do not supply a new instance but reseek is required here,
+                  // so replace the iterator into that from the copied list
+                  $iterableInput2Term = copy.iterator();
+
+                  // currently could not use the way below though it looks more pretty against
+                  // copied list
+                  //$iterableInput2Term = ($iterableInputTypeTerm2) _it2.iterator();
+                }
+
+                if (null != ${iterableInput2Term}) {
+                  while(${iterableInput2Term}.hasNext()){
+                    ${input2Term} = (${input2TypeTerm})${iterableInput2Term}.next();
+                    if(needCopy){
+                      copy.add(${input2Term});
+                    }
+        """.stripMargin
+    } else { // joinType == JoinRelType.RIGHT
+      j"""
+            if (null != ${iterableInput2Term}) {
+              long firstCnt = 0;
+              boolean needCopy = false;
+              java.util.List<${input1TypeTerm}> copy = null;
+              while(${iterableInput2Term}.hasNext()){
+                boolean matched = false;
+                ${input2Term} = (${input2TypeTerm})${iterableInput2Term}.next();
+
+                //init once
+                if (${iterableInput2Term}.hasNext() && firstCnt==0){
+                  needCopy = true;
+                  copy = new java.util.ArrayList<${input1TypeTerm}>();
+                }
+
+                if(firstCnt > 0){
+                  // it2:it1 many to one/many, restart iterator
+                  // the backend Iterator do not supply a new instance but reseek is required here,
+                  // so replace the iterator into that from the copied list
+                  $iterableInput1Term = copy.iterator();
+                  // currently could not use the way below though it looks more pretty against
+                  // copied list
+                  //$iterableInput1Term = ($iterableInputTypeTerm1) _it1.iterator();
+                }
+                if (null != ${iterableInput1Term}) {
+                  while(${iterableInput1Term}.hasNext()){
+                    ${input1Term} = (${input1TypeTerm})${iterableInput1Term}.next();
+                    if(needCopy){
+                      copy.add(${input1Term});
+                    }
+      """.stripMargin
+    }
+
+    // reuseInputUnboxingCode must duplicate now in inner 'while' and '!matched' code block
+    val funcCode =
+      j"""
+        public class $funcName
+            implements ${clazz.getCanonicalName} {
+
+          ${reuseMemberCode()}
+
+          public $funcName() throws Exception {
+            ${reuseInitCode()}
+          }
+
+          ${reuseConstructorCode(funcName)}
+
+          @Override
+          public ${samHeader._1} throws Exception {
+            ${samHeader._2.mkString("\n")}
+            ${samHeader._3.mkString("\n")}
+
+            ${partialIterationCodeBlock}
+
+                    ${reusePerRecordCode()}
+                    ${reuseInputUnboxingCode()}
+                    ${nonEquiCondition.code}
+                    if (${nonEquiCondition.resultTerm}) {
+                      ${conversion.code}
+                      matched = true;
+                      ${collectorTerm}.collect(${conversion.resultTerm});
+                    }
+                  } // end-while
+
+                  needCopy = false;// copy once
+                } // end-if
+
+                firstCnt++;
+
+                if (!matched) {
+                  ${reusePerRecordCode()}
+                  ${reuseInputUnboxingCode()}
+                  ${conversionWithNull.code}
+                  ${collectorTerm}.collect(${conversionWithNull.resultTerm});
+                } // end-if
+              } // end-while
+            } // end-if
+          } // end-method
+        } // end-class
+      """.stripMargin
+
+    GeneratedFunction(funcName, returnType, funcCode)
+  }
+
+  /**
     * Generates a values input format that can be passed to Java compiler.
     *
     * @param name Class name of the input format. Must not be unique but has to be a
@@ -457,6 +650,49 @@ class CodeGenerator(
     }
 
     generateResultExpression(input1AccessExprs ++ input2AccessExprs, returnType, resultFieldNames)
+  }
+
+  /**
+    * Similar to function [[CodeGenerator.generateConverterResultExpression]], difference is this
+    * function satisfy to that one input is null when generating result expression.
+    *
+    * @param returnType conversion target type. Inputs and output must have the same arity.
+    * @param resultFieldNames result field names necessary for a mapping to POJO fields.
+    * @param isNullFromLeft input1 is null if true, otherwise input2 is null
+    * @return
+    */
+  def generateConverterResultWithOneSideNullExpression(
+      returnType: TypeInformation[_ <: Any],
+      resultFieldNames: Seq[String],
+      isNullFromLeft: Boolean)
+    : GeneratedExpression = {
+
+    val input1AccessExprs = for (i <- 0 until input1.getArity)
+      yield if (isNullFromLeft) {
+        generateNullInputFieldAccess(input1, input1Term, i, input1PojoFieldMapping)
+      } else {
+        generateInputAccess(input1, input1Term, i, input1PojoFieldMapping)
+      }
+
+    val input2AccessExprs = input2 match {
+      case Some(ti) => for (i <- 0 until ti.getArity)
+        yield if (!isNullFromLeft) {
+          generateNullInputFieldAccess(ti, input2Term, i, input2PojoFieldMapping)
+        } else {
+          generateInputAccess(ti, input2Term, i, input2PojoFieldMapping)
+        }
+      case None => Seq() // add nothing
+    }
+
+    generateResultExpression(input1AccessExprs ++ input2AccessExprs, returnType, resultFieldNames)
+  }
+
+  def generateInput2NotNullExpression(): String = {
+    s"$input2Term != null"
+  }
+
+  def generateInput1NotNullExpression(): String = {
+    s"$input1Term != null"
   }
 
   /**
@@ -1201,6 +1437,39 @@ class CodeGenerator(
         |  $nullTerm = ${fieldAccessExpr.nullTerm};
         |}
         |""".stripMargin
+
+    GeneratedExpression(resultTerm, nullTerm, inputCheckCode, fieldType)
+  }
+
+  private def generateNullInputFieldAccess(
+      inputType: TypeInformation[_ <: Any],
+      inputTerm: String,
+      index: Int,
+      pojoFieldMapping: Option[Array[Int]])
+    : GeneratedExpression = {
+    val resultTerm = newName("result")
+    val nullTerm = newName("isNull")
+
+    val fieldType = inputType match {
+      case ct: CompositeType[_] =>
+        val fieldIndex = if (ct.isInstanceOf[PojoTypeInfo[_]]) {
+          pojoFieldMapping.get(index)
+        }
+        else {
+          index
+        }
+        ct.getTypeAt(fieldIndex)
+      case at: AtomicType[_] => at
+      case _ => throw new CodeGenException("Unsupported type for input field access.")
+    }
+    val resultTypeTerm = primitiveTypeTermForTypeInfo(fieldType)
+    val defaultValue = primitiveDefaultValue(fieldType)
+
+    val inputCheckCode =
+      s"""
+         |$resultTypeTerm $resultTerm = $defaultValue;
+         |boolean $nullTerm = true;
+         |""".stripMargin
 
     GeneratedExpression(resultTerm, nullTerm, inputCheckCode, fieldType)
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/logical/operators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/logical/operators.scala
@@ -502,10 +502,11 @@ case class Join(
         s"Invalid join condition: $expression. At least one equi-join predicate is " +
           s"required.")
     }
-    if (joinType != JoinType.INNER && (nonEquiJoinPredicateFound || localPredicateFound)) {
+    if (joinType != JoinType.INNER &&
+      ((localPredicateFound || nonEquiJoinPredicateFound ) && joinType == JoinType.FULL_OUTER)) {
       failValidation(
-        s"Invalid join condition: $expression. Non-equality join predicates or local" +
-          s" predicates are not supported in outer joins.")
+        s"Invalid join condition: $expression. Non-equi-join or local predicates are not " +
+          s"supported in full outer joins.")
     }
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/logical/operators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/logical/operators.scala
@@ -502,8 +502,7 @@ case class Join(
         s"Invalid join condition: $expression. At least one equi-join predicate is " +
           s"required.")
     }
-    if (joinType != JoinType.INNER &&
-      ((localPredicateFound || nonEquiJoinPredicateFound ) && joinType == JoinType.FULL_OUTER)) {
+    if ((localPredicateFound || nonEquiJoinPredicateFound) && joinType == JoinType.FULL_OUTER) {
       failValidation(
         s"Invalid join condition: $expression. Non-equi-join or local predicates are not " +
           s"supported in full outer joins.")

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetJoin.scala
@@ -194,15 +194,15 @@ class DataSetJoin(
       }
 
       val genFunction = generator.generateFunction(
-      ruleDescription,
-      classOf[FlatJoinFunction[Row, Row, Row]],
-      body,
-      returnType)
+        ruleDescription,
+        classOf[FlatJoinFunction[Row, Row, Row]],
+        body,
+        returnType)
 
       val joinFun = new FlatJoinRunner[Row, Row, Row](
-      genFunction.name,
-      genFunction.code,
-      genFunction.returnType)
+        genFunction.name,
+        genFunction.code,
+        genFunction.returnType)
 
       joinOperator
         .where(leftKeys.toArray: _*)
@@ -213,14 +213,14 @@ class DataSetJoin(
     } else {
       val conversionWithNull = if (joinType == JoinRelType.LEFT) {
         generator.generateConverterResultWithOneSideNullExpression(
-        returnType,
-        joinRowType.getFieldNames,
-        false)
-      }else {
+          returnType,
+          joinRowType.getFieldNames,
+          false)
+      } else {
         generator.generateConverterResultWithOneSideNullExpression(
-        returnType,
-        joinRowType.getFieldNames,
-        true)
+          returnType,
+          joinRowType.getFieldNames,
+          true)
       }
 
       val genFunction = generator.generateOuterJoinCoGroupFunction(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetJoinRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetJoinRule.scala
@@ -36,12 +36,12 @@ class DataSetJoinRule
 
   override def matches(call: RelOptRuleCall): Boolean = {
     val join: LogicalJoin = call.rel(0).asInstanceOf[LogicalJoin]
-
     val joinInfo = join.analyzeCondition
 
-    // joins require an equi-condition or a conjunctive predicate with at least one equi-condition
-    // and disable outer joins with non-equality predicates(see FLINK-5520)
-    !joinInfo.pairs().isEmpty && (joinInfo.isEqui || join.getJoinType == JoinRelType.INNER)
+    // joins require at least one equi-condition, and currently not support full outer joins with
+    // non-equi-join or local predicates.
+    !joinInfo.pairs().isEmpty &&
+      (joinInfo.isEqui || (!joinInfo.isEqui && join.getJoinType != JoinRelType.FULL))
   }
 
   override def convert(rel: RelNode): RelNode = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/OuterJoinCoGroupFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/OuterJoinCoGroupFunction.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime
+
+import org.apache.flink.api.common.functions.CoGroupFunction
+
+/**
+  * This is a mark interface for outer joins with non-equi join predicates based on coGroup
+  * operation.
+  */
+trait OuterJoinCoGroupFunction[IN1, IN2, OUT] extends CoGroupFunction[IN1, IN2, OUT] {
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/OuterJoinCoGroupRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/OuterJoinCoGroupRunner.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime
+
+import java.lang.Iterable
+
+import org.apache.flink.api.common.functions.RichCoGroupFunction
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.table.codegen.Compiler
+import org.apache.flink.util.Collector
+import org.slf4j.LoggerFactory
+
+class OuterJoinCoGroupRunner[IN1, IN2, OUT](
+    name: String,
+    code: String,
+    @transient returnType: TypeInformation[OUT])
+  extends RichCoGroupFunction[IN1, IN2, OUT]
+          with ResultTypeQueryable[OUT]
+          with Compiler[OuterJoinCoGroupFunction[IN1, IN2, OUT]] {
+
+  val LOG = LoggerFactory.getLogger(this.getClass)
+
+  private var function: OuterJoinCoGroupFunction[IN1, IN2, OUT] = null
+
+  override def open(parameters: Configuration): Unit = {
+    LOG.debug(s"Compiling FlatJoinFunction: $name \n\n Code:\n$code")
+    val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
+    LOG.debug("Instantiating FlatJoinFunction.")
+    function = clazz.newInstance()
+  }
+
+  override def coGroup(
+      first: Iterable[IN1],
+      second: Iterable[IN2],
+      out: Collector[OUT]): Unit = {
+    function.coGroup(first, second, out)
+  }
+
+  override def getProducedType: TypeInformation[OUT] = returnType
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/sql/JoinITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/sql/JoinITCase.scala
@@ -375,7 +375,7 @@ class JoinITCase(
     Assert.assertEquals(0, result)
   }
 
-  @Test(expected = classOf[TableException])
+  @Test
   def testRightOuterJoinWithNonEquiJoinPredicate(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
@@ -384,15 +384,25 @@ class JoinITCase(
 
     val sqlQuery = "SELECT c, g FROM Table3 RIGHT OUTER JOIN Table5 ON b = e and a > d"
 
-    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
-    tEnv.sql(sqlQuery).toDataSet[Row].collect()
+    val expected = "null,Hallo\n" + "Hello world,Hallo Welt\n" +
+      "Hello world, how are you?,Hallo Welt wie\n" + "I am fine.,Hallo Welt wie\n" +
+      "Luke Skywalker,Hallo Welt wie\n" + "Comment#1,Hallo Welt wie gehts?\n" +
+      "Comment#2,Hallo Welt wie gehts?\n" + "Comment#3,Hallo Welt wie gehts?\n" +
+      "Comment#4,Hallo Welt wie gehts?\n" + "Comment#5,ABC\n" + "Comment#6,ABC\n" +
+      "Comment#7,ABC\n" + "Comment#8,ABC\n" + "Comment#9,ABC\n" + "Comment#10,BCD\n" +
+      "Comment#11,BCD\n" + "Comment#12,BCD\n" + "Comment#13,BCD\n" + "Comment#14,BCD\n" +
+      "Comment#15,BCD\n" + "null,CDE\n" + "null,DEF\n" + "null,EFG\n" + "null,FGH\n" +
+      "null,GHI\n" + "null,HIJ\n" + "null,IJK\n" + "null,JKL\n" + "null,KLM\n"
+    val results = tEnv.sql(sqlQuery).toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
-  @Test(expected = classOf[TableException])
+  @Test
   def testLeftOuterJoinWithNonEquiJoinPredicate(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
@@ -401,12 +411,21 @@ class JoinITCase(
 
     val sqlQuery = "SELECT c, g FROM Table3 LEFT OUTER JOIN Table5 ON b = e and a > d"
 
-    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
-    tEnv.sql(sqlQuery).toDataSet[Row].collect()
+    val expected = "Hi,null\n" + "Hello,null\n" + "Hello world,Hallo Welt\n" +
+      "Hello world, how are you?,Hallo Welt wie\n" + "I am fine.,Hallo Welt wie\n" +
+      "Luke Skywalker,Hallo Welt wie\n" + "Comment#1,Hallo Welt wie gehts?\n" +
+      "Comment#2,Hallo Welt wie gehts?\n" + "Comment#3,Hallo Welt wie gehts?\n" +
+      "Comment#4,Hallo Welt wie gehts?\n" + "Comment#5,ABC\n" + "Comment#6,ABC\n" +
+      "Comment#7,ABC\n" + "Comment#8,ABC\n" + "Comment#9,ABC\n" + "Comment#10,BCD\n" +
+      "Comment#11,BCD\n" + "Comment#12,BCD\n" + "Comment#13,BCD\n" + "Comment#14,BCD\n" +
+      "Comment#15,BCD\n"
+    val results = tEnv.sql(sqlQuery).toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
   @Test(expected = classOf[TableException])
@@ -426,7 +445,7 @@ class JoinITCase(
     tEnv.sql(sqlQuery).toDataSet[Row].collect()
   }
 
-  @Test(expected = classOf[TableException])
+  @Test
   def testRightOuterJoinWithLocalPredicate(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
@@ -435,15 +454,24 @@ class JoinITCase(
 
     val sqlQuery = "SELECT c, g FROM Table3 RIGHT OUTER JOIN Table5 ON b = e and e > 3"
 
-    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
-    tEnv.sql(sqlQuery).toDataSet[Row].collect()
+    val expected = "null,Hallo\n" + "null,Hallo Welt\n" + "null,Hallo Welt wie\n" +
+      "Comment#1,Hallo Welt wie gehts?\n" + "Comment#2,Hallo Welt wie gehts?\n" +
+      "Comment#3,Hallo Welt wie gehts?\n" + "Comment#4,Hallo Welt wie gehts?\n" +
+      "Comment#5,ABC\n" + "Comment#6,ABC\n" + "Comment#7,ABC\n" + "Comment#8,ABC\n" +
+      "Comment#9,ABC\n" + "Comment#10,BCD\n" + "Comment#11,BCD\n" + "Comment#12,BCD\n" +
+      "Comment#13,BCD\n" + "Comment#14,BCD\n" + "Comment#15,BCD\n" + "null,CDE\n" + "null,DEF\n" +
+      "null,EFG\n" + "null,FGH\n" + "null,GHI\n" + "null,HIJ\n" + "null,IJK\n" + "null,JKL\n" +
+      "null,KLM\n"
+    val results = tEnv.sql(sqlQuery).toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
-  @Test(expected = classOf[TableException])
+  @Test
   def testLeftOuterJoinWithLocalPredicate(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
@@ -452,12 +480,20 @@ class JoinITCase(
 
     val sqlQuery = "SELECT c, g FROM Table3 LEFT OUTER JOIN Table5 ON b = e and b > 3"
 
-    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
-    tEnv.sql(sqlQuery).toDataSet[Row].collect()
+    val expected = "Hi,null\n" + "Hello,null\n" + "Hello world,null\n" +
+      "Hello world, how are you?,null\n" + "I am fine.,null\n" + "Luke Skywalker,null\n" +
+      "Comment#1,Hallo Welt wie gehts?\n" + "Comment#2,Hallo Welt wie gehts?\n" +
+      "Comment#3,Hallo Welt wie gehts?\n" + "Comment#4,Hallo Welt wie gehts?\n" +
+      "Comment#5,ABC\n" + "Comment#6,ABC\n" + "Comment#7,ABC\n" + "Comment#8,ABC\n" +
+      "Comment#9,ABC\n" + "Comment#10,BCD\n" + "Comment#11,BCD\n" + "Comment#12,BCD\n" +
+      "Comment#13,BCD\n" + "Comment#14,BCD\n" + "Comment#15,BCD\n"
+    val results = tEnv.sql(sqlQuery).toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
   @Test(expected = classOf[TableException])

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/JoinITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/JoinITCase.scala
@@ -249,7 +249,7 @@ class JoinITCase(
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
-  @Test(expected = classOf[ValidationException])
+  @Test
   def testLeftJoinWithNonEquiJoinPredicate(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
@@ -258,7 +258,16 @@ class JoinITCase(
     val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
 
-    ds1.leftOuterJoin(ds2, 'a === 'd && 'b < 'h).select('c, 'g).toDataSet[Row].collect()
+    val results = ds1.leftOuterJoin(ds2, 'a === 'd && 'b < 'h).select('c, 'g).toDataSet[Row]
+      .collect()
+
+    val expected = "Hi,null\n" + "Hello,null\n" + "Hello world,BCD\n" +
+      "Hello world, how are you?,null\n" + "I am fine.,null\n" + "Luke Skywalker,null\n" +
+      "Comment#1,null\n" + "Comment#2,null\n" + "Comment#3,null\n" + "Comment#4,null\n" +
+      "Comment#5,null\n" + "Comment#6,null\n" + "Comment#7,null\n" + "Comment#8,null\n" +
+      "Comment#9,null\n" + "Comment#10,null\n" + "Comment#11,null\n" + "Comment#12,null\n" +
+      "Comment#13,null\n" + "Comment#14,null\n" + "Comment#15,null\n"
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
   @Test(expected = classOf[ValidationException])
@@ -273,7 +282,7 @@ class JoinITCase(
     ds1.fullOuterJoin(ds2, 'a === 'd && 'b < 'h).select('c, 'g).toDataSet[Row].collect()
   }
 
-  @Test(expected = classOf[ValidationException])
+  @Test
   def testRightJoinWithNonEquiJoinPredicate(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
@@ -282,10 +291,18 @@ class JoinITCase(
     val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
 
-    ds1.rightOuterJoin(ds2, 'a === 'd && 'b < 'h).select('c, 'g).toDataSet[Row].collect()
+    val results = ds1.rightOuterJoin(ds2, 'a === 'd && 'b < 'h).select('c, 'g).toDataSet[Row]
+      .collect()
+
+    val expected = "null,Hallo\n" + "null,Hallo Welt\n" + "null,Hallo Welt wie\n" +
+      "null,Hallo Welt wie gehts?\n" + "null,ABC\n" + "Hello world,BCD\n" + "null,CDE\n" +
+      "null,DEF\n" + "null,EFG\n" + "null,FGH\n" + "null,GHI\n" + "null,HIJ\n" + "null,IJK\n" +
+      "null,JKL\n" + "null,KLM\n"
+
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
-  @Test(expected = classOf[ValidationException])
+  @Test
   def testLeftJoinWithLocalPredicate(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
@@ -293,8 +310,17 @@ class JoinITCase(
 
     val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val results = ds1.leftOuterJoin(ds2, 'a === 'd && 'b < 3).select('c, 'g).toDataSet[Row]
+      .collect()
 
-    ds1.leftOuterJoin(ds2, 'a === 'd && 'b < 3).select('c, 'g).toDataSet[Row].collect()
+    val expected = "Hi,Hallo\n" + "Hello,Hallo Welt\n" + "Hello,Hallo Welt wie\n" +
+      "Hello world,Hallo Welt wie gehts?\n" + "Hello world,ABC\n" + "Hello world,BCD\n" +
+      "Hello world, how are you?,null\n" + "I am fine.,null\n" + "Luke Skywalker,null\n" +
+      "Comment#1,null\n" + "Comment#2,null\n" + "Comment#3,null\n" + "Comment#4,null\n" +
+      "Comment#5,null\n" + "Comment#6,null\n" + "Comment#7,null\n" + "Comment#8,null\n" +
+      "Comment#9,null\n" + "Comment#10,null\n" + "Comment#11,null\n" + "Comment#12,null\n" +
+      "Comment#13,null\n" + "Comment#14,null\n" + "Comment#15,null\n"
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
   @Test(expected = classOf[ValidationException])
@@ -309,7 +335,7 @@ class JoinITCase(
     ds1.fullOuterJoin(ds2, 'a === 'd && 'b < 3).select('c, 'g).toDataSet[Row].collect()
   }
 
-  @Test(expected = classOf[ValidationException])
+  @Test
   def testRightJoinWithLocalPredicate(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
@@ -318,7 +344,13 @@ class JoinITCase(
     val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
 
-    ds1.rightOuterJoin(ds2, 'a === 'd && 'b < 3).select('c, 'g).toDataSet[Row].collect()
+    val results = ds1.rightOuterJoin(ds2, 'a === 'd && 'b < 3).select('c, 'g).toDataSet[Row]
+      .collect()
+    val expected = "Hi,Hallo\n" + "Hello,Hallo Welt\n" + "Hello,Hallo Welt wie\n" +
+      "Hello world,Hallo Welt wie gehts?\n" + "Hello world,ABC\n" + "Hello world,BCD\n" +
+      "null,CDE\n" + "null,DEF\n" + "null,EFG\n" + "null,FGH\n" + "null,GHI\n" + "null,HIJ\n" +
+      "null,IJK\n" + "null,JKL\n" + "null,KLM\n"
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
   @Test

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/validation/JoinValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/validation/JoinValidationTest.scala
@@ -110,18 +110,6 @@ class JoinValidationTest {
   }
 
   @Test(expected = classOf[ValidationException])
-  def testNoJoinCondition(): Unit = {
-    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
-    tEnv.getConfig.setNullCheck(true)
-
-    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
-
-    ds2.leftOuterJoin(ds1, 'b === 'd && 'b < 3).select('c, 'g)
-  }
-
-  @Test(expected = classOf[ValidationException])
   def testNoEquiJoin(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)


### PR DESCRIPTION
…equality predicates (and 1+ equality predicates)

Support left/right outer joins with non-equi-join conditions via coGroup operator with a generated OuterJoinCoGroupFunction.
It should be noted that current implementation is not memory safe when do a many-to-one outer
join which will copy the opposite side input into an LinkList buffer. It's a work-around for now due to the backend limitation of shared iterator instance.
In the long run, I think we should extend the runtime join operators to support such more join conditions. 
