### PR TITLE
[FLINK-2814] [optimizer] DualInputPlanNode cannot be cast to SingleInputPlanNode

### DIFF
--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/WorksetIterationNode.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/WorksetIterationNode.java
@@ -431,8 +431,8 @@ public class WorksetIterationNode extends TwoInputNode implements IterationNode 
 		LocalProperties lp = LocalProperties.EMPTY.addUniqueFields(this.solutionSetKeyFields);
 		
 		// take all combinations of solution set delta and workset plans
-		for (PlanNode solutionSetCandidate : solutionSetDeltaCandidates) {
-			for (PlanNode worksetCandidate : worksetCandidates) {
+		for (PlanNode worksetCandidate : worksetCandidates) {
+			for (PlanNode solutionSetCandidate : solutionSetDeltaCandidates) {
 				// check whether they have the same operator at their latest branching point
 				if (this.singleRoot.areBranchCompatible(solutionSetCandidate, worksetCandidate)) {
 					


### PR DESCRIPTION
WorksetIterationNode#instantiate loops over all solution and work set candidates. Since the solution set reference is modified in place when the predecessor node can be used in its place, swith this variable to the inner loop.

@StephanEwen this is similar to #2029 but resets the reference in the loop. I believe my prior suggestion to immediately return upon adding a node was incorrect as the `instantiate` methods look to be compiling all valid combinations.

IntelliJ code coverage on `flink-optimizer` shows 105 hits through `WorksetIterationNode#instantiate` and it does fix this issue with my Katz Centrality algorithm (which should not be using delta iterations, but I was young and naive when I wrote it).