### PR TITLE
[FLINK-5772] [elasticsearch] Allow Elasticsearch 1.x tests to rerun on failure

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch/pom.xml
@@ -84,4 +84,16 @@ under the License.
 
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<rerunFailingTestsCount>3</rerunFailingTestsCount>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>


### PR DESCRIPTION
It was reported that Elasticsearch 1.x tests can fail with this exception thrown from the embedded ES node used in IT tests:
`ProcessClusterEventTimeoutException[failed to process cluster event (acquire index lock) within 1m]`.

After some googling on this, it seems like this is a potential deadlock with Elasticsearch 1.x when creating indices.

From the looks of recent Travis tests, it seems that this flakiness rarely happens, so I think retrying the tests if they fail only for Elasticsearch 1.x and not newer versions would be a simple solution.

If it happens to pop out for 2.x and 5.x also, we might need to find another solution.