### PR TITLE
[FLINK-5778] [savepoints] Add savepoint serializer with relative file path serialization

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/checkpoint/savepoint/SavepointV0Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/checkpoint/savepoint/SavepointV0Serializer.java
@@ -34,7 +34,7 @@ import org.apache.flink.migration.streaming.runtime.tasks.StreamTaskState;
 import org.apache.flink.migration.streaming.runtime.tasks.StreamTaskStateList;
 import org.apache.flink.migration.util.SerializedValue;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointSerializer;
-import org.apache.flink.runtime.checkpoint.savepoint.SavepointV1;
+import org.apache.flink.runtime.checkpoint.savepoint.SavepointV2;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.state.ChainedStateHandle;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -68,7 +68,7 @@ import java.util.Map;
  * don't rely on any involved Java classes to stay the same.
  */
 @SuppressWarnings("deprecation")
-public class SavepointV0Serializer implements SavepointSerializer<SavepointV1> {
+public class SavepointV0Serializer implements SavepointSerializer<SavepointV2> {
 
 	public static final SavepointV0Serializer INSTANCE = new SavepointV0Serializer();
 	private static final StreamStateHandle SIGNAL_0 = new ByteStreamStateHandle("SIGNAL_0", new byte[]{0});
@@ -79,14 +79,13 @@ public class SavepointV0Serializer implements SavepointSerializer<SavepointV1> {
 	private SavepointV0Serializer() {
 	}
 
-
 	@Override
-	public void serialize(SavepointV1 savepoint, DataOutputStream dos) throws IOException {
+	public void serialize(SavepointV2 savepoint, Path basePath, DataOutputStream dos) throws IOException {
 		throw new UnsupportedOperationException("This serializer is read-only and only exists for backwards compatibility");
 	}
 
 	@Override
-	public SavepointV1 deserialize(DataInputStream dis, ClassLoader userClassLoader) throws IOException {
+	public SavepointV2 deserialize(DataInputStream dis, Path ignoredBasePath, ClassLoader userClassLoader) throws IOException {
 
 		long checkpointId = dis.readLong();
 
@@ -165,7 +164,7 @@ public class SavepointV0Serializer implements SavepointSerializer<SavepointV1> {
 		return serializedValue;
 	}
 
-	private SavepointV1 convertSavepoint(
+	private SavepointV2 convertSavepoint(
 			List<TaskState> taskStates,
 			ClassLoader userClassLoader,
 			long checkpointID) throws Exception {
@@ -176,7 +175,7 @@ public class SavepointV0Serializer implements SavepointSerializer<SavepointV1> {
 			newTaskStates.add(convertTaskState(taskState, userClassLoader, checkpointID));
 		}
 
-		return new SavepointV1(checkpointID, newTaskStates);
+		return new SavepointV2(checkpointID, newTaskStates);
 	}
 
 	private org.apache.flink.runtime.checkpoint.TaskState convertTaskState(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -34,7 +34,7 @@ import javax.annotation.concurrent.GuardedBy;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.checkpoint.savepoint.Savepoint;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointStore;
-import org.apache.flink.runtime.checkpoint.savepoint.SavepointV1;
+import org.apache.flink.runtime.checkpoint.savepoint.SavepointV2;
 import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -217,7 +217,7 @@ public class PendingCheckpoint {
 			// make sure we fulfill the promise with an exception if something fails
 			try {
 				// externalize the metadata
-				final Savepoint savepoint = new SavepointV1(checkpointId, taskStates.values());
+				final Savepoint savepoint = new SavepointV2(checkpointId, taskStates.values());
 
 				// TEMP FIX - The savepoint store is strictly typed to file systems currently
 				//            but the checkpoints think more generic. we need to work with file handles

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/AbstractSavepoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/AbstractSavepoint.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.savepoint;
+
+import java.util.Collection;
+import java.util.Objects;
+import org.apache.flink.runtime.checkpoint.TaskState;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A base savepoint class implementing the simple accessors of the Savepoint
+ * interface.
+ */
+abstract class AbstractSavepoint implements Savepoint {
+
+	/** The checkpoint ID */
+	private final long checkpointId;
+
+	/** The task states */
+	private final Collection<TaskState> taskStates;
+
+	AbstractSavepoint(long checkpointId, Collection<TaskState> taskStates) {
+		this.checkpointId = checkpointId;
+		this.taskStates = Preconditions.checkNotNull(taskStates, "Task States");
+	}
+
+	/**
+	 * Returns the savepoint version.
+	 *
+	 * @return Savepoint version.
+	 */
+	abstract public int getVersion();
+
+	@Override
+	public long getCheckpointId() {
+		return checkpointId;
+	}
+
+	@Override
+	public Collection<TaskState> getTaskStates() {
+		return taskStates;
+	}
+
+	@Override
+	public void dispose() throws Exception {
+		for (TaskState taskState : taskStates) {
+			taskState.discardState();
+		}
+		taskStates.clear();
+	}
+
+	@Override
+	public String toString() {
+		return "Savepoint(version=" + getVersion() + ")";
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (o == null || !(o instanceof Savepoint)) {
+			return false;
+		}
+
+		Savepoint that = (Savepoint) o;
+		return getVersion() == that.getVersion()
+			&& checkpointId == that.getCheckpointId()
+			&& getTaskStates().equals(that.getTaskStates());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getCheckpointId(), getVersion(), taskStates);
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/AbstractSavepointSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/AbstractSavepointSerializer.java
@@ -1,0 +1,386 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.savepoint;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.checkpoint.SubtaskState;
+import org.apache.flink.runtime.checkpoint.TaskState;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.state.ChainedStateHandle;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
+import org.apache.flink.runtime.state.KeyGroupsStateHandle;
+import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.filesystem.FileStateHandle;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+
+/**
+ * Abstract Serializer for {@link Savepoint} instances.
+ *
+ * <p>This is based on the {@link SavepointV1Serializer} of Flink 1.2.0 that
+ * makes sure no default Java serialization is used.
+ *
+ * <p>The abstract class allows to overwrite the serialization behaviour for
+ * {@link FileStateHandle} instances. This is the only practical difference
+ * between Flink 1.2.x and versions >= Flink 1.3.0.
+ *
+ * <p>This will probably be extended in ways that I cannot imagine at this point
+ * in time. If for whatever reason the abstract base class turns out to be a
+ * bad idea, feel free to change stuff. Right now, it's sole purpose is reducing
+ * code duplication between {@link SavepointV1Serializer} and {@link SavepointV2Serializer}.
+ */
+abstract class AbstractSavepointSerializer<T extends Savepoint> implements SavepointSerializer<T> {
+
+	private static final byte NULL_HANDLE = 0;
+	private static final byte BYTE_STREAM_STATE_HANDLE = 1;
+	private static final byte FILE_STREAM_STATE_HANDLE = 2;
+	private static final byte KEY_GROUPS_HANDLE = 3;
+	private static final byte PARTITIONABLE_OPERATOR_STATE_HANDLE = 4;
+
+	/**
+	 * Abstract method to create the special savepoint of subtype T.
+	 *
+	 * <p>I'm wondering how useful this is in practice in comparison to simply
+	 * returning the base Savepoint type.
+	 *
+	 * @param checkpointId Checkpoint ID of the savepoint.
+	 * @param taskStates Task states of the savepoint.
+	 * @return A concrete savepoint subtype of type T.
+	 */
+	abstract T createSavepoint(long checkpointId, Collection<TaskState> taskStates);
+
+	@Override
+	public void serialize(T savepoint, Path basePath, DataOutputStream dos) throws IOException {
+		try {
+			dos.writeLong(savepoint.getCheckpointId());
+
+			Collection<TaskState> taskStates = savepoint.getTaskStates();
+			dos.writeInt(taskStates.size());
+
+			for (TaskState taskState : savepoint.getTaskStates()) {
+				// Vertex ID
+				dos.writeLong(taskState.getJobVertexID().getLowerPart());
+				dos.writeLong(taskState.getJobVertexID().getUpperPart());
+
+				// Parallelism
+				int parallelism = taskState.getParallelism();
+				dos.writeInt(parallelism);
+				dos.writeInt(taskState.getMaxParallelism());
+				dos.writeInt(taskState.getChainLength());
+
+				// Sub task states
+				Map<Integer, SubtaskState> subtaskStateMap = taskState.getSubtaskStates();
+				dos.writeInt(subtaskStateMap.size());
+				for (Map.Entry<Integer, SubtaskState> entry : subtaskStateMap.entrySet()) {
+					dos.writeInt(entry.getKey());
+					serializeSubtaskState(entry.getValue(), basePath, dos);
+				}
+			}
+		} catch (Exception e) {
+			throw new IOException(e);
+		}
+	}
+
+	@Override
+	public T deserialize(DataInputStream dis, Path basePath, ClassLoader userCodeClassLoader) throws IOException {
+		long checkpointId = dis.readLong();
+
+		// Task states
+		int numTaskStates = dis.readInt();
+		List<TaskState> taskStates = new ArrayList<>(numTaskStates);
+
+		for (int i = 0; i < numTaskStates; i++) {
+			JobVertexID jobVertexId = new JobVertexID(dis.readLong(), dis.readLong());
+			int parallelism = dis.readInt();
+			int maxParallelism = dis.readInt();
+			int chainLength = dis.readInt();
+
+			// Add task state
+			TaskState taskState = new TaskState(jobVertexId, parallelism, maxParallelism, chainLength);
+			taskStates.add(taskState);
+
+			// Sub task states
+			int numSubTaskStates = dis.readInt();
+
+			for (int j = 0; j < numSubTaskStates; j++) {
+				int subtaskIndex = dis.readInt();
+				SubtaskState subtaskState = deserializeSubtaskState(basePath, dis);
+				taskState.putState(subtaskIndex, subtaskState);
+			}
+		}
+
+		return createSavepoint(checkpointId, taskStates);
+	}
+
+	private void serializeSubtaskState(SubtaskState subtaskState, Path basePath, DataOutputStream dos) throws IOException {
+		dos.writeLong(-1);
+
+		ChainedStateHandle<StreamStateHandle> nonPartitionableState = subtaskState.getLegacyOperatorState();
+
+		int len = nonPartitionableState != null ? nonPartitionableState.getLength() : 0;
+		dos.writeInt(len);
+		for (int i = 0; i < len; ++i) {
+			StreamStateHandle stateHandle = nonPartitionableState.get(i);
+			serializeStreamStateHandle(stateHandle, basePath, dos);
+		}
+
+		ChainedStateHandle<OperatorStateHandle> operatorStateBackend = subtaskState.getManagedOperatorState();
+
+		len = operatorStateBackend != null ? operatorStateBackend.getLength() : 0;
+		dos.writeInt(len);
+		for (int i = 0; i < len; ++i) {
+			OperatorStateHandle stateHandle = operatorStateBackend.get(i);
+			serializeOperatorStateHandle(stateHandle, basePath, dos);
+		}
+
+		ChainedStateHandle<OperatorStateHandle> operatorStateFromStream = subtaskState.getRawOperatorState();
+
+		len = operatorStateFromStream != null ? operatorStateFromStream.getLength() : 0;
+		dos.writeInt(len);
+		for (int i = 0; i < len; ++i) {
+			OperatorStateHandle stateHandle = operatorStateFromStream.get(i);
+			serializeOperatorStateHandle(stateHandle, basePath, dos);
+		}
+
+		KeyGroupsStateHandle keyedStateBackend = subtaskState.getManagedKeyedState();
+		serializeKeyGroupStateHandle(keyedStateBackend, basePath, dos);
+
+		KeyGroupsStateHandle keyedStateStream = subtaskState.getRawKeyedState();
+		serializeKeyGroupStateHandle(keyedStateStream, basePath, dos);
+	}
+
+	private SubtaskState deserializeSubtaskState(Path basePath, DataInputStream dis) throws IOException {
+		// Duration field has been removed from SubtaskState
+		long ignoredDuration = dis.readLong();
+
+		int len = dis.readInt();
+		List<StreamStateHandle> nonPartitionableState = new ArrayList<>(len);
+		for (int i = 0; i < len; ++i) {
+			StreamStateHandle streamStateHandle = deserializeStreamStateHandle(basePath, dis);
+			nonPartitionableState.add(streamStateHandle);
+		}
+
+
+		len = dis.readInt();
+		List<OperatorStateHandle> operatorStateBackend = new ArrayList<>(len);
+		for (int i = 0; i < len; ++i) {
+			OperatorStateHandle streamStateHandle = deserializeOperatorStateHandle(basePath, dis);
+			operatorStateBackend.add(streamStateHandle);
+		}
+
+		len = dis.readInt();
+		List<OperatorStateHandle> operatorStateStream = new ArrayList<>(len);
+		for (int i = 0; i < len; ++i) {
+			OperatorStateHandle streamStateHandle = deserializeOperatorStateHandle(basePath, dis);
+			operatorStateStream.add(streamStateHandle);
+		}
+
+		KeyGroupsStateHandle keyedStateBackend = deserializeKeyGroupStateHandle(basePath, dis);
+
+		KeyGroupsStateHandle keyedStateStream = deserializeKeyGroupStateHandle(basePath, dis);
+
+		ChainedStateHandle<StreamStateHandle> nonPartitionableStateChain =
+			new ChainedStateHandle<>(nonPartitionableState);
+
+		ChainedStateHandle<OperatorStateHandle> operatorStateBackendChain =
+			new ChainedStateHandle<>(operatorStateBackend);
+
+		ChainedStateHandle<OperatorStateHandle> operatorStateStreamChain =
+			new ChainedStateHandle<>(operatorStateStream);
+
+		return new SubtaskState(
+			nonPartitionableStateChain,
+			operatorStateBackendChain,
+			operatorStateStreamChain,
+			keyedStateBackend,
+			keyedStateStream);
+	}
+
+	private void serializeKeyGroupStateHandle(KeyGroupsStateHandle stateHandle, Path basePath, DataOutputStream dos) throws IOException {
+		if (stateHandle != null) {
+			dos.writeByte(KEY_GROUPS_HANDLE);
+			dos.writeInt(stateHandle.getGroupRangeOffsets().getKeyGroupRange().getStartKeyGroup());
+			dos.writeInt(stateHandle.getNumberOfKeyGroups());
+			for (int keyGroup : stateHandle.keyGroups()) {
+				dos.writeLong(stateHandle.getOffsetForKeyGroup(keyGroup));
+			}
+			serializeStreamStateHandle(stateHandle.getDelegateStateHandle(), basePath, dos);
+		} else {
+			dos.writeByte(NULL_HANDLE);
+		}
+	}
+
+	private KeyGroupsStateHandle deserializeKeyGroupStateHandle(Path basePath, DataInputStream dis) throws IOException {
+		final int type = dis.readByte();
+		if (NULL_HANDLE == type) {
+			return null;
+		} else if (KEY_GROUPS_HANDLE == type) {
+			int startKeyGroup = dis.readInt();
+			int numKeyGroups = dis.readInt();
+			KeyGroupRange keyGroupRange = KeyGroupRange.of(startKeyGroup, startKeyGroup + numKeyGroups - 1);
+			long[] offsets = new long[numKeyGroups];
+			for (int i = 0; i < numKeyGroups; ++i) {
+				offsets[i] = dis.readLong();
+			}
+			KeyGroupRangeOffsets keyGroupRangeOffsets = new KeyGroupRangeOffsets(keyGroupRange, offsets);
+			StreamStateHandle stateHandle = deserializeStreamStateHandle(basePath, dis);
+			return new KeyGroupsStateHandle(keyGroupRangeOffsets, stateHandle);
+		} else {
+			throw new IllegalStateException("Reading invalid KeyGroupsStateHandle, type: " + type);
+		}
+	}
+
+	private void serializeOperatorStateHandle(OperatorStateHandle stateHandle, Path basePath, DataOutputStream dos) throws IOException {
+
+		if (stateHandle != null) {
+			dos.writeByte(PARTITIONABLE_OPERATOR_STATE_HANDLE);
+			Map<String, OperatorStateHandle.StateMetaInfo> partitionOffsetsMap =
+				stateHandle.getStateNameToPartitionOffsets();
+			dos.writeInt(partitionOffsetsMap.size());
+			for (Map.Entry<String, OperatorStateHandle.StateMetaInfo> entry : partitionOffsetsMap.entrySet()) {
+				dos.writeUTF(entry.getKey());
+
+				OperatorStateHandle.StateMetaInfo stateMetaInfo = entry.getValue();
+
+				int mode = stateMetaInfo.getDistributionMode().ordinal();
+				dos.writeByte(mode);
+
+				long[] offsets = stateMetaInfo.getOffsets();
+				dos.writeInt(offsets.length);
+				for (long offset : offsets) {
+					dos.writeLong(offset);
+				}
+			}
+			serializeStreamStateHandle(stateHandle.getDelegateStateHandle(), basePath, dos);
+		} else {
+			dos.writeByte(NULL_HANDLE);
+		}
+	}
+
+	private OperatorStateHandle deserializeOperatorStateHandle(Path basePath, DataInputStream dis) throws IOException {
+		final int type = dis.readByte();
+		if (NULL_HANDLE == type) {
+			return null;
+		} else if (PARTITIONABLE_OPERATOR_STATE_HANDLE == type) {
+			int mapSize = dis.readInt();
+			Map<String, OperatorStateHandle.StateMetaInfo> offsetsMap = new HashMap<>(mapSize);
+			for (int i = 0; i < mapSize; ++i) {
+				String key = dis.readUTF();
+
+				int modeOrdinal = dis.readByte();
+				OperatorStateHandle.Mode mode = OperatorStateHandle.Mode.values()[modeOrdinal];
+
+				long[] offsets = new long[dis.readInt()];
+				for (int j = 0; j < offsets.length; ++j) {
+					offsets[j] = dis.readLong();
+				}
+
+				OperatorStateHandle.StateMetaInfo metaInfo =
+					new OperatorStateHandle.StateMetaInfo(offsets, mode);
+				offsetsMap.put(key, metaInfo);
+			}
+			StreamStateHandle stateHandle = deserializeStreamStateHandle(basePath, dis);
+			return new OperatorStateHandle(offsetsMap, stateHandle);
+		} else {
+			throw new IllegalStateException("Reading invalid OperatorStateHandle, type: " + type);
+		}
+	}
+
+	private void serializeStreamStateHandle(StreamStateHandle stateHandle, Path basePath, DataOutputStream dos) throws IOException {
+		if (stateHandle == null) {
+			dos.writeByte(NULL_HANDLE);
+
+		} else if (stateHandle instanceof FileStateHandle) {
+			dos.writeByte(FILE_STREAM_STATE_HANDLE);
+			FileStateHandle fileStateHandle = (FileStateHandle) stateHandle;
+			serializeFileStreamStateHandle(fileStateHandle, basePath, dos);
+
+		} else if (stateHandle instanceof ByteStreamStateHandle) {
+			dos.writeByte(BYTE_STREAM_STATE_HANDLE);
+			ByteStreamStateHandle byteStreamStateHandle = (ByteStreamStateHandle) stateHandle;
+			dos.writeUTF(byteStreamStateHandle.getHandleName());
+			byte[] internalData = byteStreamStateHandle.getData();
+			dos.writeInt(internalData.length);
+			dos.write(byteStreamStateHandle.getData());
+
+		} else {
+			throw new IOException("Unknown implementation of StreamStateHandle: " + stateHandle.getClass());
+		}
+
+		dos.flush();
+	}
+
+	private StreamStateHandle deserializeStreamStateHandle(Path basePath, DataInputStream dis) throws IOException {
+		int type = dis.read();
+		if (NULL_HANDLE == type) {
+			return null;
+		} else if (FILE_STREAM_STATE_HANDLE == type) {
+			return deserializeFileStreamStateHandle(basePath, dis);
+		} else if (BYTE_STREAM_STATE_HANDLE == type) {
+			String handleName = dis.readUTF();
+			int numBytes = dis.readInt();
+			byte[] data = new byte[numBytes];
+			dis.readFully(data);
+			return new ByteStreamStateHandle(handleName, data);
+		} else {
+			throw new IOException("Unknown implementation of StreamStateHandle, code: " + type);
+		}
+	}
+
+	/**
+	 * Serialize the file stream state handle <strong>without</strong> writing
+	 * the leading byte for the stream handle type. Only worry about the actual
+	 * file stream handle, please.
+	 *
+	 * @param fileStateHandle FileStateHandle to serialize
+	 * @param basePath Base path of the savepoint
+	 * @param dos DataOutputStream to serialize handle to
+	 * @throws IOException Failures during serialization are forwarded
+	 */
+	void serializeFileStreamStateHandle(FileStateHandle fileStateHandle, Path basePath, DataOutputStream dos) throws IOException {
+		dos.writeLong(fileStateHandle.getStateSize());
+		dos.writeUTF(fileStateHandle.getFilePath().toString());
+	}
+
+	/**
+	 * Deserialize the file stream state handle <strong>without</strong> reading
+	 * the leading byte for the stream handle type. Only worry about the actual
+	 * file stream handle, please.
+	 *
+	 * @param basePath Base path of the savepoint
+	 * @param dis DataInputStream to deserialize handle from
+	 * @return Deserialized FileStateHandle
+	 * @throws IOException Failures during serialization are forwarded
+	 */
+	FileStateHandle deserializeFileStreamStateHandle(Path basePath, DataInputStream dis) throws IOException {
+		long size = dis.readLong();
+		String pathString = dis.readUTF();
+		return new FileStateHandle(new Path(pathString), size);
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/FileStateHandleSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/FileStateHandleSerializer.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.savepoint;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.filesystem.FileStateHandle;
+
+interface FileStateHandleSerializer {
+
+	/**
+	 * Serialize the file stream state handle <strong>without</strong> writing
+	 * the leading byte for the stream handle type. Only worry about the actual
+	 * file stream handle, please.
+	 *
+	 * @param fileStateHandle FileStateHandle to serialize
+	 * @param basePath Base path of the savepoint
+	 * @param dos DataOutputStream to serialize handle to
+	 * @throws IOException Failures during serialization are forwarded
+	 */
+	void serializeFileStreamStateHandle(FileStateHandle fileStateHandle, Path basePath, DataOutputStream dos) throws IOException;
+
+	/**
+	 * Deserialize the file stream state handle <strong>without</strong> reading
+	 * the leading byte for the stream handle type. Only worry about the actual
+	 * file stream handle, please.
+	 *
+	 * @param basePath Base path of the savepoint
+	 * @param dis DataInputStream to deserialize handle from
+	 * @return Deserialized FileStateHandle
+	 * @throws IOException Failures during serialization are forwarded
+	 */
+	FileStateHandle deserializeFileStreamStateHandle(Path basePath, DataInputStream dis) throws IOException;
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/FileStateHandleSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/FileStateHandleSerializer.java
@@ -24,6 +24,9 @@ import java.io.IOException;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 
+/**
+ * Interface to handle file state handle serialization in the {@link GenericSavepointSerializer}.
+ */
 interface FileStateHandleSerializer {
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.savepoint;
+
+import java.util.Collection;
+import org.apache.flink.runtime.checkpoint.TaskState;
+
+/**
+ * A savepoint factory returning savepoints of a specific versioned
+ * subtype.
+ *
+ * <p>I'm wondering how useful this is in practice in comparison to simply
+ * returning the base Savepoint type.
+ *
+ * @param <T> Concrete versioned savepoint subtype
+ */
+interface SavepointFactory<T extends Savepoint> {
+
+	/**
+	 * Create a special savepoint of subtype T.
+	 *
+	 * @param checkpointId Checkpoint ID of the savepoint.
+	 * @param taskStates Task states of the savepoint.
+	 * @return A concrete savepoint subtype of type T.
+	 */
+	T createSavepoint(long checkpointId, Collection<TaskState> taskStates);
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointSerializer.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.checkpoint.savepoint;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import org.apache.flink.core.fs.Path;
 
 /**
  * Serializer for {@link Savepoint} instances.
@@ -37,19 +38,21 @@ public interface SavepointSerializer<T extends Savepoint> {
 	 * Serializes a savepoint to an output stream.
 	 *
 	 * @param savepoint Savepoint to serialize
-	 * @param dos        Output stream to serialize the savepoint to
+	 * @param basePath Base path of the savepoint
+	 * @param dos Output stream to serialize the savepoint to
 	 * @throws IOException Serialization failures are forwarded
 	 */
-	void serialize(T savepoint, DataOutputStream dos) throws IOException;
+	void serialize(T savepoint, Path basePath, DataOutputStream dos) throws IOException;
 
 	/**
 	 * Deserializes a savepoint from an input stream.
 	 *
 	 * @param dis Input stream to deserialize savepoint from
-	 * @param  userCodeClassLoader the user code class loader
+	 * @param basePath Base path of the savepoint
+	 * @param userCodeClassLoader the user code class loader
 	 * @return The deserialized savepoint
 	 * @throws IOException Serialization failures are forwarded
 	 */
-	T deserialize(DataInputStream dis, ClassLoader userCodeClassLoader) throws IOException;
+	T deserialize(DataInputStream dis, Path basePath, ClassLoader userCodeClassLoader) throws IOException;
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointSerializers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointSerializers.java
@@ -31,11 +31,12 @@ public class SavepointSerializers {
 
 
 	private static final int SAVEPOINT_VERSION_0 = 0;
-	private static final Map<Integer, SavepointSerializer<?>> SERIALIZERS = new HashMap<>(2);
+	private static final Map<Integer, SavepointSerializer<?>> SERIALIZERS = new HashMap<>(3);
 
 	static {
 		SERIALIZERS.put(SAVEPOINT_VERSION_0, SavepointV0Serializer.INSTANCE);
 		SERIALIZERS.put(SavepointV1.VERSION, SavepointV1Serializer.INSTANCE);
+		SERIALIZERS.put(SavepointV2.VERSION, SavepointV2Serializer.INSTANCE);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV1Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV1Serializer.java
@@ -18,43 +18,24 @@
 
 package org.apache.flink.runtime.checkpoint.savepoint;
 
-import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.checkpoint.SubtaskState;
-import org.apache.flink.runtime.checkpoint.TaskState;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.state.ChainedStateHandle;
-import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
-import org.apache.flink.runtime.state.KeyGroupsStateHandle;
-import org.apache.flink.runtime.state.OperatorStateHandle;
-import org.apache.flink.runtime.state.StreamStateHandle;
-import org.apache.flink.runtime.state.filesystem.FileStateHandle;
-import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
-
-import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.checkpoint.TaskState;
 
 /**
  * Serializer for {@link SavepointV1} instances.
- * <p>
+ *
  * <p>In contrast to previous savepoint versions, this serializer makes sure
  * that no default Java serialization is used for serialization. Therefore, we
  * don't rely on any involved Java classes to stay the same.
+ *
+ * @deprecated Deprecated in favour of {@link SavepointV2Serializer}. This
+ * serializer is only used to deserialize V1 savepoints.
  */
-class SavepointV1Serializer implements SavepointSerializer<SavepointV1> {
-
-	private static final byte NULL_HANDLE = 0;
-	private static final byte BYTE_STREAM_STATE_HANDLE = 1;
-	private static final byte FILE_STREAM_STATE_HANDLE = 2;
-	private static final byte KEY_GROUPS_HANDLE = 3;
-	private static final byte PARTITIONABLE_OPERATOR_STATE_HANDLE = 4;
-
+@Deprecated
+class SavepointV1Serializer extends AbstractSavepointSerializer<SavepointV1> {
 
 	public static final SavepointV1Serializer INSTANCE = new SavepointV1Serializer();
 
@@ -62,291 +43,13 @@ class SavepointV1Serializer implements SavepointSerializer<SavepointV1> {
 	}
 
 	@Override
-	public void serialize(SavepointV1 savepoint, DataOutputStream dos) throws IOException {
-		try {
-			dos.writeLong(savepoint.getCheckpointId());
-
-			Collection<TaskState> taskStates = savepoint.getTaskStates();
-			dos.writeInt(taskStates.size());
-
-			for (TaskState taskState : savepoint.getTaskStates()) {
-				// Vertex ID
-				dos.writeLong(taskState.getJobVertexID().getLowerPart());
-				dos.writeLong(taskState.getJobVertexID().getUpperPart());
-
-				// Parallelism
-				int parallelism = taskState.getParallelism();
-				dos.writeInt(parallelism);
-				dos.writeInt(taskState.getMaxParallelism());
-				dos.writeInt(taskState.getChainLength());
-
-				// Sub task states
-				Map<Integer, SubtaskState> subtaskStateMap = taskState.getSubtaskStates();
-				dos.writeInt(subtaskStateMap.size());
-				for (Map.Entry<Integer, SubtaskState> entry : subtaskStateMap.entrySet()) {
-					dos.writeInt(entry.getKey());
-					serializeSubtaskState(entry.getValue(), dos);
-				}
-			}
-		} catch (Exception e) {
-			throw new IOException(e);
-		}
-	}
-
-	@Override
-	public SavepointV1 deserialize(DataInputStream dis, ClassLoader cl) throws IOException {
-		long checkpointId = dis.readLong();
-
-		// Task states
-		int numTaskStates = dis.readInt();
-		List<TaskState> taskStates = new ArrayList<>(numTaskStates);
-
-		for (int i = 0; i < numTaskStates; i++) {
-			JobVertexID jobVertexId = new JobVertexID(dis.readLong(), dis.readLong());
-			int parallelism = dis.readInt();
-			int maxParallelism = dis.readInt();
-			int chainLength = dis.readInt();
-
-			// Add task state
-			TaskState taskState = new TaskState(jobVertexId, parallelism, maxParallelism, chainLength);
-			taskStates.add(taskState);
-
-			// Sub task states
-			int numSubTaskStates = dis.readInt();
-
-			for (int j = 0; j < numSubTaskStates; j++) {
-				int subtaskIndex = dis.readInt();
-				SubtaskState subtaskState = deserializeSubtaskState(dis);
-				taskState.putState(subtaskIndex, subtaskState);
-			}
-		}
-
+	SavepointV1 createSavepoint(long checkpointId, Collection<TaskState> taskStates) {
 		return new SavepointV1(checkpointId, taskStates);
 	}
 
-	private static void serializeSubtaskState(SubtaskState subtaskState, DataOutputStream dos) throws IOException {
-
-		dos.writeLong(-1);
-
-		ChainedStateHandle<StreamStateHandle> nonPartitionableState = subtaskState.getLegacyOperatorState();
-
-		int len = nonPartitionableState != null ? nonPartitionableState.getLength() : 0;
-		dos.writeInt(len);
-		for (int i = 0; i < len; ++i) {
-			StreamStateHandle stateHandle = nonPartitionableState.get(i);
-			serializeStreamStateHandle(stateHandle, dos);
-		}
-
-		ChainedStateHandle<OperatorStateHandle> operatorStateBackend = subtaskState.getManagedOperatorState();
-
-		len = operatorStateBackend != null ? operatorStateBackend.getLength() : 0;
-		dos.writeInt(len);
-		for (int i = 0; i < len; ++i) {
-			OperatorStateHandle stateHandle = operatorStateBackend.get(i);
-			serializeOperatorStateHandle(stateHandle, dos);
-		}
-
-		ChainedStateHandle<OperatorStateHandle> operatorStateFromStream = subtaskState.getRawOperatorState();
-
-		len = operatorStateFromStream != null ? operatorStateFromStream.getLength() : 0;
-		dos.writeInt(len);
-		for (int i = 0; i < len; ++i) {
-			OperatorStateHandle stateHandle = operatorStateFromStream.get(i);
-			serializeOperatorStateHandle(stateHandle, dos);
-		}
-
-		KeyGroupsStateHandle keyedStateBackend = subtaskState.getManagedKeyedState();
-		serializeKeyGroupStateHandle(keyedStateBackend, dos);
-
-		KeyGroupsStateHandle keyedStateStream = subtaskState.getRawKeyedState();
-		serializeKeyGroupStateHandle(keyedStateStream, dos);
-	}
-
-	private static SubtaskState deserializeSubtaskState(DataInputStream dis) throws IOException {
-		// Duration field has been removed from SubtaskState
-		long ignoredDuration = dis.readLong();
-
-		int len = dis.readInt();
-		List<StreamStateHandle> nonPartitionableState = new ArrayList<>(len);
-		for (int i = 0; i < len; ++i) {
-			StreamStateHandle streamStateHandle = deserializeStreamStateHandle(dis);
-			nonPartitionableState.add(streamStateHandle);
-		}
-
-
-		len = dis.readInt();
-		List<OperatorStateHandle> operatorStateBackend = new ArrayList<>(len);
-		for (int i = 0; i < len; ++i) {
-			OperatorStateHandle streamStateHandle = deserializeOperatorStateHandle(dis);
-			operatorStateBackend.add(streamStateHandle);
-		}
-
-		len = dis.readInt();
-		List<OperatorStateHandle> operatorStateStream = new ArrayList<>(len);
-		for (int i = 0; i < len; ++i) {
-			OperatorStateHandle streamStateHandle = deserializeOperatorStateHandle(dis);
-			operatorStateStream.add(streamStateHandle);
-		}
-
-		KeyGroupsStateHandle keyedStateBackend = deserializeKeyGroupStateHandle(dis);
-
-		KeyGroupsStateHandle keyedStateStream = deserializeKeyGroupStateHandle(dis);
-
-		ChainedStateHandle<StreamStateHandle> nonPartitionableStateChain =
-				new ChainedStateHandle<>(nonPartitionableState);
-
-		ChainedStateHandle<OperatorStateHandle> operatorStateBackendChain =
-				new ChainedStateHandle<>(operatorStateBackend);
-
-		ChainedStateHandle<OperatorStateHandle> operatorStateStreamChain =
-				new ChainedStateHandle<>(operatorStateStream);
-
-		return new SubtaskState(
-				nonPartitionableStateChain,
-				operatorStateBackendChain,
-				operatorStateStreamChain,
-				keyedStateBackend,
-				keyedStateStream);
-	}
-
-	private static void serializeKeyGroupStateHandle(
-			KeyGroupsStateHandle stateHandle, DataOutputStream dos) throws IOException {
-
-		if (stateHandle != null) {
-			dos.writeByte(KEY_GROUPS_HANDLE);
-			dos.writeInt(stateHandle.getGroupRangeOffsets().getKeyGroupRange().getStartKeyGroup());
-			dos.writeInt(stateHandle.getNumberOfKeyGroups());
-			for (int keyGroup : stateHandle.keyGroups()) {
-				dos.writeLong(stateHandle.getOffsetForKeyGroup(keyGroup));
-			}
-			serializeStreamStateHandle(stateHandle.getDelegateStateHandle(), dos);
-		} else {
-			dos.writeByte(NULL_HANDLE);
-		}
-	}
-
-	private static KeyGroupsStateHandle deserializeKeyGroupStateHandle(DataInputStream dis) throws IOException {
-		final int type = dis.readByte();
-		if (NULL_HANDLE == type) {
-			return null;
-		} else if (KEY_GROUPS_HANDLE == type) {
-			int startKeyGroup = dis.readInt();
-			int numKeyGroups = dis.readInt();
-			KeyGroupRange keyGroupRange = KeyGroupRange.of(startKeyGroup, startKeyGroup + numKeyGroups - 1);
-			long[] offsets = new long[numKeyGroups];
-			for (int i = 0; i < numKeyGroups; ++i) {
-				offsets[i] = dis.readLong();
-			}
-			KeyGroupRangeOffsets keyGroupRangeOffsets = new KeyGroupRangeOffsets(keyGroupRange, offsets);
-			StreamStateHandle stateHandle = deserializeStreamStateHandle(dis);
-			return new KeyGroupsStateHandle(keyGroupRangeOffsets, stateHandle);
-		} else {
-			throw new IllegalStateException("Reading invalid KeyGroupsStateHandle, type: " + type);
-		}
-	}
-
-	private static void serializeOperatorStateHandle(
-			OperatorStateHandle stateHandle, DataOutputStream dos) throws IOException {
-
-		if (stateHandle != null) {
-			dos.writeByte(PARTITIONABLE_OPERATOR_STATE_HANDLE);
-			Map<String, OperatorStateHandle.StateMetaInfo> partitionOffsetsMap =
-					stateHandle.getStateNameToPartitionOffsets();
-			dos.writeInt(partitionOffsetsMap.size());
-			for (Map.Entry<String, OperatorStateHandle.StateMetaInfo> entry : partitionOffsetsMap.entrySet()) {
-				dos.writeUTF(entry.getKey());
-
-				OperatorStateHandle.StateMetaInfo stateMetaInfo = entry.getValue();
-
-				int mode = stateMetaInfo.getDistributionMode().ordinal();
-				dos.writeByte(mode);
-
-				long[] offsets = stateMetaInfo.getOffsets();
-				dos.writeInt(offsets.length);
-				for (long offset : offsets) {
-					dos.writeLong(offset);
-				}
-			}
-			serializeStreamStateHandle(stateHandle.getDelegateStateHandle(), dos);
-		} else {
-			dos.writeByte(NULL_HANDLE);
-		}
-	}
-
-	private static OperatorStateHandle deserializeOperatorStateHandle(
-			DataInputStream dis) throws IOException {
-
-		final int type = dis.readByte();
-		if (NULL_HANDLE == type) {
-			return null;
-		} else if (PARTITIONABLE_OPERATOR_STATE_HANDLE == type) {
-			int mapSize = dis.readInt();
-			Map<String, OperatorStateHandle.StateMetaInfo> offsetsMap = new HashMap<>(mapSize);
-			for (int i = 0; i < mapSize; ++i) {
-				String key = dis.readUTF();
-
-				int modeOrdinal = dis.readByte();
-				OperatorStateHandle.Mode mode = OperatorStateHandle.Mode.values()[modeOrdinal];
-
-				long[] offsets = new long[dis.readInt()];
-				for (int j = 0; j < offsets.length; ++j) {
-					offsets[j] = dis.readLong();
-				}
-
-				OperatorStateHandle.StateMetaInfo metaInfo =
-						new OperatorStateHandle.StateMetaInfo(offsets, mode);
-				offsetsMap.put(key, metaInfo);
-			}
-			StreamStateHandle stateHandle = deserializeStreamStateHandle(dis);
-			return new OperatorStateHandle(offsetsMap, stateHandle);
-		} else {
-			throw new IllegalStateException("Reading invalid OperatorStateHandle, type: " + type);
-		}
-	}
-
-	private static void serializeStreamStateHandle(
-			StreamStateHandle stateHandle, DataOutputStream dos) throws IOException {
-
-		if (stateHandle == null) {
-			dos.writeByte(NULL_HANDLE);
-
-		} else if (stateHandle instanceof FileStateHandle) {
-			dos.writeByte(FILE_STREAM_STATE_HANDLE);
-			FileStateHandle fileStateHandle = (FileStateHandle) stateHandle;
-			dos.writeLong(stateHandle.getStateSize());
-			dos.writeUTF(fileStateHandle.getFilePath().toString());
-
-		} else if (stateHandle instanceof ByteStreamStateHandle) {
-			dos.writeByte(BYTE_STREAM_STATE_HANDLE);
-			ByteStreamStateHandle byteStreamStateHandle = (ByteStreamStateHandle) stateHandle;
-			dos.writeUTF(byteStreamStateHandle.getHandleName());
-			byte[] internalData = byteStreamStateHandle.getData();
-			dos.writeInt(internalData.length);
-			dos.write(byteStreamStateHandle.getData());
-
-		} else {
-			throw new IOException("Unknown implementation of StreamStateHandle: " + stateHandle.getClass());
-		}
-
-		dos.flush();
-	}
-
-	private static StreamStateHandle deserializeStreamStateHandle(DataInputStream dis) throws IOException {
-		int type = dis.read();
-		if (NULL_HANDLE == type) {
-			return null;
-		} else if (FILE_STREAM_STATE_HANDLE == type) {
-			long size = dis.readLong();
-			String pathString = dis.readUTF();
-			return new FileStateHandle(new Path(pathString), size);
-		} else if (BYTE_STREAM_STATE_HANDLE == type) {
-			String handleName = dis.readUTF();
-			int numBytes = dis.readInt();
-			byte[] data = new byte[numBytes];
-			dis.readFully(data);
-			return new ByteStreamStateHandle(handleName, data);
-		} else {
-			throw new IOException("Unknown implementation of StreamStateHandle, code: " + type);
-		}
+	@Override
+	public void serialize(SavepointV1 savepoint, Path basePath, DataOutputStream dos) throws IOException {
+		throw new UnsupportedOperationException("This serializer has been deprecated for "
+			+ "serializing savepoints. You should only use it to _de_serialize SavepointV1 instances.");
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2.java
@@ -18,24 +18,21 @@
 
 package org.apache.flink.runtime.checkpoint.savepoint;
 
+import java.util.Collection;
 import org.apache.flink.runtime.checkpoint.TaskState;
 
-import java.util.Collection;
-
 /**
- * Savepoint version 1.
+ * Savepoint version 2.
  *
- * <p>This format was introduced with Flink 1.1.0.
- *
- * @deprecated Deprecated in favour of {@link SavepointV2}.
+ * <p>This format was introduced with Flink 1.3.0. There is no difference to
+ * {@link SavepointV1} except the corresponding {@link SavepointSerializer}.
  */
-@Deprecated
-public class SavepointV1 extends AbstractSavepoint {
+public class SavepointV2 extends AbstractSavepoint {
 
 	/** The savepoint version. */
-	public static final int VERSION = 1;
+	public static final int VERSION = 2;
 
-	public SavepointV1(long checkpointId, Collection<TaskState> taskStates) {
+	public SavepointV2(long checkpointId, Collection<TaskState> taskStates) {
 		super(checkpointId, taskStates);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2Serializer.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.savepoint;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+import javax.annotation.Nullable;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.checkpoint.TaskState;
+import org.apache.flink.runtime.state.filesystem.FileStateHandle;
+
+/**
+ * A savepoint serializer that does not store absolute URIs for {@link FileStateHandle}
+ * instances, allowing users to relocate savepoints as long as the file structure
+ * within the savepoint directory stays the same.
+ */
+class SavepointV2Serializer extends AbstractSavepointSerializer<SavepointV2> {
+
+	public static final SavepointV2Serializer INSTANCE = new SavepointV2Serializer();
+
+	private SavepointV2Serializer() {
+	}
+
+	@Override
+	SavepointV2 createSavepoint(long checkpointId, Collection<TaskState> taskStates) {
+		return new SavepointV2(checkpointId, taskStates);
+	}
+
+	@Override
+	void serializeFileStreamStateHandle(FileStateHandle fileStateHandle, Path basePath, DataOutputStream dos) throws IOException {
+		dos.writeLong(fileStateHandle.getStateSize());
+
+		Path child = fileStateHandle.getFilePath();
+		Path relative = getRelativePath(basePath, child);
+
+		if (relative != null) {
+			// This boolean is new in this version of the serializer
+			dos.writeBoolean(true);
+			dos.writeUTF(relative.toString());
+		} else {
+			dos.writeBoolean(false);
+			dos.writeUTF(fileStateHandle.getFilePath().toString());
+		}
+	}
+
+	@Override
+	FileStateHandle deserializeFileStreamStateHandle(Path basePath, DataInputStream dis) throws IOException {
+		long size = dis.readLong();
+		boolean isRelative = dis.readBoolean();
+		String pathString = dis.readUTF();
+
+		Path path = isRelative ? new Path(basePath, pathString) : new Path(pathString);
+		return new FileStateHandle(path, size);
+	}
+
+	/**
+	 * Returns the childPath relative to the basePath.
+	 *
+	 * <p>If the child path is not a child of the base path, <code>null</code>
+	 * is returned.
+	 *
+	 * <pre>
+	 * getRelativePath("/base", "/base/child") -> "child"
+	 * getRelativePath("/base", "/base/parent/child") -> "parent/child"
+	 * getRelativePath("/base", "/child-of-root") -> null
+	 * getRelativePath("/base", "/other-base/child") -> null
+	 * </pre>
+	 *
+	 * @return The relative child path against base or <code>null</code> if not an actual child of
+	 * base.
+	 * @throws NullPointerException If arguments are <code>null</code>
+	 */
+	@Nullable
+	static Path getRelativePath(Path base, Path child) {
+		URI baseUri = checkNotNull(base, "base").toUri();
+		URI childUri = checkNotNull(child, "child").toUri();
+
+		// Relativize against the base path
+		URI relativeUri = baseUri.relativize(childUri);
+
+		if (!relativeUri.equals(childUri)) {
+			return new Path(relativeUri);
+		} else {
+			// If childUri is returned, childPath was not a child path of base
+			return null;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointLoaderTest.java
@@ -67,7 +67,7 @@ public class SavepointLoaderTest {
 		JobID jobId = new JobID();
 
 		// Store savepoint
-		SavepointV1 savepoint = new SavepointV1(checkpointId, taskStates.values());
+		Savepoint savepoint = new SavepointV2(checkpointId, taskStates.values());
 		String path = SavepointStore.storeSavepoint(tmp.getAbsolutePath(), savepoint);
 
 		ExecutionJobVertex vertex = mock(ExecutionJobVertex.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointStoreTest.java
@@ -18,7 +18,24 @@
 
 package org.apache.flink.runtime.checkpoint.savepoint;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
@@ -29,24 +46,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Matchers;
-
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 
 public class SavepointStoreTest {
 
@@ -199,7 +198,7 @@ public class SavepointStoreTest {
 		FileSystem fs = FileSystem.get(new Path(root).toUri());
 
 		// Store
-		SavepointV1 savepoint = new SavepointV1(1929292, SavepointV1Test.createTaskStates(4, 24));
+		SavepointV2 savepoint = new SavepointV2(1929292, SavepointV1Test.createTaskStates(4, 24));
 
 		FileStateHandle store1 = SavepointStore.storeExternalizedCheckpointToHandle(root, savepoint);
 		fs.exists(store1.getFilePath());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointStoreTest.java
@@ -68,7 +68,7 @@ public class SavepointStoreTest {
 
 		// Store
 		String savepointDirectory = SavepointStore.createSavepointDirectory(root, new JobID());
-		SavepointV1 stored = new SavepointV1(1929292, SavepointV1Test.createTaskStates(4, 24));
+		Savepoint stored = new SavepointV2(1929292, SavepointV1Test.createTaskStates(4, 24));
 		String path = SavepointStore.storeSavepoint(savepointDirectory, stored);
 
 		list = rootFile.listFiles();
@@ -141,9 +141,9 @@ public class SavepointStoreTest {
 		assertNotNull(list);
 		assertEquals(1, list.length);
 
-		// Savepoint v0
+		// Savepoint v2
 		String savepointDirectory2 = SavepointStore.createSavepointDirectory(root, new JobID());
-		Savepoint savepoint = new SavepointV1(checkpointId, SavepointV1Test.createTaskStates(4, 32));
+		Savepoint savepoint = new SavepointV2(checkpointId, SavepointV1Test.createTaskStates(4, 32));
 		String pathSavepoint = SavepointStore.storeSavepoint(savepointDirectory2, savepoint);
 
 		list = rootFile.listFiles();
@@ -173,7 +173,7 @@ public class SavepointStoreTest {
 		final int version = 123123;
 		SavepointSerializer<TestSavepoint> serializer = mock(SavepointSerializer.class);
 		doThrow(new RuntimeException("Test Exception")).when(serializer)
-				.serialize(Matchers.any(TestSavepoint.class), any(DataOutputStream.class));
+				.serialize(Matchers.any(TestSavepoint.class), any(Path.class), any(DataOutputStream.class));
 
 		serializers.put(version, serializer);
 
@@ -215,13 +215,13 @@ public class SavepointStoreTest {
 		private static final NewSavepointSerializer INSTANCE = new NewSavepointSerializer();
 
 		@Override
-		public void serialize(TestSavepoint savepoint, DataOutputStream dos) throws IOException {
+		public void serialize(TestSavepoint savepoint, Path ignoredBasePath, DataOutputStream dos) throws IOException {
 			dos.writeInt(savepoint.version);
 			dos.writeLong(savepoint.checkpointId);
 		}
 
 		@Override
-		public TestSavepoint deserialize(DataInputStream dis, ClassLoader userCL) throws IOException {
+		public TestSavepoint deserialize(DataInputStream dis, Path ignoredBasePath, ClassLoader userCL) throws IOException {
 			int version = dis.readInt();
 			long checkpointId = dis.readLong();
 			return new TestSavepoint(version, checkpointId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2SerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2SerializerTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -58,13 +59,36 @@ public class SavepointV2SerializerTest {
 		verifyGetRelativePath("hdfs:///base", "hdfs:///base/child/file", "child/file");
 
 		// Not a child
-		verifyGetRelativePath("hdfs:///base", "hdfs:///child-of-root", null);
-		verifyGetRelativePath("hdfs:///base", "hdfs:///other-base/child", null);
-		verifyGetRelativePath("hdfs:///base/child", "hdfs:///base", null);
+		try {
+			verifyGetRelativePath("hdfs:///base", "hdfs:///child-of-root", null);
+			fail("Did not throw expected Exception");
+		} catch (IllegalArgumentException expected) {
+		}
+
+		try {
+			verifyGetRelativePath("hdfs:///base", "hdfs:///other-base/child", null);
+			fail("Did not throw expected Exception");
+		} catch (IllegalArgumentException expected) {
+		}
+
+		try {
+			verifyGetRelativePath("hdfs:///base/child", "hdfs:///base", null);
+			fail("Did not throw expected Exception");
+		} catch (IllegalArgumentException expected) {
+		}
 
 		// Different schemes are not a child
-		verifyGetRelativePath("hdfs:///base", "file:///base/child", null);
-		verifyGetRelativePath("hdfs:///base", "file:///base/child/file", null);
+		try {
+			verifyGetRelativePath("hdfs:///base", "file:///base/child", null);
+			fail("Did not throw expected Exception");
+		} catch (IllegalArgumentException expected) {
+		}
+
+		try {
+			verifyGetRelativePath("hdfs:///base", "file:///base/child/file", null);
+			fail("Did not throw expected Exception");
+		} catch (IllegalArgumentException expected) {
+		}
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2SerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2SerializerTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.checkpoint.savepoint.SavepointV2Serializer.SavepointV2FileStateHandleSerializer;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 import org.apache.flink.runtime.state.filesystem.FsCheckpointStreamFactory.FsCheckpointStateOutputStream;
 import org.junit.Rule;
@@ -149,7 +150,7 @@ public class SavepointV2SerializerTest {
 		// Get the handle and serialize it
 		FileStateHandle fsHandle = (FileStateHandle) fsOutStream.closeAndGetHandle();
 
-		SavepointV2Serializer serializer = SavepointV2Serializer.INSTANCE;
+		SavepointV2FileStateHandleSerializer serializer = new SavepointV2FileStateHandleSerializer();
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		serializer.serializeFileStreamStateHandle(fsHandle, base, new DataOutputStream(baos));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2SerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2SerializerTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.savepoint;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.state.filesystem.FileStateHandle;
+import org.apache.flink.runtime.state.filesystem.FsCheckpointStreamFactory.FsCheckpointStateOutputStream;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SavepointV2SerializerTest {
+
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
+
+	/**
+	 * Tests that the relative path resolution returns sensible results.
+	 */
+	@Test
+	public void testGetRelativePath() throws Exception {
+		// Simple child
+		verifyGetRelativePath("hdfs:///base", "hdfs:///base/child", "child");
+		verifyGetRelativePath("hdfs:///base", "hdfs:///base/child/file", "child/file");
+
+		// Not a child
+		verifyGetRelativePath("hdfs:///base", "hdfs:///child-of-root", null);
+		verifyGetRelativePath("hdfs:///base", "hdfs:///other-base/child", null);
+		verifyGetRelativePath("hdfs:///base/child", "hdfs:///base", null);
+
+		// Different schemes are not a child
+		verifyGetRelativePath("hdfs:///base", "file:///base/child", null);
+		verifyGetRelativePath("hdfs:///base", "file:///base/child/file", null);
+	}
+
+	/**
+	 * Test serialization of {@link SavepointV2} instances.
+	 */
+	@Test
+	public void testSerialization() throws Exception {
+		Path ignoredBasePath = new Path("ignored");
+
+		Random r = new Random(42);
+		for (int i = 0; i < 100; ++i) {
+			SavepointV2 expected = new SavepointV2(
+				i+ 123123,
+				SavepointV1Test.createTaskStates(1 + r.nextInt(64), 1 + r.nextInt(64)));
+
+			SavepointV2Serializer serializer = SavepointV2Serializer.INSTANCE;
+
+			// Serialize
+			ByteArrayOutputStreamWithPos baos = new ByteArrayOutputStreamWithPos();
+			serializer.serialize(expected, ignoredBasePath, new DataOutputViewStreamWrapper(baos));
+			byte[] bytes = baos.toByteArray();
+
+			// Deserialize
+			ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+			Savepoint actual = serializer.deserialize(
+				new DataInputViewStreamWrapper(bais),
+				ignoredBasePath,
+				Thread.currentThread().getContextClassLoader());
+
+			assertEquals(expected, actual);
+		}
+	}
+
+	/**
+	 * Tests that file state handles serialized with this serializer can be
+	 * relocated.
+	 *
+	 * <p>Serializes data to a file, creates a file state handle, serializes the
+	 * handle, moves the data file to a new Folder, deserializes the handle with
+	 * the new base path.
+	 */
+	@Test
+	public void testSerializeDeserializeRelativeFileStateHandle() throws Exception {
+		Path base = new Path(folder.newFolder("old-base").getAbsolutePath());
+		Path newBase = new Path(folder.newFolder("new-base").getAbsolutePath());
+
+		FileSystem fs = FileSystem.get(base.toUri());
+
+		// The expected bytes
+		byte[] expected = new byte[1024];
+		ThreadLocalRandom.current().nextBytes(expected);
+
+		// Write to a file
+		FsCheckpointStateOutputStream fsOutStream = new FsCheckpointStateOutputStream(
+			base, fs, 0, 0);
+		fsOutStream.write(expected);
+
+		// Get the handle and serialize it
+		FileStateHandle fsHandle = (FileStateHandle) fsOutStream.closeAndGetHandle();
+
+		SavepointV2Serializer serializer = SavepointV2Serializer.INSTANCE;
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		serializer.serializeFileStreamStateHandle(fsHandle, base, new DataOutputStream(baos));
+
+		// Move the file
+		Path filePath = fsHandle.getFilePath();
+		Path newFilePath = new Path(newBase, filePath.getName());
+
+		assertTrue("Failed to move the file", fs.rename(filePath, newFilePath));
+
+		// Deserialize the new file
+		ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+		FileStateHandle deserializeFsHandle = serializer.deserializeFileStreamStateHandle(newBase, new DataInputStream(bais));
+
+		FSDataInputStream fsInStream = deserializeFsHandle.openInputStream();
+		byte[] actual = new byte[expected.length];
+
+		assertEquals(expected.length, fsInStream.read(actual));
+		assertEquals(-1, fsInStream.read());
+
+		assertArrayEquals(expected, actual);
+	}
+
+	private void verifyGetRelativePath(String base, String child, String expected) {
+		Path basePath = new Path(base);
+		Path childPath = new Path(child);
+		Path relativePath = SavepointV2Serializer.getRelativePath(basePath, childPath);
+
+		if (expected == null) {
+			assertNull(relativePath);
+		} else {
+			assertNotNull(relativePath);
+			assertEquals(new Path(expected), relativePath);
+			assertFalse("Path should be relative: " + relativePath, relativePath.isAbsolute());
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -57,7 +57,7 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.checkpoint.SubtaskState;
 import org.apache.flink.runtime.checkpoint.TaskState;
-import org.apache.flink.runtime.checkpoint.savepoint.SavepointV1;
+import org.apache.flink.runtime.checkpoint.savepoint.Savepoint;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.TaskInformation;
@@ -198,7 +198,7 @@ public class SavepointITCase extends TestLogger {
 			LOG.info("Requesting the savepoint.");
 			Future<Object> savepointFuture = jobManager.ask(new RequestSavepoint(savepointPath), deadline.timeLeft());
 
-			SavepointV1 savepoint = (SavepointV1) ((ResponseSavepoint) Await.result(savepointFuture, deadline.timeLeft())).savepoint();
+			Savepoint savepoint = ((ResponseSavepoint) Await.result(savepointFuture, deadline.timeLeft())).savepoint();
 			LOG.info("Retrieved savepoint: " + savepointPath + ".");
 
 			// Shut down the Flink cluster (thereby canceling the job)


### PR DESCRIPTION
This adds a new savepoint version, `SavepointV2`. The corresponding `SavepointV2Serializer` is the same as our current `SavepointV1Serializer` except that `FileStateHandle` instances are serialized with their file path relative to the savepoint base path.

As an example imagine a savepoint in directory `hdfs:///path/to/savepoint-directory` with this data file:

```
hdfs:///path/to/savepoint-directory/_metadata
hdfs:///path/to/savepoint-directory/data-X
hdfs:///path/to/savepoint-directory/data-Y
```

Previously, the complete file path was stored. With this PR, we only store `data-X` for file state handles and reconstruct the complete path from the savepoint directory on restore. This enables us to move the savepoint directory around. The only requirement is that the layout within the savepoint directory does not change. I think this is a reasonable restriction.

In addition to the added tests, I've tested this manually by triggering savepoints, moving the savepoint around in the local file system as well as to HDFS and restoring from it. 

The code between `SavepointV1` and `SavepointV2` and the respective serializers is mostly shared. Therefore, I've moved the base logic out to an abstract `AbstractSavepoint` and `AbstractSavepointSerializer`.

The migration story is that you can resume old savepoints as before and all newly triggered savepoints will be V2 savepoints that serialize file state handles with their relative path. You can also resume with `1.3-SNAPSHOT` savepoint without any issues.


