### PR TITLE
[FLINK-6087] Fix file-path filtering in ContinuousFileMonitoringFunction

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
@@ -300,7 +300,7 @@ public class ContinuousFileMonitoringFunction<OUT>
 			Map<Path, FileStatus> files = new HashMap<>();
 			// handle the new files
 			for (FileStatus status : statuses) {
-				if (!status.isDir()) {
+				if (!status.isDir() && format.acceptFile(status)) {
 					Path filePath = status.getPath();
 					long modificationTime = status.getModificationTime();
 					if (!shouldIgnore(filePath, modificationTime)) {


### PR DESCRIPTION
The Files Filter is only applied to directories, so there is no way to filter individual files. This fixes it.