### PR TITLE
[FLINK-5940] [checkpoint] Harden ZooKeeperCompletedCheckpointStore.recover method

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
@@ -195,7 +195,7 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 	}
 
 	@Override
-	public CompletedCheckpoint getLatestCheckpoint() throws Exception {
+	public CompletedCheckpoint getLatestCheckpoint() {
 		if (checkpointStateHandles.isEmpty()) {
 			return null;
 		}
@@ -205,12 +205,16 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 
 				try {
 					return retrieveCompletedCheckpoint(checkpointStateHandle);
-				} catch (FlinkException e) {
+				} catch (Exception e) {
 					LOG.warn("Could not retrieve latest checkpoint. Removing it from " +
 						"the completed checkpoint store.", e);
 
-					// remove the checkpoint with broken state handle
-					removeBrokenStateHandle(checkpointStateHandles.pollLast());
+					try {
+						// remove the checkpoint with broken state handle
+						removeBrokenStateHandle(checkpointStateHandles.pollLast());
+					} catch (Exception removeException) {
+						LOG.warn("Could not remove the latest checkpoint with a broken state handle.", removeException);
+					}
 				}
 			}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
@@ -29,12 +29,14 @@ import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.zookeeper.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
+import org.apache.flink.util.FlinkException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
@@ -162,36 +164,8 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 
 		LOG.info("Found {} checkpoints in ZooKeeper.", numberOfInitialCheckpoints);
 
-		if (numberOfInitialCheckpoints > 0) {
-			// Take the last one. This is the latest checkpoints, because path names are strictly
-			// increasing (checkpoint ID).
-			Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String> latest = initialCheckpoints
-					.get(numberOfInitialCheckpoints - 1);
-
-			CompletedCheckpoint latestCheckpoint;
-			long checkpointId = pathToCheckpointId(latest.f1);
-
-			LOG.info("Trying to retrieve checkpoint {}.", checkpointId);
-
-			try {
-				latestCheckpoint = latest.f0.retrieveState();
-			} catch (Exception e) {
-				throw new Exception("Could not retrieve the completed checkpoint " + checkpointId +
-				" from the state storage.", e);
-			}
-
-			checkpointStateHandles.add(latest);
-
-			LOG.info("Initialized with {}. Removing all older checkpoints.", latestCheckpoint);
-
-			for (int i = 0; i < numberOfInitialCheckpoints - 1; i++) {
-				try {
-					removeSubsumed(initialCheckpoints.get(i));
-				}
-				catch (Exception e) {
-					LOG.error("Failed to discard checkpoint", e);
-				}
-			}
+		for (Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String> checkpoint : initialCheckpoints) {
+			checkpointStateHandles.add(checkpoint);
 		}
 	}
 
@@ -213,7 +187,7 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 		checkpointStateHandles.addLast(new Tuple2<>(stateHandle, path));
 
 		// Everything worked, let's remove a previous checkpoint if necessary.
-		if (checkpointStateHandles.size() > maxNumberOfCheckpointsToRetain) {
+		while (checkpointStateHandles.size() > maxNumberOfCheckpointsToRetain) {
 			removeSubsumed(checkpointStateHandles.removeFirst());
 		}
 
@@ -226,7 +200,21 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 			return null;
 		}
 		else {
-			return checkpointStateHandles.getLast().f0.retrieveState();
+			while(!checkpointStateHandles.isEmpty()) {
+				Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String> checkpointStateHandle = checkpointStateHandles.peekLast();
+
+				try {
+					return retrieveCompletedCheckpoint(checkpointStateHandle);
+				} catch (FlinkException e) {
+					LOG.warn("Could not retrieve latest checkpoint. Removing it from " +
+						"the completed checkpoint store.", e);
+
+					// remove the checkpoint with broken state handle
+					removeBrokenStateHandle(checkpointStateHandles.pollLast());
+				}
+			}
+
+			return null;
 		}
 	}
 
