### PR TITLE
[FLINK-6068] [table] Support If() as a built-in function of TableAPI

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -146,6 +146,7 @@ object FunctionCatalog {
     "isFalse" -> classOf[IsFalse],
     "isNotTrue" -> classOf[IsNotTrue],
     "isNotFalse" -> classOf[IsNotFalse],
+    "if" -> classOf[If],
 
     // aggregate functions
     "avg" -> classOf[Avg],

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
@@ -154,6 +154,11 @@ class ScalarOperatorsTest extends ExpressionTestBase {
       "true.?(true.?(true.?(10, 4), 4), 4)",
       "10")
     testTableApi(true, "?((f6 && true), 'true', 'false')", "true")
+    testTableApi(
+      If('f9 > 'f8, 'f9 - 1, 'f9),
+      "If(f9 > f8, f9 - 1, f9)",
+      "9"
+    )
     testSqlApi("CASE 11 WHEN 1 THEN 'a' ELSE 'b' END", "b")
     testSqlApi("CASE 2 WHEN 1 THEN 'a' ELSE 'b' END", "b")
     testSqlApi(


### PR DESCRIPTION
Type: Improvement
Priority: Major
Components: table, udf
Problem Definition:  We didn't register the if() in the function category. We didn't support syntax 'if(a, b, c)'.

Design: 
1. Register If in function category.
1. Add some tests.

Impact Analysis: A newly registered function, without more impacts on others.
Test:
`mvn clean verify` is done