### PR TITLE
[FLINK-5948] Fix error in Python zip_with_index documentation

### DIFF
--- a/docs/dev/batch/zip_elements_guide.md
+++ b/docs/dev/batch/zip_elements_guide.md
@@ -72,7 +72,7 @@ env = get_environment()
 env.set_parallelism(2)
 input = env.from_elements("A", "B", "C", "D", "E", "F", "G", "H")
 
-result = input.zipWithIndex()
+result = input.zip_with_index()
 
 result.write_text(result_path)
 env.execute()


### PR DESCRIPTION
Fixes an issue with the documentation where the camel-cased name `zipWithIndex` is used instead of the snake-cased name (`zip_with_index`).