### PR TITLE
[FLINK-5941] Integrate Archiver pattern into handlers

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -77,6 +77,7 @@ import org.apache.flink.runtime.webmonitor.handlers.checkpoints.CheckpointStatsC
 import org.apache.flink.runtime.webmonitor.handlers.checkpoints.CheckpointStatsDetailsHandler;
 import org.apache.flink.runtime.webmonitor.handlers.checkpoints.CheckpointStatsHandler;
 import org.apache.flink.runtime.webmonitor.handlers.checkpoints.CheckpointStatsDetailsSubtasksHandler;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 import org.apache.flink.runtime.webmonitor.metrics.JobManagerMetricsHandler;
 import org.apache.flink.runtime.webmonitor.metrics.JobMetricsHandler;
 import org.apache.flink.runtime.webmonitor.metrics.JobVertexMetricsHandler;
@@ -422,6 +423,33 @@ public class WebRuntimeMonitor implements WebMonitor {
 		int port = bindAddress.getPort();
 
 		LOG.info("Web frontend listening at " + address + ':' + port);
+	}
+
+	public static Archiver[] getArchivers() {
+		Archiver[] archivers = new Archiver[]{
+			new CurrentJobsOverviewHandler.CurrentJobsOverviewArchiver(),
+
+			new JobPlanHandler.JobPlanArchiver(),
+			new JobConfigHandler.JobConfigArchiver(),
+			new JobExceptionsHandler.JobExceptionsArchiver(),
+			new JobDetailsHandler.JobDetailsArchiver(),
+			new JobAccumulatorsHandler.JobAccumulatorsArchiver(),
+
+			new CheckpointStatsHandler.CheckpointStatsArchiver(),
+			new CheckpointConfigHandler.CheckpointConfigArchiver(),
+			new CheckpointStatsDetailsHandler.CheckpointStatsDetailsArchiver(),
+			new CheckpointStatsDetailsSubtasksHandler.CheckpointStatsDetailsSubtasksArchiver(),
+				
+			new JobVertexDetailsHandler.JobVertexDetailsArchiver(),
+			new SubtasksTimesHandler.SubtasksTimesArchiver(),
+			new JobVertexTaskManagersHandler.JobVertexTaskManagersArchiver(),
+			new JobVertexAccumulatorsHandler.JobVertexAccumulatorsArchiver(),
+			new SubtasksAllAccumulatorsHandler.SubtasksAllAccumulatorsArchiver(),
+			
+			new SubtaskExecutionAttemptDetailsHandler.SubtaskExecutionAttemptDetailsArchiver(),
+			new SubtaskExecutionAttemptAccumulatorsHandler.SubtaskExecutionAttemptAccumulatorsArchiver()
+			};
+		return archivers;
 	}
 
 	@Override

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -37,6 +37,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.jobmanager.MemoryArchivist;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.runtime.webmonitor.files.StaticFileServerHandler;
@@ -425,6 +426,19 @@ public class WebRuntimeMonitor implements WebMonitor {
 		LOG.info("Web frontend listening at " + address + ':' + port);
 	}
 
