### PR TITLE
[FLINK-5135] [runtime] [FLIP-6] Expand the memory types in ResourceProfile related with ResourceSpec

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -36,27 +36,54 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 
 	private static final long serialVersionUID = 1L;
 
-	public static final ResourceProfile UNKNOWN = new ResourceProfile(-1.0, -1L);
+	public static final ResourceProfile UNKNOWN = new ResourceProfile(-1.0, -1);
 
 	// ------------------------------------------------------------------------
 
 	/** How many cpu cores are needed, use double so we can specify cpu like 0.1 */
 	private final double cpuCores;
 
-	/** How many memory in mb are needed */
-	private final long memoryInMB;
+	/** How many heap memory in mb are needed */
+	private final int heapMemoryInMB;
+
+	/** How many direct memory in mb are needed */
+	private final int directMemoryInMB;
+
+	/** How many native memory in mb are needed */
+	private final int nativeMemoryInMB;
 
 	// ------------------------------------------------------------------------
 
 	/**
 	 * Creates a new ResourceProfile.
-	 * 
-	 * @param cpuCores   The number of CPU cores (possibly fractional, i.e., 0.2 cores)
-	 * @param memoryInMB The size of the memory, in megabytes.
+	 *
+	 * @param cpuCores The number of CPU cores (possibly fractional, i.e., 0.2 cores)
+	 * @param heapMemoryInMB The size of the heap memory, in megabytes.
+	 * @param directMemoryInMB The size of the direct memory, in megabytes.
+	 * @param nativeMemoryInMB The size of the native memory, in megabytes.
 	 */
-	public ResourceProfile(double cpuCores, long memoryInMB) {
+	public ResourceProfile(
+			double cpuCores,
+			int heapMemoryInMB,
+			int directMemoryInMB,
+			int nativeMemoryInMB) {
 		this.cpuCores = cpuCores;
-		this.memoryInMB = memoryInMB;
+		this.heapMemoryInMB = heapMemoryInMB;
+		this.directMemoryInMB = directMemoryInMB;
+		this.nativeMemoryInMB = nativeMemoryInMB;
+	}
+
+	/**
+	 * Creates a new simple ResourceProfile used for testing.
+	 *
+	 * @param cpuCores The number of CPU cores (possibly fractional, i.e., 0.2 cores)
+	 * @param heapMemoryInMB The size of the heap memory, in megabytes.
+	 */
+	public ResourceProfile(double cpuCores, int heapMemoryInMB) {
+		this.cpuCores = cpuCores;
+		this.heapMemoryInMB = heapMemoryInMB;
+		this.directMemoryInMB = 0;
+		this.nativeMemoryInMB = 0;
 	}
 
 	/**
@@ -66,7 +93,9 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 	 */
 	public ResourceProfile(ResourceProfile other) {
 		this.cpuCores = other.cpuCores;
-		this.memoryInMB = other.memoryInMB;
+		this.heapMemoryInMB = other.heapMemoryInMB;
+		this.directMemoryInMB = other.directMemoryInMB;
+		this.nativeMemoryInMB = other.nativeMemoryInMB;
 	}
 
 	// ------------------------------------------------------------------------
@@ -80,11 +109,35 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 	}
 
 	/**
-	 * Get the memory needed in MB
-	 * @return The memory in MB
+	 * Get the heap memory needed in MB
+	 * @return The heap memory in MB
 	 */
