### PR TITLE
[FLINK-5598] return filename after jar upload

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHandler.java
@@ -59,10 +59,11 @@ public class JarUploadHandler extends AbstractJsonRequestHandler {
 				return "{\"error\": \"Only Jar files are allowed.\"}";
 			}
 			
-			File newFile = new File(jarDir, UUID.randomUUID() + "_" + filename);
+			String filenameWithUUID = UUID.randomUUID() + "_" + filename;
+			File newFile = new File(jarDir, filenameWithUUID);
 			if (tempFile.renameTo(newFile)) {
 				// all went well
-				return "{}";
+				return "{\"status\": \"success\", \"filename\": \"" + filenameWithUUID + "\"}";
 			}
 			else {
 				//noinspection ResultOfMethodCallIgnored


### PR DESCRIPTION
We use the Flink Web Backend to control Flink Jobs running in our Cluster. We would like to have more control in the API. This is the first change I propose, changing the output of the upload JAR Endpoint to something meaningful. To start a Flink Job you need to have the Jar Name, which gets created randomly during upload. The API now returns this.