### PR TITLE
Flip1: fine gained recovery

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -132,6 +132,9 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	 * within the job. */
 	private final SerializableObject progressLock = new SerializableObject();
 
+	/** The coordinator for failover */
+	private final FailoverCoordinator failoverCoordinator;
+
 	/** Job specific information like the job id, job name, job configuration, etc. */
 	private final JobInformation jobInformation;
 
@@ -313,6 +316,11 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 		metricGroup.gauge(RESTARTING_TIME_METRIC_NAME, new RestartTimeGauge());
 
 		this.kvStateLocationRegistry = new KvStateLocationRegistry(jobId, getAllVertices());
+
+		// initialize the FailoverCoordinator here since execution graph can not work without it
+		this.failoverCoordinator = new FailoverCoordinator(this);
+		registerExecutionListener(failoverCoordinator);
+		registerJobStatusListener(failoverCoordinator);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -728,6 +736,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 
 			this.verticesInCreationOrder.add(ejv);
 		}
+		this.failoverCoordinator.generateAllFailoverRegion();
 	}
 
 	public void scheduleForExecution(SlotProvider slotProvider) throws JobException {
@@ -893,42 +902,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	}
 
 	public void cancel() {
-		while (true) {
-			JobStatus current = state;
-
-			if (current == JobStatus.RUNNING || current == JobStatus.CREATED) {
-				if (transitionState(current, JobStatus.CANCELLING)) {
-					for (ExecutionJobVertex ejv : verticesInCreationOrder) {
-						ejv.cancel();
-					}
-					return;
-				}
-			}
-			// Executions are being canceled. Go into cancelling and wait for
-			// all vertices to be in their final state.
-			else if (current == JobStatus.FAILING) {
-				if (transitionState(current, JobStatus.CANCELLING)) {
-					return;
-				}
-			}
-			// All vertices have been cancelled and it's safe to directly go
-			// into the canceled state.
-			else if (current == JobStatus.RESTARTING) {
-				synchronized (progressLock) {
-					if (transitionState(current, JobStatus.CANCELED)) {
-						postRunCleanup();
-						progressLock.notifyAll();
-
-						LOG.info("Canceled during restart.");
-						return;
-					}
-				}
-			}
-			else {
-				// no need to treat other states
-				return;
-			}
-		}
+		this.failoverCoordinator.cancel();
 	}
 
 	public void stop() throws StoppingException {
@@ -980,39 +954,30 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 		}
 	}
 
