### PR TITLE
[backport-1.2] [FLINK-5942] [checkpoint] Harden ZooKeeperStateHandleStore to handle corrupt data

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -240,7 +240,7 @@ public class ZooKeeperStateHandleStore<T extends Serializable> {
 		try {
 			return InstantiationUtil.deserializeObject(data, Thread.currentThread().getContextClassLoader());
 		} catch (IOException | ClassNotFoundException e) {
-			throw new Exception("Failed to deserialize state handle from ZooKeeper data from " +
+			throw new IOException("Failed to deserialize state handle from ZooKeeper data from " +
 				pathInZooKeeper + '.', e);
 		}
 	}
@@ -285,6 +285,8 @@ public class ZooKeeperStateHandleStore<T extends Serializable> {
 
 		retry:
 		while (!success) {
+			stateHandles.clear();
+
 			Stat stat = client.checkExists().forPath("/");
 			if (stat == null) {
 				break; // Node does not exist, done.
@@ -303,6 +305,9 @@ public class ZooKeeperStateHandleStore<T extends Serializable> {
 					} catch (KeeperException.NoNodeException ignored) {
 						// Concurrent deletion, retry
 						continue retry;
+					} catch (IOException ioException) {
+						LOG.warn("Could not get all ZooKeeper children. Node {} contained " +
+							"corrupted data. Ignoring this node.", path, ioException);
 					}
 				}
 
@@ -333,6 +338,8 @@ public class ZooKeeperStateHandleStore<T extends Serializable> {
 
 		retry:
 		while (!success) {
+			stateHandles.clear();
+
 			Stat stat = client.checkExists().forPath("/");
 			if (stat == null) {
 				break; // Node does not exist, done.
@@ -353,6 +360,9 @@ public class ZooKeeperStateHandleStore<T extends Serializable> {
 					} catch (KeeperException.NoNodeException ignored) {
 						// Concurrent deletion, retry
 						continue retry;
+					} catch (IOException ioException) {
+						LOG.warn("Could not get all ZooKeeper children. Node {} contained " +
+							"corrupted data. Ignoring this node.", path, ioException);
 					}
 				}
 


### PR DESCRIPTION
Backport of #3446 onto the `release-1.2` branch.

If calling ZooKeeperStateHandleStore.getAll or getAllSortedByName as the
ZooKeeperCompletedCheckpointStore does in the recovery case, the operation will fail
if there exists a Znode with corrupted data. This will break Flink's recovery
mechanism, because it will read this node over and over again. In order to solve this
problem, this commit changes the behaviour such that it ignores corrupted Znodes it
cannot read.
