### PR TITLE
[FLINK-5815] Add resource files configuration for Yarn Mode

### DIFF
--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/FileUtilsTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/FileUtilsTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.hdfstests;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.util.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Created by wenlong.lwl on 2017/2/21.
+ */
+public class FileUtilsTest {
+	@ClassRule
+	public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private static File TEMP_DIR;
+
+	private static String HDFS_ROOT_URI;
+
+	private static MiniDFSCluster HDFS_CLUSTER;
+
+	private static FileSystem FS;
+
+	// ------------------------------------------------------------------------
+	//  startup / shutdown
+	// ------------------------------------------------------------------------
+
+	@BeforeClass
+	public static void createHDFS() {
+		try {
+			TEMP_DIR = temporaryFolder.newFolder();
+
+			Configuration hdConf = new Configuration();
+			hdConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TEMP_DIR.getAbsolutePath());
+			MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(hdConf);
+			HDFS_CLUSTER = builder.build();
+
+			HDFS_ROOT_URI = "hdfs://" + HDFS_CLUSTER.getURI().getHost() + ":"
+				+ HDFS_CLUSTER.getNameNodePort() + "/";
+
+			FS = FileSystem.get(new URI(HDFS_ROOT_URI));
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail("Could not create HDFS mini cluster " + e.getMessage());
+		}
+	}
+
+	@AfterClass
+	public static void destroyHDFS() {
+		try {
+			HDFS_CLUSTER.shutdown();
+		}
+		catch (Exception ignored) {}
+	}
+
+	@Test
+	public void testCompareFs() throws IOException {
+		File localDir = temporaryFolder.newFolder();
+		Assert.assertFalse(FileUtils.compareFs(new Path(localDir.toURI()).getFileSystem(), FS));
+	}
+
+	@Test
+	public void testLocalizeFile() throws IOException {
+		Path localDir = new Path(temporaryFolder.newFolder().toURI());
+		Path localDir2 = new Path(FS.getHomeDirectory(), "localDir");
+
+		Path remoteFile = new Path(FS.getHomeDirectory(), "remoteFile");
+		FSDataOutputStream outputStream = FS.create(remoteFile, FileSystem.WriteMode.OVERWRITE);
+		outputStream.write(1);
+		outputStream.close();
+
+
+		Path result = FileUtils.localizeRemoteFiles(localDir, remoteFile.toUri());
+		Assert.assertTrue(FileUtils.compareFs(result.getFileSystem(), localDir.getFileSystem()));
+		FSDataInputStream inputStream = result.getFileSystem().open(result);
+		Assert.assertEquals(1, inputStream.read());
+		Assert.assertEquals(-1, inputStream.read());
+		inputStream.close();
+
+		result = FileUtils.localizeRemoteFiles(localDir2, remoteFile.toUri());
+		Assert.assertTrue(FileUtils.compareFs(result.getFileSystem(), localDir2.getFileSystem()));
+		inputStream = result.getFileSystem().open(result);
+		Assert.assertEquals(1, inputStream.read());
+		Assert.assertEquals(-1, inputStream.read());
+		inputStream.close();
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -137,7 +137,7 @@ public final class Utils {
 			Path homedir) throws IOException {
 
 		// copy resource to HDFS
-		Path dst = getRemoteResourceRoot(appId, localRsrcPath, homedir);
+		Path dst = getRemoteResourcePath(appId, localRsrcPath, homedir);
 
 		LOG.info("Copying from " + localRsrcPath + " to " + dst);
 		fs.copyFromLocalFile(localRsrcPath, dst);
@@ -145,14 +145,15 @@ public final class Utils {
 		return dst;
 	}
 
-	public static Path getRemoteResourceRoot(
-			String appId, Path localRsrcPath,
-			Path homedir) throws IOException {
+	public static Path getRemoteResourcePath(
+			String appId,
+			Path localFile,
+			Path destDir) throws IOException {
 
 		// copy resource to HDFS
-		String suffix = ".flink/" + appId + "/" + localRsrcPath.getName();
+		String suffix = ".flink/" + appId + "/" + localFile.getName();
 
-		Path dst = new Path(homedir, suffix);
+		Path dst = new Path(destDir, suffix);
 
 		return dst;
 	}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnCLI.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnCLI.java
@@ -25,10 +25,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.client.cli.CliFrontendParser;
 import org.apache.flink.client.cli.CustomCommandLine;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.yarn.YarnClusterClientV2;
 import org.apache.flink.yarn.YarnClusterDescriptorV2;
+import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
-
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
@@ -50,9 +49,7 @@ import static org.apache.flink.client.cli.CliFrontendParser.ADDRESS_OPTION;
 public class FlinkYarnCLI implements CustomCommandLine<YarnClusterClientV2> {
 	private static final Logger LOG = LoggerFactory.getLogger(FlinkYarnCLI.class);
 
-	/**
-	 * The id for the CommandLine interface
-	 */
+	/** The id for the CommandLine interface */
 	private static final String ID = "yarn";
 
 	private static final String YARN_DYNAMIC_PROPERTIES_SEPARATOR = "@@"; // this has to be a regex for String.split()
@@ -70,14 +67,12 @@ public class FlinkYarnCLI implements CustomCommandLine<YarnClusterClientV2> {
 
 	/**
 	 * Dynamic properties allow the user to specify additional configuration values with -D, such as
-	 * -D fs.overwrite-files=true  -D taskmanager.network.numberOfBuffers=16368
+	 *  -D fs.overwrite-files=true  -D taskmanager.network.numberOfBuffers=16368
 	 */
 	private final Option DYNAMIC_PROPERTIES;
 
 	private final Option LIB_JARS;
-
 	private final Option FILES;
-
 	private final Option ARCHIVES;
 
 	//------------------------------------ Internal fields -------------------------
@@ -139,7 +134,7 @@ public class FlinkYarnCLI implements CustomCommandLine<YarnClusterClientV2> {
 			}
 		}
 
-		yarnClusterDescriptor.setLocalJarPath(new org.apache.hadoop.fs.Path(localJarPath.getPath()));
+		yarnClusterDescriptor.setLocalJarPath(localJarPath);
 
 		List<File> shipFiles = new ArrayList<>();
 		// path to directory to ship
@@ -212,7 +207,7 @@ public class FlinkYarnCLI implements CustomCommandLine<YarnClusterClientV2> {
 		}
 		yarnClusterDescriptor.setDetachedMode(this.detachedMode);
 
-		if (defaultApplicationName != null) {
+		if(defaultApplicationName != null) {
 			yarnClusterDescriptor.setName(defaultApplicationName);
 		}
 
@@ -220,7 +215,6 @@ public class FlinkYarnCLI implements CustomCommandLine<YarnClusterClientV2> {
 			String zookeeperNamespace = cmd.getOptionValue(ZOOKEEPER_NAMESPACE.getOpt());
 			yarnClusterDescriptor.setZookeeperNamespace(zookeeperNamespace);
 		}
-
 
 		return yarnClusterDescriptor;
 	}
@@ -263,18 +257,18 @@ public class FlinkYarnCLI implements CustomCommandLine<YarnClusterClientV2> {
 
 	@Override
 	public YarnClusterClientV2 retrieveCluster(
-		CommandLine cmdLine,
-		Configuration config) throws UnsupportedOperationException {
+			CommandLine cmdLine,
+			Configuration config) throws UnsupportedOperationException {
 
 		throw new UnsupportedOperationException("Not support retrieveCluster since Flip-6.");
 	}
 
 	@Override
 	public YarnClusterClientV2 createCluster(
-		String applicationName,
-		CommandLine cmdLine,
-		Configuration config,
-		List<URL> userJarFiles) {
+			String applicationName,
+			CommandLine cmdLine,
+			Configuration config,
+			List<URL> userJarFiles) {
 		Preconditions.checkNotNull(userJarFiles, "User jar files should not be null.");
 
 		YarnClusterDescriptorV2 yarnClusterDescriptor = createDescriptor(applicationName, cmdLine);
@@ -284,7 +278,8 @@ public class FlinkYarnCLI implements CustomCommandLine<YarnClusterClientV2> {
 		YarnClusterClientV2 client = null;
 		try {
 			client = new YarnClusterClientV2(yarnClusterDescriptor, config);
-		} catch (IOException e) {
+		}
+		catch (IOException e) {
 			throw new RuntimeException("Fail to create YarnClusterClientV2", e.getCause());
 		}
 		return client;
@@ -298,6 +293,5 @@ public class FlinkYarnCLI implements CustomCommandLine<YarnClusterClientV2> {
 		LOG.info(message);
 		System.out.println(message);
 	}
-
 
 }


### PR DESCRIPTION
This PR add three common resource configuration options to yarn mode, which allow user to set single file resource from both local filesystem and remote hdfs filesystem as what we can do using mapreduce, including:
1. add -yfiles . -ylibjars for adding local resource file to yarn per-job cluster, user can provide a list of file paths to add some local jars or dictionary files to yarn distributed cache.
2. add -yarchives for adding remote resource files to yarn per-job cluster, user can provide a list of uri of files which can be stored on hdfs, user can rename the file by fragment of the uri.
all of the files will be distributed to every TM and JM by yarn and added to classpath of TM and JM.