### PR TITLE
[FLINK-4460] Side Outputs in Flink

### DIFF
--- a/docs/dev/stream/side_output.md
+++ b/docs/dev/stream/side_output.md
@@ -1,0 +1,138 @@
+---
+title: "Side Outputs"
+nav-title: "Side Outputs"
+nav-parent_id: streaming
+nav-pos: 36
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+* This will be replaced by the TOC
+{:toc}
+
+In addition to the main stream that results from `DataStream` operations, you can also produce any
+number of additional side output result streams. The type of data in the result streams does not
+have to match the type of data in the main stream and the types of the different side outputs can
+also differ. This operation can be useful when you want to split a stream of data where you would
+normally have to replicate the stream and then filter out from each stream the data that you don't
+want to have.
+
+When using side outputs, you first need to define an `OutputTag` that will be used to identify a
+side output stream:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+
+{% highlight java %}
+// this needs to be an anonymous inner class, so that we can analyze the type
+OutputTag<String> outputTag = new OutputTag<String>("string-side-output") {};
+{% endhighlight %}
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val outputTag = OutputTag[String]("string-side-output")
+{% endhighlight %}
+</div>
+</div>
+
+Notice how the `OutputTag` is typed according to the type of elements that the side output stream
+contains.
+
+Emitting data to a side output it only possible when using a
+[ProcessFunction](/dev/stream/process_function.html). In the function, you can use the `Context` parameter
+to emit data to a side output identified by an `OutputTag`:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+
+{% highlight java %}
+DataStream<Integer> input = ...;
+
+final OutputTag<String> outputTag = new OutputTag<String>("side-output"){};
+
+SingleOutputStreamOperator<Integer> mainDataStream = input
+  .process(new ProcessFunction<Integer, Integer>() {
+
+      @Override
+      public void processElement(
+          Integer input,
+          Context ctx,
+          Collector<Integer> out) throws Exception {
+        // emit data to regular output
+        out.collect(value);
+
+        // emit data to side output
+        ctx.output(sideOutputTag, "sideout-" + String.valueOf(value));
+      }
+    });
+{% endhighlight %}
+
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+
+val input: DataStream[Int] = ...
+val outputTag = OutputTag[String]("string-side-output")
+
+val mainDataStream = input
+  .process(new ProcessFunction[Int, Int] {
+    override def processElement(
+        value: Int,
+        ctx: ProcessFunction[Int, Int]#Context,
+        out: Collector[Int]): Unit = {
+      // emit data to regular output
+      out.collect(value)
+
+      // emit data to side output
+      ctx.output(outputTag, "sideout-" + String.valueOf(value))
+    }
+  })
+{% endhighlight %}
+</div>
+</div>
+
+For retrieving the side output stream you use `getSideOutput(OutputTag)`
+on the result of the `DataStream` operation. This will give you a `DataStream` that is typed
+to the result of the side output stream:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+
+{% highlight java %}
+final OutputTag<String> outputTag = new OutputTag<String>("side-output"){};
+
+SingleOutputStreamOperator<Integer> mainDataStream = ...;
+
+DataStream<String> sideOutputStream = mainDataStream.getSideOutput(outputTag);
+{% endhighlight %}
+
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val outputTag = OutputTag[String]("string-side-output")
+
+val mainDataStream = ...
+
+val sideOutputStream: DataStream[String] = mainDataStream.getSideOutput(outputTag)
+{% endhighlight %}
+</div>
+</div>

--- a/docs/dev/windows.md
+++ b/docs/dev/windows.md
@@ -973,6 +973,51 @@ input
 <span class="label label-info">Note</span> When using the `GlobalWindows` window assigner no
 data is ever considered late because the end timestamp of the global window is `Long.MAX_VALUE`.
 
+### Getting late data as a side output
+
+Using Flink's [side output](/dev/stream/side_output.html) feature you can get a stream of the data
+that was discarded as late.
+
+You first need to specify that you want to get late data using `sideOutputLateData(OutputTag)` on
+the windowed stream. Then, you can get the side-output stream on the result of the windowed
+operation:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+final OutputTag<T> lateOutputTag = new OutputTag<T>("late-data"){};
+
+DataStream<T> input = ...;
+
+DataStream<T> result = input
+    .keyBy(<key selector>)
+    .window(<window assigner>)
+    .allowedLateness(<time>)
+    .sideOutputLateData(lateOutputTag)
+    .<windowed transformation>(<window function>);
+
+DataStream<T> lateStream = result.getSideOutput(lateOutputTag);
+{% endhighlight %}
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val lateOutputTag = OutputTag[T]("late-data")
+
+val input: DataStream[T] = ...
+
+val result = input
+    .keyBy(<key selector>)
+    .window(<window assigner>)
+    .allowedLateness(<time>)
+    .sideOutputLateData(lateOutputTag)
+    .<windowed transformation>(<window function>)
+
+val lateStream = result.getSideOutput(lateOutputTag)
+{% endhighlight %}
+</div>
+</div>
+
 ### Late elements considerations
 
 When specifying an allowed lateness greater than 0, the window along with its content is kept after the watermark passes

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeHint.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeHint.java
@@ -46,7 +46,14 @@ public abstract class TypeHint<T> {
 	public TypeHint() {
 		this.typeInfo = TypeExtractor.createTypeInfo(this, TypeHint.class, getClass(), 0);
 	}
-	
+
+	/**
+	 * Creates a hint for the generic type in the class signature.
+	 */
+	public TypeHint(Class<?> baseClass, Object instance, int genericParameterPos) {
+		this.typeInfo = TypeExtractor.createTypeInfo(instance, baseClass, instance.getClass(), genericParameterPos);
+	}
+
 	// ------------------------------------------------------------------------
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/util/OutputTag.java
+++ b/flink-core/src/main/java/org/apache/flink/util/OutputTag.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.util;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.InvalidTypesException;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+
+/**
+ * An {@link OutputTag} is a typed and named tag to use for tagging side outputs
+ * of an operator.
+ *
+ * <p>An {@code OutputTag} must always be an anonymous inner class so that Flink can derive
+ * a {@link TypeInformation} for the generic type parameter.
+ *
+ * <p>Example:
+ * <pre>{@code
+ * OutputTag<Tuple2<String, Long>> info = new OutputTag<Tuple2<String, Long>>("late-data"){});
+ * }</pre>
+ *
+ * @param <T> the type of elements in the side-output stream.
+ */
+@PublicEvolving
+public class OutputTag<T> implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private final String id;
+
+	private transient TypeInformation<T> typeInfo;
+
+	/**
+	 * Creates a new named {@code OutputTag} with the given id.
+	 *
+	 * @param id The id of the created {@code OutputTag}.
+     */
+	public OutputTag(String id) {
+		this.id = Preconditions.checkNotNull(id, "OutputTag id cannot be null.");
+
+		try {
+			TypeHint<T> typeHint = new TypeHint<T>(OutputTag.class, this, 0) {};
+			this.typeInfo = typeHint.getTypeInfo();
+		} catch (InvalidTypesException e) {
+			throw new InvalidTypesException("Could not determine TypeInformation for generic " +
+					"OutputTag type. Did you forget to make your OutputTag an anonymous inner class?", e);
+		}
+	}
+
+	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+		in.defaultReadObject();
+		typeInfo = null;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public TypeInformation<T> getTypeInfo() {
+		return typeInfo;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return obj instanceof OutputTag
+			&& ((OutputTag) obj).id.equals(this.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return id.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return "OutputTag(" + getTypeInfo() + ", " + id + ")";
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/util/OutputTag.java
+++ b/flink-core/src/main/java/org/apache/flink/util/OutputTag.java
@@ -67,6 +67,17 @@ public class OutputTag<T> implements Serializable {
 		}
 	}
 
+	/**
+	 * Creates a new named {@code OutputTag} with the given id and output {@link TypeInformation}.
+	 *
+	 * @param id The id of the created {@code OutputTag}.
+	 * @param typeInfo The {@code TypeInformation} for the side output.
+	 */
+	public OutputTag(String id, TypeInformation<T> typeInfo) {
+		this.id = Preconditions.checkNotNull(id, "OutputTag id cannot be null.");
+		this.typeInfo = Preconditions.checkNotNull(typeInfo, "TypeInformation cannot be null.");
+	}
+
 	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
 		in.defaultReadObject();
 		typeInfo = null;

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/sideoutput/SideOutputExample.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/sideoutput/SideOutputExample.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.examples.sideoutput;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.examples.java.wordcount.util.WordCountData;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.Collector;
+
+/**
+ * An example that illustrates the use of side outputs.
+ *
+ * <p>This is a modified version of {@link org.apache.flink.streaming.examples.windowing.WindowWordCount}
+ * that has a filter in the tokenizer and only emits some words for counting
+ * while emitting the other words to a side output.
+ */
+public class SideOutputExample {
+
+	/**
+	 * We need to create an {@link OutputTag} so that we can reference it when emitting
+	 * data to a side output and also to retrieve the side output stream from an operation.
+	 */
+	static final OutputTag<String> rejectedWordsTag = new OutputTag<String>("rejected") {};
+
+	public static void main(String[] args) throws Exception {
+
+		// Checking input parameters
+		final ParameterTool params = ParameterTool.fromArgs(args);
+
+		// set up the execution environment
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		env.setStreamTimeCharacteristic(TimeCharacteristic.IngestionTime);
+
+		// make parameters available in the web interface
+		env.getConfig().setGlobalJobParameters(params);
+
+		// get input data
+		DataStream<String> text;
+		if (params.has("input")) {
+			// read the text file from given input path
+			text = env.readTextFile(params.get("input"));
+		} else {
+			System.out.println("Executing WordCount example with default input data set.");
+			System.out.println("Use --input to specify file input.");
+			// get default test text data
+			text = env.fromElements(WordCountData.WORDS);
+		}
+
+		SingleOutputStreamOperator<Tuple2<String, Integer>> tokenized = text
+				.keyBy(new KeySelector<String, Integer>() {
+					private static final long serialVersionUID = 1L;
+					
+					@Override
+					public Integer getKey(String value) throws Exception {
+						return 0;
+					}
+				})
+				.process(new Tokenizer());
+
+		DataStream<String> rejectedWords = tokenized
+				.getSideOutput(rejectedWordsTag)
+				.map(new MapFunction<String, String>() {
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					public String map(String value) throws Exception {
+						return "rejected: " + value;
+					}
+				});
+
+		DataStream<Tuple2<String, Integer>> counts = tokenized
+				.keyBy(0)
+				.window(TumblingEventTimeWindows.of(Time.seconds(5)))
+				// group by the tuple field "0" and sum up tuple field "1"
+				.sum(1);
+
+		// emit result
+		if (params.has("output")) {
+			counts.writeAsText(params.get("output"));
+			rejectedWords.writeAsText(params.get("rejected-words-output"));
+		} else {
+			System.out.println("Printing result to stdout. Use --output to specify output path.");
+			counts.print();
+			rejectedWords.print();
+		}
+
+		// execute program
+		env.execute("Streaming WordCount SideOutput");
+	}
+
+	// *************************************************************************
+	// USER FUNCTIONS
+	// *************************************************************************
+
+	/**
+	 * Implements the string tokenizer that splits sentences into words as a
+	 * user-defined FlatMapFunction. The function takes a line (String) and
+	 * splits it into multiple pairs in the form of "(word,1)" ({@code Tuple2<String,
+	 * Integer>}).
+	 *
+	 * <p>This rejects words that are longer than 5 characters long.
+	 */
+	public static final class Tokenizer extends ProcessFunction<String, Tuple2<String, Integer>> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void processElement(
+				String value,
+				Context ctx,
+				Collector<Tuple2<String, Integer>> out) throws Exception {
+			// normalize and split the line
+			String[] tokens = value.toLowerCase().split("\\W+");
+
+			// emit the pairs
+			for (String token : tokens) {
+				if (token.length() > 5) {
+					ctx.output(rejectedWordsTag, token);
+				} else if (token.length() > 0) {
+					out.collect(new Tuple2<>(token, 1));
+				}
+			}
+
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/collector/selector/DirectedOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/collector/selector/DirectedOutput.java
@@ -32,6 +32,7 @@ import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.XORShiftRandom;
 
 
@@ -136,6 +137,11 @@ public class DirectedOutput<OUT> implements Output<StreamRecord<OUT>> {
 		for (Output<StreamRecord<OUT>> out : selectedOutputs) {
 			out.collect(record);
 		}
+	}
+
+	@Override
+	public <X> void collect(OutputTag<?> outputTag, StreamRecord<X> record) {
+		throw new UnsupportedOperationException("Cannot use split/select with side outputs.");
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.datastream;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.functions.InvalidTypesException;
+import org.apache.flink.util.OutputTag;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -27,6 +28,7 @@ import org.apache.flink.api.java.typeutils.TypeInfoParser;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
+import org.apache.flink.streaming.api.transformations.SideOutputTransformation;
 import org.apache.flink.streaming.api.transformations.StreamTransformation;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.util.Preconditions;
@@ -415,5 +417,17 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 	public SingleOutputStreamOperator<T> slotSharingGroup(String slotSharingGroup) {
 		transformation.setSlotSharingGroup(slotSharingGroup);
 		return this;
+	}
+
+	/**
+	 * Gets the {@link DataStream} that contains the elements that are emitted from an operation
+	 * into the side output with the given {@link OutputTag}.
+	 *
+	 * @see org.apache.flink.streaming.api.functions.ProcessFunction.Context#output(OutputTag, Object)
+	 */
+	public <X> DataStream<X> getSideOutput(OutputTag<X> sideOutputTag){
+		sideOutputTag = clean(sideOutputTag);
+		SideOutputTransformation<X> sideOutputTransformation = new SideOutputTransformation<>(this.getTransformation(), requireNonNull(sideOutputTag));
+		return new DataStream<>(this.getExecutionEnvironment(), sideOutputTransformation);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -73,6 +73,8 @@ import org.apache.flink.streaming.runtime.operators.windowing.WindowOperator;
 import org.apache.flink.streaming.runtime.operators.windowing.functions.InternalWindowFunction;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.Preconditions;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -120,6 +122,12 @@ public class WindowedStream<T, K, W extends Window> {
 	/** The user-specified allowed lateness. */
 	private long allowedLateness = 0L;
 
+	/**
+	 * Side output {@code OutputTag} for late data. If no tag is set late data will simply be
+	 * dropped.
+ 	 */
+	private OutputTag<T> lateDataOutputTag;
+
 	@PublicEvolving
 	public WindowedStream(KeyedStream<T, K> input,
 			WindowAssigner<? super T, W> windowAssigner) {
@@ -158,6 +166,23 @@ public class WindowedStream<T, K, W extends Window> {
 		checkArgument(millis >= 0, "The allowed lateness cannot be negative.");
 
 		this.allowedLateness = millis;
+		return this;
+	}
+
+	/**
+	 * Send late arriving data to the side output identified by the given {@link OutputTag}. Data
+	 * is considered late after the watermark has passed the end of the window plus the allowed
+	 * lateness set using {@link #allowedLateness(Time)}.
+	 *
+	 * <p>You can get the stream of late data using
+	 * {@link SingleOutputStreamOperator#getSideOutput(OutputTag)} on the
+	 * {@link SingleOutputStreamOperator} resulting from the windowed operation
+	 * with the same {@link OutputTag}.
+	 */
+	@PublicEvolving
+	public WindowedStream<T, K, W> sideOutputLateData(OutputTag<T> outputTag) {
+		Preconditions.checkNotNull(outputTag, "Side output tag must not be null.");
+		this.lateDataOutputTag = input.getExecutionEnvironment().clean(outputTag);
 		return this;
 	}
 
@@ -344,7 +369,8 @@ public class WindowedStream<T, K, W extends Window> {
 					new InternalIterableWindowFunction<>(new ReduceApplyWindowFunction<>(reduceFunction, function)),
 					trigger,
 					evictor,
-					allowedLateness);
+					allowedLateness,
+					lateDataOutputTag);
 
 		} else {
 			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>("window-contents",
@@ -362,6 +388,7 @@ public class WindowedStream<T, K, W extends Window> {
 					new InternalSingleValueWindowFunction<>(function),
 					trigger,
 					allowedLateness,
+					lateDataOutputTag,
 					legacyWindowOpType);
 		}
 
@@ -437,7 +464,8 @@ public class WindowedStream<T, K, W extends Window> {
 							new InternalIterableProcessWindowFunction<>(new ReduceApplyProcessWindowFunction<>(reduceFunction, function)),
 							trigger,
 							evictor,
-							allowedLateness);
+							allowedLateness,
+							lateDataOutputTag);
 
 		} else {
 			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>("window-contents",
@@ -454,7 +482,8 @@ public class WindowedStream<T, K, W extends Window> {
 							stateDesc,
 							new InternalSingleValueProcessWindowFunction<>(function),
 							trigger,
-							allowedLateness);
+							allowedLateness,
+							lateDataOutputTag);
 		}
 
 		return input.transform(opName, resultType, operator);
@@ -589,7 +618,8 @@ public class WindowedStream<T, K, W extends Window> {
 				new InternalIterableWindowFunction<>(new FoldApplyWindowFunction<>(initialValue, foldFunction, function, foldAccumulatorType)),
 				trigger,
 				evictor,
-				allowedLateness);
+				allowedLateness,
+				lateDataOutputTag);
 
 		} else {
 			FoldingStateDescriptor<T, ACC> stateDesc = new FoldingStateDescriptor<>("window-contents",
@@ -604,7 +634,8 @@ public class WindowedStream<T, K, W extends Window> {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(function),
 				trigger,
-				allowedLateness);
+				allowedLateness,
+				lateDataOutputTag);
 		}
 
 		return input.transform(opName, resultType, operator);
@@ -697,7 +728,8 @@ public class WindowedStream<T, K, W extends Window> {
 							new InternalIterableProcessWindowFunction<>(new FoldApplyProcessWindowFunction<>(initialValue, foldFunction, windowFunction, foldResultType)),
 							trigger,
 							evictor,
-							allowedLateness);
+							allowedLateness,
+							lateDataOutputTag);
 
 		} else {
 			FoldingStateDescriptor<T, ACC> stateDesc = new FoldingStateDescriptor<>("window-contents",
@@ -715,7 +747,8 @@ public class WindowedStream<T, K, W extends Window> {
 							stateDesc,
 							new InternalSingleValueProcessWindowFunction<>(windowFunction),
 							trigger,
-							allowedLateness);
+							allowedLateness,
+							lateDataOutputTag);
 		}
 
 		return input.transform(opName, windowResultType, operator);
@@ -890,7 +923,8 @@ public class WindowedStream<T, K, W extends Window> {
 					new InternalIterableWindowFunction<>(new AggregateApplyWindowFunction<>(aggregateFunction, windowFunction)),
 					trigger,
 					evictor,
-					allowedLateness);
+					allowedLateness,
+					lateDataOutputTag);
 
 		} else {
 			AggregatingStateDescriptor<T, ACC, V> stateDesc = new AggregatingStateDescriptor<>("window-contents",
@@ -905,7 +939,8 @@ public class WindowedStream<T, K, W extends Window> {
 					stateDesc,
 					new InternalSingleValueWindowFunction<>(windowFunction),
 					trigger,
-					allowedLateness);
+					allowedLateness,
+					lateDataOutputTag);
 		}
 
 		return input.transform(opName, resultType, operator);
