### PR TITLE
[backport-1.1] [FLINK-6006] [kafka] Always use complete restored state in FlinkKafkaConsumer

### DIFF
--- a/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
+++ b/flink-streaming-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
@@ -233,7 +233,6 @@ public class KafkaShortRetentionTestBase implements Serializable {
 		try {
 			env.execute("Test auto offset reset none");
 		} catch(Throwable e) {
-			System.out.println("MESSAGE: " + e.getCause().getCause().getMessage());
 			// check if correct exception has been thrown
 			if(!e.getCause().getCause().getMessage().contains("Unable to find previous offset")  // kafka 0.8
 			 && !e.getCause().getCause().getMessage().contains("Undefined offset with no reset policy for partition") // kafka 0.9


### PR DESCRIPTION
(This PR is the fix of FLINK-6006 for Flink 1.1)

Previously, the Kafka Consumer performs partition list querying on
restore, and then uses it to filter out restored state of partitions
that doesn't exist in the list.

If in any case the returned partitions list is incomplete (i.e. missing
partitions that existed before perhaps due to temporary ZK / broker
downtimes), then the state of the missing partitions is dropped and
cannot be recovered anymore.

This PR fixes this by always restoring the complete state, without
any sort of filtering. We simply let the consumer fail if assigned
partitions to the consuming threads / Kafka clients are unreachable when
the consumer starts running.
