### PR TITLE
[FLINK-5476] Fail fast if trying to submit a job to a non-existing Flink cluster

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -689,7 +689,7 @@ public abstract class ClusterClient {
 	public ActorGateway getJobManagerGateway() throws Exception {
 		LOG.debug("Looking up JobManager");
 		return LeaderRetrievalUtils.retrieveLeaderGateway(
-			LeaderRetrievalUtils.createLeaderRetrievalService(flinkConfig),
+			LeaderRetrievalUtils.createLeaderRetrievalService(flinkConfig, true),
 			actorSystemLoader.get(),
 			lookupTimeout);
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
@@ -43,7 +43,11 @@ public class StandaloneClusterClient extends ClusterClient {
 	}
 
 	@Override
-	public void waitForClusterToBeReady() {}
+	public void waitForClusterToBeReady() {
+		GetClusterStatusResponse clusterStatus = getClusterStatus();
+		logAndSysout("Standalone cluster ready (TaskManagers:" + clusterStatus.numRegisteredTaskManagers()
+			+ ", Slots:" + clusterStatus.totalNumberOfSlots() + ")");
+	}
 
 
 	@Override

--- a/flink-clients/src/test/java/org/apache/flink/client/RemoteExecutorHostnameResolutionTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/RemoteExecutorHostnameResolutionTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.client;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,7 +53,7 @@ public class RemoteExecutorHostnameResolutionTest {
 			exec.executePlan(getProgram());
 			fail("This should fail with an ProgramInvocationException");
 		}
-		catch (ProgramInvocationException e) {
+		catch (RuntimeException e) {
 			// that is what we want!
 			assertTrue(e.getCause() instanceof UnknownHostException);
 		}
@@ -75,7 +74,7 @@ public class RemoteExecutorHostnameResolutionTest {
 			exec.executePlan(getProgram());
 			fail("This should fail with an ProgramInvocationException");
 		}
-		catch (ProgramInvocationException e) {
+		catch (RuntimeException e) {
 			// that is what we want!
 			assertTrue(e.getCause() instanceof UnknownHostException);
 		}

--- a/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/RemoteEnvironmentITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/RemoteEnvironmentITCase.java
@@ -101,7 +101,7 @@ public class RemoteEnvironmentITCase {
 		try {
 			env.execute();
 			Assert.fail("Program should not run successfully, cause of invalid akka settings.");
-		} catch (IOException ex) {
+		} catch (RuntimeException ex) {
 			throw ex.getCause();
 		}
 	}


### PR DESCRIPTION
**ATTENTION** required task [FLINK-5786] (PR https://github.com/apache/flink/pull/3325)
Now at first submit we wait until cluster not ready.  May be customised by "akka.lookup.timeout" property.