### PR TITLE
Flink 4816 Executions failed from "DEPLOYING" should retain restored checkpoint information

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -162,6 +162,8 @@ public class CheckpointCoordinator {
 	@Nullable
 	private CheckpointStatsTracker statsTracker;
 
+	private volatile long restoredCheckpointID = -1;
+
 	// --------------------------------------------------------------------------------------------
 
 	public CheckpointCoordinator(
@@ -949,9 +951,14 @@ public class CheckpointCoordinator {
 
 				statsTracker.reportRestoredCheckpoint(restored);
 			}
-
+			// set it inside lock
+			restoredCheckpointID = latest.getCheckpointID();
 			return true;
 		}
+	}
+
+	public long getRestoredCheckpointID() {
+		return this.restoredCheckpointID;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -958,7 +958,9 @@ public class CheckpointCoordinator {
 	}
 
 	public long getRestoredCheckpointID() {
-		return this.restoredCheckpointID;
+		synchronized (lock) {
+			return this.restoredCheckpointID;
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/DeployTaskException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/DeployTaskException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.execution;
+
+/**
+ * Thrown to indicate that a task failed while in the {@link ExecutionState#DEPLOYING}
+ * and there was no checkpoint restoration
+ */
+public class DeployTaskException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public DeployTaskException(Throwable cause) {
+		super(cause);
+	}
+
+	public DeployTaskException(String msg) {
+		super(msg);
+	}
+
+	public DeployTaskException() {
+		super();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/RestoreTaskException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/RestoreTaskException.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.execution;
+
+/**
+ * Thrown to indicate that a task failed while in the {@link ExecutionState#DEPLOYING}
+ * and also a check point restore happened
+ */
+public class RestoreTaskException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
+
+	private long checkpointId;
+	public RestoreTaskException(Throwable cause, long checkpointId) {
+		super(cause);
+		this.checkpointId = checkpointId;
+	}
+
+	public RestoreTaskException(String msg, long checkpointId) {
+		super(msg);
+		this.checkpointId = checkpointId;
+	}
+
+	public long getCheckpointId() {
+		return this.checkpointId;
+	}
+	public RestoreTaskException() {
+		super();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -35,7 +35,9 @@ import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.PartialInputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionLocation;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.execution.DeployTaskException;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.execution.RestoreTaskException;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.instance.SlotProvider;
 import org.apache.flink.runtime.io.network.ConnectionID;
@@ -863,6 +865,15 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 			if (transitionState(current, FAILED, t)) {
 				// success (in a manner of speaking)
+				if (current == DEPLOYING) {
+					long restoredCheckpointID = getVertex().getExecutionGraph().getCheckpointCoordinator().getRestoredCheckpointID();
+					if (restoredCheckpointID != -1) {
+						// we have restore it from a checkpoint
+						t = new RestoreTaskException(t, restoredCheckpointID);
+					} else {
+						t = new DeployTaskException(t);
+					}
+				}
 				this.failureCause = t;
 
 				try {


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [ ] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

Just does what ever the description says. Feedback/suggestions are welcome. Ran 'mvn clean verify -DskipTests' no static comment failures.