### PR TITLE
[FLINK-5863][queryable state] Add the serialization of list states in KvStateRequestSerializer

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializer.java
@@ -36,6 +36,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -440,6 +441,38 @@ public final class KvStateRequestSerializer {
 			}
 			return value;
 		}
+	}
+
+	/**
+	 * Serializes all values with the given serializer.
+	 *
+	 * @param list            The list to serialize
+	 * @param serializer      Serializer for T
+	 * @param <T>             Type of the value
+	 * @return Serialized bytes or <code>null</code> if the list is null.
+	 * is <code>null</code>
+	 * @throws IOException On failure during deserialization
+	 */
+	public static <T> byte[] serializeList(Iterable<T> list, TypeSerializer<T> serializer) throws IOException {
+		DataOutputSerializer dos = new DataOutputSerializer(128);
+
+		if (list == null) {
+			return null;
+		}
+
+		Iterator<T> iterator = list.iterator();
+		// write the same as RocksDB writes lists, with one ',' separator
+		while (iterator.hasNext()) {
+			T element = iterator.next();
+
+			serializer.serialize(element, dos);
+
+			if (iterator.hasNext()) {
+				dos.writeByte(',');
+			}
+		}
+
+		return dos.getCopyOfBuffer();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -141,7 +141,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	}
 
 	@Override
-	public <N, V> InternalValueState<N, V> createValueState(
+	protected <N, V> InternalValueState<N, V> createValueState(
 			TypeSerializer<N> namespaceSerializer,
 			ValueStateDescriptor<V> stateDesc) throws Exception {
 
@@ -150,7 +150,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	}
 
 	@Override
-	public <N, T> InternalListState<N, T> createListState(
+	protected <N, T> InternalListState<N, T> createListState(
 			TypeSerializer<N> namespaceSerializer,
 			ListStateDescriptor<T> stateDesc) throws Exception {
 
@@ -168,7 +168,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	}
 
 	@Override
-	public <N, T> InternalReducingState<N, T> createReducingState(
+	protected <N, T> InternalReducingState<N, T> createReducingState(
 			TypeSerializer<N> namespaceSerializer,
 			ReducingStateDescriptor<T> stateDesc) throws Exception {
 
@@ -177,7 +177,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	}
 
 	@Override
-	public <N, T, ACC, R> InternalAggregatingState<N, T, R> createAggregatingState(
+	protected <N, T, ACC, R> InternalAggregatingState<N, T, R> createAggregatingState(
 			TypeSerializer<N> namespaceSerializer,
 			AggregatingStateDescriptor<T, ACC, R> stateDesc) throws Exception {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
@@ -21,13 +21,12 @@ package org.apache.flink.runtime.state.heap;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.query.netty.message.KvStateRequestSerializer;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.util.Preconditions;
 
-import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -143,21 +142,7 @@ public class HeapListState<K, N, V>
 			return null;
 		}
 
-		TypeSerializer<V> serializer = stateDesc.getElementSerializer();
-
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(baos);
-
-		// write the same as RocksDB writes lists, with one ',' separator
-		for (int i = 0; i < result.size(); i++) {
-			serializer.serialize(result.get(i), view);
-			if (i < result.size() -1) {
-				view.writeByte(',');
-			}
-		}
-		view.flush();
-
-		return baos.toByteArray();
+		return KvStateRequestSerializer.serializeList(result, stateDesc.getElementSerializer());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/netty/message/KvStateRequestSerializerTest.java
@@ -329,9 +329,11 @@ public class KvStateRequestSerializerTest {
 			);
 		longHeapKeyedStateBackend.setCurrentKey(key);
 
-		final InternalListState<VoidNamespace, Long> listState = longHeapKeyedStateBackend.createListState(
-				VoidNamespaceSerializer.INSTANCE,
-				new ListStateDescriptor<>("test", LongSerializer.INSTANCE));
+		final InternalListState<VoidNamespace, Long> listState = (InternalListState<VoidNamespace, Long>)
+				longHeapKeyedStateBackend.getPartitionedState(
+						VoidNamespace.INSTANCE,
+						VoidNamespaceSerializer.INSTANCE,
+						new ListStateDescriptor<>("test", LongSerializer.INSTANCE));
 
 		testListSerialization(key, listState);
 	}


### PR DESCRIPTION
1. Add `serializeList()` in `KvStateRequestSerialization`
2. Modify the unit tests of `KvStateRequestSerialization`, without the access to protected methods.
3. Move `KvStateRequestSerializationRocksDBTest` from package `org.apache.flink.test.query` to `org.apache.flink.contrib.streaming.state`.