### PR TITLE
[FLINK-6002] Documentation: 'MacOS X' section in Quickstart page is not rendered correctly

### DIFF
--- a/docs/quickstart/setup_quickstart.md
+++ b/docs/quickstart/setup_quickstart.md
@@ -65,6 +65,7 @@ $ cd flink-{{site.version}}
 
 <div data-lang="MacOS X" markdown="1">
 For MacOS X users, Flink can be installed through [Homebrew](https://brew.sh/).
+
 ~~~bash
 $ brew install apache-flink
 ...


### PR DESCRIPTION
Currently, ["MacOS X" section under "Setup: Download and Start Flink" in Quickstart page](https://ci.apache.org/projects/flink/flink-docs-release-1.2/quickstart/setup_quickstart.html#setup-download-and-start-flink) is not rendered correctly. 
![before](https://cloud.githubusercontent.com/assets/1892692/23719173/28a8daaa-03ef-11e7-9663-26486723c652.png)


I fixed this markdown issue by simply adding a blank line between text paragraph and code block.

Now it looks like this:
![after](https://cloud.githubusercontent.com/assets/1892692/23719258/7b0645da-03ef-11e7-8c15-e8484d71364c.png)
