### PR TITLE
[FLINK-5865][state] Throw original exception in the states

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -71,7 +71,7 @@ public class RocksDBValueState<K, N, V>
 	}
 
 	@Override
-	public V value() {
+	public V value() throws IOException {
 		try {
 			writeCurrentKeyWithGroupAndNamespace();
 			byte[] key = keySerializationStream.toByteArray();
@@ -80,8 +80,8 @@ public class RocksDBValueState<K, N, V>
 				return stateDesc.getDefaultValue();
 			}
 			return valueSerializer.deserialize(new DataInputViewStreamWrapper(new ByteArrayInputStream(valueBytes)));
-		} catch (IOException|RocksDBException e) {
-			throw new RuntimeException("Error while retrieving data from RocksDB.", e);
+		} catch (RocksDBException e) {
+			throw new IOException("Error while retrieving data from RocksDB.", e);
 		}
 	}
 
@@ -98,8 +98,8 @@ public class RocksDBValueState<K, N, V>
 			keySerializationStream.reset();
 			valueSerializer.serialize(value, out);
 			backend.db.put(columnFamily, writeOptions, key, keySerializationStream.toByteArray());
-		} catch (Exception e) {
-			throw new RuntimeException("Error while adding data to RocksDB", e);
+		} catch (RocksDBException e) {
+			throw new IOException("Error while adding data to RocksDB", e);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapState.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.util.Preconditions;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -133,7 +134,7 @@ public abstract class AbstractHeapState<K, N, SV, S extends State, SD extends St
 		return getSerializedValue(keyAndNamespace.f0, keyAndNamespace.f1);
 	}
 
-	public byte[] getSerializedValue(K key, N namespace) throws Exception {
+	public byte[] getSerializedValue(K key, N namespace) throws IOException {
 		Preconditions.checkState(namespace != null, "No namespace given.");
 		Preconditions.checkState(key != null, "No key given.");
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.internal.InternalFoldingState;
 import org.apache.flink.util.Preconditions;
 
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -89,7 +88,7 @@ public class HeapFoldingState<K, N, T, ACC>
 	}
 
 	@Override
-	public void add(T value) throws IOException {
+	public void add(T value) throws Exception {
 		Preconditions.checkState(currentNamespace != null, "No namespace set.");
 		Preconditions.checkState(backend.getCurrentKey() != null, "No key set.");
 
@@ -115,16 +114,11 @@ public class HeapFoldingState<K, N, T, ACC>
 
 		ACC currentValue = keyedMap.get(backend.<K>getCurrentKey());
 
-		try {
-
-			if (currentValue == null) {
-				keyedMap.put(backend.<K>getCurrentKey(),
-						foldFunction.fold(stateDesc.getDefaultValue(), value));
-			} else {
-				keyedMap.put(backend.<K>getCurrentKey(), foldFunction.fold(currentValue, value));
-			}
-		} catch (Exception e) {
-			throw new RuntimeException("Could not add value to folding state.", e);
+		if (currentValue == null) {
+			keyedMap.put(backend.<K>getCurrentKey(),
+					foldFunction.fold(stateDesc.getDefaultValue(), value));
+		} else {
+			keyedMap.put(backend.<K>getCurrentKey(), foldFunction.fold(currentValue, value));
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.util.Preconditions;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -120,7 +121,7 @@ public class HeapListState<K, N, V>
 	}
 
 	@Override
-	public byte[] getSerializedValue(K key, N namespace) throws Exception {
+	public byte[] getSerializedValue(K key, N namespace) throws IOException {
 		Preconditions.checkState(namespace != null, "No namespace given.");
 		Preconditions.checkState(key != null, "No key given.");
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.internal.InternalReducingState;
 import org.apache.flink.util.Preconditions;
 
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -88,7 +87,7 @@ public class HeapReducingState<K, N, V>
 	}
 
 	@Override
-	public void add(V value) throws IOException {
+	public void add(V value) throws Exception {
 		Preconditions.checkState(currentNamespace != null, "No namespace set.");
 		Preconditions.checkState(backend.getCurrentKey() != null, "No key set.");
 
@@ -117,12 +116,8 @@ public class HeapReducingState<K, N, V>
 		if (currentValue == null) {
 			// we're good, just added the new value
 		} else {
-			V reducedValue;
-			try {
-				reducedValue = reduceFunction.reduce(currentValue, value);
-			} catch (Exception e) {
-				throw new IOException("Exception while applying ReduceFunction in reducing state", e);
-			}
+			V reducedValue = reduceFunction.reduce(currentValue, value);
+
 			keyedMap.put(backend.<K>getCurrentKey(), reducedValue);
 		}
 	}


### PR DESCRIPTION
The wrapping of `RuntimeException` is removed so that we can avoid redundant stack printed in the log.