### PR TITLE
[FLINK-6040] [table] DataStreamUserDefinedFunctionITCase occasionally fails

### DIFF
--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/datastream/DataStreamUserDefinedFunctionITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/datastream/DataStreamUserDefinedFunctionITCase.scala
@@ -27,18 +27,22 @@ import org.apache.flink.table.expressions.utils.{Func13, RichFunc2}
 import org.apache.flink.table.utils._
 import org.apache.flink.types.Row
 import org.junit.Assert._
-import org.junit.Test
+import org.junit.{Before, Test}
 
 import scala.collection.mutable
 
 class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestBase {
 
+  val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+  val tEnv: StreamTableEnvironment = TableEnvironment.getTableEnvironment(env)
+
+  @Before
+  def clear(): Unit = {
+    StreamITCase.clear
+  }
+
   @Test
   def testCrossJoin(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
-    StreamITCase.clear
-
     val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
     val func0 = new TableFunc0
     val pojoFunc0 = new PojoTableFunc()
@@ -60,10 +64,6 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
 
   @Test
   def testLeftOuterJoin(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
-    StreamITCase.clear
-
     val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
     val func0 = new TableFunc0
 
@@ -83,10 +83,6 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
 
   @Test
   def testUserDefinedTableFunctionWithParameter(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
-    StreamITCase.clear
-
     val tableFunc1 = new RichTableFunc1
     tEnv.registerFunction("RichTableFunc1", tableFunc1)
     UserDefinedFunctionTestUtils.setJobParameters(env, Map("word_separator" -> " "))
@@ -107,10 +103,6 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
 
   @Test
   def testUserDefinedTableFunctionWithUserDefinedScalarFunction(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
-    StreamITCase.clear
-
     val tableFunc1 = new RichTableFunc1
     val richFunc2 = new RichFunc2
     tEnv.registerFunction("RichTableFunc1", tableFunc1)
@@ -141,10 +133,6 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
 
   @Test
   def testTableFunctionConstructorWithParams(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
-    StreamITCase.clear
-
     val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
     val config = Map("key1" -> "value1", "key2" -> "value2")
     val func30 = new TableFunc3(null)
@@ -176,10 +164,6 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
 
   @Test
   def testScalarFunctionConstructorWithParams(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
-    StreamITCase.clear
-
     val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
     val func0 = new Func13("default")
     val func1 = new Func13("Sunny")
@@ -201,15 +185,11 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
 
   @Test
   def testTableFunctionWithVariableArguments(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tableEnv = TableEnvironment.getTableEnvironment(env)
-    StreamITCase.clear
-
     val varArgsFunc0 = new VarArgsFunc0
-    tableEnv.registerFunction("VarArgsFunc0", varArgsFunc0)
+    tEnv.registerFunction("VarArgsFunc0", varArgsFunc0)
 
     val result = testData(env)
-      .toTable(tableEnv, 'a, 'b, 'c)
+      .toTable(tEnv, 'a, 'b, 'c)
       .select('c)
       .join(varArgsFunc0("1", "2", 'c))
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/datastream/DataStreamUserDefinedFunctionITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/datastream/DataStreamUserDefinedFunctionITCase.scala
@@ -85,6 +85,8 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
   def testUserDefinedTableFunctionWithParameter(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
     val tableFunc1 = new RichTableFunc1
     tEnv.registerFunction("RichTableFunc1", tableFunc1)
     UserDefinedFunctionTestUtils.setJobParameters(env, Map("word_separator" -> " "))
@@ -107,6 +109,8 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
   def testUserDefinedTableFunctionWithUserDefinedScalarFunction(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
     val tableFunc1 = new RichTableFunc1
     val richFunc2 = new RichFunc2
     tEnv.registerFunction("RichTableFunc1", tableFunc1)
@@ -199,6 +203,8 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
   def testTableFunctionWithVariableArguments(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tableEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
     val varArgsFunc0 = new VarArgsFunc0
     tableEnv.registerFunction("VarArgsFunc0", varArgsFunc0)
 


### PR DESCRIPTION
Type: Bug
Priority: Major
Components: table, test
Problem Definition: DataStreamUserDefinedFunctionITCase occasionally fails
Design:
Three test cases in `DataStreamUserDefinedFunctionITCase` forgot to call the method `StreamITCase.clear method`. This will cause the case occasionally fails. Because the result of one case may affect another sometimes. The patch the is simply adding the missing methods.
Impact Analysis:
Only the tests. No impacts on the core code.
Test:
Tested `DataStreamUserDefinedFunctionITCase` locally.