### PR TITLE
[FLINK-5109] [gelly] Interface for GraphAlgorithm results

### DIFF
--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
@@ -1126,7 +1126,7 @@ public class Graph<K, VV, EV> {
 		}
 	}
 
-	private static final class ProjectVertexWithEdgeValueMap<K, EV>	implements MapFunction<
+	private static final class ProjectVertexWithEdgeValueMap<K, EV> implements MapFunction<
 		Edge<K, EV>, Tuple2<K, EV>> {
 
 		private int fieldPosition;
@@ -1217,7 +1217,7 @@ public class Graph<K, VV, EV> {
 			this.function = fun;
 		}
 
-		public void coGroup(Iterable<Vertex<K, VV>> vertex, 	final Iterable<Tuple2<K, Edge<K, EV>>> keysWithEdges,
+		public void coGroup(Iterable<Vertex<K, VV>> vertex, final Iterable<Tuple2<K, Edge<K, EV>>> keysWithEdges,
 				Collector<T> out) throws Exception {
 
 			final Iterator<Edge<K, EV>> edgesIterator = new Iterator<Edge<K, EV>>() {
@@ -2149,12 +2149,12 @@ public class Graph<K, VV, EV> {
 
 		public void coGroup(Iterable<Vertex<K, VV>> vertex, Iterable<Tuple2<Edge<K, EV>, Vertex<K, VV>>> neighbors,
 				Collector<T> out) throws Exception {
-			function.iterateNeighbors(vertex.iterator().next(), 	neighbors, out);
+			function.iterateNeighbors(vertex.iterator().next(), neighbors, out);
 		}
 
 		@Override
 		public TypeInformation<T> getProducedType() {
-			return TypeExtractor.createTypeInfo(NeighborsFunctionWithVertexValue.class, 	function.getClass(), 3, null, null);
+			return TypeExtractor.createTypeInfo(NeighborsFunctionWithVertexValue.class, function.getClass(), 3, null, null);
 		}
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/dataset/ChecksumHashCode.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/dataset/ChecksumHashCode.java
@@ -60,6 +60,11 @@ extends AbstractDataSetAnalytic<T, Checksum> {
 		return checksumHashCodeHelper.getAccumulator(env, CHECKSUM);
 	}
 
+	/**
+	 * Helper class to count elements and sum element hashcodes.
+	 *
+	 * @param <U> element type
+	 */
 	private static class ChecksumHashCodeHelper<U>
 	extends AnalyticHelper<U> {
 		private long count;
@@ -78,6 +83,9 @@ extends AbstractDataSetAnalytic<T, Checksum> {
 		}
 	}
 
+	/**
+	 * Wraps checksum and count.
+	 */
 	public static class Checksum
 	implements SimpleAccumulator<Checksum> {
 		private long count;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/dataset/Collect.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/dataset/Collect.java
@@ -75,6 +75,11 @@ extends AbstractDataSetAnalytic<T, List<T>> {
 		}
 	}
 
+	/**
+	 * Helper class to collect elements into a serialized list.
+	 *
+	 * @param <U> element type
+	 */
 	private static class CollectHelper<U>
 	extends AnalyticHelper<U> {
 		private SerializedListAccumulator<U> accumulator;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/dataset/Count.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/dataset/Count.java
@@ -55,6 +55,11 @@ extends AbstractDataSetAnalytic<T, Long> {
 		return countHelper.getAccumulator(env, COUNT);
 	}
 
+	/**
+	 * Helper class to count elements.
+	 *
+	 * @param <U> element type
+	 */
 	private static class CountHelper<U>
 	extends AnalyticHelper<U> {
 		private long count;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/AlgorithmResult.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/AlgorithmResult.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.asm.result;
+
+import org.apache.flink.graph.GraphAlgorithm;
+
+/**
+ * Base interface for {@link GraphAlgorithm} results.
+ */
+public interface AlgorithmResult {
+
+	/**
+	 * A human-readable representation of this value.
+	 *
+	 * @return printable string
+	 */
+	String toVerboseString ();
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/AnalyticResult.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/AnalyticResult.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.asm.result;
+
+import org.apache.flink.graph.GraphAnalytic;
+
+/**
+ * Base interface for {@link GraphAnalytic} results.
+ */
+public interface AnalyticResult {
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/BinaryResult.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/BinaryResult.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.asm.result;
+
+import org.apache.flink.graph.GraphAlgorithm;
+
+/**
+ * A {@link GraphAlgorithm} result for a pair vertices.
+ */
+public interface BinaryResult<T>
+extends UnaryResult<T> {
+
+	/**
+	 * Get the second vertex ID.
+	 *
+	 * @return second vertex ID
+	 */
+	T getVertexId1();
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/TertiaryResult.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/TertiaryResult.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.asm.result;
+
+import org.apache.flink.graph.GraphAlgorithm;
+
+/**
+ * A {@link GraphAlgorithm} result for three vertices.
+ */
+public interface TertiaryResult<T>
+extends BinaryResult<T> {
+
+	/**
+	 * Get the third vertex ID.
+	 *
+	 * @return third vertex ID
+	 */
+	T getVertexId2();
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/UnaryResult.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/result/UnaryResult.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.asm.result;
+
+import org.apache.flink.graph.GraphAlgorithm;
+
+/**
+ * A {@link GraphAlgorithm} result for a single vertex.
+ */
+public interface UnaryResult<T> {
+
+	/**
+	 * Get the first vertex ID.
+	 *
+	 * @return first vertex ID
+	 */
+	T getVertexId0();
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/simple/directed/Simplify.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/simple/directed/Simplify.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.utils.proxy.GraphAlgorithmWrappingGraph;
-import org.apache.flink.types.CopyableValue;
 import org.apache.flink.util.Preconditions;
 
 import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
@@ -35,7 +34,7 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
  * @param <VV> vertex value type
  * @param <EV> edge value type
  */
-public class Simplify<K extends Comparable<K> & CopyableValue<K>, VV, EV>
+public class Simplify<K extends Comparable<K>, VV, EV>
 extends GraphAlgorithmWrappingGraph<K, VV, EV, K, VV, EV> {
 
 	// Optional configuration

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/simple/undirected/Simplify.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/simple/undirected/Simplify.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.utils.proxy.GraphAlgorithmWrappingGraph;
-import org.apache.flink.types.CopyableValue;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.Preconditions;
 
@@ -37,7 +36,7 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
  * @param <VV> vertex value type
  * @param <EV> edge value type
  */
-public class Simplify<K extends Comparable<K> & CopyableValue<K>, VV, EV>
+public class Simplify<K extends Comparable<K>, VV, EV>
 extends GraphAlgorithmWrappingGraph<K, VV, EV, K, VV, EV> {
 
 	// Required configuration

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/CompleteGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/CompleteGraph.java
@@ -29,12 +29,15 @@ import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.LongValueSequenceIterator;
+import org.apache.flink.util.Preconditions;
 
 /*
  * @see <a href="http://mathworld.wolfram.com/CompleteGraph.html">Complete Graph at Wolfram MathWorld</a>
  */
 public class CompleteGraph
 extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
+
+	public static final int MINIMUM_VERTEX_COUNT = 2;
 
 	// Required to create the DataSource
 	private final ExecutionEnvironment env;
@@ -49,9 +52,8 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 	 * @param vertexCount number of vertices
 	 */
 	public CompleteGraph(ExecutionEnvironment env, long vertexCount) {
-		if (vertexCount <= 0) {
-			throw new IllegalArgumentException("Vertex count must be greater than zero");
-		}
+		Preconditions.checkArgument(vertexCount >= MINIMUM_VERTEX_COUNT,
+			"Vertex count must be at least " + MINIMUM_VERTEX_COUNT);
 
 		this.env = env;
 		this.vertexCount = vertexCount;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/CycleGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/CycleGraph.java
@@ -22,12 +22,15 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
+import org.apache.flink.util.Preconditions;
 
 /*
  * @see <a href="http://mathworld.wolfram.com/CycleGraph.html">Cycle Graph at Wolfram MathWorld</a>
  */
 public class CycleGraph
 extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
+
+	public static final int MINIMUM_VERTEX_COUNT = 2;
 
 	// Required to create the DataSource
 	private final ExecutionEnvironment env;
@@ -42,9 +45,8 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 	 * @param vertexCount number of vertices
 	 */
 	public CycleGraph(ExecutionEnvironment env, long vertexCount) {
-		if (vertexCount <= 0) {
-			throw new IllegalArgumentException("Vertex count must be greater than zero");
-		}
+		Preconditions.checkArgument(vertexCount >= MINIMUM_VERTEX_COUNT,
+			"Vertex count must be at least " + MINIMUM_VERTEX_COUNT);
 
 		this.env = env;
 		this.vertexCount = vertexCount;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/EmptyGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/EmptyGraph.java
@@ -29,6 +29,7 @@ import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
+import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
 
@@ -37,6 +38,8 @@ import java.util.Collections;
  */
 public class EmptyGraph
 extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
+
+	public static final int MINIMUM_VERTEX_COUNT = 1;
 
 	// Required to create the DataSource
 	private final ExecutionEnvironment env;
@@ -51,9 +54,8 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 	 * @param vertexCount number of vertices
 	 */
 	public EmptyGraph(ExecutionEnvironment env, long vertexCount) {
-		if (vertexCount <= 0) {
-			throw new IllegalArgumentException("Vertex count must be greater than zero");
-		}
+		Preconditions.checkArgument(vertexCount >= MINIMUM_VERTEX_COUNT,
+			"Vertex count must be at least " + MINIMUM_VERTEX_COUNT);
 
 		this.env = env;
 		this.vertexCount = vertexCount;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/GridGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/GridGraph.java
@@ -30,6 +30,7 @@ import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.LongValueSequenceIterator;
+import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -67,9 +68,7 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 	 * @return this
 	 */
 	public GridGraph addDimension(long size, boolean wrapEndpoints) {
-		if (size <= 1) {
-			throw new IllegalArgumentException("Dimension size must be greater than 1");
-		}
+		Preconditions.checkArgument(size >= 2, "Dimension size must be at least 2");
 
 		vertexCount *= size;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/HypercubeGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/HypercubeGraph.java
@@ -22,12 +22,15 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
+import org.apache.flink.util.Preconditions;
 
 /*
  * @see <a href="http://mathworld.wolfram.com/HypercubeGraph.html">Hypercube Graph at Wolfram MathWorld</a>
  */
 public class HypercubeGraph
 extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
+
+	public static final int MINIMUM_DIMENSIONS = 1;
 
 	// Required to create the DataSource
 	private final ExecutionEnvironment env;
@@ -42,9 +45,8 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 	 * @param dimensions number of dimensions
 	 */
 	public HypercubeGraph(ExecutionEnvironment env, long dimensions) {
-		if (dimensions <= 0) {
-			throw new IllegalArgumentException("Number of dimensions must be greater than zero");
-		}
+		Preconditions.checkArgument(dimensions >= MINIMUM_DIMENSIONS,
+			"Number of dimensions must be at least " + MINIMUM_DIMENSIONS);
 
 		this.env = env;
 		this.dimensions = dimensions;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/PathGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/PathGraph.java
@@ -22,12 +22,15 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
+import org.apache.flink.util.Preconditions;
 
 /*
  * @see <a href="http://mathworld.wolfram.com/PathGraph.html">Path Graph at Wolfram MathWorld</a>
  */
 public class PathGraph
 extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
+
+	public static final int MINIMUM_VERTEX_COUNT = 2;
 
 	// Required to create the DataSource
 	private final ExecutionEnvironment env;
@@ -42,9 +45,8 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 	 * @param vertexCount number of vertices
 	 */
 	public PathGraph(ExecutionEnvironment env, long vertexCount) {
-		if (vertexCount <= 0) {
-			throw new IllegalArgumentException("Vertex count must be greater than zero");
-		}
+		Preconditions.checkArgument(vertexCount >= MINIMUM_VERTEX_COUNT,
+			"Vertex count must be at least " + MINIMUM_VERTEX_COUNT);
 
 		this.env = env;
 		this.vertexCount = vertexCount;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/RMatGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/RMatGraph.java
@@ -30,6 +30,7 @@ import org.apache.flink.graph.generator.random.RandomGenerableFactory;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
 
 import java.util.List;
 
@@ -38,6 +39,10 @@ import java.util.List;
  */
 public class RMatGraph<T extends RandomGenerator>
 extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
+
+	public static final int MINIMUM_VERTEX_COUNT = 1;
+
+	public static final int MINIMUM_EDGE_COUNT = 1;
 
 	// Default RMat constants
 	public static final float DEFAULT_A = 0.57f;
@@ -59,15 +64,15 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 	private final long edgeCount;
 
 	// Optional configuration
-	private float A = DEFAULT_A;
+	public float A = DEFAULT_A;
 
-	private float B = DEFAULT_B;
+	public float B = DEFAULT_B;
 
-	private float C = DEFAULT_C;
+	public float C = DEFAULT_C;
 
 	private boolean noiseEnabled = false;
 
-	private float noise = DEFAULT_NOISE;
+	public float noise = DEFAULT_NOISE;
 
 	/**
 	 * Generate a directed or undirected power-law {@link Graph} using the
@@ -79,13 +84,11 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 	 * @param edgeCount number of edges
 	 */
 	public RMatGraph(ExecutionEnvironment env, RandomGenerableFactory<T> randomGeneratorFactory, long vertexCount, long edgeCount) {
-		if (vertexCount <= 0) {
-			throw new IllegalArgumentException("Vertex count must be greater than zero");
-		}
+		Preconditions.checkArgument(vertexCount >= MINIMUM_VERTEX_COUNT,
+			"Vertex count must be at least " + MINIMUM_VERTEX_COUNT);
 
-		if (edgeCount <= 0) {
-			throw new IllegalArgumentException("Edge count must be greater than zero");
-		}
+		Preconditions.checkArgument(edgeCount >= MINIMUM_EDGE_COUNT,
+			"Edge count must be at least " + MINIMUM_EDGE_COUNT);
 
 		this.env = env;
 		this.randomGenerableFactory = randomGeneratorFactory;
@@ -106,9 +109,8 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 	 * @return this
 	 */
 	public RMatGraph<T> setConstants(float A, float B, float C) {
-		if (A < 0.0f || B < 0.0f || C < 0.0f || A + B + C > 1.0f) {
-			throw new RuntimeException("RMat parameters A, B, and C must be non-negative and sum to less than or equal to one");
-		}
+		Preconditions.checkArgument(A >= 0.0f && B >= 0.0f && C >= 0.0f && A + B + C <= 1.0f,
+			"RMat parameters A, B, and C must be non-negative and sum to less than or equal to one");
 
 		this.A = A;
 		this.B = B;
@@ -128,9 +130,8 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 	 * @return this
 	 */
 	public RMatGraph<T> setNoise(boolean noiseEnabled, float noise) {
-		if (noise < 0.0f || noise > 2.0f) {
-			throw new RuntimeException("RMat parameter noise must be non-negative and less than or equal to 2.0");
-		}
+		Preconditions.checkArgument(noise >= 0.0f && noise <= 2.0f,
+			"RMat parameter noise must be non-negative and less than or equal to 2.0");
 
 		this.noiseEnabled = noiseEnabled;
 		this.noise = noise;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/SingletonEdgeGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/SingletonEdgeGraph.java
@@ -28,6 +28,7 @@ import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 import org.apache.flink.util.LongValueSequenceIterator;
+import org.apache.flink.util.Preconditions;
 
 /**
  * A singleton-edge {@link Graph} contains one or more isolated two-paths. The in- and out-degree
@@ -35,6 +36,8 @@ import org.apache.flink.util.LongValueSequenceIterator;
  */
 public class SingletonEdgeGraph
 extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
+
+	public static final int MINIMUM_VERTEX_PAIR_COUNT = 1;
 
 	// Required to create the DataSource
 	private final ExecutionEnvironment env;
@@ -49,9 +52,8 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 	 * @param vertexPairCount number of pairs of vertices
 	 */
 	public SingletonEdgeGraph(ExecutionEnvironment env, long vertexPairCount) {
-		if (vertexPairCount <= 0) {
-			throw new IllegalArgumentException("Vertex pair count must be greater than zero");
-		}
+		Preconditions.checkArgument(vertexPairCount >= MINIMUM_VERTEX_PAIR_COUNT,
+			"Vertex pair count must be at least " + MINIMUM_VERTEX_PAIR_COUNT);
 
 		this.env = env;
 		this.vertexPairCount = vertexPairCount;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/StarGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/StarGraph.java
@@ -29,12 +29,15 @@ import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.LongValueSequenceIterator;
+import org.apache.flink.util.Preconditions;
 
 /*
  * @see <a href="http://mathworld.wolfram.com/StarGraph.html">Star Graph at Wolfram MathWorld</a>
  */
 public class StarGraph
 extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
+
+	public static final int MINIMUM_VERTEX_COUNT = 2;
 
 	// Required to create the DataSource
 	private final ExecutionEnvironment env;
@@ -49,9 +52,8 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 	 * @param vertexCount number of vertices
 	 */
 	public StarGraph(ExecutionEnvironment env, long vertexCount) {
-		if (vertexCount <= 0) {
-			throw new IllegalArgumentException("Vertex count must be greater than zero");
-		}
+		Preconditions.checkArgument(vertexCount >= MINIMUM_VERTEX_COUNT,
+			"Vertex count must be at least " + MINIMUM_VERTEX_COUNT);
 
 		this.env = env;
 		this.vertexCount = vertexCount;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/AverageClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/AverageClusteringCoefficient.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.graph.AbstractGraphAnalytic;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.AnalyticHelper;
+import org.apache.flink.graph.asm.result.AnalyticResult;
 import org.apache.flink.graph.library.clustering.directed.AverageClusteringCoefficient.Result;
 import org.apache.flink.types.CopyableValue;
 
@@ -129,7 +130,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	/**
 	 * Wraps global clustering coefficient metrics.
 	 */
-	public static class Result {
+	public static class Result
+	implements AnalyticResult {
 		private long vertexCount;
 		private double averageLocalClusteringCoefficient;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/GlobalClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/GlobalClusteringCoefficient.java
@@ -23,8 +23,9 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.graph.AbstractGraphAnalytic;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.library.clustering.directed.GlobalClusteringCoefficient.Result;
 import org.apache.flink.graph.asm.dataset.Count;
+import org.apache.flink.graph.asm.result.AnalyticResult;
+import org.apache.flink.graph.library.clustering.directed.GlobalClusteringCoefficient.Result;
 import org.apache.flink.graph.library.metric.directed.VertexMetrics;
 import org.apache.flink.types.CopyableValue;
 
@@ -101,7 +102,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	/**
 	 * Wraps global clustering coefficient metrics.
 	 */
-	public static class Result {
+	public static class Result
+	implements AnalyticResult {
 		private long tripletCount;
 
 		private long triangleCount;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/LocalClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/LocalClusteringCoefficient.java
@@ -25,14 +25,17 @@ import org.apache.flink.api.common.operators.base.ReduceOperatorBase.CombineHint
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.functions.FunctionAnnotation;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees.Degrees;
 import org.apache.flink.graph.library.clustering.directed.LocalClusteringCoefficient.Result;
+import org.apache.flink.graph.asm.result.AlgorithmResult;
+import org.apache.flink.graph.asm.result.UnaryResult;
 import org.apache.flink.graph.utils.Murmur3_32;
-import org.apache.flink.graph.utils.proxy.OptionalBoolean;
 import org.apache.flink.graph.utils.proxy.GraphAlgorithmWrappingDataSet;
+import org.apache.flink.graph.utils.proxy.OptionalBoolean;
 import org.apache.flink.types.CopyableValue;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.util.Collector;
@@ -223,7 +226,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	 *
 	 * @param <T> ID type
 	 */
-	@FunctionAnnotation.ForwardedFieldsFirst("0; 1.0->1.0")
+	@FunctionAnnotation.ForwardedFieldsFirst("0; 1.0->1")
 	@FunctionAnnotation.ForwardedFieldsSecond("0")
 	private static class JoinVertexDegreeWithTriangleCount<T>
 	implements JoinFunction<Vertex<T, Degrees>, Tuple2<T, LongValue>, Result<T>> {
@@ -235,29 +238,28 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		public Result<T> join(Vertex<T, Degrees> vertexAndDegree, Tuple2<T, LongValue> vertexAndTriangleCount)
 				throws Exception {
 			output.f0 = vertexAndDegree.f0;
-			output.f1.f0 = vertexAndDegree.f1.f0;
-			output.f1.f1 = (vertexAndTriangleCount == null) ? zero : vertexAndTriangleCount.f1;
+			output.f1 = vertexAndDegree.f1.f0;
+			output.f2 = (vertexAndTriangleCount == null) ? zero : vertexAndTriangleCount.f1;
 
 			return output;
 		}
 	}
 
 	/**
-	 * Wraps the vertex type to encapsulate results from the Local Clustering Coefficient algorithm.
+	 * Wraps {@link Tuple3} to encapsulate results from the Local Clustering Coefficient algorithm.
 	 *
 	 * @param <T> ID type
 	 */
 	public static class Result<T>
-	extends Vertex<T, Tuple2<LongValue, LongValue>> {
+	extends Tuple3<T, LongValue, LongValue>
+	implements AlgorithmResult, UnaryResult<T> {
 		public static final int HASH_SEED = 0x37a208c4;
 
 		private Murmur3_32 hasher = new Murmur3_32(HASH_SEED);
 
-		/**
-		 * No-args constructor.
-		 */
-		public Result() {
-			f1 = new Tuple2<>();
+		@Override
+		public T getVertexId0() {
+			return f0;
 		}
 
 		/**
@@ -266,7 +268,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		 * @return vertex degree
 		 */
 		public LongValue getDegree() {
-			return f1.f0;
+			return f1;
 		}
 
 		/**
@@ -276,7 +278,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		 * @return triangle count
 		 */
 		public LongValue getTriangleCount() {
-			return f1.f1;
+			return f2;
 		}
 
 		/**
@@ -302,7 +304,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		 * @return verbose string
 		 */
 		public String toVerboseString() {
-			return "Vertex ID: " + f0
+			return "Vertex ID: " + getVertexId0()
 				+ ", vertex degree: " + getDegree()
 				+ ", triangle count: " + getTriangleCount()
 				+ ", local clustering coefficient: " + getLocalClusteringCoefficientScore();
@@ -312,8 +314,8 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		public int hashCode() {
 			return hasher.reset()
 				.hash(f0.hashCode())
-				.hash(f1.f0.getValue())
-				.hash(f1.f1.getValue())
+				.hash(f1.getValue())
+				.hash(f2.getValue())
 				.hash();
 		}
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/TriadicCensus.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/TriadicCensus.java
@@ -27,6 +27,7 @@ import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees.Degrees;
+import org.apache.flink.graph.asm.result.AnalyticResult;
 import org.apache.flink.graph.library.clustering.directed.TriadicCensus.Result;
 import org.apache.flink.types.CopyableValue;
 import org.apache.flink.util.Preconditions;
@@ -321,7 +322,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	/**
 	 * Wraps triadic census metrics.
 	 */
-	public static class Result {
+	public static class Result
+	implements AnalyticResult {
 		private final BigInteger[] counts;
 
 		public Result(BigInteger... counts) {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/TriangleListing.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/TriangleListing.java
@@ -36,6 +36,8 @@ import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.asm.degree.annotate.directed.EdgeDegreesPair;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees.Degrees;
 import org.apache.flink.graph.library.clustering.directed.TriangleListing.Result;
+import org.apache.flink.graph.asm.result.AlgorithmResult;
+import org.apache.flink.graph.asm.result.TertiaryResult;
 import org.apache.flink.graph.utils.proxy.GraphAlgorithmWrappingDataSet;
 import org.apache.flink.graph.utils.proxy.OptionalBoolean;
 import org.apache.flink.types.ByteValue;
@@ -65,7 +67,7 @@ public class TriangleListing<K extends Comparable<K> & CopyableValue<K>, VV, EV>
 extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 
 	// Optional configuration
-	private OptionalBoolean sortTriangleVertices = new OptionalBoolean(false, false);
+	private OptionalBoolean sortTriangleVertices = new OptionalBoolean(false, true);
 
 	private int littleParallelism = PARALLELISM_DEFAULT;
 
@@ -347,7 +349,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	@ForwardedFieldsSecond("0; 1")
 	private static final class ProjectTriangles<T>
 	implements JoinFunction<Tuple4<T, T, T, ByteValue>, Tuple3<T, T, ByteValue>, Result<T>> {
-		private Result<T> output = new Result<>(null, null, null, new ByteValue());
+		private Result<T> output = new Result<>();
 
 		@Override
 		public Result<T> join(Tuple4<T, T, T, ByteValue> triplet, Tuple3<T, T, ByteValue> edge)
@@ -403,27 +405,45 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	}
 
 	/**
-	 * Wraps the vertex type to encapsulate results from the Triangle Listing algorithm.
+	 * Wraps {@link Tuple4} to encapsulate results from the directed Triangle Listing algorithm.
 	 *
 	 * @param <T> ID type
 	 */
 	public static class Result<T>
-	extends Tuple4<T, T, T, ByteValue> {
+	extends Tuple4<T, T, T, ByteValue>
+	implements AlgorithmResult, TertiaryResult<T> {
 		/**
 		 * No-args constructor.
 		 */
-		public Result() {}
+		public Result() {
+			f3 = new ByteValue();
+		}
+
+		@Override
+		public T getVertexId0() {
+			return f0;
+		}
+
+		@Override
+		public T getVertexId1() {
+			return f1;
+		}
+
+		@Override
+		public T getVertexId2() {
+			return f2;
+		}
 
 		/**
-		 * Populates parent tuple with constructor parameters.
+		 * Get the bitmask indicating the presence of the six potential
+		 * connecting edges.
 		 *
-		 * @param value0 1st triangle vertex ID
-		 * @param value1 2nd triangle vertex ID
-		 * @param value2 3rd triangle vertex ID
-		 * @param value3 bitmask indicating presence of six possible edges between triangle vertices
+		 * @return the edge bitmask
+		 *
+		 * @see EdgeOrder
 		 */
-		public Result(T value0, T value1, T value2, ByteValue value3) {
-			super(value0, value1, value2, value3);
+		public ByteValue getBitmask() {
+			return f3;
 		}
 
 		/**
@@ -434,12 +454,12 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		public String toVerboseString() {
 			byte bitmask = f3.getValue();
 
-			return "1st vertex ID: " + f0
-				+ ", 2nd vertex ID: " + f1
-				+ ", 3rd vertex ID: " + f2
-				+ ", edge directions: " + f0 + maskToString(bitmask, 4) + f1
-				+ ", " + f0 + maskToString(bitmask, 2) + f2
-				+ ", " + f1 + maskToString(bitmask, 0) + f2;
+			return "1st vertex ID: " + getVertexId0()
+				+ ", 2nd vertex ID: " + getVertexId1()
+				+ ", 3rd vertex ID: " + getVertexId2()
+				+ ", edge directions: " + getVertexId0() + maskToString(bitmask, 4) + getVertexId1()
+				+ ", " + getVertexId0() + maskToString(bitmask, 2) + getVertexId2()
+				+ ", " + getVertexId1() + maskToString(bitmask, 0) + getVertexId2();
 		}
 
 		private String maskToString(byte mask, int shift) {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/AverageClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/AverageClusteringCoefficient.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.graph.AbstractGraphAnalytic;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.AnalyticHelper;
+import org.apache.flink.graph.asm.result.AnalyticResult;
 import org.apache.flink.graph.library.clustering.undirected.AverageClusteringCoefficient.Result;
 import org.apache.flink.types.CopyableValue;
 
@@ -129,7 +130,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	/**
 	 * Wraps global clustering coefficient metrics.
 	 */
-	public static class Result {
+	public static class Result
+	implements AnalyticResult {
 		private long vertexCount;
 		private double averageLocalClusteringCoefficient;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/GlobalClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/GlobalClusteringCoefficient.java
@@ -21,11 +21,11 @@ package org.apache.flink.graph.library.clustering.undirected;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.flink.api.java.DataSet;
-import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.graph.AbstractGraphAnalytic;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.library.clustering.undirected.GlobalClusteringCoefficient.Result;
 import org.apache.flink.graph.asm.dataset.Count;
+import org.apache.flink.graph.asm.result.AnalyticResult;
+import org.apache.flink.graph.library.clustering.undirected.GlobalClusteringCoefficient.Result;
 import org.apache.flink.graph.library.metric.undirected.VertexMetrics;
 import org.apache.flink.types.CopyableValue;
 
@@ -42,7 +42,7 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
 public class GlobalClusteringCoefficient<K extends Comparable<K> & CopyableValue<K>, VV, EV>
 extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
-	private Count<Tuple3<K, K, K>> triangleCount;
+	private Count<TriangleListing.Result<K>> triangleCount;
 
 	private VertexMetrics<K, VV, EV> vertexMetrics;
 
@@ -75,7 +75,7 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 
 		triangleCount = new Count<>();
 
-		DataSet<Tuple3<K, K, K>> triangles = input
+		DataSet<TriangleListing.Result<K>> triangles = input
 			.run(new TriangleListing<K, VV, EV>()
 				.setSortTriangleVertices(false)
 				.setLittleParallelism(littleParallelism));
@@ -101,7 +101,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	/**
 	 * Wraps global clustering coefficient metrics.
 	 */
-	public static class Result {
+	public static class Result
+	implements AnalyticResult {
 		private long tripletCount;
 
 		private long triangleCount;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/LocalClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/LocalClusteringCoefficient.java
@@ -30,9 +30,11 @@ import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.asm.degree.annotate.undirected.VertexDegree;
 import org.apache.flink.graph.library.clustering.undirected.LocalClusteringCoefficient.Result;
+import org.apache.flink.graph.asm.result.AlgorithmResult;
+import org.apache.flink.graph.asm.result.UnaryResult;
 import org.apache.flink.graph.utils.Murmur3_32;
-import org.apache.flink.graph.utils.proxy.OptionalBoolean;
 import org.apache.flink.graph.utils.proxy.GraphAlgorithmWrappingDataSet;
+import org.apache.flink.graph.utils.proxy.OptionalBoolean;
 import org.apache.flink.types.CopyableValue;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.util.Collector;
@@ -138,7 +140,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	public DataSet<Result<K>> runInternal(Graph<K, VV, EV> input)
 			throws Exception {
 		// u, v, w
-		DataSet<Tuple3<K, K, K>> triangles = input
+		DataSet<TriangleListing.Result<K>> triangles = input
 			.run(new TriangleListing<K, VV, EV>()
 				.setLittleParallelism(littleParallelism));
 
@@ -176,11 +178,11 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	 * @param <T> ID type
 	 */
 	private static class SplitTriangles<T>
-	implements FlatMapFunction<Tuple3<T, T, T>, Tuple2<T, LongValue>> {
+	implements FlatMapFunction<TriangleListing.Result<T>, Tuple2<T, LongValue>> {
 		private Tuple2<T, LongValue> output = new Tuple2<>(null, new LongValue(1));
 
 		@Override
-		public void flatMap(Tuple3<T, T, T> value, Collector<Tuple2<T, LongValue>> out)
+		public void flatMap(TriangleListing.Result<T> value, Collector<Tuple2<T, LongValue>> out)
 				throws Exception {
 			output.f0 = value.f0;
 			out.collect(output);
@@ -214,7 +216,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	 *
 	 * @param <T> ID type
 	 */
-	@FunctionAnnotation.ForwardedFieldsFirst("0; 1->1.0")
+	@FunctionAnnotation.ForwardedFieldsFirst("0; 1")
 	@FunctionAnnotation.ForwardedFieldsSecond("0")
 	private static class JoinVertexDegreeWithTriangleCount<T>
 	implements JoinFunction<Vertex<T, LongValue>, Tuple2<T, LongValue>, Result<T>> {
@@ -226,26 +228,28 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		public Result<T> join(Vertex<T, LongValue> vertexAndDegree, Tuple2<T, LongValue> vertexAndTriangleCount)
 				throws Exception {
 			output.f0 = vertexAndDegree.f0;
-			output.f1.f0 = vertexAndDegree.f1;
-			output.f1.f1 = (vertexAndTriangleCount == null) ? zero : vertexAndTriangleCount.f1;
+			output.f1 = vertexAndDegree.f1;
+			output.f2 = (vertexAndTriangleCount == null) ? zero : vertexAndTriangleCount.f1;
 
 			return output;
 		}
 	}
 
 	/**
-	 * Wraps the vertex type to encapsulate results from the Local Clustering Coefficient algorithm.
+	 * Wraps {@link Tuple3} to encapsulate results from the Local Clustering Coefficient algorithm.
 	 *
 	 * @param <T> ID type
 	 */
 	public static class Result<T>
-	extends Vertex<T, Tuple2<LongValue, LongValue>> {
+	extends Tuple3<T, LongValue, LongValue>
+	implements AlgorithmResult, UnaryResult<T> {
 		private static final int HASH_SEED = 0xc23937c1;
 
 		private Murmur3_32 hasher = new Murmur3_32(HASH_SEED);
 
-		public Result() {
-			f1 = new Tuple2<>();
+		@Override
+		public T getVertexId0() {
+			return f0;
 		}
 
 		/**
@@ -254,7 +258,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		 * @return vertex degree
 		 */
 		public LongValue getDegree() {
-			return f1.f0;
+			return f1;
 		}
 
 		/**
@@ -264,7 +268,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		 * @return triangle count
 		 */
 		public LongValue getTriangleCount() {
-			return f1.f1;
+			return f2;
 		}
 
 		/**
@@ -290,7 +294,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		 * @return verbose string
 		 */
 		public String toVerboseString() {
-			return "Vertex ID: " + f0
+			return "Vertex ID: " + getVertexId0()
 				+ ", vertex degree: " + getDegree()
 				+ ", triangle count: " + getTriangleCount()
 				+ ", local clustering coefficient: " + getLocalClusteringCoefficientScore();
@@ -300,8 +304,8 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		public int hashCode() {
 			return hasher.reset()
 				.hash(f0.hashCode())
-				.hash(f1.f0.getValue())
-				.hash(f1.f1.getValue())
+				.hash(f1.getValue())
+				.hash(f2.getValue())
 				.hash();
 		}
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/TriadicCensus.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/TriadicCensus.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.graph.AbstractGraphAnalytic;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.asm.dataset.Count;
-import org.apache.flink.graph.library.clustering.directed.TriangleListing;
+import org.apache.flink.graph.asm.result.AnalyticResult;
 import org.apache.flink.graph.library.clustering.undirected.TriadicCensus.Result;
 import org.apache.flink.graph.library.metric.undirected.VertexMetrics;
 import org.apache.flink.types.CopyableValue;
@@ -140,7 +140,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	/**
 	 * Wraps triadic census metrics.
 	 */
-	public static class Result {
+	public static class Result
+	implements AnalyticResult {
 		private final BigInteger[] counts;
 
 		public Result(BigInteger... counts) {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/TriangleListing.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/TriangleListing.java
@@ -33,6 +33,9 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.asm.degree.annotate.undirected.EdgeDegreePair;
+import org.apache.flink.graph.library.clustering.undirected.TriangleListing.Result;
+import org.apache.flink.graph.asm.result.AlgorithmResult;
+import org.apache.flink.graph.asm.result.TertiaryResult;
 import org.apache.flink.graph.utils.proxy.GraphAlgorithmWrappingDataSet;
 import org.apache.flink.graph.utils.proxy.OptionalBoolean;
 import org.apache.flink.types.CopyableValue;
@@ -63,10 +66,10 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
  * @param <EV> edge value type
  */
 public class TriangleListing<K extends Comparable<K> & CopyableValue<K>, VV, EV>
-extends GraphAlgorithmWrappingDataSet<K, VV, EV, Tuple3<K, K, K>> {
+extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 
 	// Optional configuration
-	private OptionalBoolean sortTriangleVertices = new OptionalBoolean(false, false);
+	private OptionalBoolean sortTriangleVertices = new OptionalBoolean(false, true);
 
 	private int littleParallelism = PARALLELISM_DEFAULT;
 
@@ -131,7 +134,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Tuple3<K, K, K>> {
 	 */
 
 	@Override
-	public DataSet<Tuple3<K, K, K>> runInternal(Graph<K, VV, EV> input)
+	public DataSet<Result<K>> runInternal(Graph<K, VV, EV> input)
 			throws Exception {
 		// u, v where u < v
 		DataSet<Tuple2<K, K>> filteredByID = input
@@ -159,7 +162,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Tuple3<K, K, K>> {
 				.name("Generate triplets");
 
 		// u, v, w where (u, v), (u, w), and (v, w) are edges in graph, v < w
-		DataSet<Tuple3<K, K, K>> triangles = triplets
+		DataSet<Result<K>> triangles = triplets
 			.join(filteredByID, JoinOperatorBase.JoinHint.REPARTITION_HASH_SECOND)
 			.where(1, 2)
 			.equalTo(0, 1)
@@ -289,11 +292,16 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Tuple3<K, K, K>> {
 	@ForwardedFieldsFirst("0; 1; 2")
 	@ForwardedFieldsSecond("0; 1")
 	private static final class ProjectTriangles<T>
-	implements JoinFunction<Tuple3<T, T, T>, Tuple2<T, T>, Tuple3<T, T, T>> {
+	implements JoinFunction<Tuple3<T, T, T>, Tuple2<T, T>, Result<T>> {
+		private Result<T> output = new Result<>();
+
 		@Override
-		public Tuple3<T, T, T> join(Tuple3<T, T, T> triplet, Tuple2<T, T> edge)
+		public Result<T> join(Tuple3<T, T, T> triplet, Tuple2<T, T> edge)
 				throws Exception {
-			return triplet;
+			output.f0 = triplet.f0;
+			output.f1 = triplet.f1;
+			output.f2 = triplet.f2;
+			return output;
 		}
 	}
 
@@ -304,9 +312,9 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Tuple3<K, K, K>> {
 	 * @param <T> ID type
 	 */
 	private static final class SortTriangleVertices<T extends Comparable<T>>
-	implements MapFunction<Tuple3<T, T, T>, Tuple3<T, T, T>> {
+	implements MapFunction<Result<T>, Result<T>> {
 		@Override
-		public Tuple3<T, T, T> map(Tuple3<T, T, T> value)
+		public Result<T> map(Result<T> value)
 				throws Exception {
 			// by the triangle listing algorithm we know f1 < f2
 			if (value.f0.compareTo(value.f1) > 0) {
@@ -322,6 +330,41 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Tuple3<K, K, K>> {
 			}
 
 			return value;
+		}
+	}
+
+	/**
+	 * Wraps {@link Tuple3} to encapsulate results from the undirected Triangle Listing algorithm.
+	 *
+	 * @param <T> ID type
+	 */
+	public static class Result<T>
+	extends Tuple3<T, T, T>
+	implements AlgorithmResult, TertiaryResult<T> {
+		@Override
+		public T getVertexId0() {
+			return f0;
+		}
+
+		@Override
+		public T getVertexId1() {
+			return f1;
+		}
+
+		@Override
+		public T getVertexId2() {
+			return f2;
+		}
+
+		/**
+		 * Format values into a human-readable string.
+		 *
+		 * @return verbose string
+		 */
+		public String toVerboseString() {
+			return "1st vertex ID: " + getVertexId0()
+				+ ", 2nd vertex ID: " + getVertexId1()
+				+ ", 3rd vertex ID: " + getVertexId2();
 		}
 	}
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/link_analysis/HITS.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/link_analysis/HITS.java
@@ -37,8 +37,9 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.library.link_analysis.HITS.Result;
+import org.apache.flink.graph.asm.result.AlgorithmResult;
+import org.apache.flink.graph.asm.result.UnaryResult;
 import org.apache.flink.graph.utils.Murmur3_32;
 import org.apache.flink.graph.utils.proxy.GraphAlgorithmWrappingDataSet;
 import org.apache.flink.types.DoubleValue;
@@ -153,7 +154,6 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 
 		return true;
 	}
-
 
 	@Override
 	public DataSet<Result<K>> runInternal(Graph<K, VV, EV> input)
@@ -526,7 +526,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 	 *
 	 * @param <T> ID type
 	 */
-	@ForwardedFields("0")
+	@ForwardedFields("0; 1; 2")
 	private static class TranslateResult<T>
 	implements MapFunction<Tuple3<T, DoubleValue, DoubleValue>, Result<T>> {
 		private Result<T> output = new Result<>();
@@ -534,25 +534,27 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		@Override
 		public Result<T> map(Tuple3<T, DoubleValue, DoubleValue> value) throws Exception {
 			output.f0 = value.f0;
-			output.f1.f0 = value.f1;
-			output.f1.f1 = value.f2;
+			output.f1 = value.f1;
+			output.f2 = value.f2;
 			return output;
 		}
 	}
 
 	/**
-	 * Wraps the vertex type to encapsulate results from the HITS algorithm.
+	 * Wraps the {@link Tuple3} to encapsulate results from the HITS algorithm.
 	 *
 	 * @param <T> ID type
 	 */
 	public static class Result<T>
-	extends Vertex<T, Tuple2<DoubleValue, DoubleValue>> {
+	extends Tuple3<T, DoubleValue, DoubleValue>
+	implements AlgorithmResult, UnaryResult<T> {
 		public static final int HASH_SEED = 0xc7e39a63;
 
 		private Murmur3_32 hasher = new Murmur3_32(HASH_SEED);
 
-		public Result() {
-			f1 = new Tuple2<>();
+		@Override
+		public T getVertexId0() {
+			return f0;
 		}
 
 		/**
@@ -561,7 +563,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		 * @return the hub score
 		 */
 		public DoubleValue getHubScore() {
-			return f1.f0;
+			return f1;
 		}
 
 		/**
@@ -570,11 +572,11 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		 * @return the authority score
 		 */
 		public DoubleValue getAuthorityScore() {
-			return f1.f1;
+			return f2;
 		}
 
 		public String toVerboseString() {
-			return "Vertex ID: " + f0
+			return "Vertex ID: " + getVertexId0()
 				+ ", hub score: " + getHubScore()
 				+ ", authority score: " + getAuthorityScore();
 		}
@@ -583,8 +585,8 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		public int hashCode() {
 			return hasher.reset()
 				.hash(f0.hashCode())
-				.hash(f1.f0.getValue())
-				.hash(f1.f1.getValue())
+				.hash(f1.getValue())
+				.hash(f2.getValue())
 				.hash();
 		}
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/EdgeMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/EdgeMetrics.java
@@ -37,6 +37,7 @@ import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.asm.degree.annotate.directed.EdgeDegreesPair;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees.Degrees;
+import org.apache.flink.graph.asm.result.AnalyticResult;
 import org.apache.flink.graph.library.metric.directed.EdgeMetrics.Result;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.util.Collector;
@@ -272,7 +273,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	/**
 	 * Wraps edge metrics.
 	 */
-	public static class Result {
+	public static class Result
+	implements AnalyticResult {
 		private long triangleTripletCount;
 		private long rectangleTripletCount;
 		private long maximumTriangleTriplets;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/VertexMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/VertexMetrics.java
@@ -29,6 +29,7 @@ import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees;
 import org.apache.flink.graph.asm.degree.annotate.directed.VertexDegrees.Degrees;
+import org.apache.flink.graph.asm.result.AnalyticResult;
 import org.apache.flink.graph.library.metric.directed.VertexMetrics.Result;
 
 import java.io.IOException;
@@ -192,7 +193,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	/**
 	 * Wraps vertex metrics.
 	 */
-	public static class Result {
+	public static class Result
+	implements AnalyticResult {
 		private long vertexCount;
 		private long unidirectionalEdgeCount;
 		private long bidirectionalEdgeCount;
@@ -258,8 +260,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 		 *
 		 * @return average degree
 		 */
-		public float getAverageDegree() {
-			return vertexCount == 0 ? Float.NaN : getNumberOfEdges() / (float)vertexCount;
+		public double getAverageDegree() {
+			return vertexCount == 0 ? Double.NaN : getNumberOfEdges() / (double)vertexCount;
 		}
 
 		/**
@@ -270,8 +272,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 		 *
 		 * @return density
 		 */
-		public float getDensity() {
-			return vertexCount <= 1 ? Float.NaN : getNumberOfEdges() / (float)(vertexCount*(vertexCount-1));
+		public double getDensity() {
+			return vertexCount <= 1 ? Double.NaN : getNumberOfEdges() / (double)(vertexCount*(vertexCount-1));
 		}
 
 		/**
@@ -323,12 +325,16 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 		public String toString() {
 			NumberFormat nf = NumberFormat.getInstance();
 
+			// format for very small fractional numbers
+			NumberFormat ff = NumberFormat.getInstance();
+			ff.setMaximumFractionDigits(8);
+
 			return "vertex count: " + nf.format(vertexCount)
 				+ "; edge count: " + nf.format(getNumberOfEdges())
 				+ "; unidirectional edge count: " + nf.format(unidirectionalEdgeCount)
 				+ "; bidirectional edge count: " + nf.format(bidirectionalEdgeCount)
 				+ "; average degree: " + nf.format(getAverageDegree())
-				+ "; density: " + nf.format(getDensity())
+				+ "; density: " + ff.format(getDensity())
 				+ "; triplet count: " + nf.format(tripletCount)
 				+ "; maximum degree: " + nf.format(maximumDegree)
 				+ "; maximum out degree: " + nf.format(maximumOutDegree)

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/EdgeMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/EdgeMetrics.java
@@ -33,6 +33,7 @@ import org.apache.flink.graph.AnalyticHelper;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.asm.degree.annotate.undirected.EdgeDegreePair;
+import org.apache.flink.graph.asm.result.AnalyticResult;
 import org.apache.flink.graph.library.metric.undirected.EdgeMetrics.Result;
 import org.apache.flink.types.LongValue;
 
@@ -245,7 +246,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	/**
 	 * Wraps edge metrics.
 	 */
-	public static class Result {
+	public static class Result
+	implements AnalyticResult {
 		private long triangleTripletCount;
 		private long rectangleTripletCount;
 		private long maximumTriangleTriplets;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/VertexMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/VertexMetrics.java
@@ -28,6 +28,7 @@ import org.apache.flink.graph.AnalyticHelper;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.asm.degree.annotate.undirected.VertexDegree;
+import org.apache.flink.graph.asm.result.AnalyticResult;
 import org.apache.flink.graph.library.metric.undirected.VertexMetrics.Result;
 import org.apache.flink.types.LongValue;
 
@@ -183,7 +184,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 	/**
 	 * Wraps vertex metrics.
 	 */
-	public static class Result {
+	public static class Result
+	implements AnalyticResult {
 		private long vertexCount;
 		private long edgeCount;
 		private long tripletCount;
@@ -225,9 +227,9 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 		 *
 		 * @return average degree
 		 */
-		public float getAverageDegree() {
+		public double getAverageDegree() {
 			// each edge is incident on two vertices
-			return vertexCount == 0 ? Float.NaN : 2 * edgeCount / (float)vertexCount;
+			return vertexCount == 0 ? Double.NaN : 2 * edgeCount / (double)vertexCount;
 		}
 
 		/**
@@ -238,8 +240,8 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 		 *
 		 * @return density
 		 */
-		public float getDensity() {
-			return vertexCount <= 1 ? Float.NaN : edgeCount / (float)(vertexCount*(vertexCount-1)/2);
+		public double getDensity() {
+			return vertexCount <= 1 ? Double.NaN : edgeCount / (double)(vertexCount*(vertexCount-1)/2);
 		}
 
 		/**
@@ -273,10 +275,14 @@ extends AbstractGraphAnalytic<K, VV, EV, Result> {
 		public String toString() {
 			NumberFormat nf = NumberFormat.getInstance();
 
+			// format for very small fractional numbers
+			NumberFormat ff = NumberFormat.getInstance();
+			ff.setMaximumFractionDigits(8);
+
 			return "vertex count: " + nf.format(vertexCount)
 				+ "; edge count: " + nf.format(edgeCount)
 				+ "; average degree: " + nf.format(getAverageDegree())
-				+ "; density: " + nf.format(getDensity())
+				+ "; density: " + ff.format(getDensity())
 				+ "; triplet count: " + nf.format(tripletCount)
 				+ "; maximum degree: " + nf.format(maximumDegree)
 				+ "; maximum triplets: " + nf.format(maximumTriplets);

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/GraphUtils.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/GraphUtils.java
@@ -38,7 +38,9 @@ public class GraphUtils {
 		return input
 			.map(new MapTo<T, LongValue>(new LongValue(1)))
 				.returns(LONG_VALUE_TYPE_INFO)
-			.reduce(new AddLongValue());
+				.name("Emit 1")
+			.reduce(new AddLongValue())
+				.name("Sum");
 	}
 
 	/**

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/directed/LocalClusteringCoefficientTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/directed/LocalClusteringCoefficientTest.java
@@ -40,12 +40,12 @@ extends AsmTestBase {
 	public void testSimpleGraph()
 			throws Exception {
 		String expectedResult =
-			"(0,(2,1))\n" +
-			"(1,(3,2))\n" +
-			"(2,(3,2))\n" +
-			"(3,(4,1))\n" +
-			"(4,(1,0))\n" +
-			"(5,(1,0))";
+			"(0,2,1)\n" +
+			"(1,3,2)\n" +
+			"(2,3,2)\n" +
+			"(3,4,1)\n" +
+			"(4,1,0)\n" +
+			"(5,1,0)";
 
 		DataSet<Result<IntValue>> cc = directedSimpleGraph
 			.run(new LocalClusteringCoefficient<IntValue, NullValue, NullValue>());

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/LocalClusteringCoefficientTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/LocalClusteringCoefficientTest.java
@@ -41,12 +41,12 @@ extends AsmTestBase {
 	public void testSimpleGraph()
 			throws Exception {
 		String expectedResult =
-			"(0,(2,1))\n" +
-			"(1,(3,2))\n" +
-			"(2,(3,2))\n" +
-			"(3,(4,1))\n" +
-			"(4,(1,0))\n" +
-			"(5,(1,0))";
+			"(0,2,1)\n" +
+			"(1,3,2)\n" +
+			"(2,3,2)\n" +
+			"(3,4,1)\n" +
+			"(4,1,0)\n" +
+			"(5,1,0)";
 
 		DataSet<Result<IntValue>> cc = undirectedSimpleGraph
 			.run(new LocalClusteringCoefficient<IntValue, NullValue, NullValue>());

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/TriangleListingTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/TriangleListingTest.java
@@ -20,10 +20,10 @@ package org.apache.flink.graph.library.clustering.undirected;
 
 import org.apache.commons.math3.util.CombinatoricsUtils;
 import org.apache.flink.api.java.DataSet;
-import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.graph.asm.AsmTestBase;
 import org.apache.flink.graph.asm.dataset.ChecksumHashCode;
 import org.apache.flink.graph.asm.dataset.ChecksumHashCode.Checksum;
+import org.apache.flink.graph.library.clustering.undirected.TriangleListing.Result;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
@@ -38,7 +38,7 @@ extends AsmTestBase {
 	@Test
 	public void testSimpleGraph()
 			throws Exception {
-		DataSet<Tuple3<IntValue, IntValue, IntValue>> tl = undirectedSimpleGraph
+		DataSet<Result<IntValue>> tl = undirectedSimpleGraph
 			.run(new TriangleListing<IntValue, NullValue, NullValue>()
 				.setSortTriangleVertices(true));
 
@@ -55,10 +55,10 @@ extends AsmTestBase {
 		long expectedDegree = completeGraphVertexCount - 1;
 		long expectedCount = completeGraphVertexCount * CombinatoricsUtils.binomialCoefficient((int)expectedDegree, 2) / 3;
 
-		DataSet<Tuple3<LongValue, LongValue, LongValue>> tl = completeGraph
+		DataSet<Result<LongValue>> tl = completeGraph
 			.run(new TriangleListing<LongValue, NullValue, NullValue>());
 
-		Checksum checksum = new ChecksumHashCode<Tuple3<LongValue, LongValue, LongValue>>()
+		Checksum checksum = new ChecksumHashCode<Result<LongValue>>()
 			.run(tl)
 			.execute();
 
@@ -68,11 +68,11 @@ extends AsmTestBase {
 	@Test
 	public void testRMatGraph()
 			throws Exception {
-		DataSet<Tuple3<LongValue, LongValue, LongValue>> tl = undirectedRMatGraph
+		DataSet<Result<LongValue>> tl = undirectedRMatGraph
 			.run(new TriangleListing<LongValue, NullValue, NullValue>()
 				.setSortTriangleVertices(true));
 
-		Checksum checksum = new ChecksumHashCode<Tuple3<LongValue, LongValue, LongValue>>()
+		Checksum checksum = new ChecksumHashCode<Result<LongValue>>()
 			.run(tl)
 			.execute();
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/similarity/JaccardIndexTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/similarity/JaccardIndexTest.java
@@ -47,17 +47,17 @@ extends AsmTestBase {
 			.run(new JaccardIndex<IntValue, NullValue, NullValue>());
 
 		String expectedResult =
-			"(0,1,(1,4))\n" +
-			"(0,2,(1,4))\n" +
-			"(0,3,(2,4))\n" +
-			"(1,2,(2,4))\n" +
-			"(1,3,(1,6))\n" +
-			"(1,4,(1,3))\n" +
-			"(1,5,(1,3))\n" +
-			"(2,3,(1,6))\n" +
-			"(2,4,(1,3))\n" +
-			"(2,5,(1,3))\n" +
-			"(4,5,(1,1))\n";
+			"(0,1,1,4)\n" +
+			"(0,2,1,4)\n" +
+			"(0,3,2,4)\n" +
+			"(1,2,2,4)\n" +
+			"(1,3,1,6)\n" +
+			"(1,4,1,3)\n" +
+			"(1,5,1,3)\n" +
+			"(2,3,1,6)\n" +
+			"(2,4,1,3)\n" +
+			"(2,5,1,3)\n" +
+			"(4,5,1,1)\n";
 
 		TestBaseUtils.compareResultAsText(ji.collect(), expectedResult);
 	}
@@ -70,9 +70,9 @@ extends AsmTestBase {
 				.setMinimumScore(1, 2));
 
 		String expectedResult =
-			"(0,3,(2,4))\n" +
-			"(1,2,(2,4))\n" +
-			"(4,5,(1,1))\n";
+			"(0,3,2,4)\n" +
+			"(1,2,2,4)\n" +
+			"(4,5,1,1)\n";
 
 		TestBaseUtils.compareResultAsText(ji.collect(), expectedResult);
 	}
@@ -85,14 +85,14 @@ extends AsmTestBase {
 				.setMaximumScore(1, 2));
 
 		String expectedResult =
-			"(0,1,(1,4))\n" +
-			"(0,2,(1,4))\n" +
-			"(1,3,(1,6))\n" +
-			"(1,4,(1,3))\n" +
-			"(1,5,(1,3))\n" +
-			"(2,3,(1,6))\n" +
-			"(2,4,(1,3))\n" +
-			"(2,5,(1,3))\n";
+			"(0,1,1,4)\n" +
+			"(0,2,1,4)\n" +
+			"(1,3,1,6)\n" +
+			"(1,4,1,3)\n" +
+			"(1,5,1,3)\n" +
+			"(2,3,1,6)\n" +
+			"(2,4,1,3)\n" +
+			"(2,5,1,3)\n";
 
 		TestBaseUtils.compareResultAsText(ji.collect(), expectedResult);
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/DegreesITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/DegreesITCase.java
@@ -54,7 +54,6 @@ public class DegreesITCase extends MultipleProgramsTestBase {
 		DataSet<Tuple2<Long, LongValue>> data = graph.outDegrees();
 		List<Tuple2<Long, LongValue>> result = data.collect();
 
-
 		expectedResult = "1,2\n" +
 			"2,1\n" +
 			"3,2\n" +
@@ -73,7 +72,6 @@ public class DegreesITCase extends MultipleProgramsTestBase {
 
 		Graph<Long, Long, Long> graph = Graph.fromDataSet(TestGraphUtils.getLongLongVertexData(env),
 			TestGraphUtils.getLongLongEdgeDataWithZeroDegree(env), env);
-
 
 		DataSet<Tuple2<Long, LongValue>> data = graph.outDegrees();
 		List<Tuple2<Long, LongValue>> result = data.collect();


### PR DESCRIPTION
Create AlgorithmResult and AnalyticResult interfaces for library algorithms to implement. This flattens algorithm results to a single tuple.

Also create interfaces for UnaryResult, BinaryResult, and TertiaryResult implementing methods to access the 0th, 1st, and 2nd vertices.