### PR TITLE
[FLINK-5949] [yarn] Don't check Kerberos credentials for non-Kerberos authentication methods

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -414,10 +414,12 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 				// for logins based on a keytab (fixed in Hadoop 2.6.1, see HADOOP-10786),
 				// so we check only in ticket cache scenario.
 				boolean useTicketCache = flinkConfiguration.getBoolean(SecurityOptions.KERBEROS_LOGIN_USETICKETCACHE);
+
 				UserGroupInformation loginUser = UserGroupInformation.getCurrentUser();
-				if (useTicketCache && !loginUser.hasKerberosCredentials()) {
-					LOG.error("Hadoop security is enabled but the login user does not have Kerberos credentials");
-					throw new RuntimeException("Hadoop security is enabled but the login user " +
+				if (loginUser.getAuthenticationMethod() == UserGroupInformation.AuthenticationMethod.KERBEROS
+						&& useTicketCache && !loginUser.hasKerberosCredentials()) {
+					LOG.error("Hadoop security with Kerberos is enabled but the login user does not have Kerberos credentials");
+					throw new RuntimeException("Hadoop security with Kerberos is enabled but the login user " +
 							"does not have Kerberos credentials");
 				}
 			}


### PR DESCRIPTION
Additionally uses the `UserGroupInformation#getAuthenticationMethod()` to determine whether `KERBEROS` is used for authentication.

This fixes issues MapR users have been bumping into, where only MapR's custom SSL security was enabled (no Kerberos), but the Kerberos credentials were still checked for. For MapR's SSL security, the `getAuthenticationMethod()` returns `CUSTOM` (see http://apache-flink-user-mailing-list-archive.2336050.n4.nabble.com/Flink-Yarn-and-MapR-Kerberos-issue-td11996.html).

Also tested and confirmed that the change doesn't break previous Kerberos with YARN behaviours for other vendors, e.g. CDH.

This change should also be backported for {{release-1.2}}.