### PR TITLE
[FLINK-4565] Support for SQL IN operator

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -246,7 +246,7 @@ trait ImplicitExpressionOperations {
 
 
   /**
-    * Returns the start time of a window when applied on a window reference.
+    * Returns the start time (inclusive) of a window when applied on a window reference.
     */
   def start = WindowStart(expr)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -24,6 +24,7 @@ import org.apache.calcite.avatica.util.DateTimeUtils._
 import org.apache.flink.api.common.typeinfo.{SqlTimeTypeInfo, TypeInformation}
 import org.apache.flink.table.api.{TableException, CurrentRow, CurrentRange, UnboundedRow, UnboundedRange}
 import org.apache.flink.table.expressions.ExpressionUtils.{convertArray, toMilliInterval, toMonthInterval, toRowInterval}
+import org.apache.flink.table.api.Table
 import org.apache.flink.table.expressions.TimeIntervalUnit.TimeIntervalUnit
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.AggregateFunction
@@ -234,7 +235,18 @@ trait ImplicitExpressionOperations {
   def desc = Desc(expr)
 
   /**
-    * Returns the start time (inclusive) of a window when applied on a window reference.
+    * Returns true if given subquery has elements from expression.
+    */
+  def in(subquery: Expression*) = In(expr, subquery)
+
+  /**
+    * Returns true if given table has elements from expression.
+    */
+  def in(table: Table) = InSub(expr, table)
+
+
+  /**
+    * Returns the start time of a window when applied on a window reference.
     */
   def start = WindowStart(expr)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1423,6 +1423,15 @@ class CodeGenerator(
         requireTimeInterval(operand)
         generateUnaryIntervalPlusMinus(plus = true, nullCheck, operand)
 
+      case IN =>
+        val left = operands.head
+        val right = operands.tail
+        val addReusableCodeCallback = (declaration: String, initialization: String) => {
+          reusableMemberStatements.add(declaration)
+          reusableInitStatements.add(initialization)
+        }
+        generateIn(nullCheck, left, right, addReusableCodeCallback)        
+        
       // comparison
       case EQUALS =>
         val left = operands.head

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -79,6 +79,73 @@ object ScalarOperators {
     }
   }
 
+  def generateIn(
+      nullCheck: Boolean,
+      needle: GeneratedExpression,
+      haystack: scala.collection.mutable.Buffer[GeneratedExpression],
+      addReusableCodeCallback: (String, String) => Any)
+    : GeneratedExpression = {
+    val resultTerm = newName("result")
+    val isNull = newName("isNull")
+
+    //Return more common numeric type
+    val topNumericalType: Option[TypeInformation[_]] = {
+      if (isDecimal(needle.resultType) || isDecimal(haystack.head.resultType)) {
+        Some(BIG_DEC_TYPE_INFO)
+      } else if (isNumeric(needle.resultType) || isNumeric(haystack.head.resultType)) {
+        Some(DOUBLE_TYPE_INFO)
+      } else {
+        None
+      }
+     }
+
+    val castNumeric = if (topNumericalType.isEmpty) {
+      (value: GeneratedExpression) => value.resultTerm
+     } else {
+      (value: GeneratedExpression) =>
+        numericCasting(value.resultType, topNumericalType.get)(value.resultTerm)
+    }
+
+    val valuesInitialization = "//literals were initialized in constructor\n"
+
+    val hashSetVariable = newName("set")
+
+    addReusableCodeCallback(
+      s"""
+         |private java.util.Set $hashSetVariable = new java.util.HashSet();
+         """.stripMargin,
+        s"""
+           |${haystack.map(_.code).mkString("")}
+           |
+           |${haystack.map(element =>
+            s"$hashSetVariable.add(${castNumeric(element)});").mkString("\n")
+            }
+           |""".stripMargin
+    )
+     
+    val comparison = s"$resultTerm = $hashSetVariable.contains(${castNumeric(needle)});"
+
+    val code = if (nullCheck) {
+      s"""
+         |$valuesInitialization
+         |boolean $isNull = ${needle.nullTerm};
+         |boolean $resultTerm;
+         |if ($isNull) {
+         |  $resultTerm = false;
+         |} else {
+         |  $comparison
+         |}
+         |""".stripMargin
+    } else {
+      s"""
+         |$valuesInitialization
+         |boolean $resultTerm;
+         |$comparison
+         |""".stripMargin
+    }
+    GeneratedExpression(resultTerm, GeneratedExpression.NEVER_NULL, code, BOOLEAN_TYPE_INFO)
+  }  
+  
   def generateEquals(
       nullCheck: Boolean,
       left: GeneratedExpression,
@@ -1073,12 +1140,17 @@ object ScalarOperators {
     val resultTypeTerm = primitiveTypeTermForTypeInfo(resultType)
     // no casting necessary
     if (operandType == resultType) {
-      (operandTerm) => s"$operandTerm"
+      if (isDecimal(operandType)) {
+        (operandTerm) => s"$operandTerm.stripTrailingZeros()"
+      } else {
+        (operandTerm) => s"$operandTerm"
+      }
     }
     // result type is decimal but numeric operand is not
     else if (isDecimal(resultType) && !isDecimal(operandType) && isNumeric(operandType)) {
       (operandTerm) =>
-        s"java.math.BigDecimal.valueOf((${superPrimitive(operandType)}) $operandTerm)"
+        s"java.math.BigDecimal.valueOf((${superPrimitive(operandType)}) $operandTerm)" +
+          s".stripTrailingZeros()"
     }
     // numeric result type is not decimal but operand is
     else if (isNumeric(resultType) && !isDecimal(resultType) && isDecimal(operandType) ) {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/in.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/in.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.expressions
+
+import org.apache.calcite.rex.RexNode
+import org.apache.calcite.sql.fun.SqlStdOperatorTable
+import org.apache.calcite.tools.RelBuilder
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
+import org.apache.flink.table.api.Table
+import org.apache.flink.table.typeutils.TypeCheckUtils._
+import org.apache.flink.table.validate.{ValidationFailure, ValidationResult, ValidationSuccess}
+
+case class In(expression: Expression, subquery: Seq[Expression]) extends Expression  {
+  def this(expressions: Seq[Expression]) = this(expressions.head, expressions.tail)
+
+  override def toString = s"$expression.in(${subquery.mkString(", ")})"
+
+  override private[flink] def children: Seq[Expression] = expression +: subquery.distinct
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(SqlStdOperatorTable.IN, children.map(_.toRexNode): _*)
+  }
+
+  override private[flink] def validateInput(): ValidationResult = {
+    if (children.tail.contains(null)) {
+      ValidationFailure("Operands on right side of IN operator must be not null")
+    } else {
+      val types = children.tail.map(_.resultType)
+      if (types.distinct.length != 1) {
+        ValidationFailure(
+          s"Types on the right side of IN operator must be the same, got ${types.mkString(", ")}."
+        )
+      } else {
+        (children.head.resultType, children.last.resultType) match {
+          case (lType, rType) if isNumeric(lType) && isNumeric(rType) => ValidationSuccess
+          case (lType, rType) if isComparable(lType) && lType == rType => ValidationSuccess
+          case (lType, rType) =>
+            ValidationFailure(
+              s"Types on both sides of the IN operator must be numeric" +
+                s" or of the same comparable type, got $lType and $rType"
+            )
+        }
+      }
+
+    }
+  }
+
+  override private[flink] def resultType: TypeInformation[_] = BOOLEAN_TYPE_INFO
+}
+
+
+case class InSub(expression: Expression, table: Table) extends Expression {
+
+  override def toString = s"$expression.in($table)"
+
+  override private[flink] def children: Seq[Expression] = Seq(expression)
+
+  override private[flink] def resultType: TypeInformation[_] = BOOLEAN_TYPE_INFO
+}
+

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/ProjectionTranslator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/ProjectionTranslator.scala
@@ -179,6 +179,9 @@ object ProjectionTranslator {
         val newArgs = e.productIterator.map {
           case arg: Expression =>
             replaceAggregationsAndProperties(arg, tableEnv, aggNames, propNames, projectedNames)
+          case array: mutable.WrappedArray[Expression] =>
+            array.map(
+              replaceAggregationsAndProperties(_, tableEnv, aggNames, propNames, projectedNames))
         }
         e.makeCopy(newArgs.toArray)
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -160,6 +160,7 @@ object FunctionCatalog {
     "lessThan" -> classOf[LessThan],
     "lessThanOrEqual" -> classOf[LessThanOrEqual],
     "notEquals" -> classOf[NotEqualTo],
+    "in" -> classOf[In],
     "isNull" -> classOf[IsNull],
     "isNotNull" -> classOf[IsNotNull],
     "isTrue" -> classOf[IsTrue],
@@ -346,6 +347,7 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     SqlStdOperatorTable.CASE,
     SqlStdOperatorTable.REINTERPRET,
     SqlStdOperatorTable.EXTRACT_DATE,
+    SqlStdOperatorTable.IN,
     // FUNCTIONS
     SqlStdOperatorTable.SUBSTRING,
     SqlStdOperatorTable.OVERLAY,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/sql/AggregationsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/sql/AggregationsITCase.scala
@@ -111,7 +111,7 @@ class AggregationsITCase(
 
     val result = tEnv.sql(sqlQuery)
 
-    val expected = "1,1,1,1,1.5,1.5,2,Ciao,Ciao,Hello,Ciao,3.0"
+    val expected = "1,1,1,1,1.5,1.5,2,Ciao,Ciao,Hello,Ciao,3"
     val results = result.toDataSet[Row].collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.api.scala.batch.table
 
 import java.sql.Timestamp
+import javax.annotation.concurrent.NotThreadSafe
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
@@ -65,6 +65,20 @@ class InITCase(configMode: TableConfigMode)
   }
 
   @Test
+  def testSqlNotInOperator(): Unit = {
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.registerTable("T2", ds1)
+    val expected = "10,Comment#4\n11,Comment#5\n12,Comment#6\n" +
+      "13,Comment#7\n14,Comment#8\n15,Comment#9\n" +
+      "2,Hello\n3,Hello world\n4,Hello world, how are you?\n5,I am fine.\n" +
+      "6,Luke Skywalker\n7,Comment#1\n8,Comment#2\n9,Comment#3\n"
+    val sqlQuery = "SELECT a, c FROM T2 WHERE b NOT IN (SELECT b FROM T2 WHERE b = 6 OR b = 1)";
+    val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
+    compareResultAsText(result.asJava, expected)
+    tEnv.unregisterTable("T2")
+  }
+
+  @Test
   def testSqlInOperatorWithDate(): Unit = {
     val ds1 = CollectionDataSets.get5TupleDataSetOfDateTimeTimestamp(env)
       .toTable(tEnv, 'a, 'b, 'c, 'd, 'e)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
@@ -100,7 +100,7 @@ class InITCase extends TableTestBase {
 
   @Test
   def testSqlInNestedTuples(): Unit = {
-    val ds1 = CollectionDataSets.getSmallNestedTupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    val ds1 = CollectionDataSets.getSmall2NestedTupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
     tEnv.registerTable("T7", ds1)
     val expected = "(3,3),three,(3,3)"
     val sqlQuery = "SELECT a, b, c FROM T7 WHERE c IN (a)";
@@ -111,7 +111,7 @@ class InITCase extends TableTestBase {
 
   @Test
   def testInSubqueryCorrelatedNestedTuples(): Unit = {
-    val ds1 = CollectionDataSets.getSmallNestedTupleDataSet(env)
+    val ds1 = CollectionDataSets.getSmall2NestedTupleDataSet(env)
       .toTable(tEnv, 'a, 'b, 'c)
     val subquery: Table = ds1.where('b === "two").select('a).as("a1")
     val subqueryIn = ds1.select("*").where('c.in(subquery))

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
@@ -64,19 +64,6 @@ class InITCase(configMode: TableConfigMode)
     compareResultAsText(result.asJava, expected)
   }
 
-  @Test
-  def testSqlNotInOperator(): Unit = {
-    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-    tEnv.registerTable("T2", ds1)
-    val expected = "10,Comment#4\n11,Comment#5\n12,Comment#6\n" +
-      "13,Comment#7\n14,Comment#8\n15,Comment#9\n" +
-      "2,Hello\n3,Hello world\n4,Hello world, how are you?\n5,I am fine.\n" +
-      "6,Luke Skywalker\n7,Comment#1\n8,Comment#2\n9,Comment#3\n"
-    val sqlQuery = "SELECT a, c FROM T2 WHERE b NOT IN (SELECT b FROM T2 WHERE b = 6 OR b = 1)";
-    val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
-    compareResultAsText(result.asJava, expected)
-    tEnv.unregisterTable("T2")
-  }
 
   @Test
   def testSqlInOperatorWithDate(): Unit = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
@@ -48,6 +48,20 @@ class InITCase extends TableTestBase {
   }
 
   @Test
+  def testSqlNotInOperator(): Unit = {
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.registerTable("T2", ds1)
+    val expected = "10,Comment#4\n11,Comment#5\n12,Comment#6\n" +
+      "13,Comment#7\n14,Comment#8\n15,Comment#9\n" +
+      "2,Hello\n3,Hello world\n4,Hello world, how are you?\n5,I am fine.\n" +
+      "6,Luke Skywalker\n7,Comment#1\n8,Comment#2\n9,Comment#3\n"
+    val sqlQuery = "SELECT a, c FROM T2 WHERE b NOT IN (SELECT b FROM T2 WHERE b = 6 OR b = 1)";
+    val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
+    compareResultAsText(result.asJava, expected)
+    tEnv.unregisterTable("T2")
+  }
+
+  @Test
   def testSqlInOperatorWithDate(): Unit = {
     val ds1 = CollectionDataSets.get5TupleDataSetOfDateTimeTimestamp(env)
       .toTable(tEnv, 'a, 'b, 'c, 'd, 'e)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.api.scala.batch.table
 
 import java.sql.Timestamp
-import javax.annotation.concurrent.NotThreadSafe
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
@@ -49,9 +49,20 @@ class InITCase(configMode: TableConfigMode)
     val sqlQuery = "SELECT a, c FROM T1 WHERE b IN (SELECT b FROM T1 WHERE b = 6 OR b = 1)";
     val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
     compareResultAsText(result.asJava, expected)
-    tEnv.unregisterTable("T1")
   }
 
+  @Test
+  def testSqlNotInOperator(): Unit = {
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.registerTable("T2", ds1)
+    val expected = "10,Comment#4\n11,Comment#5\n12,Comment#6\n" +
+      "13,Comment#7\n14,Comment#8\n15,Comment#9\n" +
+      "2,Hello\n3,Hello world\n4,Hello world, how are you?\n5,I am fine.\n" +
+      "6,Luke Skywalker\n7,Comment#1\n8,Comment#2\n9,Comment#3\n"
+    val sqlQuery = "SELECT a, c FROM T2 WHERE b NOT IN (SELECT b FROM T2 WHERE b = 6 OR b = 1)";
+    val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
+    compareResultAsText(result.asJava, expected)
+  }
 
   @Test
   def testSqlInOperatorWithDate(): Unit = {
@@ -63,7 +74,6 @@ class InITCase(configMode: TableConfigMode)
     val sqlQuery = "SELECT a, e FROM T3 WHERE b IN (SELECT b FROM T3 WHERE a = 16)";
     val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
     compareResultAsText(result.asJava, expected)
-    tEnv.unregisterTable("T3")
   }
 
   @Test
@@ -75,7 +85,6 @@ class InITCase(configMode: TableConfigMode)
     val sqlQuery = "SELECT a, e FROM T4 WHERE c IN (SELECT c FROM T4 WHERE a = 16)";
     val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
     compareResultAsText(result.asJava, expected)
-    tEnv.unregisterTable("T4")
   }
 
   @Test
@@ -87,7 +96,6 @@ class InITCase(configMode: TableConfigMode)
     val sqlQuery = "SELECT a, e FROM T5 WHERE d IN (SELECT d FROM T5 WHERE a = 16)";
     val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
     compareResultAsText(result.asJava, expected)
-    tEnv.unregisterTable("T5")
   }
 
   @Test
@@ -100,7 +108,6 @@ class InITCase(configMode: TableConfigMode)
     val sqlQuery = "SELECT a, b, c, d, e FROM T6 WHERE a IN (c, b, 5)";
     val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
     compareResultAsText(result.asJava, expected)
-    tEnv.unregisterTable("T6")
   }
 
   @Test
@@ -111,7 +118,6 @@ class InITCase(configMode: TableConfigMode)
     val sqlQuery = "SELECT a, b, c FROM T7 WHERE c IN (a)";
     val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
     compareResultAsText(result.asJava, expected)
-    tEnv.unregisterTable("T7")
   }
 
   @Test
@@ -146,7 +152,6 @@ class InITCase(configMode: TableConfigMode)
       " as X WHERE d2=true";
     val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
     compareResultAsText(result.asJava, expected)
-    tEnv.unregisterTable("T8")
   }
 
   @Test
@@ -157,7 +162,6 @@ class InITCase(configMode: TableConfigMode)
     val sqlQuery = "SELECT * FROM (SELECT c IN (a, b, 5) as c2, d FROM T9) as X WHERE c2=true";
     val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
     compareResultAsText(result.asJava, expected)
-    tEnv.unregisterTable("T9")
   }
 
   @Test

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
@@ -19,20 +19,23 @@
 package org.apache.flink.table.api.scala.batch.table
 
 import java.sql.Timestamp
-import javax.annotation.concurrent.NotThreadSafe
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.utils.TableTestBase
 import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.Table
+import org.apache.flink.table.api.scala.batch.utils.TableProgramsCollectionTestBase
+import org.apache.flink.table.api.scala.batch.utils.TableProgramsTestBase.TableConfigMode
 import org.apache.flink.test.util.TestBaseUtils.compareResultAsText
 import org.apache.flink.types.Row
 import org.junit._
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import scala.collection.JavaConverters._
 
-@NotThreadSafe
-class InITCase extends TableTestBase {
+@RunWith(classOf[Parameterized])
+class InITCase(configMode: TableConfigMode)
+  extends TableProgramsCollectionTestBase(configMode) {
 
   val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
   val tEnv = TableEnvironment.getTableEnvironment(env)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
@@ -64,6 +64,18 @@ class InITCase(configMode: TableConfigMode)
     compareResultAsText(result.asJava, expected)
   }
 
+  @Test
+  def testSqlNotInOperator(): Unit = {
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.registerTable("T2", ds1)
+    val expected = "10,Comment#4\n11,Comment#5\n12,Comment#6\n" +
+      "13,Comment#7\n14,Comment#8\n15,Comment#9\n" +
+      "2,Hello\n3,Hello world\n4,Hello world, how are you?\n5,I am fine.\n" +
+      "6,Luke Skywalker\n7,Comment#1\n8,Comment#2\n9,Comment#3\n"
+    val sqlQuery = "SELECT a, c FROM T2 WHERE b NOT IN (SELECT b FROM T2 WHERE b = 6 OR b = 1)";
+    val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
+    compareResultAsText(result.asJava, expected)
+  }
 
   @Test
   def testSqlInOperatorWithDate(): Unit = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
@@ -47,19 +47,6 @@ class InITCase extends TableTestBase {
     tEnv.unregisterTable("T1")
   }
 
-  @Test
-  def testSqlNotInOperator(): Unit = {
-    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-    tEnv.registerTable("T2", ds1)
-    val expected = "10,Comment#4\n11,Comment#5\n12,Comment#6\n" +
-      "13,Comment#7\n14,Comment#8\n15,Comment#9\n" +
-      "2,Hello\n3,Hello world\n4,Hello world, how are you?\n5,I am fine.\n" +
-      "6,Luke Skywalker\n7,Comment#1\n8,Comment#2\n9,Comment#3\n"
-    val sqlQuery = "SELECT a, c FROM T2 WHERE b NOT IN (SELECT b FROM T2 WHERE b = 6 OR b = 1)";
-    val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
-    compareResultAsText(result.asJava, expected)
-    tEnv.unregisterTable("T2")
-  }
 
   @Test
   def testSqlInOperatorWithDate(): Unit = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.scala.batch.table
+
+import java.sql.Timestamp
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.utils.TableTestBase
+import org.apache.flink.api.scala.util.CollectionDataSets
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.Table
+import org.apache.flink.test.util.TestBaseUtils.compareResultAsText
+import org.apache.flink.types.Row
+import org.junit._
+import scala.collection.JavaConverters._
+
+class InITCase extends TableTestBase {
+
+  val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+  val tEnv = TableEnvironment.getTableEnvironment(env)
+
+  @Test
+  def testSqlInOperator(): Unit = {
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.registerTable("T1", ds1)
+    val expected = "1,Hi\n16,Comment#10\n17,Comment#11\n" +
+      "18,Comment#12\n19,Comment#13\n20,Comment#14\n21,Comment#15"
+    val sqlQuery = "SELECT a, c FROM T1 WHERE b IN (SELECT b FROM T1 WHERE b = 6 OR b = 1)";
+    val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
+    compareResultAsText(result.asJava, expected)
+    tEnv.unregisterTable("T1")
+  }
+
+  @Test
+  def testSqlInOperatorWithDate(): Unit = {
+    val ds1 = CollectionDataSets.get5TupleDataSetOfDateTimeTimestamp(env)
+      .toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
+    tEnv.registerTable("T3", ds1)
+    val expected = "14,Comment#8\n15,Comment#9\n16,Comment#10\n17,Comment#11\n" +
+      "18,Comment#12\n19,Comment#13\n20,Comment#14\n21,Comment#15"
+    val sqlQuery = "SELECT a, e FROM T3 WHERE b IN (SELECT b FROM T3 WHERE a = 16)";
+    val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
+    compareResultAsText(result.asJava, expected)
+    tEnv.unregisterTable("T3")
+  }
+
+  @Test
+  def testSqlInOperatorWithTime(): Unit = {
+    val ds1 = CollectionDataSets.get5TupleDataSetOfDateTimeTimestamp(env)
+      .toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
+    tEnv.registerTable("T4", ds1)
+    val expected = "16,Comment#10\n2,Hello\n9,Comment#3"
+    val sqlQuery = "SELECT a, e FROM T4 WHERE c IN (SELECT c FROM T4 WHERE a = 16)";
+    val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
+    compareResultAsText(result.asJava, expected)
+    tEnv.unregisterTable("T4")
+  }
+
+  @Test
+  def testSqlInOperatorWithTimestamp(): Unit = {
+    val ds1 = CollectionDataSets.get5TupleDataSetOfDateTimeTimestamp(env)
+      .toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
+    tEnv.registerTable("T5", ds1)
+    val expected = "16,Comment#10"
+    val sqlQuery = "SELECT a, e FROM T5 WHERE d IN (SELECT d FROM T5 WHERE a = 16)";
+    val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
+    compareResultAsText(result.asJava, expected)
+    tEnv.unregisterTable("T5")
+  }
+
+  @Test
+  def testSqlInOperatorWithFields(): Unit = {
+    val ds1 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
+    tEnv.registerTable("T6", ds1)
+    val expected = "1,1,0,Hallo,1\n2,2,1,Hallo Welt,2\n2,3,2,Hallo Welt wie,1\n" +
+      "3,4,3,Hallo Welt wie gehts?,2\n5,11,10,GHI,1\n5,12,11,HIJ,3\n5,13,12,IJK,3\n" +
+      "5,14,13,JKL,2\n5,15,14,KLM,2"
+    val sqlQuery = "SELECT a, b, c, d, e FROM T6 WHERE a IN (c, b, 5)";
+    val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
+    compareResultAsText(result.asJava, expected)
+    tEnv.unregisterTable("T6")
+  }
+
+  @Test
+  def testSqlInNestedTuples(): Unit = {
+    val ds1 = CollectionDataSets.getSmallNestedTupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.registerTable("T7", ds1)
+    val expected = "(3,3),three,(3,3)"
+    val sqlQuery = "SELECT a, b, c FROM T7 WHERE c IN (a)";
+    val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
+    compareResultAsText(result.asJava, expected)
+    tEnv.unregisterTable("T7")
+  }
+
+  @Test
+  def testInSubqueryCorrelatedNestedTuples(): Unit = {
+    val ds1 = CollectionDataSets.getSmallNestedTupleDataSet(env)
+      .toTable(tEnv, 'a, 'b, 'c)
+    val subquery: Table = ds1.where('b === "two").select('a).as("a1")
+    val subqueryIn = ds1.select("*").where('c.in(subquery))
+    val result = subqueryIn.toDataSet[Row].collect()
+    val expected = "(1,1),one,(2,2)\n"
+    compareResultAsText(result.asJava, expected)
+  }
+
+  @Test
+  def testInSubqueryCorrelatedWithTimeStamp(): Unit = {
+    val ds1 = CollectionDataSets.get5TupleDataSetOfDateTimeTimestamp(env)
+      .toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
+    val subquery: Table = ds1.where('a === 6).select('d)
+    val subqueryIn = ds1.select("*").where('d.in(subquery))
+    val result = subqueryIn.toDataSet[Row].collect()
+    val expected = "6,1984-07-05,23:01:01,1984-07-05 23:01:01.105,Luke Skywalker\n"
+    compareResultAsText(result.asJava, expected)
+  }
+
+  @Test
+  def testSqlInInSelect(): Unit = {
+    val ds1 = CollectionDataSets.get5TupleDataSetOfDateTimeTimestamp(env)
+      .toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
+    tEnv.registerTable("T8", ds1)
+    val expected = "true,Comment#4"
+    val sqlQuery = "SELECT * FROM (SELECT d IN ('1972-02-22 07:12:00.333') as d2, e FROM T8)" +
+      " as X WHERE d2=true";
+    val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
+    compareResultAsText(result.asJava, expected)
+    tEnv.unregisterTable("T8")
+  }
+
+  @Test
+  def testSqlInInSelectFields(): Unit = {
+    val ds1 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
+    tEnv.registerTable("T9", ds1)
+    val expected = "true,BCD\ntrue,Hallo Welt wie\ntrue,Hallo Welt wie gehts?\n"
+    val sqlQuery = "SELECT * FROM (SELECT c IN (a, b, 5) as c2, d FROM T9) as X WHERE c2=true";
+    val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
+    compareResultAsText(result.asJava, expected)
+    tEnv.unregisterTable("T9")
+  }
+
+  @Test
+  def testInInSelect(): Unit = {
+    val ds1 = CollectionDataSets.getSmall3TupleDataSetOfDateTimeTimestamp(env)
+      .toTable(tEnv, 'a, 'b, 'c)
+    val subquery: Table = ds1.select('b.in(Timestamp.valueOf("1972-02-22 07:12:00.333"))).as("b2")
+    val resultsSimple = subquery.toDataSet[Row].collect()
+    val expected = "false\nfalse\ntrue\n"
+    compareResultAsText(resultsSimple.asJava, expected)
+  }
+
+  @Test
+  def testInSubqueryWithTimeStamp(): Unit = {
+    val ds1 = CollectionDataSets.getSmall3TupleDataSetOfDateTimeTimestamp(env)
+      .toTable(tEnv, 'a, 'b, 'c)
+    val ds2 = CollectionDataSets.get5TupleDataSetOfDateTimeTimestamp(env)
+      .toTable(tEnv, 'a, 'b, 'c, 'd, 'e)
+    val subquery: Table = ds1.where('a === 2).select('b).as("b2")
+    val subqueryIn = ds2.where('d.in(subquery))
+    val resultsSimple = subqueryIn.toDataSet[Row].collect()
+    val expected = "10,1972-02-22,07:12:00,1972-02-22 07:12:00.333,Comment#4\n"
+    compareResultAsText(resultsSimple.asJava, expected)
+  }
+
+  @Test
+  def testInSubqueryCorrelated(): Unit = {
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    val subquery: Table = ds1.where('a === 6).select('c)
+    val subqueryIn = ds1.select("*").where('c.in(subquery))
+    val result = subqueryIn.toDataSet[Row].collect()
+    val expected = "6,3,Luke Skywalker\n"
+    compareResultAsText(result.asJava, expected)
+  }
+
+  @Test
+  def testInSubquery(): Unit = {
+    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f)
+    val ds2 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+    val subquery: Table = ds1.where('d === 1).select('e)
+    val subqueryIn = ds2.where('b.in(subquery))
+    val resultsSimple = subqueryIn.toDataSet[Row].collect()
+    val expected = "1,1,Hi\n"
+    compareResultAsText(resultsSimple.asJava, expected)
+  }
+
+}
+

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
@@ -65,19 +65,6 @@ class InITCase(configMode: TableConfigMode)
   }
 
   @Test
-  def testSqlNotInOperator(): Unit = {
-    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-    tEnv.registerTable("T2", ds1)
-    val expected = "10,Comment#4\n11,Comment#5\n12,Comment#6\n" +
-      "13,Comment#7\n14,Comment#8\n15,Comment#9\n" +
-      "2,Hello\n3,Hello world\n4,Hello world, how are you?\n5,I am fine.\n" +
-      "6,Luke Skywalker\n7,Comment#1\n8,Comment#2\n9,Comment#3\n"
-    val sqlQuery = "SELECT a, c FROM T2 WHERE b NOT IN (SELECT b FROM T2 WHERE b = 6 OR b = 1)";
-    val result = tEnv.sql(sqlQuery).toDataSet[Row].collect();
-    compareResultAsText(result.asJava, expected)
-  }
-
-  @Test
   def testSqlInOperatorWithDate(): Unit = {
     val ds1 = CollectionDataSets.get5TupleDataSetOfDateTimeTimestamp(env)
       .toTable(tEnv, 'a, 'b, 'c, 'd, 'e)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/InITCase.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.api.scala.batch.table
 
 import java.sql.Timestamp
+import javax.annotation.concurrent.NotThreadSafe
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.utils.TableTestBase
@@ -30,6 +31,7 @@ import org.apache.flink.types.Row
 import org.junit._
 import scala.collection.JavaConverters._
 
+@NotThreadSafe
 class InITCase extends TableTestBase {
 
   val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -20,12 +20,14 @@ package org.apache.flink.table.expressions
 
 import java.sql.{Date, Time, Timestamp}
 
-import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeinfo.{TypeInformation}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.types.Row
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.{Types, ValidationException}
 import org.apache.flink.table.expressions.utils.ExpressionTestBase
-import org.apache.flink.types.Row
+import org.codehaus.commons.compiler.CompileException
+import org.codehaus.janino.SimpleCompiler
 import org.junit.Test
 
 class ScalarFunctionsTest extends ExpressionTestBase {
@@ -1551,6 +1553,79 @@ class ScalarFunctionsTest extends ExpressionTestBase {
       "true")
   }
 
+  @Test(expected = classOf[CompileException])
+  def testInNotCompiledExpression(): Unit = {
+    val compiler = new SimpleCompiler()
+    compiler.setParentClassLoader(this.getClass.getClassLoader)
+    compiler.cook("Null(Types.INT).in(1,2,42, Null(Types.INT))")
+  }
+
+  @Test
+  def testInExpressions(): Unit = {
+    testTableApi(
+      'f2.in(1,2,42),
+      "f2.in(1,2,42)",
+      "true"
+    )
+
+    testTableApi(
+      'f2.in(BigDecimal(42.0), BigDecimal(2.00), BigDecimal(3.01)),
+      "f2.in(42.0, 2.00, 3.01)",
+      "true"
+    )
+
+    testTableApi(
+      'f0.in("This is a test String.", "Hello world", "Comment#1"),
+      "f0.in('This is a test String.', 'Hello world', 'Comment#1')",
+      "true"
+    )
+
+    testTableApi(
+      'f16.in("1996-11-10".toDate),
+      "f16.in('1996-11-10'.toDate)",
+      "true"
+    )
+
+    testTableApi(
+      'f17.in("06:55:44".toTime),
+      "f17.in('06:55:44'.toTime)",
+      "true"
+    )
+
+    testTableApi(
+      'f18.in("1996-11-10 06:55:44.333".toTimestamp),
+      "f18.in('1996-11-10 06:55:44.333'.toTimestamp)",
+      "true"
+    )
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testInValidationExceptionMoreThanOneTypes(): Unit = {
+    testTableApi(
+      'f2.in('f3, 'f4, 4),
+      "f2.in(f3, f4, 4)",
+      "true"
+    )
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def scalaInValidationExceptionDifferentOperandsTest(): Unit = {
+    testTableApi(
+      'f1.in("Hi", "Hello world", "Comment#1"),
+      "true",
+      "true"
+    )
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def javaInValidationExceptionDifferentOperandsTest(): Unit = {
+    testTableApi(
+      true,
+      "f1.in('Hi','Hello world','Comment#1')",
+      "true"
+    )
+  }  
+  
   // ----------------------------------------------------------------------------------------------
 
   def testData = {

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/util/CollectionDataSets.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/util/CollectionDataSets.scala
@@ -154,11 +154,12 @@ object CollectionDataSets {
     env.fromCollection(Random.shuffle(data))
   }
 
-  def getSmallNestedTupleDataSet(env: ExecutionEnvironment): DataSet[((Int, Int), String)] = {
-    val data = new mutable.MutableList[((Int, Int), String)]
-    data.+=(((1, 1), "one"))
-    data.+=(((2, 2), "two"))
-    data.+=(((3, 3), "three"))
+  def getSmallNestedTupleDataSet(env: ExecutionEnvironment)
+                             : DataSet[((Int, Int), String, (Int, Int))] = {
+    val data = new mutable.MutableList[((Int, Int), String, (Int, Int))]
+    data.+=(((1, 1), "one", (2, 2)))
+    data.+=(((2, 2), "two", (3, 3)))
+    data.+=(((3, 3), "three", (3, 3)))
     env.fromCollection(Random.shuffle(data))
   }
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/util/CollectionDataSets.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/util/CollectionDataSets.scala
@@ -171,15 +171,6 @@ object CollectionDataSets {
     env.fromCollection(Random.shuffle(data))
   }
 
-  def getSmall2NestedTupleDataSet(env: ExecutionEnvironment)
-  : DataSet[((Int, Int), String, (Int, Int))] = {
-    val data = new mutable.MutableList[((Int, Int), String, (Int, Int))]
-    data.+=(((1, 1), "one", (2, 2)))
-    data.+=(((2, 2), "two", (3, 3)))
-    data.+=(((3, 3), "three", (3, 3)))
-    env.fromCollection(Random.shuffle(data))
-  }
-
   def getGroupSortedNestedTupleDataSet(env: ExecutionEnvironment): DataSet[((Int, Int), String)] = {
     val data = new mutable.MutableList[((Int, Int), String)]
     data.+=(((1, 3), "a"))

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/util/CollectionDataSets.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/util/CollectionDataSets.scala
@@ -17,9 +17,9 @@
  */
 package org.apache.flink.api.scala.util
 
+import java.sql.{Date, Time, Timestamp}
 import org.apache.flink.api.scala._
 import org.apache.hadoop.io.IntWritable
-
 import scala.collection.mutable
 import scala.util.Random
 
@@ -32,6 +32,65 @@ import scala.util.Random
  * #################################################################################################
  */
 object CollectionDataSets {
+  def get5TupleDataSetOfDateTimeTimestamp(env: ExecutionEnvironment)
+                            : DataSet[(Int, Date, Time, Timestamp, String)] = {
+    val data = new mutable.MutableList[(Int, Date, Time, Timestamp, String)]
+    data.+=((1, Date.valueOf("1984-07-05"), Time.valueOf("05:40:33"),
+             Timestamp.valueOf("1984-07-05 05:40:33.333"), "Hi"))
+    data.+=((2, Date.valueOf("1984-07-05"), Time.valueOf("06:55:44"),
+             Timestamp.valueOf("1984-07-05 06:55:44.333"), "Hello"))
+    data.+=((3, Date.valueOf("1984-07-05"), Time.valueOf("07:12:00"),
+             Timestamp.valueOf("1984-07-05 07:12:00.333"), "Hello world"))
+    data.+=((4, Date.valueOf("1984-07-05"), Time.valueOf("08:15:10"),
+             Timestamp.valueOf("1984-07-05 08:15:10.105"), "Hello world, how are you?"))
+    data.+=((5, Date.valueOf("1984-07-05"), Time.valueOf("22:00:00"),
+             Timestamp.valueOf("1984-07-05 22:00:00.105"), "I am fine."))
+    data.+=((6, Date.valueOf("1984-07-05"), Time.valueOf("23:01:01"),
+             Timestamp.valueOf("1984-07-05 23:01:01.105"), "Luke Skywalker"))
+    data.+=((7, Date.valueOf("1984-07-05"), Time.valueOf("00:10:10"),
+             Timestamp.valueOf("1984-07-05 00:10:10.55"), "Comment#1"))
+    data.+=((8, Date.valueOf("1972-02-22"), Time.valueOf("05:40:33"),
+             Timestamp.valueOf("1972-02-22 05:40:33.55"), "Comment#2"))
+    data.+=((9, Date.valueOf("1972-02-22"), Time.valueOf("06:55:44"),
+             Timestamp.valueOf("1972-02-22 06:55:44.55"), "Comment#3"))
+    data.+=((10, Date.valueOf("1972-02-22"), Time.valueOf("07:12:00"),
+             Timestamp.valueOf("1972-02-22 07:12:00.333"), "Comment#4"))
+    data.+=((11, Date.valueOf("1972-02-22"), Time.valueOf("08:15:10"),
+             Timestamp.valueOf("1972-02-22 08:15:10.333"), "Comment#5"))
+    data.+=((12, Date.valueOf("1972-02-22"), Time.valueOf("22:00:00"),
+             Timestamp.valueOf("1972-02-22 22:00:00.333"), "Comment#6"))
+    data.+=((13, Date.valueOf("1972-02-22"), Time.valueOf("23:01:01"),
+             Timestamp.valueOf("1972-02-22 23:01:01.105"), "Comment#7"))
+    data.+=((14, Date.valueOf("1938-04-22"), Time.valueOf("00:10:10"),
+             Timestamp.valueOf("1938-04-22 00:10:10.105"), "Comment#8"))
+    data.+=((15, Date.valueOf("1938-04-22"), Time.valueOf("05:40:33"),
+             Timestamp.valueOf("1938-04-22 05:40:33.105"), "Comment#9"))
+    data.+=((16, Date.valueOf("1938-04-22"), Time.valueOf("06:55:44"),
+             Timestamp.valueOf("1938-04-22 06:55:44.55"), "Comment#10"))
+    data.+=((17, Date.valueOf("1938-04-22"), Time.valueOf("07:12:00"),
+             Timestamp.valueOf("1938-04-22 07:12:00.55"), "Comment#11"))
+    data.+=((18, Date.valueOf("1938-04-22"), Time.valueOf("08:15:10"),
+             Timestamp.valueOf("1938-04-22 08:15:10.55"), "Comment#12"))
+    data.+=((19, Date.valueOf("1938-04-22"), Time.valueOf("22:00:00"),
+             Timestamp.valueOf("1938-04-22 22:00:00.333"), "Comment#13"))
+    data.+=((20, Date.valueOf("1938-04-22"), Time.valueOf("23:01:01"),
+             Timestamp.valueOf("1938-04-22 23:01:01.333"), "Comment#14"))
+    data.+=((21, Date.valueOf("1938-04-22"), Time.valueOf("00:10:10"),
+             Timestamp.valueOf("1938-04-22 00:10:10.333"), "Comment#15"))
+    Random.shuffle(data)
+    env.fromCollection(Random.shuffle(data))
+  }
+
+  def getSmall3TupleDataSetOfDateTimeTimestamp(env: ExecutionEnvironment)
+                                    : DataSet[(Int, Timestamp, String)] = {
+    val data = new mutable.MutableList[(Int, Timestamp, String)]
+    data.+=((1, Timestamp.valueOf("1984-07-05 23:01:01.105"), "Hi"))
+    data.+=((2, Timestamp.valueOf("1972-02-22 07:12:00.333"), "Hello"))
+    data.+=((3, Timestamp.valueOf("1938-04-22 06:55:44.55"), "Hello world"))
+    env.fromCollection(Random.shuffle(data))
+  }
+
+
   def get3TupleDataSet(env: ExecutionEnvironment): DataSet[(Int, Long, String)] = {
     val data = new mutable.MutableList[(Int, Long, String)]
     data.+=((1, 1L, "Hi"))
@@ -95,11 +154,12 @@ object CollectionDataSets {
     env.fromCollection(Random.shuffle(data))
   }
 
-  def getSmallNestedTupleDataSet(env: ExecutionEnvironment): DataSet[((Int, Int), String)] = {
-    val data = new mutable.MutableList[((Int, Int), String)]
-    data.+=(((1, 1), "one"))
-    data.+=(((2, 2), "two"))
-    data.+=(((3, 3), "three"))
+  def getSmallNestedTupleDataSet(env: ExecutionEnvironment)
+                             : DataSet[((Int, Int), String, (Int, Int))] = {
+    val data = new mutable.MutableList[((Int, Int), String, (Int, Int))]
+    data.+=(((1, 1), "one", (2, 2)))
+    data.+=(((2, 2), "two", (3, 3)))
+    data.+=(((3, 3), "three", (3, 3)))
     env.fromCollection(Random.shuffle(data))
   }
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/util/CollectionDataSets.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/util/CollectionDataSets.scala
@@ -154,8 +154,16 @@ object CollectionDataSets {
     env.fromCollection(Random.shuffle(data))
   }
 
-  def getSmallNestedTupleDataSet(env: ExecutionEnvironment)
-                             : DataSet[((Int, Int), String, (Int, Int))] = {
+  def getSmallNestedTupleDataSet(env: ExecutionEnvironment): DataSet[((Int, Int), String)] = {
+    val data = new mutable.MutableList[((Int, Int), String)]
+    data.+=(((1, 1), "one"))
+    data.+=(((2, 2), "two"))
+    data.+=(((3, 3), "three"))
+    env.fromCollection(Random.shuffle(data))
+  }
+
+  def getSmall2NestedTupleDataSet(env: ExecutionEnvironment)
+  : DataSet[((Int, Int), String, (Int, Int))] = {
     val data = new mutable.MutableList[((Int, Int), String, (Int, Int))]
     data.+=(((1, 1), "one", (2, 2)))
     data.+=(((2, 2), "two", (3, 3)))

--- a/pom.xml
+++ b/pom.xml
@@ -1072,7 +1072,7 @@ under the License.
 						<forkNumber>0${surefire.forkNumber}</forkNumber>
 						<log4j.configuration>${log4j.configuration}</log4j.configuration>
 					</systemPropertyVariables>
-					<argLine>-Xms256m -Xmx1536m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseSerialGC</argLine>
+					<argLine>-Xms256m -Xmx800m -Dmvn.forkNumber=${surefire.forkNumber} -XX:-UseGCOverheadLimit</argLine>
 				</configuration>
 				<executions>
 					<!--execute all the unit tests-->

--- a/pom.xml
+++ b/pom.xml
@@ -1072,7 +1072,7 @@ under the License.
 						<forkNumber>0${surefire.forkNumber}</forkNumber>
 						<log4j.configuration>${log4j.configuration}</log4j.configuration>
 					</systemPropertyVariables>
-					<argLine>-Xms256m -Xmx800m -Dmvn.forkNumber=${surefire.forkNumber} -XX:-UseGCOverheadLimit</argLine>
+					<argLine>-Xms256m -Xmx1536m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseSerialGC</argLine>
 				</configuration>
 				<executions>
 					<!--execute all the unit tests-->


### PR DESCRIPTION
[FLINK-4565] Support for SQL IN operator
This PR is a part of work on SQL IN operator in Table API, which implements IN for literals.
Two cases are covered: less and great then 20 literals.

Also I have some questions:
- converting all numeric types to BigDecimal isn't ok? I decided to make so to simplify use of hashset.
- validation isn't really good. It forces to use operator with same type literals. Should I rework it or maybe just add more cases?
expressionDsl.scala:
entry point for IN operator in scala API
ScalarOperators.scala:
1) All numeric types are upcasting to BigDecimal for using in hashset, other types are unchanged in castNumeric
2) valuesInitialization used for 2 cases: when we have more then 20 operands (then we use hashset, initialized in constructor, descibed below) and less then 20 operands (then we initialize operands in method's body and use them in conjunction)
3) comparison also covers described above cases. In first case we use callback to declare and initialize hashset with all operands. Otherwise we just put all operands in conjunction.
4) Final code is built up with these code snippets.
CodeGenerator.scala:
passes arguments and callback to declare and init hashet
FunctionCatalog.scala:
registers "in" as method
InITCase:
some use cases