@@ -1017,7 +1052,8 @@ public class WindowedStream<T, K, W extends Window> {
 					new InternalAggregateProcessWindowFunction<>(aggregateFunction, windowFunction),
 					trigger,
 					evictor,
-					allowedLateness);
+					allowedLateness,
+					lateDataOutputTag);
 
 		} else {
 			AggregatingStateDescriptor<T, ACC, V> stateDesc = new AggregatingStateDescriptor<>("window-contents",
@@ -1032,7 +1068,8 @@ public class WindowedStream<T, K, W extends Window> {
 					stateDesc,
 					new InternalSingleValueProcessWindowFunction<>(windowFunction),
 					trigger,
-					allowedLateness);
+					allowedLateness,
+					lateDataOutputTag);
 		}
 
 		return input.transform(opName, resultType, operator);
@@ -1154,7 +1191,8 @@ public class WindowedStream<T, K, W extends Window> {
 					function,
 					trigger,
 					evictor,
-					allowedLateness);
+					allowedLateness,
+					lateDataOutputTag);
 
 		} else {
 			ListStateDescriptor<T> stateDesc = new ListStateDescriptor<>("window-contents",
@@ -1171,6 +1209,7 @@ public class WindowedStream<T, K, W extends Window> {
 					function,
 					trigger,
 					allowedLateness,
+					lateDataOutputTag,
 					legacyWindowOpType);
 		}
 
@@ -1252,7 +1291,8 @@ public class WindowedStream<T, K, W extends Window> {
 					new InternalIterableWindowFunction<>(new ReduceApplyWindowFunction<>(reduceFunction, function)),
 					trigger,
 					evictor,
-					allowedLateness);
+					allowedLateness,
+					lateDataOutputTag);
 
 		} else {
 			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>("window-contents",
@@ -1269,7 +1309,8 @@ public class WindowedStream<T, K, W extends Window> {
 					stateDesc,
 					new InternalSingleValueWindowFunction<>(function),
 					trigger,
-					allowedLateness);
+					allowedLateness,
+					lateDataOutputTag);
 		}
 
 		return input.transform(opName, resultType, operator);
@@ -1354,7 +1395,8 @@ public class WindowedStream<T, K, W extends Window> {
 				new InternalIterableWindowFunction<>(new FoldApplyWindowFunction<>(initialValue, foldFunction, function, resultType)),
 				trigger,
 				evictor,
-				allowedLateness);
+				allowedLateness,
+				lateDataOutputTag);
 
 		} else {
 			FoldingStateDescriptor<T, R> stateDesc = new FoldingStateDescriptor<>("window-contents",
@@ -1369,7 +1411,8 @@ public class WindowedStream<T, K, W extends Window> {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(function),
 				trigger,
-				allowedLateness);
+				allowedLateness,
+				lateDataOutputTag);
 		}
 
 		return input.transform(opName, resultType, operator);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/ProcessFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/ProcessFunction.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.streaming.api.TimeDomain;
 import org.apache.flink.streaming.api.TimerService;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
 
 /**
  * A function that processes elements of a stream.
@@ -101,6 +102,14 @@ public abstract class ProcessFunction<I, O> extends AbstractRichFunction {
 		 * A {@link TimerService} for querying time and registering timers.
 		 */
 		public abstract TimerService timerService();
+
+		/**
+		 * Emits a record to the side output identified by the {@link OutputTag}.
+		 * 
+		 * @param outputTag the {@code OutputTag} that identifies the side output to emit to.
+		 * @param value The record to emit.
+		 */
+		public abstract <X> void output(OutputTag<X> outputTag, X value);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.util.List;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.OutputTag;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 
 /**
@@ -48,15 +49,25 @@ public class StreamEdge implements Serializable {
 	 * output selection).
 	 */
 	private final List<String> selectedNames;
