### PR TITLE
[FLINK-5881] [table] ScalarFunction(UDF) should support variable types and variable arguments

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarFunctionCallGen.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarFunctionCallGen.scala
@@ -51,13 +51,11 @@ class ScalarFunctionCallGen(
 
     // zip for variable signatures
     var paramToOperands = matchingSignature.zip(operands)
-    var i = paramToOperands.length
-    while (i < operands.length
-        && matchingMethod.isVarArgs
-        && matchingSignature.last.isArray) {
-      paramToOperands = paramToOperands :+
-        (matchingSignature.last.getComponentType, operands(i))
-      i += 1
+    if (operands.length > matchingSignature.length) {
+      operands.drop(matchingSignature.length).foreach(op =>
+        paramToOperands = paramToOperands :+
+          (matchingSignature.last.getComponentType, op)
+      )
     }
 
     // convert parameters for function (output boxing)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarFunctionCallGen.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarFunctionCallGen.scala
@@ -48,10 +48,16 @@ class ScalarFunctionCallGen(
       .getOrElse(throw new CodeGenException("No matching signature found."))
     val resultClass = getResultTypeClass(scalarFunction, matchingSignature)
 
+    // zip for variable signatures
+    var paramToOperands = matchingSignature.zip(operands)
+    var i = paramToOperands.length
+    while (i < operands.length) {
+      paramToOperands = paramToOperands :+ (matchingSignature.head, operands(i))
+      i += 1
+    }
+
     // convert parameters for function (output boxing)
-    val parameters = matchingSignature
-        .zip(operands)
-        .map { case (paramClass, operandExpr) =>
+    val parameters = paramToOperands.map { case (paramClass, operandExpr) =>
           if (paramClass.isPrimitive) {
             operandExpr
           } else if (ClassUtils.isPrimitiveWrapper(paramClass)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/ScalarSqlFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/ScalarSqlFunction.scala
@@ -114,7 +114,9 @@ object ScalarSqlFunction {
 
         inferredTypes.zipWithIndex.foreach {
           case (inferredType, i) =>
-            operandTypes(i) = inferredType
+            if (operandTypes.length > 0) {
+              operandTypes(i) = inferredType
+            }
         }
       }
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/ScalarSqlFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/ScalarSqlFunction.scala
@@ -147,7 +147,7 @@ object ScalarSqlFunction {
         var max = -1
         signatures.foreach(sig => {
           var len = sig.length
-          if (len > 0 && sig(sig.length -1).isArray) {
+          if (len > 0 && sig(sig.length - 1).isArray) {
             max = 254  // according to JVM spec 4.3.3
             len = sig.length - 1
           }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/ScalarSqlFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/ScalarSqlFunction.scala
@@ -136,8 +136,18 @@ object ScalarSqlFunction {
       }
 
       override def getOperandCountRange: SqlOperandCountRange = {
-        val signatureLengths = signatures.map(_.length)
-        SqlOperandCountRanges.between(signatureLengths.min, signatureLengths.max)
+        var min = 255
+        var max = -1
+        signatures.foreach(sig => {
+          var len = sig.length
+          if (len > 0 && sig(sig.length -1).isArray) {
+            max = 254  // according to JVM spec 4.3.3
+            len = sig.length - 1
+          }
+          max = Math.max(len, max)
+          min = Math.min(len, min)
+        })
+        SqlOperandCountRanges.between(min, max)
       }
 
       override def checkOperandTypes(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/ScalarSqlFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/ScalarSqlFunction.scala
@@ -112,10 +112,15 @@ object ScalarSqlFunction {
           .getParameterTypes(foundSignature)
           .map(typeFactory.createTypeFromTypeInfo)
 
-        inferredTypes.zipWithIndex.foreach {
-          case (inferredType, i) =>
-            if (operandTypes.length > 0) {
-              operandTypes(i) = inferredType
+        operandTypes.zipWithIndex.foreach {
+          case (_, i) =>
+            if (i < inferredTypes.length - 1) {
+              operandTypes(i) = inferredTypes(i)
+            } else if (null != inferredTypes.last.getComponentType) {
+              // last arguments is a collection, the array type
+              operandTypes(i) = inferredTypes.last.getComponentType
+            } else {
+              operandTypes(i) = inferredTypes.last
             }
         }
       }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/UserDefinedFunctionUtils.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/UserDefinedFunctionUtils.scala
@@ -105,12 +105,13 @@ object UserDefinedFunctionUtils {
           }
         case cur if cur.isVarArgs =>
           val signatures = cur.getParameterTypes
-          actualSignature.zipWithIndex.forall { case (clazz, i) =>
-            (i < signatures.length - 1 &&
-              parameterTypeEquals(clazz, signatures(i))) ||
-            (i >= signatures.length - 1 &&
-              parameterTypeEquals(clazz, signatures.last.getComponentType))
-          } || (actualSignature.isEmpty && signatures.length == 1)
+          actualSignature.zipWithIndex.forall {
+            case (clazz, i) if i < signatures.length - 1  =>
+              parameterTypeEquals(clazz, signatures(i))
+            case (clazz, i) if i >= signatures.length - 1 =>
+              parameterTypeEquals(clazz, signatures.last.getComponentType)
+          } ||
+          (actualSignature.isEmpty && signatures.length == 1)
     }
 
     if (filtered.length > 1) {
@@ -155,10 +156,10 @@ object UserDefinedFunctionUtils {
         s"Function class '${function.getClass.getCanonicalName}' does not implement at least " +
           s"one method named 'eval' which is public, not abstract and " +
           s"(in case of table functions) not static.")
-    } else {
-      verifyScalaVarargsAnnotation(methods)
-      methods
     }
+
+    verifyScalaVarargsAnnotation(methods)
+    methods
   }
 
   /**

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/utils/UserDefinedScalarFunctions.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/utils/UserDefinedScalarFunctions.java
@@ -43,4 +43,14 @@ public class UserDefinedScalarFunctions {
 		}
 	}
 
+	public static class JavaFunc3 extends ScalarFunction {
+		public int eval(String a, int... b) {
+			return b.length;
+		}
+
+		public String eval(String c) {
+			return c;
+		}
+	}
+
 }

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/utils/UserDefinedScalarFunctions.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/utils/UserDefinedScalarFunctions.java
@@ -33,4 +33,14 @@ public class UserDefinedScalarFunctions {
 		}
 	}
 
+	public static class JavaFunc2 extends ScalarFunction {
+		public String eval(String s, Integer... a) {
+			int m = 1;
+			for (int n : a) {
+				m *= n;
+			}
+			return s + m;
+		}
+	}
+
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
@@ -195,6 +195,20 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       "Func14()",
       "0")
 
+    testAllApis(
+      Func15("Hello"),
+      "Func15('Hello')",
+      "Func15('Hello')",
+      "Hello0"
+    )
+
+    testAllApis(
+      Func15("Hello", 1, 2, 3),
+      "Func15('Hello', 1, 2, 3)",
+      "Func15('Hello', 1, 2, 3)",
+      "Hello3"
+    )
+
     val JavaFunc2 = new JavaFunc2
     testAllApis(
       JavaFunc2("Hi", 1, 3, 5, 7),
@@ -316,6 +330,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
     "Func11" -> Func11,
     "Func12" -> Func12,
     "Func14" -> Func14,
+    "Func15" -> Func15,
     "JavaFunc0" -> new JavaFunc0,
     "JavaFunc1" -> new JavaFunc1,
     "JavaFunc2" -> new JavaFunc2,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
@@ -24,8 +24,8 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.types.Row
-import org.apache.flink.table.api.Types
-import org.apache.flink.table.api.java.utils.UserDefinedScalarFunctions.{JavaFunc0, JavaFunc1, JavaFunc2}
+import org.apache.flink.table.api.{Types, ValidationException}
+import org.apache.flink.table.api.java.utils.UserDefinedScalarFunctions.{JavaFunc0, JavaFunc1, JavaFunc2, JavaFunc3}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils._
 import org.apache.flink.table.functions.ScalarFunction
@@ -188,12 +188,32 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       "Func14(1, 2, 3, 4)",
       "10")
 
+    // Test for empty arguments
+    testAllApis(
+      Func14(),
+      "Func14()",
+      "Func14()",
+      "0")
+
     val JavaFunc2 = new JavaFunc2
     testAllApis(
       JavaFunc2("Hi", 1, 3, 5, 7),
       "JavaFunc2('Hi', 1, 3, 5, 7)",
       "JavaFunc2('Hi', 1, 3, 5, 7)",
       "Hi105")
+
+    // Test for override
+    val JavaFunc3 = new JavaFunc3
+    try {
+      testAllApis(
+        JavaFunc3("Hi"),
+        "JavaFunc3('Hi')",
+        "JavaFunc3('Hi')",
+        "Hi")
+      throw new RuntimeException("Shouldn't be reached")
+    } catch {
+      case ex: ValidationException => // it's correct
+    }
   }
 
   @Test
@@ -299,6 +319,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
     "JavaFunc0" -> new JavaFunc0,
     "JavaFunc1" -> new JavaFunc1,
     "JavaFunc2" -> new JavaFunc2,
+    "JavaFunc3" -> new JavaFunc3,
     "RichFunc0" -> new RichFunc0,
     "RichFunc1" -> new RichFunc1,
     "RichFunc2" -> new RichFunc2

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
@@ -195,11 +195,19 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       "Func14()",
       "0")
 
+    // Test for override
     testAllApis(
       Func15("Hello"),
       "Func15('Hello')",
       "Func15('Hello')",
-      "Hello0"
+      "Hello"
+    )
+
+    testAllApis(
+      Func15('f1),
+      "Func15(f1)",
+      "Func15(f1)",
+      "Test"
     )
 
     testAllApis(
@@ -208,6 +216,26 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       "Func15('Hello', 1, 2, 3)",
       "Hello3"
     )
+
+    testAllApis(
+      Func16('f9),
+      "Func16(f9)",
+      "Func16(f9)",
+      "Hello, World"
+    )
+
+    try {
+      testAllApis(
+        Func17("Hello", "World"),
+        "Func17('Hello', 'World')",
+        "Func17('Hello', 'World')",
+        "Hello, World"
+      )
+      throw new RuntimeException("Shouldn't be reached here!")
+    } catch {
+      case ex: ValidationException =>
+        // It's normal
+    }
 
     val JavaFunc2 = new JavaFunc2
     testAllApis(
@@ -218,16 +246,17 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
 
     // Test for override
     val JavaFunc3 = new JavaFunc3
-    try {
-      testAllApis(
-        JavaFunc3("Hi"),
-        "JavaFunc3('Hi')",
-        "JavaFunc3('Hi')",
-        "Hi")
-      throw new RuntimeException("Shouldn't be reached")
-    } catch {
-      case ex: ValidationException => // it's correct
-    }
+    testAllApis(
+      JavaFunc3("Hi"),
+      "JavaFunc3('Hi')",
+      "JavaFunc3('Hi')",
+      "Hi")
+
+    testAllApis(
+      JavaFunc3('f1),
+      "JavaFunc3(f1)",
+      "JavaFunc3(f1)",
+      "Test")
   }
 
   @Test
@@ -288,7 +317,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
   // ----------------------------------------------------------------------------------------------
 
   override def testData: Any = {
-    val testData = new Row(9)
+    val testData = new Row(10)
     testData.setField(0, 42)
     testData.setField(1, "Test")
     testData.setField(2, null)
@@ -298,6 +327,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
     testData.setField(6, Timestamp.valueOf("1990-10-14 12:10:10"))
     testData.setField(7, 12)
     testData.setField(8, 1000L)
+    testData.setField(9, Seq("Hello", "World"))
     testData
   }
 
@@ -311,7 +341,8 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       Types.TIME,
       Types.TIMESTAMP,
       Types.INTERVAL_MONTHS,
-      Types.INTERVAL_MILLIS
+      Types.INTERVAL_MILLIS,
+      TypeInformation.of(classOf[Seq[String]])
     ).asInstanceOf[TypeInformation[Any]]
   }
 
@@ -331,6 +362,8 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
     "Func12" -> Func12,
     "Func14" -> Func14,
     "Func15" -> Func15,
+    "Func16" -> Func16,
+    "Func17" -> Func17,
     "JavaFunc0" -> new JavaFunc0,
     "JavaFunc1" -> new JavaFunc1,
     "JavaFunc2" -> new JavaFunc2,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.types.Row
 import org.apache.flink.table.api.Types
-import org.apache.flink.table.api.java.utils.UserDefinedScalarFunctions.{JavaFunc0, JavaFunc1}
+import org.apache.flink.table.api.java.utils.UserDefinedScalarFunctions.{JavaFunc0, JavaFunc1, JavaFunc2}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils._
 import org.apache.flink.table.functions.ScalarFunction
@@ -181,6 +181,22 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
   }
   
   @Test
+  def testVariableArgs(): Unit = {
+    testAllApis(
+      Func14(1, 2, 3, 4),
+      "Func14(1, 2, 3, 4)",
+      "Func14(1, 2, 3, 4)",
+      "10")
+
+    val JavaFunc2 = new JavaFunc2
+    testAllApis(
+      JavaFunc2("Hi", 1, 3, 5, 7),
+      "JavaFunc2('Hi', 1, 3, 5, 7)",
+      "JavaFunc2('Hi', 1, 3, 5, 7)",
+      "Hi105")
+  }
+
+  @Test
   def testJavaBoxedPrimitives(): Unit = {
     val JavaFunc0 = new JavaFunc0()
     val JavaFunc1 = new JavaFunc1()
@@ -279,8 +295,10 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
     "Func10" -> Func10,
     "Func11" -> Func11,
     "Func12" -> Func12,
+    "Func14" -> Func14,
     "JavaFunc0" -> new JavaFunc0,
     "JavaFunc1" -> new JavaFunc1,
+    "JavaFunc2" -> new JavaFunc2,
     "RichFunc0" -> new RichFunc0,
     "RichFunc1" -> new RichFunc1,
     "RichFunc2" -> new RichFunc2

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/UserDefinedScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/UserDefinedScalarFunctions.scala
@@ -243,4 +243,23 @@ object Func15 extends ScalarFunction {
   def eval(a: String, b: Int*): String = {
     a + b.length
   }
+
+  def eval(a: String): String = {
+    a
+  }
+}
+
+object Func16 extends ScalarFunction {
+
+  def eval(a: Seq[String]): String = {
+    a.mkString(", ")
+  }
+}
+
+object Func17 extends ScalarFunction {
+
+  // Without @varargs, it will throw exception
+  def eval(a: String*): String = {
+    a.mkString(", ")
+  }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/UserDefinedScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/UserDefinedScalarFunctions.scala
@@ -236,3 +236,11 @@ object Func14 extends ScalarFunction {
     a.sum
   }
 }
+
+object Func15 extends ScalarFunction {
+
+  @varargs
+  def eval(a: String, b: Int*): String = {
+    a + b.length
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/UserDefinedScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/UserDefinedScalarFunctions.scala
@@ -28,6 +28,8 @@ import org.junit.Assert
 import scala.collection.mutable
 import scala.io.Source
 
+import scala.annotation.varargs
+
 case class SimplePojo(name: String, age: Int)
 
 object Func0 extends ScalarFunction {
@@ -227,3 +229,10 @@ class Func13(prefix: String) extends ScalarFunction {
   }
 }
 
+object Func14 extends ScalarFunction {
+
+  @varargs
+  def eval(a: Int*): Int = {
+    a.sum
+  }
+}


### PR DESCRIPTION
Type: New Feature
Priority: Major
Components: table, udf, ScalarFunction
Problem Definition: [FLINK-5881] [table] ScalarFunction(UDF) should support variable types and variable arguments

Design:
1. Modified the getSignature() method in UserDefinedFunctionUtils, made trailing style of variable arguments can be found. The "(TypeA a, Type B b, TypeC... c)" or "(a: TypeA, b: TypeB, c: TypeC*)" with annotation will pass the method.
2. Modified the SqlOperandTypeChecker, made the count range of sql operands flexible. So it will pass the sql node validation of calcite.
3. Modified the checkAndExtractEvalMethods() method, and throw a human readable VaidataionException if the user specified the variable arguments in Scala and forgot to add the "@varargs" annotation. Please see the discussion in FLINK-5826. 

Impact Analysis:
It's a minor modification and it's a new feature. It impacts minimal in UDF.
Test:
Added both scala tests and java tests for all apis.