@@ -234,8 +222,21 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 	public List<CompletedCheckpoint> getAllCheckpoints() throws Exception {
 		List<CompletedCheckpoint> checkpoints = new ArrayList<>(checkpointStateHandles.size());
 
-		for (Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String> stateHandle : checkpointStateHandles) {
-			checkpoints.add(stateHandle.f0.retrieveState());
+		Iterator<Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String>> stateHandleIterator = checkpointStateHandles.iterator();
+
+		while (stateHandleIterator.hasNext()) {
+			Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String> stateHandlePath = stateHandleIterator.next();
+
+			try {
+				checkpoints.add(retrieveCompletedCheckpoint(stateHandlePath));
+			} catch (Exception e) {
+				LOG.warn("Could not retrieve checkpoint. Removing it from the completed " +
+					"checkpoint store.", e);
+
+				// remove the checkpoint with broken state handle
+				stateHandleIterator.remove();
+				removeBrokenStateHandle(stateHandlePath);
+			}
 		}
 
 		return checkpoints;
@@ -303,6 +304,10 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 		remove(stateHandleAndPath, action);
 	}
 
+	private void removeBrokenStateHandle(final Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String> stateHandleAndPath) throws Exception {
+		remove(stateHandleAndPath, null);
+	}
+
 	/**
 	 * Removes the state handle from ZooKeeper, discards the checkpoints, and the state handle.
 	 */
@@ -320,11 +325,13 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 						if (event.getResultCode() == 0) {
 							Exception exception = null;
 
-							try {
-								action.call();
-							} catch (Exception e) {
-								exception = new Exception("Could not execute callable action " +
-									"for checkpoint " + checkpointId + '.', e);
+							if (null != action) {
+								try {
+									action.call();
+								} catch (Exception e) {
+									exception = new Exception("Could not execute callable action " +
+										"for checkpoint " + checkpointId + '.', e);
+								}
 							}
 
 							try {
@@ -396,6 +403,18 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 				"checkpoint id to path conversion has changed.", path);
 
 			return -1L;
+		}
+	}
+
+	private static CompletedCheckpoint retrieveCompletedCheckpoint(Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String> stateHandlePath) throws FlinkException {
+		long checkpointId = pathToCheckpointId(stateHandlePath.f1);
+
+		LOG.info("Trying to retrieve checkpoint {}.", checkpointId);
+
+		try {
+			return stateHandlePath.f0.retrieveState();
+		} catch (Exception e) {
+			throw new FlinkException("Could not retrieve checkpoint " + checkpointId + ". The state handle seems to be broken.", e);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -27,11 +27,10 @@ import org.apache.flink.runtime.zookeeper.ZooKeeperTestEnvironment;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
-import scala.concurrent.duration.Deadline;
-import scala.concurrent.duration.FiniteDuration;
 
 import java.io.Serializable;
-import java.util.concurrent.TimeUnit;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -74,7 +73,9 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 	// ---------------------------------------------------------------------------------------------
 
 	/**
-	 * Tests that older checkpoints are cleaned up at startup.
+	 * Tests that older checkpoints are not cleaned up right away when recovering. Only after
+	 * another checkpointed has been completed the old checkpoints exceeding the number of
+	 * checkpoints to retain will be removed.
 	 */
 	@Test
 	public void testRecover() throws Exception {
@@ -96,19 +97,20 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 		// Recover
 		checkpoints.recover();
 
-		// Only the latest one should be in ZK
-		Deadline deadline = new FiniteDuration(1, TimeUnit.MINUTES).fromNow();
-
-		// Retry this operation, because removal is asynchronous
-		while (deadline.hasTimeLeft() && ZooKeeper.getClient()
-				.getChildren().forPath(CheckpointsPath).size() != 1) {
-
-			Thread.sleep(Math.min(100, deadline.timeLeft().toMillis()));
-		}
-
-		assertEquals(1, ZooKeeper.getClient().getChildren().forPath(CheckpointsPath).size());
-		assertEquals(1, checkpoints.getNumberOfRetainedCheckpoints());
+		assertEquals(3, ZooKeeper.getClient().getChildren().forPath(CheckpointsPath).size());
+		assertEquals(3, checkpoints.getNumberOfRetainedCheckpoints());
 		assertEquals(expected[2], checkpoints.getLatestCheckpoint());
+
+		List<CompletedCheckpoint> expectedCheckpoints = new ArrayList<>(3);
+		expectedCheckpoints.add(expected[1]);
+		expectedCheckpoints.add(expected[2]);
+		expectedCheckpoints.add(createCheckpoint(3));
+
+		checkpoints.addCheckpoint(expectedCheckpoints.get(2));
+
+		List<CompletedCheckpoint> actualCheckpoints = checkpoints.getAllCheckpoints();
+
+		assertEquals(expectedCheckpoints, actualCheckpoints);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -65,7 +65,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 			ZooKeeper.createClient(), CheckpointsPath, new RetrievableStateStorageHelper<CompletedCheckpoint>() {
 			@Override
 			public RetrievableStateHandle<CompletedCheckpoint> store(CompletedCheckpoint state) throws Exception {
-				return new HeapRetrievableStateHandle<CompletedCheckpoint>(state);
+				return new HeapRetrievableStateHandle<>(state);
 			}
 		}, Executors.directExecutor());
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -33,8 +33,11 @@ import org.apache.flink.runtime.zookeeper.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -52,7 +55,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ZooKeeperCompletedCheckpointStore.class)
 public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 
 	@Test
@@ -99,6 +105,7 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 		final RetrievableStateStorageHelper<CompletedCheckpoint> storageHelperMock = mock(RetrievableStateStorageHelper.class);
 
 		ZooKeeperStateHandleStore<CompletedCheckpoint> zooKeeperStateHandleStoreMock = spy(new ZooKeeperStateHandleStore<>(client, storageHelperMock, Executors.directExecutor()));
+		whenNew(ZooKeeperStateHandleStore.class).withAnyArguments().thenReturn(zooKeeperStateHandleStoreMock);
 		doReturn(checkpointsInZooKeeper).when(zooKeeperStateHandleStoreMock).getAllSortedByName();
 
 		final int numCheckpointsToRetain = 1;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -33,11 +33,8 @@ import org.apache.flink.runtime.zookeeper.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,10 +52,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(ZooKeeperCompletedCheckpointStore.class)
 public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 
 	@Test
@@ -96,19 +90,22 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 		final RetrievableStateHandle<CompletedCheckpoint> retrievableStateHandle2 = mock(RetrievableStateHandle.class);
 		when(retrievableStateHandle2.retrieveState()).thenReturn(completedCheckpoint2);
 
-		checkpointsInZooKeeper.add(Tuple2.of(retrievableStateHandle1, "foobar1"));
-		checkpointsInZooKeeper.add(Tuple2.of(failingRetrievableStateHandle, "failing1"));
-		checkpointsInZooKeeper.add(Tuple2.of(retrievableStateHandle2, "foobar2"));
-		checkpointsInZooKeeper.add(Tuple2.of(failingRetrievableStateHandle, "failing1"));
+		checkpointsInZooKeeper.add(Tuple2.of(retrievableStateHandle1, "/foobar1"));
+		checkpointsInZooKeeper.add(Tuple2.of(failingRetrievableStateHandle, "/failing1"));
+		checkpointsInZooKeeper.add(Tuple2.of(retrievableStateHandle2, "/foobar2"));
+		checkpointsInZooKeeper.add(Tuple2.of(failingRetrievableStateHandle, "/failing2"));
 
 		final CuratorFramework client = mock(CuratorFramework.class);
 		final RetrievableStateStorageHelper<CompletedCheckpoint> storageHelperMock = mock(RetrievableStateStorageHelper.class);
 
 		ZooKeeperStateHandleStore<CompletedCheckpoint> zooKeeperStateHandleStoreMock = spy(new ZooKeeperStateHandleStore<>(client, storageHelperMock, Executors.directExecutor()));
-		whenNew(ZooKeeperStateHandleStore.class).withAnyArguments().thenReturn(zooKeeperStateHandleStoreMock);
 		doReturn(checkpointsInZooKeeper).when(zooKeeperStateHandleStoreMock).getAllSortedByName();
 
 		final int numCheckpointsToRetain = 1;
+
+		// Mocking for the delete operation on the CuratorFramework client
+		// It assures that the callback is executed synchronously
+
 		final EnsurePath ensurePathMock = mock(EnsurePath.class);
 		final DeleteBuilder deleteBuilderMock = mock(DeleteBuilder.class);
 		final BackgroundVersionable backgroundVersionableMock = mock(BackgroundVersionable.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -18,11 +18,47 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.BackgroundVersionable;
+import org.apache.curator.framework.api.CuratorEvent;
+import org.apache.curator.framework.api.CuratorEventType;
+import org.apache.curator.framework.api.DeleteBuilder;
+import org.apache.curator.framework.api.Pathable;
+import org.apache.curator.utils.EnsurePath;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.state.RetrievableStateHandle;
+import org.apache.flink.runtime.zookeeper.RetrievableStateStorageHelper;
+import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.Executor;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ZooKeeperCompletedCheckpointStore.class)
 public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 
 	@Test
@@ -32,5 +68,113 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 		final String path = ZooKeeperCompletedCheckpointStore.checkpointIdToPath(checkpointId);
 
 		assertEquals(checkpointId, ZooKeeperCompletedCheckpointStore.pathToCheckpointId(path));
+	}
+
+	/**
+	 * Tests that the completed checkpoint store can retrieve all checkpoints stored in ZooKeeper
+	 * and ignores those which cannot be retrieved via their state handles.
+	 */
+	@Test
+	public void testCheckpointRecovery() throws Exception {
+		final List<Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String>> checkpointsInZooKeeper = new ArrayList<>(4);
+
+		final CompletedCheckpoint completedCheckpoint1 = mock(CompletedCheckpoint.class);
+		when(completedCheckpoint1.getCheckpointID()).thenReturn(1L);
+		final CompletedCheckpoint completedCheckpoint2 = mock(CompletedCheckpoint.class);
+		when(completedCheckpoint2.getCheckpointID()).thenReturn(2L);
+
+		final Collection<Long> expectedCheckpointIds = new HashSet<>(2);
+		expectedCheckpointIds.add(1L);
+		expectedCheckpointIds.add(2L);
+
+		final RetrievableStateHandle<CompletedCheckpoint> failingRetrievableStateHandle = mock(RetrievableStateHandle.class);
+		when(failingRetrievableStateHandle.retrieveState()).thenThrow(new Exception("Test exception"));
+
+		final RetrievableStateHandle<CompletedCheckpoint> retrievableStateHandle1 = mock(RetrievableStateHandle.class);
+		when(retrievableStateHandle1.retrieveState()).thenReturn(completedCheckpoint1);
+
+		final RetrievableStateHandle<CompletedCheckpoint> retrievableStateHandle2 = mock(RetrievableStateHandle.class);
+		when(retrievableStateHandle2.retrieveState()).thenReturn(completedCheckpoint2);
+
+		checkpointsInZooKeeper.add(Tuple2.of(retrievableStateHandle1, "foobar1"));
+		checkpointsInZooKeeper.add(Tuple2.of(failingRetrievableStateHandle, "failing1"));
+		checkpointsInZooKeeper.add(Tuple2.of(retrievableStateHandle2, "foobar2"));
+		checkpointsInZooKeeper.add(Tuple2.of(failingRetrievableStateHandle, "failing1"));
+
+		final CuratorFramework client = mock(CuratorFramework.class);
+		final RetrievableStateStorageHelper<CompletedCheckpoint> storageHelperMock = mock(RetrievableStateStorageHelper.class);
+
+		ZooKeeperStateHandleStore<CompletedCheckpoint> zooKeeperStateHandleStoreMock = spy(new ZooKeeperStateHandleStore<>(client, storageHelperMock, Executors.directExecutor()));
+		whenNew(ZooKeeperStateHandleStore.class).withAnyArguments().thenReturn(zooKeeperStateHandleStoreMock);
+		doReturn(checkpointsInZooKeeper).when(zooKeeperStateHandleStoreMock).getAllSortedByName();
+
+		final int numCheckpointsToRetain = 1;
+		final EnsurePath ensurePathMock = mock(EnsurePath.class);
+		final DeleteBuilder deleteBuilderMock = mock(DeleteBuilder.class);
+		final BackgroundVersionable backgroundVersionableMock = mock(BackgroundVersionable.class);
+
+		when(client.newNamespaceAwareEnsurePath(anyString())).thenReturn(ensurePathMock);
+		when(client.delete()).thenReturn(deleteBuilderMock);
+		when(deleteBuilderMock.deletingChildrenIfNeeded()).thenReturn(backgroundVersionableMock);
+		when(backgroundVersionableMock.inBackground(any(BackgroundCallback.class), any(Executor.class))).thenAnswer(new Answer<Pathable<Void>>() {
+			@Override
+			public Pathable<Void> answer(InvocationOnMock invocation) throws Throwable {
+				final BackgroundCallback callback = (BackgroundCallback) invocation.getArguments()[0];
+
+				final CuratorEvent curatorEventMock = mock(CuratorEvent.class);
+				when(curatorEventMock.getType()).thenReturn(CuratorEventType.DELETE);
+				when(curatorEventMock.getResultCode()).thenReturn(0);
+
+				Pathable<Void> result = mock(Pathable.class);
+
+				when(result.forPath(anyString())).thenAnswer(new Answer<Void>() {
+					@Override
+					public Void answer(InvocationOnMock invocation) throws Throwable {
+
+						callback.processResult(client, curatorEventMock);
+
+						return null;
+					}
+				});
+
+				return result;
+			}
+		});
+
+		final String checkpointsPath = "foobar";
+		final RetrievableStateStorageHelper<CompletedCheckpoint> stateSotrage = mock(RetrievableStateStorageHelper.class);
+
+		ZooKeeperCompletedCheckpointStore zooKeeperCompletedCheckpointStore = new ZooKeeperCompletedCheckpointStore(
+			numCheckpointsToRetain,
+			client,
+			checkpointsPath,
+			stateSotrage,
+			Executors.directExecutor());
+
+		zooKeeperCompletedCheckpointStore.recover();
+
+		CompletedCheckpoint latestCompletedCheckpoint = zooKeeperCompletedCheckpointStore.getLatestCheckpoint();
+
+		// check that we return the latest retrievable checkpoint
+		// this should remove the latest checkpoint because it is broken
+		assertEquals(completedCheckpoint2.getCheckpointID(), latestCompletedCheckpoint.getCheckpointID());
+
+		// this should remove the second broken checkpoint because we're iterating over all checkpoints
+		List<CompletedCheckpoint> completedCheckpoints = zooKeeperCompletedCheckpointStore.getAllCheckpoints();
+
+		Collection<Long> actualCheckpointIds = new HashSet<>(completedCheckpoints.size());
+
+		for (CompletedCheckpoint completedCheckpoint : completedCheckpoints) {
+			actualCheckpointIds.add(completedCheckpoint.getCheckpointID());
+		}
+
+		assertEquals(expectedCheckpointIds, actualCheckpointIds);
+
+		// check that we did not discard any of the state handles which were retrieved
+		verify(retrievableStateHandle1, never()).discardState();
+		verify(retrievableStateHandle2, never()).discardState();
+
+		// check that we have discarded the state handles which could not be retrieved
+		verify(failingRetrievableStateHandle, times(2)).discardState();
 	}
 }


### PR DESCRIPTION
Before ZooKeeperCompletedCheckpointStore only tried to recover the latest completed
checkpoint even though it might have read older checkpoint state handles from
ZooKeeper. In order to deal with corrupted state handles, this commit changes the
behaviour such that the completed checkpoint store adds all read retrievable
state handles from ZooKeeper and upon request of the latest checkpoint it will
return the latest completed checkpoint which could be retrieved from the state
handles. Broken state handles are removed from the completed checkpoint store and
ZooKeeper.
