### PR TITLE
[FLINK-5956] [table] Add retract method for aggregateFunction

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/AggregateFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/AggregateFunction.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.functions
 import java.util.{List => JList}
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.table.api.TableException
 
 /**
   * Base class for User-Defined Aggregates.
@@ -33,6 +34,18 @@ abstract class AggregateFunction[T] extends UserDefinedFunction {
     * @return the accumulator with the initial value
     */
   def createAccumulator(): Accumulator
+
+  /**
+    * Retract the input values from the accumulator instance.
+    *
+    * @param accumulator the accumulator which contains the current
+    *                    aggregated results
+    * @param input       the input value (usually obtained from a new arrived data)
+    */
+  def retract(accumulator: Accumulator, input: Any): Unit = {
+    throw TableException("Retract is an optional method. There is no default implementation. You " +
+                           "must implement one for yourself.")
+  }
 
   /**
     * Called every time when an aggregation result should be materialized.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/AggregateFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/AggregateFunction.scala
@@ -36,7 +36,8 @@ abstract class AggregateFunction[T] extends UserDefinedFunction {
   def createAccumulator(): Accumulator
 
   /**
-    * Retract the input values from the accumulator instance.
+    * Retract the input values from the accumulator instance. The current design assumes the
+    * inputs are the values that have been previously accumulated.
     *
     * @param accumulator the accumulator which contains the current
     *                    aggregated results

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/AvgAggFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/AvgAggFunction.scala
@@ -51,6 +51,15 @@ abstract class IntegralAvgAggFunction[T] extends AggregateFunction[T] {
     }
   }
 
+  override def retract(accumulator: Accumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[Number].longValue()
+      val accum = accumulator.asInstanceOf[IntegralAvgAccumulator]
+      accum.f0 -= v
+      accum.f1 -= 1L
+    }
+  }
+
   override def getValue(accumulator: Accumulator): T = {
     val accum = accumulator.asInstanceOf[IntegralAvgAccumulator]
     if (accum.f1 == 0) {
@@ -137,6 +146,15 @@ abstract class BigIntegralAvgAggFunction[T] extends AggregateFunction[T] {
     }
   }
 
+  override def retract(accumulator: Accumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[Long]
+      val a = accumulator.asInstanceOf[BigIntegralAvgAccumulator]
+      a.f0 = a.f0.subtract(BigInteger.valueOf(v))
+      a.f1 -= 1L
+    }
+  }
+
   override def getValue(accumulator: Accumulator): T = {
     val a = accumulator.asInstanceOf[BigIntegralAvgAccumulator]
     if (a.f1 == 0) {
@@ -206,6 +224,15 @@ abstract class FloatingAvgAggFunction[T] extends AggregateFunction[T] {
       val accum = accumulator.asInstanceOf[FloatingAvgAccumulator]
       accum.f0 += v
       accum.f1 += 1L
+    }
+  }
+
+  override def retract(accumulator: Accumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[Number].doubleValue()
+      val accum = accumulator.asInstanceOf[FloatingAvgAccumulator]
+      accum.f0 -= v
+      accum.f1 -= 1L
     }
   }
 
@@ -287,6 +314,19 @@ class DecimalAvgAggFunction extends AggregateFunction[BigDecimal] {
         accum.f0 = accum.f0.add(v)
       }
       accum.f1 += 1L
+    }
+  }
+
+  override def retract(accumulator: Accumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[BigDecimal]
+      val accum = accumulator.asInstanceOf[DecimalAvgAccumulator]
+      if (accum.f1 == 0) {
+        accum.f0 = v
+      } else {
+        accum.f0 = accum.f0.subtract(v)
+      }
+      accum.f1 -= 1L
     }
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/AvgAggFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/AvgAggFunction.scala
@@ -319,9 +319,6 @@ class DecimalAvgAggFunction extends AggregateFunction[BigDecimal] {
       val accum = accumulator.asInstanceOf[DecimalAvgAccumulator]
       accum.f0 = accum.f0.subtract(v)
       accum.f1 -= 1L
-      if (accum.f1 == 0) {
-        accum.f0 = BigDecimal.ZERO
-      }
     }
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/AvgAggFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/AvgAggFunction.scala
@@ -308,11 +308,7 @@ class DecimalAvgAggFunction extends AggregateFunction[BigDecimal] {
     if (value != null) {
       val v = value.asInstanceOf[BigDecimal]
       val accum = accumulator.asInstanceOf[DecimalAvgAccumulator]
-      if (accum.f1 == 0) {
-        accum.f0 = v
-      } else {
-        accum.f0 = accum.f0.add(v)
-      }
+      accum.f0 = accum.f0.add(v)
       accum.f1 += 1L
     }
   }
@@ -321,12 +317,11 @@ class DecimalAvgAggFunction extends AggregateFunction[BigDecimal] {
     if (value != null) {
       val v = value.asInstanceOf[BigDecimal]
       val accum = accumulator.asInstanceOf[DecimalAvgAccumulator]
-      if (accum.f1 == 0) {
-        accum.f0 = v
-      } else {
-        accum.f0 = accum.f0.subtract(v)
-      }
+      accum.f0 = accum.f0.subtract(v)
       accum.f1 -= 1L
+      if (accum.f1 == 0) {
+        accum.f0 = BigDecimal.ZERO
+      }
     }
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/CountAggFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/CountAggFunction.scala
@@ -40,6 +40,12 @@ class CountAggFunction extends AggregateFunction[Long] {
     }
   }
 
+  override def retract(accumulator: Accumulator, value: Any): Unit = {
+    if (value != null) {
+      accumulator.asInstanceOf[CountAccumulator].f0 -= 1L
+    }
+  }
+
   override def getValue(accumulator: Accumulator): Long = {
     accumulator.asInstanceOf[CountAccumulator].f0
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunction.scala
@@ -147,19 +147,6 @@ class BooleanMaxAggFunction extends MaxAggFunction[Boolean] {
   * Built-in Big Decimal Max aggregate function
   */
 class DecimalMaxAggFunction extends MaxAggFunction[BigDecimal] {
-
-  override def accumulate(accumulator: Accumulator, value: Any): Unit = {
-    if (value != null) {
-      val v = value.asInstanceOf[BigDecimal]
-      val accum = accumulator.asInstanceOf[MaxAccumulator[BigDecimal]]
-      if (!accum.f1 || accum.f0.compareTo(v) < 0) {
-        accum.f0 = v
-        accum.f1 = true
-      }
-    }
-  }
-
   override def getInitValue = BigDecimal.ZERO
-
   override def getValueTypeInfo = BasicTypeInfo.BIG_DEC_TYPE_INFO
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionWithRetract.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionWithRetract.scala
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.functions.aggfunctions
+
+import java.math.BigDecimal
+import java.util.{HashMap => JHashMap, List => JList}
+
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.java.tuple.{Tuple3 => JTuple3}
+import org.apache.flink.api.java.typeutils.{MapTypeInfo, TupleTypeInfo}
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.functions.{Accumulator, AggregateFunction}
+
+/** The initial accumulator for Max with retraction aggregate function */
+class MaxWithRetractAccumulator[T] extends JTuple3[T, Long, JHashMap[T, Long]] with Accumulator
+
+/**
+  * Base class for built-in Max with retraction aggregate function
+  *
+  * @tparam T the type for the aggregation result
+  */
+abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T]) extends AggregateFunction[T] {
+
+  override def createAccumulator(): Accumulator = {
+    val acc = new MaxWithRetractAccumulator[T]
+    acc.f0 = getInitValue //max
+    acc.f1 = 0L //total count
+    acc.f2 = new JHashMap[T, Long]() //store the count for each value
+    acc
+  }
+
+  override def accumulate(accumulator: Accumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[T]
+      val a = accumulator.asInstanceOf[MaxWithRetractAccumulator[T]]
+
+      if (a.f1 == 0 || (ord.compare(a.f0, v) < 0)) {
+        a.f0 = v
+      }
+
+      a.f1 += 1L
+
+      if (!a.f2.containsKey(v)) {
+        a.f2.put(v, 1L)
+      } else {
+        var count = a.f2.get(v)
+        count += 1L
+        a.f2.put(v, count)
+      }
+    }
+  }
+
+  override def retract(accumulator: Accumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[T]
+      val a = accumulator.asInstanceOf[MaxWithRetractAccumulator[T]]
+
+      a.f1 -= 1L
+
+      if (!a.f2.containsKey(v)) {
+        throw TableException("unexpected retract message")
+      } else {
+        var count = a.f2.get(v)
+        count -= 1L
+        if (count == 0) {
+          //remove the key v from the map if the number of appearance of the value v is 0
+          a.f2.remove(v)
+          //if the total count is 0, we could just simply set the f0(max) to the initial value
+          if (a.f1 == 0) {
+            a.f0 = getInitValue
+            return
+          }
+          //if v is the current max value, we have to iterate the map to find the 2nd biggest
+          // value to replace v as the max value
+          if (v == a.f0) {
+            val iterator = a.f2.keySet().iterator()
+            var key = iterator.next()
+            a.f0 = key
+            while (iterator.hasNext()) {
+              key = iterator.next()
+              if (ord.compare(a.f0, key) < 0) {
+                a.f0 = key
+              }
+            }
+          }
+        } else {
+          a.f2.put(v, count)
+        }
+      }
+    }
+  }
+
+  override def getValue(accumulator: Accumulator): T = {
+    val a = accumulator.asInstanceOf[MaxWithRetractAccumulator[T]]
+    if (a.f1 != 0) {
+      a.f0
+    } else {
+      null.asInstanceOf[T]
+    }
+  }
+
+  override def merge(accumulators: JList[Accumulator]): Accumulator = {
+    val ret = accumulators.get(0)
+    var i: Int = 1
+    while (i < accumulators.size()) {
+      val a = accumulators.get(i).asInstanceOf[MaxWithRetractAccumulator[T]]
+      if (a.f1 != 0) {
+        accumulate(ret.asInstanceOf[MaxWithRetractAccumulator[T]], a.f0)
+      }
+      i += 1
+    }
+    ret
+  }
+
+  override def getAccumulatorType(): TypeInformation[_] = {
+    new TupleTypeInfo(
+      new MaxWithRetractAccumulator[T].getClass,
+      getValueTypeInfo,
+      BasicTypeInfo.LONG_TYPE_INFO,
+      new MapTypeInfo(getValueTypeInfo, BasicTypeInfo.LONG_TYPE_INFO))
+  }
+
+  def getInitValue: T
+
+  def getValueTypeInfo: TypeInformation[_]
+}
+
+/**
+  * Built-in Byte Max with retraction aggregate function
+  */
+class ByteMaxWithRetractAggFunction extends MaxWithRetractAggFunction[Byte] {
+  override def getInitValue: Byte = 0.toByte
+  override def getValueTypeInfo = BasicTypeInfo.BYTE_TYPE_INFO
+}
+
+/**
+  * Built-in Short Max with retraction aggregate function
+  */
+class ShortMaxWithRetractAggFunction extends MaxWithRetractAggFunction[Short] {
+  override def getInitValue: Short = 0.toShort
+  override def getValueTypeInfo = BasicTypeInfo.SHORT_TYPE_INFO
+}
+
+/**
+  * Built-in Int Max with retraction aggregate function
+  */
+class IntMaxWithRetractAggFunction extends MaxWithRetractAggFunction[Int] {
+  override def getInitValue: Int = 0
+  override def getValueTypeInfo = BasicTypeInfo.INT_TYPE_INFO
+}
+
+/**
+  * Built-in Long Max with retraction aggregate function
+  */
+class LongMaxWithRetractAggFunction extends MaxWithRetractAggFunction[Long] {
+  override def getInitValue: Long = 0L
+  override def getValueTypeInfo = BasicTypeInfo.LONG_TYPE_INFO
+}
+
+/**
+  * Built-in Float Max with retraction aggregate function
+  */
+class FloatMaxWithRetractAggFunction extends MaxWithRetractAggFunction[Float] {
+  override def getInitValue: Float = 0.0f
+  override def getValueTypeInfo = BasicTypeInfo.FLOAT_TYPE_INFO
+}
+
+/**
+  * Built-in Double Max with retraction aggregate function
+  */
+class DoubleMaxWithRetractAggFunction extends MaxWithRetractAggFunction[Double] {
+  override def getInitValue: Double = 0.0d
+  override def getValueTypeInfo = BasicTypeInfo.DOUBLE_TYPE_INFO
+}
+
+/**
+  * Built-in Boolean Max with retraction aggregate function
+  */
+class BooleanMaxWithRetractAggFunction extends MaxWithRetractAggFunction[Boolean] {
+  override def getInitValue = false
+  override def getValueTypeInfo = BasicTypeInfo.BOOLEAN_TYPE_INFO
+}
+
+/**
+  * Built-in Big Decimal Max with retraction aggregate function
+  */
+class DecimalMaxWithRetractAggFunction extends MaxWithRetractAggFunction[BigDecimal] {
+  override def getInitValue = BigDecimal.ZERO
+  override def getValueTypeInfo = BasicTypeInfo.BIG_DEC_TYPE_INFO
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionWithRetract.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionWithRetract.scala
@@ -21,26 +21,25 @@ import java.math.BigDecimal
 import java.util.{HashMap => JHashMap, List => JList}
 
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
-import org.apache.flink.api.java.tuple.{Tuple3 => JTuple3}
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
 import org.apache.flink.api.java.typeutils.{MapTypeInfo, TupleTypeInfo}
-import org.apache.flink.table.api.TableException
 import org.apache.flink.table.functions.{Accumulator, AggregateFunction}
 
 /** The initial accumulator for Max with retraction aggregate function */
-class MaxWithRetractAccumulator[T] extends JTuple3[T, Long, JHashMap[T, Long]] with Accumulator
+class MaxWithRetractAccumulator[T] extends JTuple2[T, JHashMap[T, Long]] with Accumulator
 
 /**
   * Base class for built-in Max with retraction aggregate function
   *
   * @tparam T the type for the aggregation result
   */
-abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T]) extends AggregateFunction[T] {
+abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T])
+  extends AggregateFunction[T] {
 
   override def createAccumulator(): Accumulator = {
     val acc = new MaxWithRetractAccumulator[T]
     acc.f0 = getInitValue //max
-    acc.f1 = 0L //total count
-    acc.f2 = new JHashMap[T, Long]() //store the count for each value
+    acc.f1 = new JHashMap[T, Long]() //store the count for each value
     acc
   }
 
@@ -49,18 +48,16 @@ abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T]) extends A
       val v = value.asInstanceOf[T]
       val a = accumulator.asInstanceOf[MaxWithRetractAccumulator[T]]
 
