### PR TITLE
[backport-1.1] [FLINK-5940] [checkpoint] Harden ZooKeeperCompletedCheckpointStore.recover method

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
@@ -193,7 +193,7 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 	}
 
 	@Override
-	public CompletedCheckpoint getLatestCheckpoint() throws Exception {
+	public CompletedCheckpoint getLatestCheckpoint() {
 		if (checkpointStateHandles.isEmpty()) {
 			return null;
 		}
@@ -207,8 +207,12 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 					LOG.warn("Could not retrieve latest checkpoint. Removing it from " +
 						"the completed checkpoint store.", e);
 
-					// remove the checkpoint with broken state handle
-					removeFromZooKeeperAndDiscardCheckpoint(checkpointStateHandles.pollLast());
+					try {
+						// remove the checkpoint with broken state handle
+						removeFromZooKeeperAndDiscardCheckpoint(checkpointStateHandles.pollLast());
+					} catch (Exception removeException) {
+						LOG.warn("Could not remove the latest checkpoint with a broken state handle.", removeException);
+					}
 				}
 			}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Executor;
 
@@ -162,36 +163,8 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 
 		LOG.info("Found {} checkpoints in ZooKeeper.", numberOfInitialCheckpoints);
 
-		if (numberOfInitialCheckpoints > 0) {
-			// Take the last one. This is the latest checkpoints, because path names are strictly
-			// increasing (checkpoint ID).
-			Tuple2<StateHandle<CompletedCheckpoint>, String> latest = initialCheckpoints
-					.get(numberOfInitialCheckpoints - 1);
-
-			CompletedCheckpoint latestCheckpoint;
-			long checkpointId = pathToCheckpointId(latest.f1);
-
-			LOG.info("Trying to retrieve checkpoint {}.", checkpointId);
-
-			try {
-				latestCheckpoint = latest.f0.getState(userClassLoader);
-			} catch (Exception e) {
-				throw new Exception("Could not retrieve the completed checkpoint " + checkpointId +
-				" from the state storage.", e);
-			}
-
-			checkpointStateHandles.add(latest);
-
-			LOG.info("Initialized with {}. Removing all older checkpoints.", latestCheckpoint);
-
-			for (int i = 0; i < numberOfInitialCheckpoints - 1; i++) {
-				try {
-					removeFromZooKeeperAndDiscardCheckpoint(initialCheckpoints.get(i));
-				}
-				catch (Exception e) {
-					LOG.error("Failed to discard checkpoint", e);
-				}
-			}
+		for (Tuple2<StateHandle<CompletedCheckpoint>, String> checkpoint : initialCheckpoints) {
+			checkpointStateHandles.add(checkpoint);
 		}
 	}
 
@@ -212,7 +185,7 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 		checkpointStateHandles.addLast(new Tuple2<>(stateHandle, path));
 
 		// Everything worked, let's remove a previous checkpoint if necessary.
-		if (checkpointStateHandles.size() > maxNumberOfCheckpointsToRetain) {
+		while (checkpointStateHandles.size() > maxNumberOfCheckpointsToRetain) {
 			removeFromZooKeeperAndDiscardCheckpoint(checkpointStateHandles.removeFirst());
 		}
 
@@ -225,7 +198,21 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 			return null;
 		}
 		else {
-			return checkpointStateHandles.getLast().f0.getState(userClassLoader);
+			while(!checkpointStateHandles.isEmpty()) {
+				Tuple2<StateHandle<CompletedCheckpoint>, String> checkpointStateHandle = checkpointStateHandles.peekLast();
+
+				try {
+					return retrieveCompletedCheckpoint(checkpointStateHandle);
+				} catch (Exception e) {
+					LOG.warn("Could not retrieve latest checkpoint. Removing it from " +
+						"the completed checkpoint store.", e);
+
+					// remove the checkpoint with broken state handle
+					removeFromZooKeeperAndDiscardCheckpoint(checkpointStateHandles.pollLast());
+				}
+			}
+
+			return null;
 		}
 	}
 
