### PR TITLE
[FLINK-5501] JM use running job registry to determine whether is the first running

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FsNegativeRunningJobsRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FsNegativeRunningJobsRegistry.java
@@ -30,14 +30,19 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * This {@link RunningJobsRegistry} tracks the status jobs via marker files,
- * marking finished jobs via marker files.
+ * marking running jobs via running marker files,
+ * marking finished jobs via finished marker files.
  * 
  * <p>The general contract is the following:
  * <ul>
  *     <li>Initially, a marker file does not exist (no one created it, yet), which means
- *         the specific job is assumed to be running</li>
+ *         the specific job is pending</li>
+ *     <li>The first JobManager that granted leadership calls this service to create the running marker file,
+ *         which marks the job as running.</li>
  *     <li>The JobManager that finishes calls this service to create the marker file,
  *         which marks the job as finished.</li>
+ *     <li>If a JobManager gains leadership but see the running marker file,
+ *         it will realize that the job has been scheduled and need reconciling.</li>
  *     <li>If a JobManager gains leadership at some point when shutdown is in progress,
  *         it will see the marker file and realize that the job is finished.</li>
  *     <li>The application framework is expected to clean the file once the application
@@ -52,7 +57,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class FsNegativeRunningJobsRegistry implements RunningJobsRegistry {
 
-	private static final String PREFIX = ".job_complete_";
+	private static final String DONE_PREFIX = ".job_complete_";
+
+	private static final String RUNNING_PREFIX = ".job_runing_";
 
 	private final FileSystem fileSystem;
 
@@ -108,21 +115,19 @@ public class FsNegativeRunningJobsRegistry implements RunningJobsRegistry {
 	@Override
 	public void setJobRunning(JobID jobID) throws IOException {
 		checkNotNull(jobID, "jobID");
-		final Path filePath = createMarkerFilePath(jobID);
+		final Path filePath = createMarkerFilePath(RUNNING_PREFIX, jobID);
 
-		// delete the marker file, if it exists
-		try {
-			fileSystem.delete(filePath, false);
-		}
-		catch (FileNotFoundException e) {
-			// apparently job was already considered running
+		// create the file
+		// to avoid an exception if the job already exists, set overwrite=true
+		try (FSDataOutputStream out = fileSystem.create(filePath, true)) {
+			out.write(42);
 		}
 	}
 
 	@Override
 	public void setJobFinished(JobID jobID) throws IOException {
 		checkNotNull(jobID, "jobID");
-		final Path filePath = createMarkerFilePath(jobID);
+		final Path filePath = createMarkerFilePath(DONE_PREFIX, jobID);
 
 		// create the file
 		// to avoid an exception if the job already exists, set overwrite=true
@@ -137,47 +142,64 @@ public class FsNegativeRunningJobsRegistry implements RunningJobsRegistry {
 
 		// check for the existence of the file
 		try {
-			fileSystem.getFileStatus(createMarkerFilePath(jobID));
-			// file was found --> job is terminated
-			return false;
+			fileSystem.getFileStatus(createMarkerFilePath(RUNNING_PREFIX, jobID));
+			// file was found --> job is running
+			return true;
 		}
 		catch (FileNotFoundException e) {
-			// file does not exist, job is still running
-			return true;
+			// file does not exist, job is not running
+			return false;
 		}
 	}
 
 	@Override
-	public boolean isJobFinished(JobID jobID) throws IOException {
+	public JobSchedulingStatus getJobSchedulingStatus(JobID jobID) throws IOException {
 		checkNotNull(jobID, "jobID");
 
-		// check for the existence of the file
+		// first check for the existence of the complete file
 		try {
-			fileSystem.getFileStatus(createMarkerFilePath(jobID));
-			// file was found --> job is terminated
-			return true;
+			fileSystem.getFileStatus(createMarkerFilePath(DONE_PREFIX, jobID));
+			// complete file was found --> job is terminated
+			return JobSchedulingStatus.DONE;
 		}
 		catch (FileNotFoundException e) {
-			// file does not exist, job is still running
-			return false;
+			// file does not exist, job is running or pending
+		}
+		// check for the existence of the running file
+		try {
+			fileSystem.getFileStatus(createMarkerFilePath(RUNNING_PREFIX, jobID));
+			// running file was found --> job is terminated
+			return JobSchedulingStatus.RUNNING;
+		}
+		catch (FileNotFoundException e) {
+			// file does not exist, job is not scheduled
+			return JobSchedulingStatus.PENDING;
 		}
 	}
 
 	@Override
 	public void clearJob(JobID jobID) throws IOException {
 		checkNotNull(jobID, "jobID");
-		final Path filePath = createMarkerFilePath(jobID);
+		final Path runningFilePath = createMarkerFilePath(RUNNING_PREFIX, jobID);
 
-		// delete the marker file, if it exists
+		// delete the running marker file, if it exists
 		try {
-			fileSystem.delete(filePath, false);
+			fileSystem.delete(runningFilePath, false);
 		}
 		catch (FileNotFoundException e) {
 		}
 
+		final Path doneFilePath = createMarkerFilePath(DONE_PREFIX, jobID);
+
+		// delete the finished marker file, if it exists
+		try {
+			fileSystem.delete(doneFilePath, false);
+		}
+		catch (FileNotFoundException e) {
+		}
 	}
 
-	private Path createMarkerFilePath(JobID jobId) {
-		return new Path(basePath, PREFIX + jobId.toString());
+	private Path createMarkerFilePath(String prefix, JobID jobId) {
+		return new Path(basePath, prefix + jobId.toString());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FsNegativeRunningJobsRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FsNegativeRunningJobsRegistry.java
@@ -147,6 +147,36 @@ public class FsNegativeRunningJobsRegistry implements RunningJobsRegistry {
 		}
 	}
 
+	@Override
+	public boolean isJobFinished(JobID jobID) throws IOException {
+		checkNotNull(jobID, "jobID");
+
+		// check for the existence of the file
+		try {
+			fileSystem.getFileStatus(createMarkerFilePath(jobID));
+			// file was found --> job is terminated
+			return true;
+		}
+		catch (FileNotFoundException e) {
+			// file does not exist, job is still running
+			return false;
+		}
+	}
+
+	@Override
+	public void clearJob(JobID jobID) throws IOException {
+		checkNotNull(jobID, "jobID");
+		final Path filePath = createMarkerFilePath(jobID);
+
+		// delete the marker file, if it exists
+		try {
+			fileSystem.delete(filePath, false);
+		}
+		catch (FileNotFoundException e) {
+		}
+
+	}
+
 	private Path createMarkerFilePath(JobID jobId) {
 		return new Path(basePath, PREFIX + jobId.toString());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/RunningJobsRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/RunningJobsRegistry.java
@@ -33,6 +33,17 @@ import java.io.IOException;
  */
 public interface RunningJobsRegistry {
 
+	public enum JobSchedulingStatus {
+		/** Job has not been scheduled */
+		PENDING,
+
+		/** Job has been scheduled */
+		RUNNING,
+
+		/** Job has been finished */
+		DONE;
+	}
+
 	/**
 	 * Marks a job as running.
 	 * 
@@ -65,15 +76,15 @@ public interface RunningJobsRegistry {
 	boolean isJobRunning(JobID jobID) throws IOException;
 
 	/**
-	 * Checks whether a job has finished.
+	 * Get the scheduing status of a job.
 	 *
 	 * @param jobID The id of the job to check.
-	 * @return True if the job is finished.
+	 * @return The job scheduling status.
 	 * 
 	 * @throws IOException Thrown when the communication with the highly-available storage or registry
 	 *                     failed and could not be retried.
 	 */
-	boolean isJobFinished(JobID jobID) throws IOException;
+	JobSchedulingStatus getJobSchedulingStatus(JobID jobID) throws IOException;
 
 	/**
 	 * Clear job state form the registry, usually called after job finish

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/RunningJobsRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/RunningJobsRegistry.java
@@ -63,4 +63,25 @@ public interface RunningJobsRegistry {
 	 *                     failed and could not be retried.
 	 */
 	boolean isJobRunning(JobID jobID) throws IOException;
+
+	/**
+	 * Checks whether a job has finished.
+	 *
+	 * @param jobID The id of the job to check.
+	 * @return True if the job is finished.
+	 * 
+	 * @throws IOException Thrown when the communication with the highly-available storage or registry
+	 *                     failed and could not be retried.
+	 */
+	boolean isJobFinished(JobID jobID) throws IOException;
+
+	/**
+	 * Clear job state form the registry, usually called after job finish
+	 *
+	 * @param jobID The id of the job to check.
+	 * 
+	 * @throws IOException Thrown when the communication with the highly-available storage or registry
+	 *                     failed and could not be retried.
+	 */
+	void clearJob(JobID jobID) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/NonHaRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/NonHaRegistry.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.highavailability.nonha;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
+import org.apache.flink.runtime.highavailability.RunningJobsRegistry.JobSchedulingStatus;
 
 import java.util.HashSet;
 
@@ -66,11 +67,17 @@ public class NonHaRegistry implements RunningJobsRegistry {
 	}
 
 	@Override
-	public boolean isJobFinished(JobID jobID) {
+	public JobSchedulingStatus getJobSchedulingStatus(JobID jobID) {
 		checkNotNull(jobID);
 
 		synchronized (running) {
-			return finished.contains(jobID);
+			if (finished.contains(jobID)) {
+				return JobSchedulingStatus.DONE;
+			} else if (running.contains(jobID)) {
+				return JobSchedulingStatus.RUNNING;
+			} else {
+				return JobSchedulingStatus.PENDING;
+			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/NonHaRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/NonHaRegistry.java
@@ -33,12 +33,16 @@ public class NonHaRegistry implements RunningJobsRegistry {
 	/** The currently running jobs */
 	private final HashSet<JobID> running = new HashSet<>();
 
+	/** The currently finished jobs */
+	private final HashSet<JobID> finished = new HashSet<>();
+
 	@Override
 	public void setJobRunning(JobID jobID) {
 		checkNotNull(jobID);
 
 		synchronized (running) {
 			running.add(jobID);
+			finished.remove(jobID);
 		}
 	}
 
@@ -48,6 +52,7 @@ public class NonHaRegistry implements RunningJobsRegistry {
 
 		synchronized (running) {
 			running.remove(jobID);
+			finished.add(jobID);
 		}
 	}
 
@@ -57,6 +62,25 @@ public class NonHaRegistry implements RunningJobsRegistry {
 
 		synchronized (running) {
 			return running.contains(jobID);
+		}
+	}
+
+	@Override
+	public boolean isJobFinished(JobID jobID) {
+		checkNotNull(jobID);
+
+		synchronized (running) {
+			return finished.contains(jobID);
+		}
+	}
+
+	@Override
+	public void clearJob(JobID jobID) {
+		checkNotNull(jobID);
+
+		synchronized (running) {
+			running.remove(jobID);
+			finished.remove(jobID);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterJobDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterJobDispatcher.java
@@ -182,7 +182,7 @@ public class MiniClusterJobDispatcher {
 			checkState(!shutdown, "mini cluster is shut down");
 			checkState(runners == null, "mini cluster can only execute one job at a time");
 
-			DetachedFinalizer finalizer = new DetachedFinalizer(numJobManagers);
+			DetachedFinalizer finalizer = new DetachedFinalizer(job.getJobID(), numJobManagers);
 
 			this.runners = startJobRunners(job, finalizer, finalizer);
 		}
@@ -217,6 +217,7 @@ public class MiniClusterJobDispatcher {
 		finally {
 			// always clear the status for the next job
 			runners = null;
+			clearJobRunningState(job.getJobID());
 		}
 	}
 
@@ -226,16 +227,6 @@ public class MiniClusterJobDispatcher {
 			FatalErrorHandler errorHandler) throws JobExecutionException {
 
 		LOG.info("Starting {} JobMaster(s) for job {} ({})", numJobManagers, job.getName(), job.getJobID());
-
-		// we first need to mark the job as running in the HA services, so that the
-		// JobManager leader will recognize that it as work to do
-		try {
-			haServices.getRunningJobsRegistry().setJobRunning(job.getJobID());
-		}
-		catch (Throwable t) {
-			throw new JobExecutionException(job.getJobID(),
-					"Could not register the job at the high-availability services", t);
-		}
 
 		// start all JobManagers
 		JobManagerRunner[] runners = new JobManagerRunner[numJobManagers];
@@ -273,6 +264,17 @@ public class MiniClusterJobDispatcher {
 		return runners;
 	}
 
+	private void clearJobRunningState(JobID jobID) {
+		// we mark the job as finished in the HA services, so need
+		// to remove the data after job finished
+		try {
+			haServices.getRunningJobsRegistry().clearJob(jobID);
+		}
+		catch (Throwable t) {
+			LOG.warn("Could not clear the job {} at the high-availability services", jobID.toString(), t);
+		}
+	}
+
 	// ------------------------------------------------------------------------
 	//  test methods to simulate job master failures
 	// ------------------------------------------------------------------------
@@ -298,9 +300,12 @@ public class MiniClusterJobDispatcher {
 	 */
 	private class DetachedFinalizer implements OnCompletionActions, FatalErrorHandler {
 
+		private final JobID jobID;
+
 		private final AtomicInteger numJobManagersToWaitFor;
 
-		private DetachedFinalizer(int numJobManagersToWaitFor) {
+		private DetachedFinalizer(JobID jobID, int numJobManagersToWaitFor) {
+			this.jobID = jobID;
 			this.numJobManagersToWaitFor = new AtomicInteger(numJobManagersToWaitFor);
 		}
 
@@ -327,6 +332,7 @@ public class MiniClusterJobDispatcher {
 		private void decrementCheckAndCleanup() {
 			if (numJobManagersToWaitFor.decrementAndGet() == 0) {
 				MiniClusterJobDispatcher.this.runners = null;
+				MiniClusterJobDispatcher.this.clearJobRunningState(jobID);
 			}
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/ZooKeeperRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/ZooKeeperRegistryTest.java
@@ -68,7 +68,11 @@ public class ZooKeeperRegistryTest extends TestLogger {
 
 			zkRegistry.setJobFinished(jobID);
 			assertTrue(!zkRegistry.isJobRunning(jobID));
+			assertTrue(zkRegistry.isJobFinished(jobID));
 
+			zkRegistry.clearJob(jobID);
+			assertTrue(!zkRegistry.isJobRunning(jobID));
+			assertTrue(!zkRegistry.isJobFinished(jobID));
 		} finally {
 			if (zkHaService != null) {
 				zkHaService.close();


### PR DESCRIPTION
This pr if for jira-#[5501](https://issues.apache.org/jira/browse/FLINK-5501).

The main changes are:
1. Add interface isJobFinished() and clearJob() to RunningJobRegistry and implement them.
2. After grantLeadership, JMRunner will first check whether the job is finished, if finished, it means that other JM has finished the job, it only need to exist.
3. Then JMRunner will check whether the job is running, if running, it means other JM has run it, but not succeeded, so it need to recover it.
4. If the job is not running, it mean the first running, the JMRunner will setJobRunning in RunningJobRegistry.
5. After job finished, will clear the job state from RunningJobRegistry 