-      if (a.f1 == 0 || (ord.compare(a.f0, v) < 0)) {
+      if (a.f1.size() == 0 || (ord.compare(a.f0, v) < 0)) {
         a.f0 = v
       }
 
-      a.f1 += 1L
-
-      if (!a.f2.containsKey(v)) {
-        a.f2.put(v, 1L)
+      if (!a.f1.containsKey(v)) {
+        a.f1.put(v, 1L)
       } else {
-        var count = a.f2.get(v)
+        var count = a.f1.get(v)
         count += 1L
-        a.f2.put(v, count)
+        a.f1.put(v, count)
       }
     }
   }
@@ -70,22 +67,20 @@ abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T]) extends A
       val v = value.asInstanceOf[T]
       val a = accumulator.asInstanceOf[MaxWithRetractAccumulator[T]]
 
-      a.f1 -= 1L
-
-      var count = a.f2.get(v)
+      var count = a.f1.get(v)
       count -= 1L
       if (count == 0) {
         //remove the key v from the map if the number of appearance of the value v is 0
-        a.f2.remove(v)
+        a.f1.remove(v)
         //if the total count is 0, we could just simply set the f0(max) to the initial value
-        if (a.f1 == 0) {
+        if (a.f1.size() == 0) {
           a.f0 = getInitValue
           return
         }
         //if v is the current max value, we have to iterate the map to find the 2nd biggest
         // value to replace v as the max value
         if (v == a.f0) {
-          val iterator = a.f2.keySet().iterator()
+          val iterator = a.f1.keySet().iterator()
           var key = iterator.next()
           a.f0 = key
           while (iterator.hasNext()) {
@@ -96,7 +91,7 @@ abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T]) extends A
           }
         }
       } else {
-        a.f2.put(v, count)
+        a.f1.put(v, count)
       }
     }
 