@@ -233,8 +220,21 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 	public List<CompletedCheckpoint> getAllCheckpoints() throws Exception {
 		List<CompletedCheckpoint> checkpoints = new ArrayList<>(checkpointStateHandles.size());
 
-		for (Tuple2<StateHandle<CompletedCheckpoint>, String> stateHandle : checkpointStateHandles) {
-			checkpoints.add(stateHandle.f0.getState(userClassLoader));
+		Iterator<Tuple2<StateHandle<CompletedCheckpoint>, String>> stateHandleIterator = checkpointStateHandles.iterator();
+
+		while (stateHandleIterator.hasNext()) {
+			Tuple2<StateHandle<CompletedCheckpoint>, String> stateHandlePath = stateHandleIterator.next();
+
+			try {
+				checkpoints.add(retrieveCompletedCheckpoint(stateHandlePath));
+			} catch (Exception e) {
+				LOG.warn("Could not retrieve checkpoint. Removing it from the completed " +
+					"checkpoint store.", e);
+
+				// remove the checkpoint with broken state handle
+				stateHandleIterator.remove();
+				removeFromZooKeeperAndDiscardCheckpoint(stateHandlePath);
+			}
 		}
 
 		return checkpoints;
@@ -292,9 +292,9 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 							// The checkpoint
 							CompletedCheckpoint checkpoint = null;
 
-							try {
+								try {
 								checkpoint = stateHandleAndPath.f0.getState(userClassLoader);
-							} catch (Exception e) {
+								} catch (Exception e) {
 								Exception newException = new Exception("Could not retrieve the completed checkpoint " +
 									checkpointId + " from the state storage.", e);
 
@@ -383,6 +383,18 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 				"checkpoint id to path conversion has changed.", path);
 
 			return -1L;
+		}
+	}
+
+	private CompletedCheckpoint retrieveCompletedCheckpoint(Tuple2<StateHandle<CompletedCheckpoint>, String> stateHandlePath) throws Exception {
+		long checkpointId = pathToCheckpointId(stateHandlePath.f1);
+
+		LOG.info("Trying to retrieve checkpoint {}.", checkpointId);
+
+		try {
+			return stateHandlePath.f0.getState(userClassLoader);
+		} catch (Exception e) {
+			throw new Exception("Could not retrieve checkpoint " + checkpointId + ". The state handle seems to be broken.", e);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -27,10 +27,9 @@ import org.apache.flink.runtime.zookeeper.ZooKeeperTestEnvironment;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
-import scala.concurrent.duration.Deadline;
-import scala.concurrent.duration.FiniteDuration;
 
-import java.util.concurrent.TimeUnit;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -73,7 +72,9 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 	// ---------------------------------------------------------------------------------------------
 
 	/**
-	 * Tests that older checkpoints are cleaned up at startup.
+	 * Tests that older checkpoints are not cleaned up right away when recovering. Only after
+	 * another checkpointed has been completed the old checkpoints exceeding the number of
+	 * checkpoints to retain will be removed.
 	 */
 	@Test
 	public void testRecover() throws Exception {
@@ -96,19 +97,20 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 		// Recover
 		checkpoints.recover();
 
-		// Only the latest one should be in ZK
-		Deadline deadline = new FiniteDuration(1, TimeUnit.MINUTES).fromNow();
-
-		// Retry this operation, because removal is asynchronous
-		while (deadline.hasTimeLeft() && ZooKeeper.getClient()
-				.getChildren().forPath(CheckpointsPath).size() != 1) {
-
-			Thread.sleep(Math.min(100, deadline.timeLeft().toMillis()));
-		}
-
-		assertEquals(1, ZooKeeper.getClient().getChildren().forPath(CheckpointsPath).size());
-		assertEquals(1, checkpoints.getNumberOfRetainedCheckpoints());
+		assertEquals(3, ZooKeeper.getClient().getChildren().forPath(CheckpointsPath).size());
+		assertEquals(3, checkpoints.getNumberOfRetainedCheckpoints());
 		assertEquals(expected[2], checkpoints.getLatestCheckpoint());
+
+		List<CompletedCheckpoint> expectedCheckpoints = new ArrayList<>(3);
+		expectedCheckpoints.add(expected[1]);
+		expectedCheckpoints.add(expected[2]);
+		expectedCheckpoints.add(createCheckpoint(3));
+
+		checkpoints.addCheckpoint(expectedCheckpoints.get(2));
+
+		List<CompletedCheckpoint> actualCheckpoints = checkpoints.getAllCheckpoints();
+
+		assertEquals(expectedCheckpoints, actualCheckpoints);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -33,8 +33,11 @@ import org.apache.flink.runtime.zookeeper.StateStorageHelper;
 import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -53,7 +56,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ZooKeeperCompletedCheckpointStore.class)
 public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 
 	@Test
@@ -100,6 +106,7 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 		final StateStorageHelper<Serializable> storageHelperMock = mock(StateStorageHelper.class);
 
 		ZooKeeperStateHandleStore<Serializable> zooKeeperStateHandleStoreMock = spy(new ZooKeeperStateHandleStore<>(client, storageHelperMock, MoreExecutors.directExecutor()));
+		whenNew(ZooKeeperStateHandleStore.class).withAnyArguments().thenReturn(zooKeeperStateHandleStoreMock);
 		doReturn(checkpointsInZooKeeper).when(zooKeeperStateHandleStoreMock).getAllSortedByName();
 
 		final int numCheckpointsToRetain = 1;


### PR DESCRIPTION
Backpor of #3446 onto `release-1.1` branch.

The ZooKeeperCompletedCheckpointStore only tries to recover the latest completed
checkpoint even though it might have read older checkpoint state handles from
ZooKeeper. In order to deal with corrupted state handles, this commit changes the
behaviour such that the completed checkpoint store adds all read retrievable
state handles from ZooKeeper and upon request of the latest checkpoint it will
return the latest completed checkpoint which could be retrieved from the state
handles. Broken state handles are removed from the completed checkpoint store and
ZooKeeper.
