### PR TITLE
[FLINK-6076] Refactor HeartbeatManager to extend HeartbeatTarget

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManager.java
@@ -32,7 +32,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
  * @param <I> Type of the incoming payload
  * @param <O> Type of the outgoing payload
  */
-public interface HeartbeatManager<I, O> {
+public interface HeartbeatManager<I, O> extends HeartbeatTarget<I> {
 
 	/**
 	 * Start monitoring a {@link HeartbeatTarget}. Heartbeat timeouts for this target are reported
@@ -50,15 +50,6 @@ public interface HeartbeatManager<I, O> {
 	 * @param resourceID Resource ID of the heartbeat target which shall no longer be monitored
 	 */
 	void unmonitorTarget(ResourceID resourceID);
-
-	/**
-	 * Starts the heartbeat manager with the given {@link HeartbeatListener}. The heartbeat listener
-	 * is notified about heartbeat timeouts and heartbeat payloads are reported and retrieved to
-	 * and from it.
-	 *
-	 * @param heartbeatListener Heartbeat listener associated with the heartbeat manager
-	 */
-	void start(HeartbeatListener<I, O> heartbeatListener);
 
 	/**
 	 * Stops the heartbeat manager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
@@ -40,13 +40,20 @@ public class HeartbeatManagerSenderImpl<I, O> extends HeartbeatManagerImpl<I, O>
 	private final ScheduledFuture<?> triggerFuture;
 
 	public HeartbeatManagerSenderImpl(
-		long heartbeatPeriod,
-		long heartbeatTimeout,
-		ResourceID ownResourceID,
-		ExecutorService executorService,
-		ScheduledExecutorService scheduledExecutorService,
-		Logger log) {
-		super(heartbeatTimeout, ownResourceID, executorService, scheduledExecutorService, log);
+			long heartbeatPeriod,
+			long heartbeatTimeout,
+			ResourceID ownResourceID,
+			HeartbeatListener<I, O> heartbeatListener,
+			ExecutorService executorService,
+			ScheduledExecutorService scheduledExecutorService,
+			Logger log) {
+		super(
+			heartbeatTimeout,
+			ownResourceID,
+			heartbeatListener,
+			executorService,
+			scheduledExecutorService,
+			log);
 
 		triggerFuture = scheduledExecutorService.scheduleAtFixedRate(this, 0L, heartbeatPeriod, TimeUnit.MILLISECONDS);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatTarget.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatTarget.java
@@ -34,17 +34,17 @@ public interface HeartbeatTarget<I> {
 	 * Sends a heartbeat response to the target. Each heartbeat response can carry a payload which
 	 * contains additional information for the heartbeat target.
 	 *
-	 * @param resourceID Resource ID identifying the machine for which a heartbeat shall be reported.
-	 * @param payload Payload of the heartbeat response. Null indicates an empty payload.
+	 * @param heartbeatOrigin Resource ID identifying the machine for which a heartbeat shall be reported.
+	 * @param heartbeatPayload Payload of the heartbeat. Null indicates an empty payload.
 	 */
-	void sendHeartbeat(ResourceID resourceID, I payload);
+	void receiveHeartbeat(ResourceID heartbeatOrigin, I heartbeatPayload);
 
 	/**
 	 * Requests a heartbeat from the target. Each heartbeat request can carry a payload which
 	 * contains additional information for the heartbeat target.
 	 *
-	 * @param resourceID Resource ID identifying the machine issuing the heartbeat request.
-	 * @param payload Payload of the heartbeat response. Null indicates an empty payload.
+	 * @param requestOrigin Resource ID identifying the machine issuing the heartbeat request.
+	 * @param heartbeatPayload Payload of the heartbeat request. Null indicates an empty payload.
 	 */
-	void requestHeartbeat(ResourceID resourceID, I payload);
+	void requestHeartbeat(ResourceID requestOrigin, I heartbeatPayload);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
@@ -72,11 +72,10 @@ public class HeartbeatManagerTest extends TestLogger {
 		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
 			ownResourceID,
+			heartbeatListener,
 			new DirectExecutorService(),
 			scheduledExecutorService,
 			LOG);
-
-		heartbeatManager.start(heartbeatListener);
 
 		HeartbeatTarget<Object> heartbeatTarget = mock(HeartbeatTarget.class);
 
@@ -86,9 +85,9 @@ public class HeartbeatManagerTest extends TestLogger {
 
 		verify(heartbeatListener, times(1)).reportPayload(targetResourceID, expectedObject);
 		verify(heartbeatListener, times(1)).retrievePayload();
-		verify(heartbeatTarget, times(1)).sendHeartbeat(ownResourceID, expectedObject);
+		verify(heartbeatTarget, times(1)).receiveHeartbeat(ownResourceID, expectedObject);
 
-		heartbeatManager.sendHeartbeat(targetResourceID, expectedObject);
+		heartbeatManager.receiveHeartbeat(targetResourceID, expectedObject);
 
 		verify(heartbeatListener, times(2)).reportPayload(targetResourceID, expectedObject);
 	}
@@ -114,17 +113,16 @@ public class HeartbeatManagerTest extends TestLogger {
 		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
 			ownResourceID,
+			heartbeatListener,
 			new DirectExecutorService(),
 			scheduledExecutorService,
 			LOG);
-
-		heartbeatManager.start(heartbeatListener);
 
 		HeartbeatTarget<Object> heartbeatTarget = mock(HeartbeatTarget.class);
 
 		heartbeatManager.monitorTarget(targetResourceID, heartbeatTarget);
 
-		heartbeatManager.sendHeartbeat(targetResourceID, expectedObject);
+		heartbeatManager.receiveHeartbeat(targetResourceID, expectedObject);
 
 		verify(scheduledFuture, times(1)).cancel(true);
 		verify(scheduledExecutorService, times(2)).schedule(any(Runnable.class), eq(heartbeatTimeout), eq(TimeUnit.MILLISECONDS));
@@ -155,11 +153,10 @@ public class HeartbeatManagerTest extends TestLogger {
 		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
 			ownResourceID,
+			heartbeatListener,
 			new DirectExecutorService(),
 			new ScheduledThreadPoolExecutor(1),
 			LOG);
-
-		heartbeatManager.start(heartbeatListener);
 
 		HeartbeatTarget<Object> heartbeatTarget = mock(HeartbeatTarget.class);
 
@@ -168,7 +165,7 @@ public class HeartbeatManagerTest extends TestLogger {
 		heartbeatManager.monitorTarget(targetResourceID, heartbeatTarget);
 
 		for (int i = 0; i < numHeartbeats; i++) {
-			heartbeatManager.sendHeartbeat(targetResourceID, expectedObject);
+			heartbeatManager.receiveHeartbeat(targetResourceID, expectedObject);
 			Thread.sleep(heartbeatInterval);
 		}
 
@@ -206,6 +203,7 @@ public class HeartbeatManagerTest extends TestLogger {
 		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
 			resourceID,
+			heartbeatListener,
 			new DirectExecutorService(),
 			new ScheduledThreadPoolExecutor(1),
 			LOG);
@@ -214,12 +212,10 @@ public class HeartbeatManagerTest extends TestLogger {
 			heartbeatPeriod,
 			heartbeatTimeout,
 			resourceID2,
+			heartbeatListener2,
 			new DirectExecutorService(),
 			new ScheduledThreadPoolExecutor(1),
 			LOG);;
-
-		heartbeatManager.start(heartbeatListener);
-		heartbeatManager2.start(heartbeatListener2);
 
 		heartbeatManager.monitorTarget(resourceID2, heartbeatManager2);
 		heartbeatManager2.monitorTarget(resourceID, heartbeatManager);
@@ -251,16 +247,15 @@ public class HeartbeatManagerTest extends TestLogger {
 		ResourceID targetID = new ResourceID("target");
 		Object object = new Object();
 
+		TestingHeartbeatListener heartbeatListener = new TestingHeartbeatListener(object);
+
 		HeartbeatManager<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
 			resourceID,
+			heartbeatListener,
 			new DirectExecutorService(),
 			new ScheduledThreadPoolExecutor(1),
 			LOG);
-
-		TestingHeartbeatListener heartbeatListener = new TestingHeartbeatListener(object);
-
-		heartbeatManager.start(heartbeatListener);
 
 		heartbeatManager.monitorTarget(targetID, mock(HeartbeatTarget.class));
 


### PR DESCRIPTION
Let the `HeartbeatManager` extend the `HeartbeatTarget` interface, because all `HeartbeatManager` implementations implement the `HeartbeatTarget` as well. Furthermore, this PR removes the `HeartbeatManager#start` method and passes an `HeartbeatListener` instance directly to the `HeartbeatManagerImpl` and `HeartbeatManagerSenderImpl`.
