### PR TITLE
[FLINK-5871] [cep] Enforce uniqueness of pattern names in CEP.

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/MalformedPatternException.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/MalformedPatternException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep.nfa.compiler;
+
+/**
+ * An exception used to indicate that a {@link org.apache.flink.cep.pattern.Pattern}
+ * was not specified correctly.
+ */
+public class MalformedPatternException extends RuntimeException {
+
+	private static final long serialVersionUID = 7751134834983361543L;
+
+	public MalformedPatternException(String message) {
+		super(message);
+	}
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Compiler class containing methods to compile a {@link Pattern} into a {@link NFA} or a
@@ -84,12 +85,16 @@ public class NFACompiler {
 			Map<String, State<T>> states = new HashMap<>();
 			long windowTime;
 
+			// this is used to enforse pattern name uniqueness.
+			Set<String> patternNames = new HashSet<>();
+
 			Pattern<T, ?> succeedingPattern;
 			State<T> succeedingState;
 			Pattern<T, ?> currentPattern = pattern;
 
 			// we're traversing the pattern from the end to the beginning --> the first state is the final state
 			State<T> currentState = new State<>(currentPattern.getName(), State.StateType.Final);
+			patternNames.add(currentPattern.getName());
 
 			states.put(currentPattern.getName(), currentState);
 
@@ -99,6 +104,11 @@ public class NFACompiler {
 				succeedingPattern = currentPattern;
 				succeedingState = currentState;
 				currentPattern = currentPattern.getPrevious();
+
+				if (!patternNames.add(currentPattern.getName())) {
+					throw new MalformedPatternException("Duplicate pattern name: " + currentPattern.getName() + ". " +
+						"Pattern names must be unique.");
+				}
 
 				Time currentWindowTime = currentPattern.getWindowTime();
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/Pattern.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/Pattern.java
@@ -93,7 +93,7 @@ public class Pattern<T, F extends T> {
 	}
 
 	/**
-	 * Specifies a filter condition which is ORed with an existing filter function.
+	 * Specifies a filter condition which is OR'ed with an existing filter function.
 	 *
 	 * @param orFilterFunction OR filter condition
 	 * @return The same pattern operator where the new filter condition is set


### PR DESCRIPTION
Description of the problem can be found in the related JIRA:

https://issues.apache.org/jira/browse/FLINK-5871