### PR TITLE
[FLINK-5897] &  [FLINK-5822]  First step towards Generic State Backends and Global State Cleanup Hooks

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -29,10 +29,12 @@ import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.util.AbstractID;
+
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.NativeLibraryLoader;
 import org.rocksdb.RocksDB;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -160,7 +162,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 
 	private void lazyInitializeForJob(
 			Environment env,
-			String operatorIdentifier) throws Exception {
+			String operatorIdentifier) throws IOException {
 
 		if (isInitialized) {
 			return;
@@ -193,7 +195,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 			}
 
 			if (dirs.isEmpty()) {
-				throw new Exception("No local storage directories available. " + errorMessage);
+				throw new IOException("No local storage directories available. " + errorMessage);
 			} else {
 				initializedDbBasePaths = dirs.toArray(new File[dirs.size()]);
 			}
@@ -235,7 +237,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 			TypeSerializer<K> keySerializer,
 			int numberOfKeyGroups,
 			KeyGroupRange keyGroupRange,
-			TaskKvStateRegistry kvStateRegistry) throws Exception {
+			TaskKvStateRegistry kvStateRegistry) throws IOException {
 
 		// first, make sure that the RocksDB JNI library is loaded
 		// we do this explicitly here to have better error handling
@@ -437,7 +439,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	//  static library loading utilities
 	// ------------------------------------------------------------------------
 
-	private void ensureRocksDBIsLoaded(String tempDirectory) throws Exception {
+	private void ensureRocksDBIsLoaded(String tempDirectory) throws IOException {
 		synchronized (RocksDBStateBackend.class) {
 			if (!rocksDbInitialized) {
 
@@ -488,7 +490,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 					}
 				}
 
-				throw new Exception("Could not load the native RocksDB library", lastException);
+				throw new IOException("Could not load the native RocksDB library", lastException);
 			}
 		}
 	}

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactory.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactory.java
@@ -15,24 +15,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.StateBackendFactory;
-import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 
 /**
  * A factory that creates an {@link org.apache.flink.contrib.streaming.state.RocksDBStateBackend}
  * from a configuration.
  */
-public class RocksDBStateBackendFactory implements StateBackendFactory<FsStateBackend> {
+public class RocksDBStateBackendFactory implements StateBackendFactory<RocksDBStateBackend> {
 
 	protected static final Logger LOG = LoggerFactory.getLogger(RocksDBStateBackendFactory.class);
 
@@ -44,9 +45,11 @@ public class RocksDBStateBackendFactory implements StateBackendFactory<FsStateBa
 	public static final String ROCKSDB_CHECKPOINT_DIRECTORY_URI_CONF_KEY = "state.backend.rocksdb.checkpointdir";
 
 	@Override
-	public AbstractStateBackend createFromConfig(Configuration config) throws Exception {
-		String checkpointDirURI = config.getString(CHECKPOINT_DIRECTORY_URI_CONF_KEY, null);
-		String rocksdbLocalPath = config.getString(ROCKSDB_CHECKPOINT_DIRECTORY_URI_CONF_KEY, null);
+	public RocksDBStateBackend createFromConfig(Configuration config) 
+			throws IllegalConfigurationException, IOException {
+
+		final String checkpointDirURI = config.getString(CHECKPOINT_DIRECTORY_URI_CONF_KEY, null);
+		final String rocksdbLocalPath = config.getString(ROCKSDB_CHECKPOINT_DIRECTORY_URI_CONF_KEY, null);
 
 		if (checkpointDirURI == null) {
 			throw new IllegalConfigurationException(
@@ -67,8 +70,8 @@ public class RocksDBStateBackendFactory implements StateBackendFactory<FsStateBa
 			return backend;
 		}
 		catch (IllegalArgumentException e) {
-			throw new Exception("Cannot initialize RocksDB State Backend with URI '"
-									+ checkpointDirURI + '.', e);
+			throw new IllegalConfigurationException(
+					"Cannot initialize RocksDB State Backend with URI '" + checkpointDirURI + '.', e);
 		}
 	}
 }

--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
@@ -74,7 +74,7 @@ public class JMXJobManagerMetricTest {
 				Collections.<JobVertexID>emptyList(),
 				Collections.<JobVertexID>emptyList(),
 				Collections.<JobVertexID>emptyList(),
-				500, 500, 50, 5, ExternalizedCheckpointSettings.none(), true));
+				500, 500, 50, 5, ExternalizedCheckpointSettings.none(), null, true));
 
 			flink.waitForActorsToBeAlive();
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandlerTest.java
@@ -56,6 +56,7 @@ public class CheckpointConfigHandlerTest {
 			minPause,
 			maxConcurrent,
 			externalized,
+			null,
 			true);
 
 		AccessExecutionGraph graph = mock(AccessExecutionGraph.class);
@@ -92,6 +93,7 @@ public class CheckpointConfigHandlerTest {
 			1212L,
 			12,
 			ExternalizedCheckpointSettings.none(),
+			null,
 			false); // at least once
 
 		AccessExecutionGraph graph = mock(AccessExecutionGraph.class);
