### PR TITLE
[FLINK-6128] Optimize JVM options for improve test performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1027,7 +1027,7 @@ under the License.
 						<forkNumber>0${surefire.forkNumber}</forkNumber>
 						<log4j.configuration>${log4j.configuration}</log4j.configuration>
 					</systemPropertyVariables>
-					<argLine>-Xms256m -Xmx800m -Dmvn.forkNumber=${surefire.forkNumber} -XX:-UseGCOverheadLimit</argLine>
+					<argLine>-Xms256m -Xmx1536m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseSerialGC</argLine>
 				</configuration>
 				<executions>
 					<!--execute all the unit tests-->

--- a/pom.xml
+++ b/pom.xml
@@ -1027,7 +1027,7 @@ under the License.
 						<forkNumber>0${surefire.forkNumber}</forkNumber>
 						<log4j.configuration>${log4j.configuration}</log4j.configuration>
 					</systemPropertyVariables>
-					<argLine>-Xms256m -Xmx1536m -XX:+UseSerialGC -Dmvn.forkNumber=${surefire.forkNumber}</argLine>
+					<argLine>-Xms256m -Xmx1536m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseSerialGC</argLine>
 				</configuration>
 				<executions>
 					<!--execute all the unit tests-->

--- a/pom.xml
+++ b/pom.xml
@@ -1027,7 +1027,7 @@ under the License.
 						<forkNumber>0${surefire.forkNumber}</forkNumber>
 						<log4j.configuration>${log4j.configuration}</log4j.configuration>
 					</systemPropertyVariables>
-					<argLine>-Xms256m -Xmx1536m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseSerialGC</argLine>
+					<argLine>-Xms256m -Xmx1536m -XX:+UseSerialGC -Dmvn.forkNumber=${surefire.forkNumber}</argLine>
 				</configuration>
 				<executions>
 					<!--execute all the unit tests-->


### PR DESCRIPTION
The main goal of this PR improve latency of running tests with travis and prevent OOM.
1. Increased heap size
2. Use UseSerialGC
3. Remove UseGCOverheadLimit option

- [ ] General
  - The pull request references the related JIRA issue ("[FLINK-6128] Optimize JVM options for improve test performance")
