### PR TITLE
[FLINK-5955] [table] Merging a list of buffered records will have problem when ObjectReuse is turned on

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateReduceGroupFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateReduceGroupFunction.scala
@@ -22,6 +22,7 @@ import java.util.{ArrayList => JArrayList}
 
 import org.apache.flink.api.common.functions.RichGroupReduceFunction
 import org.apache.flink.configuration.Configuration
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.functions.{Accumulator, AggregateFunction}
 import org.apache.flink.types.Row
 import org.apache.flink.util.{Collector, Preconditions}
@@ -51,7 +52,6 @@ class AggregateReduceGroupFunction(
   protected var aggregateBuffer: Row = _
   private var output: Row = _
   private var intermediateGroupKeys: Option[Array[Int]] = None
-  protected val maxMergeLen = 16
   val accumulatorList = Array.fill(aggregates.length) {
     new JArrayList[Accumulator]()
   }
@@ -80,29 +80,31 @@ class AggregateReduceGroupFunction(
     // merge intermediate aggregate value to buffer.
     var last: Row = null
     accumulatorList.foreach(_.clear())
+    for (i <- aggregates.indices) {
+      val accumulator = aggregates(i).createAccumulator()
+      accumulatorList(i).add(accumulator)
+      accumulatorList(i).add(accumulator)
+    }
 
     val iterator = records.iterator()
 
-    var count: Int = 0
     while (iterator.hasNext) {
       val record = iterator.next()
-      count += 1
-      // per each aggregator, collect its accumulators to a list
+
       for (i <- aggregates.indices) {
-        accumulatorList(i).add(record.getField(groupKeysMapping.length + i)
-                                 .asInstanceOf[Accumulator])
-      }
-      // if the number of buffered accumulators is bigger than maxMergeLen, merge them into one
-      // accumulator
-      if (count > maxMergeLen) {
-        count = 0
-        for (i <- aggregates.indices) {
-          val agg = aggregates(i)
-          val accumulator = agg.merge(accumulatorList(i))
-          accumulatorList(i).clear()
-          accumulatorList(i).add(accumulator)
+        val newAcc = record.getField(groupKeysMapping.length + i)
+          .asInstanceOf[Accumulator]
+        accumulatorList(i).set(1, newAcc)
+        val retAcc = aggregates(i).merge(accumulatorList(i))
+        if (System.identityHashCode(newAcc) == System.identityHashCode(retAcc)) {
+          throw TableException(
+            "Due to the Object Reuse, it is not safe to use the newACC intance (index = 1) to " +
+              "save the merge result. You can change your merge function to use the first " +
+              "instance (index = 0) instead.")
         }
+        accumulatorList(i).set(0, retAcc)
       }
+
       last = record
     }
 
@@ -116,8 +118,7 @@ class AggregateReduceGroupFunction(
     aggregateMapping.foreach {
       case (after, previous) => {
         val agg = aggregates(previous)
-        val accumulator = agg.merge(accumulatorList(previous))
-        val result = agg.getValue(accumulator)
+        val result = agg.getValue(accumulatorList(previous).get(0))
         output.setField(after, result)
       }
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetTumbleTimeWindowAggReduceCombineFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetTumbleTimeWindowAggReduceCombineFunction.scala
@@ -18,9 +18,9 @@
 package org.apache.flink.table.runtime.aggregate
 
 import java.lang.Iterable
-import java.util.{ArrayList => JArrayList}
 
 import org.apache.flink.api.common.functions.CombineFunction
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.functions.{Accumulator, AggregateFunction}
 import org.apache.flink.types.Row
 
@@ -68,38 +68,39 @@ class DataSetTumbleTimeWindowAggReduceCombineFunction(
   override def combine(records: Iterable[Row]): Row = {
 
     var last: Row = null
+
     accumulatorList.foreach(_.clear())
+    for (i <- aggregates.indices) {
+      val accumulator = aggregates(i).createAccumulator()
+      accumulatorList(i).add(accumulator)
+      accumulatorList(i).add(accumulator)
+    }
 
     val iterator = records.iterator()
 
-    var count: Int = 0
     while (iterator.hasNext) {
       val record = iterator.next()
-      count += 1
-      // per each aggregator, collect its accumulators to a list
+
       for (i <- aggregates.indices) {
-        accumulatorList(i).add(record.getField(groupKeysMapping.length + i)
-                                 .asInstanceOf[Accumulator])
-      }
-      // if the number of buffered accumulators is bigger than maxMergeLen, merge them into one
-      // accumulator
-      if (count > maxMergeLen) {
-        count = 0
-        for (i <- aggregates.indices) {
-          val agg = aggregates(i)
-          val accumulator = agg.merge(accumulatorList(i))
-          accumulatorList(i).clear()
-          accumulatorList(i).add(accumulator)
+        val newAcc = record.getField(groupKeysMapping.length + i)
+          .asInstanceOf[Accumulator]
+        accumulatorList(i).set(1, newAcc)
+        val retAcc = aggregates(i).merge(accumulatorList(i))
+        if (System.identityHashCode(newAcc) == System.identityHashCode(retAcc)) {
+          throw TableException(
+            "Due to the Object Reuse, it is not safe to use the newACC intance (index = 1) to " +
+              "save the merge result. You can change your merge function to use the first " +
+              "instance (index = 0) instead.")
         }
+        accumulatorList(i).set(0, retAcc)
       }
+
       last = record
     }
 
-    // per each aggregator, merge list of accumulators into one and save the result to the
-    // intermediate aggregate buffer
+    // set the partial merged result to the aggregateBuffer
     for (i <- aggregates.indices) {
-      val agg = aggregates(i)
-      aggregateBuffer.setField(groupKeysMapping.length + i, agg.merge(accumulatorList(i)))
+      aggregateBuffer.setField(groupKeysMapping.length + i, accumulatorList(i).get(0))
     }
 
     // set group keys to aggregateBuffer.


### PR DESCRIPTION
This PR changes the dataSet AGG merge to pair-merge. 

If we buffer the iterated records for group-merge, we will get wrong error when ObjectReuse is turned on. Alternatively, we could deep-copy every record and buffer them for group-merge. But I think that is expense in terms of memory and also CPU. We could later add group-merge when needed (in the future we should add rules to select either pair-merge or group-merge, but for now all built-in aggregates should work fine with pair-merge).

Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [X] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [X] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
