### PR TITLE
[FLINK-6056] [build]apache-rat exclude flink directory in tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -936,6 +936,7 @@ under the License.
 						<exclude>build-target/**</exclude>
 						<!-- Tools: watchdog -->
 						<exclude>tools/artifacts/**</exclude>
+						<exclude>tools/flink*/**</exclude>
 						<!-- PyCharm -->
 						<exclude>**/.idea/**</exclude>
 					</excludes>


### PR DESCRIPTION
The flink* directory in the tools is temporary cloned when build distribution.
So when build the Flink project, we should exclude the flink* directory.

- [X] General
  - The pull request references the related JIRA issue ("[FLINK-6056] apache-rat exclude flink directory in tools")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [X] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [X] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