+	/**
+	 * Returns an array of all {@link JsonArchivist}s that are relevant for the history server.
+	 * 
+	 * This method is static to allow easier access from the {@link MemoryArchivist}. Requiring a reference
+	 * would imply that the WebRuntimeMonitor is always created before the archivist, which may not hold for all
+	 * deployment modes.
+	 * 
+	 * Similarly, no handler implements the JsonArchivist interface itself but instead contains a separate implementing
+	 * class; otherwise we would either instantiate several handlers even though their main functionality isn't
+	 * required, or yet again require that the WebRuntimeMonitor is started before the archivist.
+	 * 
+	 * @return array of all JsonArchivists relevant for the history server
+	 */
 	public static JsonArchivist[] getArchivers() {
 		JsonArchivist[] archivists = new JsonArchivist[]{
 			new CurrentJobsOverviewHandler.CurrentJobsOverviewJsonArchivist(),

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -77,7 +77,7 @@ import org.apache.flink.runtime.webmonitor.handlers.checkpoints.CheckpointStatsC
 import org.apache.flink.runtime.webmonitor.handlers.checkpoints.CheckpointStatsDetailsHandler;
 import org.apache.flink.runtime.webmonitor.handlers.checkpoints.CheckpointStatsHandler;
 import org.apache.flink.runtime.webmonitor.handlers.checkpoints.CheckpointStatsDetailsSubtasksHandler;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.metrics.JobManagerMetricsHandler;
 import org.apache.flink.runtime.webmonitor.metrics.JobMetricsHandler;
 import org.apache.flink.runtime.webmonitor.metrics.JobVertexMetricsHandler;
@@ -425,31 +425,31 @@ public class WebRuntimeMonitor implements WebMonitor {
 		LOG.info("Web frontend listening at " + address + ':' + port);
 	}
 
-	public static Archiver[] getArchivers() {
-		Archiver[] archivers = new Archiver[]{
-			new CurrentJobsOverviewHandler.CurrentJobsOverviewArchiver(),
+	public static JsonArchivist[] getArchivers() {
+		JsonArchivist[] archivists = new JsonArchivist[]{
+			new CurrentJobsOverviewHandler.CurrentJobsOverviewJsonArchivist(),
 
-			new JobPlanHandler.JobPlanArchiver(),
-			new JobConfigHandler.JobConfigArchiver(),
-			new JobExceptionsHandler.JobExceptionsArchiver(),
-			new JobDetailsHandler.JobDetailsArchiver(),
-			new JobAccumulatorsHandler.JobAccumulatorsArchiver(),
+			new JobPlanHandler.JobPlanJsonArchivist(),
+			new JobConfigHandler.JobConfigJsonArchivist(),
+			new JobExceptionsHandler.JobExceptionsJsonArchivist(),
+			new JobDetailsHandler.JobDetailsJsonArchivist(),
+			new JobAccumulatorsHandler.JobAccumulatorsJsonArchivist(),
 
-			new CheckpointStatsHandler.CheckpointStatsArchiver(),
-			new CheckpointConfigHandler.CheckpointConfigArchiver(),
-			new CheckpointStatsDetailsHandler.CheckpointStatsDetailsArchiver(),
-			new CheckpointStatsDetailsSubtasksHandler.CheckpointStatsDetailsSubtasksArchiver(),
+			new CheckpointStatsHandler.CheckpointStatsJsonArchivist(),
+			new CheckpointConfigHandler.CheckpointConfigJsonArchivist(),
+			new CheckpointStatsDetailsHandler.CheckpointStatsDetailsJsonArchivist(),
+			new CheckpointStatsDetailsSubtasksHandler.CheckpointStatsDetailsSubtasksJsonArchivist(),
 				
-			new JobVertexDetailsHandler.JobVertexDetailsArchiver(),
-			new SubtasksTimesHandler.SubtasksTimesArchiver(),
-			new JobVertexTaskManagersHandler.JobVertexTaskManagersArchiver(),
-			new JobVertexAccumulatorsHandler.JobVertexAccumulatorsArchiver(),
-			new SubtasksAllAccumulatorsHandler.SubtasksAllAccumulatorsArchiver(),
+			new JobVertexDetailsHandler.JobVertexDetailsJsonArchivist(),
+			new SubtasksTimesHandler.SubtasksTimesJsonArchivist(),
+			new JobVertexTaskManagersHandler.JobVertexTaskManagersJsonArchivist(),
+			new JobVertexAccumulatorsHandler.JobVertexAccumulatorsJsonArchivist(),
+			new SubtasksAllAccumulatorsHandler.SubtasksAllAccumulatorsJsonArchivist(),
 			
-			new SubtaskExecutionAttemptDetailsHandler.SubtaskExecutionAttemptDetailsArchiver(),
-			new SubtaskExecutionAttemptAccumulatorsHandler.SubtaskExecutionAttemptAccumulatorsArchiver()
+			new SubtaskExecutionAttemptDetailsHandler.SubtaskExecutionAttemptDetailsJsonArchivist(),
+			new SubtaskExecutionAttemptAccumulatorsHandler.SubtaskExecutionAttemptAccumulatorsJsonArchivist()
 			};
-		return archivers;
+		return archivists;
 	}
 
 	@Override

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandler.java
@@ -20,10 +20,14 @@ package org.apache.flink.runtime.webmonitor.handlers;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.messages.webmonitor.RequestJobDetails;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
@@ -118,6 +122,26 @@ public class CurrentJobsOverviewHandler extends AbstractJsonRequestHandler {
 		}
 		catch (Exception e) {
 			throw new Exception("Failed to fetch the status overview: " + e.getMessage(), e);
+		}
+	}
+
+	public static class CurrentJobsOverviewArchiver implements Archiver {
+
+		@Override
+		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+			StringWriter writer = new StringWriter();
+			try (JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer)) {
+				gen.writeStartObject();
+				gen.writeArrayFieldStart("running");
+				gen.writeEndArray();
+				gen.writeArrayFieldStart("finished");
+				writeJobDetailOverviewAsJson(WebMonitorUtils.createDetailsForJob(graph), gen, System.currentTimeMillis());
+				gen.writeEndArray();
+				gen.writeEndObject();
+			}
+			String json = writer.toString();
+			String path = ALL_JOBS_REST_PATH;
+			return new ArchivedJson[]{new ArchivedJson(path, json)};
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandler.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.messages.webmonitor.RequestJobDetails;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
@@ -125,7 +125,7 @@ public class CurrentJobsOverviewHandler extends AbstractJsonRequestHandler {
 		}
 	}
 
-	public static class CurrentJobsOverviewArchiver implements Archiver {
+	public static class CurrentJobsOverviewJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandler.java
@@ -34,6 +34,8 @@ import scala.concurrent.duration.FiniteDuration;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -128,7 +130,7 @@ public class CurrentJobsOverviewHandler extends AbstractJsonRequestHandler {
 	public static class CurrentJobsOverviewJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			StringWriter writer = new StringWriter();
 			try (JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer)) {
 				gen.writeStartObject();
@@ -141,7 +143,7 @@ public class CurrentJobsOverviewHandler extends AbstractJsonRequestHandler {
 			}
 			String json = writer.toString();
 			String path = ALL_JOBS_REST_PATH;
-			return new ArchivedJson[]{new ArchivedJson(path, json)};
+			return Collections.singleton(new ArchivedJson(path, json));
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandler.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -50,7 +50,7 @@ public class JobAccumulatorsHandler extends AbstractExecutionGraphRequestHandler
 		return createJobAccumulatorsJson(graph);
 	}
 
-	public static class JobAccumulatorsArchiver implements Archiver {
+	public static class JobAccumulatorsJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandler.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -46,6 +48,17 @@ public class JobAccumulatorsHandler extends AbstractExecutionGraphRequestHandler
 	@Override
 	public String handleRequest(AccessExecutionGraph graph, Map<String, String> params) throws Exception {
 		return createJobAccumulatorsJson(graph);
+	}
+
+	public static class JobAccumulatorsArchiver implements Archiver {
+
+		@Override
+		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+			String json = createJobAccumulatorsJson(graph);
+			String path = JOB_ACCUMULATORS_REST_PATH
+				.replace(":jobid", graph.getJobID().toString());
+			return new ArchivedJson[]{new ArchivedJson(path, json)};
+		}
 	}
 
 	public static String createJobAccumulatorsJson(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandler.java
@@ -27,6 +27,8 @@ import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -53,11 +55,11 @@ public class JobAccumulatorsHandler extends AbstractExecutionGraphRequestHandler
 	public static class JobAccumulatorsJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			String json = createJobAccumulatorsJson(graph);
 			String path = JOB_ACCUMULATORS_REST_PATH
 				.replace(":jobid", graph.getJobID().toString());
-			return new ArchivedJson[]{new ArchivedJson(path, json)};
+			return Collections.singletonList(new ArchivedJson(path, json));
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandler.java
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.api.common.ArchivedExecutionConfig;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 
 /**
  * Request handler that returns the execution config of a job.
@@ -46,6 +48,17 @@ public class JobConfigHandler extends AbstractExecutionGraphRequestHandler {
 	@Override
 	public String handleRequest(AccessExecutionGraph graph, Map<String, String> params) throws Exception {
 		return createJobConfigJson(graph);
+	}
+
+	public static class JobConfigArchiver implements Archiver {
+
+		@Override
+		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+			String json = createJobConfigJson(graph);
+			String path = JOB_CONFIG_REST_PATH
+				.replace(":jobid", graph.getJobID().toString());
+			return new ArchivedJson[]{new ArchivedJson(path, json)};
+		}
 	}
 
 	public static String createJobConfigJson(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandler.java
@@ -27,7 +27,7 @@ import org.apache.flink.api.common.ArchivedExecutionConfig;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 /**
  * Request handler that returns the execution config of a job.
@@ -50,7 +50,7 @@ public class JobConfigHandler extends AbstractExecutionGraphRequestHandler {
 		return createJobConfigJson(graph);
 	}
 
-	public static class JobConfigArchiver implements Archiver {
+	public static class JobConfigJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandler.java
@@ -29,6 +29,9 @@ import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
+import java.util.Collection;
+import java.util.Collections;
+
 /**
  * Request handler that returns the execution config of a job.
  */
@@ -53,11 +56,11 @@ public class JobConfigHandler extends AbstractExecutionGraphRequestHandler {
 	public static class JobConfigJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			String json = createJobConfigJson(graph);
 			String path = JOB_CONFIG_REST_PATH
 				.replace(":jobid", graph.getJobID().toString());
-			return new ArchivedJson[]{new ArchivedJson(path, json)};
+			return Collections.singletonList(new ArchivedJson(path, json));
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandler.java
@@ -35,6 +35,8 @@ import org.apache.flink.runtime.webmonitor.utils.MutableIOMetrics;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -72,13 +74,16 @@ public class JobDetailsHandler extends AbstractExecutionGraphRequestHandler {
 	public static class JobDetailsJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			String json = createJobDetailsJson(graph, null);
 			String path1 = JOB_DETAILS_REST_PATH
 				.replace(":jobid", graph.getJobID().toString());
 			String path2 = JOB_DETAILS_VERTICES_REST_PATH
 				.replace(":jobid", graph.getJobID().toString());
-			return new ArchivedJson[]{new ArchivedJson(path1, json), new ArchivedJson(path2, json)};
+			Collection<ArchivedJson> archives = new ArrayList();
+			archives.add(new ArchivedJson(path1, json));
+			archives.add(new ArchivedJson(path2, json));
+			return archives;
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandler.java
@@ -28,7 +28,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
 import org.apache.flink.runtime.webmonitor.utils.MutableIOMetrics;
 
@@ -69,7 +69,7 @@ public class JobDetailsHandler extends AbstractExecutionGraphRequestHandler {
 		return createJobDetailsJson(graph, fetcher);
 	}
 
-	public static class JobDetailsArchiver implements Archiver {
+	public static class JobDetailsJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandler.java
@@ -27,6 +27,8 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
 import org.apache.flink.runtime.webmonitor.utils.MutableIOMetrics;
 
@@ -65,6 +67,19 @@ public class JobDetailsHandler extends AbstractExecutionGraphRequestHandler {
 	@Override
 	public String handleRequest(AccessExecutionGraph graph, Map<String, String> params) throws Exception {
 		return createJobDetailsJson(graph, fetcher);
+	}
+
+	public static class JobDetailsArchiver implements Archiver {
+
+		@Override
+		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+			String json = createJobDetailsJson(graph, null);
+			String path1 = JOB_DETAILS_REST_PATH
+				.replace(":jobid", graph.getJobID().toString());
+			String path2 = JOB_DETAILS_VERTICES_REST_PATH
+				.replace(":jobid", graph.getJobID().toString());
+			return new ArchivedJson[]{new ArchivedJson(path1, json), new ArchivedJson(path2, json)};
+		}
 	}
 
 	public static String createJobDetailsJson(AccessExecutionGraph graph, @Nullable MetricFetcher fetcher) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandler.java
@@ -29,6 +29,8 @@ import org.apache.flink.util.ExceptionUtils;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -57,11 +59,11 @@ public class JobExceptionsHandler extends AbstractExecutionGraphRequestHandler {
 	public static class JobExceptionsJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			String json = createJobExceptionsJson(graph);
 			String path = JOB_EXCEPTIONS_REST_PATH
 				.replace(":jobid", graph.getJobID().toString());
-			return new ArchivedJson[]{new ArchivedJson(path, json)};
+			return Collections.singletonList(new ArchivedJson(path, json));
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandler.java
@@ -23,6 +23,8 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 import org.apache.flink.util.ExceptionUtils;
 
 import java.io.IOException;
@@ -50,6 +52,17 @@ public class JobExceptionsHandler extends AbstractExecutionGraphRequestHandler {
 	@Override
 	public String handleRequest(AccessExecutionGraph graph, Map<String, String> params) throws Exception {
 		return createJobExceptionsJson(graph);
+	}
+
+	public static class JobExceptionsArchiver implements Archiver {
+
+		@Override
+		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+			String json = createJobExceptionsJson(graph);
+			String path = JOB_EXCEPTIONS_REST_PATH
+				.replace(":jobid", graph.getJobID().toString());
+			return new ArchivedJson[]{new ArchivedJson(path, json)};
+		}
 	}
 
 	public static String createJobExceptionsJson(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandler.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.util.ExceptionUtils;
 
 import java.io.IOException;
@@ -54,7 +54,7 @@ public class JobExceptionsHandler extends AbstractExecutionGraphRequestHandler {
 		return createJobExceptionsJson(graph);
 	}
 
-	public static class JobExceptionsArchiver implements Archiver {
+	public static class JobExceptionsJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobPlanHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobPlanHandler.java
@@ -20,7 +20,10 @@ package org.apache.flink.runtime.webmonitor.handlers;
 
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -42,5 +45,16 @@ public class JobPlanHandler extends AbstractExecutionGraphRequestHandler {
 	@Override
 	public String handleRequest(AccessExecutionGraph graph, Map<String, String> params) throws Exception {
 		return graph.getJsonPlan();
+	}
+
+	public static class JobPlanArchiver implements Archiver {
+
+		@Override
+		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+			String path = JOB_PLAN_REST_PATH
+				.replace(":jobid", graph.getJobID().toString());
+			String json = graph.getJsonPlan();
+			return new ArchivedJson[]{new ArchivedJson(path, json)};
+		}
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobPlanHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobPlanHandler.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.webmonitor.handlers;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import java.io.IOException;
 import java.util.Map;
@@ -47,7 +47,7 @@ public class JobPlanHandler extends AbstractExecutionGraphRequestHandler {
 		return graph.getJsonPlan();
 	}
 
-	public static class JobPlanArchiver implements Archiver {
+	public static class JobPlanJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobPlanHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobPlanHandler.java
@@ -24,6 +24,8 @@ import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -50,11 +52,11 @@ public class JobPlanHandler extends AbstractExecutionGraphRequestHandler {
 	public static class JobPlanJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			String path = JOB_PLAN_REST_PATH
 				.replace(":jobid", graph.getJobID().toString());
 			String json = graph.getJsonPlan();
-			return new ArchivedJson[]{new ArchivedJson(path, json)};
+			return Collections.singletonList(new ArchivedJson(path, json));
 		}
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandler.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -55,7 +56,7 @@ public class JobVertexAccumulatorsHandler extends AbstractJobVertexRequestHandle
 	public static class JobVertexAccumulatorsJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			List<ArchivedJson> archive = new ArrayList<>();
 			for (AccessExecutionJobVertex task : graph.getAllVertices().values()) {
 				String json = createVertexAccumulatorsJson(task);
@@ -64,7 +65,7 @@ public class JobVertexAccumulatorsHandler extends AbstractJobVertexRequestHandle
 					.replace(":vertexid", task.getJobVertexId().toString());
 				archive.add(new ArchivedJson(path, json));
 			}
-			return archive.toArray(new ArchivedJson[archive.size()]);
+			return archive;
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandler.java
@@ -21,11 +21,16 @@ package org.apache.flink.runtime.webmonitor.handlers;
 import com.fasterxml.jackson.core.JsonGenerator;
 
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 
@@ -45,6 +50,22 @@ public class JobVertexAccumulatorsHandler extends AbstractJobVertexRequestHandle
 	@Override
 	public String handleRequest(AccessExecutionJobVertex jobVertex, Map<String, String> params) throws Exception {
 		return createVertexAccumulatorsJson(jobVertex);
+	}
+
+	public static class JobVertexAccumulatorsArchiver implements Archiver {
+
+		@Override
+		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+			List<ArchivedJson> archive = new ArrayList<>();
+			for (AccessExecutionJobVertex task : graph.getAllVertices().values()) {
+				String json = createVertexAccumulatorsJson(task);
+				String path = JOB_VERTEX_ACCUMULATORS_REST_PATH
+					.replace(":jobid", graph.getJobID().toString())
+					.replace(":vertexid", task.getJobVertexId().toString());
+				archive.add(new ArchivedJson(path, json));
+			}
+			return archive.toArray(new ArchivedJson[archive.size()]);
+		}
 	}
 
 	public static String createVertexAccumulatorsJson(AccessExecutionJobVertex jobVertex) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandler.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -52,7 +52,7 @@ public class JobVertexAccumulatorsHandler extends AbstractJobVertexRequestHandle
 		return createVertexAccumulatorsJson(jobVertex);
 	}
 
-	public static class JobVertexAccumulatorsArchiver implements Archiver {
+	public static class JobVertexAccumulatorsJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandler.java
@@ -35,6 +35,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -66,7 +67,7 @@ public class JobVertexDetailsHandler extends AbstractJobVertexRequestHandler {
 	public static class JobVertexDetailsJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			List<ArchivedJson> archive = new ArrayList<>();
 			for (AccessExecutionJobVertex task : graph.getAllVertices().values()) {
 				String json = createVertexDetailsJson(task, graph.getJobID().toString(), null);
@@ -75,7 +76,7 @@ public class JobVertexDetailsHandler extends AbstractJobVertexRequestHandler {
 					.replace(":vertexid", task.getJobVertexId().toString());
 				archive.add(new ArchivedJson(path, json));
 			}
-			return archive.toArray(new ArchivedJson[archive.size()]);
+			return archive;
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandler.java
@@ -27,7 +27,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
 import org.apache.flink.runtime.webmonitor.utils.MutableIOMetrics;
 
@@ -63,7 +63,7 @@ public class JobVertexDetailsHandler extends AbstractJobVertexRequestHandler {
 		return createVertexDetailsJson(jobVertex, params.get("jobid"), fetcher);
 	}
 
-	public static class JobVertexDetailsArchiver implements Archiver {
+	public static class JobVertexDetailsJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandler.java
@@ -21,16 +21,21 @@ package org.apache.flink.runtime.webmonitor.handlers;
 import com.fasterxml.jackson.core.JsonGenerator;
 
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
 import org.apache.flink.runtime.webmonitor.utils.MutableIOMetrics;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -56,6 +61,22 @@ public class JobVertexDetailsHandler extends AbstractJobVertexRequestHandler {
 	@Override
 	public String handleRequest(AccessExecutionJobVertex jobVertex, Map<String, String> params) throws Exception {
 		return createVertexDetailsJson(jobVertex, params.get("jobid"), fetcher);
+	}
+
+	public static class JobVertexDetailsArchiver implements Archiver {
+
+		@Override
+		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+			List<ArchivedJson> archive = new ArrayList<>();
+			for (AccessExecutionJobVertex task : graph.getAllVertices().values()) {
+				String json = createVertexDetailsJson(task, graph.getJobID().toString(), null);
+				String path = JOB_VERTEX_DETAILS_REST_PATH
+					.replace(":jobid", graph.getJobID().toString())
+					.replace(":vertexid", task.getJobVertexId().toString());
+				archive.add(new ArchivedJson(path, json));
+			}
+			return archive.toArray(new ArchivedJson[archive.size()]);
+		}
 	}
 
 	public static String createVertexDetailsJson(

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexTaskManagersHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexTaskManagersHandler.java
@@ -35,6 +35,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +68,7 @@ public class JobVertexTaskManagersHandler extends AbstractJobVertexRequestHandle
 	public static class JobVertexTaskManagersJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			List<ArchivedJson> archive = new ArrayList<>();
 			for (AccessExecutionJobVertex task : graph.getAllVertices().values()) {
 				String json = createVertexDetailsByTaskManagerJson(task, graph.getJobID().toString(), null);
@@ -76,7 +77,7 @@ public class JobVertexTaskManagersHandler extends AbstractJobVertexRequestHandle
 					.replace(":vertexid", task.getJobVertexId().toString());
 				archive.add(new ArchivedJson(path, json));
 			}
-			return archive.toArray(new ArchivedJson[archive.size()]);
+			return archive;
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexTaskManagersHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexTaskManagersHandler.java
@@ -27,7 +27,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
 import org.apache.flink.runtime.webmonitor.utils.MutableIOMetrics;
 
@@ -64,7 +64,7 @@ public class JobVertexTaskManagersHandler extends AbstractJobVertexRequestHandle
 		return createVertexDetailsByTaskManagerJson(jobVertex, params.get("jobid"), fetcher);
 	}
 
-	public static class JobVertexTaskManagersArchiver implements Archiver {
+	public static class JobVertexTaskManagersJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandler.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -56,7 +56,7 @@ public class SubtaskExecutionAttemptAccumulatorsHandler extends AbstractSubtaskA
 		return createAttemptAccumulatorsJson(execAttempt);
 	}
 		
-	public static class SubtaskExecutionAttemptAccumulatorsArchiver implements Archiver {
+	public static class SubtaskExecutionAttemptAccumulatorsJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandler.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -59,7 +60,7 @@ public class SubtaskExecutionAttemptAccumulatorsHandler extends AbstractSubtaskA
 	public static class SubtaskExecutionAttemptAccumulatorsJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			List<ArchivedJson> archive = new ArrayList<>();
 			for (AccessExecutionJobVertex task : graph.getAllVertices().values()) {
 				for (AccessExecutionVertex subtask : task.getTaskVertices()) {
@@ -84,7 +85,7 @@ public class SubtaskExecutionAttemptAccumulatorsHandler extends AbstractSubtaskA
 					}
 				}
 			}
-			return archive.toArray(new ArchivedJson[archive.size()]);
+			return archive;
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandler.java
@@ -21,10 +21,17 @@ package org.apache.flink.runtime.webmonitor.handlers;
 import com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.executiongraph.AccessExecution;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -49,6 +56,38 @@ public class SubtaskExecutionAttemptAccumulatorsHandler extends AbstractSubtaskA
 		return createAttemptAccumulatorsJson(execAttempt);
 	}
 		
+	public static class SubtaskExecutionAttemptAccumulatorsArchiver implements Archiver {
+
+		@Override
+		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+			List<ArchivedJson> archive = new ArrayList<>();
+			for (AccessExecutionJobVertex task : graph.getAllVertices().values()) {
+				for (AccessExecutionVertex subtask : task.getTaskVertices()) {
+					String curAttemptJson = createAttemptAccumulatorsJson(subtask.getCurrentExecutionAttempt());
+					String curAttemptPath = SUBTASK_ATTEMPT_ACCUMULATORS_REST_PATH
+						.replace(":jobid", graph.getJobID().toString())
+						.replace(":vertexid", task.getJobVertexId().toString())
+						.replace(":subtasknum", String.valueOf(subtask.getParallelSubtaskIndex()))
+						.replace(":attempt", String.valueOf(subtask.getCurrentExecutionAttempt().getAttemptNumber()));
+
+					archive.add(new ArchivedJson(curAttemptPath, curAttemptJson));
+
+					for (int x = 0; x < subtask.getCurrentExecutionAttempt().getAttemptNumber(); x++) {
+						AccessExecution attempt = subtask.getPriorExecutionAttempt(x);
+						String json = createAttemptAccumulatorsJson(attempt);
+						String path = SUBTASK_ATTEMPT_ACCUMULATORS_REST_PATH
+							.replace(":jobid", graph.getJobID().toString())
+							.replace(":vertexid", task.getJobVertexId().toString())
+							.replace(":subtasknum", String.valueOf(subtask.getParallelSubtaskIndex()))
+							.replace(":attempt", String.valueOf(attempt.getAttemptNumber()));
+						archive.add(new ArchivedJson(path, json));
+					}
+				}
+			}
+			return archive.toArray(new ArchivedJson[archive.size()]);
+		}
+	}
+
 	public static String createAttemptAccumulatorsJson(AccessExecution execAttempt) throws IOException {
 		StringWriter writer = new StringWriter();
 		JsonGenerator gen = JsonFactory.jacksonFactory.createGenerator(writer);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandler.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -68,7 +69,7 @@ public class SubtaskExecutionAttemptDetailsHandler extends AbstractSubtaskAttemp
 	public static class SubtaskExecutionAttemptDetailsJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			List<ArchivedJson> archive = new ArrayList<>();
 			for (AccessExecutionJobVertex task : graph.getAllVertices().values()) {
 				for (AccessExecutionVertex subtask : task.getTaskVertices()) {
@@ -98,7 +99,7 @@ public class SubtaskExecutionAttemptDetailsHandler extends AbstractSubtaskAttemp
 					}
 				}
 			}
-			return archive.toArray(new ArchivedJson[archive.size()]);
+			return archive;
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandler.java
@@ -28,7 +28,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
 import org.apache.flink.runtime.webmonitor.utils.MutableIOMetrics;
 
@@ -65,7 +65,7 @@ public class SubtaskExecutionAttemptDetailsHandler extends AbstractSubtaskAttemp
 		return createAttemptDetailsJson(execAttempt, params.get("jobid"), params.get("vertexid"), fetcher);
 	}
 
-	public static class SubtaskExecutionAttemptDetailsArchiver implements Archiver {
+	public static class SubtaskExecutionAttemptDetailsJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandler.java
@@ -22,15 +22,24 @@ import com.fasterxml.jackson.core.JsonGenerator;
 
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecution;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 import org.apache.flink.runtime.webmonitor.metrics.MetricFetcher;
 import org.apache.flink.runtime.webmonitor.utils.MutableIOMetrics;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+
+import static org.apache.flink.runtime.webmonitor.handlers.SubtaskCurrentAttemptDetailsHandler.SUBTASK_CURRENT_ATTEMPT_DETAILS_REST_PATH;
 
 /**
  * Request handler providing details about a single task execution attempt.
@@ -54,6 +63,43 @@ public class SubtaskExecutionAttemptDetailsHandler extends AbstractSubtaskAttemp
 	@Override
 	public String handleRequest(AccessExecution execAttempt, Map<String, String> params) throws Exception {
 		return createAttemptDetailsJson(execAttempt, params.get("jobid"), params.get("vertexid"), fetcher);
+	}
+
+	public static class SubtaskExecutionAttemptDetailsArchiver implements Archiver {
+
+		@Override
+		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+			List<ArchivedJson> archive = new ArrayList<>();
+			for (AccessExecutionJobVertex task : graph.getAllVertices().values()) {
+				for (AccessExecutionVertex subtask : task.getTaskVertices()) {
+					String curAttemptJson = createAttemptDetailsJson(subtask.getCurrentExecutionAttempt(), graph.getJobID().toString(), task.getJobVertexId().toString(), null);
+					String curAttemptPath1 = SUBTASK_CURRENT_ATTEMPT_DETAILS_REST_PATH
+						.replace(":jobid", graph.getJobID().toString())
+						.replace(":vertexid", task.getJobVertexId().toString())
+						.replace(":subtasknum", String.valueOf(subtask.getParallelSubtaskIndex()));
+					String curAttemptPath2 = SUBTASK_ATTEMPT_DETAILS_REST_PATH
+						.replace(":jobid", graph.getJobID().toString())
+						.replace(":vertexid", task.getJobVertexId().toString())
+						.replace(":subtasknum", String.valueOf(subtask.getParallelSubtaskIndex()))
+						.replace(":attempt", String.valueOf(subtask.getCurrentExecutionAttempt().getAttemptNumber()));
+					
+					archive.add(new ArchivedJson(curAttemptPath1, curAttemptJson));
+					archive.add(new ArchivedJson(curAttemptPath2, curAttemptJson));
+
+					for (int x = 0; x < subtask.getCurrentExecutionAttempt().getAttemptNumber(); x++) {
+						AccessExecution attempt = subtask.getPriorExecutionAttempt(x);
+						String json = createAttemptDetailsJson(attempt, graph.getJobID().toString(), task.getJobVertexId().toString(), null);
+						String path = SUBTASK_ATTEMPT_DETAILS_REST_PATH
+							.replace(":jobid", graph.getJobID().toString())
+							.replace(":vertexid", task.getJobVertexId().toString())
+							.replace(":subtasknum", String.valueOf(subtask.getParallelSubtaskIndex()))
+							.replace(":attempt", String.valueOf(attempt.getAttemptNumber()));
+						archive.add(new ArchivedJson(path, json));
+					}
+				}
+			}
+			return archive.toArray(new ArchivedJson[archive.size()]);
+		}
 	}
 
 	public static String createAttemptDetailsJson(

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandler.java
@@ -27,7 +27,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -56,7 +56,7 @@ public class SubtasksAllAccumulatorsHandler extends AbstractJobVertexRequestHand
 		return createSubtasksAccumulatorsJson(jobVertex);
 	}
 
-	public static class SubtasksAllAccumulatorsArchiver implements Archiver {
+	public static class SubtasksAllAccumulatorsJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandler.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -59,7 +60,7 @@ public class SubtasksAllAccumulatorsHandler extends AbstractJobVertexRequestHand
 	public static class SubtasksAllAccumulatorsJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			List<ArchivedJson> archive = new ArrayList<>();
 			for (AccessExecutionJobVertex task : graph.getAllVertices().values()) {
 				String json = createSubtasksAccumulatorsJson(task);
@@ -68,7 +69,7 @@ public class SubtasksAllAccumulatorsHandler extends AbstractJobVertexRequestHand
 					.replace(":vertexid", task.getJobVertexId().toString());
 				archive.add(new ArchivedJson(path, json));
 			}
-			return archive.toArray(new ArchivedJson[archive.size()]);
+			return archive;
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandler.java
@@ -21,13 +21,18 @@ package org.apache.flink.runtime.webmonitor.handlers;
 import com.fasterxml.jackson.core.JsonGenerator;
 
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -49,6 +54,22 @@ public class SubtasksAllAccumulatorsHandler extends AbstractJobVertexRequestHand
 	@Override
 	public String handleRequest(AccessExecutionJobVertex jobVertex, Map<String, String> params) throws Exception {
 		return createSubtasksAccumulatorsJson(jobVertex);
+	}
+
+	public static class SubtasksAllAccumulatorsArchiver implements Archiver {
+
+		@Override
+		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+			List<ArchivedJson> archive = new ArrayList<>();
+			for (AccessExecutionJobVertex task : graph.getAllVertices().values()) {
+				String json = createSubtasksAccumulatorsJson(task);
+				String path = SUBTASKS_ALL_ACCUMULATORS_REST_PATH
+					.replace(":jobid", graph.getJobID().toString())
+					.replace(":vertexid", task.getJobVertexId().toString());
+				archive.add(new ArchivedJson(path, json));
+			}
+			return archive.toArray(new ArchivedJson[archive.size()]);
+		}
 	}
 
 	public static String createSubtasksAccumulatorsJson(AccessExecutionJobVertex jobVertex) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandler.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -60,7 +61,7 @@ public class SubtasksTimesHandler extends AbstractJobVertexRequestHandler {
 	public static class SubtasksTimesJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			List<ArchivedJson> archive = new ArrayList<>();
 			for (AccessExecutionJobVertex task : graph.getAllVertices().values()) {
 				String json = createSubtaskTimesJson(task);
@@ -69,7 +70,7 @@ public class SubtasksTimesHandler extends AbstractJobVertexRequestHandler {
 					.replace(":vertexid", task.getJobVertexId().toString());
 				archive.add(new ArchivedJson(path, json));
 			}
-			return archive.toArray(new ArchivedJson[archive.size()]);
+			return archive;
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandler.java
@@ -21,13 +21,18 @@ package org.apache.flink.runtime.webmonitor.handlers;
 import com.fasterxml.jackson.core.JsonGenerator;
 
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -50,6 +55,22 @@ public class SubtasksTimesHandler extends AbstractJobVertexRequestHandler {
 	@Override
 	public String handleRequest(AccessExecutionJobVertex jobVertex, Map<String, String> params) throws Exception {
 		return createSubtaskTimesJson(jobVertex);
+	}
+
+	public static class SubtasksTimesArchiver implements Archiver {
+
+		@Override
+		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+			List<ArchivedJson> archive = new ArrayList<>();
+			for (AccessExecutionJobVertex task : graph.getAllVertices().values()) {
+				String json = createSubtaskTimesJson(task);
+				String path = SUBTASK_TIMES_REST_PATH
+					.replace(":jobid", graph.getJobID().toString())
+					.replace(":vertexid", task.getJobVertexId().toString());
+				archive.add(new ArchivedJson(path, json));
+			}
+			return archive.toArray(new ArchivedJson[archive.size()]);
+		}
 	}
 
 	public static String createSubtaskTimesJson(AccessExecutionJobVertex jobVertex) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandler.java
@@ -27,7 +27,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -57,7 +57,7 @@ public class SubtasksTimesHandler extends AbstractJobVertexRequestHandler {
 		return createSubtaskTimesJson(jobVertex);
 	}
 
-	public static class SubtasksTimesArchiver implements Archiver {
+	public static class SubtasksTimesJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandler.java
@@ -30,6 +30,8 @@ import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -56,11 +58,11 @@ public class CheckpointConfigHandler extends AbstractExecutionGraphRequestHandle
 	public static class CheckpointConfigJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			String json = createCheckpointConfigJson(graph);
 			String path = CHECKPOINT_CONFIG_REST_PATH
 				.replace(":jobid", graph.getJobID().toString());
-			return new ArchivedJson[]{new ArchivedJson(path, json)};
+			return Collections.singletonList(new ArchivedJson(path, json));
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandler.java
@@ -25,6 +25,8 @@ import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.handlers.AbstractExecutionGraphRequestHandler;
 import org.apache.flink.runtime.webmonitor.handlers.JsonFactory;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -49,6 +51,17 @@ public class CheckpointConfigHandler extends AbstractExecutionGraphRequestHandle
 	@Override
 	public String handleRequest(AccessExecutionGraph graph, Map<String, String> params) throws Exception {
 		return createCheckpointConfigJson(graph);
+	}
+
+	public static class CheckpointConfigArchiver implements Archiver {
+
+		@Override
+		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+			String json = createCheckpointConfigJson(graph);
+			String path = CHECKPOINT_CONFIG_REST_PATH
+				.replace(":jobid", graph.getJobID().toString());
+			return new ArchivedJson[]{new ArchivedJson(path, json)};
+		}
 	}
 
 	private static String createCheckpointConfigJson(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandler.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.handlers.AbstractExecutionGraphRequestHandler;
 import org.apache.flink.runtime.webmonitor.handlers.JsonFactory;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -53,7 +53,7 @@ public class CheckpointConfigHandler extends AbstractExecutionGraphRequestHandle
 		return createCheckpointConfigJson(graph);
 	}
 
-	public static class CheckpointConfigArchiver implements Archiver {
+	public static class CheckpointConfigJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsHandler.java
@@ -35,6 +35,8 @@ import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -87,10 +89,10 @@ public class CheckpointStatsDetailsHandler extends AbstractExecutionGraphRequest
 	public static class CheckpointStatsDetailsJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			CheckpointStatsSnapshot stats = graph.getCheckpointStatsSnapshot();
 			if (stats == null) {
-				return new ArchivedJson[0];
+				return Collections.emptyList();
 			}
 			CheckpointStatsHistory history = stats.getHistory();
 			List<ArchivedJson> archive = new ArrayList<>();
@@ -101,7 +103,7 @@ public class CheckpointStatsDetailsHandler extends AbstractExecutionGraphRequest
 					.replace(":checkpointid", String.valueOf(checkpoint.getCheckpointId()));
 				archive.add(new ArchivedJson(path, json));
 			}
-			return archive.toArray(new ArchivedJson[archive.size()]);
+			return archive;
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsHandler.java
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.handlers.AbstractExecutionGraphRequestHandler;
 import org.apache.flink.runtime.webmonitor.handlers.JsonFactory;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -84,7 +84,7 @@ public class CheckpointStatsDetailsHandler extends AbstractExecutionGraphRequest
 		return createCheckpointDetailsJson(checkpoint);
 	}
 
-	public static class CheckpointStatsDetailsArchiver implements Archiver {
+	public static class CheckpointStatsDetailsJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsSubtasksHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsSubtasksHandler.java
@@ -38,6 +38,8 @@ import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -112,10 +114,10 @@ public class CheckpointStatsDetailsSubtasksHandler extends AbstractExecutionGrap
 	public static class CheckpointStatsDetailsSubtasksJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			CheckpointStatsSnapshot stats = graph.getCheckpointStatsSnapshot();
 			if (stats == null) {
-				return new ArchivedJson[0];
+				return Collections.emptyList();
 			}
 			CheckpointStatsHistory history = stats.getHistory();
 			List<ArchivedJson> archive = new ArrayList<>();
@@ -129,7 +131,7 @@ public class CheckpointStatsDetailsSubtasksHandler extends AbstractExecutionGrap
 					archive.add(new ArchivedJson(path, json));
 				}
 			}
-			return archive.toArray(new ArchivedJson[archive.size()]);
+			return archive;
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsSubtasksHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsSubtasksHandler.java
@@ -33,7 +33,7 @@ import org.apache.flink.runtime.webmonitor.handlers.AbstractExecutionGraphReques
 import org.apache.flink.runtime.webmonitor.handlers.AbstractJobVertexRequestHandler;
 import org.apache.flink.runtime.webmonitor.handlers.JsonFactory;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -109,7 +109,7 @@ public class CheckpointStatsDetailsSubtasksHandler extends AbstractExecutionGrap
 		return createSubtaskCheckpointDetailsJson(checkpoint, taskStats);
 	}
 
-	public static class CheckpointStatsDetailsSubtasksArchiver implements Archiver {
+	public static class CheckpointStatsDetailsSubtasksJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsSubtasksHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsSubtasksHandler.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.webmonitor.handlers.checkpoints;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.runtime.checkpoint.AbstractCheckpointStats;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsHistory;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.MinMaxAvgStats;
 import org.apache.flink.runtime.checkpoint.SubtaskStateStats;
@@ -31,9 +32,13 @@ import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.handlers.AbstractExecutionGraphRequestHandler;
 import org.apache.flink.runtime.webmonitor.handlers.AbstractJobVertexRequestHandler;
 import org.apache.flink.runtime.webmonitor.handlers.JsonFactory;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.runtime.webmonitor.handlers.checkpoints.CheckpointStatsHandler.writeMinMaxAvg;
@@ -102,6 +107,30 @@ public class CheckpointStatsDetailsSubtasksHandler extends AbstractExecutionGrap
 		}
 		
 		return createSubtaskCheckpointDetailsJson(checkpoint, taskStats);
+	}
+
+	public static class CheckpointStatsDetailsSubtasksArchiver implements Archiver {
+
+		@Override
+		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+			CheckpointStatsSnapshot stats = graph.getCheckpointStatsSnapshot();
+			if (stats == null) {
+				return new ArchivedJson[0];
+			}
+			CheckpointStatsHistory history = stats.getHistory();
+			List<ArchivedJson> archive = new ArrayList<>();
+			for (AbstractCheckpointStats checkpoint : history.getCheckpoints()) {
+				for (TaskStateStats subtaskStats : checkpoint.getAllTaskStateStats()) {
+					String json = createSubtaskCheckpointDetailsJson(checkpoint, subtaskStats);
+					String path = CHECKPOINT_STATS_DETAILS_SUBTASKS_REST_PATH
+						.replace(":jobid", graph.getJobID().toString())
+						.replace(":checkpointid", String.valueOf(checkpoint.getCheckpointId()))
+						.replace(":vertexid", subtaskStats.getJobVertexId().toString());
+					archive.add(new ArchivedJson(path, json));
+				}
+			}
+			return archive.toArray(new ArchivedJson[archive.size()]);
+		}
 	}
 
 	private static String createSubtaskCheckpointDetailsJson(AbstractCheckpointStats checkpoint, TaskStateStats taskStats) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandler.java
@@ -38,6 +38,8 @@ import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -64,11 +66,11 @@ public class CheckpointStatsHandler extends AbstractExecutionGraphRequestHandler
 	public static class CheckpointStatsJsonArchivist implements JsonArchivist {
 
 		@Override
-		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+		public Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
 			String json = createCheckpointStatsJson(graph);
 			String path = CHECKPOINT_STATS_REST_PATH
 				.replace(":jobid", graph.getJobID().toString());
-			return new ArchivedJson[]{new ArchivedJson(path, json)};
+			return Collections.singletonList(new ArchivedJson(path, json));
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandler.java
@@ -33,7 +33,7 @@ import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.handlers.AbstractExecutionGraphRequestHandler;
 import org.apache.flink.runtime.webmonitor.handlers.JsonFactory;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -61,7 +61,7 @@ public class CheckpointStatsHandler extends AbstractExecutionGraphRequestHandler
 		return createCheckpointStatsJson(graph);
 	}
 
-	public static class CheckpointStatsArchiver implements Archiver {
+	public static class CheckpointStatsJsonArchivist implements JsonArchivist {
 
 		@Override
 		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandler.java
@@ -32,6 +32,8 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.handlers.AbstractExecutionGraphRequestHandler;
 import org.apache.flink.runtime.webmonitor.handlers.JsonFactory;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -57,6 +59,17 @@ public class CheckpointStatsHandler extends AbstractExecutionGraphRequestHandler
 	@Override
 	public String handleRequest(AccessExecutionGraph graph, Map<String, String> params) throws Exception {
 		return createCheckpointStatsJson(graph);
+	}
+
+	public static class CheckpointStatsArchiver implements Archiver {
+
+		@Override
+		public ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException {
+			String json = createCheckpointStatsJson(graph);
+			String path = CHECKPOINT_STATS_REST_PATH
+				.replace(":jobid", graph.getJobID().toString());
+			return new ArchivedJson[]{new ArchivedJson(path, json)};
+		}
 	}
 
 	private static String createCheckpointStatsJson(AccessExecutionGraph graph) throws IOException {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandlerTest.java
@@ -19,19 +19,46 @@ package org.apache.flink.runtime.webmonitor.handlers;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import scala.concurrent.duration.FiniteDuration;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.concurrent.TimeUnit;
 
 public class CurrentJobsOverviewHandlerTest {
+
+	@Test
+	public void testArchiver() throws Exception {
+		Archiver archiver = new CurrentJobsOverviewHandler.CurrentJobsOverviewArchiver();
+		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
+		JobDetails expectedDetails = WebMonitorUtils.createDetailsForJob(originalJob);
+
+		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.length);
+
+		ArchivedJson archive = archives[0];
+		Assert.assertEquals("/joboverview", archive.path);
+
+		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(archive.json);
+		ArrayNode running = (ArrayNode) result.get("running");
+		Assert.assertEquals(0, running.size());
+
+		ArrayNode finished = (ArrayNode) result.get("finished");
+		Assert.assertEquals(1, finished.size());
+
+		compareJobOverview(expectedDetails, finished.get(0).toString());
+	}
+
 	@Test
 	public void testGetPaths() {
 		CurrentJobsOverviewHandler handlerAll = new CurrentJobsOverviewHandler(new FiniteDuration(0, TimeUnit.SECONDS), true, true);
@@ -58,8 +85,10 @@ public class CurrentJobsOverviewHandlerTest {
 		try (JsonGenerator gen = ArchivedJobGenerationUtils.jacksonFactory.createGenerator(writer)) {
 			CurrentJobsOverviewHandler.writeJobDetailOverviewAsJson(expectedDetails, gen, 0);
 		}
-		String answer = writer.toString();
+		compareJobOverview(expectedDetails, writer.toString());
+	}
 
+	private static void compareJobOverview(JobDetails expectedDetails, String answer) throws IOException {
 		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(answer);
 
 		Assert.assertEquals(expectedDetails.getJobId().toString(), result.get("jid").asText());

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandlerTest.java
@@ -47,9 +47,9 @@ public class CurrentJobsOverviewHandlerTest {
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];
-		Assert.assertEquals("/joboverview", archive.path);
+		Assert.assertEquals("/joboverview", archive.getPath());
 
-		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(archive.json);
+		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(archive.getJson());
 		ArrayNode running = (ArrayNode) result.get("running");
 		Assert.assertEquals(0, running.size());
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandlerTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -39,11 +39,11 @@ public class CurrentJobsOverviewHandlerTest {
 
 	@Test
 	public void testArchiver() throws Exception {
-		Archiver archiver = new CurrentJobsOverviewHandler.CurrentJobsOverviewArchiver();
+		JsonArchivist archivist = new CurrentJobsOverviewHandler.CurrentJobsOverviewJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 		JobDetails expectedDetails = WebMonitorUtils.createDetailsForJob(originalJob);
 
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/CurrentJobsOverviewHandlerTest.java
@@ -33,6 +33,7 @@ import scala.concurrent.duration.FiniteDuration;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
 public class CurrentJobsOverviewHandlerTest {
@@ -43,10 +44,10 @@ public class CurrentJobsOverviewHandlerTest {
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 		JobDetails expectedDetails = WebMonitorUtils.createDetailsForJob(originalJob);
 
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
-		Assert.assertEquals(1, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.size());
 
-		ArchivedJson archive = archives[0];
+		ArchivedJson archive = archives.iterator().next();
 		Assert.assertEquals("/joboverview", archive.getPath());
 
 		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(archive.getJson());

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandlerTest.java
@@ -20,11 +20,29 @@ package org.apache.flink.runtime.webmonitor.handlers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+
 public class JobAccumulatorsHandlerTest {
+
+	@Test
+	public void testArchiver() throws Exception {
+		Archiver archiver = new JobAccumulatorsHandler.JobAccumulatorsArchiver();
+		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
+
+		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.length);
+
+		ArchivedJson archive = archives[0];
+		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/accumulators", archive.path);
+		compareAccumulators(originalJob, archive.json);
+	}
+
 	@Test
 	public void testGetPaths() {
 		JobAccumulatorsHandler handler = new JobAccumulatorsHandler(null);
@@ -38,6 +56,10 @@ public class JobAccumulatorsHandlerTest {
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 		String json = JobAccumulatorsHandler.createJobAccumulatorsJson(originalJob);
 
+		compareAccumulators(originalJob, json);
+	}
+
+	private static void compareAccumulators(AccessExecutionGraph originalJob, String json) throws IOException {
 		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
 
 		ArrayNode accs = (ArrayNode) result.get("job-accumulators");

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandlerTest.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
 
 public class JobAccumulatorsHandlerTest {
 
@@ -35,10 +36,10 @@ public class JobAccumulatorsHandlerTest {
 		JsonArchivist archivist = new JobAccumulatorsHandler.JobAccumulatorsJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
-		Assert.assertEquals(1, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.size());
 
-		ArchivedJson archive = archives[0];
+		ArchivedJson archive = archives.iterator().next();
 		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/accumulators", archive.getPath());
 		compareAccumulators(originalJob, archive.getJson());
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandlerTest.java
@@ -39,8 +39,8 @@ public class JobAccumulatorsHandlerTest {
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];
-		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/accumulators", archive.path);
-		compareAccumulators(originalJob, archive.json);
+		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/accumulators", archive.getPath());
+		compareAccumulators(originalJob, archive.getJson());
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobAccumulatorsHandlerTest.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,10 +32,10 @@ public class JobAccumulatorsHandlerTest {
 
 	@Test
 	public void testArchiver() throws Exception {
-		Archiver archiver = new JobAccumulatorsHandler.JobAccumulatorsArchiver();
+		JsonArchivist archivist = new JobAccumulatorsHandler.JobAccumulatorsJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandlerTest.java
@@ -40,8 +40,8 @@ public class JobConfigHandlerTest {
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];
-		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/config", archive.path);
-		compareJobConfig(originalJob, archive.json);
+		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/config", archive.getPath());
+		compareJobConfig(originalJob, archive.getJson());
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandlerTest.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
 
 public class JobConfigHandlerTest {
@@ -36,10 +37,10 @@ public class JobConfigHandlerTest {
 		JsonArchivist archivist = new JobConfigHandler.JobConfigJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
-		Assert.assertEquals(1, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.size());
 
-		ArchivedJson archive = archives[0];
+		ArchivedJson archive = archives.iterator().next();
 		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/config", archive.getPath());
 		compareJobConfig(originalJob, archive.getJson());
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobConfigHandlerTest.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.api.common.ArchivedExecutionConfig;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -33,10 +33,10 @@ public class JobConfigHandlerTest {
 
 	@Test
 	public void testArchiver() throws Exception {
-		Archiver archiver = new JobConfigHandler.JobConfigArchiver();
+		JsonArchivist archivist = new JobConfigHandler.JobConfigJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandlerTest.java
@@ -33,6 +33,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
 public class JobDetailsHandlerTest {
@@ -42,14 +44,15 @@ public class JobDetailsHandlerTest {
 		JsonArchivist archivist = new JobDetailsHandler.JobDetailsJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
-		Assert.assertEquals(2, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(2, archives.size());
 
-		ArchivedJson archive1 = archives[0];
+		Iterator<ArchivedJson> iterator = archives.iterator();
+		ArchivedJson archive1 = iterator.next();
 		Assert.assertEquals("/jobs/" + originalJob.getJobID(), archive1.getPath());
 		compareJobDetails(originalJob, archive1.getJson());
 
-		ArchivedJson archive2 = archives[1];
+		ArchivedJson archive2 = iterator.next();
 		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices", archive2.getPath());
 		compareJobDetails(originalJob, archive2.getJson());
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandlerTest.java
@@ -27,7 +27,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IOMetrics;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -39,10 +39,10 @@ public class JobDetailsHandlerTest {
 
 	@Test
 	public void testArchiver() throws Exception {
-		Archiver archiver = new JobDetailsHandler.JobDetailsArchiver();
+		JsonArchivist archivist = new JobDetailsHandler.JobDetailsJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
 		Assert.assertEquals(2, archives.length);
 
 		ArchivedJson archive1 = archives[0];

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobDetailsHandlerTest.java
@@ -46,12 +46,12 @@ public class JobDetailsHandlerTest {
 		Assert.assertEquals(2, archives.length);
 
 		ArchivedJson archive1 = archives[0];
-		Assert.assertEquals("/jobs/" + originalJob.getJobID(), archive1.path);
-		compareJobDetails(originalJob, archive1.json);
+		Assert.assertEquals("/jobs/" + originalJob.getJobID(), archive1.getPath());
+		compareJobDetails(originalJob, archive1.getJson());
 
 		ArchivedJson archive2 = archives[1];
-		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices", archive2.path);
-		compareJobDetails(originalJob, archive2.json);
+		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices", archive2.getPath());
+		compareJobDetails(originalJob, archive2.getJson());
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandlerTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.junit.Assert;
@@ -35,10 +35,10 @@ public class JobExceptionsHandlerTest {
 
 	@Test
 	public void testArchiver() throws Exception {
-		Archiver archiver = new JobExceptionsHandler.JobExceptionsArchiver();
+		JsonArchivist archivist = new JobExceptionsHandler.JobExceptionsJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandlerTest.java
@@ -42,8 +42,8 @@ public class JobExceptionsHandlerTest {
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];
-		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/exceptions", archive.path);
-		compareExceptions(originalJob, archive.json);
+		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/exceptions", archive.getPath());
+		compareExceptions(originalJob, archive.getJson());
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobExceptionsHandlerTest.java
@@ -30,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
 
 public class JobExceptionsHandlerTest {
 
@@ -38,10 +39,10 @@ public class JobExceptionsHandlerTest {
 		JsonArchivist archivist = new JobExceptionsHandler.JobExceptionsJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
-		Assert.assertEquals(1, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.size());
 
-		ArchivedJson archive = archives[0];
+		ArchivedJson archive = archives.iterator().next();
 		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/exceptions", archive.getPath());
 		compareExceptions(originalJob, archive.getJson());
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobPlanHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobPlanHandlerTest.java
@@ -17,10 +17,28 @@
  */
 package org.apache.flink.runtime.webmonitor.handlers;
 
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class JobPlanHandlerTest {
+
+	@Test
+	public void testArchiver() throws Exception {
+		Archiver archiver = new JobPlanHandler.JobPlanArchiver();
+		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
+
+		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.length);
+
+		ArchivedJson archive = archives[0];
+		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/plan", archive.path);
+		Assert.assertEquals(originalJob.getJsonPlan(), archive.json);
+	}
+
 	@Test
 	public void testGetPaths() {
 		JobPlanHandler handler = new JobPlanHandler(null);

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobPlanHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobPlanHandlerTest.java
@@ -24,6 +24,8 @@ import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collection;
+
 public class JobPlanHandlerTest {
 
 	@Test
@@ -31,10 +33,10 @@ public class JobPlanHandlerTest {
 		JsonArchivist archivist = new JobPlanHandler.JobPlanJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
-		Assert.assertEquals(1, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.size());
 
-		ArchivedJson archive = archives[0];
+		ArchivedJson archive = archives.iterator().next();
 		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/plan", archive.getPath());
 		Assert.assertEquals(originalJob.getJsonPlan(), archive.getJson());
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobPlanHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobPlanHandlerTest.java
@@ -19,7 +19,7 @@ package org.apache.flink.runtime.webmonitor.handlers;
 
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -28,10 +28,10 @@ public class JobPlanHandlerTest {
 
 	@Test
 	public void testArchiver() throws Exception {
-		Archiver archiver = new JobPlanHandler.JobPlanArchiver();
+		JsonArchivist archivist = new JobPlanHandler.JobPlanJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobPlanHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobPlanHandlerTest.java
@@ -35,8 +35,8 @@ public class JobPlanHandlerTest {
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];
-		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/plan", archive.path);
-		Assert.assertEquals(originalJob.getJsonPlan(), archive.json);
+		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/plan", archive.getPath());
+		Assert.assertEquals(originalJob.getJsonPlan(), archive.getJson());
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandlerTest.java
@@ -42,8 +42,8 @@ public class JobVertexAccumulatorsHandlerTest {
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];
-		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId() + "/accumulators", archive.path);
-		compareAccumulators(originalTask, archive.json);
+		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId() + "/accumulators", archive.getPath());
+		compareAccumulators(originalTask, archive.getJson());
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandlerTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,11 +34,11 @@ public class JobVertexAccumulatorsHandlerTest {
 
 	@Test
 	public void testArchiver() throws Exception {
-		Archiver archiver = new JobVertexAccumulatorsHandler.JobVertexAccumulatorsArchiver();
+		JsonArchivist archivist = new JobVertexAccumulatorsHandler.JobVertexAccumulatorsJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
 
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandlerTest.java
@@ -29,6 +29,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
 
 public class JobVertexAccumulatorsHandlerTest {
 
@@ -38,10 +39,10 @@ public class JobVertexAccumulatorsHandlerTest {
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
 
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
-		Assert.assertEquals(1, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.size());
 
-		ArchivedJson archive = archives[0];
+		ArchivedJson archive = archives.iterator().next();
 		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId() + "/accumulators", archive.getPath());
 		compareAccumulators(originalTask, archive.getJson());
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexAccumulatorsHandlerTest.java
@@ -20,12 +20,32 @@ package org.apache.flink.runtime.webmonitor.handlers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+
 public class JobVertexAccumulatorsHandlerTest {
+
+	@Test
+	public void testArchiver() throws Exception {
+		Archiver archiver = new JobVertexAccumulatorsHandler.JobVertexAccumulatorsArchiver();
+		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
+		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
+
+		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.length);
+
+		ArchivedJson archive = archives[0];
+		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId() + "/accumulators", archive.path);
+		compareAccumulators(originalTask, archive.json);
+	}
+
 	@Test
 	public void testGetPaths() {
 		JobVertexAccumulatorsHandler handler = new JobVertexAccumulatorsHandler(null);
@@ -39,6 +59,10 @@ public class JobVertexAccumulatorsHandlerTest {
 		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
 		String json = JobVertexAccumulatorsHandler.createVertexAccumulatorsJson(originalTask);
 
+		compareAccumulators(originalTask, json);
+	}
+
+	private static void compareAccumulators(AccessExecutionJobVertex originalTask, String json) throws IOException {
 		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
 
 		Assert.assertEquals(originalTask.getJobVertexId().toString(), result.get("id").asText());

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandlerTest.java
@@ -44,8 +44,8 @@ public class JobVertexDetailsHandlerTest {
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];
-		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId(), archive.path);
-		compareVertexDetails(originalTask, archive.json);
+		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId(), archive.getPath());
+		compareVertexDetails(originalTask, archive.getJson());
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandlerTest.java
@@ -20,14 +20,34 @@ package org.apache.flink.runtime.webmonitor.handlers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+
 public class JobVertexDetailsHandlerTest {
+
+	@Test
+	public void testArchiver() throws Exception {
+		Archiver archiver = new JobVertexDetailsHandler.JobVertexDetailsArchiver();
+		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
+		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
+
+		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.length);
+
+		ArchivedJson archive = archives[0];
+		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId(), archive.path);
+		compareVertexDetails(originalTask, archive.json);
+	}
+
 	@Test
 	public void testGetPaths() {
 		JobVertexDetailsHandler handler = new JobVertexDetailsHandler(null, null);
@@ -42,6 +62,10 @@ public class JobVertexDetailsHandlerTest {
 		String json = JobVertexDetailsHandler.createVertexDetailsJson(
 			originalTask, ArchivedJobGenerationUtils.getTestJob().getJobID().toString(), null);
 
+		compareVertexDetails(originalTask, json);
+	}
+
+	private static void compareVertexDetails(AccessExecutionJobVertex originalTask, String json) throws IOException {
 		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
 
 		Assert.assertEquals(originalTask.getJobVertexId().toString(), result.get("id").asText());

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandlerTest.java
@@ -31,6 +31,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
 
 public class JobVertexDetailsHandlerTest {
 
@@ -40,10 +41,10 @@ public class JobVertexDetailsHandlerTest {
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
 
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
-		Assert.assertEquals(1, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.size());
 
-		ArchivedJson archive = archives[0];
+		ArchivedJson archive = archives.iterator().next();
 		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId(), archive.getPath());
 		compareVertexDetails(originalTask, archive.getJson());
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexDetailsHandlerTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -36,11 +36,11 @@ public class JobVertexDetailsHandlerTest {
 
 	@Test
 	public void testArchiver() throws Exception {
-		Archiver archiver = new JobVertexDetailsHandler.JobVertexDetailsArchiver();
+		JsonArchivist archivist = new JobVertexDetailsHandler.JobVertexDetailsJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
 
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexTaskManagersHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexTaskManagersHandlerTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IOMetrics;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -37,12 +37,12 @@ public class JobVertexTaskManagersHandlerTest {
 
 	@Test
 	public void testArchiver() throws Exception {
-		Archiver archiver = new JobVertexTaskManagersHandler.JobVertexTaskManagersArchiver();
+		JsonArchivist archivist = new JobVertexTaskManagersHandler.JobVertexTaskManagersJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
 		AccessExecutionVertex originalSubtask = ArchivedJobGenerationUtils.getTestSubtask();
 
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexTaskManagersHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexTaskManagersHandlerTest.java
@@ -32,6 +32,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
 
 public class JobVertexTaskManagersHandlerTest {
 
@@ -42,10 +43,10 @@ public class JobVertexTaskManagersHandlerTest {
 		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
 		AccessExecutionVertex originalSubtask = ArchivedJobGenerationUtils.getTestSubtask();
 
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
-		Assert.assertEquals(1, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.size());
 
-		ArchivedJson archive = archives[0];
+		ArchivedJson archive = archives.iterator().next();
 		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId() + "/taskmanagers", archive.getPath());
 		compareVertexTaskManagers(originalTask, originalSubtask, archive.getJson());
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexTaskManagersHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobVertexTaskManagersHandlerTest.java
@@ -46,8 +46,8 @@ public class JobVertexTaskManagersHandlerTest {
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];
-		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId() + "/taskmanagers", archive.path);
-		compareVertexTaskManagers(originalTask, originalSubtask, archive.json);
+		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId() + "/taskmanagers", archive.getPath());
+		compareVertexTaskManagers(originalTask, originalSubtask, archive.getJson());
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
@@ -49,8 +49,8 @@ public class SubtaskExecutionAttemptAccumulatorsHandlerTest {
 			"/subtasks/" + originalAttempt.getParallelSubtaskIndex() +
 			"/attempts/" + originalAttempt.getAttemptNumber() + 
 			"/accumulators",
-			archive.path);
-		compareAttemptAccumulators(originalAttempt, archive.json);
+			archive.getPath());
+		compareAttemptAccumulators(originalAttempt, archive.getJson());
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
@@ -29,6 +29,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
 
 public class SubtaskExecutionAttemptAccumulatorsHandlerTest {
 
@@ -39,10 +40,10 @@ public class SubtaskExecutionAttemptAccumulatorsHandlerTest {
 		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
 		AccessExecution originalAttempt = ArchivedJobGenerationUtils.getTestAttempt();
 
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
-		Assert.assertEquals(1, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.size());
 
-		ArchivedJson archive = archives[0];
+		ArchivedJson archive = archives.iterator().next();
 		Assert.assertEquals(
 			"/jobs/" + originalJob.getJobID() +
 			"/vertices/" + originalTask.getJobVertexId() +

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
@@ -20,11 +20,39 @@ package org.apache.flink.runtime.webmonitor.handlers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.flink.runtime.executiongraph.AccessExecution;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+
 public class SubtaskExecutionAttemptAccumulatorsHandlerTest {
+
+	@Test
+	public void testArchiver() throws Exception {
+		Archiver archiver = new SubtaskExecutionAttemptAccumulatorsHandler.SubtaskExecutionAttemptAccumulatorsArchiver();
+		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
+		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
+		AccessExecution originalAttempt = ArchivedJobGenerationUtils.getTestAttempt();
+
+		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.length);
+
+		ArchivedJson archive = archives[0];
+		Assert.assertEquals(
+			"/jobs/" + originalJob.getJobID() +
+			"/vertices/" + originalTask.getJobVertexId() +
+			"/subtasks/" + originalAttempt.getParallelSubtaskIndex() +
+			"/attempts/" + originalAttempt.getAttemptNumber() + 
+			"/accumulators",
+			archive.path);
+		compareAttemptAccumulators(originalAttempt, archive.json);
+	}
+
 	@Test
 	public void testGetPaths() {
 		SubtaskExecutionAttemptAccumulatorsHandler handler = new SubtaskExecutionAttemptAccumulatorsHandler(null);
@@ -38,6 +66,10 @@ public class SubtaskExecutionAttemptAccumulatorsHandlerTest {
 		AccessExecution originalAttempt = ArchivedJobGenerationUtils.getTestAttempt();
 		String json = SubtaskExecutionAttemptAccumulatorsHandler.createAttemptAccumulatorsJson(originalAttempt);
 
+		compareAttemptAccumulators(originalAttempt, json);
+	}
+
+	private static void compareAttemptAccumulators(AccessExecution originalAttempt, String json) throws IOException {
 		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
 
 		Assert.assertEquals(originalAttempt.getParallelSubtaskIndex(), result.get("subtask").asInt());

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecution;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,12 +34,12 @@ public class SubtaskExecutionAttemptAccumulatorsHandlerTest {
 
 	@Test
 	public void testArchiver() throws Exception {
-		Archiver archiver = new SubtaskExecutionAttemptAccumulatorsHandler.SubtaskExecutionAttemptAccumulatorsArchiver();
+		JsonArchivist archivist = new SubtaskExecutionAttemptAccumulatorsHandler.SubtaskExecutionAttemptAccumulatorsJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
 		AccessExecution originalAttempt = ArchivedJobGenerationUtils.getTestAttempt();
 
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandlerTest.java
@@ -47,8 +47,8 @@ public class SubtaskExecutionAttemptDetailsHandlerTest {
 			"/jobs/" + originalJob.getJobID() +
 				"/vertices/" + originalTask.getJobVertexId() +
 				"/subtasks/" + originalAttempt.getParallelSubtaskIndex(),
-			archive1.path);
-		compareAttemptDetails(originalAttempt, archive1.json);
+			archive1.getPath());
+		compareAttemptDetails(originalAttempt, archive1.getJson());
 
 		ArchivedJson archive2 = archives[1];
 		Assert.assertEquals(
@@ -56,8 +56,8 @@ public class SubtaskExecutionAttemptDetailsHandlerTest {
 				"/vertices/" + originalTask.getJobVertexId() +
 				"/subtasks/" + originalAttempt.getParallelSubtaskIndex() +
 				"/attempts/" + originalAttempt.getAttemptNumber(),
-			archive2.path);
-		compareAttemptDetails(originalAttempt, archive2.json);
+			archive2.getPath());
+		compareAttemptDetails(originalAttempt, archive2.getJson());
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandlerTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecution;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,12 +34,12 @@ public class SubtaskExecutionAttemptDetailsHandlerTest {
 
 	@Test
 	public void testArchiver() throws Exception {
-		Archiver archiver = new SubtaskExecutionAttemptDetailsHandler.SubtaskExecutionAttemptDetailsArchiver();
+		JsonArchivist archivist = new SubtaskExecutionAttemptDetailsHandler.SubtaskExecutionAttemptDetailsJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
 		AccessExecution originalAttempt = ArchivedJobGenerationUtils.getTestAttempt();
 
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
 		Assert.assertEquals(2, archives.length);
 
 		ArchivedJson archive1 = archives[0];

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtaskExecutionAttemptDetailsHandlerTest.java
@@ -29,6 +29,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
 
 public class SubtaskExecutionAttemptDetailsHandlerTest {
 
@@ -39,10 +41,11 @@ public class SubtaskExecutionAttemptDetailsHandlerTest {
 		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
 		AccessExecution originalAttempt = ArchivedJobGenerationUtils.getTestAttempt();
 
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
-		Assert.assertEquals(2, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(2, archives.size());
 
-		ArchivedJson archive1 = archives[0];
+		Iterator<ArchivedJson> iterator = archives.iterator();
+		ArchivedJson archive1 = iterator.next();
 		Assert.assertEquals(
 			"/jobs/" + originalJob.getJobID() +
 				"/vertices/" + originalTask.getJobVertexId() +
@@ -50,7 +53,7 @@ public class SubtaskExecutionAttemptDetailsHandlerTest {
 			archive1.getPath());
 		compareAttemptDetails(originalAttempt, archive1.getJson());
 
-		ArchivedJson archive2 = archives[1];
+		ArchivedJson archive2 = iterator.next();
 		Assert.assertEquals(
 			"/jobs/" + originalJob.getJobID() +
 				"/vertices/" + originalTask.getJobVertexId() +

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandlerTest.java
@@ -29,6 +29,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
 
 public class SubtasksAllAccumulatorsHandlerTest {
 
@@ -38,10 +39,10 @@ public class SubtasksAllAccumulatorsHandlerTest {
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
 
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
-		Assert.assertEquals(1, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.size());
 
-		ArchivedJson archive = archives[0];
+		ArchivedJson archive = archives.iterator().next();
 		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId() + 
 			"/subtasks/accumulators", archive.getPath());
 		compareSubtaskAccumulators(originalTask, archive.getJson());

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandlerTest.java
@@ -43,8 +43,8 @@ public class SubtasksAllAccumulatorsHandlerTest {
 
 		ArchivedJson archive = archives[0];
 		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId() + 
-			"/subtasks/accumulators", archive.path);
-		compareSubtaskAccumulators(originalTask, archive.json);
+			"/subtasks/accumulators", archive.getPath());
+		compareSubtaskAccumulators(originalTask, archive.getJson());
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksAllAccumulatorsHandlerTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,11 +34,11 @@ public class SubtasksAllAccumulatorsHandlerTest {
 
 	@Test
 	public void testArchiver() throws Exception {
-		Archiver archiver = new SubtasksAllAccumulatorsHandler.SubtasksAllAccumulatorsArchiver();
+		JsonArchivist archivist = new SubtasksAllAccumulatorsHandler.SubtasksAllAccumulatorsJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
 
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandlerTest.java
@@ -30,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
 
 public class SubtasksTimesHandlerTest {
 
@@ -40,10 +41,10 @@ public class SubtasksTimesHandlerTest {
 		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
 		AccessExecution originalAttempt = ArchivedJobGenerationUtils.getTestAttempt();
 
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
-		Assert.assertEquals(1, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.size());
 
-		ArchivedJson archive = archives[0];
+		ArchivedJson archive = archives.iterator().next();
 		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId() + "/subtasktimes", archive.getPath());
 		compareSubtaskTimes(originalTask, originalAttempt, archive.getJson());
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandlerTest.java
@@ -44,8 +44,8 @@ public class SubtasksTimesHandlerTest {
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];
-		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId() + "/subtasktimes", archive.path);
-		compareSubtaskTimes(originalTask, originalAttempt, archive.json);
+		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId() + "/subtasktimes", archive.getPath());
+		compareSubtaskTimes(originalTask, originalAttempt, archive.getJson());
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandlerTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecution;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,12 +35,12 @@ public class SubtasksTimesHandlerTest {
 
 	@Test
 	public void testArchiver() throws Exception {
-		Archiver archiver = new SubtasksTimesHandler.SubtasksTimesArchiver();
+		JsonArchivist archivist = new SubtasksTimesHandler.SubtasksTimesJsonArchivist();
 		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
 		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
 		AccessExecution originalAttempt = ArchivedJobGenerationUtils.getTestAttempt();
 
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(originalJob);
 		Assert.assertEquals(1, archives.length);
 
 		ArchivedJson archive = archives[0];

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/SubtasksTimesHandlerTest.java
@@ -21,12 +21,33 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecution;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
 import org.apache.flink.runtime.webmonitor.utils.ArchivedJobGenerationUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+
 public class SubtasksTimesHandlerTest {
+
+	@Test
+	public void testArchiver() throws Exception {
+		Archiver archiver = new SubtasksTimesHandler.SubtasksTimesArchiver();
+		AccessExecutionGraph originalJob = ArchivedJobGenerationUtils.getTestJob();
+		AccessExecutionJobVertex originalTask = ArchivedJobGenerationUtils.getTestTask();
+		AccessExecution originalAttempt = ArchivedJobGenerationUtils.getTestAttempt();
+
+		ArchivedJson[] archives = archiver.archiveJsonWithPath(originalJob);
+		Assert.assertEquals(1, archives.length);
+
+		ArchivedJson archive = archives[0];
+		Assert.assertEquals("/jobs/" + originalJob.getJobID() + "/vertices/" + originalTask.getJobVertexId() + "/subtasktimes", archive.path);
+		compareSubtaskTimes(originalTask, originalAttempt, archive.json);
+	}
+
 	@Test
 	public void testGetPaths() {
 		SubtasksTimesHandler handler = new SubtasksTimesHandler(null);
@@ -41,6 +62,10 @@ public class SubtasksTimesHandlerTest {
 		AccessExecution originalAttempt = ArchivedJobGenerationUtils.getTestAttempt();
 		String json = SubtasksTimesHandler.createSubtaskTimesJson(originalTask);
 
+		compareSubtaskTimes(originalTask, originalAttempt, json);
+	}
+	
+	private static void compareSubtaskTimes(AccessExecutionJobVertex originalTask, AccessExecution originalAttempt, String json) throws IOException {
 		JsonNode result = ArchivedJobGenerationUtils.mapper.readTree(json);
 
 		Assert.assertEquals(originalTask.getJobVertexId().toString(), result.get("id").asText());

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandlerTest.java
@@ -20,14 +20,19 @@ package org.apache.flink.runtime.webmonitor.handlers.checkpoints;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.ExternalizedCheckpointSettings;
 import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
+
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
@@ -36,6 +41,37 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class CheckpointConfigHandlerTest {
+
+	@Test
+	public void testArchiver() throws IOException {
+		Archiver archiver = new CheckpointConfigHandler.CheckpointConfigArchiver();
+		GraphAndSettings graphAndSettings = createGraphAndSettings(true, true);
+
+		AccessExecutionGraph graph = graphAndSettings.graph;
+		when(graph.getJobID()).thenReturn(new JobID());
+		JobSnapshottingSettings settings = graphAndSettings.snapshottingSettings;
+		ExternalizedCheckpointSettings externalizedSettings = graphAndSettings.externalizedSettings;
+		
+		ArchivedJson[] archives = archiver.archiveJsonWithPath(graph);
+		Assert.assertEquals(1, archives.length);
+		ArchivedJson archive = archives[0];
+		Assert.assertEquals("/jobs/" + graph.getJobID() + "/checkpoints/config", archive.path);
+
+		ObjectMapper mapper = new ObjectMapper();
+		JsonNode rootNode = mapper.readTree(archive.json);
+
+		Assert.assertEquals("exactly_once", rootNode.get("mode").asText());
+		Assert.assertEquals(settings.getCheckpointInterval(), rootNode.get("interval").asLong());
+		Assert.assertEquals(settings.getCheckpointTimeout(), rootNode.get("timeout").asLong());
+		Assert.assertEquals(settings.getMinPauseBetweenCheckpoints(), rootNode.get("min_pause").asLong());
+		Assert.assertEquals(settings.getMaxConcurrentCheckpoints(), rootNode.get("max_concurrent").asInt());
+
+		JsonNode externalizedNode = rootNode.get("externalization");
+		Assert.assertNotNull(externalizedNode);
+		Assert.assertEquals(externalizedSettings.externalizeCheckpoints(), externalizedNode.get("enabled").asBoolean());
+		Assert.assertEquals(externalizedSettings.deleteOnCancellation(), externalizedNode.get("delete_on_cancellation").asBoolean());
+
+	}
 
 	@Test
 	public void testGetPaths() {
@@ -50,26 +86,10 @@ public class CheckpointConfigHandlerTest {
 	 */
 	@Test
 	public void testSimpleConfig() throws Exception {
-		long interval = 18231823L;
-		long timeout = 996979L;
-		long minPause = 119191919L;
-		int maxConcurrent = 12929329;
-		ExternalizedCheckpointSettings externalized = ExternalizedCheckpointSettings.none();
+		GraphAndSettings graphAndSettings = createGraphAndSettings(false, true);
 
-		JobSnapshottingSettings settings = new JobSnapshottingSettings(
-			Collections.<JobVertexID>emptyList(),
-			Collections.<JobVertexID>emptyList(),
-			Collections.<JobVertexID>emptyList(),
-			interval,
-			timeout,
-			minPause,
-			maxConcurrent,
-			externalized,
-			null,
-			true);
-
-		AccessExecutionGraph graph = mock(AccessExecutionGraph.class);
-		when(graph.getJobSnapshottingSettings()).thenReturn(settings);
+		AccessExecutionGraph graph = graphAndSettings.graph;
+		JobSnapshottingSettings settings = graphAndSettings.snapshottingSettings;
 
 		CheckpointConfigHandler handler = new CheckpointConfigHandler(mock(ExecutionGraphHolder.class));
 		String json = handler.handleRequest(graph, Collections.<String, String>emptyMap());
@@ -78,10 +98,10 @@ public class CheckpointConfigHandlerTest {
 		JsonNode rootNode = mapper.readTree(json);
 
 		assertEquals("exactly_once", rootNode.get("mode").asText());
-		assertEquals(interval, rootNode.get("interval").asLong());
-		assertEquals(timeout, rootNode.get("timeout").asLong());
-		assertEquals(minPause, rootNode.get("min_pause").asLong());
-		assertEquals(maxConcurrent, rootNode.get("max_concurrent").asInt());
+		assertEquals(settings.getCheckpointInterval(), rootNode.get("interval").asLong());
+		assertEquals(settings.getCheckpointTimeout(), rootNode.get("timeout").asLong());
+		assertEquals(settings.getMinPauseBetweenCheckpoints(), rootNode.get("min_pause").asLong());
+		assertEquals(settings.getMaxConcurrentCheckpoints(), rootNode.get("max_concurrent").asInt());
 
 		JsonNode externalizedNode = rootNode.get("externalization");
 		assertNotNull(externalizedNode);
@@ -93,20 +113,9 @@ public class CheckpointConfigHandlerTest {
 	 */
 	@Test
 	public void testAtLeastOnce() throws Exception {
-		JobSnapshottingSettings settings = new JobSnapshottingSettings(
-			Collections.<JobVertexID>emptyList(),
-			Collections.<JobVertexID>emptyList(),
-			Collections.<JobVertexID>emptyList(),
-			996979L,
-			1818L,
-			1212L,
-			12,
-			ExternalizedCheckpointSettings.none(),
-			null,
-			false); // at least once
+		GraphAndSettings graphAndSettings = createGraphAndSettings(false, false);
 
-		AccessExecutionGraph graph = mock(AccessExecutionGraph.class);
-		when(graph.getJobSnapshottingSettings()).thenReturn(settings);
+		AccessExecutionGraph graph = graphAndSettings.graph;
 
 		CheckpointConfigHandler handler = new CheckpointConfigHandler(mock(ExecutionGraphHolder.class));
 		String json = handler.handleRequest(graph, Collections.<String, String>emptyMap());
@@ -122,22 +131,10 @@ public class CheckpointConfigHandlerTest {
 	 */
 	@Test
 	public void testEnabledExternalizedCheckpointSettings() throws Exception {
-		ExternalizedCheckpointSettings externalizedSettings = ExternalizedCheckpointSettings.externalizeCheckpoints(true);
+		GraphAndSettings graphAndSettings = createGraphAndSettings(true, false);
 
-		JobSnapshottingSettings settings = new JobSnapshottingSettings(
-			Collections.<JobVertexID>emptyList(),
-			Collections.<JobVertexID>emptyList(),
-			Collections.<JobVertexID>emptyList(),
-			996979L,
-			1818L,
-			1212L,
-			12,
-			externalizedSettings,
-			null,
-			false); // at least once
-
-		AccessExecutionGraph graph = mock(AccessExecutionGraph.class);
-		when(graph.getJobSnapshottingSettings()).thenReturn(settings);
+		AccessExecutionGraph graph = graphAndSettings.graph;
+		ExternalizedCheckpointSettings externalizedSettings = graphAndSettings.externalizedSettings;
 
 		CheckpointConfigHandler handler = new CheckpointConfigHandler(mock(ExecutionGraphHolder.class));
 		String json = handler.handleRequest(graph, Collections.<String, String>emptyMap());
@@ -147,5 +144,47 @@ public class CheckpointConfigHandlerTest {
 		assertNotNull(externalizedNode);
 		assertEquals(externalizedSettings.externalizeCheckpoints(), externalizedNode.get("enabled").asBoolean());
 		assertEquals(externalizedSettings.deleteOnCancellation(), externalizedNode.get("delete_on_cancellation").asBoolean());
+	}
+
+	private static GraphAndSettings createGraphAndSettings(boolean externalized, boolean exactlyOnce) {
+		long interval = 18231823L;
+		long timeout = 996979L;
+		long minPause = 119191919L;
+		int maxConcurrent = 12929329;
+		ExternalizedCheckpointSettings externalizedSetting = externalized
+			? ExternalizedCheckpointSettings.externalizeCheckpoints(true)
+			: ExternalizedCheckpointSettings.none();
+
+		JobSnapshottingSettings settings = new JobSnapshottingSettings(
+			Collections.<JobVertexID>emptyList(),
+			Collections.<JobVertexID>emptyList(),
+			Collections.<JobVertexID>emptyList(),
+			interval,
+			timeout,
+			minPause,
+			maxConcurrent,
+			externalizedSetting,
+			null,
+			exactlyOnce);
+
+		AccessExecutionGraph graph = mock(AccessExecutionGraph.class);
+		when(graph.getJobSnapshottingSettings()).thenReturn(settings);
+
+		return new GraphAndSettings(graph, settings, externalizedSetting);
+	}
+
+	private static class GraphAndSettings {
+		public final AccessExecutionGraph graph;
+		public final JobSnapshottingSettings snapshottingSettings;
+		public final ExternalizedCheckpointSettings externalizedSettings;
+
+		public GraphAndSettings(
+				AccessExecutionGraph graph,
+				JobSnapshottingSettings snapshottingSettings,
+				ExternalizedCheckpointSettings externalizedSettings) {
+			this.graph = graph;
+			this.snapshottingSettings = snapshottingSettings;
+			this.externalizedSettings = externalizedSettings;
+		}
 	}
 }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandlerTest.java
@@ -33,6 +33,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
@@ -52,9 +53,9 @@ public class CheckpointConfigHandlerTest {
 		JobSnapshottingSettings settings = graphAndSettings.snapshottingSettings;
 		ExternalizedCheckpointSettings externalizedSettings = graphAndSettings.externalizedSettings;
 		
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(graph);
-		Assert.assertEquals(1, archives.length);
-		ArchivedJson archive = archives[0];
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(graph);
+		Assert.assertEquals(1, archives.size());
+		ArchivedJson archive = archives.iterator().next();
 		Assert.assertEquals("/jobs/" + graph.getJobID() + "/checkpoints/config", archive.getPath());
 
 		ObjectMapper mapper = new ObjectMapper();

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandlerTest.java
@@ -27,7 +27,7 @@ import org.apache.flink.runtime.jobgraph.tasks.ExternalizedCheckpointSettings;
 import org.apache.flink.runtime.jobgraph.tasks.JobSnapshottingSettings;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -44,7 +44,7 @@ public class CheckpointConfigHandlerTest {
 
 	@Test
 	public void testArchiver() throws IOException {
-		Archiver archiver = new CheckpointConfigHandler.CheckpointConfigArchiver();
+		JsonArchivist archivist = new CheckpointConfigHandler.CheckpointConfigJsonArchivist();
 		GraphAndSettings graphAndSettings = createGraphAndSettings(true, true);
 
 		AccessExecutionGraph graph = graphAndSettings.graph;
@@ -52,7 +52,7 @@ public class CheckpointConfigHandlerTest {
 		JobSnapshottingSettings settings = graphAndSettings.snapshottingSettings;
 		ExternalizedCheckpointSettings externalizedSettings = graphAndSettings.externalizedSettings;
 		
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(graph);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(graph);
 		Assert.assertEquals(1, archives.length);
 		ArchivedJson archive = archives[0];
 		Assert.assertEquals("/jobs/" + graph.getJobID() + "/checkpoints/config", archive.getPath());

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointConfigHandlerTest.java
@@ -55,10 +55,10 @@ public class CheckpointConfigHandlerTest {
 		ArchivedJson[] archives = archiver.archiveJsonWithPath(graph);
 		Assert.assertEquals(1, archives.length);
 		ArchivedJson archive = archives[0];
-		Assert.assertEquals("/jobs/" + graph.getJobID() + "/checkpoints/config", archive.path);
+		Assert.assertEquals("/jobs/" + graph.getJobID() + "/checkpoints/config", archive.getPath());
 
 		ObjectMapper mapper = new ObjectMapper();
-		JsonNode rootNode = mapper.readTree(archive.json);
+		JsonNode rootNode = mapper.readTree(archive.getJson());
 
 		Assert.assertEquals("exactly_once", rootNode.get("mode").asText());
 		Assert.assertEquals(settings.getCheckpointInterval(), rootNode.get("interval").asLong());

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsHandlerTest.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 
 import org.junit.Assert;
@@ -60,7 +60,7 @@ public class CheckpointStatsDetailsHandlerTest {
 	
 	@Test
 	public void testArchiver() throws IOException {
-		Archiver archiver = new CheckpointStatsDetailsHandler.CheckpointStatsDetailsArchiver();
+		JsonArchivist archivist = new CheckpointStatsDetailsHandler.CheckpointStatsDetailsJsonArchivist();
 
 		CompletedCheckpointStats completedCheckpoint = createCompletedCheckpoint();
 		FailedCheckpointStats failedCheckpoint = createFailedCheckpoint();
@@ -79,7 +79,7 @@ public class CheckpointStatsDetailsHandlerTest {
 
 		ObjectMapper mapper = new ObjectMapper();
 		
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(graph);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(graph);
 		Assert.assertEquals(2, archives.length);
 		
 		ArchivedJson archive1 = archives[0];

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsHandlerTest.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
@@ -79,16 +80,17 @@ public class CheckpointStatsDetailsHandlerTest {
 
 		ObjectMapper mapper = new ObjectMapper();
 		
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(graph);
-		Assert.assertEquals(2, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(graph);
+		Assert.assertEquals(2, archives.size());
 		
-		ArchivedJson archive1 = archives[0];
+		Iterator<ArchivedJson> iterator = archives.iterator();
+		ArchivedJson archive1 = iterator.next();
 		Assert.assertEquals(
 			"/jobs/" + graph.getJobID() + "/checkpoints/details/" + failedCheckpoint.getCheckpointId(),
 			archive1.getPath());
 		compareFailedCheckpoint(failedCheckpoint, mapper.readTree(archive1.getJson()));
 
-		ArchivedJson archive2 = archives[1];
+		ArchivedJson archive2 = iterator.next();
 		Assert.assertEquals(
 			"/jobs/" + graph.getJobID() + "/checkpoints/details/" + completedCheckpoint.getCheckpointId(),
 			archive2.getPath());

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsHandlerTest.java
@@ -85,14 +85,14 @@ public class CheckpointStatsDetailsHandlerTest {
 		ArchivedJson archive1 = archives[0];
 		Assert.assertEquals(
 			"/jobs/" + graph.getJobID() + "/checkpoints/details/" + failedCheckpoint.getCheckpointId(),
-			archive1.path);
-		compareFailedCheckpoint(failedCheckpoint, mapper.readTree(archive1.json));
+			archive1.getPath());
+		compareFailedCheckpoint(failedCheckpoint, mapper.readTree(archive1.getJson()));
 
 		ArchivedJson archive2 = archives[1];
 		Assert.assertEquals(
 			"/jobs/" + graph.getJobID() + "/checkpoints/details/" + completedCheckpoint.getCheckpointId(),
-			archive2.path);
-		compareCompletedCheckpoint(completedCheckpoint, mapper.readTree(archive2.json));
+			archive2.getPath());
+		compareCompletedCheckpoint(completedCheckpoint, mapper.readTree(archive2.getJson()));
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsDetailsHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.webmonitor.handlers.checkpoints;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.checkpoint.AbstractCheckpointStats;
 import org.apache.flink.runtime.checkpoint.CheckpointProperties;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsHistory;
@@ -32,10 +33,16 @@ import org.apache.flink.runtime.checkpoint.TaskStateStats;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
+
+
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -50,6 +57,43 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class CheckpointStatsDetailsHandlerTest {
+	
+	@Test
+	public void testArchiver() throws IOException {
+		Archiver archiver = new CheckpointStatsDetailsHandler.CheckpointStatsDetailsArchiver();
+
+		CompletedCheckpointStats completedCheckpoint = createCompletedCheckpoint();
+		FailedCheckpointStats failedCheckpoint = createFailedCheckpoint();
+		List<AbstractCheckpointStats> checkpoints = new ArrayList<>();
+		checkpoints.add(failedCheckpoint);
+		checkpoints.add(completedCheckpoint);
+		
+		CheckpointStatsHistory history = mock(CheckpointStatsHistory.class);
+		when(history.getCheckpoints()).thenReturn(checkpoints);
+		CheckpointStatsSnapshot snapshot = mock(CheckpointStatsSnapshot.class);
+		when(snapshot.getHistory()).thenReturn(history);
+
+		AccessExecutionGraph graph = mock(AccessExecutionGraph.class);
+		when(graph.getCheckpointStatsSnapshot()).thenReturn(snapshot);
+		when(graph.getJobID()).thenReturn(new JobID());
+
+		ObjectMapper mapper = new ObjectMapper();
+		
+		ArchivedJson[] archives = archiver.archiveJsonWithPath(graph);
+		Assert.assertEquals(2, archives.length);
+		
+		ArchivedJson archive1 = archives[0];
+		Assert.assertEquals(
+			"/jobs/" + graph.getJobID() + "/checkpoints/details/" + failedCheckpoint.getCheckpointId(),
+			archive1.path);
+		compareFailedCheckpoint(failedCheckpoint, mapper.readTree(archive1.json));
+
+		ArchivedJson archive2 = archives[1];
+		Assert.assertEquals(
+			"/jobs/" + graph.getJobID() + "/checkpoints/details/" + completedCheckpoint.getCheckpointId(),
+			archive2.path);
+		compareCompletedCheckpoint(completedCheckpoint, mapper.readTree(archive2.json));
+	}
 
 	@Test
 	public void testGetPaths() {
@@ -146,8 +190,7 @@ public class CheckpointStatsDetailsHandlerTest {
 		assertEquals(checkpoint.getNumberOfSubtasks(), rootNode.get("num_subtasks").asInt());
 		assertEquals(checkpoint.getNumberOfAcknowledgedSubtasks(), rootNode.get("num_acknowledged_subtasks").asInt());
 
-		verifyTaskNode(task1, rootNode);
-		verifyTaskNode(task2, rootNode);
+		verifyTaskNodes(taskStats, rootNode);
 	}
 
 	/**
@@ -155,6 +198,32 @@ public class CheckpointStatsDetailsHandlerTest {
 	 */
 	@Test
 	public void testCheckpointDetailsRequestCompletedCheckpoint() throws Exception {
+		CompletedCheckpointStats checkpoint = createCompletedCheckpoint();
+
+		JsonNode rootNode = triggerRequest(checkpoint);
+
+		compareCompletedCheckpoint(checkpoint, rootNode);
+
+		verifyTaskNodes(checkpoint.getAllTaskStateStats(), rootNode);
+	}
+
+	/**
+	 * Tests a checkpoint details request for a failed checkpoint.
+	 */
+	@Test
+	public void testCheckpointDetailsRequestFailedCheckpoint() throws Exception {
+		FailedCheckpointStats checkpoint = createFailedCheckpoint();
+
+		JsonNode rootNode = triggerRequest(checkpoint);
+
+		compareFailedCheckpoint(checkpoint, rootNode);
+
+		verifyTaskNodes(checkpoint.getAllTaskStateStats(), rootNode);
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static CompletedCheckpointStats createCompletedCheckpoint() {
 		CompletedCheckpointStats checkpoint = mock(CompletedCheckpointStats.class);
 		when(checkpoint.getCheckpointId()).thenReturn(1818213L);
 		when(checkpoint.getStatus()).thenReturn(CheckpointStatsStatus.COMPLETED);
@@ -177,8 +246,10 @@ public class CheckpointStatsDetailsHandlerTest {
 
 		when(checkpoint.getAllTaskStateStats()).thenReturn(taskStats);
 
-		JsonNode rootNode = triggerRequest(checkpoint);
+		return checkpoint;
+	}
 
+	private static void compareCompletedCheckpoint(CompletedCheckpointStats checkpoint, JsonNode rootNode) {
 		assertEquals(checkpoint.getCheckpointId(), rootNode.get("id").asLong());
 		assertEquals(checkpoint.getStatus().toString(), rootNode.get("status").asText());
 		assertEquals(checkpoint.getProperties().isSavepoint(), rootNode.get("is_savepoint").asBoolean());
@@ -191,18 +262,11 @@ public class CheckpointStatsDetailsHandlerTest {
 		assertEquals(checkpoint.getExternalPath(), rootNode.get("external_path").asText());
 		assertEquals(checkpoint.getNumberOfSubtasks(), rootNode.get("num_subtasks").asInt());
 		assertEquals(checkpoint.getNumberOfAcknowledgedSubtasks(), rootNode.get("num_acknowledged_subtasks").asInt());
-
-		verifyTaskNode(task1, rootNode);
-		verifyTaskNode(task2, rootNode);
 	}
 
-	/**
-	 * Tests a checkpoint details request for a failed checkpoint.
-	 */
-	@Test
-	public void testCheckpointDetailsRequestFailedCheckpoint() throws Exception {
+	private static FailedCheckpointStats createFailedCheckpoint() {
 		FailedCheckpointStats checkpoint = mock(FailedCheckpointStats.class);
-		when(checkpoint.getCheckpointId()).thenReturn(1818213L);
+		when(checkpoint.getCheckpointId()).thenReturn(1818214L);
 		when(checkpoint.getStatus()).thenReturn(CheckpointStatsStatus.FAILED);
 		when(checkpoint.getProperties()).thenReturn(CheckpointProperties.forStandardSavepoint());
 		when(checkpoint.getTriggerTimestamp()).thenReturn(1818L);
@@ -223,8 +287,10 @@ public class CheckpointStatsDetailsHandlerTest {
 
 		when(checkpoint.getAllTaskStateStats()).thenReturn(taskStats);
 
-		JsonNode rootNode = triggerRequest(checkpoint);
+		return checkpoint;
+	}
 
+	private static void compareFailedCheckpoint(FailedCheckpointStats checkpoint, JsonNode rootNode) {
 		assertEquals(checkpoint.getCheckpointId(), rootNode.get("id").asLong());
 		assertEquals(checkpoint.getStatus().toString(), rootNode.get("status").asText());
 		assertEquals(checkpoint.getProperties().isSavepoint(), rootNode.get("is_savepoint").asBoolean());
@@ -237,12 +303,7 @@ public class CheckpointStatsDetailsHandlerTest {
 		assertEquals(checkpoint.getFailureMessage(), rootNode.get("failure_message").asText());
 		assertEquals(checkpoint.getNumberOfSubtasks(), rootNode.get("num_subtasks").asInt());
 		assertEquals(checkpoint.getNumberOfAcknowledgedSubtasks(), rootNode.get("num_acknowledged_subtasks").asInt());
-
-		verifyTaskNode(task1, rootNode);
-		verifyTaskNode(task2, rootNode);
 	}
-
-	// ------------------------------------------------------------------------
 
 	private static JsonNode triggerRequest(AbstractCheckpointStats checkpoint) throws Exception {
 		CheckpointStatsHistory history = mock(CheckpointStatsHistory.class);
@@ -262,16 +323,18 @@ public class CheckpointStatsDetailsHandlerTest {
 		return mapper.readTree(json);
 	}
 
-	private static void verifyTaskNode(TaskStateStats task, JsonNode parentNode) {
-		long duration = ThreadLocalRandom.current().nextInt(128);
+	private static void verifyTaskNodes(Collection<TaskStateStats> tasks, JsonNode parentNode) {
+		for (TaskStateStats task : tasks) {
+			long duration = ThreadLocalRandom.current().nextInt(128);
 
-		JsonNode taskNode = parentNode.get("tasks").get(task.getJobVertexId().toString());
-		assertEquals(task.getLatestAckTimestamp(), taskNode.get("latest_ack_timestamp").asLong());
-		assertEquals(task.getStateSize(), taskNode.get("state_size").asLong());
-		assertEquals(task.getEndToEndDuration(task.getLatestAckTimestamp() - duration), taskNode.get("end_to_end_duration").asLong());
-		assertEquals(task.getAlignmentBuffered(), taskNode.get("alignment_buffered").asLong());
-		assertEquals(task.getNumberOfSubtasks(), taskNode.get("num_subtasks").asInt());
-		assertEquals(task.getNumberOfAcknowledgedSubtasks(), taskNode.get("num_acknowledged_subtasks").asInt());
+			JsonNode taskNode = parentNode.get("tasks").get(task.getJobVertexId().toString());
+			assertEquals(task.getLatestAckTimestamp(), taskNode.get("latest_ack_timestamp").asLong());
+			assertEquals(task.getStateSize(), taskNode.get("state_size").asLong());
+			assertEquals(task.getEndToEndDuration(task.getLatestAckTimestamp() - duration), taskNode.get("end_to_end_duration").asLong());
+			assertEquals(task.getAlignmentBuffered(), taskNode.get("alignment_buffered").asLong());
+			assertEquals(task.getNumberOfSubtasks(), taskNode.get("num_subtasks").asInt());
+			assertEquals(task.getNumberOfAcknowledgedSubtasks(), taskNode.get("num_acknowledged_subtasks").asInt());
+		}
 	}
 
 	private static TaskStateStats createTaskStateStats() {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.webmonitor.handlers.checkpoints;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.checkpoint.AbstractCheckpointStats;
 import org.apache.flink.runtime.checkpoint.CheckpointProperties;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsCounts;
@@ -34,9 +35,13 @@ import org.apache.flink.runtime.checkpoint.PendingCheckpointStats;
 import org.apache.flink.runtime.checkpoint.RestoredCheckpointStats;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
+
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -51,6 +56,31 @@ import static org.mockito.Mockito.when;
 public class CheckpointStatsHandlerTest {
 
 	@Test
+	public void testArchiver() throws IOException {
+		Archiver archiver = new CheckpointStatsDetailsHandler.CheckpointStatsDetailsArchiver();
+		TestCheckpointStats testCheckpointStats = createTestCheckpointStats();
+		when(testCheckpointStats.graph.getJobID()).thenReturn(new JobID());
+		
+		ArchivedJson[] archives = archiver.archiveJsonWithPath(testCheckpointStats.graph);
+		Assert.assertEquals(3, archives.length);
+
+		ObjectMapper mapper = new ObjectMapper();
+		
+		ArchivedJson archive1 = archives[0];
+		Assert.assertEquals("/jobs/" + testCheckpointStats.graph.getJobID() + "/checkpoints/details/" + testCheckpointStats.inProgress.getCheckpointId(), archive1.path);
+		compareInProgressCheckpoint(testCheckpointStats.inProgress, mapper.readTree(archive1.json));
+
+		ArchivedJson archive2 = archives[1];
+		Assert.assertEquals("/jobs/" + testCheckpointStats.graph.getJobID() + "/checkpoints/details/" + testCheckpointStats.completedSavepoint.getCheckpointId(), archive2.path);
+		compareCompletedSavepoint(testCheckpointStats.completedSavepoint, mapper.readTree(archive2.json));
+		
+		ArchivedJson archive3 = archives[2];
+		Assert.assertEquals("/jobs/" + testCheckpointStats.graph.getJobID() + "/checkpoints/details/" + testCheckpointStats.failed.getCheckpointId(), archive3.path);
+		compareFailedCheckpoint(testCheckpointStats.failed, mapper.readTree(archive3.json));
+	}
+	
+
+	@Test
 	public void testGetPaths() {
 		CheckpointStatsHandler handler = new CheckpointStatsHandler(mock(ExecutionGraphHolder.class));
 		String[] paths = handler.getPaths();
@@ -63,6 +93,18 @@ public class CheckpointStatsHandlerTest {
 	 */
 	@Test
 	public void testCheckpointStatsRequest() throws Exception {
+		TestCheckpointStats testCheckpointStats = createTestCheckpointStats();
+
+		CheckpointStatsHandler handler = new CheckpointStatsHandler(mock(ExecutionGraphHolder.class));
+		String json = handler.handleRequest(testCheckpointStats.graph, Collections.<String, String>emptyMap());
+
+		ObjectMapper mapper = new ObjectMapper();
+		JsonNode rootNode = mapper.readTree(json);
+
+		compareCheckpointStats(testCheckpointStats, rootNode);
+	}
+
+	private static TestCheckpointStats createTestCheckpointStats() {
 		// Counts
 		CheckpointStatsCounts counts = mock(CheckpointStatsCounts.class);
 		when(counts.getNumberOfRestoredCheckpoints()).thenReturn(123123123L);
@@ -104,7 +146,7 @@ public class CheckpointStatsHandlerTest {
 		when(latestCompleted.getExternalPath()).thenReturn("latest-completed-external-path");
 
 		CompletedCheckpointStats latestSavepoint = mock(CompletedCheckpointStats.class);
-		when(latestSavepoint.getCheckpointId()).thenReturn(1992139L);
+		when(latestSavepoint.getCheckpointId()).thenReturn(1992140L);
 		when(latestSavepoint.getTriggerTimestamp()).thenReturn(1919191900L);
 		when(latestSavepoint.getLatestAckTimestamp()).thenReturn(1977791901L);
 		when(latestSavepoint.getStateSize()).thenReturn(111939272822L);
@@ -133,7 +175,7 @@ public class CheckpointStatsHandlerTest {
 		List<AbstractCheckpointStats> checkpoints = new ArrayList<>();
 
 		PendingCheckpointStats inProgress = mock(PendingCheckpointStats.class);
-		when(inProgress.getCheckpointId()).thenReturn(1992139L);
+		when(inProgress.getCheckpointId()).thenReturn(1992141L);
 		when(inProgress.getStatus()).thenReturn(CheckpointStatsStatus.IN_PROGRESS);
 		when(inProgress.getProperties()).thenReturn(CheckpointProperties.forStandardCheckpoint());
 		when(inProgress.getTriggerTimestamp()).thenReturn(1919191900L);
@@ -189,12 +231,15 @@ public class CheckpointStatsHandlerTest {
 		AccessExecutionGraph graph = mock(AccessExecutionGraph.class);
 		when(graph.getCheckpointStatsSnapshot()).thenReturn(snapshot);
 
-		CheckpointStatsHandler handler = new CheckpointStatsHandler(mock(ExecutionGraphHolder.class));
-		String json = handler.handleRequest(graph, Collections.<String, String>emptyMap());
+		return new TestCheckpointStats(
+			graph, counts, stateSizeSummary, durationSummary, alignmentBufferedSummary, summary,
+			latestCompleted, latestSavepoint, latestFailed, latestRestored, inProgress, 
+			completedSavepoint, failed, history, snapshot
+		);
+	}
 
-		ObjectMapper mapper = new ObjectMapper();
-		JsonNode rootNode = mapper.readTree(json);
-
+	private static void compareCheckpointStats(TestCheckpointStats checkpointStats, JsonNode rootNode) {
+		CheckpointStatsCounts counts = checkpointStats.counts;
 		JsonNode countNode = rootNode.get("counts");
 		assertEquals(counts.getNumberOfRestoredCheckpoints(), countNode.get("restored").asLong());
 		assertEquals(counts.getTotalNumberOfCheckpoints(), countNode.get("total").asLong());
@@ -202,22 +247,26 @@ public class CheckpointStatsHandlerTest {
 		assertEquals(counts.getNumberOfCompletedCheckpoints(), countNode.get("completed").asLong());
 		assertEquals(counts.getNumberOfFailedCheckpoints(), countNode.get("failed").asLong());
 
+		MinMaxAvgStats stateSizeSummary = checkpointStats.stateSizeSummary;
 		JsonNode summaryNode = rootNode.get("summary");
 		JsonNode sizeSummaryNode = summaryNode.get("state_size");
 		assertEquals(stateSizeSummary.getMinimum(), sizeSummaryNode.get("min").asLong());
 		assertEquals(stateSizeSummary.getMaximum(), sizeSummaryNode.get("max").asLong());
 		assertEquals(stateSizeSummary.getAverage(), sizeSummaryNode.get("avg").asLong());
 
+		MinMaxAvgStats durationSummary = checkpointStats.durationSummary;
 		JsonNode durationSummaryNode = summaryNode.get("end_to_end_duration");
 		assertEquals(durationSummary.getMinimum(), durationSummaryNode.get("min").asLong());
 		assertEquals(durationSummary.getMaximum(), durationSummaryNode.get("max").asLong());
 		assertEquals(durationSummary.getAverage(), durationSummaryNode.get("avg").asLong());
 
+		MinMaxAvgStats alignmentBufferedSummary = checkpointStats.alignmentBufferedSummary;
 		JsonNode alignmentBufferedNode = summaryNode.get("alignment_buffered");
 		assertEquals(alignmentBufferedSummary.getMinimum(), alignmentBufferedNode.get("min").asLong());
 		assertEquals(alignmentBufferedSummary.getMaximum(), alignmentBufferedNode.get("max").asLong());
 		assertEquals(alignmentBufferedSummary.getAverage(), alignmentBufferedNode.get("avg").asLong());
 
+		CompletedCheckpointStats latestCompleted = checkpointStats.latestCompleted;
 		JsonNode latestNode = rootNode.get("latest");
 		JsonNode latestCheckpointNode = latestNode.get("completed");
 		assertEquals(latestCompleted.getCheckpointId(), latestCheckpointNode.get("id").asLong());
@@ -228,6 +277,7 @@ public class CheckpointStatsHandlerTest {
 		assertEquals(latestCompleted.getAlignmentBuffered(), latestCheckpointNode.get("alignment_buffered").asLong());
 		assertEquals(latestCompleted.getExternalPath(), latestCheckpointNode.get("external_path").asText());
 
+		CompletedCheckpointStats latestSavepoint = checkpointStats.latestSavepoint;
 		JsonNode latestSavepointNode = latestNode.get("savepoint");
 		assertEquals(latestSavepoint.getCheckpointId(), latestSavepointNode.get("id").asLong());
 		assertEquals(latestSavepoint.getTriggerTimestamp(), latestSavepointNode.get("trigger_timestamp").asLong());
@@ -237,6 +287,7 @@ public class CheckpointStatsHandlerTest {
 		assertEquals(latestSavepoint.getAlignmentBuffered(), latestSavepointNode.get("alignment_buffered").asLong());
 		assertEquals(latestSavepoint.getExternalPath(), latestSavepointNode.get("external_path").asText());
 
+		FailedCheckpointStats latestFailed = checkpointStats.latestFailed;
 		JsonNode latestFailedNode = latestNode.get("failed");
 		assertEquals(latestFailed.getCheckpointId(), latestFailedNode.get("id").asLong());
 		assertEquals(latestFailed.getTriggerTimestamp(), latestFailedNode.get("trigger_timestamp").asLong());
@@ -247,6 +298,7 @@ public class CheckpointStatsHandlerTest {
 		assertEquals(latestFailed.getFailureTimestamp(), latestFailedNode.get("failure_timestamp").asLong());
 		assertEquals(latestFailed.getFailureMessage(), latestFailedNode.get("failure_message").asText());
 
+		RestoredCheckpointStats latestRestored = checkpointStats.latestRestored;
 		JsonNode latestRestoredNode = latestNode.get("restored");
 		assertEquals(latestRestored.getCheckpointId(), latestRestoredNode.get("id").asLong());
 		assertEquals(latestRestored.getRestoreTimestamp(), latestRestoredNode.get("restore_timestamp").asLong());
@@ -259,6 +311,25 @@ public class CheckpointStatsHandlerTest {
 		assertTrue(it.hasNext());
 		JsonNode inProgressNode = it.next();
 
+		PendingCheckpointStats inProgress = checkpointStats.inProgress;
+		compareInProgressCheckpoint(inProgress, inProgressNode);
+
+		assertTrue(it.hasNext());
+		JsonNode completedSavepointNode = it.next();
+
+		CompletedCheckpointStats completedSavepoint = checkpointStats.completedSavepoint;
+		compareCompletedSavepoint(completedSavepoint, completedSavepointNode);
+
+		assertTrue(it.hasNext());
+		JsonNode failedNode = it.next();
+
+		FailedCheckpointStats failed = checkpointStats.failed;
+		compareFailedCheckpoint(failed, failedNode);
+
+		assertFalse(it.hasNext());
+	}
+
+	private static void compareInProgressCheckpoint(PendingCheckpointStats inProgress, JsonNode inProgressNode) {
 		assertEquals(inProgress.getCheckpointId(), inProgressNode.get("id").asLong());
 		assertEquals(inProgress.getStatus().toString(), inProgressNode.get("status").asText());
 		assertEquals(inProgress.getProperties().isSavepoint(), inProgressNode.get("is_savepoint").asBoolean());
@@ -269,10 +340,9 @@ public class CheckpointStatsHandlerTest {
 		assertEquals(inProgress.getAlignmentBuffered(), inProgressNode.get("alignment_buffered").asLong());
 		assertEquals(inProgress.getNumberOfSubtasks(), inProgressNode.get("num_subtasks").asInt());
 		assertEquals(inProgress.getNumberOfAcknowledgedSubtasks(), inProgressNode.get("num_acknowledged_subtasks").asInt());
+	}
 
-		assertTrue(it.hasNext());
-		JsonNode completedSavepointNode = it.next();
-
+	private static void compareCompletedSavepoint(CompletedCheckpointStats completedSavepoint, JsonNode completedSavepointNode) {
 		assertEquals(completedSavepoint.getCheckpointId(), completedSavepointNode.get("id").asLong());
 		assertEquals(completedSavepoint.getStatus().toString(), completedSavepointNode.get("status").asText());
 		assertEquals(completedSavepoint.getProperties().isSavepoint(), completedSavepointNode.get("is_savepoint").asBoolean());
@@ -286,10 +356,9 @@ public class CheckpointStatsHandlerTest {
 
 		assertEquals(completedSavepoint.getExternalPath(), completedSavepointNode.get("external_path").asText());
 		assertEquals(completedSavepoint.isDiscarded(), completedSavepointNode.get("discarded").asBoolean());
+	}
 
-		assertTrue(it.hasNext());
-		JsonNode failedNode = it.next();
-
+	private static void compareFailedCheckpoint(FailedCheckpointStats failed, JsonNode failedNode) {
 		assertEquals(failed.getCheckpointId(), failedNode.get("id").asLong());
 		assertEquals(failed.getStatus().toString(), failedNode.get("status").asText());
 		assertEquals(failed.getProperties().isSavepoint(), failedNode.get("is_savepoint").asBoolean());
@@ -303,7 +372,56 @@ public class CheckpointStatsHandlerTest {
 
 		assertEquals(failed.getFailureTimestamp(), failedNode.get("failure_timestamp").asLong());
 		assertEquals(failed.getFailureMessage(), failedNode.get("failure_message").asText());
+	}
+	
+	private static class TestCheckpointStats {
+		public final AccessExecutionGraph graph;
+		public final CheckpointStatsCounts counts;
+		public final MinMaxAvgStats stateSizeSummary;
+		public final MinMaxAvgStats durationSummary;
+		public final MinMaxAvgStats alignmentBufferedSummary;
+		public final CompletedCheckpointStatsSummary summary;
+		public final CompletedCheckpointStats latestCompleted;
+		public final CompletedCheckpointStats latestSavepoint;
+		public final FailedCheckpointStats latestFailed;
+		public final RestoredCheckpointStats latestRestored;
+		public final PendingCheckpointStats inProgress;
+		public final CompletedCheckpointStats completedSavepoint;
+		public final FailedCheckpointStats failed;
+		public final CheckpointStatsHistory history;
+		public final CheckpointStatsSnapshot snapshot;
 
-		assertFalse(it.hasNext());
+		public TestCheckpointStats(
+				AccessExecutionGraph graph,
+				CheckpointStatsCounts counts,
+				MinMaxAvgStats stateSizeSummary,
+				MinMaxAvgStats durationSummary,
+				MinMaxAvgStats alignmentBufferedSummary,
+				CompletedCheckpointStatsSummary summary,
+				CompletedCheckpointStats latestCompleted,
+				CompletedCheckpointStats latestSavepoint,
+				FailedCheckpointStats latestFailed,
+				RestoredCheckpointStats latestRestored,
+				PendingCheckpointStats inProgress,
+				CompletedCheckpointStats completedSavepoint,
+				FailedCheckpointStats failed,
+				CheckpointStatsHistory history,
+				CheckpointStatsSnapshot snapshot) {
+			this.graph = graph;
+			this.counts = counts;
+			this.stateSizeSummary = stateSizeSummary;
+			this.durationSummary = durationSummary;
+			this.alignmentBufferedSummary = alignmentBufferedSummary;
+			this.summary = summary;
+			this.latestCompleted = latestCompleted;
+			this.latestSavepoint = latestSavepoint;
+			this.latestFailed = latestFailed;
+			this.latestRestored = latestRestored;
+			this.inProgress = inProgress;
+			this.completedSavepoint = completedSavepoint;
+			this.failed = failed;
+			this.history = history;
+			this.snapshot = snapshot;
+		}
 	}
 }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandlerTest.java
@@ -36,7 +36,7 @@ import org.apache.flink.runtime.checkpoint.RestoredCheckpointStats;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -57,11 +57,11 @@ public class CheckpointStatsHandlerTest {
 
 	@Test
 	public void testArchiver() throws IOException {
-		Archiver archiver = new CheckpointStatsDetailsHandler.CheckpointStatsDetailsArchiver();
+		JsonArchivist archivist = new CheckpointStatsDetailsHandler.CheckpointStatsDetailsJsonArchivist();
 		TestCheckpointStats testCheckpointStats = createTestCheckpointStats();
 		when(testCheckpointStats.graph.getJobID()).thenReturn(new JobID());
 		
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(testCheckpointStats.graph);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(testCheckpointStats.graph);
 		Assert.assertEquals(3, archives.length);
 
 		ObjectMapper mapper = new ObjectMapper();

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandlerTest.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -61,20 +62,21 @@ public class CheckpointStatsHandlerTest {
 		TestCheckpointStats testCheckpointStats = createTestCheckpointStats();
 		when(testCheckpointStats.graph.getJobID()).thenReturn(new JobID());
 		
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(testCheckpointStats.graph);
-		Assert.assertEquals(3, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(testCheckpointStats.graph);
+		Assert.assertEquals(3, archives.size());
 
 		ObjectMapper mapper = new ObjectMapper();
 		
-		ArchivedJson archive1 = archives[0];
+		Iterator<ArchivedJson> iterator = archives.iterator();
+		ArchivedJson archive1 = iterator.next();
 		Assert.assertEquals("/jobs/" + testCheckpointStats.graph.getJobID() + "/checkpoints/details/" + testCheckpointStats.inProgress.getCheckpointId(), archive1.getPath());
 		compareInProgressCheckpoint(testCheckpointStats.inProgress, mapper.readTree(archive1.getJson()));
 
-		ArchivedJson archive2 = archives[1];
+		ArchivedJson archive2 = iterator.next();
 		Assert.assertEquals("/jobs/" + testCheckpointStats.graph.getJobID() + "/checkpoints/details/" + testCheckpointStats.completedSavepoint.getCheckpointId(), archive2.getPath());
 		compareCompletedSavepoint(testCheckpointStats.completedSavepoint, mapper.readTree(archive2.getJson()));
 		
-		ArchivedJson archive3 = archives[2];
+		ArchivedJson archive3 = iterator.next();
 		Assert.assertEquals("/jobs/" + testCheckpointStats.graph.getJobID() + "/checkpoints/details/" + testCheckpointStats.failed.getCheckpointId(), archive3.getPath());
 		compareFailedCheckpoint(testCheckpointStats.failed, mapper.readTree(archive3.getJson()));
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsHandlerTest.java
@@ -67,16 +67,16 @@ public class CheckpointStatsHandlerTest {
 		ObjectMapper mapper = new ObjectMapper();
 		
 		ArchivedJson archive1 = archives[0];
-		Assert.assertEquals("/jobs/" + testCheckpointStats.graph.getJobID() + "/checkpoints/details/" + testCheckpointStats.inProgress.getCheckpointId(), archive1.path);
-		compareInProgressCheckpoint(testCheckpointStats.inProgress, mapper.readTree(archive1.json));
+		Assert.assertEquals("/jobs/" + testCheckpointStats.graph.getJobID() + "/checkpoints/details/" + testCheckpointStats.inProgress.getCheckpointId(), archive1.getPath());
+		compareInProgressCheckpoint(testCheckpointStats.inProgress, mapper.readTree(archive1.getJson()));
 
 		ArchivedJson archive2 = archives[1];
-		Assert.assertEquals("/jobs/" + testCheckpointStats.graph.getJobID() + "/checkpoints/details/" + testCheckpointStats.completedSavepoint.getCheckpointId(), archive2.path);
-		compareCompletedSavepoint(testCheckpointStats.completedSavepoint, mapper.readTree(archive2.json));
+		Assert.assertEquals("/jobs/" + testCheckpointStats.graph.getJobID() + "/checkpoints/details/" + testCheckpointStats.completedSavepoint.getCheckpointId(), archive2.getPath());
+		compareCompletedSavepoint(testCheckpointStats.completedSavepoint, mapper.readTree(archive2.getJson()));
 		
 		ArchivedJson archive3 = archives[2];
-		Assert.assertEquals("/jobs/" + testCheckpointStats.graph.getJobID() + "/checkpoints/details/" + testCheckpointStats.failed.getCheckpointId(), archive3.path);
-		compareFailedCheckpoint(testCheckpointStats.failed, mapper.readTree(archive3.json));
+		Assert.assertEquals("/jobs/" + testCheckpointStats.graph.getJobID() + "/checkpoints/details/" + testCheckpointStats.failed.getCheckpointId(), archive3.getPath());
+		compareFailedCheckpoint(testCheckpointStats.failed, mapper.readTree(archive3.getJson()));
 	}
 	
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsSubtaskDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsSubtaskDetailsHandlerTest.java
@@ -86,8 +86,8 @@ public class CheckpointStatsSubtaskDetailsHandlerTest {
 		ArchivedJson archive = archives[0];
 		Assert.assertEquals(
 			"/jobs/" + graph.getJobID() + "/checkpoints/details/" + checkpoint.getCheckpointId() + "/subtasks/" + task.getJobVertexId(),
-			archive.path);
-		JsonNode rootNode = mapper.readTree(archive.json);
+			archive.getPath());
+		JsonNode rootNode = mapper.readTree(archive.getJson());
 		assertEquals(checkpoint.getCheckpointId(), rootNode.get("id").asLong());
 		assertEquals(checkpoint.getStatus().toString(), rootNode.get("status").asText());
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsSubtaskDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsSubtaskDetailsHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.webmonitor.handlers.checkpoints;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.checkpoint.AbstractCheckpointStats;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsHistory;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
@@ -31,6 +32,9 @@ import org.apache.flink.runtime.checkpoint.TaskStateStats;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
+import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
+import org.apache.flink.runtime.webmonitor.history.Archiver;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -53,6 +57,42 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class CheckpointStatsSubtaskDetailsHandlerTest {
+
+	@Test
+	public void testArchiver() throws Exception {
+		Archiver archiver = new CheckpointStatsDetailsSubtasksHandler.CheckpointStatsDetailsSubtasksArchiver();
+		ObjectMapper mapper = new ObjectMapper();
+
+		PendingCheckpointStats checkpoint = mock(PendingCheckpointStats.class);
+		when(checkpoint.getCheckpointId()).thenReturn(1992139L);
+		when(checkpoint.getStatus()).thenReturn(CheckpointStatsStatus.IN_PROGRESS);
+		when(checkpoint.getTriggerTimestamp()).thenReturn(0L); // ack timestamp = duration
+
+		TaskStateStats task = createTaskStateStats(1237);
+		when(checkpoint.getAllTaskStateStats()).thenReturn(Collections.singletonList(task));
+
+		CheckpointStatsHistory history = mock(CheckpointStatsHistory.class);
+		when(history.getCheckpoints()).thenReturn(Collections.<AbstractCheckpointStats>singletonList(checkpoint));
+		CheckpointStatsSnapshot snapshot = mock(CheckpointStatsSnapshot.class);
+		when(snapshot.getHistory()).thenReturn(history);
+
+		AccessExecutionGraph graph = mock(AccessExecutionGraph.class);
+		when(graph.getCheckpointStatsSnapshot()).thenReturn(snapshot);
+		when(graph.getJobID()).thenReturn(new JobID());
+		
+		ArchivedJson[] archives = archiver.archiveJsonWithPath(graph);
+		Assert.assertEquals(1, archives.length);
+		
+		ArchivedJson archive = archives[0];
+		Assert.assertEquals(
+			"/jobs/" + graph.getJobID() + "/checkpoints/details/" + checkpoint.getCheckpointId() + "/subtasks/" + task.getJobVertexId(),
+			archive.path);
+		JsonNode rootNode = mapper.readTree(archive.json);
+		assertEquals(checkpoint.getCheckpointId(), rootNode.get("id").asLong());
+		assertEquals(checkpoint.getStatus().toString(), rootNode.get("status").asText());
+
+		verifyTaskNode(rootNode, task, checkpoint.getTriggerTimestamp());
+	}
 
 	@Test
 	public void testGetPaths() {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsSubtaskDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsSubtaskDetailsHandlerTest.java
@@ -33,7 +33,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.webmonitor.ExecutionGraphHolder;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
-import org.apache.flink.runtime.webmonitor.history.Archiver;
+import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -60,7 +60,7 @@ public class CheckpointStatsSubtaskDetailsHandlerTest {
 
 	@Test
 	public void testArchiver() throws Exception {
-		Archiver archiver = new CheckpointStatsDetailsSubtasksHandler.CheckpointStatsDetailsSubtasksArchiver();
+		JsonArchivist archivist = new CheckpointStatsDetailsSubtasksHandler.CheckpointStatsDetailsSubtasksJsonArchivist();
 		ObjectMapper mapper = new ObjectMapper();
 
 		PendingCheckpointStats checkpoint = mock(PendingCheckpointStats.class);
@@ -80,7 +80,7 @@ public class CheckpointStatsSubtaskDetailsHandlerTest {
 		when(graph.getCheckpointStatsSnapshot()).thenReturn(snapshot);
 		when(graph.getJobID()).thenReturn(new JobID());
 		
-		ArchivedJson[] archives = archiver.archiveJsonWithPath(graph);
+		ArchivedJson[] archives = archivist.archiveJsonWithPath(graph);
 		Assert.assertEquals(1, archives.length);
 		
 		ArchivedJson archive = archives[0];

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsSubtaskDetailsHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/checkpoints/CheckpointStatsSubtaskDetailsHandlerTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -80,10 +81,10 @@ public class CheckpointStatsSubtaskDetailsHandlerTest {
 		when(graph.getCheckpointStatsSnapshot()).thenReturn(snapshot);
 		when(graph.getJobID()).thenReturn(new JobID());
 		
-		ArchivedJson[] archives = archivist.archiveJsonWithPath(graph);
-		Assert.assertEquals(1, archives.length);
+		Collection<ArchivedJson> archives = archivist.archiveJsonWithPath(graph);
+		Assert.assertEquals(1, archives.size());
 		
-		ArchivedJson archive = archives[0];
+		ArchivedJson archive = archives.iterator().next();
 		Assert.assertEquals(
 			"/jobs/" + graph.getJobID() + "/checkpoints/details/" + checkpoint.getCheckpointId() + "/subtasks/" + task.getJobVertexId(),
 			archive.getPath());

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/ArchivedJobGenerationUtils.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/ArchivedJobGenerationUtils.java
@@ -105,7 +105,7 @@ public class ArchivedJobGenerationUtils {
 		originalAttempt = new ArchivedExecutionBuilder()
 			.setStateTimestamps(new long[]{1, 2, 3, 4, 5, 6, 7, 8, 9})
 			.setParallelSubtaskIndex(1)
-			.setAttemptNumber(3)
+			.setAttemptNumber(0)
 			.setAssignedResourceLocation(location)
 			.setUserAccumulators(new StringifiedAccumulatorResult[]{acc1, acc2})
 			.setState(ExecutionState.FINISHED)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
@@ -23,7 +23,7 @@ import org.apache.flink.util.Preconditions;
 /**
  * A simple container for a handler's JSON response and the REST URLs for which the response would've been returned.
  * 
- * These are created by {@link Archiver}s, and used by the {@link MemoryArchivist} to create a directory structure
+ * These are created by {@link JsonArchivist}s, and used by the {@link MemoryArchivist} to create a directory structure
  * resembling the REST API.
  */
 public class ArchivedJson {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.webmonitor.history;
 
 import org.apache.flink.runtime.jobmanager.MemoryArchivist;
+import org.apache.flink.util.Preconditions;
 
 /**
  * A simple container for a handler's JSON response and the REST URLs for which the response would've been returned.
@@ -30,8 +31,8 @@ public class ArchivedJson {
 	private final String json;
 	
 	public ArchivedJson(String path, String json) {
-		this.path = path;
-		this.json = json;
+		this.path = Preconditions.checkNotNull(path);
+		this.json = Preconditions.checkNotNull(json);
 	}
 
 	public String getPath() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
@@ -17,6 +17,14 @@
  */
 package org.apache.flink.runtime.webmonitor.history;
 
+import org.apache.flink.runtime.jobmanager.MemoryArchivist;
+
+/**
+ * A simple container for a handler's JSON response and the REST URLs for which the response would've been returned.
+ * 
+ * These are created by {@link Archiver}s, and used by the {@link MemoryArchivist} to create a directory structure
+ * resembling the REST API.
+ */
 public class ArchivedJson {
 	private final String path;
 	private final String json;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
@@ -18,11 +18,19 @@
 package org.apache.flink.runtime.webmonitor.history;
 
 public class ArchivedJson {
-	public final String path;
-	public final String json;
+	private final String path;
+	private final String json;
 	
 	public ArchivedJson(String path, String json) {
 		this.path = path;
 		this.json = json;
+	}
+
+	public String getPath() {
+		return path;
+	}
+
+	public String getJson() {
+		return json;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.history;
+
+public class ArchivedJson {
+	public final String path;
+	public final String json;
+	
+	public ArchivedJson(String path, String json) {
+		this.path = path;
+		this.json = json;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/Archiver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/Archiver.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.webmonitor.history;
+
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+
+import java.io.IOException;
+
+public interface Archiver {
+	ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/JsonArchivist.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/JsonArchivist.java
@@ -22,6 +22,25 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import java.io.IOException;
 import java.util.Collection;
 
+/**
+ * Interface for all classes that want to participate in the archiving of job-related json responses.
+ * 
+ * Note that all JsonArchivists that are to be used for the history server must be added
+ * to {@link WebRuntimeMonitor#getArchivers()}.
+ */
 public interface JsonArchivist {
+
+	/**
+	 * Returns a {@link Collection} of {@link ArchivedJson}s containing JSON responses and their respective REST URL
+	 * for a given job.
+	 *
+	 * The collection should contain one entry for every response that could be generated for the given
+	 * job, for example one entry for each task. The REST URLs should be unique and must not contain placeholders.
+	 *
+	 * @param graph AccessExecutionGraph for which the responses should be generated
+	 *
+	 * @return Collection containing an ArchivedJson for every response that could be generated for the given job
+	 * @throws IOException thrown if the JSON generation fails
+	 */
 	Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/JsonArchivist.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/JsonArchivist.java
@@ -21,6 +21,6 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 
 import java.io.IOException;
 
-public interface Archiver {
+public interface JsonArchivist {
 	ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/JsonArchivist.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/JsonArchivist.java
@@ -20,7 +20,8 @@ package org.apache.flink.runtime.webmonitor.history;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 
 import java.io.IOException;
+import java.util.Collection;
 
 public interface JsonArchivist {
-	ArchivedJson[] archiveJsonWithPath(AccessExecutionGraph graph) throws IOException;
+	Collection<ArchivedJson> archiveJsonWithPath(AccessExecutionGraph graph) throws IOException;
 }


### PR DESCRIPTION
This PR adds the last piece to the foundation of the HistoryServer. ~~It builds on top of #3365 and #3376, meaning that only 58649fb is relevant for this PR.~~

The key addition is the ```JsonArchivist``` interface. An ```JsonArchivist``` generates Json responses and their respective REST paths for a given ```AccessExecutionGraph```.

The goal here is to allow writing these responses to files contained in a directory structure resembling the REST API, without defining the structure in 2 different places. With the additions made here the writing of files can be done in a simple loop:
```
AccessExecutiongraph graph = ...
for (JsonArchivistarchiver : WebRuntimeMonitor.getArchivers()) {
	for (ArchivedJson archive : archiver.archive(graph)) {
		File f = createFile(basePath, archive.path);
		writeJson(f, archive.json);
	}
}
```

Instead of extending existing job-related handlers I've added a new class in each of them that implements the new interface. This makes testing easier and also allows for easier refactoring/relocation.