### PR TITLE
[FLINK-5975] Add volume support to flink-mesos

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -478,6 +478,8 @@ May be set to -1 to disable this feature.
 
 - `mesos.resourcemanager.tasks.container.image.name`: Image name to use for the container (**NO DEFAULT**)
 
+- `mesos.resourcemanager.tasks.container.image.volumes`: A comma seperated list of [host_path:]container_path[:RO|RW]. This allows for mounting additional volumes into your container. (**NO DEFAULT**)
+
 - `high-availability.zookeeper.path.mesos-workers`: The ZooKeeper root path for persisting the Mesos worker information.
 
 ### High Availability (HA)

--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -148,7 +148,7 @@ Below is a list of currently first-class supported connectors or components by F
 
 - Zookeeper (for HA): see [here]({{site.baseurl}}/setup/jobmanager_high_availability.html#configuring-for-zookeeper-security) for details on Zookeeper security configuration to work with the Kerberos-based security configurations mentioned here.
 
-For more information on how Flink security internally setups Kerberos authentication, please see [here]({{site.baseurl}}/ops/security-kerberos.html). 
+For more information on how Flink security internally setups Kerberos authentication, please see [here]({{site.baseurl}}/ops/security-kerberos.html).
 
 ### Other
 
@@ -190,7 +190,7 @@ will be used under the directory specified by jobmanager.web.tmpdir.
 
 - `blob.service.ssl.enabled`: Flag to enable ssl for the blob client/server communication. This is applicable only when the global ssl flag security.ssl.enabled is set to true (DEFAULT: true).
 
-- `restart-strategy`: Default [restart strategy]({{site.baseurl}}/dev/restart_strategies.html) to use in case no 
+- `restart-strategy`: Default [restart strategy]({{site.baseurl}}/dev/restart_strategies.html) to use in case no
 restart strategy has been specified for the job.
 The options are:
     - fixed delay strategy: `fixed-delay`.
@@ -203,7 +203,7 @@ The options are:
 Default value is 1, unless "fixed-delay" was activated by enabling checkpoints, in which case the default is `Integer.MAX_VALUE`.
 
 - `restart-strategy.fixed-delay.delay`: Delay between restart attempts, used if the default restart strategy is set to "fixed-delay".
-Default value is the `akka.ask.timeout`, unless "fixed-delay" was activated by enabling checkpoints, in which case 
+Default value is the `akka.ask.timeout`, unless "fixed-delay" was activated by enabling checkpoints, in which case
 the default is 10s.
 
 - `restart-strategy.failure-rate.max-failures-per-interval`: Maximum number of restarts in given time interval before failing a job in "failure-rate" strategy.
@@ -478,7 +478,7 @@ May be set to -1 to disable this feature.
 
 - `mesos.resourcemanager.tasks.container.image.name`: Image name to use for the container (**NO DEFAULT**)
 
-- `mesos.resourcemanager.tasks.container.image.volumes`: A comma seperated list of [host_path:]container_path[:RO|RW]. This allows for mounting additional volumes into your container. (**NO DEFAULT**)
+- `mesos.resourcemanager.tasks.container.volumes`: A comma seperated list of [host_path:]container_path[:RO|RW]. This allows for mounting additional volumes into your container. (**NO DEFAULT**)
 
 - `high-availability.zookeeper.path.mesos-workers`: The ZooKeeper root path for persisting the Mesos worker information.
 

--- a/docs/setup/mesos.md
+++ b/docs/setup/mesos.md
@@ -257,3 +257,5 @@ May be set to -1 to disable this feature.
 `mesos.resourcemanager.tasks.container.type`: Type of the containerization used: "mesos" or "docker" (DEFAULT: mesos);
 
 `mesos.resourcemanager.tasks.container.image.name`: Image name to use for the container (**NO DEFAULT**)
+
+`mesos.resourcemanager.tasks.container.image.volumes`: A comma seperated list of [host_path:]container_path[:RO|RW]. This allows for mounting additional volumes into your container. (**NO DEFAULT**)

--- a/docs/setup/mesos.md
+++ b/docs/setup/mesos.md
@@ -258,4 +258,4 @@ May be set to -1 to disable this feature.
 
 `mesos.resourcemanager.tasks.container.image.name`: Image name to use for the container (**NO DEFAULT**)
 
-`mesos.resourcemanager.tasks.container.image.volumes`: A comma seperated list of [host_path:]container_path[:RO|RW]. This allows for mounting additional volumes into your container. (**NO DEFAULT**)
+`mesos.resourcemanager.tasks.container.volumes`: A comma seperated list of [host_path:]container_path[:RO|RW]. This allows for mounting additional volumes into your container. (**NO DEFAULT**)

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -262,10 +262,10 @@ public class LaunchableMesosWorker implements LaunchableTask {
 				throw new IllegalStateException("unsupported container type");
 		}
 		if(containerInfo != null) {
+			containerInfo.addAllVolumes(params.containerVolumes());
 			taskInfo.setContainer(containerInfo);
 		}
 
-		containerInfo.addAllVolumes(params.containerVolumes());
 
 		return taskInfo.build();
 	}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -56,6 +56,9 @@ public class MesosTaskManagerParameters {
 		key("mesos.resourcemanager.tasks.container.image.name")
 			.noDefaultValue();
 
+	public static final ConfigOption<String> MESOS_RM_CONTAINER_VOLUMES =
+		key("mesos.resourcemanager.tasks.container.volumes")
+			.noDefaultValue();
 	/**
 	 * Value for {@code MESOS_RESOURCEMANAGER_TASKS_CONTAINER_TYPE} setting. Tells to use the Mesos containerizer.
 	 */
@@ -73,16 +76,20 @@ public class MesosTaskManagerParameters {
 
 	private final ContaineredTaskManagerParameters containeredParameters;
 
+	private final Option<String> containerVolumes;
+
 	public MesosTaskManagerParameters(
 		double cpus,
 		ContainerType containerType,
 		Option<String> containerImageName,
-		ContaineredTaskManagerParameters containeredParameters) {
+		ContaineredTaskManagerParameters containeredParameters,
+		Option<String> containerVolumes) {
 		requireNonNull(containeredParameters);
 		this.cpus = cpus;
 		this.containerType = containerType;
 		this.containerImageName = containerImageName;
 		this.containeredParameters = containeredParameters;
+		this.containerVolumes =  containerVolumes;
 	}
 
 	/**
@@ -114,6 +121,11 @@ public class MesosTaskManagerParameters {
 	public ContaineredTaskManagerParameters containeredParameters() {
 		return containeredParameters;
 	}
+
+	/**
+	 * Get the container volumes string
+	 */
+	public Option<String> containerVolumes() { return containerVolumes; }
 
 	@Override
 	public String toString() {
@@ -162,11 +174,14 @@ public class MesosTaskManagerParameters {
 				throw new IllegalConfigurationException("invalid container type: " + containerTypeString);
 		}
 
+		String containerVolumes = flinkConfig.getString(MESOS_RM_CONTAINER_VOLUMES);
+
 		return new MesosTaskManagerParameters(
 			cpus,
 			containerType,
 			Option.apply(imageName),
-			containeredParameters);
+			containeredParameters,
+			Option.apply(containerVolumes));
 	}
 
 	public enum ContainerType {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -23,7 +23,11 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
+import org.apache.mesos.Protos;
 import scala.Option;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.flink.configuration.ConfigOptions.key;
@@ -76,14 +80,14 @@ public class MesosTaskManagerParameters {
 
 	private final ContaineredTaskManagerParameters containeredParameters;
 
-	private final Option<String> containerVolumes;
+	private final List<Protos.Volume> containerVolumes;
 
 	public MesosTaskManagerParameters(
 		double cpus,
 		ContainerType containerType,
 		Option<String> containerImageName,
 		ContaineredTaskManagerParameters containeredParameters,
-		Option<String> containerVolumes) {
+		List<Protos.Volume> containerVolumes) {
 		requireNonNull(containeredParameters);
 		this.cpus = cpus;
 		this.containerType = containerType;
@@ -92,7 +96,8 @@ public class MesosTaskManagerParameters {
 		this.containerVolumes =  containerVolumes;
 	}
 
-	/**
+
+    /**
 	 * Get the CPU units to use for the TaskManager process.
      */
 	public double cpus() {
@@ -125,7 +130,7 @@ public class MesosTaskManagerParameters {
 	/**
 	 * Get the container volumes string
 	 */
-	public Option<String> containerVolumes() {
+	public List<Protos.Volume> containerVolumes() {
 		return containerVolumes;
 	}
 
@@ -136,6 +141,7 @@ public class MesosTaskManagerParameters {
 			", containerType=" + containerType +
 			", containerImageName=" + containerImageName +
 			", containeredParameters=" + containeredParameters +
+			", containerVolumes=" + containerVolumes.toString()	+
 			'}';
 	}
 
@@ -176,14 +182,65 @@ public class MesosTaskManagerParameters {
 				throw new IllegalConfigurationException("invalid container type: " + containerTypeString);
 		}
 
-		String containerVolumes = flinkConfig.getString(MESOS_RM_CONTAINER_VOLUMES);
+		Option<String> containerVolOpt = Option.<String>apply(flinkConfig.getString(MESOS_RM_CONTAINER_VOLUMES));
+		List<Protos.Volume> containerVolumes = buildVolumes(containerVolOpt);
 
 		return new MesosTaskManagerParameters(
 			cpus,
 			containerType,
 			Option.apply(imageName),
 			containeredParameters,
-			Option.apply(containerVolumes));
+			containerVolumes);
+	}
+
+	/**
+	 * Used to build volume specs for mesos. This allows for mounting additional volumes into a container
+	 *
+	 * @param containerVolumes a comma delimited optional string of [host_path:]container_path[:RO|RW] that
+	 *                         defines mount points for a container volume. If None or empty string, returns
+	 *                         an empty iterator
+	 */
+	public static List<Protos.Volume> buildVolumes(Option<String> containerVolumes) {
+		if (containerVolumes.isEmpty()) {
+			return new ArrayList<Protos.Volume>();
+		}
+		String[] specs = containerVolumes.get().split(",");
+		List<Protos.Volume> vols = new ArrayList<Protos.Volume>();
+		for (String s : specs) {
+			if (s.trim().isEmpty()) {
+				continue;
+			}
+			Protos.Volume.Builder vol = Protos.Volume.newBuilder();
+			vol.setMode(Protos.Volume.Mode.RW);
+
+			String[] parts = s.split(":");
+			switch (parts.length) {
+				case 1:
+					vol.setContainerPath(parts[0]);
+					break;
+				case 2:
+					try {
+						Protos.Volume.Mode mode = Protos.Volume.Mode.valueOf(parts[1].trim().toUpperCase());
+						vol.setMode(mode)
+								.setContainerPath(parts[0]);
+					} catch (IllegalArgumentException e) {
+						vol.setHostPath(parts[0])
+								.setContainerPath(parts[1]);
+					}
+					break;
+				case 3:
+					Protos.Volume.Mode mode = Protos.Volume.Mode.valueOf(parts[2].trim().toUpperCase());
+					vol.setMode(mode)
+							.setHostPath(parts[0])
+							.setContainerPath(parts[1]);
+					break;
+				default:
+					throw new IllegalArgumentException("volume specification is invalid, given: " + s);
+			}
+
+			vols.add(vol.build());
+		}
+		return vols;
 	}
 
 	public enum ContainerType {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -125,7 +125,9 @@ public class MesosTaskManagerParameters {
 	/**
 	 * Get the container volumes string
 	 */
-	public Option<String> containerVolumes() { return containerVolumes; }
+	public Option<String> containerVolumes() {
+		return containerVolumes;
+	}
 
 	@Override
 	public String toString() {

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorkerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorkerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.mesos.runtime.clusterframework;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.mesos.util.MesosArtifactResolver;
+import org.apache.flink.runtime.clusterframework.ContainerSpecification;
+import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
+import org.apache.flink.util.TestLogger;
+import org.apache.mesos.Protos;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import scala.Option;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class LaunchableMesosWorkerTest extends TestLogger {
+	MesosTaskManagerParameters params = Mockito.mock(MesosTaskManagerParameters.class);
+	MesosArtifactResolver resolver = Mockito.mock(MesosArtifactResolver.class);
+	ContainerSpecification containerSpec = Mockito.mock(ContainerSpecification.class);
+	Protos.TaskID taskId = Protos.TaskID.newBuilder().setValue("1234").build();
+	LaunchableMesosWorker worker = new LaunchableMesosWorker(resolver, params, containerSpec, taskId);
+
+	@Test
+	public void volumes() throws Exception {
+		List<Protos.Volume> vols;
+		assertEquals(worker.volumes(Option.<String>apply(null)).size(), 0);
+		String spec1 = "/host/path:/container/path:RO,/container/path:ro,/host/path:/container/path,/container/path";
+		vols = worker.volumes(Option.<String>apply(spec1));
+		assertEquals(vols.size(), 4);
+		assertEquals("/container/path", vols.get(0).getContainerPath());
+		assertEquals("/host/path", vols.get(0).getHostPath());
+		assertEquals(Protos.Volume.Mode.RO, vols.get(0).getMode());
+		assertEquals("/container/path", vols.get(1).getContainerPath());
+		assertEquals(Protos.Volume.Mode.RO, vols.get(1).getMode());
+		assertEquals("/container/path", vols.get(2).getContainerPath());
+		assertEquals("/host/path", vols.get(2).getHostPath());
+		assertEquals(Protos.Volume.Mode.RW, vols.get(2).getMode());
+		assertEquals("/container/path", vols.get(3).getContainerPath());
+		assertEquals(Protos.Volume.Mode.RW, vols.get(3).getMode());
+
+		// should handle empty strings, but not error
+		assertEquals(0, worker.volumes(Option.<String>apply("")).size());
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void volumesBadMode() throws Exception {
+		worker.volumes(Option.<String>apply("/hp:/cp:RF"));
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void volumesMalformed() throws Exception {
+		worker.volumes(Option.<String>apply("/hp:/cp:ro:extra"));
+	}
+
+}

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorkerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorkerTest.java
@@ -18,14 +18,11 @@
 
 package org.apache.flink.mesos.runtime.clusterframework;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.mesos.util.MesosArtifactResolver;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
-import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.util.TestLogger;
 import org.apache.mesos.Protos;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import scala.Option;
 
@@ -34,18 +31,13 @@ import java.util.List;
 import static org.junit.Assert.*;
 
 public class LaunchableMesosWorkerTest extends TestLogger {
-	MesosTaskManagerParameters params = Mockito.mock(MesosTaskManagerParameters.class);
-	MesosArtifactResolver resolver = Mockito.mock(MesosArtifactResolver.class);
-	ContainerSpecification containerSpec = Mockito.mock(ContainerSpecification.class);
-	Protos.TaskID taskId = Protos.TaskID.newBuilder().setValue("1234").build();
-	LaunchableMesosWorker worker = new LaunchableMesosWorker(resolver, params, containerSpec, taskId);
 
 	@Test
-	public void volumes() throws Exception {
+	public void testBuildVolumes() throws Exception {
 		List<Protos.Volume> vols;
-		assertEquals(worker.volumes(Option.<String>apply(null)).size(), 0);
+		assertEquals(LaunchableMesosWorker.buildVolumes(Option.<String>apply(null)).size(), 0);
 		String spec1 = "/host/path:/container/path:RO,/container/path:ro,/host/path:/container/path,/container/path";
-		vols = worker.volumes(Option.<String>apply(spec1));
+		vols = LaunchableMesosWorker.buildVolumes(Option.<String>apply(spec1));
 		assertEquals(vols.size(), 4);
 		assertEquals("/container/path", vols.get(0).getContainerPath());
 		assertEquals("/host/path", vols.get(0).getHostPath());
@@ -59,17 +51,17 @@ public class LaunchableMesosWorkerTest extends TestLogger {
 		assertEquals(Protos.Volume.Mode.RW, vols.get(3).getMode());
 
 		// should handle empty strings, but not error
-		assertEquals(0, worker.volumes(Option.<String>apply("")).size());
+		assertEquals(0, LaunchableMesosWorker.buildVolumes(Option.<String>apply("")).size());
 	}
 
 	@Test(expected=IllegalArgumentException.class)
-	public void volumesBadMode() throws Exception {
-		worker.volumes(Option.<String>apply("/hp:/cp:RF"));
+	public void testBuildVolumesBadMode() throws Exception {
+		LaunchableMesosWorker.buildVolumes(Option.<String>apply("/hp:/cp:RF"));
 	}
 
 	@Test(expected=IllegalArgumentException.class)
-	public void volumesMalformed() throws Exception {
-		worker.volumes(Option.<String>apply("/hp:/cp:ro:extra"));
+	public void testBuildVolumesMalformed() throws Exception {
+		LaunchableMesosWorker.buildVolumes(Option.<String>apply("/hp:/cp:ro:extra"));
 	}
 
 }

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
@@ -57,11 +57,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.*;
+
 import static java.util.Collections.singletonList;
-import java.util.HashMap;
 
 import static org.apache.flink.mesos.runtime.clusterframework.MesosFlinkResourceManager.extractGoalState;
 import static org.apache.flink.mesos.runtime.clusterframework.MesosFlinkResourceManager.extractResourceID;
@@ -201,7 +199,7 @@ public class MesosFlinkResourceManagerTest extends TestLogger {
 			ContaineredTaskManagerParameters containeredParams =
 				new ContaineredTaskManagerParameters(1024, 768, 256, 4, new HashMap<String, String>());
 			MesosTaskManagerParameters tmParams = new MesosTaskManagerParameters(
-				1.0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams, Option.<String>empty());
+				1.0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams, new ArrayList<Protos.Volume>());
 
 			TestActorRef<TestingMesosFlinkResourceManager> resourceManagerRef =
 				TestActorRef.create(system, MesosFlinkResourceManager.createActorProps(

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
@@ -201,7 +201,7 @@ public class MesosFlinkResourceManagerTest extends TestLogger {
 			ContaineredTaskManagerParameters containeredParams =
 				new ContaineredTaskManagerParameters(1024, 768, 256, 4, new HashMap<String, String>());
 			MesosTaskManagerParameters tmParams = new MesosTaskManagerParameters(
-				1.0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams);
+				1.0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams, Option.<String>empty());
 
 			TestActorRef<TestingMesosFlinkResourceManager> resourceManagerRef =
 				TestActorRef.create(system, MesosFlinkResourceManager.createActorProps(

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -18,26 +18,24 @@
 
 package org.apache.flink.mesos.runtime.clusterframework;
 
-import org.apache.flink.mesos.util.MesosArtifactResolver;
-import org.apache.flink.runtime.clusterframework.ContainerSpecification;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.TestLogger;
 import org.apache.mesos.Protos;
 import org.junit.Test;
-import org.mockito.Mockito;
 import scala.Option;
 
 import java.util.List;
 
 import static org.junit.Assert.*;
 
-public class LaunchableMesosWorkerTest extends TestLogger {
+public class MesosTaskManagerParametersTest extends TestLogger {
 
 	@Test
 	public void testBuildVolumes() throws Exception {
 		List<Protos.Volume> vols;
-		assertEquals(LaunchableMesosWorker.buildVolumes(Option.<String>apply(null)).size(), 0);
+		assertEquals(MesosTaskManagerParameters.buildVolumes(Option.<String>apply(null)).size(), 0);
 		String spec1 = "/host/path:/container/path:RO,/container/path:ro,/host/path:/container/path,/container/path";
-		vols = LaunchableMesosWorker.buildVolumes(Option.<String>apply(spec1));
+		vols = MesosTaskManagerParameters.buildVolumes(Option.<String>apply(spec1));
 		assertEquals(vols.size(), 4);
 		assertEquals("/container/path", vols.get(0).getContainerPath());
 		assertEquals("/host/path", vols.get(0).getHostPath());
@@ -51,17 +49,29 @@ public class LaunchableMesosWorkerTest extends TestLogger {
 		assertEquals(Protos.Volume.Mode.RW, vols.get(3).getMode());
 
 		// should handle empty strings, but not error
-		assertEquals(0, LaunchableMesosWorker.buildVolumes(Option.<String>apply("")).size());
+		assertEquals(0, MesosTaskManagerParameters.buildVolumes(Option.<String>apply("")).size());
 	}
 
 	@Test(expected=IllegalArgumentException.class)
 	public void testBuildVolumesBadMode() throws Exception {
-		LaunchableMesosWorker.buildVolumes(Option.<String>apply("/hp:/cp:RF"));
+		MesosTaskManagerParameters.buildVolumes(Option.<String>apply("/hp:/cp:RF"));
 	}
 
 	@Test(expected=IllegalArgumentException.class)
 	public void testBuildVolumesMalformed() throws Exception {
-		LaunchableMesosWorker.buildVolumes(Option.<String>apply("/hp:/cp:ro:extra"));
+		MesosTaskManagerParameters.buildVolumes(Option.<String>apply("/hp:/cp:ro:extra"));
+	}
+
+	@Test
+	public void testContainerVolumes() throws Exception {
+		Configuration config = new Configuration();
+		config.setString(MesosTaskManagerParameters.MESOS_RM_CONTAINER_VOLUMES, "/host/path:/container/path:ro");
+
+		MesosTaskManagerParameters params = MesosTaskManagerParameters.create(config);
+		assertEquals(1, params.containerVolumes().size());
+		assertEquals("/container/path", params.containerVolumes().get(0).getContainerPath());
+		assertEquals("/host/path", params.containerVolumes().get(0).getHostPath());
+		assertEquals(Protos.Volume.Mode.RO, params.containerVolumes().get(0).getMode());
 	}
 
 }


### PR DESCRIPTION
When using containerization, specifically, docker, it is useful to be
able to attach additional volumes, such as an NFS share.

This adds support for volumes to be attached via specifying a new config
values `mesos.resourcemanager.tasks.container.volumes`. This is comma
delimited string of `[host_path:]container_path[:RO|RW]`.

It is modeled after the spark mesos framework

Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
