### PR TITLE
[FLINK-6050] [robustness] Register exception handler on thenAccept futures

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RegisteredRpcConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RegisteredRpcConnection.java
@@ -95,7 +95,7 @@ public abstract class RegisteredRpcConnection<Gateway extends RpcGateway, Succes
 
 		Future<Tuple2<Gateway, Success>> future = pendingRegistration.getFuture();
 
-		future.thenAcceptAsync(new AcceptFunction<Tuple2<Gateway, Success>>() {
+		Future<Void> registrationSuccessFuture = future.thenAcceptAsync(new AcceptFunction<Tuple2<Gateway, Success>>() {
 			@Override
 			public void accept(Tuple2<Gateway, Success> result) {
 				targetGateway = result.f0;
@@ -104,7 +104,7 @@ public abstract class RegisteredRpcConnection<Gateway extends RpcGateway, Succes
 		}, executor);
 
 		// this future should only ever fail if there is a bug, not if the registration is declined
-		future.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
+		registrationSuccessFuture.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
 			@Override
 			public Void apply(Throwable failure) {
 				onRegistrationFailure(failure);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistration.java
@@ -182,7 +182,7 @@ public abstract class RetryingRegistration<Gateway extends RpcGateway, Success e
 			Future<Gateway> resourceManagerFuture = rpcService.connect(targetAddress, targetType);
 	
 			// upon success, start the registration attempts
-			resourceManagerFuture.thenAcceptAsync(new AcceptFunction<Gateway>() {
+			Future<Void> resourceManagerAcceptFuture = resourceManagerFuture.thenAcceptAsync(new AcceptFunction<Gateway>() {
 				@Override
 				public void accept(Gateway result) {
 					log.info("Resolved {} address, beginning registration", targetName);
@@ -191,7 +191,7 @@ public abstract class RetryingRegistration<Gateway extends RpcGateway, Success e
 			}, rpcService.getExecutor());
 
 			// upon failure, retry, unless this is cancelled
-			resourceManagerFuture.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
+			resourceManagerAcceptFuture.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
 				@Override
 				public Void apply(Throwable failure) {
 					if (!isCanceled()) {
@@ -225,7 +225,7 @@ public abstract class RetryingRegistration<Gateway extends RpcGateway, Success e
 			Future<RegistrationResponse> registrationFuture = invokeRegistration(gateway, leaderId, timeoutMillis);
 	
 			// if the registration was successful, let the TaskExecutor know
-			registrationFuture.thenAcceptAsync(new AcceptFunction<RegistrationResponse>() {
+			Future<Void> registrationAcceptFuture = registrationFuture.thenAcceptAsync(new AcceptFunction<RegistrationResponse>() {
 				@Override
 				public void accept(RegistrationResponse result) {
 					if (!isCanceled()) {
@@ -251,7 +251,7 @@ public abstract class RetryingRegistration<Gateway extends RpcGateway, Success e
 			}, rpcService.getExecutor());
 	
 			// upon failure, retry
-			registrationFuture.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
+			registrationAcceptFuture.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
 				@Override
 				public Void apply(Throwable failure) {
 					if (!isCanceled()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -456,7 +456,7 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 		} else {
 			Future<InfoMessageListenerRpcGateway> infoMessageListenerRpcGatewayFuture = getRpcService().connect(address, InfoMessageListenerRpcGateway.class);
 
-			infoMessageListenerRpcGatewayFuture.thenAcceptAsync(new AcceptFunction<InfoMessageListenerRpcGateway>() {
+			Future<Void> infoMessageListenerAcceptFuture = infoMessageListenerRpcGatewayFuture.thenAcceptAsync(new AcceptFunction<InfoMessageListenerRpcGateway>() {
 				@Override
 				public void accept(InfoMessageListenerRpcGateway gateway) {
 					log.info("Receive a registration from info message listener on ({})", address);
@@ -464,7 +464,7 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 				}
 			}, getMainThreadExecutor());
 
-			infoMessageListenerRpcGatewayFuture.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
+			infoMessageListenerAcceptFuture.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
 				@Override
 				public Void apply(Throwable failure) {
 					log.warn("Receive a registration from unreachable info message listener on ({})", address);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SlotPoolTest.java
@@ -49,6 +49,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -82,7 +83,7 @@ public class SlotPoolTest extends TestLogger {
 		this.resourceManagerGateway = mock(ResourceManagerGateway.class);
 		when(resourceManagerGateway
 			.requestSlot(any(UUID.class), any(UUID.class), any(SlotRequest.class), any(Time.class)))
-			.thenReturn(mock(Future.class));
+			.thenReturn(mock(Future.class, RETURNS_MOCKS));
 
 		slotPool.connectToResourceManager(UUID.randomUUID(), resourceManagerGateway);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -150,6 +150,11 @@ public class TaskExecutorITCase {
 		when(jmGateway.registerTaskManager(any(String.class), any(TaskManagerLocation.class), eq(jmLeaderId), any(Time.class)))
 			.thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(new JMTMRegistrationSuccess(taskManagerResourceId, 1234)));
 		when(jmGateway.getHostname()).thenReturn(jmAddress);
+		when(jmGateway.offerSlots(
+			eq(taskManagerResourceId),
+			any(Iterable.class),
+			eq(jmLeaderId),
+			any(Time.class))).thenReturn(mock(Future.class, RETURNS_MOCKS));
 
 
 		rpcService.registerGateway(rmAddress, resourceManager.getSelf());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -67,7 +67,6 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestRegistered;
 import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestRejected;
 import org.apache.flink.runtime.resourcemanager.messages.taskexecutor.TMSlotRequestReply;
-import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.TestingSerialRpcService;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
@@ -216,13 +215,11 @@ public class TaskExecutorTest extends TestLogger {
 
 		final TestingSerialRpcService rpc = new TestingSerialRpcService();
 		try {
-			final FatalErrorHandler errorHandler = mock(FatalErrorHandler.class);
-
 			// register a mock resource manager gateway
 			ResourceManagerGateway rmGateway = mock(ResourceManagerGateway.class);
 			when(rmGateway.registerTaskExecutor(
 					any(UUID.class), anyString(), any(ResourceID.class), any(SlotReport.class), any(Time.class)))
-				.thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(new RegistrationResponse.Success()));
+				.thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(new TaskExecutorRegistrationSuccess(new InstanceID(), 10L)));
 
 			TaskManagerConfiguration taskManagerServicesConfiguration = mock(TaskManagerConfiguration.class);
 			when(taskManagerServicesConfiguration.getNumberSlots()).thenReturn(1);
@@ -289,10 +286,12 @@ public class TaskExecutorTest extends TestLogger {
 
 			when(rmGateway1.registerTaskExecutor(
 					any(UUID.class), anyString(), any(ResourceID.class), any(SlotReport.class), any(Time.class)))
-					.thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(new RegistrationResponse.Success()));
+					.thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(
+						new TaskExecutorRegistrationSuccess(new InstanceID(), 10L)));
 			when(rmGateway2.registerTaskExecutor(
 					any(UUID.class), anyString(), any(ResourceID.class), any(SlotReport.class), any(Time.class)))
-					.thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(new RegistrationResponse.Success()));
+					.thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(
+						new TaskExecutorRegistrationSuccess(new InstanceID(), 10L)));
 
 			rpc.registerGateway(address1, rmGateway1);
 			rpc.registerGateway(address2, rmGateway2);
@@ -547,6 +546,11 @@ public class TaskExecutorTest extends TestLogger {
 				any(Time.class)
 		)).thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(new JMTMRegistrationSuccess(jmResourceId, blobPort)));
 		when(jobMasterGateway.getHostname()).thenReturn(jobManagerAddress);
+		when(jobMasterGateway.offerSlots(
+			any(ResourceID.class),
+			any(Iterable.class),
+			any(UUID.class),
+			any(Time.class))).thenReturn(mock(Future.class, RETURNS_MOCKS));
 
 		rpc.registerGateway(resourceManagerAddress, resourceManagerGateway);
 		rpc.registerGateway(jobManagerAddress, jobMasterGateway);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -199,7 +199,7 @@ public class TaskExecutorTest extends TestLogger {
 					eq(taskManager.getAddress()), eq(taskManagerLocation), eq(jmLeaderId), any(Time.class));
 
 			// the timeout should trigger disconnecting from the JobManager
-			verify(jobMasterGateway, timeout(heartbeatTimeout * 5)).disconnectTaskManager(eq(taskManagerLocation.getResourceID()), any(TimeoutException.class));
+			verify(jobMasterGateway, timeout(heartbeatTimeout * 50L)).disconnectTaskManager(eq(taskManagerLocation.getResourceID()), any(TimeoutException.class));
 
 			// check if a concurrent error occurred
 			testingFatalErrorHandler.rethrowError();


### PR DESCRIPTION
When applying an AcceptFunction on a Future x, then we should register the exception handler
on the returned thenAccept future instead of on x. This has the advantage that we also catch
exceptions which are thrown inside of the AcceptFunction and not only those which originate
from x. The PR adapts the code respectively.