+
+	/**
+	 * The side-output tag (if any) of this {@link StreamEdge}.
+	 */
+	private final OutputTag outputTag;
+
+	/**
+	 * The {@link StreamPartitioner} on this {@link StreamEdge}.
+	 */
 	private StreamPartitioner<?> outputPartitioner;
 
 	public StreamEdge(StreamNode sourceVertex, StreamNode targetVertex, int typeNumber,
-			List<String> selectedNames, StreamPartitioner<?> outputPartitioner) {
+			List<String> selectedNames, StreamPartitioner<?> outputPartitioner, OutputTag outputTag) {
 		this.sourceVertex = sourceVertex;
 		this.targetVertex = targetVertex;
 		this.typeNumber = typeNumber;
 		this.selectedNames = selectedNames;
 		this.outputPartitioner = outputPartitioner;
+		this.outputTag = outputTag;
 
 		this.edgeId = sourceVertex + "_" + targetVertex + "_" + typeNumber + "_" + selectedNames
 				+ "_" + outputPartitioner;
@@ -85,6 +96,8 @@ public class StreamEdge implements Serializable {
 	public List<String> getSelectedNames() {
 		return selectedNames;
 	}
+
+	public OutputTag getOutputTag() {return this.outputTag;}
 
 	public StreamPartitioner<?> getPartitioner() {
 		return outputPartitioner;
@@ -117,6 +130,6 @@ public class StreamEdge implements Serializable {
 	public String toString() {
 		return "(" + sourceVertex + " -> " + targetVertex + ", typeNumber=" + typeNumber
 				+ ", selectedNames=" + selectedNames + ", outputPartitioner=" + outputPartitioner
-				+ ')';
+				+ ", outputTag=" + outputTag + ')';
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -308,6 +308,23 @@ public class StreamGraph extends StreamingPlan {
 			throw new IllegalStateException("Already has virtual output node with id " + virtualId);
 		}
 
+		// verify that we don't already have a virtual node for the given originalId/outputTag
+		// combination with a different TypeInformation. This would indicate that someone is trying
+		// to read a side output from an operation with a different type for the same side output
+		// id.
+
+		for (Tuple2<Integer, OutputTag> tag : virtualSideOutputNodes.values()) {
+			if (!tag.f0.equals(originalId)) {
+				// different source operator
+				continue;
+			}
+
+			if (!tag.f1.getTypeInfo().equals(outputTag.getTypeInfo())) {
+				throw new IllegalArgumentException("Trying to add a side input for the same id " +
+						"with a different type. This is not allowed.");
+			}
+		}
+
 		virtualSideOutputNodes.put(virtualId, new Tuple2<>(originalId, outputTag));
 	}
 
@@ -356,7 +373,8 @@ public class StreamGraph extends StreamingPlan {
 				downStreamVertexID,
 				typeNumber,
 				null,
-				new ArrayList<String>(), null);
+				new ArrayList<String>(),
+				null);
 
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -28,6 +28,7 @@ import org.apache.flink.streaming.api.transformations.FeedbackTransformation;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.streaming.api.transformations.SelectTransformation;
+import org.apache.flink.streaming.api.transformations.SideOutputTransformation;
 import org.apache.flink.streaming.api.transformations.SinkTransformation;
 import org.apache.flink.streaming.api.transformations.SourceTransformation;
 import org.apache.flink.streaming.api.transformations.SplitTransformation;
@@ -182,6 +183,8 @@ public class StreamGraphGenerator {
 			transformedIds = transformCoFeedback((CoFeedbackTransformation<?>) transform);
 		} else if (transform instanceof PartitionTransformation<?>) {
 			transformedIds = transformPartition((PartitionTransformation<?>) transform);
+		} else if (transform instanceof SideOutputTransformation<?>) {
+			transformedIds = transformSideOutput((SideOutputTransformation<?>) transform);
 		} else {
 			throw new IllegalStateException("Unknown transformation: " + transform);
 		}
@@ -294,6 +297,35 @@ public class StreamGraphGenerator {
 		for (int inputId : resultIds) {
 			int virtualId = StreamTransformation.getNewNodeId();
 			streamGraph.addVirtualSelectNode(inputId, virtualId, select.getSelectedNames());
+			virtualResultIds.add(virtualId);
+		}
+		return virtualResultIds;
+	}
+
+	/**
+	 * Transforms a {@code SideOutputTransformation}.
+	 *
+	 * <p>
+	 * For this we create a virtual node in the {@code StreamGraph} that holds the side-output
+	 * {@link org.apache.flink.util.OutputTag}.
+	 *
+	 * @see org.apache.flink.streaming.api.graph.StreamGraphGenerator
+	 */
+	private <T> Collection<Integer> transformSideOutput(SideOutputTransformation<T> sideOutput) {
+		StreamTransformation<?> input = sideOutput.getInput();
+		Collection<Integer> resultIds = transform(input);
+
+
+		// the recursive transform might have already transformed this
+		if (alreadyTransformed.containsKey(sideOutput)) {
+			return alreadyTransformed.get(sideOutput);
+		}
+
+		List<Integer> virtualResultIds = new ArrayList<>();
+
+		for (int inputId : resultIds) {
+			int virtualId = StreamTransformation.getNewNodeId();
+			streamGraph.addVirtualSideOutputNode(inputId, virtualId, sideOutput.getOutputTag());
 			virtualResultIds.add(virtualId);
 		}
 		return virtualResultIds;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -370,6 +370,25 @@ public class StreamingJobGraphGenerator {
 		config.setTypeSerializerIn2(vertex.getTypeSerializerIn2());
 		config.setTypeSerializerOut(vertex.getTypeSerializerOut());
 
+		// iterate edges, find sideOutput edges create and save serializers for each outputTag type
+		for (StreamEdge edge : chainableOutputs) {
+			if (edge.getOutputTag() != null) {
+				config.setTypeSerializerSideOut(
+					edge.getOutputTag(),
+					edge.getOutputTag().getTypeInfo().createSerializer(streamGraph.getExecutionConfig())
+				);
+			}
+		}
+		for (StreamEdge edge : nonChainableOutputs) {
+			if (edge.getOutputTag() != null) {
+				config.setTypeSerializerSideOut(
+						edge.getOutputTag(),
+						edge.getOutputTag().getTypeInfo().createSerializer(streamGraph.getExecutionConfig())
+				);
+			}
+		}
+
+
 		config.setStreamOperator(vertex.getOperator());
 		config.setOutputSelectors(vertex.getOutputSelectors());
 
@@ -465,6 +484,7 @@ public class StreamingJobGraphGenerator {
 					headOperator.getChainingStrategy() == ChainingStrategy.ALWAYS)
 				&& (edge.getPartitioner() instanceof ForwardPartitioner)
 				&& upStreamVertex.getParallelism() == downStreamVertex.getParallelism()
+				&& edge.getOutputTag() == null // disable chaining for side outputs
 				&& streamGraph.isChainingEnabled();
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -484,7 +484,6 @@ public class StreamingJobGraphGenerator {
 					headOperator.getChainingStrategy() == ChainingStrategy.ALWAYS)
 				&& (edge.getPartitioner() instanceof ForwardPartitioner)
 				&& upStreamVertex.getParallelism() == downStreamVertex.getParallelism()
-				&& edge.getOutputTag() == null // disable chaining for side outputs
 				&& streamGraph.isChainingEnabled();
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -66,6 +66,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.OperatorStateHandles;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.util.OutputTag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -859,6 +860,12 @@ public abstract class AbstractStreamOperator<OUT>
 		public void collect(StreamRecord<OUT> record) {
 			numRecordsOut.inc();
 			output.collect(record);
+		}
+
+		@Override
+		public <X> void collect(OutputTag<?> outputTag, StreamRecord<X> record) {
+			numRecordsOut.inc();
+			output.collect(outputTag, record);
 		}
 
 		@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/Output.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/Output.java
@@ -20,7 +20,9 @@ package org.apache.flink.streaming.api.operators;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
 
 /**
  * A {@link org.apache.flink.streaming.api.operators.StreamOperator} is supplied with an object
@@ -40,6 +42,13 @@ public interface Output<T> extends Collector<T> {
 	 * timestamp will be emitted in the future.
 	 */
 	void emitWatermark(Watermark mark);
+
+	/**
+	 * Emits a record the the side output identified by the given {@link OutputTag}.
+	 *
+	 * @param record The record to collect.
+	 */
+	<X> void collect(OutputTag<?> outputTag, StreamRecord<X> record);
 
 	void emitLatencyMarker(LatencyMarker latencyMarker);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/ProcessOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/ProcessOperator.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.util.OutputTag;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -90,6 +91,11 @@ public class ProcessOperator<IN, OUT>
 			} else {
 				return null;
 			}
+		}
+
+		@Override
+		public <X> void output(OutputTag<X> outputTag, X value) {
+			output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp()));
 		}
 
 		@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SideOutputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SideOutputTransformation.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.api.transformations;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.Lists;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+
+import java.util.Collection;
+import java.util.List;
+
+
+/**
+ * This transformation represents a selection of a side output of an upstream operation with a
+ * given {@link OutputTag}.
+ *
+ * <p>This does not create a physical operation, it only affects how upstream operations are
+ * connected to downstream operations.
+ *
+ * @param <T> The type of the elements that result from this {@code SideOutputTransformation}
+ */
+public class SideOutputTransformation<T> extends StreamTransformation<T> {
+	private final StreamTransformation<?> input;
+
+	private final OutputTag<T> tag;
+
+	public SideOutputTransformation(StreamTransformation<?> input, final OutputTag<T> tag) {
+		super("SideOutput", tag.getTypeInfo(), requireNonNull(input).getParallelism());
+		this.input = input;
+		this.tag = requireNonNull(tag);
+	}
+
+	/**
+	 * Returns the input {@code StreamTransformation}.
+	 */
+	public StreamTransformation<?> getInput() {
+		return input;
+	}
+
+	public OutputTag<T> getOutputTag() {
+		return tag;
+	}
+
+	@Override
+	public Collection<StreamTransformation<?>> getTransitivePredecessors() {
+		List<StreamTransformation<?>> result = Lists.newArrayList();
+		result.add(this);
+		result.addAll(input.getTransitivePredecessors());
+		return result;
+	}
+
+	@Override
+	public final void setChainingStrategy(ChainingStrategy strategy) {
+		throw new UnsupportedOperationException("Cannot set chaining strategy on SideOutput Transformation.");
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -273,7 +273,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 			StreamConfig chainedOpConfig = chainedConfigs.get(outputId);
 
 			Output<StreamRecord<T>> output = createChainedOperator(
-					containingTask, chainedOpConfig, chainedConfigs, userCodeClassloader, streamOutputs, allOperators);
+					containingTask, chainedOpConfig, chainedConfigs, userCodeClassloader, streamOutputs, allOperators, outputEdge.getOutputTag());
 			allOutputs.add(new Tuple2<>(output, outputEdge));
 		}
 		
@@ -327,7 +327,8 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 			Map<Integer, StreamConfig> chainedConfigs,
 			ClassLoader userCodeClassloader,
 			Map<StreamEdge, RecordWriterOutput<?>> streamOutputs,
-			List<StreamOperator<?>> allOperators)
+			List<StreamOperator<?>> allOperators,
+			OutputTag<IN> outputTag)
 	{
 		// create the output that the operator writes to first. this may recursively create more operators
 		Output<StreamRecord<OUT>> output = createOutputCollector(
@@ -335,16 +336,17 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 
 		// now create the operator and give it the output collector to write its output to
 		OneInputStreamOperator<IN, OUT> chainedOperator = operatorConfig.getStreamOperator(userCodeClassloader);
+
 		chainedOperator.setup(containingTask, operatorConfig, output);
 
 		allOperators.add(chainedOperator);
 
 		if (containingTask.getExecutionConfig().isObjectReuseEnabled()) {
-			return new ChainingOutput<>(chainedOperator, this);
+			return new ChainingOutput<>(chainedOperator, this, outputTag);
 		}
 		else {
 			TypeSerializer<IN> inSerializer = operatorConfig.getTypeSerializerIn1(userCodeClassloader);
-			return new CopyingChainingOutput<>(chainedOperator, inSerializer, this);
+			return new CopyingChainingOutput<>(chainedOperator, inSerializer, outputTag, this);
 		}
 	}
 	
@@ -358,14 +360,11 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 
 		if (edge.getOutputTag() != null) {
 			// side output
-			outSerializer =
-					upStreamConfig.getTypeSerializerSideOut(
-							edge.getOutputTag(),
-							taskEnvironment.getUserClassLoader());
+			outSerializer = upStreamConfig.getTypeSerializerSideOut(
+					edge.getOutputTag(), taskEnvironment.getUserClassLoader());
 		} else {
 			// main output
-			outSerializer =
-					upStreamConfig.getTypeSerializerOut(taskEnvironment.getUserClassLoader());
+			outSerializer = upStreamConfig.getTypeSerializerOut(taskEnvironment.getUserClassLoader());
 		}
 
 		@SuppressWarnings("unchecked")
@@ -401,27 +400,53 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 
 		protected final StreamStatusProvider streamStatusProvider;
 
-		public ChainingOutput(OneInputStreamOperator<T, ?> operator, StreamStatusProvider streamStatusProvider) {
+		protected final OutputTag<T> outputTag;
+
+		public ChainingOutput(
+				OneInputStreamOperator<T, ?> operator,
+				StreamStatusProvider streamStatusProvider,
+				OutputTag<T> outputTag) {
 			this.operator = operator;
 			this.numRecordsIn = ((OperatorMetricGroup) operator.getMetricGroup()).getIOMetricGroup().getNumRecordsInCounter();
 			this.streamStatusProvider = streamStatusProvider;
+			this.outputTag = outputTag;
 		}
 
 		@Override
 		public void collect(StreamRecord<T> record) {
-			try {
-				numRecordsIn.inc();
-				operator.setKeyContextElement1(record);
-				operator.processElement(record);
+			if (this.outputTag != null) {
+				// we are only responsible for emitting to the main input
+				return;
 			}
-			catch (Exception e) {
-				throw new ExceptionInChainedOperatorException(e);
-			}
+
+			pushToOperator(record);
 		}
 
 		@Override
 		public <X> void collect(OutputTag<?> outputTag, StreamRecord<X> record) {
-			// ignore
+			if (this.outputTag == null || !this.outputTag.equals(outputTag)) {
+				// we are only responsible for emitting to the side-output specified by our
+				// OutputTag.
+				return;
+			}
+
+			pushToOperator(record);
+		}
+
+		protected <X> void pushToOperator(StreamRecord<X> record) {
+			try {
+				// we know that the given outputTag matches our OutputTag so the record
+				// must be of the type that our operator expects.
+				@SuppressWarnings("unchecked")
+				StreamRecord<T> castRecord = (StreamRecord<T>) record;
+
+				numRecordsIn.inc();
+				operator.setKeyContextElement1(castRecord);
+				operator.processElement(castRecord);
+			}
+			catch (Exception e) {
+				throw new ExceptionInChainedOperatorException(e);
+			}
 		}
 
 		@Override
@@ -460,25 +485,53 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 	private static final class CopyingChainingOutput<T> extends ChainingOutput<T> {
 		
 		private final TypeSerializer<T> serializer;
-		
+
 		public CopyingChainingOutput(
 				OneInputStreamOperator<T, ?> operator,
 				TypeSerializer<T> serializer,
+				OutputTag<T> outputTag,
 				StreamStatusProvider streamStatusProvider) {
-			super(operator, streamStatusProvider);
+			super(operator, streamStatusProvider, outputTag);
 			this.serializer = serializer;
 		}
 
 		@Override
 		public void collect(StreamRecord<T> record) {
+			if (this.outputTag != null) {
+				// we are only responsible for emitting to the main input
+				return;
+			}
+
+			pushToOperator(record);
+		}
+
+		@Override
+		public <X> void collect(OutputTag<?> outputTag, StreamRecord<X> record) {
+			if (this.outputTag == null || !this.outputTag.equals(outputTag)) {
+				// we are only responsible for emitting to the side-output specified by our
+				// OutputTag.
+				return;
+			}
+
+			pushToOperator(record);
+		}
+
+		@Override
+		protected <X> void pushToOperator(StreamRecord<X> record) {
 			try {
+				// we know that the given outputTag matches our OutputTag so the record
+				// must be of the type that our operator (and Serializer) expects.
+				@SuppressWarnings("unchecked")
+				StreamRecord<T> castRecord = (StreamRecord<T>) record;
+
 				numRecordsIn.inc();
-				StreamRecord<T> copy = record.copy(serializer.copy(record.getValue()));
+				StreamRecord<T> copy = castRecord.copy(serializer.copy(castRecord.getValue()));
 				operator.setKeyContextElement1(copy);
 				operator.processElement(copy);
 			} catch (Exception e) {
 				throw new RuntimeException("Could not forward element to next operator", e);
 			}
+
 		}
 	}
 	
@@ -508,7 +561,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 
 		@Override
 		public void emitLatencyMarker(LatencyMarker latencyMarker) {
-			if(outputs.length <= 0) {
+			if (outputs.length <= 0) {
 				// ignore
 			} else if(outputs.length == 1) {
 				outputs[0].emitLatencyMarker(latencyMarker);
@@ -526,8 +579,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 		}
 
 		@Override
-		public <X> void collect(
-				OutputTag<?> outputTag, StreamRecord<X> record) {
+		public <X> void collect(OutputTag<?> outputTag, StreamRecord<X> record) {
 			for (Output<StreamRecord<T>> output : outputs) {
 				output.collect(outputTag, record);
 			}
@@ -564,6 +616,24 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 
 			// don't copy for the last output
 			outputs[outputs.length - 1].collect(record);
+		}
+
+		@Override
+		public <X> void collect(OutputTag<?> outputTag, StreamRecord<X> record) {
+			for (int i = 0; i < outputs.length - 1; i++) {
+				Output<StreamRecord<T>> output = outputs[i];
+
+				// due to side outputs, StreamRecords of varying types can pass through the broadcasting
+				// collector so we need to cast
+				@SuppressWarnings({"unchecked", "rawtypes"})
+				StreamRecord<T> shallowCopy = (StreamRecord<T>) record.copy(record.getValue());
+				output.collect(outputTag, shallowCopy);
+			}
+
+			// don't copy for the last output
+			@SuppressWarnings({"unchecked", "rawtypes"})
+			StreamRecord<T> castRecord = (StreamRecord<T>) record;
+			outputs[outputs.length - 1].collect(outputTag, castRecord);
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationTail.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationTail.java
@@ -28,6 +28,7 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.BlockingQueueBroker;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,6 +120,12 @@ public class StreamIterationTail<IN> extends OneInputStreamTask<IN, IN> {
 			} catch (InterruptedException e) {
 				throw new RuntimeException(e);
 			}
+		}
+
+		@Override
+		public <X> void collect(OutputTag<?> outputTag, StreamRecord<X> record) {
+			throw new UnsupportedOperationException("Side outputs not used in iteration tail");
+
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorTest.java
@@ -89,7 +89,8 @@ public class EvictingWindowOperatorTest {
 			new InternalIterableWindowFunction<>(new RichSumReducer<GlobalWindow>(closeCalled)),
 			CountTrigger.of(TRIGGER_COUNT),
 			CountEvictor.of(WINDOW_SIZE,EVICT_AFTER),
-			0);
+			0,
+			null /* late data output tag */);
 
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
@@ -169,7 +170,8 @@ public class EvictingWindowOperatorTest {
 			new InternalIterableWindowFunction<>(new RichSumReducer<GlobalWindow>(closeCalled)),
 			CountTrigger.of(TRIGGER_COUNT),
 			TimeEvictor.of(Time.seconds(2), EVICT_AFTER),
-			0);
+			0,
+			null /* late data output tag */);
 
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
@@ -243,7 +245,8 @@ public class EvictingWindowOperatorTest {
 			new InternalIterableWindowFunction<>(new RichSumReducer<TimeWindow>(closeCalled)),
 			CountTrigger.of(TRIGGER_COUNT),
 			TimeEvictor.of(Time.seconds(2)),
-			0);
+			0,
+			null /* late data output tag */);
 
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
@@ -319,7 +322,8 @@ public class EvictingWindowOperatorTest {
 			new InternalIterableWindowFunction<>(new RichSumReducer<GlobalWindow>(closeCalled)),
 			CountTrigger.of(TRIGGER_COUNT),
 			TimeEvictor.of(Time.seconds(2), EVICT_AFTER),
-			0);
+			0,
+			null /* late data output tag */);
 
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
@@ -398,7 +402,8 @@ public class EvictingWindowOperatorTest {
 					return newDataPoint.f1 - oldDataPoint.f1;
 				}
 			}, EVICT_AFTER),
-			0);
+			0,
+			null /* late data output tag */);
 
 
 
