### PR TITLE
[FLINK-5861] Components of TaskManager support updating JobManagerConnection

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobManagerConnectionListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobManagerConnectionListener.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+
+import java.util.UUID;
+
+/**
+ * Listener that will be notified when {@link JobManagerConnection} changed.
+ */
+public interface JobManagerConnectionListener {
+	/**
+	 * Notify job manager connection changed.
+	 *
+	 * @param jobMasterGateway   the job master gateway
+	 * @param jobMasterLeaderID the job master leader id
+	 */
+	void notifyJobManagerConnectionChanged(JobMasterGateway jobMasterGateway, UUID jobMasterLeaderID);
+}
+

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -44,7 +44,6 @@ import org.apache.flink.runtime.io.network.netty.PartitionProducerStateChecker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
-import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.jobmaster.JMTMRegistrationSuccess;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
@@ -308,13 +307,15 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 				tdd.getSubtaskIndex(),
 				tdd.getAttemptNumber());
 
-		InputSplitProvider inputSplitProvider = new RpcInputSplitProvider(
+		RpcInputSplitProvider inputSplitProvider = new RpcInputSplitProvider(
 				jobManagerConnection.getLeaderId(),
 				jobManagerConnection.getJobManagerGateway(),
 				jobInformation.getJobId(),
 				taskInformation.getJobVertexId(),
 				tdd.getExecutionAttemptId(),
 				taskManagerConfiguration.getTimeout());
+
+		jobManagerConnection.registerListener(inputSplitProvider);
 
 		TaskManagerActions taskManagerActions = jobManagerConnection.getTaskManagerActions();
 		CheckpointResponder checkpointResponder = jobManagerConnection.getCheckpointResponder();
@@ -788,9 +789,9 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 		Preconditions.checkNotNull(jobMasterGateway);
 		Preconditions.checkArgument(blobPort > 0 || blobPort < MAX_BLOB_PORT, "Blob port is out of range.");
 
-		TaskManagerActions taskManagerActions = new TaskManagerActionsImpl(jobManagerLeaderId, jobMasterGateway);
+		TaskManagerActionsImpl taskManagerActions = new TaskManagerActionsImpl(jobManagerLeaderId, jobMasterGateway);
 
-		CheckpointResponder checkpointResponder = new RpcCheckpointResponder(jobMasterGateway);
+		RpcCheckpointResponder checkpointResponder = new RpcCheckpointResponder(jobMasterGateway);
 
 		InetSocketAddress address = new InetSocketAddress(jobMasterGateway.getAddress(), blobPort);
 
@@ -809,15 +810,15 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 			throw new RuntimeException(message, e);
 		}
 
-		ResultPartitionConsumableNotifier resultPartitionConsumableNotifier = new RpcResultPartitionConsumableNotifier(
+		RpcResultPartitionConsumableNotifier resultPartitionConsumableNotifier = new RpcResultPartitionConsumableNotifier(
 			jobManagerLeaderId,
 			jobMasterGateway,
 			getRpcService().getExecutor(),
 			taskManagerConfiguration.getTimeout());
 
-		PartitionProducerStateChecker partitionStateChecker = new RpcPartitionStateChecker(jobManagerLeaderId, jobMasterGateway);
+		RpcPartitionStateChecker partitionStateChecker = new RpcPartitionStateChecker(jobManagerLeaderId, jobMasterGateway);
 
-		return new JobManagerConnection(
+		final JobManagerConnection jobManagerConnection = new JobManagerConnection(
 			jobMasterGateway,
 			jobManagerLeaderId,
 			taskManagerActions,
@@ -825,6 +826,13 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 			libraryCacheManager,
 			resultPartitionConsumableNotifier,
 			partitionStateChecker);
+
+		jobManagerConnection.registerListener(taskManagerActions);
+		jobManagerConnection.registerListener(checkpointResponder);
+		jobManagerConnection.registerListener(resultPartitionConsumableNotifier);
+		jobManagerConnection.registerListener(partitionStateChecker);
+
+		return jobManagerConnection;
 	}
 
 	private void disassociateFromJobManager(JobManagerConnection jobManagerConnection) throws IOException {
@@ -1075,9 +1083,9 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 		}
 	}
 
