### PR TITLE
[FLINK-6132]Remove redundant code in CliFrontend.java

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -1079,7 +1079,7 @@ public class CliFrontend {
 		// do action
 		switch (action) {
 			case ACTION_RUN:
-				return CliFrontend.this.run(params);
+				return run(params);
 			case ACTION_LIST:
 				return list(params);
 			case ACTION_INFO:


### PR DESCRIPTION


Look at the switch case block in method parseParameters of CliFrontend.java.

```
// do action
switch (action) {
case ACTION_RUN:
return CliFrontend.this.run(params);
case ACTION_LIST:
return list(params);
case ACTION_INFO:
return info(params);
case ACTION_CANCEL:
return cancel(params);
case ACTION_STOP:
return stop(params);
case ACTION_SAVEPOINT:
return savepoint(params);
```

It's better to change the first case return clause
from：
`return CliFrontend.this.run(params);`
to：
`return run(params);`