### PR TITLE
[FLINK-5893] [ResourceManager] [FLIP-6] Fix the bug of race condition for removing previous JobManagerRegistration in ResourceManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -813,7 +813,12 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 
 		@Override
 		public void jobLeaderLostLeadership(final JobID jobId, final UUID oldJobLeaderId) {
-			ResourceManager.this.jobLeaderLostLeadership(jobId, oldJobLeaderId);
+			runAsync(new Runnable() {
+				@Override
+				public void run() {
+					ResourceManager.this.jobLeaderLostLeadership(jobId, oldJobLeaderId);
+				}
+			});
 		}
 
 		@Override


### PR DESCRIPTION
In flip-6, the map of `JobManagerRegistration` in ResourceManager is not thread-safe, and currently there may be two threads to operate the map concurrently to bring unexpected results.

The scenario is like this :

- `registerJobManager`: When the job leader changes and the new JobManager leader registers to ResourceManager, the new `JobManagerRegistration` will replace the old one in the map with the same key `JobID`. This process is triggered by rpc thread.
- Meanwhile, the `JobLeaderIdService` in ResourceManager could be aware of job leader change and trigger the action `jobLeaderLostLeadership` in another thread. In this action, it will remove the previous `JobManagerRegistration` from the map by `JobID`, but the old `JobManagerRegistration` may be already replaced by the new one from `registerJobManager`.

In summary, this race condition may cause the new `JobManagerRegistration` removed from ResourceManager, resulting in exception when request slot from ResourceManager. It can occur in small probability when running JobManager failure ITCase.

Consider the solution of this issue, the `jobLeaderLostLeadership` can be scheduled by `runAsync` in rpc thread.

BTW, the `mvn clean verify` is successful in my machine.