@@ -475,7 +480,8 @@ public class EvictingWindowOperatorTest {
 					return newDataPoint.f1 - oldDataPoint.f1;
 				}
 			}, EVICT_AFTER),
-			0);
+			0,
+			null /* late data output tag */);
 
 
 
@@ -543,7 +549,8 @@ public class EvictingWindowOperatorTest {
 				new InternalIterableWindowFunction<>(new ReduceIterableWindowFunction<String, GlobalWindow, Tuple2<String, Integer>>(new SumReducer())),
 				CountTrigger.of(WINDOW_SLIDE),
 				CountEvictor.of(WINDOW_SIZE),
-				0);
+				0,
+				null /* late data output tag */);
 
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
@@ -615,7 +622,8 @@ public class EvictingWindowOperatorTest {
 			new InternalIterableWindowFunction<>(new RichSumReducer<GlobalWindow>(closeCalled)),
 			CountTrigger.of(WINDOW_SLIDE),
 			CountEvictor.of(WINDOW_SIZE),
-			0);
+			0,
+			null /* late data output tag */);
 
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
@@ -686,7 +694,8 @@ public class EvictingWindowOperatorTest {
 			new InternalIterableWindowFunction<>(new RichSumReducer<TimeWindow>(closeCalled)),
 			EventTimeTrigger.create(),
 			CountEvictor.of(WINDOW_SIZE),
-			0);
+			0,
+			null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorContractTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorContractTest.java
@@ -47,6 +47,7 @@ import org.apache.flink.streaming.runtime.tasks.OperatorStateHandles;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 import org.mockito.Matchers;
@@ -297,6 +298,75 @@ public class WindowOperatorContractTest extends TestLogger {
 	private static <T> void shouldFireAndPurgeOnProcessingTime(Trigger<T, TimeWindow> mockTrigger) throws Exception {
 		when(mockTrigger.onProcessingTime(anyLong(), Matchers.<TimeWindow>any(), anyTriggerContext())).thenReturn(TriggerResult.FIRE_AND_PURGE);
 	}
+
+	/**
+	 * Verify that there is no late-date side output if the {@code WindowAssigner} does
+	 * not assign any windows.
+	 */
+	@Test
+	public void testNoLateSideOutputForSkippedWindows() throws Exception {
+
+		OutputTag<Integer> lateOutputTag = new OutputTag<Integer>("late"){};
+
+		WindowAssigner<Integer, TimeWindow> mockAssigner = mockTimeWindowAssigner();
+		Trigger<Integer, TimeWindow> mockTrigger = mockTrigger();
+		InternalWindowFunction<Iterable<Integer>, Void, Integer, TimeWindow> mockWindowFunction = mockWindowFunction();
+
+		OneInputStreamOperatorTestHarness<Integer, Void> testHarness =
+				createWindowOperator(mockAssigner, mockTrigger, 0L, intListDescriptor, mockWindowFunction, lateOutputTag);
+
+		testHarness.open();
+
+		when(mockAssigner.assignWindows(anyInt(), anyLong(), anyAssignerContext()))
+				.thenReturn(Collections.<TimeWindow>emptyList());
+
+		testHarness.processWatermark(0);
+		testHarness.processElement(new StreamRecord<>(0, 5L));
+
+		verify(mockAssigner, times(1)).assignWindows(eq(0), eq(5L), anyAssignerContext());
+
+		assertTrue(testHarness.getSideOutput(lateOutputTag) == null || testHarness.getSideOutput(lateOutputTag).isEmpty());
+	}
+
+	@Test
+	public void testLateSideOutput() throws Exception {
+
+		OutputTag<Integer> lateOutputTag = new OutputTag<Integer>("late"){};
+
+		WindowAssigner<Integer, TimeWindow> mockAssigner = mockTimeWindowAssigner();
+		Trigger<Integer, TimeWindow> mockTrigger = mockTrigger();
+		InternalWindowFunction<Iterable<Integer>, Void, Integer, TimeWindow> mockWindowFunction = mockWindowFunction();
+
+		OneInputStreamOperatorTestHarness<Integer, Void> testHarness =
+				createWindowOperator(mockAssigner, mockTrigger, 0L, intListDescriptor, mockWindowFunction, lateOutputTag);
+
+		testHarness.open();
+
+		when(mockAssigner.assignWindows(anyInt(), anyLong(), anyAssignerContext()))
+				.thenReturn(Collections.singletonList(new TimeWindow(0, 0)));
+
+		testHarness.processWatermark(20);
+		testHarness.processElement(new StreamRecord<>(0, 5L));
+
+		verify(mockAssigner, times(1)).assignWindows(eq(0), eq(5L), anyAssignerContext());
+
+		assertThat(testHarness.getSideOutput(lateOutputTag),
+				containsInAnyOrder(isStreamRecord(0, 5L)));
+
+		// we should also see side output if the WindowAssigner assigns no windows
+		when(mockAssigner.assignWindows(anyInt(), anyLong(), anyAssignerContext()))
+				.thenReturn(Collections.<TimeWindow>emptyList());
+
+		testHarness.processElement(new StreamRecord<>(0, 10L));
+
+		verify(mockAssigner, times(1)).assignWindows(eq(0), eq(5L), anyAssignerContext());
+		verify(mockAssigner, times(1)).assignWindows(eq(0), eq(10L), anyAssignerContext());
+
+		assertThat(testHarness.getSideOutput(lateOutputTag),
+				containsInAnyOrder(isStreamRecord(0, 5L), isStreamRecord(0, 10L)));
+
+	}
+
 
 	@Test
 	public void testAssignerIsInvokedOncePerElement() throws Exception {
@@ -2302,7 +2372,8 @@ public class WindowOperatorContractTest extends TestLogger {
 			Trigger<Integer, W> trigger,
 			long allowedLatenss,
 			StateDescriptor<? extends AppendingState<Integer, ACC>, ?> stateDescriptor,
-			InternalWindowFunction<ACC, OUT, Integer, W> windowFunction) throws Exception {
+			InternalWindowFunction<ACC, OUT, Integer, W> windowFunction,
+			OutputTag<Integer> lateOutputTag) throws Exception {
 
 		KeySelector<Integer, Integer> keySelector = new KeySelector<Integer, Integer>() {
 			private static final long serialVersionUID = 1L;
@@ -2323,12 +2394,27 @@ public class WindowOperatorContractTest extends TestLogger {
 				windowFunction,
 				trigger,
 				allowedLatenss,
-				null /*late data output tag */);
+				lateOutputTag);
 
 		return new KeyedOneInputStreamOperatorTestHarness<>(
 				operator,
 				keySelector,
 				BasicTypeInfo.INT_TYPE_INFO);
+	}
+
+	private <W extends Window, ACC, OUT> KeyedOneInputStreamOperatorTestHarness<Integer, Integer, OUT> createWindowOperator(
+			WindowAssigner<Integer, W> assigner,
+			Trigger<Integer, W> trigger,
+			long allowedLatenss,
+			StateDescriptor<? extends AppendingState<Integer, ACC>, ?> stateDescriptor,
+			InternalWindowFunction<ACC, OUT, Integer, W> windowFunction) throws Exception {
+		return createWindowOperator(
+				assigner,
+				trigger,
+				allowedLatenss,
+				stateDescriptor,
+				windowFunction,
+				null /* late output tag */);
 	}
 
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorContractTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorContractTest.java
@@ -2322,7 +2322,8 @@ public class WindowOperatorContractTest extends TestLogger {
 				stateDescriptor,
 				windowFunction,
 				trigger,
-				allowedLatenss);
+				allowedLatenss,
+				null /*late data output tag */);
 
 		return new KeyedOneInputStreamOperatorTestHarness<>(
 				operator,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorMigrationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorMigrationTest.java
@@ -100,7 +100,8 @@ public class WindowOperatorMigrationTest {
 				stateDesc,
 				new InternalIterableWindowFunction<>(new SessionWindowFunction()),
 				PurgingTrigger.of(CountTrigger.of(4)),
-				0);
+				0,
+				null /* late data output tag */);
 
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
 
@@ -181,7 +182,8 @@ public class WindowOperatorMigrationTest {
 				stateDesc,
 				new InternalIterableWindowFunction<>(new SessionWindowFunction()),
 				PurgingTrigger.of(CountTrigger.of(4)),
-				0);
+				0,
+				null /* late data output tag */);
 
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
 
@@ -258,7 +260,8 @@ public class WindowOperatorMigrationTest {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
 				EventTimeTrigger.create(),
-				0);
+				0,
+				null /* late data output tag */);
 
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
 
