### PR TITLE
[FLINK-5945] [core] Close function in OuterJoinOperatorBase#executeOnCollections

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/base/OuterJoinOperatorBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/base/OuterJoinOperatorBase.java
@@ -103,7 +103,6 @@ public class OuterJoinOperatorBase<IN1, IN2, OUT, FT extends FlatJoinFunction<IN
 		FunctionUtils.setFunctionRuntimeContext(function, runtimeContext);
 		FunctionUtils.openFunction(function, this.parameters);
 
-
 		List<OUT> result = new ArrayList<>();
 		Collector<OUT> collector = new CopyingListCollector<>(result, outInformation.createSerializer(executionConfig));
 
@@ -112,6 +111,8 @@ public class OuterJoinOperatorBase<IN1, IN2, OUT, FT extends FlatJoinFunction<IN
 			IN2 right = outerJoinIterator.getRight();
 			function.join(left == null ? null : leftSerializer.copy(left), right == null ? null : rightSerializer.copy(right), collector);
 		}
+
+		FunctionUtils.closeFunction(function);
 
 		return result;
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/link_analysis/HITSTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/link_analysis/HITSTest.java
@@ -80,7 +80,7 @@ extends AsmTestBase {
 	public void testWithRMatGraph()
 			throws Exception {
 		DataSet<Result<LongValue>> hits = directedRMatGraph
-			.run(new HITS<LongValue, NullValue, NullValue>(0.000001));
+			.run(new HITS<LongValue, NullValue, NullValue>(1));
 
 		Checksum checksum = new ChecksumHashCode<Result<LongValue>>()
 			.run(hits)


### PR DESCRIPTION
Conclude OuterJoinOperatorBase#executeOnCollections with a call to FunctionUtils.closeFunction(function) in order to close rich user functions.