### PR TITLE
[FLINK-5668] Reduce dependency on HDFS at job startup time

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
@@ -308,7 +307,6 @@ public final class Utils {
 		YarnConfiguration yarnConfig,
 		Map<String, String> env,
 		ContaineredTaskManagerParameters tmParams,
-		org.apache.flink.configuration.Configuration taskManagerConfig,
 		String workingDirectory,
 		Class<?> taskManagerMainClass,
 		Logger log) throws Exception {
@@ -383,26 +381,8 @@ public final class Utils {
 			registerLocalResource(fs, remoteJarPath, flinkJar);
 		}
 
-		// register conf with local fs
-		LocalResource flinkConf = Records.newRecord(LocalResource.class);
-		{
-			// write the TaskManager configuration to a local file
-			final File taskManagerConfigFile =
-					new File(workingDirectory, UUID.randomUUID() + "-taskmanager-conf.yaml");
-			log.debug("Writing TaskManager configuration to {}", taskManagerConfigFile.getAbsolutePath());
-			BootstrapTools.writeConfiguration(taskManagerConfig, taskManagerConfigFile);
-
-			Path homeDirPath = new Path(clientHomeDir);
-			FileSystem fs = homeDirPath.getFileSystem(yarnConfig);
-			setupLocalResource(fs, appId,
-					new Path(taskManagerConfigFile.toURI()), flinkConf, new Path(clientHomeDir));
-
-			log.info("Prepared local resource for modified yaml: {}", flinkConf);
-		}
-
 		Map<String, LocalResource> taskManagerLocalResources = new HashMap<>();
 		taskManagerLocalResources.put("flink.jar", flinkJar);
-		taskManagerLocalResources.put("flink-conf.yaml", flinkConf);
 
 		//To support Yarn Secure Integration Test Scenario
 		if(yarnConfResource != null && krb5ConfResource != null) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -318,9 +318,11 @@ public class YarnApplicationMasterRunner {
 					config, akkaHostname, akkaPort, slotsPerTaskManager, TASKMANAGER_REGISTRATION_TIMEOUT);
 			LOG.debug("TaskManager configuration: {}", taskManagerConfig);
 
+			taskManagerParameters.taskManagerEnv().putAll(taskManagerConfig.toMap());
+
 			final ContainerLaunchContext taskManagerContext = Utils.createTaskExecutorContext(
 				config, yarnConfig, ENV,
-				taskManagerParameters, taskManagerConfig,
+				taskManagerParameters,
 				currDir, getTaskManagerClass(), LOG);
 
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -343,10 +343,10 @@ public class YarnResourceManager extends ResourceManager<ResourceID> implements 
 		final Configuration taskManagerConfig = BootstrapTools.generateTaskManagerConfiguration(
 				flinkConfig, "", 0, 1, teRegistrationTimeout);
 		LOG.debug("TaskManager configuration: {}", taskManagerConfig);
-
+		taskManagerParameters.taskManagerEnv().putAll(taskManagerConfig.toMap());
 		ContainerLaunchContext taskExecutorLaunchContext = Utils.createTaskExecutorContext(
 				flinkConfig, yarnConfig, ENV,
-				taskManagerParameters, taskManagerConfig,
+				taskManagerParameters,
 				currDir, YarnTaskExecutorRunner.class, LOG);
 
 		// set a special environment variable to uniquely identify this container

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskManagerRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskManagerRunner.java
@@ -54,9 +54,13 @@ public class YarnTaskManagerRunner {
 		JvmShutdownSafeguard.installAsShutdownHook(LOG);
 
 		// try to parse the command line arguments
-		final Configuration configuration;
+		final Configuration configuration = new Configuration();
 		try {
-			configuration = TaskManager.parseArgsAndLoadConfig(args);
+			synchronized (configuration) {
+				for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
+					configuration.setString(entry.getKey(), entry.getValue());
+				}
+			}
 		}
 		catch (Throwable t) {
 			LOG.error(t.getMessage(), t);

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnApplicationMasterRunnerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnApplicationMasterRunnerTest.java
@@ -82,12 +82,11 @@ public class YarnApplicationMasterRunnerTest {
 			.put(FLINK_JAR_PATH, root.toURI().toString())
 			.build();
 		ContaineredTaskManagerParameters tmParams = mock(ContaineredTaskManagerParameters.class);
-		Configuration taskManagerConf = new Configuration();
 
 		String workingDirectory = root.getAbsolutePath();
 		Class<?> taskManagerMainClass = YarnApplicationMasterRunnerTest.class;
 		ContainerLaunchContext ctx = Utils.createTaskExecutorContext(flinkConf, yarnConf, env, tmParams,
-			taskManagerConf, workingDirectory, taskManagerMainClass, LOG);
+			workingDirectory, taskManagerMainClass, LOG);
 		assertEquals("file", ctx.getLocalResources().get("flink.jar").getResource().getScheme());
 	}
 }


### PR DESCRIPTION
In current implementation, Job manager writes task manager configuration into a file and upload it to HDFS. This file's used to bootstrap taskmanager.

In this PR, it switches to use system environment instead of HDFS file to pass the configuration from job manager to task manager, which reduce the dependency on HDFS. 
  