### PR TITLE
[FLINK-5402] [FLINK-5389] Increase test timeouts

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
@@ -63,7 +63,7 @@ import static org.junit.Assert.fail;
  */
 public class JobSubmitTest {
 
-	private static final FiniteDuration timeout = new FiniteDuration(5000, TimeUnit.MILLISECONDS);
+	private static final FiniteDuration timeout = new FiniteDuration(60000, TimeUnit.MILLISECONDS);
 
 	private static ActorSystem jobManagerSystem;
 	private static ActorGateway jmGateway;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -135,7 +135,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 	 * @throws ExecutionException
 	 * @throws InterruptedException
 	 */
-	@Test(timeout = 1000)
+	@Test
 	public void testTerminationFuture() throws ExecutionException, InterruptedException {
 		final ActorSystem actorSystem = AkkaUtils.createDefaultActorSystem();
 		final AkkaRpcService rpcService = new AkkaRpcService(actorSystem, Time.milliseconds(1000));
@@ -160,7 +160,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 	 * Tests a simple scheduled runnable being executed by the RPC services scheduled executor
 	 * service.
 	 */
-	@Test(timeout = 1000)
+	@Test
 	public void testScheduledExecutorServiceSimpleSchedule() throws ExecutionException, InterruptedException {
 		ScheduledExecutor scheduledExecutor = akkaRpcService.getScheduledExecutor();
 
@@ -186,7 +186,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 	 * Tests that the RPC service's scheduled executor service can execute runnables at a fixed
 	 * rate.
 	 */
-	@Test(timeout = 1000)
+	@Test
 	public void testScheduledExecutorServicePeriodicSchedule() throws ExecutionException, InterruptedException {
 		ScheduledExecutor scheduledExecutor = akkaRpcService.getScheduledExecutor();
 
@@ -226,7 +226,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 	 * Tests that the RPC service's scheduled executor service can execute runnable with a fixed
 	 * delay.
 	 */
-	@Test(timeout = 1000)
+	@Test
 	public void testScheduledExecutorServiceWithFixedDelaySchedule() throws ExecutionException, InterruptedException {
 		ScheduledExecutor scheduledExecutor = akkaRpcService.getScheduledExecutor();
 


### PR DESCRIPTION
Some users reported running into timeouts due to too "aggressive" timeouts for certain configurations (as mentioned by Dawid in FLINK-5402).

The changed timeouts don't affect the failure free runtime of the tests.