@@ -346,7 +349,8 @@ public class WindowOperatorMigrationTest {
 				stateDesc,
 				new InternalIterableWindowFunction<>(new RichSumReducer<TimeWindow>()),
 				EventTimeTrigger.create(),
-				0);
+				0,
+				null /* late data output tag */);
 
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
 
@@ -435,7 +439,8 @@ public class WindowOperatorMigrationTest {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
 				ProcessingTimeTrigger.create(),
-				0);
+				0,
+				null /* late data output tag */);
 
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
 
@@ -510,7 +515,8 @@ public class WindowOperatorMigrationTest {
 				stateDesc,
 				new InternalIterableWindowFunction<>(new RichSumReducer<TimeWindow>()),
 				ProcessingTimeTrigger.create(),
-				0);
+				0,
+				null /* late data output tag */);
 
 		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
 
@@ -633,6 +639,7 @@ public class WindowOperatorMigrationTest {
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
 				ProcessingTimeTrigger.create(),
 				0,
+				null /* late data output tag */,
 				LegacyWindowOperatorType.FAST_AGGREGATING);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
@@ -735,6 +742,7 @@ public class WindowOperatorMigrationTest {
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
 				ProcessingTimeTrigger.create(),
 				0,
+				null /* late data output tag */,
 				LegacyWindowOperatorType.FAST_ACCUMULATING);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
@@ -1333,7 +1333,7 @@ public class WindowOperatorTest extends TestLogger {
 		TestHarnessUtil.assertOutputEqualsSorted(
 				"SideOutput was not correct.",
 				lateExpected,
-				testHarness.getSideOutput(lateOutputTag),
+				(Iterable) testHarness.getSideOutput(lateOutputTag),
 				new Tuple2ResultSortComparator());
 
 		testHarness.close();
@@ -1467,7 +1467,7 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new Watermark(3999));
 
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, testHarness.getOutput(), new Tuple2ResultSortComparator());
-		TestHarnessUtil.assertOutputEqualsSorted("SideOutput was not correct.", sideExpected, testHarness.getSideOutput(
+		TestHarnessUtil.assertOutputEqualsSorted("SideOutput was not correct.", sideExpected, (Iterable) testHarness.getSideOutput(
 				lateOutputTag), new Tuple2ResultSortComparator());
 		testHarness.close();
 	}
@@ -1548,7 +1548,7 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new Watermark(25000));
 
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, testHarness.getOutput(), new Tuple2ResultSortComparator());
-		TestHarnessUtil.assertOutputEqualsSorted("SideOutput was not correct.", sideExpected, testHarness.getSideOutput(lateOutputTag), new Tuple2ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("SideOutput was not correct.", sideExpected, (Iterable) testHarness.getSideOutput(lateOutputTag), new Tuple2ResultSortComparator());
 		testHarness.close();
 	}
 
@@ -1636,10 +1636,10 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new Watermark(100000));
 
 		ConcurrentLinkedQueue<Object> actual = testHarness.getOutput();
-		ConcurrentLinkedQueue<Object> sideActual = testHarness.getSideOutput(lateOutputTag);
+		ConcurrentLinkedQueue<StreamRecord<Tuple2<String, Integer>>> sideActual = testHarness.getSideOutput(lateOutputTag);
 
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, actual, new Tuple2ResultSortComparator());
-		TestHarnessUtil.assertOutputEqualsSorted("SideOutput was not correct.", sideExpected, sideActual, new Tuple2ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("SideOutput was not correct.", sideExpected, (Iterable) sideActual, new Tuple2ResultSortComparator());
 
 		testHarness.close();
 	}
@@ -1723,9 +1723,10 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new Watermark(100000));
 
 		ConcurrentLinkedQueue<Object> actual = testHarness.getOutput();
-		ConcurrentLinkedQueue<Object> sideActual = testHarness.getSideOutput(lateOutputTag);
+		ConcurrentLinkedQueue<StreamRecord<Tuple2<String, Integer>>> sideActual = testHarness.getSideOutput(
+				lateOutputTag);
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, actual, new Tuple2ResultSortComparator());
-		TestHarnessUtil.assertOutputEqualsSorted("SideOutput was not correct.", sideExpected, sideActual, new Tuple2ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("SideOutput was not correct.", sideExpected, (Iterable) sideActual, new Tuple2ResultSortComparator());
 		testHarness.close();
 	}
 
@@ -1897,7 +1898,8 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new StreamRecord<>(new Tuple3<>("key2-2", 10000L, 14600L), 14599));
 
 		ConcurrentLinkedQueue<Object> actual = testHarness.getOutput();
-		ConcurrentLinkedQueue<Object> sideActual = testHarness.getSideOutput(lateOutputTag);
+		ConcurrentLinkedQueue<StreamRecord<Tuple2<String, Integer>>> sideActual = testHarness.getSideOutput(
+				lateOutputTag);
 
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
 		assertEquals(null, sideActual);
@@ -1989,7 +1991,7 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new StreamRecord<>(new Tuple3<>("key2-1", 1000L, 14600L), 14599));
 
 		ConcurrentLinkedQueue<Object> actual = testHarness.getOutput();
-		ConcurrentLinkedQueue<Object> sideActual = testHarness.getSideOutput(lateOutputTag);
+		ConcurrentLinkedQueue<StreamRecord<Tuple2<String, Integer>>> sideActual = testHarness.getSideOutput(lateOutputTag);
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
 		assertEquals(null, sideActual);
 
@@ -2082,7 +2084,7 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new StreamRecord<>(new Tuple3<>("key2-7", 1000L, 14600L), 14599));
 
 		ConcurrentLinkedQueue<Object> actual = testHarness.getOutput();
-		ConcurrentLinkedQueue<Object> sideActual = testHarness.getSideOutput(lateOutputTag);
+		ConcurrentLinkedQueue<StreamRecord<Tuple2<String, Integer>>> sideActual = testHarness.getSideOutput(lateOutputTag);
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
 		assertEquals(null, sideActual);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.state.FoldingStateDescriptor;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.ReducingStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.util.OutputTag;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -91,6 +92,9 @@ public class WindowOperatorTest extends TestLogger {
 
 	// For counting if close() is called the correct number of times on the SumReducer
 	private static AtomicInteger closeCalled = new AtomicInteger(0);
+
+	// late arriving event OutputTag<StreamRecord<IN>>
+	private static final OutputTag<Tuple2<String, Integer>> lateOutputTag = new OutputTag<Tuple2<String, Integer>>("late-output") {};
 
 	private void testSlidingEventTimeWindows(OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness) throws Exception {
 
@@ -181,7 +185,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
 				EventTimeTrigger.create(),
-				0);
+				0,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -215,7 +220,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalIterableWindowFunction<>(new RichSumReducer<TimeWindow>()),
 				EventTimeTrigger.create(),
-				0);
+				0,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -314,7 +320,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
 				EventTimeTrigger.create(),
-				0);
+				0,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -346,7 +353,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalIterableWindowFunction<>(new RichSumReducer<TimeWindow>()),
 				EventTimeTrigger.create(),
-				0);
+				0,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -381,7 +389,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalIterableWindowFunction<>(new SessionWindowFunction()),
 				EventTimeTrigger.create(),
-				0);
+				0,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -453,7 +462,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalIterableProcessWindowFunction<>(new SessionProcessWindowFunction()),
 				EventTimeTrigger.create(),
-				0);
+				0,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -525,7 +535,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new ReducedSessionWindowFunction()),
 				EventTimeTrigger.create(),
-				0);
+				0,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -595,7 +606,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueProcessWindowFunction<>(new ReducedProcessSessionWindowFunction()),
 				EventTimeTrigger.create(),
-				0);
+				0,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -669,7 +681,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalIterableWindowFunction<>(new SessionWindowFunction()),
 				PurgingTrigger.of(CountTrigger.of(4)),
-				0);
+				0,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -739,7 +752,8 @@ public class WindowOperatorTest extends TestLogger {
 			stateDesc,
 			new InternalIterableWindowFunction<>(new SessionWindowFunction()),
 			ContinuousEventTimeTrigger.of(Time.seconds(2)),
-			0);
+			0,
+			null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -843,7 +857,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalIterableWindowFunction<>(new SessionWindowFunction()),
 				EventTimeTrigger.create(),
-				0);
+				0,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -901,7 +916,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, GlobalWindow, Tuple2<String, Integer>>()),
 				ContinuousEventTimeTrigger.of(Time.of(WINDOW_SIZE, TimeUnit.SECONDS)),
-				0);
+				0,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -989,7 +1005,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, GlobalWindow, Tuple2<String, Integer>>()),
 				PurgingTrigger.of(CountTrigger.of(WINDOW_SIZE)),
-				0);
+				0,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -1030,7 +1047,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, GlobalWindow, Tuple2<String, Integer>>()),
 				PurgingTrigger.of(CountTrigger.of(WINDOW_SIZE)),
-				0);
+				0,
+				null /* late data output tag */);
 
 		testHarness = new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
 
@@ -1075,7 +1093,9 @@ public class WindowOperatorTest extends TestLogger {
 				BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
-				ProcessingTimeTrigger.create(), 0);
+				ProcessingTimeTrigger.create(),
+				0,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -1132,7 +1152,9 @@ public class WindowOperatorTest extends TestLogger {
 				BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
-				ProcessingTimeTrigger.create(), 0);
+				ProcessingTimeTrigger.create(),
+				0,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -1202,7 +1224,9 @@ public class WindowOperatorTest extends TestLogger {
 				BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()),
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
-				ProcessingTimeTrigger.create(), 0);
+				ProcessingTimeTrigger.create(),
+				0,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -1267,7 +1291,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
 				PurgingTrigger.of(EventTimeTrigger.create()),
-				LATENESS);
+				LATENESS,
+				lateOutputTag);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -1275,6 +1300,7 @@ public class WindowOperatorTest extends TestLogger {
 		testHarness.open();
 		
 		ConcurrentLinkedQueue<Object> expected = new ConcurrentLinkedQueue<>();
+		ConcurrentLinkedQueue<Object> lateExpected = new ConcurrentLinkedQueue<>();
 
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 500));
 		testHarness.processWatermark(new Watermark(1500));
@@ -1287,7 +1313,7 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new StreamRecord<>(new Tuple2<>("key2", 2), 1999));
 		expected.add(new Watermark(2300));
 
-		// this will not be dropped because window.maxTimestamp() + allowedLateness > currentWatermark
+		// this will not be sideoutput because window.maxTimestamp() + allowedLateness > currentWatermark
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 1997));
 		testHarness.processWatermark(new Watermark(6000));
 
@@ -1295,13 +1321,21 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new StreamRecord<>(new Tuple2<>("key2", 1), 1999));
 		expected.add(new Watermark(6000));
 
-		// this will be dropped because window.maxTimestamp() + allowedLateness < currentWatermark
+		// this will be side output because window.maxTimestamp() + allowedLateness < currentWatermark
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 1998));
 		testHarness.processWatermark(new Watermark(7000));
 
+		lateExpected.add(new StreamRecord<>(new Tuple2<>("key2", 1), 1998));
 		expected.add(new Watermark(7000));
 
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, testHarness.getOutput(), new Tuple2ResultSortComparator());
+		
+		TestHarnessUtil.assertOutputEqualsSorted(
+				"SideOutput was not correct.",
+				lateExpected,
+				testHarness.getSideOutput(lateOutputTag),
+				new Tuple2ResultSortComparator());
+
 		testHarness.close();
 	}
 
@@ -1327,7 +1361,8 @@ public class WindowOperatorTest extends TestLogger {
 					stateDesc,
 					new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
 					EventTimeTrigger.create(),
-					LATENESS);
+					LATENESS,
+					null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -1374,7 +1409,7 @@ public class WindowOperatorTest extends TestLogger {
 	}
 
 	@Test
-	public void testDropDueToLatenessTumbling() throws Exception {
+	public void testSideOutputDueToLatenessTumbling() throws Exception {
 		final int WINDOW_SIZE = 2;
 		final long LATENESS = 0;
 
@@ -1393,7 +1428,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
 				EventTimeTrigger.create(),
-				LATENESS);
+				LATENESS,
+				lateOutputTag);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -1401,6 +1437,7 @@ public class WindowOperatorTest extends TestLogger {
 		testHarness.open();
 
 		ConcurrentLinkedQueue<Object> expected = new ConcurrentLinkedQueue<>();
+		ConcurrentLinkedQueue<Object> sideExpected = new ConcurrentLinkedQueue<>();
 
 		// normal element
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 1000));
@@ -1415,8 +1452,9 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new StreamRecord<>(new Tuple2<>("key2", 2), 1999));
 		expected.add(new Watermark(1999));
 
-		// dropped as late
+		// sideoutput as late, will reuse previous timestamp since only input tuple is sideoutputed
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 1998));
+		sideExpected.add(new StreamRecord<>(new Tuple2<>("key2", 1), 1998));
 
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 2001));
 		testHarness.processWatermark(new Watermark(2999));
@@ -1429,11 +1467,13 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new Watermark(3999));
 
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, testHarness.getOutput(), new Tuple2ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("SideOutput was not correct.", sideExpected, testHarness.getSideOutput(
+				lateOutputTag), new Tuple2ResultSortComparator());
 		testHarness.close();
 	}
 
 	@Test