@@ -104,7 +99,7 @@ abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T]) extends A
 
   override def getValue(accumulator: Accumulator): T = {
     val a = accumulator.asInstanceOf[MaxWithRetractAccumulator[T]]
-    if (a.f1 != 0) {
+    if (a.f1.size() != 0) {
       a.f0
     } else {
       null.asInstanceOf[T]
@@ -116,22 +111,19 @@ abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T]) extends A
     var i: Int = 1
     while (i < accumulators.size()) {
       val a = accumulators.get(i).asInstanceOf[MaxWithRetractAccumulator[T]]
-      if (a.f1 != 0) {
-        val iterator = a.f2.keySet().iterator()
+      if (a.f1.size() != 0) {
+        // set max element
+        if (ord.compare(ret.f0, a.f0) < 0) {
+          ret.f0 = a.f0
+        }
+        // merge the count for each key
+        val iterator = a.f1.keySet().iterator()
         while (iterator.hasNext()) {
           val key = iterator.next()
-          //updating the resulting max value if needed
-          if (ord.compare(ret.f0, key) < 0) {
-            ret.f0 = key
-          }
-          //add the total count
-          val count = a.f2.get(key)
-          ret.f1 += count
-          //merge the count for each key
-          if (ret.f2.containsKey(key)) {
-            ret.f2.put(key, ret.f2.get(key) + count)
+          if (ret.f1.containsKey(key)) {
+            ret.f1.put(key, ret.f1.get(key) + a.f1.get(key))
           } else {
-            ret.f2.put(key, a.f2.get(key))
+            ret.f1.put(key, a.f1.get(key))
           }
         }
       }
@@ -144,7 +136,6 @@ abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T]) extends A
     new TupleTypeInfo(
       new MaxWithRetractAccumulator[T].getClass,
       getValueTypeInfo,
-      BasicTypeInfo.LONG_TYPE_INFO,
       new MapTypeInfo(getValueTypeInfo, BasicTypeInfo.LONG_TYPE_INFO))
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MinAggFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MinAggFunction.scala
@@ -147,19 +147,6 @@ class BooleanMinAggFunction extends MinAggFunction[Boolean] {
   * Built-in Big Decimal Min aggregate function
   */
 class DecimalMinAggFunction extends MinAggFunction[BigDecimal] {
-
-  override def accumulate(accumulator: Accumulator, value: Any): Unit = {
-    if (value != null) {
-      val v = value.asInstanceOf[BigDecimal]
-      val accum = accumulator.asInstanceOf[MinAccumulator[BigDecimal]]
-      if (!accum.f1 || accum.f0.compareTo(v) > 0) {
-        accum.f0 = v
-        accum.f1 = true
-      }
-    }
-  }
-
   override def getInitValue: BigDecimal = BigDecimal.ZERO
-
   override def getValueTypeInfo = BasicTypeInfo.BIG_DEC_TYPE_INFO
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MinAggFunctionWithRetract.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MinAggFunctionWithRetract.scala
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.functions.aggfunctions
+
+import java.math.BigDecimal
+import java.util.{HashMap => JHashMap, List => JList}
+
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.java.tuple.{Tuple3 => JTuple3}
+import org.apache.flink.api.java.typeutils.{MapTypeInfo, TupleTypeInfo}
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.functions.{Accumulator, AggregateFunction}
+
+/** The initial accumulator for Min with retraction aggregate function */
+class MinWithRetractAccumulator[T] extends JTuple3[T, Long, JHashMap[T, Long]] with Accumulator
+
+/**
+  * Base class for built-in Min with retraction aggregate function
+  *
+  * @tparam T the type for the aggregation result
+  */
+abstract class MinWithRetractAggFunction[T](implicit ord: Ordering[T]) extends AggregateFunction[T] {
+
+  override def createAccumulator(): Accumulator = {
+    val acc = new MinWithRetractAccumulator[T]
+    acc.f0 = getInitValue //min
+    acc.f1 = 0L //total count
+    acc.f2 = new JHashMap[T, Long]() //store the count for each value
+    acc
+  }
+
+  override def accumulate(accumulator: Accumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[T]
+      val a = accumulator.asInstanceOf[MinWithRetractAccumulator[T]]
+
+      if (a.f1 == 0 || (ord.compare(a.f0, v) > 0)) {
+        a.f0 = v
+      }
+
+      a.f1 += 1L
+
+      if (!a.f2.containsKey(v)) {
+        a.f2.put(v, 1L)
+      } else {
+        var count = a.f2.get(v)
+        count += 1L
+        a.f2.put(v, count)
+      }
+    }
+  }
+
+  override def retract(accumulator: Accumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[T]
+      val a = accumulator.asInstanceOf[MinWithRetractAccumulator[T]]
+
+      a.f1 -= 1L
+
+      if (!a.f2.containsKey(v)) {
+        throw TableException("unexpected retract message")
+      } else {
+        var count = a.f2.get(v)
+        count -= 1L
+        if (count == 0) {
+          //remove the key v from the map if the number of appearance of the value v is 0
+          a.f2.remove(v)
+          //if the total count is 0, we could just simply set the f0(min) to the initial value
+          if (a.f1 == 0) {
+            a.f0 = getInitValue
+            return
+          }
+          //if v is the current min value, we have to iterate the map to find the 2nd smallest
+          // value to replace v as the min value
+          if (v == a.f0) {
+            val iterator = a.f2.keySet().iterator()
+            var key = iterator.next()
+            a.f0 = key
+            while (iterator.hasNext()) {
+              key = iterator.next()
+              if (ord.compare(a.f0, key) > 0) {
+                a.f0 = key
+              }
+            }
+          }
+        } else {
+          a.f2.put(v, count)
+        }
+      }
+    }
+  }
+
+  override def getValue(accumulator: Accumulator): T = {
+    val a = accumulator.asInstanceOf[MinWithRetractAccumulator[T]]
+    if (a.f1 != 0) {
+      a.f0
+    } else {
+      null.asInstanceOf[T]
+    }
+  }
+
+  override def merge(accumulators: JList[Accumulator]): Accumulator = {
+    val ret = accumulators.get(0)
+    var i: Int = 1
+    while (i < accumulators.size()) {
+      val a = accumulators.get(i).asInstanceOf[MinWithRetractAccumulator[T]]
+      if (a.f1 != 0) {
+        accumulate(ret.asInstanceOf[MinWithRetractAccumulator[T]], a.f0)
+      }
+      i += 1
+    }
+    ret
+  }
+
+  override def getAccumulatorType(): TypeInformation[_] = {
+    new TupleTypeInfo(
+      new MinWithRetractAccumulator[T].getClass,
+      getValueTypeInfo,
+      BasicTypeInfo.LONG_TYPE_INFO,
+      new MapTypeInfo(getValueTypeInfo, BasicTypeInfo.LONG_TYPE_INFO))
+  }
+
+  def getInitValue: T
+
+  def getValueTypeInfo: TypeInformation[_]
+}
+
+/**
+  * Built-in Byte Min with retraction aggregate function
+  */
+class ByteMinWithRetractAggFunction extends MinWithRetractAggFunction[Byte] {
+  override def getInitValue: Byte = 0.toByte
+  override def getValueTypeInfo = BasicTypeInfo.BYTE_TYPE_INFO
+}
+
+/**
+  * Built-in Short Min with retraction aggregate function
+  */
+class ShortMinWithRetractAggFunction extends MinWithRetractAggFunction[Short] {
+  override def getInitValue: Short = 0.toShort
+  override def getValueTypeInfo = BasicTypeInfo.SHORT_TYPE_INFO
+}
+
+/**
+  * Built-in Int Min with retraction aggregate function
+  */
+class IntMinWithRetractAggFunction extends MinWithRetractAggFunction[Int] {
+  override def getInitValue: Int = 0
+  override def getValueTypeInfo = BasicTypeInfo.INT_TYPE_INFO
+}
+
+/**
+  * Built-in Long Min with retraction aggregate function
+  */
+class LongMinWithRetractAggFunction extends MinWithRetractAggFunction[Long] {
+  override def getInitValue: Long = 0L
+  override def getValueTypeInfo = BasicTypeInfo.LONG_TYPE_INFO
+}
+
+/**
+  * Built-in Float Min with retraction aggregate function
+  */
+class FloatMinWithRetractAggFunction extends MinWithRetractAggFunction[Float] {
+  override def getInitValue: Float = 0.0f
+  override def getValueTypeInfo = BasicTypeInfo.FLOAT_TYPE_INFO
+}
+
+/**
+  * Built-in Double Min with retraction aggregate function
+  */
+class DoubleMinWithRetractAggFunction extends MinWithRetractAggFunction[Double] {
+  override def getInitValue: Double = 0.0d
+  override def getValueTypeInfo = BasicTypeInfo.DOUBLE_TYPE_INFO
+}
+
+/**
+  * Built-in Boolean Min with retraction aggregate function
+  */
+class BooleanMinWithRetractAggFunction extends MinWithRetractAggFunction[Boolean] {
+  override def getInitValue: Boolean = false
+  override def getValueTypeInfo = BasicTypeInfo.BOOLEAN_TYPE_INFO
+}
+
+/**
+  * Built-in Big Decimal Min with retraction aggregate function
+  */
+class DecimalMinWithRetractAggFunction extends MinWithRetractAggFunction[BigDecimal] {
+  override def getInitValue: BigDecimal = BigDecimal.ZERO
+  override def getValueTypeInfo = BasicTypeInfo.BIG_DEC_TYPE_INFO
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MinAggFunctionWithRetract.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MinAggFunctionWithRetract.scala
@@ -72,37 +72,34 @@ abstract class MinWithRetractAggFunction[T](implicit ord: Ordering[T]) extends A
 
       a.f1 -= 1L
 
-      if (!a.f2.containsKey(v)) {
-        throw TableException("unexpected retract message")
-      } else {
-        var count = a.f2.get(v)
-        count -= 1L
-        if (count == 0) {
-          //remove the key v from the map if the number of appearance of the value v is 0
-          a.f2.remove(v)
-          //if the total count is 0, we could just simply set the f0(min) to the initial value
-          if (a.f1 == 0) {
-            a.f0 = getInitValue
-            return
-          }
-          //if v is the current min value, we have to iterate the map to find the 2nd smallest
-          // value to replace v as the min value
-          if (v == a.f0) {
-            val iterator = a.f2.keySet().iterator()
-            var key = iterator.next()
-            a.f0 = key
-            while (iterator.hasNext()) {
-              key = iterator.next()
-              if (ord.compare(a.f0, key) > 0) {
-                a.f0 = key
-              }
+      var count = a.f2.get(v)
+      count -= 1L
+      if (count == 0) {
+        //remove the key v from the map if the number of appearance of the value v is 0
+        a.f2.remove(v)
+        //if the total count is 0, we could just simply set the f0(min) to the initial value
+        if (a.f1 == 0) {
+          a.f0 = getInitValue
+          return
+        }
+        //if v is the current min value, we have to iterate the map to find the 2nd smallest
+        // value to replace v as the min value
+        if (v == a.f0) {
+          val iterator = a.f2.keySet().iterator()
+          var key = iterator.next()
+          a.f0 = key
+          while (iterator.hasNext()) {
+            key = iterator.next()
+            if (ord.compare(a.f0, key) > 0) {
+              a.f0 = key
             }
           }
-        } else {
-          a.f2.put(v, count)
         }
+      } else {
+        a.f2.put(v, count)
       }
     }
+
   }
 
   override def getValue(accumulator: Accumulator): T = {
@@ -115,12 +112,28 @@ abstract class MinWithRetractAggFunction[T](implicit ord: Ordering[T]) extends A
   }
 
   override def merge(accumulators: JList[Accumulator]): Accumulator = {
-    val ret = accumulators.get(0)
+    val ret = accumulators.get(0).asInstanceOf[MinWithRetractAccumulator[T]]
     var i: Int = 1
     while (i < accumulators.size()) {
       val a = accumulators.get(i).asInstanceOf[MinWithRetractAccumulator[T]]
       if (a.f1 != 0) {
-        accumulate(ret.asInstanceOf[MinWithRetractAccumulator[T]], a.f0)
+        val iterator = a.f2.keySet().iterator()
+        while (iterator.hasNext()) {
+          val key = iterator.next()
+          //updating the resulting max value if needed
+          if (ord.compare(ret.f0, key) > 0) {
+            ret.f0 = key
+          }
+          //add the total count
+          val count = a.f2.get(key)
+          ret.f1 += count
+          //merge the count for each key
+          if (ret.f2.containsKey(key)) {
+            ret.f2.put(key, ret.f2.get(key) + count)
+          } else {
+            ret.f2.put(key, a.f2.get(key))
+          }
+        }
       }
       i += 1
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/SumAggFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/SumAggFunction.scala
@@ -23,11 +23,10 @@ import java.util.{List => JList}
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
 import org.apache.flink.api.java.typeutils.TupleTypeInfo
-import org.apache.flink.table.api.TableException
 import org.apache.flink.table.functions.{Accumulator, AggregateFunction}
 
 /** The initial accumulator for Sum aggregate function */
-class SumAccumulator[T] extends JTuple2[T, Long] with Accumulator
+class SumAccumulator[T] extends JTuple2[T, Boolean] with Accumulator
 
 /**
   * Base class for built-in Sum aggregate function
@@ -41,7 +40,7 @@ abstract class SumAggFunction[T: Numeric] extends AggregateFunction[T] {
   override def createAccumulator(): Accumulator = {
     val acc = new SumAccumulator[T]()
     acc.f0 = numeric.zero //sum
-    acc.f1 = 0L
+    acc.f1 = false
     acc
   }
 
@@ -50,25 +49,13 @@ abstract class SumAggFunction[T: Numeric] extends AggregateFunction[T] {
       val v = value.asInstanceOf[T]
       val a = accumulator.asInstanceOf[SumAccumulator[T]]
       a.f0 = numeric.plus(v, a.f0)
-      a.f1 += 1
-    }
-  }
-
-  override def retract(accumulator: Accumulator, value: Any): Unit = {
-    if (value != null) {
-      val v = value.asInstanceOf[T]
-      val a = accumulator.asInstanceOf[SumAccumulator[T]]
-      a.f0 = numeric.plus(v, a.f0)
-      a.f1 -= 1
-      if (a.f1 < 0) {
-        throw TableException("unexpected retract message")
-      }
+      a.f1 = true
     }
   }
 
   override def getValue(accumulator: Accumulator): T = {
     val a = accumulator.asInstanceOf[SumAccumulator[T]]
-    if (a.f1 > 0) {
+    if (a.f1) {
       a.f0
     } else {
       null.asInstanceOf[T]
@@ -80,9 +67,9 @@ abstract class SumAggFunction[T: Numeric] extends AggregateFunction[T] {
     var i: Int = 0
     while (i < accumulators.size()) {
       val a = accumulators.get(i).asInstanceOf[SumAccumulator[T]]
-      if (a.f1 > 0) {
+      if (a.f1) {
         ret.f0 = numeric.plus(ret.f0, a.f0)
-        ret.f1 += a.f1
+        ret.f1 = true
       }
       i += 1
     }
@@ -93,7 +80,7 @@ abstract class SumAggFunction[T: Numeric] extends AggregateFunction[T] {
     new TupleTypeInfo(
       (new SumAccumulator).getClass,
       getValueTypeInfo,
-      BasicTypeInfo.LONG_TYPE_INFO)
+      BasicTypeInfo.BOOLEAN_TYPE_INFO)
   }
 
   def getValueTypeInfo: TypeInformation[_]
@@ -142,9 +129,9 @@ class DoubleSumAggFunction extends SumAggFunction[Double] {
 }
 
 /** The initial accumulator for Big Decimal Sum aggregate function */
-class DecimalSumAccumulator extends JTuple2[BigDecimal, Long] with Accumulator {
+class DecimalSumAccumulator extends JTuple2[BigDecimal, Boolean] with Accumulator {
   f0 = BigDecimal.ZERO
-  f1 = 0L
+  f1 = false
 }
 
 /**
@@ -161,24 +148,12 @@ class DecimalSumAggFunction extends AggregateFunction[BigDecimal] {
       val v = value.asInstanceOf[BigDecimal]
       val accum = accumulator.asInstanceOf[DecimalSumAccumulator]
       accum.f0 = accum.f0.add(v)
-      accum.f1 += 1L
-    }
-  }
-
-  override def retract(accumulator: Accumulator, value: Any): Unit = {
-    if (value != null) {
-      val v = value.asInstanceOf[BigDecimal]
-      val accum = accumulator.asInstanceOf[DecimalSumAccumulator]
-      accum.f0 = accum.f0.add(v)
-      accum.f1 -= 1L
-      if (accum.f1 < 0) {
-        throw TableException("unexpected retract message")
-      }
+      accum.f1 = true
     }
   }
 
   override def getValue(accumulator: Accumulator): BigDecimal = {
-    if (accumulator.asInstanceOf[DecimalSumAccumulator].f1 == 0) {
+    if (!accumulator.asInstanceOf[DecimalSumAccumulator].f1) {
       null.asInstanceOf[BigDecimal]
     } else {
       accumulator.asInstanceOf[DecimalSumAccumulator].f0
@@ -190,9 +165,9 @@ class DecimalSumAggFunction extends AggregateFunction[BigDecimal] {
     var i: Int = 1
     while (i < accumulators.size()) {
       val a = accumulators.get(i).asInstanceOf[DecimalSumAccumulator]
-      if (a.f1 > 0) {
-        accumulate(ret, a.f0)
-        ret.f1 += a.f1
+      if (a.f1) {
+        ret.f0 = ret.f0.add(a.f0)
+        ret.f1 = true
       }
       i += 1
     }
@@ -203,6 +178,6 @@ class DecimalSumAggFunction extends AggregateFunction[BigDecimal] {
     new TupleTypeInfo(
       (new DecimalSumAccumulator).getClass,
       BasicTypeInfo.BIG_DEC_TYPE_INFO,
-      BasicTypeInfo.LONG_TYPE_INFO)
+      BasicTypeInfo.BOOLEAN_TYPE_INFO)
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/SumWithRetractAggFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/SumWithRetractAggFunction.scala
@@ -23,7 +23,6 @@ import java.util.{List => JList}
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
 import org.apache.flink.api.java.typeutils.TupleTypeInfo
-import org.apache.flink.table.api.TableException
 import org.apache.flink.table.functions.{Accumulator, AggregateFunction}
 
 /** The initial accumulator for Sum with retract aggregate function */
@@ -166,9 +165,6 @@ class DecimalSumWithRetractAggFunction extends AggregateFunction[BigDecimal] {
       val accum = accumulator.asInstanceOf[DecimalSumWithRetractAccumulator]
       accum.f0 = accum.f0.subtract(v)
       accum.f1 -= 1L
-      if (accum.f1 == 0) {
-        accum.f0 = BigDecimal.ZERO
-      }
     }
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/SumWithRetractAggFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/SumWithRetractAggFunction.scala
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.functions.aggfunctions
+
+import java.math.BigDecimal
+import java.util.{List => JList}
+
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
+import org.apache.flink.api.java.typeutils.TupleTypeInfo
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.functions.{Accumulator, AggregateFunction}
+
+/** The initial accumulator for Sum with retract aggregate function */
+class SumWithRetractAccumulator[T] extends JTuple2[T, Long] with Accumulator
+
+/**
+  * Base class for built-in Sum with retract aggregate function
+  *
+  * @tparam T the type for the aggregation result
+  */
+abstract class SumWithRetractAggFunction[T: Numeric] extends AggregateFunction[T] {
+
+  private val numeric = implicitly[Numeric[T]]
+
+  override def createAccumulator(): Accumulator = {
+    val acc = new SumWithRetractAccumulator[T]()
+    acc.f0 = numeric.zero //sum
+    acc.f1 = 0L //total count
+    acc
+  }
+
+  override def accumulate(accumulator: Accumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[T]
+      val a = accumulator.asInstanceOf[SumWithRetractAccumulator[T]]
+      a.f0 = numeric.plus(a.f0, v)
+      a.f1 += 1
+    }
+  }
+
+  override def retract(accumulator: Accumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[T]
+      val a = accumulator.asInstanceOf[SumWithRetractAccumulator[T]]
+      a.f0 = numeric.minus(a.f0, v)
+      a.f1 -= 1
+    }
+  }
+
+  override def getValue(accumulator: Accumulator): T = {
+    val a = accumulator.asInstanceOf[SumWithRetractAccumulator[T]]
+    if (a.f1 > 0) {
+      a.f0
+    } else {
+      null.asInstanceOf[T]
+    }
+  }
+
+  override def merge(accumulators: JList[Accumulator]): Accumulator = {
+    val ret = createAccumulator().asInstanceOf[SumWithRetractAccumulator[T]]
+    var i: Int = 0
+    while (i < accumulators.size()) {
+      val a = accumulators.get(i).asInstanceOf[SumWithRetractAccumulator[T]]
+      ret.f0 = numeric.plus(ret.f0, a.f0)
+      ret.f1 += a.f1
+      i += 1
+    }
+    ret
+  }
+
+  override def getAccumulatorType(): TypeInformation[_] = {
+    new TupleTypeInfo(
+      (new SumWithRetractAccumulator).getClass,
+      getValueTypeInfo,
+      BasicTypeInfo.LONG_TYPE_INFO)
+  }
+
+  def getValueTypeInfo: TypeInformation[_]
+}
+
+/**
+  * Built-in Byte Sum with retract aggregate function
+  */
+class ByteSumWithRetractAggFunction extends SumWithRetractAggFunction[Byte] {
+  override def getValueTypeInfo = BasicTypeInfo.BYTE_TYPE_INFO
+}
+
+/**
+  * Built-in Short Sum with retract aggregate function
+  */
+class ShortSumWithRetractAggFunction extends SumWithRetractAggFunction[Short] {
+  override def getValueTypeInfo = BasicTypeInfo.SHORT_TYPE_INFO
+}
+
+/**
+  * Built-in Int Sum with retract aggregate function
+  */
+class IntSumWithRetractAggFunction extends SumWithRetractAggFunction[Int] {
+  override def getValueTypeInfo = BasicTypeInfo.INT_TYPE_INFO
+}
+
+/**
+  * Built-in Long Sum with retract aggregate function
+  */
+class LongSumWithRetractAggFunction extends SumWithRetractAggFunction[Long] {
+  override def getValueTypeInfo = BasicTypeInfo.LONG_TYPE_INFO
+}
+
+/**
+  * Built-in Float Sum with retract aggregate function
+  */
+class FloatSumWithRetractAggFunction extends SumWithRetractAggFunction[Float] {
+  override def getValueTypeInfo = BasicTypeInfo.FLOAT_TYPE_INFO
+}
+
+/**
+  * Built-in Double Sum with retract aggregate function
+  */
+class DoubleSumWithRetractAggFunction extends SumWithRetractAggFunction[Double] {
+  override def getValueTypeInfo = BasicTypeInfo.DOUBLE_TYPE_INFO
+}
+
+/** The initial accumulator for Big Decimal Sum with retract aggregate function */
+class DecimalSumWithRetractAccumulator extends JTuple2[BigDecimal, Long] with Accumulator {
+  f0 = BigDecimal.ZERO
+  f1 = 0L
+}
+
+/**
+  * Built-in Big Decimal Sum with retract aggregate function
+  */
+class DecimalSumWithRetractAggFunction extends AggregateFunction[BigDecimal] {
+
+  override def createAccumulator(): Accumulator = {
+    new DecimalSumWithRetractAccumulator
+  }
+
+  override def accumulate(accumulator: Accumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[BigDecimal]
+      val accum = accumulator.asInstanceOf[DecimalSumWithRetractAccumulator]
+      accum.f0 = accum.f0.add(v)
+      accum.f1 += 1L
+    }
+  }
+
+  override def retract(accumulator: Accumulator, value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[BigDecimal]
+      val accum = accumulator.asInstanceOf[DecimalSumWithRetractAccumulator]
+      accum.f0 = accum.f0.subtract(v)
+      accum.f1 -= 1L
+      if (accum.f1 == 0) {
+        accum.f0 = BigDecimal.ZERO
+      }
+    }
+  }
+
+  override def getValue(accumulator: Accumulator): BigDecimal = {
+    if (accumulator.asInstanceOf[DecimalSumWithRetractAccumulator].f1 == 0) {
+      null.asInstanceOf[BigDecimal]
+    } else {
+      accumulator.asInstanceOf[DecimalSumWithRetractAccumulator].f0
+    }
+  }
+
+  override def merge(accumulators: JList[Accumulator]): Accumulator = {
+    val ret = accumulators.get(0).asInstanceOf[DecimalSumWithRetractAccumulator]
+    var i: Int = 1
+    while (i < accumulators.size()) {
+      val a = accumulators.get(i).asInstanceOf[DecimalSumWithRetractAccumulator]
+      ret.f0 = ret.f0.add(a.f0)
+      ret.f1 += a.f1
+      i += 1
+    }
+    ret
+  }
+
+  override def getAccumulatorType(): TypeInformation[_] = {
+    new TupleTypeInfo(
+      (new DecimalSumWithRetractAccumulator).getClass,
+      BasicTypeInfo.BIG_DEC_TYPE_INFO,
+      BasicTypeInfo.LONG_TYPE_INFO)
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionTest.scala
@@ -61,6 +61,8 @@ abstract class MaxAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T] {
     maxVal,
     null.asInstanceOf[T]
   )
+
+  override def ifSupportRetraction: Boolean = false
 }
 
 class ByteMaxAggFunctionTest extends MaxAggFunctionTest[Byte] {
@@ -154,6 +156,8 @@ class BooleanMaxAggFunctionTest extends AggFunctionTestBase[Boolean] {
   )
 
   override def aggregator: AggregateFunction[Boolean] = new BooleanMaxAggFunction()
+
+  override def ifSupportRetraction: Boolean = false
 }
 
 class DecimalMaxAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
@@ -185,4 +189,6 @@ class DecimalMaxAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
   )
 
   override def aggregator: AggregateFunction[BigDecimal] = new DecimalMaxAggFunction()
+
+  override def ifSupportRetraction: Boolean = false
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionTest.scala
@@ -62,7 +62,7 @@ abstract class MaxAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T] {
     null.asInstanceOf[T]
   )
 
-  override def ifSupportRetraction: Boolean = false
+  override def supportRetraction: Boolean = false
 }
 
 class ByteMaxAggFunctionTest extends MaxAggFunctionTest[Byte] {
@@ -157,7 +157,7 @@ class BooleanMaxAggFunctionTest extends AggFunctionTestBase[Boolean] {
 
   override def aggregator: AggregateFunction[Boolean] = new BooleanMaxAggFunction()
 
-  override def ifSupportRetraction: Boolean = false
+  override def supportRetraction: Boolean = false
 }
 
 class DecimalMaxAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
@@ -190,5 +190,5 @@ class DecimalMaxAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
 
   override def aggregator: AggregateFunction[BigDecimal] = new DecimalMaxAggFunction()
 
-  override def ifSupportRetraction: Boolean = false
+  override def supportRetraction: Boolean = false
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MaxWithRetractAggFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MaxWithRetractAggFunctionTest.scala
@@ -21,11 +21,11 @@ import java.math.BigDecimal
 import org.apache.flink.table.functions.AggregateFunction
 
 /**
-  * Test case for built-in min aggregate function
+  * Test case for built-in max with retraction aggregate function
   *
   * @tparam T the type for the aggregation result
   */
-abstract class MinAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T] {
+abstract class MaxWithRetractAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T] {
 
   private val numeric: Numeric[T] = implicitly[Numeric[T]]
 
@@ -58,68 +58,66 @@ abstract class MinAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T] {
   )
 
   override def expectedResults: Seq[T] = Seq(
-    minVal,
+    maxVal,
     null.asInstanceOf[T]
   )
-
-  override def ifSupportRetraction: Boolean = false
 }
 
