### PR TITLE
[FLINK-5907] [java api] Fix trailing empty fields in CsvInputFormat

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
@@ -358,14 +358,14 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 		for (int field = 0, output = 0; field < fieldIncluded.length; field++) {
 			
 			// check valid start position
-			if (startPos >= limit) {
+			if (startPos > limit || (startPos == limit && field != fieldIncluded.length - 1)) {
 				if (lenient) {
 					return false;
 				} else {
 					throw new ParseException("Row too short: " + new String(bytes, offset, numBytes));
 				}
 			}
-			
+
 			if (fieldIncluded[field]) {
 				// parse field
 				@SuppressWarnings("unchecked")

--- a/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
@@ -156,6 +156,27 @@ public abstract class FieldParser<T> {
 		return true;
 		
 	}
+
+	/**
+	 * Checks if the given bytes ends with the delimiter at the given end position.
+	 *
+	 * @param bytes  The byte array that holds the value.
+	 * @param endPos The index of the byte array where the check for the delimiter ends.
+	 * @param delim  The delimiter to check for.
+	 *
+	 * @return true if a delimiter ends at the given end position, false otherwise.
+	 */
+	public static final boolean endsWithDelimiter(byte[] bytes, int endPos, byte[] delim) {
+		if (endPos < delim.length - 1) {
+			return false;
+		}
+		for (int pos = 0; pos < delim.length; ++pos) {
+			if (delim[pos] != bytes[endPos - delim.length + 1 + pos]) {
+				return false;
+			}
+		}
+		return true;
+	}
 	
 	/**
 	 * Sets the error state of the parser. Called by subclasses of the parser to set the type of error

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/GenericCsvInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/GenericCsvInputFormatTest.java
@@ -522,14 +522,14 @@ public class GenericCsvInputFormatTest {
 									"kkz|777|foobar|hhg\n" +  // wrong data type in field
 									"kkz|777foobarhhg  \n" +  // too short, a skipped field never ends
 									"xyx|ignored|42|\n";      // another good line
-			final FileInputSplit split = createTempFile(fileContent);	
+			final FileInputSplit split = createTempFile(fileContent);
 		
 			final Configuration parameters = new Configuration();
 
 			format.setFieldDelimiter("|");
 			format.setFieldTypesGeneric(StringValue.class, null, IntValue.class);
 			format.setLenient(true);
-			
+
 			format.configure(parameters);
 			format.open(split);
 			

--- a/flink-core/src/test/java/org/apache/flink/types/parser/FieldParserTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/parser/FieldParserTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.types.parser;
 
 import org.junit.Test;

--- a/flink-core/src/test/java/org/apache/flink/types/parser/FieldParserTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/parser/FieldParserTest.java
@@ -1,0 +1,28 @@
+package org.apache.flink.types.parser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class FieldParserTest {
+
+	@Test
+	public void testDelimiterNext() throws Exception {
+		byte[] bytes = "aaabc".getBytes();
+		byte[] delim = "aa".getBytes();
+		assertTrue(FieldParser.delimiterNext(bytes, 0, delim));
+		assertTrue(FieldParser.delimiterNext(bytes, 1, delim));
+		assertFalse(FieldParser.delimiterNext(bytes, 2, delim));
+	}
+
+	@Test
+	public void testEndsWithDelimiter() throws Exception {
+		byte[] bytes = "aabc".getBytes();
+		byte[] delim = "ab".getBytes();
+		assertFalse(FieldParser.endsWithDelimiter(bytes, 0, delim));
+		assertFalse(FieldParser.endsWithDelimiter(bytes, 1, delim));
+		assertTrue(FieldParser.endsWithDelimiter(bytes, 2, delim));
+		assertFalse(FieldParser.endsWithDelimiter(bytes, 3, delim));
+	}
+
+}

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/RowCsvInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/RowCsvInputFormat.java
@@ -197,9 +197,12 @@ public class RowCsvInputFormat extends CsvInputFormat<Row> implements ResultType
 			if (startPos < 0) {
 				throw new ParseException(String.format("Unexpected parser position for column %1$s of row '%2$s'",
 					field, new String(bytes, offset, numBytes)));
-			} else if (startPos == limit
+			}
+			else if (startPos == limit
 					&& field != fieldIncluded.length - 1
 					&& !FieldParser.endsWithDelimiter(bytes, startPos - 1, fieldDelimiter)) {
+				// We are at the end of the record, but not all fields have been read
+				// and the end is not a field delimiter indicating an empty last field.
 				if (isLenient()) {
 					return false;
 				} else {

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/RowCsvInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/RowCsvInputFormat.java
@@ -197,6 +197,14 @@ public class RowCsvInputFormat extends CsvInputFormat<Row> implements ResultType
 			if (startPos < 0) {
 				throw new ParseException(String.format("Unexpected parser position for column %1$s of row '%2$s'",
 					field, new String(bytes, offset, numBytes)));
+			} else if (startPos == limit
+					&& field != fieldIncluded.length - 1
+					&& !FieldParser.endsWithDelimiter(bytes, startPos - 1, fieldDelimiter)) {
+				if (isLenient()) {
+					return false;
+				} else {
+					throw new ParseException("Row too short: " + new String(bytes, offset, numBytes));
+				}
 			}
 
 			field++;

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/RowCsvInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/RowCsvInputFormat.java
@@ -151,7 +151,7 @@ public class RowCsvInputFormat extends CsvInputFormat<Row> implements ResultType
 		while (field < fieldIncluded.length) {
 
 			// check valid start position
-			if (startPos >= limit) {
+			if (startPos > limit || (startPos == limit && field != fieldIncluded.length - 1)) {
 				if (isLenient()) {
 					return false;
 				} else {

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/CsvInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/CsvInputFormatTest.java
@@ -400,7 +400,7 @@ public class CsvInputFormatTest {
 	@Test
 	public void readStringFieldsWithTrailingDelimiters() {
 		try {
-			final String fileContent = "abc|-def|-ghijk\nabc|-|-hhg\n|-|-|-\n|-|-\nabc|-def\n";
+			final String fileContent = "abc|-def|-ghijk\nabc|-|-hhg\n|-|-|-\n";
 			final FileInputSplit split = createTempFile(fileContent);
 
 			final TupleTypeInfo<Tuple3<String, String, String>> typeInfo = TupleTypeInfo.getBasicTupleTypeInfo(String.class, String.class, String.class);
@@ -432,19 +432,63 @@ public class CsvInputFormatTest {
 			assertEquals("", result.f2);
 
 			result = format.nextRecord(result);
-			assertNotNull(result);
-			assertEquals("", result.f0);
-			assertEquals("", result.f1);
-			assertEquals("", result.f2);
-
-			try {
-				format.nextRecord(result);
-				fail("Parse Exception was not thrown! (Row too short)");
-			} catch (ParseException e) {}
+			assertNull(result);
+			assertTrue(format.reachedEnd());
 		}
 		catch (Exception ex) {
 			fail("Test failed due to a " + ex.getClass().getName() + ": " + ex.getMessage());
 		}
+	}
+
+	@Test
+	public void testTailingEmptyFields() throws Exception {
+		final String fileContent = "aa,bb,cc\n" + // ok
+				"aa,bb,\n" +  // the last field is empty
+				"aa,,\n" +    // the last two fields are empty
+				",,\n" +      // all fields are empty
+				"aa,bb";      // row too short
+		final FileInputSplit split = createTempFile(fileContent);
+
+		final TupleTypeInfo<Tuple3<String, String, String>> typeInfo =
+				TupleTypeInfo.getBasicTupleTypeInfo(String.class, String.class, String.class);
+		final CsvInputFormat<Tuple3<String, String, String>> format =
+				new TupleCsvInputFormat<Tuple3<String, String, String>>(PATH, typeInfo);
+
+		format.setFieldDelimiter(",");
+
+		format.configure(new Configuration());
+		format.open(split);
+
+		Tuple3<String, String, String> result = new Tuple3<String, String, String>();
+
+		result = format.nextRecord(result);
+		assertNotNull(result);
+		assertEquals("aa", result.f0);
+		assertEquals("bb", result.f1);
+		assertEquals("cc", result.f2);
+
+		result = format.nextRecord(result);
+		assertNotNull(result);
+		assertEquals("aa", result.f0);
+		assertEquals("bb", result.f1);
+		assertEquals("", result.f2);
+
+		result = format.nextRecord(result);
+		assertNotNull(result);
+		assertEquals("aa", result.f0);
+		assertEquals("", result.f1);
+		assertEquals("", result.f2);
+
+		result = format.nextRecord(result);
+		assertNotNull(result);
+		assertEquals("", result.f0);
+		assertEquals("", result.f1);
+		assertEquals("", result.f2);
+
+		try {
+			format.nextRecord(result);
+			fail("Parse Exception was not thrown! (Row too short)");
+		} catch (ParseException e) {}
 	}
 
 	@Test
@@ -965,23 +1009,15 @@ public class CsvInputFormatTest {
 
 	@Test
 	public void testPojoTypeWithTrailingEmptyFields() throws Exception {
-		File tempFile = File.createTempFile("CsvReaderPojoType", "tmp");
-		tempFile.deleteOnExit();
-		tempFile.setWritable(true);
-
-		OutputStreamWriter wrt = new OutputStreamWriter(new FileOutputStream(tempFile));
-		wrt.write("123,,3.123,,\n");
-		wrt.write("456,BBB,3.23,,\n");
-		wrt.close();
+		final String fileContent = "123,,3.123,,\n456,BBB,3.23,,";
+		final FileInputSplit split = createTempFile(fileContent);
 
 		@SuppressWarnings("unchecked")
 		PojoTypeInfo<PrivatePojoItem> typeInfo = (PojoTypeInfo<PrivatePojoItem>) TypeExtractor.createTypeInfo(PrivatePojoItem.class);
-		CsvInputFormat<PrivatePojoItem> inputFormat = new PojoCsvInputFormat<PrivatePojoItem>(new Path(tempFile.toURI().toString()), typeInfo);
+		CsvInputFormat<PrivatePojoItem> inputFormat = new PojoCsvInputFormat<PrivatePojoItem>(PATH, typeInfo);
 
 		inputFormat.configure(new Configuration());
-
-		FileInputSplit[] splits = inputFormat.createInputSplits(1);
-		inputFormat.open(splits[0]);
+		inputFormat.open(split);
 
 		PrivatePojoItem item = new PrivatePojoItem();
 		inputFormat.nextRecord(item);

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/CsvInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/CsvInputFormatTest.java
@@ -400,7 +400,7 @@ public class CsvInputFormatTest {
 	@Test
 	public void readStringFieldsWithTrailingDelimiters() {
 		try {
-			final String fileContent = "abc|-def|-ghijk\nabc|-|-hhg\n|-|-|-\n|-|-";
+			final String fileContent = "abc|-def|-ghijk\nabc|-|-hhg\n|-|-|-\n|-|-\nabc|-def\n";
 			final FileInputSplit split = createTempFile(fileContent);
 
 			final TupleTypeInfo<Tuple3<String, String, String>> typeInfo = TupleTypeInfo.getBasicTupleTypeInfo(String.class, String.class, String.class);
@@ -437,9 +437,10 @@ public class CsvInputFormatTest {
 			assertEquals("", result.f1);
 			assertEquals("", result.f2);
 
-			result = format.nextRecord(result);
-			assertNull(result);
-			assertTrue(format.reachedEnd());
+			try {
+				format.nextRecord(result);
+				fail("Parse Exception was not thrown! (Row too short)");
+			} catch (ParseException e) {}
 		}
 		catch (Exception ex) {
 			fail("Test failed due to a " + ex.getClass().getName() + ": " + ex.getMessage());

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/RowCsvInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/RowCsvInputFormatTest.java
@@ -230,7 +230,7 @@ public class RowCsvInputFormatTest {
 
 	@Test
 	public void readStringFields() throws Exception {
-		String fileContent = "abc|def|ghijk\nabc||hhg\n|||";
+		String fileContent = "abc|def|ghijk\nabc||hhg\n|||\n||";
 
 		FileInputSplit split = createTempFile(fileContent);
 
@@ -264,13 +264,19 @@ public class RowCsvInputFormatTest {
 		assertEquals("", result.getField(2));
 
 		result = format.nextRecord(result);
+		assertNotNull(result);
+		assertEquals("", result.getField(0));
+		assertEquals("", result.getField(1));
+		assertEquals("", result.getField(2));
+
+		result = format.nextRecord(result);
 		assertNull(result);
 		assertTrue(format.reachedEnd());
 	}
 
 	@Test
 	public void readMixedQuotedStringFields() throws Exception {
-		String fileContent = "@a|b|c@|def|@ghijk@\nabc||@|hhg@\n|||";
+		String fileContent = "@a|b|c@|def|@ghijk@\nabc||@|hhg@\n|||\n";
 
 		FileInputSplit split = createTempFile(fileContent);
 
@@ -311,7 +317,7 @@ public class RowCsvInputFormatTest {
 
 	@Test
 	public void readStringFieldsWithTrailingDelimiters() throws Exception {
-		String fileContent = "abc|-def|-ghijk\nabc|-|-hhg\n|-|-|-\n";
+		String fileContent = "abc|-def|-ghijk\nabc|-|-hhg\n|-|-|-\n|-|-\n";
 
 		FileInputSplit split = createTempFile(fileContent);
 
@@ -338,6 +344,12 @@ public class RowCsvInputFormatTest {
 		assertEquals("abc", result.getField(0));
 		assertEquals("", result.getField(1));
 		assertEquals("hhg", result.getField(2));
+
+		result = format.nextRecord(result);
+		assertNotNull(result);
+		assertEquals("", result.getField(0));
+		assertEquals("", result.getField(1));
+		assertEquals("", result.getField(2));
 
 		result = format.nextRecord(result);
 		assertNotNull(result);
@@ -396,12 +408,12 @@ public class RowCsvInputFormatTest {
 	public void testEmptyFields() throws Exception {
 		String fileContent =
 			",,,,,,,,\n" +
+				",,,,,,,\n" +
+				",,,,,,,,\n" +
+				",,,,,,,\n" +
 				",,,,,,,,\n" +
 				",,,,,,,,\n" +
-				",,,,,,,,\n" +
-				",,,,,,,,\n" +
-				",,,,,,,,\n" +
-				",,,,,,,,\n" +
+				",,,,,,,\n" +
 				",,,,,,,,\n";
 
 		FileInputSplit split = createTempFile(fileContent);

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/RowCsvInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/RowCsvInputFormatTest.java
@@ -317,7 +317,7 @@ public class RowCsvInputFormatTest {
 
 	@Test
 	public void readStringFieldsWithTrailingDelimiters() throws Exception {
-		String fileContent = "abc|-def|-ghijk\nabc|-|-hhg\n|-|-|-\n|-|-\n";
+		String fileContent = "abc|-def|-ghijk\nabc|-|-hhg\n|-|-|-\n|-|-\nabc|-def\n";
 
 		FileInputSplit split = createTempFile(fileContent);
 
@@ -357,9 +357,10 @@ public class RowCsvInputFormatTest {
 		assertEquals("", result.getField(1));
 		assertEquals("", result.getField(2));
 
-		result = format.nextRecord(result);
-		assertNull(result);
-		assertTrue(format.reachedEnd());
+		try {
+			format.nextRecord(result);
+			fail("Parse Exception was not thrown! (Row too short)");
+		} catch (ParseException e) {}
 	}
 
 	@Test


### PR DESCRIPTION
If there are 3 fields with field delimiter ",", both these two line should be parsed successfully:
aaa,bbb,,
aaa,bbb,