-	public void fail(Throwable t) {
+	public void toFinalState(JobStatus status, Throwable t) {
 		while (true) {
+
 			JobStatus current = state;
-			// stay in these states
-			if (current == JobStatus.FAILING ||
-				current == JobStatus.SUSPENDED ||
-				current.isGloballyTerminalState()) {
-				return;
-			} else if (current == JobStatus.RESTARTING) {
-				this.failureCause = t;
-
-				if (tryRestartOrFail()) {
-					return;
-				}
-				// concurrent job status change, let's check again
-			} else if (transitionState(current, JobStatus.FAILING, t)) {
-				this.failureCause = t;
-
-				if (!verticesInCreationOrder.isEmpty()) {
-					// cancel all. what is failed will not cancel but stay failed
-					for (ExecutionJobVertex ejv : verticesInCreationOrder) {
-						ejv.cancel();
-					}
-				} else {
-					// set the state of the job to failed
-					transitionState(JobStatus.FAILING, JobStatus.FAILED, t);
-				}
-
-				return;
+			if (current.isGloballyTerminalState()) {
+				LOG.info("Job is already in final state {}", current);
+				break;
 			}
-
-			// no need to treat other states
+			else if(transitionState(current, status, t)) {
+				this.failureCause = t;
+				synchronized (progressLock) {
+					postRunCleanup();
+					progressLock.notifyAll();
+				}
+				break;
+			}
 		}
+	}
+
+	public void fail(Throwable t) {
+		LOG.info("Execution graph is failing", t);
+		//TODO: Temporaly use the FAILING status to trigger failover coordinator, 
+		// adding a method to failover coordinator may be better
+		notifyJobStatusChange(JobStatus.FAILING, t);
 	}
 
 	public void restart() {
@@ -1142,6 +1107,15 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 		}
 	}
 
+	// JobVertex has finished, but its downstream can not read its result, so need it to run again.
+	void finishedJobVertexRestarted() {
+		if (numFinishedJobVertices >= verticesInCreationOrder.size()) {
+			throw new IllegalStateException("All vertices are already finished, cannot transition vertex to finished.");
+		}
+
+		numFinishedJobVertices--;
+	}
+
 	void jobVertexInFinalState() {
 		synchronized (progressLock) {
 			if (numFinishedJobVertices >= verticesInCreationOrder.size()) {
@@ -1162,18 +1136,6 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 							postRunCleanup();
 							break;
 						}
-					}
-					else if (current == JobStatus.CANCELLING) {
-						if (transitionState(current, JobStatus.CANCELED)) {
-							postRunCleanup();
-							break;
-						}
-					}
-					else if (current == JobStatus.FAILING) {
-						if (tryRestartOrFail()) {
-							break;
-						}
-						// concurrent job status change, let's check again
 					}
 					else if (current == JobStatus.SUSPENDED) {
 						// we've already cleaned up when entering the SUSPENDED state
@@ -1410,6 +1372,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 		ExecutionJobVertex vertex = getJobVertex(vertexId);
 
 		if (executionListeners.size() > 0) {
+			//TODO: not change the error to String, need the error to know whether upstream node to rerun
 			final String message = error == null ? null : ExceptionUtils.stringifyException(error);
 			final long timestamp = System.currentTimeMillis();
 
@@ -1423,11 +1386,6 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 					LOG.warn("Error while notifying ExecutionStatusListener", t);
 				}
 			}
-		}
-
-		// see what this means for us. currently, the first FAILED state means -> FAILED
-		if (newExecutionState == ExecutionState.FAILED) {
-			fail(error);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -510,17 +510,29 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 	//---------------------------------------------------------------------------------------------
 	
 	void vertexFinished(int subtask) {
-		subtaskInFinalState(subtask);
+		//subtaskInFinalState(subtask);
 	}
 	
 	void vertexCancelled(int subtask) {
-		subtaskInFinalState(subtask);
+		//subtaskInFinalState(subtask);
 	}
 	
 	void vertexFailed(int subtask, Throwable error) {
 		subtaskInFinalState(subtask);
 	}
-	
+
+	void vertexRestarted(int subtask) {
+		if (finishedSubtasks[subtask]) {
+			finishedSubtasks[subtask] = false;
+			numSubtasksInFinalState--;
+
+			if (numSubtasksInFinalState + 1 == parallelism) {
+				// tell the graph
+				graph.finishedJobVertexRestarted();
+			}
+		}
+	}
+
 	private void subtaskInFinalState(int subtask) {
 		synchronized (stateMonitor) {
 			if (!finishedSubtasks[subtask]) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -521,6 +521,7 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 				if (grp != null) {
 					this.locationConstraint = grp.getLocationConstraint(subTaskIndex);
 				}
+				jobVertex.vertexRestarted(subTaskIndex);
 			}
 			else {
 				throw new IllegalStateException("Cannot reset a vertex that is in state " + state);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/FailoverCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/FailoverCoordinator.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A coordinator which generate {@code FailoverRegion} for all executions when initialing, and
+ * A {@code ExecutionStatusListener} and {@code JobStatusListener} 
+ * that finds a {@code FailoverRegion} to do failover for each execution failure.
+ */
+public class FailoverCoordinator implements ExecutionStatusListener, JobStatusListener {
+	private static final AtomicReferenceFieldUpdater<FailoverCoordinator, JobStatus> STATE_UPDATER =
+			AtomicReferenceFieldUpdater.newUpdater(FailoverCoordinator.class, JobStatus.class, "state");
+
+	/** The log object used for debugging. */
+	static final Logger LOG = LoggerFactory.getLogger(FailoverCoordinator.class);
+
+	private final Object lock = new Object();
+
+	private final ExecutionGraph executionGraph;
+
+	private final RestartStrategy restartStrategy;
+
+	private final Map<FailoverRegion, Boolean> failoverRegions = new HashMap<>(1);
+
+	private volatile int regionInFinalStateNumber;
+
+	private JobStatus state = JobStatus.RUNNING;
+
+	public FailoverCoordinator(ExecutionGraph executionGraph) {
+		this.executionGraph = checkNotNull(executionGraph);
+		this.restartStrategy = checkNotNull(executionGraph.getRestartStrategy());
+		regionInFinalStateNumber = 0;
+	}
+
+	@Override
+	public void jobStatusChanges(JobID jobId, JobStatus newJobStatus, long timestamp, Throwable error){
+		//TODO: this is for original fail() in EG, maybe not using FAILING to trigger it is better
+		if (newJobStatus.equals(JobStatus.FAILING)) {
+			if (restartStrategy.canRestart()) {
+				for (FailoverRegion failoverRegion : failoverRegions.keySet()) {
+					failoverRegion.failover(true);
+				}
+			}
+			else {
+				fail();
+			}
+		}
+	}
+
+	@Override
+	public void executionStatusChanged(
+			JobID jobID, JobVertexID vertexID,
+			String taskName, int taskParallelism, int subtaskIndex,
+			ExecutionAttemptID executionID, ExecutionState newExecutionState,
+			long timestamp, String optionalMessage) {
+
+		ExecutionVertex ev = executionGraph.getJobVertex(vertexID).getTaskVertices()[subtaskIndex];
+		if (ev == null) {
+			LOG.warn("Not find execution vertex for job vertex id {}, sub index {}", vertexID.toString(), subtaskIndex);
+			return;
+		}
+		FailoverRegion failoverRegion = getFailoverRegion(ev);
+		if (failoverRegion == null) {
+			executionGraph.fail(new Exception("Can not find a failover region for the execution " + ev.getSimpleName()));
+		}
+		else {
+			failoverRegion.notifyExecutionChange(ev, newExecutionState);
+		}
+	}
+
+	public ExecutionGraph getExecutionGraph() {
+		return this.executionGraph;
+	}
+
+	// when the job is canceled, need to cancel all executions and wait for them to be canceled
+	public void cancel() {
+		JobStatus curStatus = state;
+		while (true) {
+			if (curStatus.equals(JobStatus.RUNNING)) {
+				if (transitionState(curStatus, JobStatus.CANCELLING)) {
+					regionInFinalStateNumber = 0;
+					for (FailoverRegion failoverRegion : failoverRegions.keySet()) {
+						failoverRegion.failover(true);
+					}
+					break;
+				}
+			} else {
+				LOG.info("Failover coordinator already in {} when cancel", curStatus);
+			}
+		}
+	}
+
+	// the job need to fail, cancel all executions and wait for them to be canceled
+	public void fail() {
+		JobStatus curStatus = state;
+		while (true) {
+			if (curStatus.equals(JobStatus.RUNNING)) {
+				if (transitionState(curStatus, JobStatus.FAILING)) {
+					regionInFinalStateNumber = 0;
+					for (FailoverRegion failoverRegion : failoverRegions.keySet()) {
+						failoverRegion.failover(true);
+					}
+					break;
+				}
+			} else {
+				LOG.info("Failover coordinator already in {} when fail", curStatus);
+			}
+		}
+	}
+
+	// is the whole job is failing or canceling
+	public boolean shuttingDown() {
+		return state.equals(JobStatus.FAILING) || state.equals(JobStatus.CANCELLING);
+	}
+
+	// Notice by a failover region that it is in CANCELED 
+	public void failoverRegionCanceled(FailoverRegion region) {
+		synchronized (lock) {
+			// need not check exist as failoverRegions are constructed at initializing
+			if (!failoverRegions.get(region)) {
+				failoverRegions.put(region, true);
+				regionInFinalStateNumber++;
+			}
+		}
+		if (regionInFinalStateNumber == failoverRegions.size()) {
+			JobStatus curStatus = state;
+			if (curStatus.equals(JobStatus.FAILING)) {
+				if (transitionState(curStatus, JobStatus.FAILED)) {
+					this.executionGraph.toFinalState(JobStatus.FAILED, null);
+				}
+			}
+			else if (curStatus.equals(JobStatus.CANCELLING)) {
+				if (transitionState(curStatus, JobStatus.CANCELED)) {
+					this.executionGraph.toFinalState(JobStatus.CANCELED, null);
+				}
+			}
+		}
+	}
+
+	// find the failover region that contains the execution vertex
+	@VisibleForTesting
+	FailoverRegion getFailoverRegion(ExecutionVertex ev) {
+		for (FailoverRegion region : failoverRegions.keySet()) {
+			if (region.containsExecution(ev)) {
+				return region;
+			}
+		}
+		return null;
+	}
+
+	// Generate all the FailoverRegion from the ExecutionGraph
+	public void generateAllFailoverRegion() {
+		failoverRegions.clear();
+		for (ExecutionVertex ev : executionGraph.getAllExecutionVertices()) {
+			if (getFailoverRegion(ev) != null) {
+				continue;
+			}
+			List<ExecutionVertex> pipelinedExecutions = new LinkedList<>();
+			List<ExecutionVertex> orgExecutions = new LinkedList<>();
+			orgExecutions.add(ev);
+			pipelinedExecutions.add(ev);
+			getAllPipelinedConnectedVertexes(orgExecutions, pipelinedExecutions);
+			failoverRegions.put(new FailoverRegion(this, pipelinedExecutions), false);
+		}
+		buildRelationOfFailoverRegions();
+	}
+
+	/**
+	 * Get all connected executions of the original executions
+	 *
+	 * @param orgExecutions  the original execution vertexes
+	 * @param connectedExecutions  the total connected executions
+	 */
+	private static void getAllPipelinedConnectedVertexes(List<ExecutionVertex> orgExecutions, List<ExecutionVertex> connectedExecutions) {
+		List<ExecutionVertex> newAddedExecutions = new LinkedList<>();
+		for (ExecutionVertex ev : orgExecutions) {
+			// Add downstream ExecutionVertex
+			for (IntermediateResultPartition irp : ev.getProducedPartitions().values()) {
+				if (irp.getResultType().isPipelined()) {
+					for (List<ExecutionEdge> consumers : irp.getConsumers()) {
+						for (ExecutionEdge consumer : consumers) {
+							ExecutionVertex cev = consumer.getTarget();
+							if (!connectedExecutions.contains(cev)) {
+								newAddedExecutions.add(cev);
+							}
+						}
+					}
+				}
+			}
+			if (!newAddedExecutions.isEmpty()) {
+				connectedExecutions.addAll(newAddedExecutions);
+				getAllPipelinedConnectedVertexes(newAddedExecutions, connectedExecutions);
+				newAddedExecutions.clear();
+			}
+			// Add upstream ExecutionVertex
+			int inputNum = ev.getNumberOfInputs();
+			for (int i = 0; i < inputNum; i++) {
+				for (ExecutionEdge input : ev.getInputEdges(i)) {
+					if (input.getSource().getResultType().isPipelined()) {
+						ExecutionVertex pev = input.getSource().getProducer();
+						if (!connectedExecutions.contains(pev)) {
+							newAddedExecutions.add(pev);
+						}
+					}
+				}
+			}
+			if (!newAddedExecutions.isEmpty()) {
+				connectedExecutions.addAll(0, newAddedExecutions);
+				getAllPipelinedConnectedVertexes(newAddedExecutions, connectedExecutions);
+				newAddedExecutions.clear();
+			}
+		}
+	}
+
+	private void buildRelationOfFailoverRegions() {
+		for (FailoverRegion failoverRegion : failoverRegions.keySet()) {
+			for (ExecutionVertex ev : failoverRegion.getAllExecutionVertexes()) {
+				for (int i = 0; i < ev.getNumberOfInputs(); i++) {
+					for (ExecutionEdge edge : ev.getInputEdges(i)) {
+						ExecutionVertex previous = edge.getSource().getProducer();
+						if (failoverRegion.containsExecution(previous)) {
+							continue;
+						}
+						else {
+							for (FailoverRegion region : failoverRegions.keySet()) {
+								if (region.containsExecution(previous)) {
+									failoverRegion.addPrecedingFailoverRegion(region);
+									region.addSucceedingFailoverRegion(failoverRegion);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private boolean transitionState(JobStatus current, JobStatus newState) {
+		if (STATE_UPDATER.compareAndSet(this, current, newState)) {
+			LOG.info("FailoverCoordinator switched from state {} to {}.", current, newState);
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/FailoverRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/FailoverRegion.java
@@ -1,0 +1,363 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * FailoverRegion manages the failover of a minimal pipeline connected sub graph.
+ * It will change from CREATED to CANCELING and then to CANCELLED and at last to RUNNING,
+ */
+public class FailoverRegion {
+	private static final AtomicReferenceFieldUpdater<FailoverRegion, JobStatus> STATE_UPDATER =
+			AtomicReferenceFieldUpdater.newUpdater(FailoverRegion.class, JobStatus.class, "state");
+
+	/** The log object used for debugging. */
+	static final Logger LOG = LoggerFactory.getLogger(FailoverRegion.class);
+
+	// a unique id for debugging
+	private final ResourceID id = ResourceID.generate();
+
+	/** Current status of the job execution */
+	private volatile JobStatus state = JobStatus.CREATED;
+
+	private final FailoverCoordinator failoverCoordinator;
+
+	private final List<ExecutionVertex> connectedExecutionVertexes;
+
+	private final List<FailoverRegion> precedingRegions;
+
+	private final List<FailoverRegion> succeedingRegions;
+
+	// When a region failover, it should know whether its preceding is doing failover. 
+	// If precedings are not doing failover, it should reset all its executions and start them.
+	// Or else, it just reset its executions, when preceding execution, it will notice its executions to start.
+	private volatile boolean waitPrecedings = false;
+
+	public FailoverRegion(FailoverCoordinator failoverCoordinator, List<ExecutionVertex> connectedExecutions) {
+		this.failoverCoordinator = checkNotNull(failoverCoordinator);
+		this.connectedExecutionVertexes = checkNotNull(connectedExecutions);
+		this.precedingRegions = new LinkedList<>();
+		this.succeedingRegions = new LinkedList<>();
+		LOG.info("FailoverRegion {} contains {}", id.toString(), connectedExecutions.toString());
+	}
+
+	// notice of state changing of execution from FailoverCoordinator
+	public void notifyExecutionChange(ExecutionVertex ev, ExecutionState newState) {
+		LOG.debug("{} change to state {}", ev.getSimpleName(), newState);
+		while (true) {
+			JobStatus curStatus = this.state;
+			if (curStatus.equals(JobStatus.CREATED) && (newState.equals(ExecutionState.RUNNING)
+					|| newState.equals(ExecutionState.SCHEDULED) || newState.equals(ExecutionState.DEPLOYING))) {
+				if (transitionState(curStatus, JobStatus.RUNNING)) {
+					this.waitPrecedings = false;
+					break;
+				}
+			}
+			else if (curStatus.equals(JobStatus.CANCELLING) && newState.isTerminal()) {
+				//TODO: maybe recording the finished number as EG do now is better
+				for (ExecutionVertex cev : connectedExecutionVertexes) {
+					if (!cev.getExecutionState().isTerminal()) {
+						return;
+					}
+				}
+				if (transitionState(curStatus, JobStatus.CANCELED)) {
+					if (this.failoverCoordinator.shuttingDown()) {
+						this.failoverCoordinator.failoverRegionCanceled(this);
+					}
+					else {
+						reset();
+					}
+					break;
+				}
+			}
+			else if (newState.equals(ExecutionState.FAILED)) {
+				// TODO: judge where preceding need failover
+				if (curStatus.equals(JobStatus.CREATED) || curStatus.equals(JobStatus.CANCELED)) {
+					LOG.debug("Execution ({}) changed to FAILED while region is {}.", ev.getSimpleName(), curStatus);
+					break;
+				}
+				else {
+					if (!this.failoverCoordinator.getExecutionGraph().getRestartStrategy().canRestart()) {
+						this.failoverCoordinator.fail();
+					}
+					else if (transitionState(curStatus, JobStatus.CANCELLING)) {
+						noticeSucceedingFailover();
+						//TODO: RestartStrategy should be change to restart at failover region level
+						this.failoverCoordinator.getExecutionGraph().getRestartStrategy().restart(
+								this.failoverCoordinator.getExecutionGraph());
+						cancel();
+						break;
+					}
+				}
+			}
+			else {
+				LOG.debug("Execution ({}) changed to state {} while region is {}.", ev.getSimpleName(), newState, state);
+				break;
+			}
+		}
+	}
+
+	public JobStatus getState() {
+		return state;
+	}
+
+	/**
+	 *  whether an execution vertex is contained in this sub graph
+	 */
+	public boolean containsExecution(ExecutionVertex ev) {
+		for (ExecutionVertex vertex : connectedExecutionVertexes) {
+			if (vertex.equals(ev)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * get all execution vertexes contained in this region
+	 */
+	public List<ExecutionVertex> getAllExecutionVertexes() {
+		return connectedExecutionVertexes;
+	}
+
+	public void addPrecedingFailoverRegion(FailoverRegion region) {
+		if (!this.precedingRegions.contains(region)) {
+			this.precedingRegions.add(region);
+		}
+	}
+
+	public void addSucceedingFailoverRegion(FailoverRegion region) {
+		if (!this.succeedingRegions.contains(region)) {
+			this.succeedingRegions.add(region);
+		}
+	}
+
+	// Notice the region to failover, 
+	public void failover(boolean waitPrecedings) {
+		while (true) {
+			JobStatus curStatus = this.state;
+			if (curStatus.equals(JobStatus.RUNNING)) {
+				if (!this.failoverCoordinator.shuttingDown()
+						&& !this.failoverCoordinator.getExecutionGraph().getRestartStrategy().canRestart()) {
+					this.failoverCoordinator.fail();
+				}
+				else if (transitionState(curStatus, JobStatus.CANCELLING)) {
+					this.waitPrecedings = waitPrecedings;
+					if (this.failoverCoordinator.getExecutionGraph().getRestartStrategy().canRestart()) {
+						this.failoverCoordinator.getExecutionGraph().getRestartStrategy().restart(
+								this.failoverCoordinator.getExecutionGraph());
+					}
+					cancel();
+					break;
+				}
+			}
+			else {
+				if(this.waitPrecedings == false) {
+					this.waitPrecedings = waitPrecedings;
+				}
+				LOG.info("FailoverRegion {} do failover while in {}", id.toString(), curStatus);
+				if ((curStatus.equals(JobStatus.CREATED) || curStatus.equals(JobStatus.CANCELED))
+						&& this.failoverCoordinator.shuttingDown()) {
+					this.failoverCoordinator.failoverRegionCanceled(this);
+				}
+				break;
+			}
+		}
+		// Its succeeding regions should always do failover
+		noticeSucceedingFailover();
+	}
+
+	// noticed by its succeeding that it change to CREATED
+	public void succeedingCreated() {
+		JobStatus curState = state;
+		if (state.equals(JobStatus.CREATED)) {
+			if ((!waitPrecedings || precedingRegions.size() == 0) && allSucceedingCreated()) {
+				restart();
+			}
+		}
+	}
+
+	// tell all its succeedings to failover
+	public void noticeSucceedingFailover() {
+		for (FailoverRegion region : succeedingRegions) {
+			region.failover(true);
+		}
+	}
+
+	/**
+	 * judge whether all its succeedings are in CREATED 
+	 */
+	public boolean allSucceedingCreated() {
+		boolean running = true;
+		for (FailoverRegion region : succeedingRegions) {
+			if (!region.getState().equals(JobStatus.CREATED)) {
+				running = false;
+				break;
+			}
+		}
+		return running;
+	}
+
+	// cancel all executions in this sub graph
+	private void cancel() {
+		try {
+			int waitingCancelExecutionNum = 0;
+			for (ExecutionVertex ev : connectedExecutionVertexes) {
+				ev.cancel();
+				if (!ev.getCurrentExecutionAttempt().isFinished()) {
+					waitingCancelExecutionNum++;
+				}
+			}
+			LOG.debug("After {} cancel, waiting to be canceled number {}", id.toString(), waitingCancelExecutionNum);
+			if (waitingCancelExecutionNum <= 0) {
+				if (transitionState(JobStatus.CANCELLING, JobStatus.CANCELED)) {
+					if (!this.failoverCoordinator.shuttingDown()) {
+						reset();
+					}
+					else {
+						this.failoverCoordinator.failoverRegionCanceled(this);
+					}
+
+				}
+				else {
+					LOG.info("FailoverRegion {} switched from CANCELLING to CANCELED fail, will fail this region again", 
+							id.toString());
+					failover(this.waitPrecedings);
+				}
+			}
+		} catch (Exception e) {
+			LOG.info("FailoverRegion {} cancel fail, failover again", id.toString());
+			failover(this.waitPrecedings);
+		}
+	}
+
+	// reset all executions in this sub graph
+	private void reset() {
+		try {
+			//reset all connected ExecutionVertexes
+			Collection<CoLocationGroup> colGroups = new HashSet<>();
+			for (ExecutionVertex ev : connectedExecutionVertexes) {
+				CoLocationGroup cgroup = ev.getJobVertex().getCoLocationGroup();
+				if(cgroup != null && !colGroups.contains(cgroup)){
+					cgroup.resetConstraints();
+					colGroups.add(cgroup);
+				}
+				ev.resetForNewExecution();
+			}
+			if (transitionState(JobStatus.CANCELED, JobStatus.CREATED)) {
+				LOG.debug("FailoverRegion {} switched from CANCELLED to CREATED", id.toString());
+			}
+			else {
+				LOG.info("FailoverRegion {} switched from CANCELLING to CREATED fail, will fail this region again", id.toString());
+				failover(this.waitPrecedings);
+				return;
+			}
+			LOG.debug("Reset all execution vertexes for region {}", id.toString());
+
+			noticePrecedingsCreated();
+
+			if ((!waitPrecedings || precedingRegions.size() == 0) && allSucceedingCreated()) {
+				restart();
+			}
+		} catch (Throwable e) {
+			LOG.info("FailoverRegion {} reset fail, will failover again", id.toString());
+			failover(this.waitPrecedings);
+		}
+	}
+
+	// notice its precedings that it is created
+	private void noticePrecedingsCreated() {
+		for (FailoverRegion region : this.precedingRegions) {
+			region.succeedingCreated();
+		}
+	}
+
+	// restart all executions in this sub graph
+	private void restart() {
+		try {
+			if (transitionState(JobStatus.CREATED, JobStatus.RUNNING)) {
+				LOG.debug("FailoverRegion {} switched from CREATED to RUNNING", id.toString());
+				// if we have checkpointed state, reload it into the executions
+				//TODO: checkpoint support restore part ExecutionVertex cp
+				/**
+				if (failoverCoordinator.getExecutionGraph().getCheckpointCoordinator() != null) {
+					failoverCoordinator.getExecutionGraph().getCheckpointCoordinator().restoreLatestCheckpointedState(
+							connectedExecutionVertexes, false, false);
+				}
+				*/
+				//restart all connected ExecutionVertexes
+				for (ExecutionVertex ev : connectedExecutionVertexes) {
+					try {
+						ev.scheduleForExecution(failoverCoordinator.getExecutionGraph().getSlotProvider(), 
+								failoverCoordinator.getExecutionGraph().isQueuedSchedulingAllowed());
+					}
+					catch (Throwable e) {
+						failover(this.waitPrecedings);
+					}
+				}
+			}
+			else {
+				LOG.info("FailoverRegion {} switched from CREATED to RUNNING fail, will fail this region again", id.toString());
+				failover(this.waitPrecedings);
+			}
+		} catch (Exception e) {
+			LOG.info("FailoverRegion {} restart failed, failover again.", id.toString(), e);
+			failover(this.waitPrecedings);
+		}
+	}
+
+	private boolean transitionState(JobStatus current, JobStatus newState) {
+		if (STATE_UPDATER.compareAndSet(this, current, newState)) {
+			LOG.info("FailoverRegion {} switched from state {} to {}.", id.toString(), current, newState);
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+
+	//----------------------------------
+	// Methods only for tests
+	//----------------------------------
+	@VisibleForTesting
+	List<FailoverRegion> getPrecedingRegions() {
+		return this.precedingRegions;
+	}
+
+	@VisibleForTesting
+	List<FailoverRegion> getSucceedingRegions() {
+		return this.succeedingRegions;
+	}
+
+}


### PR DESCRIPTION
This is an informal pr for the implementation of flip1 version 1. 
It enable that when a task fail, only restart the minimal pipelined connected executions instead of the whole execution graph.
Main changes:
1. ExecutionGraph doesn't manage the failover any more, it only record the finished JobVertex number and turn to FINISHED when all vertexes finish(maybe later FailoverCoordinator will take over this). Its state can only be CREATED, RUNNING, FAILED, FINISHED or SUSPENDED now.
2. FailoverCoordinator will manage the failover now. It will generate several FailoverRegions when the EG is attached. It listens for the fail of executions. When an execution fail, it finds a FailoverRegion to finish the failover.
3. When JM need the EG to be canceled or failed, EG will also notice FailoverCoordinator, FailoverCoordinator will notice all FailoverRegions to cancel their executions and when all executions are canceled, FailoverCoordinator will notice EG to be CANCELED or FAILED.
4. FailoverCoordinator has server state, RUNNING, FAILING, CANCELLING, FAILED, CANCELED. 
5. FailoverRegion contains the minimal pipelined connected executions and manager the failover of them.
6. FailoverRegion has CREATED, RUNNING, CANCELLING, CANCELLED.
7. One FailoverRegion may be the succeeding or preceding of others. When a preceding region failover, its all succeedings should failover too. And the succeedings should just reset its executions and wait for the preceding to start it when preceding finish. Preceding should wait for its succeedings to be CREATED and then schedule again.