-class ByteMinAggFunctionTest extends MinAggFunctionTest[Byte] {
+class ByteMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[Byte] {
 
   override def minVal = (Byte.MinValue + 1).toByte
 
   override def maxVal = (Byte.MaxValue - 1).toByte
 
-  override def aggregator: AggregateFunction[Byte] = new ByteMinAggFunction()
+  override def aggregator: AggregateFunction[Byte] = new ByteMaxWithRetractAggFunction()
 }
 
-class ShortMinAggFunctionTest extends MinAggFunctionTest[Short] {
+class ShortMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[Short] {
 
   override def minVal = (Short.MinValue + 1).toShort
 
   override def maxVal = (Short.MaxValue - 1).toShort
 
-  override def aggregator: AggregateFunction[Short] = new ShortMinAggFunction()
+  override def aggregator: AggregateFunction[Short] = new ShortMaxWithRetractAggFunction()
 }
 
-class IntMinAggFunctionTest extends MinAggFunctionTest[Int] {
+class IntMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[Int] {
 
   override def minVal = Int.MinValue + 1
 
   override def maxVal = Int.MaxValue - 1
 
-  override def aggregator: AggregateFunction[Int] = new IntMinAggFunction()
+  override def aggregator: AggregateFunction[Int] = new IntMaxWithRetractAggFunction()
 }
 
-class LongMinAggFunctionTest extends MinAggFunctionTest[Long] {
+class LongMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[Long] {
 
   override def minVal = Long.MinValue + 1
 
   override def maxVal = Long.MaxValue - 1
 
-  override def aggregator: AggregateFunction[Long] = new LongMinAggFunction()
+  override def aggregator: AggregateFunction[Long] = new LongMaxWithRetractAggFunction()
 }
 
-class FloatMinAggFunctionTest extends MinAggFunctionTest[Float] {
+class FloatMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[Float] {
 
   override def minVal = Float.MinValue / 2
 
   override def maxVal = Float.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Float] = new FloatMinAggFunction()
+  override def aggregator: AggregateFunction[Float] = new FloatMaxWithRetractAggFunction()
 }
 
-class DoubleMinAggFunctionTest extends MinAggFunctionTest[Double] {
+class DoubleMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[Double] {
 
   override def minVal = Double.MinValue / 2
 
   override def maxVal = Double.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Double] = new DoubleMinAggFunction()
+  override def aggregator: AggregateFunction[Double] = new DoubleMaxWithRetractAggFunction()
 }
 
-class BooleanMinAggFunctionTest extends AggFunctionTestBase[Boolean] {
+class BooleanMaxWithRetractAggFunctionTest extends AggFunctionTestBase[Boolean] {
 
   override def inputValueSets: Seq[Seq[Boolean]] = Seq(
     Seq(
@@ -151,21 +149,19 @@ class BooleanMinAggFunctionTest extends AggFunctionTestBase[Boolean] {
   override def expectedResults: Seq[Boolean] = Seq(
     false,
     true,
-    false,
+    true,
     null.asInstanceOf[Boolean]
   )
 
-  override def aggregator: AggregateFunction[Boolean] = new BooleanMinAggFunction()
-
-  override def ifSupportRetraction: Boolean = false
+  override def aggregator: AggregateFunction[Boolean] = new BooleanMaxWithRetractAggFunction()
 }
 
-class DecimalMinAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
+class DecimalMaxWithRetractAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
 
   override def inputValueSets: Seq[Seq[_]] = Seq(
     Seq(
       new BigDecimal("1"),
-      new BigDecimal("1000"),
+      new BigDecimal("1000.000001"),
       new BigDecimal("-1"),
       new BigDecimal("-999.998999"),
       null,
@@ -184,11 +180,9 @@ class DecimalMinAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
   )
 
   override def expectedResults: Seq[BigDecimal] = Seq(
-    new BigDecimal("-999.999"),
+    new BigDecimal("1000.000001"),
     null
   )
 
-  override def aggregator: AggregateFunction[BigDecimal] = new DecimalMinAggFunction()
-
-  override def ifSupportRetraction: Boolean = false
+  override def aggregator: AggregateFunction[BigDecimal] = new DecimalMaxWithRetractAggFunction()
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MinAggFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MinAggFunctionTest.scala
@@ -62,7 +62,7 @@ abstract class MinAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T] {
     null.asInstanceOf[T]
   )
 
-  override def ifSupportRetraction: Boolean = false
+  override def supportRetraction: Boolean = false
 }
 
 class ByteMinAggFunctionTest extends MinAggFunctionTest[Byte] {
@@ -157,7 +157,7 @@ class BooleanMinAggFunctionTest extends AggFunctionTestBase[Boolean] {
 
   override def aggregator: AggregateFunction[Boolean] = new BooleanMinAggFunction()
 
-  override def ifSupportRetraction: Boolean = false
+  override def supportRetraction: Boolean = false
 }
 
 class DecimalMinAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
@@ -190,5 +190,5 @@ class DecimalMinAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
 
   override def aggregator: AggregateFunction[BigDecimal] = new DecimalMinAggFunction()
 
-  override def ifSupportRetraction: Boolean = false
+  override def supportRetraction: Boolean = false
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MinWithRetractAggFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MinWithRetractAggFunctionTest.scala
@@ -21,11 +21,11 @@ import java.math.BigDecimal
 import org.apache.flink.table.functions.AggregateFunction
 
 /**
-  * Test case for built-in min aggregate function
+  * Test case for built-in Min with retraction aggregate function
   *
   * @tparam T the type for the aggregation result
   */
-abstract class MinAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T] {
+abstract class MinWithRetractAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T] {
 
   private val numeric: Numeric[T] = implicitly[Numeric[T]]
 
@@ -61,65 +61,63 @@ abstract class MinAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T] {
     minVal,
     null.asInstanceOf[T]
   )
-
-  override def ifSupportRetraction: Boolean = false
 }
 
-class ByteMinAggFunctionTest extends MinAggFunctionTest[Byte] {
+class ByteMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[Byte] {
 
   override def minVal = (Byte.MinValue + 1).toByte
 
   override def maxVal = (Byte.MaxValue - 1).toByte
 
-  override def aggregator: AggregateFunction[Byte] = new ByteMinAggFunction()
+  override def aggregator: AggregateFunction[Byte] = new ByteMinWithRetractAggFunction()
 }
 
-class ShortMinAggFunctionTest extends MinAggFunctionTest[Short] {
+class ShortMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[Short] {
 
   override def minVal = (Short.MinValue + 1).toShort
 
   override def maxVal = (Short.MaxValue - 1).toShort
 
-  override def aggregator: AggregateFunction[Short] = new ShortMinAggFunction()
+  override def aggregator: AggregateFunction[Short] = new ShortMinWithRetractAggFunction()
 }
 
-class IntMinAggFunctionTest extends MinAggFunctionTest[Int] {
+class IntMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[Int] {
 
   override def minVal = Int.MinValue + 1
 
   override def maxVal = Int.MaxValue - 1
 
-  override def aggregator: AggregateFunction[Int] = new IntMinAggFunction()
+  override def aggregator: AggregateFunction[Int] = new IntMinWithRetractAggFunction()
 }
 
-class LongMinAggFunctionTest extends MinAggFunctionTest[Long] {
+class LongMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[Long] {
 
   override def minVal = Long.MinValue + 1
 
   override def maxVal = Long.MaxValue - 1
 
-  override def aggregator: AggregateFunction[Long] = new LongMinAggFunction()
+  override def aggregator: AggregateFunction[Long] = new LongMinWithRetractAggFunction()
 }
 
-class FloatMinAggFunctionTest extends MinAggFunctionTest[Float] {
+class FloatMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[Float] {
 
   override def minVal = Float.MinValue / 2
 
   override def maxVal = Float.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Float] = new FloatMinAggFunction()
+  override def aggregator: AggregateFunction[Float] = new FloatMinWithRetractAggFunction()
 }
 
-class DoubleMinAggFunctionTest extends MinAggFunctionTest[Double] {
+class DoubleMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[Double] {
 
   override def minVal = Double.MinValue / 2
 
   override def maxVal = Double.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Double] = new DoubleMinAggFunction()
+  override def aggregator: AggregateFunction[Double] = new DoubleMinWithRetractAggFunction()
 }
 
-class BooleanMinAggFunctionTest extends AggFunctionTestBase[Boolean] {
+class BooleanMinWithRetractAggFunctionTest extends AggFunctionTestBase[Boolean] {
 
   override def inputValueSets: Seq[Seq[Boolean]] = Seq(
     Seq(
@@ -155,12 +153,10 @@ class BooleanMinAggFunctionTest extends AggFunctionTestBase[Boolean] {
     null.asInstanceOf[Boolean]
   )
 
-  override def aggregator: AggregateFunction[Boolean] = new BooleanMinAggFunction()
-
-  override def ifSupportRetraction: Boolean = false
+  override def aggregator: AggregateFunction[Boolean] = new BooleanMinWithRetractAggFunction()
 }
 
-class DecimalMinAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
+class DecimalMinWithRetractAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
 
   override def inputValueSets: Seq[Seq[_]] = Seq(
     Seq(
@@ -188,7 +184,5 @@ class DecimalMinAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
     null
   )
 
-  override def aggregator: AggregateFunction[BigDecimal] = new DecimalMinAggFunction()
-
-  override def ifSupportRetraction: Boolean = false
+  override def aggregator: AggregateFunction[BigDecimal] = new DecimalMinWithRetractAggFunction()
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/SumWithRetractAggFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/SumWithRetractAggFunctionTest.scala
@@ -22,11 +22,11 @@ import java.math.BigDecimal
 import org.apache.flink.table.functions.AggregateFunction
 
 /**
-  * Test case for built-in sum aggregate function
+  * Test case for built-in sum with retract aggregate function
   *
   * @tparam T the type for the aggregation result
   */
-abstract class SumAggFunctionTestBase[T: Numeric] extends AggFunctionTestBase[T] {
+abstract class SumWithRetractAggFunctionTestBase[T: Numeric] extends AggFunctionTestBase[T] {
 
   private val numeric: Numeric[T] = implicitly[Numeric[T]]
 
@@ -63,54 +63,52 @@ abstract class SumAggFunctionTestBase[T: Numeric] extends AggFunctionTestBase[T]
     numeric.fromInt(2),
     null.asInstanceOf[T]
   )
-
-  override def supportRetraction: Boolean = false
 }
 
-class ByteSumAggFunctionTest extends SumAggFunctionTestBase[Byte] {
+class ByteSumWithRetractAggFunctionTest extends SumWithRetractAggFunctionTestBase[Byte] {
 
   override def maxVal = (Byte.MaxValue / 2).toByte
 
-  override def aggregator: AggregateFunction[Byte] = new ByteSumAggFunction
+  override def aggregator: AggregateFunction[Byte] = new ByteSumWithRetractAggFunction
 }
 
-class ShortSumAggFunctionTest extends SumAggFunctionTestBase[Short] {
+class ShortSumWithRetractAggFunctionTest extends SumWithRetractAggFunctionTestBase[Short] {
 
   override def maxVal = (Short.MaxValue / 2).toShort
 
-  override def aggregator: AggregateFunction[Short] = new ShortSumAggFunction
+  override def aggregator: AggregateFunction[Short] = new ShortSumWithRetractAggFunction
 }
 
-class IntSumAggFunctionTest extends SumAggFunctionTestBase[Int] {
+class IntSumWithRetractAggFunctionTest extends SumWithRetractAggFunctionTestBase[Int] {
 
   override def maxVal = Int.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Int] = new IntSumAggFunction
+  override def aggregator: AggregateFunction[Int] = new IntSumWithRetractAggFunction
 }
 
-class LongSumAggFunctionTest extends SumAggFunctionTestBase[Long] {
+class LongSumWithRetractAggFunctionTest extends SumWithRetractAggFunctionTestBase[Long] {
 
   override def maxVal = Long.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Long] = new LongSumAggFunction
+  override def aggregator: AggregateFunction[Long] = new LongSumWithRetractAggFunction
 }
 
-class FloatSumAggFunctionTest extends SumAggFunctionTestBase[Float] {
+class FloatSumWithRetractAggFunctionTest extends SumWithRetractAggFunctionTestBase[Float] {
 
   override def maxVal = 12345.6789f
 
-  override def aggregator: AggregateFunction[Float] = new FloatSumAggFunction
+  override def aggregator: AggregateFunction[Float] = new FloatSumWithRetractAggFunction
 }
 
-class DoubleSumAggFunctionTest extends SumAggFunctionTestBase[Double] {
+class DoubleSumWithRetractAggFunctionTest extends SumWithRetractAggFunctionTestBase[Double] {
 
   override def maxVal = 12345.6789d
 
-  override def aggregator: AggregateFunction[Double] = new DoubleSumAggFunction
+  override def aggregator: AggregateFunction[Double] = new DoubleSumWithRetractAggFunction
 }
 
 
-class DecimalSumAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
+class DecimalSumWithRetractAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
 
   override def inputValueSets: Seq[Seq[_]] = Seq(
     Seq(
@@ -143,9 +141,7 @@ class DecimalSumAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
     null
   )
 
-  override def aggregator: AggregateFunction[BigDecimal] = new DecimalSumAggFunction()
-
-  override def supportRetraction: Boolean = false
+  override def aggregator: AggregateFunction[BigDecimal] = new DecimalSumWithRetractAggFunction()
 }
 
 


### PR DESCRIPTION
This PR adds retraction method for AggregateFunction, it also implements retract methods as well as test cases for all built-in aggregates.

Retraction method is help for processing update message. It will also very helpful for the grouping window and over window aggregation where we may want to retract the out of window data from the accumulator. 


Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
