### PR TITLE
[FLINK-6032] [cep] Clean-up operator state when not needed.

### DIFF
--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
@@ -501,7 +501,7 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 		result.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
 
 		// the expected sequences of matching event ids
-		expected = "Left(1.0)\nRight(2.0,2.0,2.0)";
+		expected = "Left(1.0)\nLeft(2.0)\nLeft(2.0)\nRight(2.0,2.0,2.0)";
 
 		env.execute();
 	}

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/SubEvent.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/SubEvent.java
@@ -31,6 +31,18 @@ public class SubEvent extends Event {
 	}
 
 	@Override
+	public boolean equals(Object obj) {
+		return obj instanceof SubEvent &&
+				super.equals(obj) &&
+				((SubEvent) obj).volume == volume;
+	}
+
+	@Override
+	public int hashCode() {
+		return super.hashCode() + (int) volume;
+	}
+
+	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
 


### PR DESCRIPTION
The CEP operator now cleans the registered state for a key. This happens:
1) for the priority queue, when the queue is empty.
2) for the NFA, when its shared buffer is empty.
3) the key is removed from the `InternalWatermarkCallbackService` when both of the above are empty.