-	public long getMemoryInMB() {
-		return memoryInMB;
+	public long getHeapMemoryInMB() {
+		return heapMemoryInMB;
+	}
+
+	/**
+	 * Get the direct memory needed in MB
+	 * @return The direct memory in MB
+	 */
+	public int getDirectMemoryInMB() {
+		return directMemoryInMB;
+	}
+
+	/**
+	 * Get the native memory needed in MB
+	 * @return The native memory in MB
+	 */
+	public int getNativeMemoryInMB() {
+		return nativeMemoryInMB;
+	}
+
+	/**
+	 * Get the total memory needed in MB
+	 * @return The total memory in MB
+	 */
+	public int getMemoryInMB() {
+		return heapMemoryInMB + directMemoryInMB + nativeMemoryInMB;
 	}
 
 	/**
@@ -94,22 +147,29 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 	 * @return true if the requirement is matched, otherwise false
 	 */
 	public boolean isMatching(ResourceProfile required) {
-		return cpuCores >= required.getCpuCores() && memoryInMB >= required.getMemoryInMB();
+		return cpuCores >= required.getCpuCores() &&
+				heapMemoryInMB >= required.getHeapMemoryInMB() &&
+				directMemoryInMB >= required.getDirectMemoryInMB() &&
+				nativeMemoryInMB >= required.getNativeMemoryInMB();
 	}
 
 	@Override
 	public int compareTo(@Nonnull ResourceProfile other) {
-		int cmp1 = Long.compare(this.memoryInMB, other.memoryInMB);
+		int cmp1 = Integer.compare(this.getMemoryInMB(), other.getMemoryInMB());
 		int cmp2 = Double.compare(this.cpuCores, other.cpuCores);
-		return (cmp1 != 0) ? cmp1 : cmp2; 
+		return (cmp1 != 0) ? cmp1 : cmp2;
 	}
 
 	// ------------------------------------------------------------------------
 
 	@Override
 	public int hashCode() {
-		long cpuBits = Double.doubleToRawLongBits(cpuCores);
-		return (int) (cpuBits ^ (cpuBits >>> 32) ^ memoryInMB ^ (memoryInMB >> 32));
+		final long cpuBits =  Double.doubleToLongBits(cpuCores);
+		int result = (int) (cpuBits ^ (cpuBits >>> 32));
+		result = 31 * result + heapMemoryInMB;
+		result = 31 * result + directMemoryInMB;
+		result = 31 * result + nativeMemoryInMB;
+		return result;
 	}
 
 	@Override
@@ -119,7 +179,9 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 		}
 		else if (obj != null && obj.getClass() == ResourceProfile.class) {
 			ResourceProfile that = (ResourceProfile) obj;
-			return this.cpuCores == that.cpuCores && this.memoryInMB == that.memoryInMB; 
+			return this.cpuCores == that.cpuCores &&
+					this.heapMemoryInMB == that.heapMemoryInMB &&
+					this.directMemoryInMB == that.directMemoryInMB;
 		}
 		else {
 			return false;
@@ -130,7 +192,9 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 	public String toString() {
 		return "ResourceProfile{" +
 			"cpuCores=" + cpuCores +
-			", memoryInMB=" + memoryInMB +
+			", heapMemoryInMB=" + heapMemoryInMB +
+			", directMemoryInMB=" + directMemoryInMB +
+			", nativeMemoryInMB=" + nativeMemoryInMB +
 			'}';
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -201,7 +201,7 @@ public class TaskManagerServices {
 		final List<ResourceProfile> resourceProfiles = new ArrayList<>(taskManagerServicesConfiguration.getNumberOfSlots());
 
 		for (int i = 0; i < taskManagerServicesConfiguration.getNumberOfSlots(); i++) {
-			resourceProfiles.add(new ResourceProfile(1.0, 42L));
+			resourceProfiles.add(new ResourceProfile(1.0, 42));
 		}
 
 		final TimerService<AllocationID> timerService = new TimerService<>(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
@@ -27,10 +27,10 @@ public class ResourceProfileTest {
 
 	@Test
 	public void testMatchRequirement() throws Exception {
-		ResourceProfile rp1 = new ResourceProfile(1.0, 100);
-		ResourceProfile rp2 = new ResourceProfile(1.0, 200);
-		ResourceProfile rp3 = new ResourceProfile(2.0, 100);
-		ResourceProfile rp4 = new ResourceProfile(2.0, 200);
+		ResourceProfile rp1 = new ResourceProfile(1.0, 100, 100, 100);
+		ResourceProfile rp2 = new ResourceProfile(1.0, 200, 200, 200);
+		ResourceProfile rp3 = new ResourceProfile(2.0, 100, 100, 100);
+		ResourceProfile rp4 = new ResourceProfile(2.0, 200, 200, 200);
 
 		assertFalse(rp1.isMatching(rp2));
 		assertTrue(rp2.isMatching(rp1));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
@@ -53,7 +53,7 @@ public class SlotManagerTest {
 
 	private static final double DEFAULT_TESTING_CPU_CORES = 1.0;
 
-	private static final long DEFAULT_TESTING_MEMORY = 512;
+	private static final int DEFAULT_TESTING_MEMORY = 512;
 
 	private static final ResourceProfile DEFAULT_TESTING_PROFILE =
 		new ResourceProfile(DEFAULT_TESTING_CPU_CORES, DEFAULT_TESTING_MEMORY);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -86,7 +86,7 @@ public class TaskExecutorITCase {
 		final String jmAddress = "jm";
 		final UUID jmLeaderId = UUID.randomUUID();
 		final JobID jobId = new JobID();
-		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1L);
+		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
 
 		testingHAServices.setResourceManagerLeaderElectionService(rmLeaderElectionService);
 		testingHAServices.setResourceManagerLeaderRetriever(rmLeaderRetrievalService);


### PR DESCRIPTION
This is a part of fine-grained resource configuration in `flip6`

The `JobManager` requests slot with `ResourceProfile` from `ResourceManager` before deployment. Currently the `ResourceProfile` only contains cpu cores and memory fields. The memory should be expanded to different types like heap memory, direct memory and native memory corresponding with `ResourceSpec`.

Further, the direct memory in `ResourceProfile` would be considered in `ContaineredTaskManagerParameters` used to set JVM options before launching the `TaskManager` process.

And some other related processes in runtime would be submitted later:
1. `SlotPool` requests slot to get preferred resource from `JobVertex`, which is blocked by [PR-3455](https://github.com/apache/flink/pull/3455)
2. Sets the `ResourceProfile` to `TaskManager` by `ResourceManager`

BTW, the `mvn clean verify` is successful in my machine.