-	public void testDropDueToLatenessSliding() throws Exception {
+	public void testSideOutputDueToLatenessSliding() throws Exception {
 		final int WINDOW_SIZE = 3;
 		final int WINDOW_SLIDE = 1;
 		final long LATENESS = 0;
@@ -1453,7 +1493,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
 				EventTimeTrigger.create(),
-				LATENESS);
+				LATENESS,
+				lateOutputTag /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -1461,6 +1502,7 @@ public class WindowOperatorTest extends TestLogger {
 		testHarness.open();
 		
 		ConcurrentLinkedQueue<Object> expected = new ConcurrentLinkedQueue<>();
+		ConcurrentLinkedQueue<Object> sideExpected = new ConcurrentLinkedQueue<>();
 
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 1000));
 		testHarness.processWatermark(new Watermark(1999));
@@ -1497,19 +1539,21 @@ public class WindowOperatorTest extends TestLogger {
 
 		expected.add(new Watermark(6000));
 
-		// dropped due to lateness
+		// sideoutput element due to lateness
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 1), 3001));
+		sideExpected.add(new StreamRecord<>(new Tuple2<>("key1", 1), 3001));
 
 		testHarness.processWatermark(new Watermark(25000));
 
 		expected.add(new Watermark(25000));
 
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, testHarness.getOutput(), new Tuple2ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("SideOutput was not correct.", sideExpected, testHarness.getSideOutput(lateOutputTag), new Tuple2ResultSortComparator());
 		testHarness.close();
 	}
 
 	@Test
-	public void testDropDueToLatenessSessionZeroLatenessPurgingTrigger() throws Exception {
+	public void testSideOutputDueToLatenessSessionZeroLatenessPurgingTrigger() throws Exception {
 		final int GAP_SIZE = 3;
 		final long LATENESS = 0;
 
@@ -1528,7 +1572,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new ReducedSessionWindowFunction()),
 				PurgingTrigger.of(EventTimeTrigger.create()),
-				LATENESS);
+				LATENESS,
+				lateOutputTag);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -1536,6 +1581,7 @@ public class WindowOperatorTest extends TestLogger {
 		testHarness.open();
 		
 		ConcurrentLinkedQueue<Object> expected = new ConcurrentLinkedQueue<>();
+		ConcurrentLinkedQueue<Object> sideExpected = new ConcurrentLinkedQueue<>();
 
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 1000));
 		testHarness.processWatermark(new Watermark(1999));
@@ -1571,10 +1617,13 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new StreamRecord<>(new Tuple3<>("key2-1", 11600L, 14600L), 14599));
 		expected.add(new Watermark(14600));
 
-		// this is dropped as late
+		// this is side output as late
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 10000));
-		// this is also dropped as late (we test that they are not accidentally merged)
+		sideExpected.add(new StreamRecord<>(new Tuple2<>("key2", 1), 10000));
+
+		// this is also side output as late (we test that they are not accidentally merged)
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 10100));
+		sideExpected.add(new StreamRecord<>(new Tuple2<>("key2", 1), 10100));
 
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 14500));
 		testHarness.processWatermark(new Watermark(20000));
@@ -1587,19 +1636,16 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new Watermark(100000));
 
 		ConcurrentLinkedQueue<Object> actual = testHarness.getOutput();
+		ConcurrentLinkedQueue<Object> sideActual = testHarness.getSideOutput(lateOutputTag);
 
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, actual, new Tuple2ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("SideOutput was not correct.", sideExpected, sideActual, new Tuple2ResultSortComparator());
+
 		testHarness.close();
 	}
 
 	@Test
-	public void testDropDueToLatenessSessionZeroLateness() throws Exception {
-		// same as testDropDueToLatenessSessionZeroLateness() but with an accumulating trigger, i.e.
-		// one that does not return FIRE_AND_PURGE when firing but just FIRE
-
-		// this has the same output as testDropDueToLatenessSessionZeroLateness() because
-		// accumulating/discarding does not make a difference with "allowed lateness" = 0.
-
+	public void testSideOutputDueToLatenessSessionZeroLateness() throws Exception {
 		final int GAP_SIZE = 3;
 		final long LATENESS = 0;
 
@@ -1618,7 +1664,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new ReducedSessionWindowFunction()),
 				EventTimeTrigger.create(),
-				LATENESS);
+				LATENESS,
+				lateOutputTag);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -1626,6 +1673,7 @@ public class WindowOperatorTest extends TestLogger {
 		testHarness.open();
 		
 		ConcurrentLinkedQueue<Object> expected = new ConcurrentLinkedQueue<>();
+		ConcurrentLinkedQueue<Object> sideExpected = new ConcurrentLinkedQueue<>();
 
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 1000));
 		testHarness.processWatermark(new Watermark(1999));
@@ -1661,8 +1709,9 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new StreamRecord<>(new Tuple3<>("key2-1", 11600L, 14600L), 14599));
 		expected.add(new Watermark(14600));
 
-		// this is dropped as late
+		// this is sideoutput as late, reuse last timestamp
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 10000));
+		sideExpected.add(new StreamRecord<>(new Tuple2<>("key2", 1), 10000));
 
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 14500));
 		testHarness.processWatermark(new Watermark(20000));
@@ -1674,14 +1723,16 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new Watermark(100000));
 
 		ConcurrentLinkedQueue<Object> actual = testHarness.getOutput();
+		ConcurrentLinkedQueue<Object> sideActual = testHarness.getSideOutput(lateOutputTag);
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, actual, new Tuple2ResultSortComparator());
+		TestHarnessUtil.assertOutputEqualsSorted("SideOutput was not correct.", sideExpected, sideActual, new Tuple2ResultSortComparator());
 		testHarness.close();
 	}
 
 	@Test
 	public void testDropDueToLatenessSessionWithLatenessPurgingTrigger() throws Exception {
 
-		// this has the same output as testDropDueToLatenessSessionZeroLateness() because
+		// this has the same output as testSideOutputDueToLatenessSessionZeroLateness() because
 		// the allowed lateness is too small to make a difference
 
 		final int GAP_SIZE = 3;
@@ -1702,7 +1753,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new ReducedSessionWindowFunction()),
 				PurgingTrigger.of(EventTimeTrigger.create()),
-				LATENESS);
+				LATENESS,
+				lateOutputTag);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -1710,7 +1762,7 @@ public class WindowOperatorTest extends TestLogger {
 		testHarness.open();
 
 		ConcurrentLinkedQueue<Object> expected = new ConcurrentLinkedQueue<>();
-		
+
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 1000));
 		testHarness.processWatermark(new Watermark(1999));
 
@@ -1759,13 +1811,14 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new Watermark(100000));
 
 		ConcurrentLinkedQueue<Object> actual = testHarness.getOutput();
+
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
 		testHarness.close();
 	}
 
 	@Test
-	public void testDropDueToLatenessSessionWithLateness() throws Exception {
-		// same as testDropDueToLatenessSessionWithLateness() but with an accumulating trigger, i.e.
+	public void testNotSideOutputDueToLatenessSessionWithLateness() throws Exception {
+		// same as testSideOutputDueToLatenessSessionWithLateness() but with an accumulating trigger, i.e.
 		// one that does not return FIRE_AND_PURGE when firing but just FIRE. The expected
 		// results are therefore slightly different.
 
@@ -1787,7 +1840,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new ReducedSessionWindowFunction()),
 				EventTimeTrigger.create(),
-				LATENESS);
+				LATENESS,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -1806,7 +1860,7 @@ public class WindowOperatorTest extends TestLogger {
 
 		expected.add(new Watermark(4998));
 
-		// this will not be dropped because the session we're adding two has maxTimestamp
+		// this will not be sideoutput because the session we're adding two has maxTimestamp
 		// after the current watermark
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 4500));
 
@@ -1832,7 +1886,7 @@ public class WindowOperatorTest extends TestLogger {
 
 		// because of the small allowed lateness and because the trigger is accumulating
 		// this will be merged into the session (11600-14600) and therefore will not
-		// be dropped as late
+		// be sideoutput as late
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 10000));
 
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 14500));
@@ -1843,7 +1897,10 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new StreamRecord<>(new Tuple3<>("key2-2", 10000L, 14600L), 14599));
 
 		ConcurrentLinkedQueue<Object> actual = testHarness.getOutput();
+		ConcurrentLinkedQueue<Object> sideActual = testHarness.getSideOutput(lateOutputTag);
+
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
+		assertEquals(null, sideActual);
 
 		testHarness.processWatermark(new Watermark(20000));
 
@@ -1855,12 +1912,15 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new Watermark(100000));
 
 		actual = testHarness.getOutput();
+		sideActual = testHarness.getSideOutput(lateOutputTag);
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
+		assertEquals(null, sideActual);
+
 		testHarness.close();
 	}
 
 	@Test
-	public void testDropDueToLatenessSessionWithHugeLatenessPurgingTrigger() throws Exception {
+	public void testNotSideOutputDueToLatenessSessionWithHugeLatenessPurgingTrigger() throws Exception {
 
 		final int GAP_SIZE = 3;
 		final long LATENESS = 10000;
@@ -1880,7 +1940,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new ReducedSessionWindowFunction()),
 				PurgingTrigger.of(EventTimeTrigger.create()),
-				LATENESS);
+				LATENESS,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -1899,7 +1960,7 @@ public class WindowOperatorTest extends TestLogger {
 
 		expected.add(new Watermark(4998));
 
-		// this will not be dropped because the session we're adding two has maxTimestamp
+		// this will not be sideoutput because the session we're adding two has maxTimestamp
 		// after the current watermark
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 4500));
 
@@ -1928,7 +1989,9 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new StreamRecord<>(new Tuple3<>("key2-1", 1000L, 14600L), 14599));
 
 		ConcurrentLinkedQueue<Object> actual = testHarness.getOutput();
+		ConcurrentLinkedQueue<Object> sideActual = testHarness.getSideOutput(lateOutputTag);
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
+		assertEquals(null, sideActual);
 
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 14500));
 		testHarness.processWatermark(new Watermark(20000));
@@ -1941,12 +2004,15 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new Watermark(100000));
 
 		actual = testHarness.getOutput();
+		sideActual = testHarness.getSideOutput(lateOutputTag);
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
+		assertEquals(null, sideActual);
+
 		testHarness.close();
 	}
 
 	@Test
-	public void testDropDueToLatenessSessionWithHugeLateness() throws Exception {
+	public void testNotSideOutputDueToLatenessSessionWithHugeLateness() throws Exception {
 		final int GAP_SIZE = 3;
 		final long LATENESS = 10000;
 
@@ -1965,7 +2031,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new ReducedSessionWindowFunction()),
 				EventTimeTrigger.create(),
-				LATENESS);
+				LATENESS,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -1984,7 +2051,7 @@ public class WindowOperatorTest extends TestLogger {
 
 		expected.add(new Watermark(4998));
 
-		// this will not be dropped because the session we're adding two has maxTimestamp
+		// this will not be sideoutput because the session we're adding two has maxTimestamp
 		// after the current watermark
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 4500));
 
@@ -2015,7 +2082,9 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new StreamRecord<>(new Tuple3<>("key2-7", 1000L, 14600L), 14599));
 
 		ConcurrentLinkedQueue<Object> actual = testHarness.getOutput();
+		ConcurrentLinkedQueue<Object> sideActual = testHarness.getSideOutput(lateOutputTag);
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
+		assertEquals(null, sideActual);
 
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 14500));
 		testHarness.processWatermark(new Watermark(20000));
@@ -2027,7 +2096,11 @@ public class WindowOperatorTest extends TestLogger {
 		expected.add(new Watermark(100000));
 
 		actual = testHarness.getOutput();
+		sideActual = testHarness.getSideOutput(lateOutputTag);
+
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
+		assertEquals(null, sideActual);
+
 		testHarness.close();
 	}
 
@@ -2050,7 +2123,8 @@ public class WindowOperatorTest extends TestLogger {
 				windowStateDesc,
 				new InternalIterableWindowFunction<>(new PassThroughFunction2()),
 					new EventTimeTriggerAccumGC(LATENESS),
-				LATENESS);
+				LATENESS,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, String> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -2104,7 +2178,8 @@ public class WindowOperatorTest extends TestLogger {
 				windowStateDesc,
 				new InternalIterableWindowFunction<>(new PassThroughFunction()),
 				EventTimeTrigger.create(),
-				LATENESS);
+				LATENESS,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -2150,7 +2225,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughWindowFunction<String, TimeWindow, Tuple2<String, Integer>>()),
 				EventTimeTrigger.create(),
-				LATENESS);
+				LATENESS,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -2207,7 +2283,8 @@ public class WindowOperatorTest extends TestLogger {
 				windowStateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughFunction()),
 				EventTimeTrigger.create(),
