### PR TITLE
[FLINK-6127] [checkstyle] Add MissingDeprecation check

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer081.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer081.java
@@ -22,6 +22,8 @@ import java.util.Properties;
 
 /**
  * THIS CLASS IS DEPRECATED. Use FlinkKafkaConsumer08 instead.
+ *
+ * @deprecated Use {@link FlinkKafkaConsumer08}
  */
 @Deprecated
 public class FlinkKafkaConsumer081<T> extends FlinkKafkaConsumer08<T> {
@@ -30,6 +32,8 @@ public class FlinkKafkaConsumer081<T> extends FlinkKafkaConsumer08<T> {
 
 	/**
 	 * THIS CONSTRUCTOR IS DEPRECATED. Use FlinkKafkaConsumer08 instead.
+	 *
+	 * @deprecated Use {@link FlinkKafkaConsumer08#FlinkKafkaConsumer08(String, DeserializationSchema, Properties)}
 	 */
 	@Deprecated
 	public FlinkKafkaConsumer081(String topic, DeserializationSchema<T> valueDeserializer, Properties props) {

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer082.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer082.java
@@ -22,6 +22,8 @@ import java.util.Properties;
 
 /**
  * THIS CLASS IS DEPRECATED. Use FlinkKafkaConsumer08 instead.
+ *
+ * @deprecated Use {@link FlinkKafkaConsumer08}
  */
 @Deprecated
 public class FlinkKafkaConsumer082<T> extends FlinkKafkaConsumer08<T> {
@@ -30,6 +32,8 @@ public class FlinkKafkaConsumer082<T> extends FlinkKafkaConsumer08<T> {
 
 	/**
 	 * THIS CONSTRUCTOR IS DEPRECATED. Use FlinkKafkaConsumer08 instead.
+	 *
+	 * @deprecated Use {@link FlinkKafkaConsumer08#FlinkKafkaConsumer08(String, DeserializationSchema, Properties)}
 	 */
 	@Deprecated
 	public FlinkKafkaConsumer082(String topic, DeserializationSchema<T> valueDeserializer, Properties props) {

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -26,36 +26,56 @@ import java.util.Properties;
 
 /**
  * THIS CLASS IS DEPRECATED. Use FlinkKafkaProducer08 instead.
+ *
+ * @deprecated Use {@link FlinkKafkaProducer08}.
  */
 @Deprecated
 public class FlinkKafkaProducer<IN> extends FlinkKafkaProducer08<IN>  {
 
+	/**
+	 * @deprecated Use {@link FlinkKafkaProducer08#FlinkKafkaProducer08(String, String, SerializationSchema)}
+	 */
 	@Deprecated
 	public FlinkKafkaProducer(String brokerList, String topicId, SerializationSchema<IN> serializationSchema) {
 		super(topicId, new KeyedSerializationSchemaWrapper<>(serializationSchema), getPropertiesFromBrokerList(brokerList), null);
 	}
 
+	/**
+	 * @deprecated Use {@link FlinkKafkaProducer08#FlinkKafkaProducer08(String, SerializationSchema, Properties)}
+	 */
 	@Deprecated
 	public FlinkKafkaProducer(String topicId, SerializationSchema<IN> serializationSchema, Properties producerConfig) {
 		super(topicId, new KeyedSerializationSchemaWrapper<>(serializationSchema), producerConfig, null);
 	}
 
+	/**
+	 * @deprecated Use {@link FlinkKafkaProducer08#FlinkKafkaProducer08(String, SerializationSchema, Properties, KafkaPartitioner)}
+	 */
 	@Deprecated
 	public FlinkKafkaProducer(String topicId, SerializationSchema<IN> serializationSchema, Properties producerConfig, KafkaPartitioner customPartitioner) {
 		super(topicId, new KeyedSerializationSchemaWrapper<>(serializationSchema), producerConfig, customPartitioner);
 
 	}
 
+	/**
+	 * @deprecated Use {@link FlinkKafkaProducer08#FlinkKafkaProducer08(String, String, KeyedSerializationSchema)}
+	 */
 	@Deprecated
 	public FlinkKafkaProducer(String brokerList, String topicId, KeyedSerializationSchema<IN> serializationSchema) {
 		super(topicId, serializationSchema, getPropertiesFromBrokerList(brokerList), null);
 	}
 
+	/**
+	 * @deprecated Use {@link FlinkKafkaProducer08#FlinkKafkaProducer08(String, KeyedSerializationSchema, Properties)}
+	 */
 	@Deprecated
 	public FlinkKafkaProducer(String topicId, KeyedSerializationSchema<IN> serializationSchema, Properties producerConfig) {
 		super(topicId, serializationSchema, producerConfig, null);
 	}
 
+	/**
+	 * @deprecated Use {@link FlinkKafkaProducer08#FlinkKafkaProducer08(String, KeyedSerializationSchema, Properties, KafkaPartitioner)}
+	 */
 	@Deprecated
 	public FlinkKafkaProducer(String topicId, KeyedSerializationSchema<IN> serializationSchema, Properties producerConfig, KafkaPartitioner customPartitioner) {
 		super(topicId, serializationSchema, producerConfig, customPartitioner);

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -1141,6 +1141,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 	/**
 	 * For backwards compatibility, remove again later!
+	 *
+	 * @deprecated Internal method used for backwards compatability.
 	 */
 	@Deprecated
 	private void restoreOldSavepointKeyedState(Collection<KeyGroupsStateHandle> restoreState) throws Exception {

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -1142,7 +1142,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	/**
 	 * For backwards compatibility, remove again later!
 	 *
-	 * @deprecated Internal method used for backwards compatability.
+	 * @deprecated Internal method used for backwards compatibility.
 	 */
 	@Deprecated
 	private void restoreOldSavepointKeyedState(Collection<KeyGroupsStateHandle> restoreState) throws Exception {

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/migration/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/migration/contrib/streaming/state/RocksDBStateBackend.java
@@ -28,8 +28,8 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
-/***
- * @deprecated Internal class used for backwards compatability.
+/**
+ * @deprecated Internal class used for backwards compatibility.
  */
 @Deprecated
 public class RocksDBStateBackend extends AbstractStateBackend {

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/migration/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/migration/contrib/streaming/state/RocksDBStateBackend.java
@@ -28,6 +28,9 @@ import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
 
+/***
+ * @deprecated Internal class used for backwards compatability.
+ */
 @Deprecated
 public class RocksDBStateBackend extends AbstractStateBackend {
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/api/common/JobExecutionResult.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/JobExecutionResult.java
@@ -104,6 +104,7 @@ public class JobExecutionResult extends JobSubmissionResult {
 	 * @param accumulatorName Name of the counter
 	 * @return Result of the counter, or null if the counter does not exist
 	 * @throws java.lang.ClassCastException Thrown, if the accumulator was not aggregating a {@link java.lang.Integer}
+	 * @deprecated Will be removed in future versions. Use {@link #getAccumulatorResult} instead.
 	 */
 	@Deprecated
 	@PublicEvolving

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -89,7 +89,7 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 	private static int MAX_SAMPLE_LEN;
 
 	/**
-	 * @Deprecated Please use {@code loadConfigParameters(Configuration config}
+	 * @deprecated Please use {@code loadConfigParameters(Configuration config}
 	 */
 	@Deprecated
 	protected static void loadGlobalConfigParams() {

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
@@ -55,7 +55,17 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	 */
 	// IMPORTANT: Do not change the order of the elements in this enum, ordinal is used in serialization
 	public enum Type {
-		@Deprecated UNKNOWN, VALUE, LIST, REDUCING, FOLDING, AGGREGATING, MAP
+		/**
+		 * @deprecated Enum for migrating from old checkpoints/savepoint versions.
+		 */
+		@Deprecated
+		UNKNOWN,
+		VALUE,
+		LIST,
+		REDUCING,
+		FOLDING,
+		AGGREGATING,
+		MAP
 	}
 
 	private static final long serialVersionUID = 1L;

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -284,7 +284,7 @@ public final class ConfigConstants {
 	public static final String TASK_MANAGER_REFUSED_REGISTRATION_PAUSE = "taskmanager.refused-registration-pause";
 
 	/**
-	 * Deprecated. Please use {@link TaskManagerOptions#TASK_CANCELLATION_INTERVAL}.
+	 * @deprecated Deprecated. Please use {@link TaskManagerOptions#TASK_CANCELLATION_INTERVAL}.
 	 */
 	@PublicEvolving
 	@Deprecated
@@ -373,6 +373,8 @@ public final class ConfigConstants {
 
 	/**
 	 * Reallocate failed YARN containers.
+	 *
+	 * @deprecated Not used anymore
 	 */
 	@Deprecated
 	public static final String YARN_REALLOCATE_FAILED_CONTAINERS = "yarn.reallocate-failed";
@@ -419,9 +421,11 @@ public final class ConfigConstants {
 	@Deprecated
 	public static final String YARN_APPLICATION_MASTER_ENV_PREFIX = "yarn.application-master.env.";
 
-	// these default values are not used anymore, but remain here until Flink 2.0
+	/** @deprecated Not used anymore, but remain here until Flink 2.0 */
 	@Deprecated
 	public static final String DEFAULT_YARN_APPLICATION_MASTER_PORT = "deprecated";
+
+	/** @deprecated Not used anymore, but remain here until Flink 2.0 */
 	@Deprecated
 	public static final int DEFAULT_YARN_MIN_HEAP_CUTOFF = -1;
 
@@ -817,9 +821,7 @@ public final class ConfigConstants {
 	@Deprecated
 	public static final String FLINK_BASE_DIR_PATH_KEY = "flink.base.dir.path";
 
-	/**
-	 * @deprecated Use {@link CoreOptions#FLINK_JVM_OPTIONS} instead.
-	 */
+	/** @deprecated Use {@link CoreOptions#FLINK_JVM_OPTIONS} instead. */
 	@Deprecated
 	public static final String FLINK_JVM_OPTIONS = "env.java.opts";
 
@@ -837,15 +839,15 @@ public final class ConfigConstants {
 	@PublicEvolving
 	public static final String HA_JOB_DELAY = "high-availability.job.delay";
 
-	/** Deprecated in favour of {@link #HA_MODE}. */
+	/** @deprecated Deprecated in favour of {@link #HA_MODE}. */
 	@Deprecated
 	public static final String RECOVERY_MODE = "recovery.mode";
 
-	/** Deprecated in favour of {@link #HA_JOB_MANAGER_PORT}. */
+	/** @deprecated Deprecated in favour of {@link #HA_JOB_MANAGER_PORT}. */
 	@Deprecated
 	public static final String RECOVERY_JOB_MANAGER_PORT = "recovery.jobmanager.port";
 
-	/** Deprecated in favour of {@link #HA_JOB_DELAY}. */
+	/** @deprecated Deprecated in favour of {@link #HA_JOB_DELAY}. */
 	@Deprecated
 	public static final String RECOVERY_JOB_DELAY = "recovery.job.delay";
 
@@ -912,59 +914,59 @@ public final class ConfigConstants {
 	@PublicEvolving
 	public static final String ZOOKEEPER_SASL_SERVICE_NAME = "zookeeper.sasl.service-name";
 
-	/** Deprecated in favour of {@link #HA_ZOOKEEPER_QUORUM_KEY}. */
+	/** @deprecated Deprecated in favour of {@link #HA_ZOOKEEPER_QUORUM_KEY}. */
 	@Deprecated
 	public static final String ZOOKEEPER_QUORUM_KEY = "recovery.zookeeper.quorum";
 
-	/** Deprecated in favour of {@link #HA_ZOOKEEPER_STORAGE_PATH}. */
+	/** @deprecated Deprecated in favour of {@link #HA_ZOOKEEPER_STORAGE_PATH}. */
 	@Deprecated
 	public static final String ZOOKEEPER_RECOVERY_PATH = "recovery.zookeeper.storageDir";
 
-	/** Deprecated in favour of {@link #HA_ZOOKEEPER_DIR_KEY}. */
+	/** @deprecated Deprecated in favour of {@link #HA_ZOOKEEPER_DIR_KEY}. */
 	@Deprecated
 	public static final String ZOOKEEPER_DIR_KEY = "recovery.zookeeper.path.root";
 
-	/** Deprecated in favour of {@link #HA_ZOOKEEPER_NAMESPACE_KEY}. */
+	/** @deprecated Deprecated in favour of {@link #HA_ZOOKEEPER_NAMESPACE_KEY}. */
 	@Deprecated
 	public static final String ZOOKEEPER_NAMESPACE_KEY = "recovery.zookeeper.path.namespace";
 
-	/** Deprecated in favour of {@link #HA_ZOOKEEPER_LATCH_PATH}. */
+	/** @deprecated Deprecated in favour of {@link #HA_ZOOKEEPER_LATCH_PATH}. */
 	@Deprecated
 	public static final String ZOOKEEPER_LATCH_PATH = "recovery.zookeeper.path.latch";
 
-	/** Deprecated in favour of {@link #HA_ZOOKEEPER_LEADER_PATH}. */
+	/** @deprecated Deprecated in favour of {@link #HA_ZOOKEEPER_LEADER_PATH}. */
 	@Deprecated
 	public static final String ZOOKEEPER_LEADER_PATH = "recovery.zookeeper.path.leader";
 
-	/** Deprecated in favour of {@link #HA_ZOOKEEPER_JOBGRAPHS_PATH}. */
+	/** @deprecated Deprecated in favour of {@link #HA_ZOOKEEPER_JOBGRAPHS_PATH}. */
 	@Deprecated
 	public static final String ZOOKEEPER_JOBGRAPHS_PATH = "recovery.zookeeper.path.jobgraphs";
 
-	/** Deprecated in favour of {@link #HA_ZOOKEEPER_CHECKPOINTS_PATH}. */
+	/** @deprecated Deprecated in favour of {@link #HA_ZOOKEEPER_CHECKPOINTS_PATH}. */
 	@Deprecated
 	public static final String ZOOKEEPER_CHECKPOINTS_PATH = "recovery.zookeeper.path.checkpoints";
 
-	/** Deprecated in favour of {@link #HA_ZOOKEEPER_CHECKPOINT_COUNTER_PATH}. */
+	/** @deprecated Deprecated in favour of {@link #HA_ZOOKEEPER_CHECKPOINT_COUNTER_PATH}. */
 	@Deprecated
 	public static final String ZOOKEEPER_CHECKPOINT_COUNTER_PATH = "recovery.zookeeper.path.checkpoint-counter";
 
-	/** Deprecated in favour of {@link #HA_ZOOKEEPER_MESOS_WORKERS_PATH}. */
+	/** @deprecated Deprecated in favour of {@link #HA_ZOOKEEPER_MESOS_WORKERS_PATH}. */
 	@Deprecated
 	public static final String ZOOKEEPER_MESOS_WORKERS_PATH = "recovery.zookeeper.path.mesos-workers";
 
-	/** Deprecated in favour of {@link #HA_ZOOKEEPER_SESSION_TIMEOUT}. */
+	/** @deprecated Deprecated in favour of {@link #HA_ZOOKEEPER_SESSION_TIMEOUT}. */
 	@Deprecated
 	public static final String ZOOKEEPER_SESSION_TIMEOUT = "recovery.zookeeper.client.session-timeout";
 
-	/** Deprecated in favour of {@link #HA_ZOOKEEPER_CONNECTION_TIMEOUT}. */
+	/** @deprecated Deprecated in favour of {@link #HA_ZOOKEEPER_CONNECTION_TIMEOUT}. */
 	@Deprecated
 	public static final String ZOOKEEPER_CONNECTION_TIMEOUT = "recovery.zookeeper.client.connection-timeout";
 
-	/** Deprecated in favour of {@link #HA_ZOOKEEPER_RETRY_WAIT}. */
+	/** @deprecated Deprecated in favour of {@link #HA_ZOOKEEPER_RETRY_WAIT}. */
 	@Deprecated
 	public static final String ZOOKEEPER_RETRY_WAIT = "recovery.zookeeper.client.retry-wait";
 
-	/** Deprecated in favour of {@link #HA_ZOOKEEPER_MAX_RETRY_ATTEMPTS}. */
+	/** @deprecated Deprecated in favour of {@link #HA_ZOOKEEPER_MAX_RETRY_ATTEMPTS}. */
 	@Deprecated
 	public static final String ZOOKEEPER_MAX_RETRY_ATTEMPTS = "recovery.zookeeper.client.max-retry-attempts";
 
@@ -1038,7 +1040,7 @@ public final class ConfigConstants {
 	public static final String CHECKPOINTS_DIRECTORY_KEY = "state.checkpoints.dir";
 
 	/**
-	 * This key was used in Flink versions <= 1.1.X with the savepoint backend
+	 * @deprecated This key was used in Flink versions <= 1.1.X with the savepoint backend
 	 * configuration. We now always use the FileSystem for savepoints. For this,
 	 * the only relevant config key is {@link #SAVEPOINT_DIRECTORY_KEY}.
 	 */
@@ -1181,9 +1183,7 @@ public final class ConfigConstants {
 	 */
 	public static final boolean DEFAULT_TASK_MANAGER_MEMORY_PRE_ALLOCATE = false;
 
-	/**
-	 * Deprecated. Please use {@link TaskManagerOptions#TASK_CANCELLATION_INTERVAL}.
-	 */
+	/** @deprecated Please use {@link TaskManagerOptions#TASK_CANCELLATION_INTERVAL}. */
 	@Deprecated
 	public static final long DEFAULT_TASK_CANCELLATION_INTERVAL_MILLIS = 30000;
 
@@ -1321,7 +1321,7 @@ public final class ConfigConstants {
 	/** By default, submitting jobs from the web-frontend is allowed. */
 	public static final boolean DEFAULT_JOB_MANAGER_WEB_SUBMIT_ENABLED = true;
 
-	/** Config key has been deprecated. Therefore, no default value required. */
+	/** @deprecated Config key has been deprecated. Therefore, no default value required. */
 	@Deprecated
 	public static final boolean DEFAULT_JOB_MANAGER_WEB_CHECKPOINTS_DISABLE = false;
 
@@ -1402,7 +1402,7 @@ public final class ConfigConstants {
 	@PublicEvolving
 	public static String DEFAULT_HA_MODE = "none";
 
-	/** Deprecated in favour of {@link #DEFAULT_HA_MODE} */
+	/** @deprecated Deprecated in favour of {@link #DEFAULT_HA_MODE} */
 	@Deprecated
 	public static String DEFAULT_RECOVERY_MODE = "standalone";
 
@@ -1413,7 +1413,7 @@ public final class ConfigConstants {
 	@PublicEvolving
 	public static final String DEFAULT_HA_JOB_MANAGER_PORT = "0";
 
-	/** Deprecated in favour of {@link #DEFAULT_HA_JOB_MANAGER_PORT} */
+	/** @deprecated Deprecated in favour of {@link #DEFAULT_HA_JOB_MANAGER_PORT} */
 	@Deprecated
 	public static final String DEFAULT_RECOVERY_JOB_MANAGER_PORT = "0";
 

--- a/flink-core/src/main/java/org/apache/flink/migration/util/SerializedValue.java
+++ b/flink-core/src/main/java/org/apache/flink/migration/util/SerializedValue.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
  * provide the corresponding class loader.
  *
  * @param <T> The type of the value held.
+ * @deprecated Only used internally when migrating from previous savepoint versions.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
@@ -108,6 +108,8 @@ public class CsvReader {
 	 * 
 	 * @param delimiter The delimiter that separates the fields in one row.
 	 * @return The CSV reader instance itself, to allow for fluent function chaining.
+	 *
+	 * @deprecated Please use {@link #fieldDelimiter(String)}.
 	 */
 	@Deprecated
 	@PublicEvolving

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/CrossOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/CrossOperator.java
@@ -301,7 +301,7 @@ public class CrossOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT,
 		}
 
 		/**
-		 * Deprecated method only kept for compatibility.
+		 * @deprecated Deprecated method only kept for compatibility.
 		 */
 		@SuppressWarnings({ "hiding", "unchecked" })
 		@Deprecated

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/DataSink.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/DataSink.java
@@ -117,6 +117,8 @@ public class DataSink<T> {
 	 *
 	 * @see org.apache.flink.api.java.tuple.Tuple
 	 * @see Order
+	 *
+	 * @deprecated Use {@link DataSet#sortPartition(int, Order)} instead
 	 */
 	@Deprecated
 	@PublicEvolving
@@ -164,6 +166,8 @@ public class DataSink<T> {
 	 * @return This data sink operator with specified output order.
 	 *
 	 * @see Order
+	 *
+	 * @deprecated Use {@link DataSet#sortPartition(String, Order)} instead
 	 */
 	@Deprecated
 	@PublicEvolving

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/JoinOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/JoinOperator.java
@@ -735,7 +735,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		}
 
 		/**
-		 * Deprecated method only kept for compatibility.
+		 * @deprecated Deprecated method only kept for compatibility.
 		 *
 		 * @param types
 		 */

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/ProjectOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/ProjectOperator.java
@@ -71,7 +71,7 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		return ppo;
 	}
 	/**
-	 * Deprecated method only kept for compatibility.
+	 * @deprecated Deprecated method only kept for compatibility.
 	 */
 	@SuppressWarnings("unchecked")
 	@Deprecated

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/calcite/rules/FlinkAggregateExpandDistinctAggregatesRule.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/calcite/rules/FlinkAggregateExpandDistinctAggregatesRule.java
@@ -114,7 +114,10 @@ public final class FlinkAggregateExpandDistinctAggregatesRule extends RelOptRule
 		this.useGroupingSets = useGroupingSets;
 	}
 
-	@Deprecated // to be removed before 2.0
+	/**
+	 * @deprecated to be removed before 2.0
+	 */
+	@Deprecated
 	public FlinkAggregateExpandDistinctAggregatesRule(
 			Class<? extends LogicalAggregate> clazz,
 			boolean useGroupingSets,
@@ -122,7 +125,10 @@ public final class FlinkAggregateExpandDistinctAggregatesRule extends RelOptRule
 		this(clazz, useGroupingSets, RelBuilder.proto(Contexts.of(joinFactory)));
 	}
 
-	@Deprecated // to be removed before 2.0
+	/**
+	 * @deprecated to be removed before 2.0
+	 */
+	@Deprecated
 	public FlinkAggregateExpandDistinctAggregatesRule(
 			Class<? extends LogicalAggregate> clazz,
 			RelFactories.JoinFactory joinFactory) {

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/calcite/rules/FlinkAggregateJoinTransposeRule.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/calcite/rules/FlinkAggregateJoinTransposeRule.java
@@ -78,22 +78,34 @@ public class FlinkAggregateJoinTransposeRule extends RelOptRule {
 		this.allowFunctions = allowFunctions;
 	}
 
-	@Deprecated // to be removed before 2.0
+	/**
+	 * @deprecated to be removed before 2.0
+	 */
+	@Deprecated
 	public FlinkAggregateJoinTransposeRule(Class<? extends Aggregate> aggregateClass, RelFactories.AggregateFactory aggregateFactory, Class<? extends Join> joinClass, RelFactories.JoinFactory joinFactory) {
 		this(aggregateClass, joinClass, RelBuilder.proto(aggregateFactory, joinFactory), false);
 	}
 
-	@Deprecated // to be removed before 2.0
+	/**
+	 * @deprecated to be removed before 2.0
+	 */
+	@Deprecated
 	public FlinkAggregateJoinTransposeRule(Class<? extends Aggregate> aggregateClass, RelFactories.AggregateFactory aggregateFactory, Class<? extends Join> joinClass, RelFactories.JoinFactory joinFactory, boolean allowFunctions) {
 		this(aggregateClass, joinClass, RelBuilder.proto(aggregateFactory, joinFactory), allowFunctions);
 	}
 
-	@Deprecated // to be removed before 2.0
+	/**
+	 * @deprecated to be removed before 2.0
+	 */
+	@Deprecated
 	public FlinkAggregateJoinTransposeRule(Class<? extends Aggregate> aggregateClass, RelFactories.AggregateFactory aggregateFactory, Class<? extends Join> joinClass, RelFactories.JoinFactory joinFactory, RelFactories.ProjectFactory projectFactory) {
 		this(aggregateClass, joinClass, RelBuilder.proto(aggregateFactory, joinFactory, projectFactory), false);
 	}
 
-	@Deprecated // to be removed before 2.0
+	/**
+	 * @deprecated to be removed before 2.0
+	 */
+	@Deprecated
 	public FlinkAggregateJoinTransposeRule(Class<? extends Aggregate> aggregateClass, RelFactories.AggregateFactory aggregateFactory, Class<? extends Join> joinClass, RelFactories.JoinFactory joinFactory, RelFactories.ProjectFactory projectFactory, boolean allowFunctions) {
 		this(aggregateClass, joinClass, RelBuilder.proto(aggregateFactory, joinFactory, projectFactory), allowFunctions);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/migration/MigrationNamespaceSerializerProxy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/MigrationNamespaceSerializerProxy.java
@@ -30,6 +30,8 @@ import java.io.Serializable;
  * Flink 1.1 savepoint (which did not include the namespace serializer) to Flink 1.2 (which always must include a
  * (non-null) namespace serializer. This is then replaced as soon as the user is re-registering her state again for
  * the first run under Flink 1.2 and provides again the real namespace serializer.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/MigrationNamespaceSerializerProxy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/MigrationNamespaceSerializerProxy.java
@@ -31,7 +31,7 @@ import java.io.Serializable;
  * (non-null) namespace serializer. This is then replaced as soon as the user is re-registering her state again for
  * the first run under Flink 1.2 and provides again the real namespace serializer.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/ListStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/ListStateDescriptor.java
@@ -29,7 +29,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
  * The old version of the {@link org.apache.flink.api.common.state.ListStateDescriptor}, retained for
  * serialization backwards compatibility.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Internal
 @Deprecated

--- a/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/ListStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/api/common/state/ListStateDescriptor.java
@@ -28,6 +28,8 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 /**
  * The old version of the {@link org.apache.flink.api.common.state.ListStateDescriptor}, retained for
  * serialization backwards compatibility.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Internal
 @Deprecated

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/checkpoint/KeyGroupState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/checkpoint/KeyGroupState.java
@@ -31,7 +31,7 @@ import java.io.Serializable;
  * The key group state handle is kept in serialized form because it can contain user code classes
  * which might not be available on the JobManager.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/checkpoint/KeyGroupState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/checkpoint/KeyGroupState.java
@@ -30,6 +30,8 @@ import java.io.Serializable;
  *
  * The key group state handle is kept in serialized form because it can contain user code classes
  * which might not be available on the JobManager.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/checkpoint/SubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/checkpoint/SubtaskState.java
@@ -25,6 +25,9 @@ import java.io.Serializable;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
+/**
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ */
 @Deprecated
 @SuppressWarnings("deprecation")
 public class SubtaskState implements Serializable {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/checkpoint/SubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/checkpoint/SubtaskState.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/checkpoint/TaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/checkpoint/TaskState.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/checkpoint/TaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/checkpoint/TaskState.java
@@ -29,6 +29,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+/**
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ */
 @Deprecated
 @SuppressWarnings("deprecation")
 public class TaskState implements Serializable {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/AbstractCloseableHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/AbstractCloseableHandle.java
@@ -28,6 +28,8 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
  * 
  * Offers to register a stream (or other closable object) that close calls are delegated to if
  * the handle is closed or was already closed.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/AbstractCloseableHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/AbstractCloseableHandle.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
  * Offers to register a stream (or other closable object) that close calls are delegated to if
  * the handle is closed or was already closed.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/AbstractStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/AbstractStateBackend.java
@@ -27,7 +27,7 @@ import java.io.Serializable;
 /**
  * A state backend defines how state is stored and snapshotted during checkpoints.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/AbstractStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/AbstractStateBackend.java
@@ -26,6 +26,8 @@ import java.io.Serializable;
 
 /**
  * A state backend defines how state is stored and snapshotted during checkpoints.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/KvStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/KvStateSnapshot.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 
 /**
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/KvStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/KvStateSnapshot.java
@@ -21,6 +21,9 @@ package org.apache.flink.migration.runtime.state;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 
+/**
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ */
 @Deprecated
 @SuppressWarnings("deprecation")
 public interface KvStateSnapshot<K, N, S extends State, SD extends StateDescriptor<S, ?>>

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/StateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/StateHandle.java
@@ -23,7 +23,7 @@ package org.apache.flink.migration.runtime.state;
  * A StateHandle implementation can for example include the state itself in cases where the state 
  * is lightweight or fetching it lazily from some external storage when the state is too large.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/StateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/StateHandle.java
@@ -22,6 +22,8 @@ package org.apache.flink.migration.runtime.state;
  * StateHandle is a general handle interface meant to abstract operator state fetching. 
  * A StateHandle implementation can for example include the state itself in cases where the state 
  * is lightweight or fetching it lazily from some external storage when the state is too large.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/StateObject.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/StateObject.java
@@ -32,6 +32,8 @@ package org.apache.flink.migration.runtime.state;
  *         stop the current access or recovery to the state. Called for example when an operation is
  *         canceled during recovery.</li>
  * </ul>
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/StateObject.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/StateObject.java
@@ -33,7 +33,7 @@ package org.apache.flink.migration.runtime.state;
  *         canceled during recovery.</li>
  * </ul>
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/StreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/StreamStateHandle.java
@@ -24,7 +24,7 @@ import java.io.Serializable;
 /**
  * A state handle that produces an input stream when resolved.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/StreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/StreamStateHandle.java
@@ -23,6 +23,8 @@ import java.io.Serializable;
 
 /**
  * A state handle that produces an input stream when resolved.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/AbstractFileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/AbstractFileStateHandle.java
@@ -31,7 +31,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Base class for state that is stored in a file.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/AbstractFileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/AbstractFileStateHandle.java
@@ -30,6 +30,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Base class for state that is stored in a file.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/AbstractFsStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/AbstractFsStateSnapshot.java
@@ -40,6 +40,8 @@ import java.io.IOException;
  * @param <K> The type of the key in the snapshot state.
  * @param <N> The type of the namespace in the snapshot state.
  * @param <SV> The type of the state value.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/AbstractFsStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/AbstractFsStateSnapshot.java
@@ -41,7 +41,7 @@ import java.io.IOException;
  * @param <N> The type of the namespace in the snapshot state.
  * @param <SV> The type of the state value.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FileSerializableStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FileSerializableStateHandle.java
@@ -32,7 +32,7 @@ import java.io.Serializable;
  * 
  * @param <T> The type of state pointed to by the state handle.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FileSerializableStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FileSerializableStateHandle.java
@@ -31,6 +31,8 @@ import java.io.Serializable;
  * A state handle that points to state stored in a file via Java Serialization.
  * 
  * @param <T> The type of state pointed to by the state handle.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FileStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FileStreamStateHandle.java
@@ -29,7 +29,7 @@ import java.io.Serializable;
 /**
  * A state handle that points to state in a file system, accessible as an input stream.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FileStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FileStreamStateHandle.java
@@ -28,6 +28,8 @@ import java.io.Serializable;
 
 /**
  * A state handle that points to state in a file system, accessible as an input stream.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsFoldingState.java
@@ -23,6 +23,9 @@ import org.apache.flink.api.common.state.FoldingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
 
+/**
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ */
 @Deprecated
 @SuppressWarnings("deprecation")
 public class FsFoldingState<K, N, T, ACC> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsFoldingState.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
 
 /**
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsListState.java
@@ -25,6 +25,9 @@ import org.apache.flink.core.fs.Path;
 
 import java.util.ArrayList;
 
+/**
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ */
 @Deprecated
 @SuppressWarnings("deprecation")
 public class FsListState<K, N, V> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsListState.java
@@ -26,7 +26,7 @@ import org.apache.flink.core.fs.Path;
 import java.util.ArrayList;
 
 /**
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsReducingState.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
 
 /**
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsReducingState.java
@@ -23,6 +23,9 @@ import org.apache.flink.api.common.state.ReducingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
 
+/**
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ */
 @Deprecated
 @SuppressWarnings("deprecation")
 public class FsReducingState<K, N, V> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsStateBackend.java
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsStateBackend.java
@@ -23,6 +23,9 @@ import org.apache.flink.migration.runtime.state.AbstractStateBackend;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ */
 @Deprecated
 @SuppressWarnings("deprecation")
 public class FsStateBackend extends AbstractStateBackend {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsValueState.java
@@ -23,6 +23,9 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
 
+/**
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ */
 @Deprecated
 @SuppressWarnings("deprecation")
 public class FsValueState<K, N, V> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/filesystem/FsValueState.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.Path;
 
 /**
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/AbstractMemStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/AbstractMemStateSnapshot.java
@@ -29,6 +29,9 @@ import org.apache.flink.runtime.util.DataInputDeserializer;
 
 import java.io.IOException;
 
+/**
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ */
 @Deprecated
 @SuppressWarnings("deprecation")
 public abstract class AbstractMemStateSnapshot<K, N, SV, S extends State, SD extends StateDescriptor<S, ?>> 

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/AbstractMemStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/AbstractMemStateSnapshot.java
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.util.DataInputDeserializer;
 import java.io.IOException;
 
 /**
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/AbstractMigrationRestoreStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/AbstractMigrationRestoreStrategy.java
@@ -38,6 +38,8 @@ import java.io.IOException;
  * @param <K> type of key.
  * @param <N> type of namespace.
  * @param <S> type of state.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Deprecated
 public abstract class AbstractMigrationRestoreStrategy<K, N, S> implements MigrationRestoreSnapshot<K, N, S> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/AbstractMigrationRestoreStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/AbstractMigrationRestoreStrategy.java
@@ -39,7 +39,7 @@ import java.io.IOException;
  * @param <N> type of namespace.
  * @param <S> type of state.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 public abstract class AbstractMigrationRestoreStrategy<K, N, S> implements MigrationRestoreSnapshot<K, N, S> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/ByteStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/ByteStreamStateHandle.java
@@ -27,6 +27,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 
+/**
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ */
 @Deprecated
 @SuppressWarnings("deprecation")
 public final class ByteStreamStateHandle extends AbstractCloseableHandle implements StreamStateHandle {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/ByteStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/ByteStreamStateHandle.java
@@ -28,7 +28,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 
 /**
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemFoldingState.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.state.FoldingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 /**
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemFoldingState.java
@@ -22,6 +22,9 @@ import org.apache.flink.api.common.state.FoldingState;
 import org.apache.flink.api.common.state.FoldingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
+/**
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ */
 @Deprecated
 @SuppressWarnings("deprecation")
 public class MemFoldingState<K, N, T, ACC> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemListState.java
@@ -24,6 +24,9 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import java.util.ArrayList;
 
+/**
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ */
 @Deprecated
 @SuppressWarnings("deprecation")
 public class MemListState<K, N, V> {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemListState.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import java.util.ArrayList;
 
 /**
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemReducingState.java
@@ -30,7 +30,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
  * @param <N> The type of the namespace.
  * @param <V> The type of the values in the list state.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemReducingState.java
@@ -29,6 +29,8 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
  * @param <K> The type of the key.
  * @param <N> The type of the namespace.
  * @param <V> The type of the values in the list state.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemValueState.java
@@ -29,7 +29,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
  * @param <N> The type of the namespace.
  * @param <V> The type of the value.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MemValueState.java
@@ -28,6 +28,8 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
  * @param <K> The type of the key.
  * @param <N> The type of the namespace.
  * @param <V> The type of the value.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Deprecated
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MigrationRestoreSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MigrationRestoreSnapshot.java
@@ -25,6 +25,9 @@ import org.apache.flink.util.Migration;
 
 import java.io.IOException;
 
+/**
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ */
 @Deprecated
 @Internal
 public interface MigrationRestoreSnapshot<K, N, S> extends Migration {

--- a/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MigrationRestoreSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/runtime/state/memory/MigrationRestoreSnapshot.java
@@ -26,7 +26,7 @@ import org.apache.flink.util.Migration;
 import java.io.IOException;
 
 /**
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @Internal

--- a/flink-runtime/src/main/java/org/apache/flink/migration/state/MigrationKeyGroupStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/state/MigrationKeyGroupStateHandle.java
@@ -27,6 +27,8 @@ import org.apache.flink.util.Migration;
 /**
  * This class is just a KeyGroupsStateHandle that is tagged as migration, to figure out which restore logic to apply,
  * e.g. when restoring backend data from a state handle.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Internal
 @Deprecated

--- a/flink-runtime/src/main/java/org/apache/flink/migration/state/MigrationKeyGroupStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/state/MigrationKeyGroupStateHandle.java
@@ -28,7 +28,7 @@ import org.apache.flink.util.Migration;
  * This class is just a KeyGroupsStateHandle that is tagged as migration, to figure out which restore logic to apply,
  * e.g. when restoring backend data from a state handle.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Internal
 @Deprecated

--- a/flink-runtime/src/main/java/org/apache/flink/migration/state/MigrationStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/state/MigrationStreamStateHandle.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * This class is just a StreamStateHandle that is tagged as migration, to figure out which restore logic to apply, e.g.
  * when restoring backend data from a state handle.
  *
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Internal
 @Deprecated

--- a/flink-runtime/src/main/java/org/apache/flink/migration/state/MigrationStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/state/MigrationStreamStateHandle.java
@@ -29,6 +29,8 @@ import java.io.IOException;
 /**
  * This class is just a StreamStateHandle that is tagged as migration, to figure out which restore logic to apply, e.g.
  * when restoring backend data from a state handle.
+ *
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
  */
 @Internal
 @Deprecated

--- a/flink-runtime/src/main/java/org/apache/flink/migration/streaming/runtime/tasks/StreamTaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/streaming/runtime/tasks/StreamTaskState.java
@@ -27,6 +27,9 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 
+/**
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ */
 @Deprecated
 @Internal
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/streaming/runtime/tasks/StreamTaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/streaming/runtime/tasks/StreamTaskState.java
@@ -28,7 +28,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 
 /**
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @Internal

--- a/flink-runtime/src/main/java/org/apache/flink/migration/streaming/runtime/tasks/StreamTaskStateList.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/streaming/runtime/tasks/StreamTaskStateList.java
@@ -25,6 +25,9 @@ import org.apache.flink.migration.runtime.state.StateHandle;
 import java.io.IOException;
 import java.util.HashMap;
 
+/**
+ * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ */
 @Deprecated
 @Internal
 @SuppressWarnings("deprecation")

--- a/flink-runtime/src/main/java/org/apache/flink/migration/streaming/runtime/tasks/StreamTaskStateList.java
+++ b/flink-runtime/src/main/java/org/apache/flink/migration/streaming/runtime/tasks/StreamTaskStateList.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.util.HashMap;
 
 /**
- * @deprecated Internal class for savepoint backwards compatability. Don't use for other purposes.
+ * @deprecated Internal class for savepoint backwards compatibility. Don't use for other purposes.
  */
 @Deprecated
 @Internal

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskState.java
@@ -39,6 +39,9 @@ public class SubtaskState implements StateObject {
 
 	/**
 	 * Legacy (non-repartitionable) operator state.
+	 *
+	 * @deprecated Non-repartitionable operator state that has been deprecated.
+	 * Can be removed when we remove the APIs for non-repartitionable operator state.
 	 */
 	@Deprecated
 	private final ChainedStateHandle<StreamStateHandle> legacyOperatorState;
@@ -101,6 +104,10 @@ public class SubtaskState implements StateObject {
 
 	// --------------------------------------------------------------------------------------------
 
+	/**
+	 * @deprecated Non-repartitionable operator state that has been deprecated.
+	 * Can be removed when we remove the APIs for non-repartitionable operator state.
+	 */
 	@Deprecated
 	public ChainedStateHandle<StreamStateHandle> getLegacyOperatorState() {
 		return legacyOperatorState;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/StandaloneLeaderRetrievalService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/StandaloneLeaderRetrievalService.java
@@ -52,6 +52,7 @@ public class StandaloneLeaderRetrievalService implements LeaderRetrievalService 
 	 * The leaderId will be null.
 	 *
 	 * @param leaderAddress The leader's pre-configured address
+	 * @deprecated Use {@link #StandaloneLeaderRetrievalService(String, UUID)} instead
 	 */
 	@Deprecated
 	public StandaloneLeaderRetrievalService(String leaderAddress) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/InMemoryPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/InMemoryPartition.java
@@ -248,6 +248,8 @@ public class InMemoryPartition<T> {
 	 * @param pointer pointer to start of record
 	 * @param record record to overwrite old one with
 	 * @throws IOException
+	 * @deprecated Don't use this, overwrites record and causes inconsistency or data loss for
+	 * overwriting everything but records of the exact same size
 	 */
 	@Deprecated
 	public void overwriteRecordAt(long pointer, T record) throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateHandles.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateHandles.java
@@ -35,7 +35,12 @@ public class TaskStateHandles implements Serializable {
 
 	private static final long serialVersionUID = 267686583583579359L;
 
-	/** State handle with the (non-partitionable) legacy operator state*/
+	/**
+	 * State handle with the (non-partitionable) legacy operator state
+	 *
+	 * @deprecated Non-repartitionable operator state that has been deprecated.
+	 * Can be removed when we remove the APIs for non-repartitionable operator state.
+	 */
 	@Deprecated
 	private final ChainedStateHandle<StreamStateHandle> legacyOperatorState;
 
@@ -77,6 +82,10 @@ public class TaskStateHandles implements Serializable {
 		this.rawOperatorState = rawOperatorState;
 	}
 
+	/**
+	 * @deprecated Non-repartitionable operator state that has been deprecated.
+	 * Can be removed when we remove the APIs for non-repartitionable operator state.
+	 */
 	@Deprecated
 	public ChainedStateHandle<StreamStateHandle> getLegacyOperatorState() {
 		return legacyOperatorState;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -447,7 +447,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	}
 
 	/**
-	 * @deprecated Used for backwards compatability with previous savepoint versions.
+	 * @deprecated Used for backwards compatibility with previous savepoint versions.
 	 */
 	@SuppressWarnings({"unchecked", "rawtypes", "DeprecatedIsStillUsed"})
 	@Deprecated

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -446,6 +446,9 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		return "HeapKeyedStateBackend";
 	}
 
+	/**
+	 * @deprecated Used for backwards compatability with previous savepoint versions.
+	 */
 	@SuppressWarnings({"unchecked", "rawtypes", "DeprecatedIsStillUsed"})
 	@Deprecated
 	private void restoreOldSavepointKeyedState(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedRestoring.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedRestoring.java
@@ -25,6 +25,8 @@ import java.io.Serializable;
 /**
  * This deprecated interface contains the methods for restoring from the legacy checkpointing mechanism of state.
  * @param <T> type of the restored state.
+ *
+ * @deprecated Please use {@link CheckpointedFunction} or {@link ListCheckpointed} after restoring your legacy state.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -349,6 +349,9 @@ public abstract class StreamExecutionEnvironment {
 	 *            The checkpointing mode, selecting between "exactly once" and "at least once" guaranteed.
 	 * @param force
 	 *            If true checkpointing will be enabled for iterative jobs as well.
+	 *
+	 * @deprecated Use {@link #enableCheckpointing(long, CheckpointingMode)} instead.
+	 * Forcing checkpoints will be removed in the future.
 	 */
 	@Deprecated
 	@SuppressWarnings("deprecation")
@@ -396,6 +399,8 @@ public abstract class StreamExecutionEnvironment {
 
 	/**
 	 * Returns whether checkpointing is force-enabled.
+	 *
+	 * @deprecated Forcing checkpoints will be removed in future version.
 	 */
 	@Deprecated
 	@SuppressWarnings("deprecation")

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/AscendingTimestampExtractor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/AscendingTimestampExtractor.java
@@ -29,6 +29,8 @@ import org.apache.flink.annotation.PublicEvolving;
  * {@link org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor}.
  *
  * @param <T> The type of the elements that this function can extract timestamps from
+ *
+ * @deprecated Extend {@link org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor} instead.
  */
 @PublicEvolving
 @Deprecated

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FileMonitoringFunction.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.api.functions.source;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
@@ -31,6 +32,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * @deprecated Internal class deprecated in favour of {@link ContinuousFileMonitoringFunction}.
+ */
+@Internal
 @Deprecated
 public class FileMonitoringFunction implements SourceFunction<Tuple3<String, Long, Long>> {
 	private static final long serialVersionUID = 1L;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FileReadFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FileReadFunction.java
@@ -21,6 +21,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URI;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.core.fs.FSDataInputStream;
@@ -28,6 +29,10 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.Collector;
 
+/**
+ * @deprecated Internal class deprecated in favour of {@link ContinuousFileMonitoringFunction}.
+ */
+@Internal
 @Deprecated
 public class FileReadFunction implements FlatMapFunction<Tuple3<String, Long, Long>, String> {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -249,6 +249,10 @@ public abstract class AbstractStreamOperator<OUT>
 		}
 	}
 
+	/**
+	 * @deprecated Non-repartitionable operator state that has been deprecated.
+	 * Can be removed when we remove the APIs for non-repartitionable operator state.
+	 */
 	@Deprecated
 	private void restoreStreamCheckpointed(OperatorStateHandles stateHandles) throws Exception {
 		StreamStateHandle state = stateHandles.getLegacyOperatorState();
@@ -436,6 +440,10 @@ public abstract class AbstractStreamOperator<OUT>
 		}
 	}
 
+	/**
+	 * @deprecated Non-repartitionable operator state that has been deprecated.
+	 * Can be removed when we remove the APIs for non-repartitionable operator state.
+	 */
 	@SuppressWarnings("deprecation")
 	@Deprecated
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/CheckpointedRestoringOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/CheckpointedRestoringOperator.java
@@ -19,12 +19,16 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.streaming.api.checkpoint.Checkpointed;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 
 /**
  * Interface for {@link StreamOperator StreamOperators} that can restore from a Flink 1.1
  * legacy snapshot that was done using the {@link StreamCheckpointedOperator} interface.
+ *
+ * @deprecated {@link Checkpointed} has been deprecated as well. This class can be
+ * removed when we remove that interface.
  */
 @Deprecated
 public interface CheckpointedRestoringOperator {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamCheckpointedOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamCheckpointedOperator.java
@@ -21,7 +21,7 @@ package org.apache.flink.streaming.api.operators;
 import org.apache.flink.core.fs.FSDataOutputStream;
 
 /**
- * This interface is deprecated without replacement.
+ * @deprecated This interface is deprecated without replacement.
  * All operators are now checkpointed.
  */
 @Deprecated

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/Trigger.java
@@ -201,6 +201,7 @@ public abstract class Trigger<T, W extends Window> implements Serializable {
 		 * @return The partitioned state object.
 		 * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
 		 *                                       function (function is not part os a KeyedStream).
+		 * @deprecated Use {@link #getPartitionedState(StateDescriptor)}.
 		 */
 		@Deprecated
 		<S extends Serializable> ValueState<S> getKeyValueState(String name, Class<S> stateType, S defaultState);
@@ -221,6 +222,7 @@ public abstract class Trigger<T, W extends Window> implements Serializable {
 		 * @return The partitioned state object.
 		 * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
 		 *                                       function (function is not part os a KeyedStream).
+		 * @deprecated Use {@link #getPartitionedState(StateDescriptor)}.
 		 */
 		@Deprecated
 		<S extends Serializable> ValueState<S> getKeyValueState(String name, TypeInformation<S> stateType, S defaultState);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AbstractAlignedProcessingTimeWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AbstractAlignedProcessingTimeWindowOperator.java
@@ -38,6 +38,10 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * @deprecated Deprecated in favour of the generic {@link WindowOperator}. This was an
+ * optimized implementation used for aligned windows.
+ */
 @Internal
 @Deprecated
 public abstract class AbstractAlignedProcessingTimeWindowOperator<KEY, IN, OUT, STATE, F extends Function> 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AccumulatingProcessingTimeWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AccumulatingProcessingTimeWindowOperator.java
@@ -29,6 +29,10 @@ import org.apache.flink.streaming.runtime.operators.windowing.functions.Internal
 
 import java.util.ArrayList;
 
+/**
+ * @deprecated Deprecated in favour of the generic {@link WindowOperator}. This was an
+ * optimized implementation used for aligned windows.
+ */
 @Internal
 @Deprecated
 public class AccumulatingProcessingTimeWindowOperator<KEY, IN, OUT>

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AggregatingProcessingTimeWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AggregatingProcessingTimeWindowOperator.java
@@ -24,6 +24,10 @@ import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 
+/**
+ * @deprecated Deprecated in favour of the generic {@link WindowOperator}. This was an
+ * optimized implementation used for aligned windows.
+ */
 @Internal
 @Deprecated
 public class AggregatingProcessingTimeWindowOperator<KEY, IN> 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -105,6 +105,12 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 	private final Option SLOTS;
 	private final Option DETACHED;
 	private final Option ZOOKEEPER_NAMESPACE;
+
+	/**
+	 * @deprecated Streaming mode has been deprecated without replacement. Set the
+	 * {@link ConfigConstants#TASK_MANAGER_MEMORY_PRE_ALLOCATE_KEY} configuration
+	 * key to true to get the previous batch mode behaviour.
+	 */
 	@Deprecated
 	private final Option STREAMING;
 	private final Option NAME;

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -124,6 +124,8 @@ under the License.
 
 		<module name="FileContentsHolder"/>
 
+		<module name="MissingDeprecated"/>
+
 	<!--	<module name="ConstantName" />
 		<module name="LocalFinalVariableName" />
 		<module name="LocalVariableName" />


### PR DESCRIPTION
Adds the MissingDeprecation check to our set of checkstyle rules.

Requires every `@Deprecated` annotation to have a `@deprecated` JavaDoc, forcing us to have both or none. This also applies for internal classes.

Most of the changes were cosmetic (e.g. we had some comments but were not using the `@deprecated` JavaDoc).