-	private final class TaskManagerActionsImpl implements TaskManagerActions {
-		private final UUID jobMasterLeaderId;
-		private final JobMasterGateway jobMasterGateway;
+	private final class TaskManagerActionsImpl implements TaskManagerActions, JobManagerConnectionListener {
+		private UUID jobMasterLeaderId;
+		private JobMasterGateway jobMasterGateway;
 
 		private TaskManagerActionsImpl(UUID jobMasterLeaderId, JobMasterGateway jobMasterGateway) {
 			this.jobMasterLeaderId = Preconditions.checkNotNull(jobMasterLeaderId);
@@ -1113,6 +1121,12 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 		@Override
 		public void updateTaskExecutionState(final TaskExecutionState taskExecutionState) {
 			TaskExecutor.this.updateTaskExecutionState(jobMasterLeaderId, jobMasterGateway, taskExecutionState);
+		}
+
+		@Override
+		public void notifyJobManagerConnectionChanged(JobMasterGateway jobMasterGateway, UUID jobMasterLeaderID) {
+			this.jobMasterGateway = jobMasterGateway;
+			this.jobMasterLeaderId = jobMasterLeaderID;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcCheckpointResponder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcCheckpointResponder.java
@@ -23,12 +23,16 @@ import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorGateway;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.SubtaskState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+import org.apache.flink.runtime.taskexecutor.JobManagerConnectionListener;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.util.Preconditions;
 
-public class RpcCheckpointResponder implements CheckpointResponder {
+import java.util.UUID;
 
-	private final CheckpointCoordinatorGateway checkpointCoordinatorGateway;
+public class RpcCheckpointResponder implements CheckpointResponder, JobManagerConnectionListener {
+
+	private CheckpointCoordinatorGateway checkpointCoordinatorGateway;
 
 	public RpcCheckpointResponder(CheckpointCoordinatorGateway checkpointCoordinatorGateway) {
 		this.checkpointCoordinatorGateway = Preconditions.checkNotNull(checkpointCoordinatorGateway);
@@ -57,5 +61,10 @@ public class RpcCheckpointResponder implements CheckpointResponder {
 			Throwable cause) {
 
 		checkpointCoordinatorGateway.declineCheckpoint(jobID, executionAttemptID, checkpointId, cause);
+	}
+
+	@Override
+	public void notifyJobManagerConnectionChanged(JobMasterGateway jobMasterGateway, UUID jobMasterLeaderID) {
+		this.checkpointCoordinatorGateway = jobMasterGateway;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcInputSplitProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcInputSplitProvider.java
@@ -28,14 +28,15 @@ import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProviderException;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.jobmaster.SerializedInputSplit;
+import org.apache.flink.runtime.taskexecutor.JobManagerConnectionListener;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 
 import java.util.UUID;
 
-public class RpcInputSplitProvider implements InputSplitProvider {
-	private final UUID jobMasterLeaderId;
-	private final JobMasterGateway jobMasterGateway;
+public class RpcInputSplitProvider implements InputSplitProvider, JobManagerConnectionListener {
+	private UUID jobMasterLeaderId;
+	private JobMasterGateway jobMasterGateway;
 	private final JobID jobID;
 	private final JobVertexID jobVertexID;
 	private final ExecutionAttemptID executionAttemptID;
@@ -75,5 +76,11 @@ public class RpcInputSplitProvider implements InputSplitProvider {
 		} catch (Exception e) {
 			throw new InputSplitProviderException("Requesting the next input split failed.", e);
 		}
+	}
+
+	@Override
+	public void notifyJobManagerConnectionChanged(JobMasterGateway jobMasterGateway, UUID jobMasterLeaderID) {
+		this.jobMasterGateway = jobMasterGateway;
+		this.jobMasterLeaderId = jobMasterLeaderID;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcPartitionStateChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcPartitionStateChecker.java
@@ -25,14 +25,15 @@ import org.apache.flink.runtime.io.network.netty.PartitionProducerStateChecker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+import org.apache.flink.runtime.taskexecutor.JobManagerConnectionListener;
 import org.apache.flink.util.Preconditions;
 
 import java.util.UUID;
 
-public class RpcPartitionStateChecker implements PartitionProducerStateChecker {
+public class RpcPartitionStateChecker implements PartitionProducerStateChecker, JobManagerConnectionListener {
 
-	private final UUID jobMasterLeaderId;
-	private final JobMasterGateway jobMasterGateway;
+	private UUID jobMasterLeaderId;
+	private JobMasterGateway jobMasterGateway;
 
 	public RpcPartitionStateChecker(UUID jobMasterLeaderId, JobMasterGateway jobMasterGateway) {
 		this.jobMasterLeaderId = Preconditions.checkNotNull(jobMasterLeaderId);
@@ -46,5 +47,11 @@ public class RpcPartitionStateChecker implements PartitionProducerStateChecker {
 			ResultPartitionID partitionId) {
 
 		return jobMasterGateway.requestPartitionState(jobMasterLeaderId, resultId, partitionId);
+	}
+
+	@Override
+	public void notifyJobManagerConnectionChanged(JobMasterGateway jobMasterGateway, UUID jobMasterLeaderID) {
+		this.jobMasterGateway = jobMasterGateway;
+		this.jobMasterLeaderId = jobMasterLeaderID;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcResultPartitionConsumableNotifier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcResultPartitionConsumableNotifier.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNo
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.taskexecutor.JobManagerConnectionListener;
 import org.apache.flink.runtime.taskmanager.TaskActions;
 import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
@@ -34,12 +35,12 @@ import org.slf4j.LoggerFactory;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 
-public class RpcResultPartitionConsumableNotifier implements ResultPartitionConsumableNotifier {
+public class RpcResultPartitionConsumableNotifier implements ResultPartitionConsumableNotifier, JobManagerConnectionListener {
 
 	private static final Logger LOG = LoggerFactory.getLogger(RpcResultPartitionConsumableNotifier.class);
 
-	private final UUID jobMasterLeaderId;
-	private final JobMasterGateway jobMasterGateway;
+	private UUID jobMasterLeaderId;
+	private JobMasterGateway jobMasterGateway;
 	private final Executor executor;
 	private final Time timeout;
 
@@ -68,5 +69,11 @@ public class RpcResultPartitionConsumableNotifier implements ResultPartitionCons
 				return null;
 			}
 		}, executor);
+	}
+
+	@Override
+	public void notifyJobManagerConnectionChanged(JobMasterGateway jobMasterGateway, UUID jobMasterLeaderID) {
+		this.jobMasterGateway = jobMasterGateway;
+		this.jobMasterLeaderId = jobMasterLeaderID;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/JobManagerConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/JobManagerConnectionTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
+import org.apache.flink.runtime.io.network.netty.PartitionProducerStateChecker;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+import org.apache.flink.runtime.taskmanager.CheckpointResponder;
+import org.apache.flink.runtime.taskmanager.TaskManagerActions;
+import org.junit.Test;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class JobManagerConnectionTest {
+
+	@Test
+	public void testJobManagerUpdateListener() {
+		JobManagerConnection jobManagerConnection = new JobManagerConnection(
+			mock(JobMasterGateway.class),
+			UUID.randomUUID(),
+			mock(TaskManagerActions.class),
+			mock(CheckpointResponder.class),
+			mock(LibraryCacheManager.class),
+			mock(ResultPartitionConsumableNotifier.class),
+			mock(PartitionProducerStateChecker.class)
+		);
+
+		final AtomicInteger listenerNotified1 = new AtomicInteger(0);
+		final AtomicInteger listenerNotified2 = new AtomicInteger(0);
+
+		jobManagerConnection.registerListener(new JobManagerConnectionListener() {
+			@Override
+			public void notifyJobManagerConnectionChanged(JobMasterGateway jobMasterGateway,
+														  UUID jobMasterLeaderID) {
+				listenerNotified1.incrementAndGet();
+			}
+		});
+
+		jobManagerConnection.registerListener(new JobManagerConnectionListener() {
+			@Override
+			public void notifyJobManagerConnectionChanged(JobMasterGateway jobMasterGateway,
+														  UUID jobMasterLeaderID) {
+				listenerNotified2.incrementAndGet();
+			}
+		});
+
+		JobManagerConnection newJobManagerConnection = mock(JobManagerConnection.class);
+		jobManagerConnection.notifyListener(newJobManagerConnection);
+
+		verify(newJobManagerConnection, times(2)).getJobManagerGateway();
+		verify(newJobManagerConnection, times(2)).getLeaderId();
+
+		assertEquals(1, listenerNotified1.get());
+		assertEquals(1, listenerNotified2.get());
+	}
+}
+

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/rpc/RpcCheckpointResponderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/rpc/RpcCheckpointResponderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.rpc;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.*;
+
+public class RpcCheckpointResponderTest {
+	@Test
+	public void testNotifyJobManagerConnectionChanged() {
+		JobMasterGateway jobMasterGateway = mock(JobMasterGateway.class);
+
+		RpcCheckpointResponder rpcCheckpointResponder = new RpcCheckpointResponder(jobMasterGateway);
+
+		JobMasterGateway newJobMasterGateway = mock(JobMasterGateway.class);
+
+		doNothing().when(jobMasterGateway)
+			.declineCheckpoint(any(JobID.class), any(ExecutionAttemptID.class), anyLong(), any(Exception.class));
+		doNothing().when(newJobMasterGateway)
+			.declineCheckpoint(any(JobID.class), any(ExecutionAttemptID.class), anyLong(), any(Exception.class));
+
+		rpcCheckpointResponder.notifyJobManagerConnectionChanged(newJobMasterGateway, UUID.randomUUID());
+
+		rpcCheckpointResponder.declineCheckpoint(JobID.generate(), new ExecutionAttemptID(), 0L, new Exception());
+
+		// Verification
+		verify(jobMasterGateway, never())
+			.declineCheckpoint(any(JobID.class), any(ExecutionAttemptID.class), anyLong(), any(Exception.class));
+		verify(newJobMasterGateway, times(1))
+			.declineCheckpoint(any(JobID.class), any(ExecutionAttemptID.class), anyLong(), any(Exception.class));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/rpc/RpcInputSplitProviderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/rpc/RpcInputSplitProviderTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.rpc;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+import org.apache.flink.runtime.jobmaster.SerializedInputSplit;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class RpcInputSplitProviderTest {
+	@Test
+	public void notifyJobManagerConnectionChanged() throws Exception {
+		JobMasterGateway jobMasterGateway = mock(JobMasterGateway.class);
+		UUID jobMasterLeaderId = UUID.randomUUID();
+
+		RpcInputSplitProvider rpcInputSplitProvider =
+			new RpcInputSplitProvider(
+				jobMasterLeaderId,
+				jobMasterGateway,
+				JobID.generate(),
+				new JobVertexID(),
+				new ExecutionAttemptID(),
+				Time.minutes(1L));
+
+		JobMasterGateway newJobMasterGateway = mock(JobMasterGateway.class);
+		UUID newJobMasterLeaderId = UUID.randomUUID();
+
+		Future<SerializedInputSplit> future = mock(Future.class);
+
+		when(future.get(anyLong(), any(TimeUnit.class))).thenReturn(new SerializedInputSplit(null));
+
+		when(jobMasterGateway.requestNextInputSplit(
+			any(UUID.class), any(JobVertexID.class), any(ExecutionAttemptID.class)))
+			.thenReturn(future);
+
+		when(newJobMasterGateway.requestNextInputSplit(
+			any(UUID.class), any(JobVertexID.class), any(ExecutionAttemptID.class)))
+			.thenReturn(future);
+
+		rpcInputSplitProvider.notifyJobManagerConnectionChanged(newJobMasterGateway, newJobMasterLeaderId);
+
+		rpcInputSplitProvider.getNextInputSplit(Thread.currentThread().getContextClassLoader());
+
+		// Verification
+		verify(jobMasterGateway, never())
+			.requestNextInputSplit(any(UUID.class), any(JobVertexID.class), any(ExecutionAttemptID.class));
+
+		ArgumentCaptor<UUID> argumentCaptor = ArgumentCaptor.forClass(UUID.class);
+		verify(newJobMasterGateway, times(1))
+			.requestNextInputSplit(argumentCaptor.capture(), any(JobVertexID.class), any(ExecutionAttemptID.class));
+
+		assertEquals(newJobMasterLeaderId, argumentCaptor.getValue());
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/rpc/RpcPartitionStateCheckerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/rpc/RpcPartitionStateCheckerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.rpc;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class RpcPartitionStateCheckerTest {
+	@Test
+	public void testNotifyJobManagerConnectionChanged() {
+		JobMasterGateway jobMasterGateway = mock(JobMasterGateway.class);
+		UUID jobMasterLeaderId = UUID.randomUUID();
+
+		when(jobMasterGateway.requestPartitionState(
+			any(UUID.class), any(IntermediateDataSetID.class), any(ResultPartitionID.class)))
+			.thenReturn(null);
+
+		RpcPartitionStateChecker rpcPartitionStateChecker =
+			new RpcPartitionStateChecker(jobMasterLeaderId, jobMasterGateway);
+
+		JobMasterGateway newJobMasterGateway = mock(JobMasterGateway.class);
+		UUID newJobMasterLeaderId = UUID.randomUUID();
+
+		when(newJobMasterGateway.requestPartitionState(
+			any(UUID.class), any(IntermediateDataSetID.class), any(ResultPartitionID.class)))
+			.thenReturn(null);
+
+		rpcPartitionStateChecker.notifyJobManagerConnectionChanged(newJobMasterGateway, newJobMasterLeaderId);
+
+		rpcPartitionStateChecker.requestPartitionProducerState(
+			JobID.generate(), new IntermediateDataSetID(), new ResultPartitionID());
+
+		// Verification
+		verify(jobMasterGateway, never()).requestPartitionState(
+			any(UUID.class), any(IntermediateDataSetID.class), any(ResultPartitionID.class));
+
+		ArgumentCaptor<UUID> argumentCaptor = ArgumentCaptor.forClass(UUID.class);
+		verify(newJobMasterGateway, times(1)).requestPartitionState(
+			argumentCaptor.capture(), any(IntermediateDataSetID.class), any(ResultPartitionID.class));
+
+		assertEquals(newJobMasterLeaderId, argumentCaptor.getValue());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/rpc/RpcResultPartitionConsumableNotifierTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/rpc/RpcResultPartitionConsumableNotifierTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.rpc;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.taskmanager.TaskActions;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class RpcResultPartitionConsumableNotifierTest {
+	@Test
+	public void testNotifyJobManagerConnectionChanged() {
+		JobMasterGateway jobMasterGateway = mock(JobMasterGateway.class);
+		UUID jobMasterLeaderId = UUID.randomUUID();
+
+		RpcResultPartitionConsumableNotifier rpcResultPartitionConsumableNotifier =
+			new RpcResultPartitionConsumableNotifier(
+				jobMasterLeaderId, jobMasterGateway, mock(Executor.class), Time.minutes(1L));
+
+		JobMasterGateway newJobMasterGateway = mock(JobMasterGateway.class);
+		UUID newJobMasterLeaderId = UUID.randomUUID();
+
+		Future<Acknowledge> future = mock(Future.class);
+
+		when(jobMasterGateway.scheduleOrUpdateConsumers(any(UUID.class), any(ResultPartitionID.class), any(Time.class)))
+			.thenReturn(future);
+
+		when(newJobMasterGateway
+			.scheduleOrUpdateConsumers(any(UUID.class), any(ResultPartitionID.class), any(Time.class)))
+			.thenReturn(future);
+
+		rpcResultPartitionConsumableNotifier.notifyJobManagerConnectionChanged(newJobMasterGateway, newJobMasterLeaderId);
+
+		rpcResultPartitionConsumableNotifier
+			.notifyPartitionConsumable(JobID.generate(), new ResultPartitionID(), mock(TaskActions.class));
+
+		// Verification
+		verify(jobMasterGateway, never())
+			.scheduleOrUpdateConsumers(any(UUID.class), any(ResultPartitionID.class), any(Time.class));
+
+		ArgumentCaptor<UUID> argumentCaptor = ArgumentCaptor.forClass(UUID.class);
+		verify(newJobMasterGateway, times(1))
+			.scheduleOrUpdateConsumers(argumentCaptor.capture(), any(ResultPartitionID.class), any(Time.class));
+
+		assertEquals(newJobMasterLeaderId, argumentCaptor.getValue());
+	}
+}


### PR DESCRIPTION
This is a sub task of FLINK-4911. TaskManager need to support not canceling running tasks when detects JobManager failure. And all the tasks can continue running when connected with new JobManager leader. Some components of TaskManager keep the old JobManagerConnection, we have to update it.