-				LATENESS);
+				LATENESS,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -2252,7 +2329,8 @@ public class WindowOperatorTest extends TestLogger {
 				windowStateDesc,
 				new InternalIterableWindowFunction<>(new PassThroughFunction()),
 				EventTimeTrigger.create(),
-				LATENESS);
+				LATENESS,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -2296,7 +2374,8 @@ public class WindowOperatorTest extends TestLogger {
 				stateDesc,
 				new InternalSingleValueWindowFunction<>(new ReducedSessionWindowFunction()),
 				EventTimeTrigger.create(),
-				LATENESS);
+				LATENESS,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple3<String, Long, Long>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);
@@ -2351,7 +2430,8 @@ public class WindowOperatorTest extends TestLogger {
 				windowStateDesc,
 				new InternalSingleValueWindowFunction<>(new PassThroughFunction()),
 				EventTimeTrigger.create(),
-				LATENESS);
+				LATENESS,
+				null /* late data output tag */);
 
 		OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>> testHarness =
 			new KeyedOneInputStreamOperatorTestHarness<>(operator, new TupleKeySelector(), BasicTypeInfo.STRING_TYPE_INFO);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -270,6 +270,7 @@ public class OneInputStreamTaskTest extends TestLogger {
 			new StreamNode(null, 1, null, null, null, null, null),
 			0,
 			Collections.<String>emptyList(),
+			null,
 			null
 		)));
 
@@ -281,6 +282,7 @@ public class OneInputStreamTaskTest extends TestLogger {
 			new StreamNode(null, 2, null, null, null, null, null),
 			0,
 			Collections.<String>emptyList(),
+			null,
 			null
 		)));
 
@@ -290,7 +292,8 @@ public class OneInputStreamTaskTest extends TestLogger {
 			new StreamNode(null, 3, null, null, null, null, null),
 			0,
 			Collections.<String>emptyList(),
-			new BroadcastPartitioner<Object>()));
+			new BroadcastPartitioner<Object>(),
+			null));
 
 		tailOperatorConfig.setStreamOperator(tailOperator);
 		tailOperatorConfig.setTypeSerializerIn1(StringSerializer.INSTANCE);
@@ -641,6 +644,7 @@ public class OneInputStreamTaskTest extends TestLogger {
 				),
 				0,
 				Collections.<String>emptyList(),
+				null,
 				null
 			);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -153,7 +153,8 @@ public class StreamTaskTestHarness<OUT> {
 		List<StreamEdge> outEdgesInOrder = new LinkedList<StreamEdge>();
 		StreamNode sourceVertexDummy = new StreamNode(null, 0, "group", dummyOperator, "source dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
 		StreamNode targetVertexDummy = new StreamNode(null, 1, "group", dummyOperator, "target dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
-		outEdgesInOrder.add(new StreamEdge(sourceVertexDummy, targetVertexDummy, 0, new LinkedList<String>(), new BroadcastPartitioner<Object>()));
+
+		outEdgesInOrder.add(new StreamEdge(sourceVertexDummy, targetVertexDummy, 0, new LinkedList<String>(), new BroadcastPartitioner<Object>(), null /* output tag */));
 
 		streamConfig.setOutEdgesInOrder(outEdgesInOrder);
 		streamConfig.setNonChainedOutputs(outEdgesInOrder);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
@@ -128,7 +128,8 @@ public class TwoInputStreamTaskTestHarness<IN1, IN2, OUT> extends StreamTaskTest
 							targetVertexDummy,
 							1,
 							new LinkedList<String>(),
-							new BroadcastPartitioner<Object>());
+							new BroadcastPartitioner<Object>(),
+							null /* output tag */);
 
 					inPhysicalEdges.add(streamEdge);
 					break;
@@ -143,7 +144,8 @@ public class TwoInputStreamTaskTestHarness<IN1, IN2, OUT> extends StreamTaskTest
 							targetVertexDummy,
 							2,
 							new LinkedList<String>(),
-							new BroadcastPartitioner<Object>());
+							new BroadcastPartitioner<Object>(),
+							null /* output tag */);
 
 					inPhysicalEdges.add(streamEdge);
 					break;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.util;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.util.OutputTag;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.configuration.Configuration;