@@ -122,6 +124,7 @@ public class CheckpointConfigHandlerTest {
 			1212L,
 			12,
 			externalizedSettings,
+			null,
 			false); // at least once
 
 		AccessExecutionGraph graph = mock(AccessExecutionGraph.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.TaskStateHandles;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -758,13 +759,19 @@ public class CheckpointCoordinator {
 		CompletedCheckpoint completedCheckpoint = null;
 
 		try {
-			completedCheckpoint = pendingCheckpoint.finalizeCheckpoint();
+			// externalize the checkpoint if required
+			if (pendingCheckpoint.getProps().externalizeCheckpoint()) {
+				completedCheckpoint = pendingCheckpoint.finalizeCheckpointExternalized();
+			} else {
+				completedCheckpoint = pendingCheckpoint.finalizeCheckpointNonExternalized();
+			}
 
 			completedCheckpointStore.addCheckpoint(completedCheckpoint);
 
 			rememberRecentCheckpointId(checkpointId);
 			dropSubsumedCheckpoints(checkpointId);
-		} catch (Exception exception) {
+		}
+		catch (Exception exception) {
 			// abort the current pending checkpoint if it has not been discarded yet
 			if (!pendingCheckpoint.isDiscarded()) {
 				pendingCheckpoint.abortError(exception);
@@ -779,8 +786,8 @@ public class CheckpointCoordinator {
 					public void run() {
 						try {
 							cc.discard();
-						} catch (Exception nestedException) {
-							LOG.warn("Could not properly discard completed checkpoint {}.", cc.getCheckpointID(), nestedException);
+						} catch (Throwable t) {
+							LOG.warn("Could not properly discard completed checkpoint {}.", cc.getCheckpointID(), t);
 						}
 					}
 				});
@@ -808,11 +815,12 @@ public class CheckpointCoordinator {
 				builder.append(", ");
 			}
 			// Remove last two chars ", "
-			builder.delete(builder.length() - 2, builder.length());
+			builder.setLength(builder.length() - 2);
 
 			LOG.debug(builder.toString());
 		}
 
+		// send the "notify complete" call to all vertices
 		final long timestamp = completedCheckpoint.getTimestamp();
 
 		for (ExecutionVertex ev : tasksToCommitTo) {
@@ -934,7 +942,7 @@ public class CheckpointCoordinator {
 					latest.getCheckpointID(),
 					latest.getProperties(),
 					restoreTimestamp,
-					latest.getExternalPath());
+					latest.getExternalPointer());
 
 				statsTracker.reportRestoredCheckpoint(restored);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.checkpoint.savepoint.SavepointStore;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStats.DiscardCallback;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.state.StateUtil;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.util.ExceptionUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,8 +38,36 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * A successful checkpoint describes a checkpoint after all required tasks acknowledged it (with their state)
- * and that is considered completed.
+ * A CompletedCheckpoint describes a checkpoint after all required tasks acknowledged it (with their state)
+ * and that is considered successful. The CompletedCheckpoint class contains all the metadata of the
+ * checkpoint, i.e., checkpoint ID, timestamps, and the handles to all states that are part of the
+ * checkpoint.
+ * 
+ * <h2>Size the CompletedCheckpoint Instances</h2>
+ * 
+ * In most cases, the CompletedCheckpoint objects are very small, because the handles to the checkpoint
+ * states are only pointers (such as file paths). However, the some state backend implementations may
+ * choose to store some payload data directly with the metadata (for example to avoid many small files).
+ * If those thresholds are increased to large values, the memory consumption of the CompletedCheckpoint
+ * objects can be significant.
+ * 
+ * <h2>Externalized Metadata</h2>
+ * 
+ * The metadata of the CompletedCheckpoint is optionally also persisted in an external storage
+ * system. In that case, the checkpoint is called <i>externalized</i>.
+ * 
+ * <p>Externalized checkpoints have an external pointer, which points to the metadata. For example
+ * when externalizing to a file system, that pointer is the file path to the checkpoint's folder
+ * or the metadata file. For a state backend that stores metadata in database tables, the pointer
+ * could be the table name and row key. The pointer is encoded as a String.
+ * 
+ * <h2>Externalized Metadata and High-availability</h2>
+ * 
+ * For high availability setups, the checkpoint metadata must be stored persistent and available
+ * as well. The high-availability services that stores the checkpoint ground-truth (meaning what are
+ * the latest completed checkpoints in what order) often rely on checkpoints being externalized. That
+ * way, those services only store pointers to the externalized metadata, rather than the complete
+ * metadata itself (for example ZooKeeper's ZNode payload should ideally be less than megabytes).
  */
 public class CompletedCheckpoint implements Serializable {
 
@@ -44,8 +75,12 @@ public class CompletedCheckpoint implements Serializable {
 
 	private static final long serialVersionUID = -8360248179615702014L;
 
+	// ------------------------------------------------------------------------
+
+	/** The ID of the job that the checkpoint belongs to */
 	private final JobID job;
 
+	/** The ID (logical timestamp) of the checkpoint */
 	private final long checkpointID;
 
 	/** The timestamp when the checkpoint was triggered. */
@@ -60,23 +95,41 @@ public class CompletedCheckpoint implements Serializable {
 	/** Properties for this checkpoint. */
 	private final CheckpointProperties props;
 
-	/** External path if persisted checkpoint; <code>null</code> otherwise. */
-	private final String externalPath;
+	/** The state handle to the externalized meta data, if the metadata has been externalized */
+	@Nullable
+	private final StreamStateHandle externalizedMetadata;
+
+	/** External pointer to the completed checkpoint (for example file path) if externalized; null otherwise. */
+	@Nullable
+	private final String externalPointer;
 
 	/** Optional stats tracker callback for discard. */
 	@Nullable
-	private transient CompletedCheckpointStats.DiscardCallback discardCallback;
+	private transient volatile DiscardCallback discardCallback;
 
 	// ------------------------------------------------------------------------
 
-	public CompletedCheckpoint(
+	@VisibleForTesting
+	CompletedCheckpoint(
 			JobID job,
 			long checkpointID,
 			long timestamp,
 			long completionTimestamp,
 			Map<JobVertexID, TaskState> taskStates) {
 
-		this(job, checkpointID, timestamp, completionTimestamp, taskStates, CheckpointProperties.forStandardCheckpoint(), null);
+		this(job, checkpointID, timestamp, completionTimestamp, taskStates,
+				CheckpointProperties.forStandardCheckpoint());
+	}
+
+	public CompletedCheckpoint(
+			JobID job,
+			long checkpointID,
+			long timestamp,
+			long completionTimestamp,
+			Map<JobVertexID, TaskState> taskStates,
+			CheckpointProperties props) {
+
+		this(job, checkpointID, timestamp, completionTimestamp, taskStates, props, null, null);
 	}
 
 	public CompletedCheckpoint(
@@ -86,11 +139,18 @@ public class CompletedCheckpoint implements Serializable {
 			long completionTimestamp,
 			Map<JobVertexID, TaskState> taskStates,
 			CheckpointProperties props,
-			String externalPath) {
+			@Nullable StreamStateHandle externalizedMetadata,
+			@Nullable String externalPointer) {
 
 		checkArgument(checkpointID >= 0);
 		checkArgument(timestamp >= 0);
 		checkArgument(completionTimestamp >= 0);
+
+		checkArgument((externalPointer == null) == (externalizedMetadata == null),
+				"external pointer without externalized metadata must be both null or both non-null");
+
+		checkArgument(!props.externalizeCheckpoint() || externalPointer != null, 
+			"Checkpoint properties require externalized checkpoint, but checkpoint is not externalized");
 
 		this.job = checkNotNull(job);
 		this.checkpointID = checkpointID;
@@ -98,12 +158,8 @@ public class CompletedCheckpoint implements Serializable {
 		this.duration = completionTimestamp - timestamp;
 		this.taskStates = checkNotNull(taskStates);
 		this.props = checkNotNull(props);
-		this.externalPath = externalPath;
-
-		if (props.externalizeCheckpoint() && externalPath == null) {
-			throw new NullPointerException("Checkpoint properties say that the checkpoint " +
-					"should have been persisted, but missing external path.");
-		}
+		this.externalizedMetadata = externalizedMetadata;
+		this.externalPointer = externalPointer;
 	}
 
 	// ------------------------------------------------------------------------
@@ -146,10 +202,9 @@ public class CompletedCheckpoint implements Serializable {
 			discard();
 			return true;
 		} else {
-			if (externalPath != null) {
+			if (externalPointer != null) {
 				LOG.info("Persistent checkpoint with ID {} at '{}' not discarded.",
-						checkpointID,
-						externalPath);
+						checkpointID, externalPointer);
 			}
 
 			return false;
@@ -158,14 +213,36 @@ public class CompletedCheckpoint implements Serializable {
 
 	void discard() throws Exception {
 		try {
-			if (externalPath != null) {
-				SavepointStore.removeSavepointFile(externalPath);
+			// collect exceptions and continue cleanup
+			Exception exception = null;
+
+			// drop the metadata, if we have some
+			if (externalizedMetadata != null) {
+				try {
+					externalizedMetadata.discardState();
+				}
+				catch (Exception e) {
+					exception = e;
+				}
 			}
 
-			StateUtil.bestEffortDiscardAllStateObjects(taskStates.values());
-		} finally {
+			// drop the actual state
+			try {
+				StateUtil.bestEffortDiscardAllStateObjects(taskStates.values());
+			}
+			catch (Exception e) {
+				exception = ExceptionUtils.firstOrSuppressed(e, exception);
+			}
+
+			if (exception != null) {
+				throw exception;
+			}
+		}
+		finally {
 			taskStates.clear();
 
+			// to be null-pointer safe, copy reference to stack
+			DiscardCallback discardCallback = this.discardCallback;
 			if (discardCallback != null) {
 				discardCallback.notifyDiscardedCheckpoint();
 			}
@@ -190,8 +267,18 @@ public class CompletedCheckpoint implements Serializable {
 		return taskStates.get(jobVertexID);
 	}
 
-	public String getExternalPath() {
-		return externalPath;
+	public boolean isExternalized() {
+		return externalizedMetadata != null;
+	}
+
+	@Nullable
+	public StreamStateHandle getExternalizedMetadata() {
+		return externalizedMetadata;
+	}
+
+	@Nullable
+	public String getExternalPointer() {
+		return externalPointer;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
@@ -72,4 +72,5 @@ public interface CompletedCheckpointStore {
 	 */
 	int getNumberOfRetainedCheckpoints();
 
+	boolean requiresExternalizedCheckpoints();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
@@ -96,4 +96,8 @@ public class StandaloneCompletedCheckpointStore implements CompletedCheckpointSt
 		}
 	}
 
+	@Override
+	public boolean requiresExternalizedCheckpoints() {
+		return false;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
@@ -125,6 +125,11 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 		LOG.info("Initialized in '{}'.", checkpointsPath);
 	}
 
+	@Override
+	public boolean requiresExternalizedCheckpoints() {
+		return true;
+	}
+
 	/**
 	 * Gets the latest checkpoint from ZooKeeper and removes all others.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointStore.java
@@ -19,12 +19,15 @@
 package org.apache.flink.runtime.checkpoint.savepoint;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.Preconditions;
 
@@ -118,6 +121,28 @@ public class SavepointStore {
 	 * @throws IOException Failures during store are forwarded
 	 */
 	public static <T extends Savepoint> String storeSavepoint(String directory, T savepoint) throws IOException {
+		// write and create the file handle
+		FileStateHandle metadataFileHandle = storeSavepointToHandle(directory, savepoint);
+
+		// we return the savepoint directory path here!
+		// The directory path also works to resume from and is more elegant than the direct
+		// metadata file pointer
+		return metadataFileHandle.getFilePath().getParent().toString();
+	}
+
+	/**
+	 * Stores the savepoint metadata file to a state handle.
+	 *
+	 * @param directory Target directory to store savepoint in
+	 * @param savepoint Savepoint to be stored
+	 *                     
+	 * @return State handle to the checkpoint metadata
+	 * @throws IOException Failures during store are forwarded
+	 */
+	public static <T extends Savepoint> FileStateHandle storeSavepointToHandle(
+			String directory,
+			T savepoint) throws IOException {
+
 		checkNotNull(directory, "Target directory");
 		checkNotNull(savepoint, "Savepoint");
 
@@ -127,10 +152,9 @@ public class SavepointStore {
 		final FileSystem fs = FileSystem.get(basePath.toUri());
 
 		boolean success = false;
-		try (FSDataOutputStream fdos = fs.create(metadataFilePath, WriteMode.NO_OVERWRITE); 
+		try (FSDataOutputStream fdos = fs.create(metadataFilePath, WriteMode.NO_OVERWRITE);
 				DataOutputStream dos = new DataOutputStream(fdos))
 		{
-
 			// Write header
 			dos.writeInt(MAGIC_NUMBER);
 			dos.writeInt(savepoint.getVersion());
@@ -138,7 +162,13 @@ public class SavepointStore {
 			// Write savepoint
 			SavepointSerializer<T> serializer = SavepointSerializers.getSerializer(savepoint);
 			serializer.serialize(savepoint, dos);
+
+			// construct result handle
+			FileStateHandle handle = new FileStateHandle(metadataFilePath, dos.size());
+
+			// all good!
 			success = true;
+			return handle;
 		}
 		finally {
 			if (!success && fs.exists(metadataFilePath)) {
@@ -147,22 +177,37 @@ public class SavepointStore {
 				}
 			}
 		}
-
-		// we return the savepoint directory path here!
-		// The directory path also works to resume from and is more elegant than the direct
-		// metadata file pointer
-		return basePath.toString();
 	}
 
 	/**
 	 * Loads the savepoint at the specified path.
 	 *
 	 * @param savepointFileOrDirectory Path to the parent savepoint directory or the meta data file.
+	 * @param classLoader The class loader used to resolve serialized classes from legacy savepoint formats.
 	 * @return The loaded savepoint
+	 * 
 	 * @throws IOException Failures during load are forwarded
 	 */
-	public static Savepoint loadSavepoint(String savepointFileOrDirectory, ClassLoader userClassLoader) throws IOException {
-		Preconditions.checkNotNull(savepointFileOrDirectory, "Path");
+	public static Savepoint loadSavepoint(String savepointFileOrDirectory, ClassLoader classLoader) throws IOException {
+		return loadSavepointWithHandle(savepointFileOrDirectory, classLoader).f0;
+	}
+
+	/**
+	 * Loads the savepoint at the specified path. This methods returns the savepoint, as well as the
+	 * handle to the metadata.
+	 *
+	 * @param savepointFileOrDirectory Path to the parent savepoint directory or the meta data file.
+	 * @param classLoader The class loader used to resolve serialized classes from legacy savepoint formats.
+	 * @return The loaded savepoint
+	 *
+	 * @throws IOException Failures during load are forwarded
+	 */
+	public static Tuple2<Savepoint, StreamStateHandle> loadSavepointWithHandle(
+			String savepointFileOrDirectory,
+			ClassLoader classLoader) throws IOException {
+		
+		checkNotNull(savepointFileOrDirectory, "savepointFileOrDirectory");
+		checkNotNull(classLoader, "classLoader");
 
 		Path path = new Path(savepointFileOrDirectory);
 
@@ -180,11 +225,13 @@ public class SavepointStore {
 				LOG.info("Using savepoint file in {}", path);
 			} else {
 				throw new IOException("Cannot find meta data file in directory " + path
-					+ ". Please try to load the savepoint directly from the meta data file "
-					+ "instead of the directory.");
+						+ ". Please try to load the savepoint directly from the meta data file "
+						+ "instead of the directory.");
 			}
 		}
 
+		// load the savepoint
+		final Savepoint savepoint;
 		try (DataInputStream dis = new DataInputViewStreamWrapper(fs.open(path))) {
 			int magicNumber = dis.readInt();
 
@@ -192,15 +239,27 @@ public class SavepointStore {
 				int version = dis.readInt();
 
 				SavepointSerializer<?> serializer = SavepointSerializers.getSerializer(version);
-				return serializer.deserialize(dis, userClassLoader);
+				savepoint = serializer.deserialize(dis, classLoader);
 			} else {
-				throw new RuntimeException("Unexpected magic number. This is most likely " +
-						"caused by trying to load a Flink 1.0 savepoint. You cannot load a " +
-						"savepoint triggered by Flink 1.0 with this version of Flink. If it is " +
-						"_not_ a Flink 1.0 savepoint, this error indicates that the specified " +
-						"file is not a proper savepoint or the file has been corrupted.");
+				throw new RuntimeException("Unexpected magic number. This can have multiple reasons: " +
+						"(1) You are trying to load a Flink 1.0 savepoint, which is not supported by this " +
+						"version of Flink. (2) The file you were pointing to is not a savepoint at all. " +
+						"(3) The savepoint file has been corrupted.");
 			}
 		}
+
+		// construct the stream handle to the metadata file
+		// we get the size best-effort
+		long size = 0;
+		try {
+			size = fs.getFileStatus(path).getLen();
+		}
+		catch (Exception ignored) {
+			// we don't know the size, but we don't want to fail the savepoint loading for that
+		}
+		StreamStateHandle metadataHandle = new FileStateHandle(path, size);
+
+		return new Tuple2<>(savepoint, metadataHandle);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -61,6 +61,7 @@ import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.util.SerializableObject;
 import org.apache.flink.runtime.util.SerializedThrowable;
@@ -348,7 +349,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 		return false;
 	}
 
-	public void enableSnapshotCheckpointing(
+	public void enableCheckpointing(
 			long interval,
 			long checkpointTimeout,
 			long minPauseBetweenCheckpoints,
@@ -360,6 +361,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 			CheckpointIDCounter checkpointIDCounter,
 			CompletedCheckpointStore checkpointStore,
 			String checkpointDir,
+			StateBackend metadataStore,
 			CheckpointStatsTracker statsTracker) {
 
 		// simple sanity checks

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
@@ -37,6 +38,9 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.jsonplan.JsonPlanGenerator;
 import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
+import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.util.DynamicCodeLoadingException;
 import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
@@ -71,8 +75,8 @@ public class ExecutionGraphBuilder {
 			MetricGroup metrics,
 			int parallelismForAutoMax,
 			Logger log)
-		throws JobExecutionException, JobException
-	{
+		throws JobExecutionException, JobException {
+
 		checkNotNull(jobGraph, "job graph cannot be null");
 
 		final String jobName = jobGraph.getName();
@@ -191,7 +195,28 @@ public class ExecutionGraphBuilder {
 			String externalizedCheckpointsDir = jobManagerConfig.getString(
 					ConfigConstants.CHECKPOINTS_DIRECTORY_KEY, null);
 
-			executionGraph.enableSnapshotCheckpointing(
+			// load the state backend for checkpoint metadata.
+			// if specified in the application, use from there, otherwise load from configuration
+			final StateBackend metadataBackend;
+
+			final StateBackend applicationConfiguredBackend = snapshotSettings.getDefaultStateBackend();
+			if (applicationConfiguredBackend != null) {
+				metadataBackend = applicationConfiguredBackend;
+
+				log.info("Using application-defined state backend for checkpoint/savepoint metadata: {}.",
+						applicationConfiguredBackend);
+			}
+			else {
+				try {
+					metadataBackend = AbstractStateBackend
+							.loadStateBackendFromConfigOrCreateDefault(jobManagerConfig, classLoader, log);
+				}
+				catch (IllegalConfigurationException | IOException | DynamicCodeLoadingException e) {
+					throw new JobExecutionException(jobId, "Could not instantiate configured state backend", e);
+				}
+			}
+
+			executionGraph.enableCheckpointing(
 					snapshotSettings.getCheckpointInterval(),
 					snapshotSettings.getCheckpointTimeout(),
 					snapshotSettings.getMinPauseBetweenCheckpoints(),
@@ -203,6 +228,7 @@ public class ExecutionGraphBuilder {
 					checkpointIdCounter,
 					completedCheckpoints,
 					externalizedCheckpointsDir,
+					metadataBackend,
 					checkpointStatsTracker);
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/JobSnapshottingSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/JobSnapshottingSettings.java
@@ -19,7 +19,9 @@
 package org.apache.flink.runtime.jobgraph.tasks;
 
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.state.StateBackend;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
@@ -50,6 +52,10 @@ public class JobSnapshottingSettings implements java.io.Serializable {
 	/** Settings for externalized checkpoints. */
 	private final ExternalizedCheckpointSettings externalizedCheckpointSettings;
 
+	/** The default state backend, if configured by the user in the job */
+	@Nullable
+	private final StateBackend defaultStateBackend;
+
 	/**
 	 * Flag indicating whether exactly once checkpoint mode has been configured.
 	 * If <code>false</code>, at least once mode has been configured. This is
@@ -58,7 +64,7 @@ public class JobSnapshottingSettings implements java.io.Serializable {
 	 * UI.
 	 */
 	private final boolean isExactlyOnce;
-	
+
 	public JobSnapshottingSettings(
 			List<JobVertexID> verticesToTrigger,
 			List<JobVertexID> verticesToAcknowledge,
@@ -68,6 +74,7 @@ public class JobSnapshottingSettings implements java.io.Serializable {
 			long minPauseBetweenCheckpoints,
 			int maxConcurrentCheckpoints,
 			ExternalizedCheckpointSettings externalizedCheckpointSettings,
+			@Nullable StateBackend defaultStateBackend,
 			boolean isExactlyOnce) {
 
 		// sanity checks
@@ -84,6 +91,7 @@ public class JobSnapshottingSettings implements java.io.Serializable {
 		this.minPauseBetweenCheckpoints = minPauseBetweenCheckpoints;
 		this.maxConcurrentCheckpoints = maxConcurrentCheckpoints;
 		this.externalizedCheckpointSettings = requireNonNull(externalizedCheckpointSettings);
+		this.defaultStateBackend = defaultStateBackend;
 		this.isExactlyOnce = isExactlyOnce;
 	}
 	
@@ -119,6 +127,11 @@ public class JobSnapshottingSettings implements java.io.Serializable {
 
 	public ExternalizedCheckpointSettings getExternalizedCheckpointSettings() {
 		return externalizedCheckpointSettings;
+	}
+
+	@Nullable
+	public StateBackend getDefaultStateBackend() {
+		return defaultStateBackend;
 	}
 
 	public boolean isExactlyOnce() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
@@ -21,19 +21,49 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.util.DynamicCodeLoadingException;
+
+import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * An abstract base implementation of the {@link StateBackend} interface.
+ * 
+ * <p>
  */
 @PublicEvolving
 public abstract class AbstractStateBackend implements StateBackend, java.io.Serializable {
 
 	private static final long serialVersionUID = 4620415814639230247L;
+
+	// ------------------------------------------------------------------------
+	//  Configuration shortcut names
+	// ------------------------------------------------------------------------
+
+	/** The shortcut configuration name for the MemoryState backend that checkpoints to the JobManager */
+	public static final String MEMORY_STATE_BACKEND_NAME = "jobmanager";
+
+	/** The shortcut configuration name for the FileSystem State backend */ 
+	public static final String FS_STATE_BACKEND_NAME = "filesystem";
+
+	/** The shortcut configuration name for the RocksDB State Backend */
+	public static final String ROCKSDB_STATE_BACKEND_NAME = "rocksdb";
+
+	// ------------------------------------------------------------------------
+	//  State Backend - Persisting Byte Storage
+	// ------------------------------------------------------------------------
 
 	@Override
 	public abstract CheckpointStreamFactory createStreamFactory(
@@ -46,6 +76,10 @@ public abstract class AbstractStateBackend implements StateBackend, java.io.Seri
 			String operatorIdentifier,
 			@Nullable String targetLocation) throws IOException;
 
+	// ------------------------------------------------------------------------
+	//  State Backend - State-Holding Backends
+	// ------------------------------------------------------------------------
+
 	@Override
 	public abstract <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(
 			Environment env,
@@ -54,7 +88,7 @@ public abstract class AbstractStateBackend implements StateBackend, java.io.Seri
 			TypeSerializer<K> keySerializer,
 			int numberOfKeyGroups,
 			KeyGroupRange keyGroupRange,
-			TaskKvStateRegistry kvStateRegistry) throws Exception;
+			TaskKvStateRegistry kvStateRegistry) throws IOException;
 
 	@Override
 	public OperatorStateBackend createOperatorStateBackend(
@@ -62,5 +96,142 @@ public abstract class AbstractStateBackend implements StateBackend, java.io.Seri
 			String operatorIdentifier) throws Exception {
 
 		return new DefaultOperatorStateBackend(env.getUserClassLoader());
+	}
+
+	// ------------------------------------------------------------------------
+	//  Loading the state backend from a configuration 
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Loads the state backend from the configuration, from the parameter 'state.backend', as defined
+	 * in {@link CoreOptions#STATE_BACKEND}.
+	 * 
+	 * <p>The state backends can be specified either via their shortcut name, or via the class name
+	 * of a {@link StateBackendFactory}. If a StateBackendFactory class name is specified, the factory
+	 * is instantiated (via its zero-argument constructor) and its
+	 * {@link StateBackendFactory#createFromConfig(Configuration)} method is called.
+	 *
+	 * <p>Recognized shortcut names are '{@value AbstractStateBackend#MEMORY_STATE_BACKEND_NAME}',
+	 * '{@value AbstractStateBackend#FS_STATE_BACKEND_NAME}', and
+	 * '{@value AbstractStateBackend#ROCKSDB_STATE_BACKEND_NAME}'.
+	 * 
+	 * @param config The configuration to load the state backend from
+	 * @param classLoader The class loader that should be used to load the state backend
+	 * @param logger Optionally, a logger to log actions to (may be null)
+	 * 
+	 * @return The instantiated state backend.
+	 * 
+	 * @throws DynamicCodeLoadingException
+	 *             Thrown if a state backend factory is configured and the factory class was not
+	 *             found or the factory could not be instantiated
+	 * @throws IllegalConfigurationException
+	 *             May be thrown by the StateBackendFactory when creating / configuring the state
+	 *             backend in the factory
+	 * @throws IOException
+	 *             May be thrown by the StateBackendFactory when instantiating the state backend
+	 */
+	public static StateBackend loadStateBackendFromConfig(
+			Configuration config,
+			ClassLoader classLoader,
+			@Nullable Logger logger) throws IllegalConfigurationException, DynamicCodeLoadingException, IOException {
+
+		checkNotNull(config, "config");
+		checkNotNull(classLoader, "classLoader");
+
+		final String backendName = config.getString(CoreOptions.STATE_BACKEND);
+		if (backendName == null) {
+			return null;
+		}
+
+		// by default the factory class is the backend name 
+		String factoryClassName = backendName;
+
+		switch (backendName.toLowerCase()) {
+			case MEMORY_STATE_BACKEND_NAME:
+				if (logger != null) {
+					logger.info("State backend is set to heap memory (checkpoint to JobManager)");
+				}
+				return new MemoryStateBackend();
+
+			case FS_STATE_BACKEND_NAME:
+				FsStateBackend fsBackend = new FsStateBackendFactory().createFromConfig(config);
+				if (logger != null) {
+					logger.info("State backend is set to heap memory (checkpoints to filesystem \"{}\")",
+							fsBackend.getBasePath());
+				}
+				return fsBackend;
+
+			case ROCKSDB_STATE_BACKEND_NAME:
+				factoryClassName = "org.apache.flink.contrib.streaming.state.RocksDBStateBackendFactory";
+				// fall through to the 'default' case that uses reflection to load the backend
+				// that way we can keep RocksDB in a separate module
+
+			default:
+				if (logger != null) {
+					logger.info("Loading state backend via factory {}", factoryClassName);
+				}
+
+				StateBackendFactory<?> factory;
+				try {
+					@SuppressWarnings("rawtypes")
+					Class<? extends StateBackendFactory> clazz = 
+							Class.forName(factoryClassName, false, classLoader)
+									.asSubclass(StateBackendFactory.class);
+
+					factory = clazz.newInstance();
+				}
+				catch (ClassNotFoundException e) {
+					throw new DynamicCodeLoadingException(
+							"Cannot find configured state backend factory class: " + backendName, e);
+				}
+				catch (ClassCastException | InstantiationException | IllegalAccessException e) {
+					throw new DynamicCodeLoadingException("The class configured under '" +
+							CoreOptions.STATE_BACKEND.key() + "' is not a valid state backend factory (" +
+							backendName + ')', e);
+				}
+				
+				return factory.createFromConfig(config);
+		}
+	}
+
+	/**
+	 * Loads the state backend from the configuration, from the parameter 'state.backend', as defined
+	 * in {@link CoreOptions#STATE_BACKEND}. If no state backend is configures, this instantiates the
+	 * default state backend (the {@link MemoryStateBackend}). 
+	 *
+	 * <p>Refer to {@link #loadStateBackendFromConfig(Configuration, ClassLoader, Logger)} for details on
+	 * how the state backend is loaded from the configuration.
+	 *
+	 * @param config The configuration to load the state backend from
+	 * @param classLoader The class loader that should be used to load the state backend
+	 * @param logger Optionally, a logger to log actions to (may be null)
+	 *
+	 * @return The instantiated state backend.
+	 *
+	 * @throws DynamicCodeLoadingException
+	 *             Thrown if a state backend factory is configured and the factory class was not
+	 *             found or the factory could not be instantiated
+	 * @throws IllegalConfigurationException
+	 *             May be thrown by the StateBackendFactory when creating / configuring the state
+	 *             backend in the factory
+	 * @throws IOException
+	 *             May be thrown by the StateBackendFactory when instantiating the state backend
+	 */
+	public static StateBackend loadStateBackendFromConfigOrCreateDefault(
+			Configuration config,
+			ClassLoader classLoader,
+			@Nullable Logger logger) throws IllegalConfigurationException, DynamicCodeLoadingException, IOException {
+
+		final StateBackend fromConfig = loadStateBackendFromConfig(config, classLoader, logger);
+
+		if (fromConfig != null) {
+			return fromConfig;
+		}
+		else {
+			if (logger != null) {
+				logger.info("No state backend has been configured, using default state backend (Memory / JobManager)");
+			}
+			return new MemoryStateBackend();
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendFactory.java
@@ -18,17 +18,24 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
 
+import java.io.IOException;
 import java.io.Serializable;
 
 /**
  * A factory to create a specific state backend. The state backend creation gets a Configuration
  * object that can be used to read further config values.
  * 
+ * <p>The state backend factory is typically specified in the configuration to produce a
+ * configured state backend.
+ * 
  * @param <T> The type of the state backend created.
  */
-public interface StateBackendFactory<T extends AbstractStateBackend> extends Serializable {
+@PublicEvolving
+public interface StateBackendFactory<T extends StateBackend> extends Serializable {
 
 	/**
 	 * Creates the state backend, optionally using the given configuration.
@@ -36,7 +43,10 @@ public interface StateBackendFactory<T extends AbstractStateBackend> extends Ser
 	 * @param config The Flink configuration (loaded by the TaskManager).
 	 * @return The created state backend. 
 	 * 
-	 * @throws Exception Exceptions during instantiation can be forwarded.
+	 * @throws IllegalConfigurationException
+	 *             If the configuration misses critical values, or specifies invalid values
+	 * @throws IOException
+	 *             If the state backend initialization failed due to an I/O exception
 	 */
-	AbstractStateBackend createFromConfig(Configuration config) throws Exception;
+	T createFromConfig(Configuration config) throws IllegalConfigurationException, IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FutureUtil;
 
 import java.util.concurrent.RunnableFuture;
@@ -42,26 +43,22 @@ public class StateUtil {
 			Iterable<? extends StateObject> handlesToDiscard) throws Exception {
 
 		if (handlesToDiscard != null) {
-
-			Exception suppressedExceptions = null;
+			Exception exception = null;
 
 			for (StateObject state : handlesToDiscard) {
 
 				if (state != null) {
 					try {
 						state.discardState();
-					} catch (Exception ex) {
-						//best effort to still cleanup other states and deliver exceptions in the end
-						if (suppressedExceptions == null) {
-							suppressedExceptions = new Exception(ex);
-						}
-						suppressedExceptions.addSuppressed(ex);
+					}
+					catch (Exception ex) {
+						exception = ExceptionUtils.firstOrSuppressed(ex, exception);
 					}
 				}
 			}
 
-			if (suppressedExceptions != null) {
-				throw suppressedExceptions;
+			if (exception != null) {
+				throw exception;
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/package-info.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains the classes for key/value state backends that store the state
+ * on the JVM heap as objects.
+ */
+package org.apache.flink.runtime.state.heap;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/internal/package-info.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/internal/package-info.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package holds the classes of the <b>internal state type hierarchy</b>.
+ *
+ * <p>The internal state classes give access to the namespace getters and setters and access to
+ * additional functionality, like raw value access or state merging.
+ *
+ * <p>The public API state hierarchy is intended to be programmed against by Flink applications.
+ * The internal state hierarchy holds all the auxiliary methods that are used by the runtime and not
+ * intended to be used by user applications. These internal methods are considered of limited use to users and
+ * only confusing, and are usually not regarded as stable across releases.
+ *
+ * <p>Each specific type in the internal state hierarchy extends the type from the public
+ * state hierarchy. The following illustrates the relationship between the public- and the internal
+ * hierarchy at the example of a subset of the classes:
+ *
+ * <pre>
+ *             State
+ *               |
+ *               +-------------------InternalKvState
+ *               |                         |
+ *          MergingState                   |
+ *               |                         |
+ *               +-----------------InternalMergingState
+ *               |                         |
+ *      +--------+------+                  |
+ *      |               |                  |
+ * ReducingState    ListState        +-----+-----------------+
+ *      |               |            |                       |
+ *      |               +-----------   -----------------InternalListState
+ *      |                            |
+ *      +------------------InternalReducingState
+ * </pre>
+ */
+package org.apache.flink.runtime.state.internal;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -90,7 +90,7 @@ public class MemoryStateBackend extends AbstractStateBackend {
 			TypeSerializer<K> keySerializer,
 			int numberOfKeyGroups,
 			KeyGroupRange keyGroupRange,
-			TaskKvStateRegistry kvStateRegistry) throws IOException {
+			TaskKvStateRegistry kvStateRegistry) {
 
 		return new HeapKeyedStateBackend<>(
 				kvStateRegistry,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -134,5 +134,10 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 		public int getNumberOfRetainedCheckpoints() {
 			return -1;
 		}
+
+		@Override
+		public boolean requiresExternalizedCheckpoints() {
+			return false;
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
@@ -62,6 +62,7 @@ public class CheckpointStatsTrackerTest {
 			191929L,
 			123,
 			ExternalizedCheckpointSettings.none(),
+			null,
 			false);
 
 		CheckpointStatsTracker tracker = new CheckpointStatsTracker(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
@@ -237,7 +237,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
 			Map<JobVertexID, TaskState> taskGroupStates,
 			CheckpointProperties props) {
 
-			super(jobId, checkpointId, timestamp, Long.MAX_VALUE, taskGroupStates, props, null);
+			super(jobId, checkpointId, timestamp, Long.MAX_VALUE, taskGroupStates, props);
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CoordinatorShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CoordinatorShutdownTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
-import org.apache.flink.runtime.testtasks.NoOpInvokable;
 
 import org.junit.Test;
 
@@ -67,7 +66,7 @@ public class CoordinatorShutdownTest {
 			
 			JobGraph testGraph = new JobGraph("test job", vertex);
 			testGraph.setSnapshotSettings(new JobSnapshottingSettings(vertexIdList, vertexIdList, vertexIdList, 
-					5000, 60000, 0L, Integer.MAX_VALUE, ExternalizedCheckpointSettings.none(), true));
+					5000, 60000, 0L, Integer.MAX_VALUE, ExternalizedCheckpointSettings.none(), null, true));
 			
 			ActorGateway jmGateway = cluster.getLeaderGateway(TestingUtils.TESTING_DURATION());
 
@@ -126,7 +125,7 @@ public class CoordinatorShutdownTest {
 
 			JobGraph testGraph = new JobGraph("test job", vertex);
 			testGraph.setSnapshotSettings(new JobSnapshottingSettings(vertexIdList, vertexIdList, vertexIdList,
-					5000, 60000, 0L, Integer.MAX_VALUE, ExternalizedCheckpointSettings.none(), true));
+					5000, 60000, 0L, Integer.MAX_VALUE, ExternalizedCheckpointSettings.none(), null, true));
 			
 			ActorGateway jmGateway = cluster.getLeaderGateway(TestingUtils.TESTING_DURATION());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -106,7 +106,7 @@ public class ExecutionGraphCheckpointCoordinatorTest {
 			ClassLoader.getSystemClassLoader(),
 			new UnregisteredMetricsGroup());
 
-		executionGraph.enableSnapshotCheckpointing(
+		executionGraph.enableCheckpointing(
 				100,
 				100,
 				100,
@@ -117,6 +117,7 @@ public class ExecutionGraphCheckpointCoordinatorTest {
 				Collections.<ExecutionJobVertex>emptyList(),
 				counter,
 				store,
+				null,
 				null,
 				CheckpointStatsTrackerTest.createTestTracker());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -112,7 +112,7 @@ public class ArchivedExecutionGraphTest {
 				mock(JobSnapshottingSettings.class),
 				new UnregisteredMetricsGroup());
 
-		runtimeGraph.enableSnapshotCheckpointing(
+		runtimeGraph.enableCheckpointing(
 			100,
 			100,
 			100,
@@ -123,6 +123,7 @@ public class ArchivedExecutionGraphTest {
 			Collections.<ExecutionJobVertex>emptyList(),
 			new StandaloneCheckpointIDCounter(),
 			new StandaloneCompletedCheckpointStore(1),
+			null,
 			null,
 			statsTracker);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/tasks/JobSnapshottingSettingsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/tasks/JobSnapshottingSettingsTest.java
@@ -20,11 +20,14 @@ package org.apache.flink.runtime.jobgraph.tasks;
 
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.junit.Test;
 
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class JobSnapshottingSettingsTest {
 
@@ -42,6 +45,7 @@ public class JobSnapshottingSettingsTest {
 			112,
 			12,
 			ExternalizedCheckpointSettings.externalizeCheckpoints(true),
+			new MemoryStateBackend(),
 			false);
 
 		JobSnapshottingSettings copy = CommonTestUtils.createCopySerializable(settings);
@@ -55,5 +59,7 @@ public class JobSnapshottingSettingsTest {
 		assertEquals(settings.getExternalizedCheckpointSettings().externalizeCheckpoints(), copy.getExternalizedCheckpointSettings().externalizeCheckpoints());
 		assertEquals(settings.getExternalizedCheckpointSettings().deleteOnCancellation(), copy.getExternalizedCheckpointSettings().deleteOnCancellation());
 		assertEquals(settings.isExactlyOnce(), copy.isExactlyOnce());
+		assertNotNull(copy.getDefaultStateBackend());
+		assertTrue(copy.getDefaultStateBackend().getClass() == MemoryStateBackend.class);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -225,6 +225,7 @@ public class JobManagerHARecoveryTest {
 					0,
 					1,
 					ExternalizedCheckpointSettings.none(),
+					null,
 					true));
 
 			BlockingStatefulInvokable.initializeStaticHelpers(slots);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -483,6 +483,10 @@ public class JobManagerHARecoveryTest {
 			return checkpoints.size();
 		}
 
+		@Override
+		public boolean requiresExternalizedCheckpoints() {
+			return false;
+		}
 	}
 
 	static class MyCheckpointRecoveryFactory implements CheckpointRecoveryFactory {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
@@ -829,6 +829,7 @@ public class JobManagerTest {
 					0,
 					Integer.MAX_VALUE,
 					ExternalizedCheckpointSettings.none(),
+					null,
 					true);
 
 			jobGraph.setSnapshotSettings(snapshottingSettings);
@@ -954,6 +955,7 @@ public class JobManagerTest {
 				0,
 				Integer.MAX_VALUE,
 				ExternalizedCheckpointSettings.none(),
+				null,
 				true);
 
 			jobGraph.setSnapshotSettings(snapshottingSettings);
@@ -1059,6 +1061,7 @@ public class JobManagerTest {
 					0,
 					Integer.MAX_VALUE,
 					ExternalizedCheckpointSettings.none(),
+					null,
 					true);
 
 			jobGraph.setSnapshotSettings(snapshottingSettings);
@@ -1161,6 +1164,7 @@ public class JobManagerTest {
 					0,
 					Integer.MAX_VALUE,
 					ExternalizedCheckpointSettings.none(),
+					null,
 					true);
 
 			jobGraph.setSnapshotSettings(snapshottingSettings);
@@ -1207,6 +1211,7 @@ public class JobManagerTest {
 					0,
 					Integer.MAX_VALUE,
 					ExternalizedCheckpointSettings.none(),
+					null,
 					true);
 
 			newJobGraph.setSnapshotSettings(newSnapshottingSettings);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
@@ -229,7 +229,7 @@ public class JobSubmitTest {
 
 		JobGraph jg = new JobGraph("test job", jobVertex);
 		jg.setSnapshotSettings(new JobSnapshottingSettings(vertexIdList, vertexIdList, vertexIdList,
-			5000, 5000, 0L, 10, ExternalizedCheckpointSettings.none(), true));
+			5000, 5000, 0L, 10, ExternalizedCheckpointSettings.none(), null, true));
 		return jg;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.util.DynamicCodeLoadingException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * This test validates that state backends are properly loaded from configuration.
+ */
+public class StateBackendLoadingTest {
+
+	@Rule
+	public final TemporaryFolder tmp = new TemporaryFolder();
+
+	private final ClassLoader cl = getClass().getClassLoader();
+
+	private final String backendKey = CoreOptions.STATE_BACKEND.key();
+
+	// ------------------------------------------------------------------------
+
+	@Test
+	public void testNoStateBackendDefined() throws Exception {
+		assertNull(AbstractStateBackend.loadStateBackendFromConfig(new Configuration(), cl, null));
+	}
+
+	@Test
+	public void testInstantiateMemoryBackendByDefault() throws Exception {
+		StateBackend backend = AbstractStateBackend
+				.loadStateBackendFromConfigOrCreateDefault(new Configuration(), cl, null);
+
+		assertTrue(backend instanceof MemoryStateBackend);
+	}
+
+	@Test
+	public void testLoadMemoryStateBackend() throws Exception {
+		// we configure with the explicit string (rather than AbstractStateBackend#X_STATE_BACKEND_NAME)
+		// to guard against config-breaking changes of the name 
+		final Configuration config = new Configuration();
+		config.setString(backendKey, "jobmanager");
+
+		StateBackend backend = AbstractStateBackend
+				.loadStateBackendFromConfigOrCreateDefault(new Configuration(), cl, null);
+
+		assertTrue(backend instanceof MemoryStateBackend);
+	}
+
+	@Test
+	public void testLoadFileSystemStateBackend() throws Exception {
+		final String checkpointDir = new Path(tmp.getRoot().toURI()).toString();
+		final Path expectedPath = new Path(checkpointDir);
+		final int threshold = 1000000;
+
+		// we configure with the explicit string (rather than AbstractStateBackend#X_STATE_BACKEND_NAME)
+		// to guard against config-breaking changes of the name 
+		final Configuration config1 = new Configuration();
+		config1.setString(backendKey, "filesystem");
+		config1.setString("state.checkpoints.dir", checkpointDir);
+		config1.setString("state.backend.fs.checkpointdir", checkpointDir);
+		config1.setInteger("state.backend.fs.memory-threshold", threshold);
+
+		final Configuration config2 = new Configuration();
+		config2.setString(backendKey, FsStateBackendFactory.class.getName());
+		config2.setString("state.checkpoints.dir", checkpointDir);
+		config2.setString("state.backend.fs.checkpointdir", checkpointDir);
+		config2.setInteger("state.backend.fs.memory-threshold", threshold);
+
+		StateBackend backend1 = AbstractStateBackend
+				.loadStateBackendFromConfigOrCreateDefault(config1, cl, null);
+
+		StateBackend backend2 = AbstractStateBackend
+				.loadStateBackendFromConfigOrCreateDefault(config2, cl, null);
+
+		assertTrue(backend1 instanceof FsStateBackend);
+		assertTrue(backend2 instanceof FsStateBackend);
+
+		FsStateBackend fs1 = (FsStateBackend) backend1;
+		FsStateBackend fs2 = (FsStateBackend) backend2;
+
+		assertEquals(expectedPath, fs1.getBasePath());
+		assertEquals(expectedPath, fs2.getBasePath());
+		assertEquals(threshold, fs1.getMinFileSizeThreshold());
+		assertEquals(threshold, fs2.getMinFileSizeThreshold());
+	}
+
+	/**
+	 * This test makes sure that failures properly manifest when the state backend could not be loaded.
+	 */
+	@Test
+	public void testLoadingFails() throws Exception {
+		final Configuration config = new Configuration();
+
+		// try a value that is neither recognized as a name, nor corresponds to a class
+		config.setString(backendKey, "does.not.exist");
+		try {
+			AbstractStateBackend.loadStateBackendFromConfigOrCreateDefault(config, cl, null);
+			fail("should fail with an exception");
+		} catch (DynamicCodeLoadingException ignored) {
+			// expected
+		}
+
+		// try a class that is not a factory
+		config.setString(backendKey, java.io.File.class.getName());
+		try {
+			AbstractStateBackend.loadStateBackendFromConfigOrCreateDefault(config, cl, null);
+			fail("should fail with an exception");
+		} catch (DynamicCodeLoadingException ignored) {
+			// expected
+		}
+
+		// a factory that fails
+		config.setString(backendKey, FailingFactory.class.getName());
+		try {
+			AbstractStateBackend.loadStateBackendFromConfigOrCreateDefault(config, cl, null);
+			fail("should fail with an exception");
+		} catch (IOException ignored) {
+			// expected
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	static final class FailingFactory implements StateBackendFactory<StateBackend> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public StateBackend createFromConfig(Configuration config) throws IllegalConfigurationException, IOException {
+			throw new IOException("fail!");
+		}
+	}
+}

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
@@ -822,6 +822,7 @@ class JobManagerITCase(_system: ActorSystem)
             60000,
             1,
             ExternalizedCheckpointSettings.none,
+            null,
             true))
 
           // Submit job...
@@ -881,6 +882,7 @@ class JobManagerITCase(_system: ActorSystem)
             60000,
             1,
             ExternalizedCheckpointSettings.none,
+            null,
             true))
 
           // Submit job...
@@ -948,6 +950,7 @@ class JobManagerITCase(_system: ActorSystem)
             60000,
             1,
             ExternalizedCheckpointSettings.none,
+            null,
             true))
 
           // Submit job...

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
@@ -979,7 +979,7 @@ class JobManagerITCase(_system: ActorSystem)
           jobManager.tell(TriggerSavepoint(jobGraph.getJobID(), Option.apply("any")), testActor)
 
           val checkpoint = Mockito.mock(classOf[CompletedCheckpoint])
-          when(checkpoint.getExternalPath).thenReturn("Expected test savepoint path")
+          when(checkpoint.getExternalPointer).thenReturn("Expected test savepoint path")
 
           // Succeed the promise
           savepointPromise.complete(checkpoint)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -82,7 +82,7 @@ public class StreamGraphGenerator {
 	public static final int UPPER_BOUND_MAX_PARALLELISM = KeyGroupRangeAssignment.UPPER_BOUND_MAX_PARALLELISM;
 
 	// The StreamGraph that is being built, this is initialized at the beginning.
-	private StreamGraph streamGraph;
+	private final StreamGraph streamGraph;
 
 	private final StreamExecutionEnvironment env;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -539,6 +539,7 @@ public class StreamingJobGraphGenerator {
 				cfg.getCheckpointTimeout(), cfg.getMinPauseBetweenCheckpoints(),
 				cfg.getMaxConcurrentCheckpoints(),
 				externalizedCheckpointSettings,
+				streamGraph.getStateBackend(),
 				isExactlyOnce);
 
 		jobGraph.setSnapshotSettings(settings);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
@@ -183,7 +183,7 @@ public class BlockingCheckpointsTest {
 		public <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(
 				Environment env, JobID jobID, String operatorIdentifier,
 				TypeSerializer<K> keySerializer, int numberOfKeyGroups,
-				KeyGroupRange keyGroupRange, TaskKvStateRegistry kvStateRegistry) throws Exception {
+				KeyGroupRange keyGroupRange, TaskKvStateRegistry kvStateRegistry) {
 
 			throw new UnsupportedOperationException();
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -807,33 +807,39 @@ public class StreamTaskTest extends TestLogger {
 		private static final long serialVersionUID = 1L;
 
 		@Override
-		public AbstractStateBackend createFromConfig(Configuration config) throws Exception {
+		public AbstractStateBackend createFromConfig(Configuration config) {
 			AbstractStateBackend stateBackendMock = mock(AbstractStateBackend.class);
 
-			Mockito.when(stateBackendMock.createOperatorStateBackend(
-					Mockito.any(Environment.class),
-					Mockito.any(String.class)))
-				.thenAnswer(new Answer<OperatorStateBackend>() {
-					@Override
-					public OperatorStateBackend answer(InvocationOnMock invocationOnMock) throws Throwable {
-						return Mockito.mock(OperatorStateBackend.class);
-					}
-				});
-
-			Mockito.when(stateBackendMock.createKeyedStateBackend(
-					Mockito.any(Environment.class),
-					Mockito.any(JobID.class),
-					Mockito.any(String.class),
-					Mockito.any(TypeSerializer.class),
-					Mockito.any(int.class),
-					Mockito.any(KeyGroupRange.class),
-					Mockito.any(TaskKvStateRegistry.class)))
-				.thenAnswer(new Answer<AbstractKeyedStateBackend>() {
-					@Override
-					public AbstractKeyedStateBackend answer(InvocationOnMock invocationOnMock) throws Throwable {
-						return Mockito.mock(AbstractKeyedStateBackend.class);
-					}
-				});
+			try {
+				Mockito.when(stateBackendMock.createOperatorStateBackend(
+						Mockito.any(Environment.class),
+						Mockito.any(String.class)))
+					.thenAnswer(new Answer<OperatorStateBackend>() {
+						@Override
+						public OperatorStateBackend answer(InvocationOnMock invocationOnMock) throws Throwable {
+							return Mockito.mock(OperatorStateBackend.class);
+						}
+					});
+	
+				Mockito.when(stateBackendMock.createKeyedStateBackend(
+						Mockito.any(Environment.class),
+						Mockito.any(JobID.class),
+						Mockito.any(String.class),
+						Mockito.any(TypeSerializer.class),
+						Mockito.any(int.class),
+						Mockito.any(KeyGroupRange.class),
+						Mockito.any(TaskKvStateRegistry.class)))
+					.thenAnswer(new Answer<AbstractKeyedStateBackend>() {
+						@Override
+						public AbstractKeyedStateBackend answer(InvocationOnMock invocationOnMock) throws Throwable {
+							return Mockito.mock(AbstractKeyedStateBackend.class);
+						}
+					});
+			}
+			catch (Exception e) {
+				// this is needed, because the signatures of the mocked methods throw 'Exception'
+				throw new RuntimeException(e);
+			}
 
 			return stateBackendMock;
 		}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHACheckpointRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHACheckpointRecoveryITCase.java
@@ -167,7 +167,7 @@ public class JobManagerHACheckpointRecoveryITCase extends TestLogger {
 		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, Parallelism);
 
 		ActorSystem testSystem = null;
-		JobManagerProcess[] jobManagerProcess = new JobManagerProcess[2];
+		final JobManagerProcess[] jobManagerProcess = new JobManagerProcess[2];
 		LeaderRetrievalService leaderRetrievalService = null;
 		ActorSystem taskManagerSystem = null;
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
@@ -109,7 +109,7 @@ public class StateBackendITCase extends StreamingMultipleProgramsTestBase {
 				TypeSerializer<K> keySerializer,
 				int numberOfKeyGroups,
 				KeyGroupRange keyGroupRange,
-				TaskKvStateRegistry kvStateRegistry) throws Exception {
+				TaskKvStateRegistry kvStateRegistry) throws IOException {
 			throw new SuccessException();
 		}
 	}


### PR DESCRIPTION
**This is the first part of a larger parent issue: Self-contained externalized checkpoints and global cleanup hooks.**

Parts of the changes may seem incomplete, because they are preparation for later changes. To avoid too large pull requests, this is the first part that by itself is stable and compatible with the prior behavior.

## High-level changes

  1. The Checkpoint Coordinator knows about the base state backend. That is the first step towards generic storage of checkpoints (not file system specific) and global cleanup hooks (rather than tracking for example each file cleanup individually).
  
  2. The CompletedCheckpoint is not assuming that it is stored on a FileSystem, but holds now a `StreamStateHandle` to its metadata (if externalized) and a generic external pointer. In the case of a checkpoint on a FileSystem, this pointer is the file path.



## Detailed Changed

  - This moves the logic to load a statebackend from the configuration out of the `StreamTask` and into the `AbstractStateBackend`, because both JobManager and TaskManager now share the same logic.
  
  - Adds tests for the loading behavior of state backends
  
  - Improves the Exception signatures of state backend loading
  
  - Allows CompletedCheckpointStores to specify whether they require externalized checkpoints.
    That is important for the next step, where the ZooKeeper store only stores pointers and does not externalize the metadata an additional time.

  - `CompletedCheckpoint` holds pointer to metadata
  
  - CheckpointCoordinator externalizes the checkpoint explicitly (rather than the pending checkpoint does it implicitly).
  
  - More comments and JavaDocs
  
## Tests

Most of the functionality just made some parts more generic and needs no additional tests.

Additional tests were added for the passing of state backend from program to checkpoint coordinator, and for the loading of the state backend from the configurations.