### PR TITLE
[FLINK-6061] Introduced IllegalStateException when operating RocksDB …

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -158,6 +158,8 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 			ByteArrayOutputStreamWithPos keySerializationStream,
 			DataOutputView keySerializationDataOutputView) throws IOException {
 
+		Preconditions.checkNotNull(key, "No key set. This method should not be called outside of a keyed context.");
+
 		keySerializationStream.reset();
 		writeKeyGroup(keyGroup, keySerializationDataOutputView);
 		writeKey(key, keySerializationStream, keySerializationDataOutputView);


### PR DESCRIPTION
…keyed state with no key set

This PR fixes [FLINK-6061]. I throws an `IllegalStateException` when keyed state is accessed and no key is set in the backend.
