### PR TITLE
[FLINK-5890] [gelly] GatherSumApply broken when object reuse enabled

### DIFF
--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/ConnectedComponents.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/ConnectedComponents.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.graph.examples;
 
-import org.apache.flink.graph.examples.data.ConnectedComponentsDefaultData;
 import org.apache.flink.api.common.ProgramDescription;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.DataSet;
@@ -27,8 +26,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
+import org.apache.flink.graph.examples.data.ConnectedComponentsDefaultData;
 import org.apache.flink.graph.library.GSAConnectedComponents;
-import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
 /**
@@ -60,17 +59,17 @@ public class ConnectedComponents implements ProgramDescription {
 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
-		DataSet<Edge<LongValue, NullValue>> edges = getEdgesDataSet(env);
+		DataSet<Edge<Long, NullValue>> edges = getEdgesDataSet(env);
 
-		Graph<LongValue, LongValue, NullValue> graph = Graph.fromDataSet(edges, new MapFunction<LongValue, LongValue>() {
+		Graph<Long, Long, NullValue> graph = Graph.fromDataSet(edges, new MapFunction<Long, Long>() {
 			@Override
-			public LongValue map(LongValue value) throws Exception {
+			public Long map(Long value) throws Exception {
 				return value;
 			}
 		}, env);
 
-		DataSet<Vertex<LongValue, LongValue>> verticesWithMinIds = graph
-				.run(new GSAConnectedComponents<LongValue, LongValue, NullValue>(maxIterations));
+		DataSet<Vertex<Long, Long>> verticesWithMinIds = graph
+				.run(new GSAConnectedComponents<Long, Long, NullValue>(maxIterations));
 
 		// emit result
 		if (fileOutput) {
@@ -121,17 +120,17 @@ public class ConnectedComponents implements ProgramDescription {
 	}
 
 	@SuppressWarnings("serial")
-	private static DataSet<Edge<LongValue, NullValue>> getEdgesDataSet(ExecutionEnvironment env) {
+	private static DataSet<Edge<Long, NullValue>> getEdgesDataSet(ExecutionEnvironment env) {
 
 		if(fileOutput) {
 			return env.readCsvFile(edgeInputPath)
 					.ignoreComments("#")
 					.fieldDelimiter("\t")
 					.lineDelimiter("\n")
-					.types(LongValue.class, LongValue.class)
-					.map(new MapFunction<Tuple2<LongValue, LongValue>, Edge<LongValue, NullValue>>() {
+					.types(Long.class, Long.class)
+					.map(new MapFunction<Tuple2<Long, Long>, Edge<Long, NullValue>>() {
 						@Override
-						public Edge<LongValue, NullValue> map(Tuple2<LongValue, LongValue> value) throws Exception {
+						public Edge<Long, NullValue> map(Tuple2<Long, Long> value) throws Exception {
 							return new Edge<>(value.f0, value.f1, NullValue.getInstance());
 						}
 					});

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/ConnectedComponents.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/ConnectedComponents.java
@@ -28,6 +28,7 @@ import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.library.GSAConnectedComponents;
+import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
 /**
@@ -59,17 +60,17 @@ public class ConnectedComponents implements ProgramDescription {
 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
-		DataSet<Edge<Long, NullValue>> edges = getEdgesDataSet(env);
+		DataSet<Edge<LongValue, NullValue>> edges = getEdgesDataSet(env);
 
-		Graph<Long, Long, NullValue> graph = Graph.fromDataSet(edges, new MapFunction<Long, Long>() {
+		Graph<LongValue, LongValue, NullValue> graph = Graph.fromDataSet(edges, new MapFunction<LongValue, LongValue>() {
 			@Override
-			public Long map(Long value) throws Exception {
+			public LongValue map(LongValue value) throws Exception {
 				return value;
 			}
 		}, env);
 
-		DataSet<Vertex<Long, Long>> verticesWithMinIds = graph
-				.run(new GSAConnectedComponents<Long, Long, NullValue>(maxIterations));
+		DataSet<Vertex<LongValue, LongValue>> verticesWithMinIds = graph
+				.run(new GSAConnectedComponents<LongValue, LongValue, NullValue>(maxIterations));
 
 		// emit result
 		if (fileOutput) {
@@ -120,17 +121,17 @@ public class ConnectedComponents implements ProgramDescription {
 	}
 
 	@SuppressWarnings("serial")
-	private static DataSet<Edge<Long, NullValue>> getEdgesDataSet(ExecutionEnvironment env) {
+	private static DataSet<Edge<LongValue, NullValue>> getEdgesDataSet(ExecutionEnvironment env) {
 
 		if(fileOutput) {
 			return env.readCsvFile(edgeInputPath)
 					.ignoreComments("#")
 					.fieldDelimiter("\t")
 					.lineDelimiter("\n")
-					.types(Long.class, Long.class)
-					.map(new MapFunction<Tuple2<Long, Long>, Edge<Long, NullValue>>() {
+					.types(LongValue.class, LongValue.class)
+					.map(new MapFunction<Tuple2<LongValue, LongValue>, Edge<LongValue, NullValue>>() {
 						@Override
-						public Edge<Long, NullValue> map(Tuple2<Long, Long> value) throws Exception {
+						public Edge<LongValue, NullValue> map(Tuple2<LongValue, LongValue> value) throws Exception {
 							return new Edge<>(value.f0, value.f1, NullValue.getInstance());
 						}
 					});

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/ConnectedComponentsDefaultData.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/ConnectedComponentsDefaultData.java
@@ -21,6 +21,7 @@ package org.apache.flink.graph.examples.data;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.graph.Edge;
+import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
 import java.util.LinkedList;
@@ -43,10 +44,10 @@ public class ConnectedComponentsDefaultData {
 		new Object[]{3L, 4L}
 	};
 
-	public static DataSet<Edge<Long, NullValue>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
-		List<Edge<Long, NullValue>> edgeList = new LinkedList<Edge<Long, NullValue>>();
+	public static DataSet<Edge<LongValue, NullValue>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
+		List<Edge<LongValue, NullValue>> edgeList = new LinkedList<>();
 		for (Object[] edge : DEFAULT_EDGES) {
-			edgeList.add(new Edge<Long, NullValue>((Long) edge[0], (Long) edge[1], NullValue.getInstance()));
+			edgeList.add(new Edge<>(new LongValue((long)edge[0]), new LongValue((long)edge[1]), NullValue.getInstance()));
 		}
 		return env.fromCollection(edgeList);
 	}

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/ConnectedComponentsDefaultData.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/ConnectedComponentsDefaultData.java
@@ -21,7 +21,6 @@ package org.apache.flink.graph.examples.data;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.graph.Edge;
-import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
 import java.util.LinkedList;
@@ -44,10 +43,10 @@ public class ConnectedComponentsDefaultData {
 		new Object[]{3L, 4L}
 	};
 
-	public static DataSet<Edge<LongValue, NullValue>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
-		List<Edge<LongValue, NullValue>> edgeList = new LinkedList<>();
+	public static DataSet<Edge<Long, NullValue>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
+		List<Edge<Long, NullValue>> edgeList = new LinkedList<>();
 		for (Object[] edge : DEFAULT_EDGES) {
-			edgeList.add(new Edge<>(new LongValue((long)edge[0]), new LongValue((long)edge[1]), NullValue.getInstance()));
+			edgeList.add(new Edge<>((long)edge[0], (long)edge[1], NullValue.getInstance()));
 		}
 		return env.fromCollection(edgeList);
 	}

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/test/GatherSumApplyITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/test/GatherSumApplyITCase.java
@@ -19,13 +19,18 @@
 package org.apache.flink.graph.test;
 
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
+import org.apache.flink.graph.asm.translate.Translate;
+import org.apache.flink.graph.asm.translate.translators.LongToLongValue;
 import org.apache.flink.graph.examples.data.ConnectedComponentsDefaultData;
 import org.apache.flink.graph.examples.data.SingleSourceShortestPathsData;
 import org.apache.flink.graph.library.GSAConnectedComponents;
 import org.apache.flink.graph.library.GSASingleSourceShortestPaths;
+import org.apache.flink.graph.utils.GraphUtils.IdentityMapper;
 import org.apache.flink.test.util.MultipleProgramsTestBase;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
@@ -42,30 +47,46 @@ public class GatherSumApplyITCase extends MultipleProgramsTestBase {
 		super(mode);
 	}
 
-	private String expectedResult;
-
 	// --------------------------------------------------------------------------------------------
 	//  Connected Components Test
 	// --------------------------------------------------------------------------------------------
 
+	private String expectedResultCC = "1,1\n" +
+		"2,1\n" +
+		"3,1\n" +
+		"4,1\n";
+
 	@Test
-	public void testConnectedComponents() throws Exception {
+	public void testConnectedComponentsWithObjectReuseDisabled() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().disableObjectReuse();
+
+		Graph<Long, Long, NullValue> inputGraph = Graph.fromDataSet(
+			ConnectedComponentsDefaultData.getDefaultEdgeDataSet(env),
+			new IdentityMapper<Long>(), env);
+
+		List<Vertex<Long, Long>> result = inputGraph.run(
+			new GSAConnectedComponents<Long, Long, NullValue>(16)).collect();
+
+		compareResultAsTuples(result, expectedResultCC);
+	}
+
+	@Test
+	public void testConnectedComponentsWithObjectReuseEnabled() throws Exception {
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.getConfig().enableObjectReuse();
 
-		Graph<LongValue, LongValue, NullValue> inputGraph = Graph.fromDataSet(
+		DataSet<Edge<LongValue, NullValue>> edges = Translate.translateEdgeIds(
 			ConnectedComponentsDefaultData.getDefaultEdgeDataSet(env),
-			new InitMapperCC(), env);
+			new LongToLongValue());
+
+		Graph<LongValue, LongValue, NullValue> inputGraph = Graph.fromDataSet(
+			edges, new IdentityMapper<LongValue>(), env);
 
 		List<Vertex<LongValue, LongValue>> result = inputGraph.run(
 			new GSAConnectedComponents<LongValue, LongValue, NullValue>(16)).collect();
 
-		expectedResult = "1,1\n" +
-			"2,1\n" +
-			"3,1\n" +
-			"4,1\n";
-
-		compareResultAsTuples(result, expectedResult);
+		compareResultAsTuples(result, expectedResultCC);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -83,20 +104,13 @@ public class GatherSumApplyITCase extends MultipleProgramsTestBase {
 		List<Vertex<Long, Double>> result = inputGraph.run(
 			new GSASingleSourceShortestPaths<Long, NullValue>(1L, 16)).collect();
 
-		expectedResult = "1,0.0\n" +
+		String expectedResult = "1,0.0\n" +
 			"2,12.0\n" +
 			"3,13.0\n" +
 			"4,47.0\n" +
 			"5,48.0\n";
 
 		compareResultAsTuples(result, expectedResult);
-	}
-
-	@SuppressWarnings("serial")
-	private static final class InitMapperCC implements MapFunction<LongValue, LongValue> {
-		public LongValue map(LongValue value) {
-			return value;
-		}
 	}
 
 	@SuppressWarnings("serial")

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/test/GatherSumApplyITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/test/GatherSumApplyITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.graph.examples.data.SingleSourceShortestPathsData;
 import org.apache.flink.graph.library.GSAConnectedComponents;
 import org.apache.flink.graph.library.GSASingleSourceShortestPaths;
 import org.apache.flink.test.util.MultipleProgramsTestBase;
+import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,13 +51,14 @@ public class GatherSumApplyITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testConnectedComponents() throws Exception {
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().enableObjectReuse();
 
-		Graph<Long, Long, NullValue> inputGraph = Graph.fromDataSet(
+		Graph<LongValue, LongValue, NullValue> inputGraph = Graph.fromDataSet(
 			ConnectedComponentsDefaultData.getDefaultEdgeDataSet(env),
 			new InitMapperCC(), env);
 
-		List<Vertex<Long, Long>> result = inputGraph.run(
-			new GSAConnectedComponents<Long, Long, NullValue>(16)).collect();
+		List<Vertex<LongValue, LongValue>> result = inputGraph.run(
+			new GSAConnectedComponents<LongValue, LongValue, NullValue>(16)).collect();
 
 		expectedResult = "1,1\n" +
 			"2,1\n" +
@@ -91,8 +93,8 @@ public class GatherSumApplyITCase extends MultipleProgramsTestBase {
 	}
 
 	@SuppressWarnings("serial")
-	private static final class InitMapperCC implements MapFunction<Long, Long> {
-		public Long map(Long value) {
+	private static final class InitMapperCC implements MapFunction<LongValue, LongValue> {
+		public LongValue map(LongValue value) {
 			return value;
 		}
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongToLongValue.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongToLongValue.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.asm.translate.translators;
+
+import org.apache.flink.graph.asm.translate.TranslateFunction;
+import org.apache.flink.types.LongValue;
+
+/**
+ * Translate {@link Long} to {@link LongValue}.
+ */
+public class LongToLongValue
+implements TranslateFunction<Long, LongValue> {
+
+	@Override
+	public LongValue translate(Long value, LongValue reuse)
+			throws Exception {
+		if (reuse == null) {
+			reuse = new LongValue();
+		}
+
+		reuse.setValue(value);
+		return reuse;
+	}
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/gsa/ApplyFunction.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/gsa/ApplyFunction.java
@@ -137,7 +137,9 @@ public abstract class ApplyFunction<K, VV, M> implements Serializable {
 
 	private Collector<Vertex<K, VV>> out;
 
-	private Vertex<K, VV> outVal;
+	// use a local vertex instance so that the user does not overwrite a system
+	// instance used by JoinDriver
+	private Vertex<K, VV> outVal = new Vertex<>();
 
 	public void init(IterationRuntimeContext iterationRuntimeContext) {
 		this.runtimeContext = iterationRuntimeContext;
@@ -145,7 +147,7 @@ public abstract class ApplyFunction<K, VV, M> implements Serializable {
 
 	public void setOutput(Vertex<K, VV> vertex, Collector<Vertex<K, VV>> out) {
 		this.out = out;
-		this.outVal = vertex;
+		this.outVal.f0 = vertex.f0;
 	}
 
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/gsa/GatherSumApplyIteration.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/gsa/GatherSumApplyIteration.java
@@ -332,6 +332,15 @@ public class GatherSumApplyIteration<K, VV, EV, M> implements CustomUnaryOperati
 		public Tuple2<K, M> reduce(Tuple2<K, M> arg0, Tuple2<K, M> arg1) throws Exception {
 			K key = arg0.f0;
 			M result = this.sumFunction.sum(arg0.f1, arg1.f1);
+
+			// if the user returns value from the right argument then swap as
+			// in ReduceDriver.run()
+			if (result == arg1.f1) {
+				M tmp = arg1.f1;
+				arg1.f1 = arg0.f1;
+				arg0.f1 = tmp;
+			}
+
 			return new Tuple2<>(key, result);
 		}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/GraphUtils.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/GraphUtils.java
@@ -44,6 +44,18 @@ public class GraphUtils {
 	}
 
 	/**
+	 * The identity mapper returns the input as output.
+	 *
+	 * @param <T> element type
+	 */
+	public static final class IdentityMapper<T>
+	implements MapFunction<T, T> {
+		public T map(T value) {
+			return value;
+		}
+	}
+
+	/**
 	 * Map each element to a value.
 	 *
 	 * @param <I> input type


### PR DESCRIPTION
GatherSumApplyIteration uses reduce and join for which extra care must be taken when object reuse is enabled. Adds a check for objects returned by the user to prevent system objects from being overwritten.

Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
