### PR TITLE
[FLINK-4714] [runtime] [streaming] Set task state to RUNNING after state has been restored

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -38,6 +38,20 @@ public abstract class AbstractInvokable {
 	private Environment environment;
 
 	/**
+	 * Initials the execution.
+	 *
+	 * This method is called when task needs to separate initialization apart from execution,
+	 * so that the state transition can change the task state to RUNNING between {@link #open()}
+	 * and {@link #invoke()}
+	 *
+	 * @throws Exception
+	 *         Tasks may forward their exceptions for the TaskManager to handle through failure/recovery.
+	 */
+	public void open() throws Exception {
+		// The default implementation does nothing.
+	}
+
+	/**
 	 * Starts the execution.
 	 *
 	 * <p>Must be overwritten by the concrete task implementation. This method

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -386,6 +386,7 @@ public class StreamTaskTestHarness<OUT> {
 		@Override
 		public void run() {
 			try {
+				task.open();
 				task.invoke();
 				shutdownIOManager();
 				shutdownMemoryManager();


### PR DESCRIPTION
The changes in this PR are

- add `open()` method in `AbstractInvokable` to let the invokable can be initialized during `DEPLOYING` state in `Task`. The default behavior is do nothing.
- separate `invokable.invoke()` into `invokable.open()` and `invokable.invoke()` in `Task`, and transit task state from `DEPLOYING` to `RUNNING` between them.
- `TaskCanceler` should be used to cancel the invokable in `DEPLOYING` state because invokable might be called in that state now.
- update `StreamTask` and `StreamTaskTestHarness` to solve this issue in FLINK-4714