### PR TITLE
[FLINK-5965] Typo on DropWizard wrappers

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -172,7 +172,7 @@ public class MyMapper extends RichMapFunction<Long, Integer> {
 
     this.histogram = getRuntimeContext()
       .getMetricGroup()
-      .histogram("myHistogram", new DropWizardHistogramWrapper(histogram));
+      .histogram("myHistogram", new DropwizardHistogramWrapper(histogram));
   }
 }
 {% endhighlight %}
@@ -221,7 +221,7 @@ public class MyMapper extends RichMapFunction<Long, Integer> {
 
     this.meter = getRuntimeContext()
       .getMetricGroup()
-      .meter("myMeter", new DropWizardMeterWrapper(meter));
+      .meter("myMeter", new DropwizardMeterWrapper(meter));
   }
 }
 {% endhighlight %}


### PR DESCRIPTION
This PR fixes two small typos in the metrics doc:

* `DropWizardHistogramWrapper` should be `DropwizardHistogramWrapper`
* `DropWizardMeterWrapper` should be `DropwizardMeterWrapper`