### PR TITLE
[FLINK-5981][SECURITY]make ssl version and cipher suites work as configured

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -325,7 +325,7 @@ The following parameters configure Flink's JobManager and TaskManagers.
 
 - `security.ssl.truststore-password`: The secret to decrypt the truststore.
 
-- `security.ssl.protocol`: The SSL protocol version to be supported for the ssl transport (DEFAULT: **TLSv1.2**).
+- `security.ssl.protocol`: The SSL protocol version to be supported for the ssl transport (DEFAULT: **TLSv1.2**). Note that it doesn't support comma separated list.
 
 - `security.ssl.algorithms`: The comma separated list of standard SSL algorithms to be supported. Read more [here](http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#ciphersuites) (DEFAULT: **TLS_RSA_WITH_AES_128_CBC_SHA**).
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosArtifactServer.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosArtifactServer.java
@@ -130,6 +130,7 @@ public class MesosArtifactServer implements MesosArtifactResolver {
 
 		router = new Router();
 
+		final Configuration sslConfig = config;
 		ChannelInitializer<SocketChannel> initializer = new ChannelInitializer<SocketChannel>() {
 
 			@Override
@@ -139,6 +140,7 @@ public class MesosArtifactServer implements MesosArtifactResolver {
 				// SSL should be the first handler in the pipeline
 				if (serverSSLContext != null) {
 					SSLEngine sslEngine = serverSSLContext.createSSLEngine();
+					SSLUtils.setSSLVerAndCipherSuites(sslEngine, sslConfig);
 					sslEngine.setUseClientMode(false);
 					ch.pipeline().addLast("ssl", new SslHandler(sslEngine));
 				}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -380,6 +380,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 			LOG.warn("Error while adding shutdown hook", t);
 		}
 
+		final Configuration sslConfig = config;
 		ChannelInitializer<SocketChannel> initializer = new ChannelInitializer<SocketChannel>() {
 
 			@Override
@@ -389,6 +390,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 				// SSL should be the first handler in the pipeline
 				if (serverSSLContext != null) {
 					SSLEngine sslEngine = serverSSLContext.createSSLEngine();
+					SSLUtils.setSSLVerAndCipherSuites(sslEngine, sslConfig);
 					sslEngine.setUseClientMode(false);
 					ch.pipeline().addLast("ssl", new SslHandler(sslEngine));
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -168,6 +168,7 @@ public class BlobServer extends Thread implements BlobService {
 		if(socketAttempt == null) {
 			throw new IOException("Unable to allocate socket for blob server in specified port range: "+serverPortRange);
 		} else {
+			SSLUtils.setSSLVerAndCipherSuites(socketAttempt, config);
 			this.serverSocket = socketAttempt;
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -169,7 +169,7 @@ public class BlobServer extends Thread implements BlobService {
 			throw new IOException("Unable to allocate socket for blob server in specified port range: "+serverPortRange);
 		} else {
 			SSLUtils.setSSLVerAndCipherSuites(socketAttempt, config);
-		this.serverSocket = socketAttempt;
+			this.serverSocket = socketAttempt;
 		}
 
 		// start the server thread

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -169,7 +169,7 @@ public class BlobServer extends Thread implements BlobService {
 			throw new IOException("Unable to allocate socket for blob server in specified port range: "+serverPortRange);
 		} else {
 			SSLUtils.setSSLVerAndCipherSuites(socketAttempt, config);
-			this.serverSocket = socketAttempt;
+		this.serverSocket = socketAttempt;
 		}
 
 		// start the server thread

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 import java.net.InetAddress;
 
@@ -234,6 +235,10 @@ public class NettyConfig {
 		return config.getBoolean(ConfigConstants.TASK_MANAGER_DATA_SSL_ENABLED,
 				ConfigConstants.DEFAULT_TASK_MANAGER_DATA_SSL_ENABLED)
 			&& SSLUtils.getSSLEnabled(config);
+	}
+
+	public void setSSLVerAndCipherSuites(SSLEngine engine) {
+		SSLUtils.setSSLVerAndCipherSuites(engine, config);
 	}
 
 	public void setSSLVerifyHostname(SSLParameters sslParams) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -140,6 +140,7 @@ class NettyServer {
 			public void initChannel(SocketChannel channel) throws Exception {
 				if (serverSSLContext != null) {
 					SSLEngine sslEngine = serverSSLContext.createSSLEngine();
+					config.setSSLVerAndCipherSuites(sslEngine);
 					sslEngine.setUseClientMode(false);
 					channel.pipeline().addLast("ssl", new SslHandler(sslEngine));
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
@@ -27,10 +27,13 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.File;
 import java.io.FileInputStream;
+import java.net.ServerSocket;
 import java.security.KeyStore;
 
 /**
@@ -52,6 +55,42 @@ public class SSLUtils {
 
 		return sslConfig.getBoolean( ConfigConstants.SECURITY_SSL_ENABLED,
 			ConfigConstants.DEFAULT_SECURITY_SSL_ENABLED);
+	}
+
+	/**
+	 * Sets SSl version and cipher suites for SSLServerSocket
+	 * @param socket
+	 *        Socket to be handled
+	 * @param config
+	 *        The application configuration
+	 */
+	public static void setSSLVerAndCipherSuites(ServerSocket socket, Configuration config) {
+		if (socket instanceof SSLServerSocket) {
+			((SSLServerSocket) socket).setEnabledProtocols(config.getString(
+				ConfigConstants.SECURITY_SSL_PROTOCOL,
+				ConfigConstants.DEFAULT_SECURITY_SSL_PROTOCOL).split(","));
+			((SSLServerSocket) socket).setEnabledCipherSuites(config.getString(
+				ConfigConstants.SECURITY_SSL_ALGORITHMS,
+				ConfigConstants.DEFAULT_SECURITY_SSL_ALGORITHMS).split(","));
+		} else {
+			LOG.warn("Not a SSL socket, will skip setting tls version and ciper suites.");
+		}
+	}
+
+	/**
+	 * Sets SSL version and cipher suites for SSLEngine
+	 * @param engine
+	 *        SSLEngine to be handled
+	 * @param config
+	 *        The application configuration
+	 */
+	public static void setSSLVerAndCipherSuites(SSLEngine engine, Configuration config) {
+		engine.setEnabledProtocols(config.getString(
+			ConfigConstants.SECURITY_SSL_PROTOCOL,
+			ConfigConstants.DEFAULT_SECURITY_SSL_PROTOCOL).split(","));
+		engine.setEnabledCipherSuites(config.getString(
+			ConfigConstants.SECURITY_SSL_ALGORITHMS,
+			ConfigConstants.DEFAULT_SECURITY_SSL_ALGORITHMS).split(","));
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
@@ -73,7 +73,7 @@ public class SSLUtils {
 				ConfigConstants.SECURITY_SSL_ALGORITHMS,
 				ConfigConstants.DEFAULT_SECURITY_SSL_ALGORITHMS).split(","));
 		} else {
-			LOG.warn("Not a SSL socket, will skip setting tls version and ciper suites.");
+			LOG.warn("Not a SSL socket, will skip setting tls version and cipher suites.");
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
@@ -173,16 +173,16 @@ public class SSLUtilsTest {
 			String[] protocols = ((SSLServerSocket) socket).getEnabledProtocols();
 			String[] algorithms = ((SSLServerSocket) socket).getEnabledCipherSuites();
 
-			Assert.assertNotEquals(protocols.length, 1);
-			Assert.assertNotEquals(algorithms.length, 2);
+			Assert.assertNotEquals(1, protocols.length);
+			Assert.assertNotEquals(2, algorithms.length);
 
 			SSLUtils.setSSLVerAndCipherSuites(socket, serverConfig);
 			protocols = ((SSLServerSocket) socket).getEnabledProtocols();
 			algorithms = ((SSLServerSocket) socket).getEnabledCipherSuites();
 
-			Assert.assertEquals(protocols.length, 1);
-			Assert.assertEquals(protocols[0], "TLSv1.1");
-			Assert.assertEquals(algorithms.length, 2);
+			Assert.assertEquals(1, protocols.length);
+			Assert.assertEquals("TLSv1.1", protocols[0]);
+			Assert.assertEquals(2, algorithms.length);
 			Assert.assertTrue(algorithms[0].equals("TLS_RSA_WITH_AES_128_CBC_SHA") || algorithms[0].equals("TLS_RSA_WITH_AES_128_CBC_SHA256"));
 			Assert.assertTrue(algorithms[1].equals("TLS_RSA_WITH_AES_128_CBC_SHA") || algorithms[1].equals("TLS_RSA_WITH_AES_128_CBC_SHA256"));
 		} finally {
@@ -212,16 +212,16 @@ public class SSLUtilsTest {
 		String[] protocols = engine.getEnabledProtocols();
 		String[] algorithms = engine.getEnabledCipherSuites();
 
-		Assert.assertNotEquals(protocols.length, 1);
-		Assert.assertNotEquals(algorithms.length, 2);
+		Assert.assertNotEquals(1, protocols.length);
+		Assert.assertNotEquals(2, algorithms.length);
 
 		SSLUtils.setSSLVerAndCipherSuites(engine, serverConfig);
 		protocols = engine.getEnabledProtocols();
 		algorithms = engine.getEnabledCipherSuites();
 
-		Assert.assertEquals(protocols.length, 1);
-		Assert.assertEquals(protocols[0], "TLSv1");
-		Assert.assertEquals(algorithms.length, 2);
+		Assert.assertEquals(1, protocols.length);
+		Assert.assertEquals("TLSv1", protocols[0]);
+		Assert.assertEquals(2, algorithms.length);
 		Assert.assertTrue(algorithms[0].equals("TLS_DHE_RSA_WITH_AES_128_CBC_SHA") || algorithms[0].equals("TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"));
 		Assert.assertTrue(algorithms[1].equals("TLS_DHE_RSA_WITH_AES_128_CBC_SHA") || algorithms[1].equals("TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"));
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
@@ -172,15 +172,17 @@ public class SSLUtilsTest {
 
 			String[] protocols = ((SSLServerSocket) socket).getEnabledProtocols();
 			String[] algorithms = ((SSLServerSocket) socket).getEnabledCipherSuites();
-			Assert.assertTrue(protocols.length > 1);
-			Assert.assertTrue(algorithms.length > 2);
+
+			Assert.assertNotEquals(protocols.length, 1);
+			Assert.assertNotEquals(algorithms.length, 2);
 
 			SSLUtils.setSSLVerAndCipherSuites(socket, serverConfig);
 			protocols = ((SSLServerSocket) socket).getEnabledProtocols();
 			algorithms = ((SSLServerSocket) socket).getEnabledCipherSuites();
-			Assert.assertTrue(protocols.length == 1);
-			Assert.assertTrue(protocols[0].equals("TLSv1.1"));
-			Assert.assertTrue(algorithms.length == 2);
+
+			Assert.assertEquals(protocols.length, 1);
+			Assert.assertEquals(protocols[0], "TLSv1.1");
+			Assert.assertEquals(algorithms.length, 2);
 			Assert.assertTrue(algorithms[0].equals("TLS_RSA_WITH_AES_128_CBC_SHA") || algorithms[0].equals("TLS_RSA_WITH_AES_128_CBC_SHA256"));
 			Assert.assertTrue(algorithms[1].equals("TLS_RSA_WITH_AES_128_CBC_SHA") || algorithms[1].equals("TLS_RSA_WITH_AES_128_CBC_SHA256"));
 		} finally {
@@ -210,16 +212,16 @@ public class SSLUtilsTest {
 		String[] protocols = engine.getEnabledProtocols();
 		String[] algorithms = engine.getEnabledCipherSuites();
 
-		Assert.assertTrue(protocols.length > 1);
-		Assert.assertTrue(algorithms.length > 2);
+		Assert.assertNotEquals(protocols.length, 1);
+		Assert.assertNotEquals(algorithms.length, 2);
 
 		SSLUtils.setSSLVerAndCipherSuites(engine, serverConfig);
 		protocols = engine.getEnabledProtocols();
 		algorithms = engine.getEnabledCipherSuites();
 
-		Assert.assertTrue(protocols.length == 1);
-		Assert.assertTrue(protocols[0].equals("TLSv1"));
-		Assert.assertTrue(algorithms.length == 2);
+		Assert.assertEquals(protocols.length, 1);
+		Assert.assertEquals(protocols[0], "TLSv1");
+		Assert.assertEquals(algorithms.length, 2);
 		Assert.assertTrue(algorithms[0].equals("TLS_DHE_RSA_WITH_AES_128_CBC_SHA") || algorithms[0].equals("TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"));
 		Assert.assertTrue(algorithms[1].equals("TLS_DHE_RSA_WITH_AES_128_CBC_SHA") || algorithms[1].equals("TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"));
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
@@ -164,11 +164,10 @@ public class SSLUtilsTest {
 		serverConfig.setString(ConfigConstants.SECURITY_SSL_PROTOCOL, "TLSv1.1");
 		serverConfig.setString(ConfigConstants.SECURITY_SSL_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA256");
 
-		int port = new Random().nextInt(65535);
 		SSLContext serverContext = SSLUtils.createSSLServerContext(serverConfig);
 		ServerSocket socket = null;
 		try {
-			socket = serverContext.getServerSocketFactory().createServerSocket(port);
+			socket = serverContext.getServerSocketFactory().createServerSocket(0);
 
 			String[] protocols = ((SSLServerSocket) socket).getEnabledProtocols();
 			String[] algorithms = ((SSLServerSocket) socket).getEnabledCipherSuites();

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaSslITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaSslITCase.scala
@@ -71,6 +71,33 @@ class AkkaSslITCase(_system: ActorSystem)
       assert(cluster.running)
     }
 
+    "Failed to start ssl enabled akka with two protocols set" in {
+
+      an[Exception] should be thrownBy {
+
+        val config = new Configuration()
+        config.setString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, "127.0.0.1")
+        config.setString(ConfigConstants.TASK_MANAGER_HOSTNAME_KEY, "127.0.0.1")
+        config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 1)
+        config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1)
+
+        config.setBoolean(ConfigConstants.SECURITY_SSL_ENABLED, true)
+        config.setString(ConfigConstants.SECURITY_SSL_KEYSTORE,
+          getClass.getResource("/local127.keystore").getPath)
+        config.setString(ConfigConstants.SECURITY_SSL_KEYSTORE_PASSWORD, "password")
+        config.setString(ConfigConstants.SECURITY_SSL_KEY_PASSWORD, "password")
+        config.setString(ConfigConstants.SECURITY_SSL_TRUSTSTORE,
+          getClass.getResource("/local127.truststore").getPath)
+
+        config.setString(ConfigConstants.SECURITY_SSL_TRUSTSTORE_PASSWORD, "password")
+        config.setString(ConfigConstants.SECURITY_SSL_ALGORITHMS, "TLSv1,TLSv1.1")
+
+        val cluster = new TestingCluster(config, false)
+
+        cluster.start(true)
+      }
+    }
+
     "start with akka ssl disabled" in {
 
       val config = new Configuration()


### PR DESCRIPTION
I configured ssl and start flink job, but found configured properties cannot apply properly:
```
akka port: only ciper suites apply right, ssl version not
blob server/netty server: both ssl version and ciper suites are not like what I configured
```
I've found out the reason why:

http://stackoverflow.com/questions/11504173/sslcontext-initialization  (for blob server and netty server)
https://groups.google.com/forum/#!topic/akka-user/JH6bGnWE8kY (for akka ssl version, it's fixed in akka 2.4: https://github.com/akka/akka/pull/21078)

Configs:
```
security.ssl.protocol: TLSv1.1

security.ssl.algorithms: TLS_RSA_WITH_AES_128_CBC_SHA
```
**The scan results before:**
![before_blob_server](https://cloud.githubusercontent.com/assets/5276001/23655830/d37eb680-0371-11e7-952c-4a6514b1c42b.JPG)
**The scan results after fix:**
![after_blob_server](https://cloud.githubusercontent.com/assets/5276001/23655841/dfc09da0-0371-11e7-8486-bc807e877dff.JPG)