### PR TITLE
[FLINK-6020]add a random integer suffix to blob key to avoid naming conflicting

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -531,7 +531,7 @@ public final class BlobClient implements Closeable {
 				throw new IOException("Detected data corruption during transfer");
 			}
 
-			return localKey;
+			return remoteKey;
 		}
 		else if (response == RETURN_ERROR) {
 			Throwable cause = readExceptionFromStream(is);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
@@ -34,6 +34,7 @@ import java.io.OutputStream;
 import java.net.Socket;
 import java.net.SocketException;
 import java.security.MessageDigest;
+import java.util.Random;
 
 import static org.apache.flink.runtime.blob.BlobServerProtocol.BUFFER_SIZE;
 import static org.apache.flink.runtime.blob.BlobServerProtocol.CONTENT_ADDRESSABLE;
@@ -337,7 +338,8 @@ class BlobServerConnection extends Thread {
 				outputStream.write(RETURN_OKAY);
 			}
 			else {
-				BlobKey blobKey = new BlobKey(md.digest());
+				Random rand = new Random();
+				BlobKey blobKey = new BlobKey(md.digest(), rand.nextInt());
 				File storageFile = blobServer.getStorageLocation(blobKey);
 				Files.move(incomingFile, storageFile);
 				incomingFile = null;

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1242,7 +1242,7 @@ class JobManager(
               "Cannot set up the user code libraries: " + t.getMessage, t)
         }
 
-        var userCodeLoader = libraryCacheManager.getClassLoader(jobGraph.getJobID)
+        val userCodeLoader = libraryCacheManager.getClassLoader(jobGraph.getJobID)
         if (userCodeLoader == null) {
           throw new JobSubmissionException(jobId,
             "The user code class loader could not be initialized.")


### PR DESCRIPTION
In yarn-cluster mode, if we submit one same job multiple times parallelly, the task will encounter class load problem and lease occuputation.

**Way to reproduce:**
1. launch a yarn session with enough slots
2. run a script contains 20 lines of `flink run ../examples/steaming/WindowJoin.jar &` to submit same job multiple times in parallel

Because blob server stores user jars in name with generated sha1sum of those, first writes a temp file and move it to finalialize. For recovery it also will put them to HDFS with same file name.

In same time, when multiple clients sumit same job with same jar, the local jar files in blob server and those file on hdfs will be handled in multiple threads(BlobServerConnection), and impact each other.

I've found a way to solve this by adding a random integer suffix to blob key. Like changed here.