### PR TITLE
[FLINK-6007] Allow key removal from within the watermark callback.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -957,4 +957,10 @@ public abstract class AbstractStreamOperator<OUT>
 		return timeServiceManager == null ? 0 :
 			timeServiceManager.numEventTimeTimers();
 	}
+
+	@VisibleForTesting
+	public int numKeysForWatermarkCallback() {
+		return timeServiceManager == null ? 0 :
+			timeServiceManager.numKeysForWatermarkCallback();
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -188,4 +188,9 @@ class InternalTimeServiceManager<K, N> {
 		}
 		return count;
 	}
+
+	@VisibleForTesting
+	public int numKeysForWatermarkCallback() {
+		return watermarkCallbackService.numKeysForWatermarkCallback();
+	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -597,6 +597,15 @@ public class AbstractStreamOperatorTestHarness<OUT> {
 		}
 	}
 
+	@VisibleForTesting
+	public int numKeysForWatermarkCallback() {
+		if (operator instanceof AbstractStreamOperator) {
+			return ((AbstractStreamOperator) operator).numKeysForWatermarkCallback();
+		} else {
+			throw new UnsupportedOperationException();
+		}
+	}
+
 	private class MockOutput implements Output<StreamRecord<OUT>> {
 
 		private TypeSerializer<OUT> outputSerializer;


### PR DESCRIPTION
When deleting a key from the `InternalWatermarkCallbackService`, the deleted key is put into a separate set, and the actual deletion happens after the iteration over all keys has finished. To avoid
checkpointing the deletion set, the actual cleanup also happens upon checkpointing.

R @aljoscha 