### PR TITLE
[FLINK-6005] fix some ArrayList initializations without initial size

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ListSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ListSerializerTest.java
@@ -71,8 +71,9 @@ public class ListSerializerTest extends SerializerTestBase<List<Long>> {
 			list7.add(rnd.nextLong());
 		}
 
-		final List<Long> list8 = new ArrayList<>();
-		for (int i = 0; i < rnd.nextInt(200); i++) {
+		int list8Len = rnd.nextInt(200);
+		final List<Long> list8 = new ArrayList<>(list8Len);
+		for (int i = 0; i < list8Len; i++) {
 			list8.add(rnd.nextLong());
 		}
 

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/SummarizationITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/SummarizationITCase.java
@@ -185,8 +185,9 @@ public class SummarizationITCase extends MultipleProgramsTestBase {
 	}
 
 	private List<Long> getListFromIdRange(String idRange) {
-		List<Long> result = new ArrayList<>();
-		for (String id : ID_SEPARATOR.split(idRange)) {
+		String[] split = ID_SEPARATOR.split(idRange);
+		List<Long> result = new ArrayList<>(split.length);
+		for (String id : split) {
 			result.add(Long.parseLong(id));
 		}
 		return result;

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/TestUtils.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/TestUtils.java
@@ -57,9 +57,10 @@ public final class TestUtils {
 	private static <K, VV, EV> void compareVertices(Graph<K, VV, EV> graph, String expectedVertices)
 			throws Exception {
 		if (expectedVertices != null) {
-			List<String> resultVertices = new ArrayList<>();
+			List<Vertex<K, VV>> vertices = graph.getVertices().collect();
+			List<String> resultVertices = new ArrayList<>(vertices.size());
 
-			for (Vertex<K, VV> vertex : graph.getVertices().collect()) {
+			for (Vertex<K, VV> vertex : vertices) {
 				resultVertices.add(vertex.f0.toString());
 			}
 
@@ -70,9 +71,10 @@ public final class TestUtils {
 	private static <K, VV, EV> void compareEdges(Graph<K, VV, EV> graph, String expectedEdges)
 			throws Exception {
 		if (expectedEdges != null) {
-			List<String> resultEdges = new ArrayList<>();
+			List<Edge<K, EV>> edges = graph.getEdges().collect();
+			List<String> resultEdges = new ArrayList<>(edges.size());
 
-			for (Edge<K, EV> edge : graph.getEdges().collect()) {
+			for (Edge<K, EV> edge : edges) {
 				resultEdges.add(edge.f0.toString() + "," + edge.f1.toString());
 			}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/serialization/LargeRecordsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/serialization/LargeRecordsTest.java
@@ -54,8 +54,8 @@ public class LargeRecordsTest {
 
 			final Buffer buffer = new Buffer(MemorySegmentFactory.allocateUnpooledSegment(SEGMENT_SIZE), mock(BufferRecycler.class));
 
-			List<SerializationTestType> originalRecords = new ArrayList<SerializationTestType>();
-			List<SerializationTestType> deserializedRecords = new ArrayList<SerializationTestType>();
+			List<SerializationTestType> originalRecords = new ArrayList<SerializationTestType>((NUM_RECORDS + 1) / 2);
+			List<SerializationTestType> deserializedRecords = new ArrayList<SerializationTestType>((NUM_RECORDS + 1) / 2);
 			
 			LargeObjectType genLarge = new LargeObjectType();
 			
@@ -154,8 +154,8 @@ public class LargeRecordsTest {
 
 			final Buffer buffer = new Buffer(MemorySegmentFactory.allocateUnpooledSegment(SEGMENT_SIZE), mock(BufferRecycler.class));
 
-			List<SerializationTestType> originalRecords = new ArrayList<SerializationTestType>();
-			List<SerializationTestType> deserializedRecords = new ArrayList<SerializationTestType>();
+			List<SerializationTestType> originalRecords = new ArrayList<>((NUM_RECORDS + 1) / 2);
+			List<SerializationTestType> deserializedRecords = new ArrayList<>((NUM_RECORDS + 1) / 2);
 			
 			LargeObjectType genLarge = new LargeObjectType();
 			


### PR DESCRIPTION
This is just to give some ArrayList initializations an initial size value to reduce tests overhead.