### PR TITLE
[FLINK-6027][checkpoint] Ignore the exception thrown by the subsuming of completed checkppoints

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
@@ -67,7 +67,7 @@ public class StandaloneCompletedCheckpointStore implements CompletedCheckpointSt
 			try {
 				checkpoints.remove().subsume();
 			} catch (Exception e) {
-				LOG.error("Fail to subsume the old checkpoint.", e);
+				LOG.warn("Fail to subsume the old checkpoint.", e);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
@@ -64,7 +64,11 @@ public class StandaloneCompletedCheckpointStore implements CompletedCheckpointSt
 	public void addCheckpoint(CompletedCheckpoint checkpoint) throws Exception {
 		checkpoints.add(checkpoint);
 		if (checkpoints.size() > maxNumberOfCheckpointsToRetain) {
-			checkpoints.remove().subsume();
+			try {
+				checkpoints.remove().subsume();
+			} catch (Exception e) {
+				LOG.error("Fail to subsume the old checkpoint.", e);
+			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
@@ -188,7 +188,11 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 
 		// Everything worked, let's remove a previous checkpoint if necessary.
 		while (checkpointStateHandles.size() > maxNumberOfCheckpointsToRetain) {
-			removeSubsumed(checkpointStateHandles.removeFirst());
+			try {
+				removeSubsumed(checkpointStateHandles.removeFirst());
+			} catch (Exception e) {
+				LOG.error("Failed to subsume the old checkpoint", e);
+			}
 		}
 
 		LOG.debug("Added {} to {}.", checkpoint, path);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
@@ -191,7 +191,7 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 			try {
 				removeSubsumed(checkpointStateHandles.removeFirst());
 			} catch (Exception e) {
-				LOG.error("Failed to subsume the old checkpoint", e);
+				LOG.warn("Failed to subsume the old checkpoint", e);
 			}
 		}
 


### PR DESCRIPTION
The exception thrown during the subsuming of old checkpoints now will be ignored. Now, `CompletedCheckpointStore#addCheckpoint` will throw exceptions only when the completed checkpoint is not written in the store. In such cases, the coordinator is safe to delete the states in the checkpoint because we are impossible to recover from the checkpoint.