@@ -70,8 +71,10 @@ import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.mockito.Matchers.any;
@@ -87,6 +90,8 @@ public class AbstractStreamOperatorTestHarness<OUT> {
 	final protected StreamOperator<OUT> operator;
 
 	final protected ConcurrentLinkedQueue<Object> outputList;
+
+	final protected Map<OutputTag<?>, ConcurrentLinkedQueue<Object>> sideOutputLists;
 
 	final protected StreamConfig config;
 
@@ -147,6 +152,8 @@ public class AbstractStreamOperatorTestHarness<OUT> {
 			final Environment environment) throws Exception {
 		this.operator = operator;
 		this.outputList = new ConcurrentLinkedQueue<>();
+		this.sideOutputLists = new HashMap<>();
+
 		Configuration underlyingConfig = environment.getTaskConfiguration();
 		this.config = new StreamConfig(underlyingConfig);
 		this.config.setCheckpointingEnabled(true);
@@ -261,6 +268,10 @@ public class AbstractStreamOperatorTestHarness<OUT> {
 	 */
 	public ConcurrentLinkedQueue<Object> getOutput() {
 		return outputList;
+	}
+
+	public ConcurrentLinkedQueue<Object> getSideOutput(OutputTag tag) {
+		return sideOutputLists.get(tag);
 	}
 
 	/**
@@ -610,6 +621,8 @@ public class AbstractStreamOperatorTestHarness<OUT> {
 
 		private TypeSerializer<OUT> outputSerializer;
 
+		private TypeSerializer sideOutputSerializer;
+
 		MockOutput() {
 			this(null);
 		}
@@ -634,10 +647,27 @@ public class AbstractStreamOperatorTestHarness<OUT> {
 				outputSerializer = TypeExtractor.getForObject(element.getValue()).createSerializer(executionConfig);
 			}
 			if (element.hasTimestamp()) {
-				outputList.add(new StreamRecord<>(outputSerializer.copy(element.getValue()),element.getTimestamp()));
+				outputList.add(new StreamRecord<>(outputSerializer.copy(element.getValue()), element.getTimestamp()));
 			} else {
 				outputList.add(new StreamRecord<>(outputSerializer.copy(element.getValue())));
 			}
+		}
+
+		@Override
+		public <X> void collect(OutputTag<?> outputTag, StreamRecord<X> record) {
+			sideOutputSerializer = TypeExtractor.getForObject(record.getValue()).createSerializer(executionConfig);
+
+			ConcurrentLinkedQueue<Object> sideOutputList = sideOutputLists.get(outputTag);
+			if (sideOutputList == null) {
+				sideOutputList = new ConcurrentLinkedQueue<>();
+				sideOutputLists.put(outputTag, sideOutputList);
+			}
+			if (record.hasTimestamp()) {
+				sideOutputList.add(new StreamRecord<>(sideOutputSerializer.copy(record.getValue()), record.getTimestamp()));
+			} else {
+				sideOutputList.add(new StreamRecord<>(sideOutputSerializer.copy(record.getValue())));
+			}
+
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -270,8 +270,9 @@ public class AbstractStreamOperatorTestHarness<OUT> {
 		return outputList;
 	}
 
-	public ConcurrentLinkedQueue<Object> getSideOutput(OutputTag tag) {
-		return sideOutputLists.get(tag);
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public <X> ConcurrentLinkedQueue<StreamRecord<X>> getSideOutput(OutputTag<X> tag) {
+		return (ConcurrentLinkedQueue) sideOutputLists.get(tag);
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/CollectorOutput.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/CollectorOutput.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
 
 import java.io.Serializable;
 import java.util.List;
@@ -50,6 +51,11 @@ public class CollectorOutput<T> implements Output<StreamRecord<T>> {
 	public void collect(StreamRecord<T> record) {
 		T copied = SerializationUtils.deserialize(SerializationUtils.serialize((Serializable) record.getValue()));
 		list.add(record.copy(copied));
+	}
+
+	@Override
+	public <X> void collect(OutputTag<?> outputTag, StreamRecord<X> record) {
+		throw new UnsupportedOperationException("Side output not supported for CollectorOutput");
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockOutput.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockOutput.java
@@ -25,6 +25,7 @@ import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
 
 public class MockOutput<T> implements Output<StreamRecord<T>> {
 	private Collection<T> outputs;
@@ -37,6 +38,11 @@ public class MockOutput<T> implements Output<StreamRecord<T>> {
 	public void collect(StreamRecord<T> record) {
 		T copied = SerializationUtils.deserialize(SerializationUtils.serialize((Serializable) record.getValue()));
 		outputs.add(copied);
+	}
+
+	@Override
+	public <X> void collect(OutputTag<?> outputTag, StreamRecord<X> record) {
+		throw new UnsupportedOperationException("Side output not supported for MockOutput");
 	}
 
 	@Override

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AllWindowedStream.scala
@@ -30,7 +30,7 @@ import org.apache.flink.streaming.api.windowing.evictors.Evictor
 import org.apache.flink.streaming.api.windowing.time.Time
 import org.apache.flink.streaming.api.windowing.triggers.Trigger
 import org.apache.flink.streaming.api.windowing.windows.Window
-import org.apache.flink.util.Collector
+import org.apache.flink.util.{Collector, OutputTag}
 import org.apache.flink.util.Preconditions.checkNotNull
 
 /**
@@ -68,6 +68,20 @@ class AllWindowedStream[T, W <: Window](javaStream: JavaAllWStream[T, W]) {
   @PublicEvolving
   def allowedLateness(lateness: Time): AllWindowedStream[T, W] = {
     javaStream.allowedLateness(lateness)
+    this
+  }
+
+  /**
+   * Send late arriving data to the side output identified by the given [[OutputTag]]. Data
+   * is considered late after the watermark has passed the end of the window plus the allowed
+   * lateness set using [[allowedLateness(Time)]].
+   *
+   * You can get the stream of late data using [[DataStream.getSideOutput()]] on the [[DataStream]]
+   * resulting from the windowed operation with the same [[OutputTag]].
+   */
+  @PublicEvolving
+  def sideOutputLateData(outputTag: OutputTag[T]): AllWindowedStream[T, W] = {
+    javaStream.sideOutputLateData(outputTag)
     this
   }
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -39,7 +39,7 @@ import org.apache.flink.streaming.api.windowing.assigners._
 import org.apache.flink.streaming.api.windowing.time.Time
 import org.apache.flink.streaming.api.windowing.windows.{GlobalWindow, TimeWindow, Window}
 import org.apache.flink.streaming.util.serialization.SerializationSchema
-import org.apache.flink.util.Collector
+import org.apache.flink.util.{Collector, OutputTag}
 
 import scala.collection.JavaConverters._
 
@@ -237,6 +237,12 @@ class DataStream[T](stream: JavaStream[T]) {
     case stream : SingleOutputStreamOperator[T] => asScalaStream(stream.uid(uid))
     case _ => throw new UnsupportedOperationException("Only supported for operators.")
     this
+  }
+
+  @PublicEvolving
+  def getSideOutput[X: OutputTag](tag: OutputTag[X]): DataStream[X] = javaStream match {
+    case stream : SingleOutputStreamOperator[X] =>
+      asScalaStream(stream.getSideOutput(tag: OutputTag[X]))
   }
 
   /**

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -240,7 +240,7 @@ class DataStream[T](stream: JavaStream[T]) {
   }
 
   @PublicEvolving
-  def getSideOutput[X: OutputTag](tag: OutputTag[X]): DataStream[X] = javaStream match {
+  def getSideOutput[X: TypeInformation](tag: OutputTag[X]): DataStream[X] = javaStream match {
     case stream : SingleOutputStreamOperator[X] =>
       asScalaStream(stream.getSideOutput(tag: OutputTag[X]))
   }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/OutputTag.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/OutputTag.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.api.scala
+
+import org.apache.flink.annotation.PublicEvolving
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.util.{OutputTag => JOutputTag}
+
+
+/**
+ * An [[OutputTag]] is a typed and named tag to use for tagging side outputs
+ * of an operator.
+ *
+ * Example:
+ * {{{
+ *   val outputTag = OutputTag[String]("late-data")
+ * }}}
+ *
+ * @tparam T the type of elements in the side-output stream.
+ */
+@PublicEvolving
+class OutputTag[T: TypeInformation](
+    id: String) extends JOutputTag[T](id, implicitly[TypeInformation[T]])
+
+object OutputTag {
+  def apply[T: TypeInformation](id: String): OutputTag[T] = new OutputTag(id)
+}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
@@ -19,8 +19,6 @@
 package org.apache.flink.streaming.api.scala
 
 import org.apache.flink.annotation.{Public, PublicEvolving}
-import org.apache.flink.api.common.functions.{FoldFunction, ReduceFunction}
-import org.apache.flink.annotation.{PublicEvolving, Public}
 import org.apache.flink.api.common.functions.{AggregateFunction, FoldFunction, ReduceFunction}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.datastream.{WindowedStream => JavaWStream}
@@ -32,7 +30,7 @@ import org.apache.flink.streaming.api.windowing.evictors.Evictor
 import org.apache.flink.streaming.api.windowing.time.Time
 import org.apache.flink.streaming.api.windowing.triggers.Trigger
 import org.apache.flink.streaming.api.windowing.windows.Window
-import org.apache.flink.util.Collector
+import org.apache.flink.util.{Collector, OutputTag}
 
 /**
  * A [[WindowedStream]] represents a data stream where elements are grouped by
@@ -72,6 +70,20 @@ class WindowedStream[T, K, W <: Window](javaStream: JavaWStream[T, K, W]) {
   @PublicEvolving
   def allowedLateness(lateness: Time): WindowedStream[T, K, W] = {
     javaStream.allowedLateness(lateness)
+    this
+  }
+
+  /**
+   * Send late arriving data to the side output identified by the given [[OutputTag]]. Data
+   * is considered late after the watermark has passed the end of the window plus the allowed
+   * lateness set using [[allowedLateness(Time)]].
+   *
+   * You can get the stream of late data using [[DataStream.getSideOutput()]] on the [[DataStream]]
+   * resulting from the windowed operation with the same [[OutputTag]].
+   */
+  @PublicEvolving
+  def sideOutputLateData(outputTag: OutputTag[T]): WindowedStream[T, K, W] = {
+    javaStream.sideOutputLateData(outputTag)
     this
   }
 

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/SideOutputITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/SideOutputITCase.scala
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.scala
+
+import java.util
+
+import org.apache.flink.streaming.api.TimeCharacteristic
+import org.apache.flink.streaming.api.functions.{AssignerWithPunctuatedWatermarks, ProcessFunction}
+import org.apache.flink.streaming.api.scala.function.{ProcessAllWindowFunction, ProcessWindowFunction}
+import org.apache.flink.streaming.api.watermark.Watermark
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows
+import org.apache.flink.streaming.api.windowing.time.Time
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow
+import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase
+import org.apache.flink.test.streaming.runtime.util.TestListResultSink
+import org.apache.flink.util.Collector
+import org.junit.Assert._
+import org.junit.Test
+
+/**
+ * Integration test for streaming programs using side outputs.
+ */
+class SideOutputITCase extends StreamingMultipleProgramsTestBase {
+
+  /**
+    * Test ProcessFunction side output.
+    */
+  @Test
+  def testProcessFunctionSideOutput() {
+    val sideOutputResultSink = new TestListResultSink[String]
+    val resultSink = new TestListResultSink[Int]
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(3)
+
+    val dataStream = env.fromElements(1, 2, 5, 3, 4)
+
+    val outputTag = OutputTag[String]("side")
+
+    val passThroughtStream = dataStream
+      .process(new ProcessFunction[Int, Int] {
+        override def processElement(
+            value: Int, ctx: ProcessFunction[Int, Int]#Context, out: Collector[Int]): Unit = {
+          out.collect(value)
+          ctx.output(outputTag, "sideout-" + String.valueOf(value))
+        }
+      })
+
+    passThroughtStream.getSideOutput(outputTag).addSink(sideOutputResultSink)
+    passThroughtStream.addSink(resultSink)
+
+    env.execute()
+    
+    assertEquals(
+      util.Arrays.asList("sideout-1", "sideout-2", "sideout-3", "sideout-4", "sideout-5"),
+      sideOutputResultSink.getSortedResult)
+    
+    assertEquals(util.Arrays.asList(1, 2, 3, 4, 5), resultSink.getSortedResult)
+  }
+
+  /**
+   * Test keyed ProcessFunction side output.
+   */
+  @Test
+  def testKeyedProcessFunctionSideOutput() {
+    val sideOutputResultSink = new TestListResultSink[String]
+    val resultSink = new TestListResultSink[Int]
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(3)
+
+    val dataStream = env.fromElements(1, 2, 5, 3, 4)
+
+    val outputTag = OutputTag[String]("side")
+
+    val passThroughtStream = dataStream
+      .keyBy(x => x)
+      .process(new ProcessFunction[Int, Int] {
+        override def processElement(
+            value: Int, ctx: ProcessFunction[Int, Int]#Context, out: Collector[Int]): Unit = {
+          out.collect(value)
+          ctx.output(outputTag, "sideout-" + String.valueOf(value))
+        }
+      })
+
+    passThroughtStream.getSideOutput(outputTag).addSink(sideOutputResultSink)
+    passThroughtStream.addSink(resultSink)
+
+    env.execute()
+
+    assertEquals(
+      util.Arrays.asList("sideout-1", "sideout-2", "sideout-3", "sideout-4", "sideout-5"),
+      sideOutputResultSink.getSortedResult)
+
+    assertEquals(util.Arrays.asList(1, 2, 3, 4, 5), resultSink.getSortedResult)
+  }
+
+  /**
+   * Test ProcessFunction side outputs with wrong [[OutputTag]].
+   */
+  @Test
+  def testProcessFunctionSideOutputWithWrongTag() {
+    val sideOutputResultSink = new TestListResultSink[String]
+    val resultSink = new TestListResultSink[Int]
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(3)
+
+    val dataStream = env.fromElements(1, 2, 5, 3, 4)
+
+    val outputTag = OutputTag[String]("side")
+    val otherOutputTag = OutputTag[String]("other-side")
+
+    val passThroughtStream = dataStream
+      .process(new ProcessFunction[Int, Int] {
+        override def processElement(
+            value: Int,
+            ctx: ProcessFunction[Int, Int]#Context,
+            out: Collector[Int]): Unit = {
+          ctx.output(otherOutputTag, "sideout-" + String.valueOf(value))
+        }
+      })
+
+    passThroughtStream.getSideOutput(outputTag).addSink(sideOutputResultSink)
+
+    env.execute()
+
+    assertTrue(sideOutputResultSink.getSortedResult.isEmpty)
+  }
+
+  /**
+   * Test window late arriving events stream
+   */
+  @Test
+  def testAllWindowLateArrivingEvents() {
+    val resultSink = new TestListResultSink[String]
+    val lateResultSink = new TestListResultSink[(String, Int)]
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(1)
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+
+    val dataStream = env.fromElements(("1", 1), ("2", 2), ("5", 5), ("3", 3), ("4", 4))
+
+
+    val lateDataTag = OutputTag[(String, Int)]("late")
+
+    val windowOperator = dataStream
+      .assignTimestampsAndWatermarks(new TestAssigner)
+      .windowAll(TumblingEventTimeWindows.of(Time.milliseconds(1)))
+      .sideOutputLateData(lateDataTag)
+      .process(new ProcessAllWindowFunction[(String, Int), String, TimeWindow] {
+        override def process(
+            context: Context,
+            elements: Iterable[(String, Int)],
+            out: Collector[String]): Unit = {
+          for (in <- elements) {
+            out.collect(in._1)
+          }
+        }
+      })
+
+    windowOperator
+      .getSideOutput(lateDataTag)
+      .addSink(lateResultSink)
+
+    windowOperator.addSink(resultSink)
+
+    env.execute()
+    
+    assertEquals(util.Arrays.asList("1", "2", "5"), resultSink.getResult)
+    assertEquals(util.Arrays.asList(("3", 3), ("4", 4)), lateResultSink.getResult)
+  }
+
+  /**
+   * Test window late arriving events stream
+   */
+  @Test
+  def testKeyedWindowLateArrivingEvents() {
+    val resultSink = new TestListResultSink[String]
+    val lateResultSink = new TestListResultSink[(String, Int)]
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(1)
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+
+    val dataStream = env.fromElements(("1", 1), ("2", 2), ("5", 5), ("3", 3), ("4", 4))
+
+
+    val lateDataTag = OutputTag[(String, Int)]("late")
+
+    val windowOperator = dataStream
+      .assignTimestampsAndWatermarks(new TestAssigner)
+      .keyBy(i => i._1)
+      .window(TumblingEventTimeWindows.of(Time.milliseconds(1)))
+      .sideOutputLateData(lateDataTag)
+      .process(new ProcessWindowFunction[(String, Int), String, String, TimeWindow] {
+        override def process(
+            key:String,
+            context: Context,
+            elements: Iterable[(String, Int)],
+            out: Collector[String]): Unit = {
+          for (in <- elements) {
+            out.collect(in._1)
+          }
+        }
+      })
+
+    windowOperator
+      .getSideOutput(lateDataTag)
+      .addSink(lateResultSink)
+
+    windowOperator.addSink(resultSink)
+
+    env.execute()
+
+    assertEquals(util.Arrays.asList("1", "2", "5"), resultSink.getResult)
+    assertEquals(util.Arrays.asList(("3", 3), ("4", 4)), lateResultSink.getResult)
+  }
+
+}
+
+class TestAssigner extends AssignerWithPunctuatedWatermarks[(String, Int)] {
+  override def checkAndGetNextWatermark(
+  lastElement: (String, Int),
+  extractedTimestamp: Long): Watermark = new Watermark(extractedTimestamp)
+
+  override def extractTimestamp(
+  element: (String, Int),
+  previousElementTimestamp: Long): Long = element._2.toLong
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SideOutputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SideOutputITCase.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.runtime;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
+import org.apache.flink.streaming.api.functions.windowing.AllWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
+import org.apache.flink.test.streaming.runtime.util.TestListResultSink;
+import org.apache.flink.util.Collector;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Integration test for streaming programs using side outputs.
+ */
+public class SideOutputITCase extends StreamingMultipleProgramsTestBase {
+
+	static List<Integer> elements = new ArrayList<>();
+	static {
+		elements.add(1);
+		elements.add(2);
+		elements.add(5);
+		elements.add(3);
+		elements.add(4);
+	}
+
+	private static class TestWatermarkAssigner implements AssignerWithPunctuatedWatermarks<Integer> {
+		private static final long serialVersionUID = 1L;
+
+		@Nullable
+		@Override
+		public Watermark checkAndGetNextWatermark(Integer lastElement, long extractedTimestamp) {
+			return new Watermark(extractedTimestamp);
+		}
+
+		@Override
+		public long extractTimestamp(Integer element, long previousElementTimestamp) {
+			return Long.valueOf(element);
+		}
+	}
+
+	private static class TestKeySelector implements KeySelector<Integer, Integer> {
+		private static final long serialVersionUID = 1L;
+		
+		@Override
+		public Integer getKey(Integer value) throws Exception {
+			return value;
+		}
+	}
+
+	/**
+	 * Test window late arriving events stream
+	 */
+	@Test
+	public void testAllWindowLateArrivingEvents() throws Exception {
+		TestListResultSink<String> sideOutputResultSink = new TestListResultSink<>();
+
+		StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
+		see.setParallelism(1);
+		see.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+
+		DataStream<Integer> dataStream = see.fromCollection(elements);
+
+		OutputTag<Integer> lateDataTag = new OutputTag<Integer>("late"){};
+
+		SingleOutputStreamOperator<Integer> windowOperator = dataStream
+				.assignTimestampsAndWatermarks(new TestWatermarkAssigner())
+				.timeWindowAll(Time.milliseconds(1), Time.milliseconds(1))
+				.sideOutputLateData(lateDataTag)
+				.apply(new AllWindowFunction<Integer, Integer, TimeWindow>() {
+					private static final long serialVersionUID = 1L;
+					
+					@Override
+					public void apply(TimeWindow window, Iterable<Integer> values, Collector<Integer> out) throws Exception {
+							for(Integer val : values) {
+								out.collect(val);
+							}
+					}
+				});
+
+		windowOperator
+				.getSideOutput(lateDataTag)
+				.flatMap(new FlatMapFunction<Integer, String>() {
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					public void flatMap(Integer value, Collector<String> out) throws Exception {
+						out.collect("late-" + String.valueOf(value));
+					}
+				})
+				.addSink(sideOutputResultSink);
+
+		see.execute();
+		assertEquals(sideOutputResultSink.getSortedResult(), Arrays.asList("late-3", "late-4"));
+
+	}
+
+	@Test
+	public void testKeyedWindowLateArrivingEvents() throws Exception {
+		TestListResultSink<String> resultSink = new TestListResultSink<>();
+		TestListResultSink<Integer> lateResultSink = new TestListResultSink<>();
+
+		StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
+		see.setParallelism(3);
+		see.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+
+		DataStream<Integer> dataStream = see.fromCollection(elements);
+
+		OutputTag<Integer> lateDataTag = new OutputTag<Integer>("late"){};
+
+		SingleOutputStreamOperator<String> windowOperator = dataStream
+				.assignTimestampsAndWatermarks(new TestWatermarkAssigner())
+				.keyBy(new TestKeySelector())
+				.timeWindow(Time.milliseconds(1), Time.milliseconds(1))
+				.allowedLateness(Time.milliseconds(2))
+				.sideOutputLateData(lateDataTag)
+				.apply(new WindowFunction<Integer, String, Integer, TimeWindow>() {
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					public void apply(Integer key, TimeWindow window, Iterable<Integer> input, Collector<String> out) throws Exception {
+						for(Integer val : input) {
+							out.collect(String.valueOf(key) + "-" + String.valueOf(val));
+						}
+					}
+				});
+
+		windowOperator
+				.addSink(resultSink);
+
+		windowOperator
+				.getSideOutput(lateDataTag)
+				.addSink(lateResultSink);
+
+		see.execute();
+		assertEquals(Arrays.asList("1-1", "2-2", "4-4", "5-5"), resultSink.getSortedResult());
+		assertEquals(Collections.singletonList(3), lateResultSink.getSortedResult());
+	}
+
+}


### PR DESCRIPTION
This is a refinement of #2982 by @chenqin.

I changed the API a bit, added support for side outputs to `ProcessFunction`, enabled side outputs to work with chaining, added proper Scala API and a Scala API test and added documentation.

R: @uce @kl0u and @chenqin for review, please