### PR TITLE
[FLINK-6134] Set UUID(0L, 0L) as default leader session id

### DIFF
--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameter
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 import org.apache.flink.runtime.clusterframework.messages.*;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
@@ -208,7 +209,7 @@ public class MesosFlinkResourceManagerTest extends TestLogger {
 					TestingMesosFlinkResourceManager.class,
 					config, mesosConfig, workerStore, retrievalService, tmParams, containerSpecification, artifactResolver, LOG));
 			resourceManagerInstance = resourceManagerRef.underlyingActor();
-			resourceManager = new AkkaActorGateway(resourceManagerRef, null);
+			resourceManager = new AkkaActorGateway(resourceManagerRef, HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 			verify(schedulerDriver).start();
 			resourceManagerInstance.connectionMonitor.expectMsgClass(ConnectionMonitor.Start.class);

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerITCase.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.client.JobClient;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -138,7 +139,7 @@ public class BackPressureStatsTrackerITCase extends TestLogger {
 					@Override
 					protected void run() {
 						try {
-							ActorGateway testActor = new AkkaActorGateway(getTestActor(), null);
+							ActorGateway testActor = new AkkaActorGateway(getTestActor(), HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 							// Submit the job and wait until it is running
 							JobClient.submitJobDetached(

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorITCase.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.client.JobClient;
 import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -110,7 +111,7 @@ public class StackTraceSampleCoordinatorITCase extends TestLogger {
 					@Override
 					protected void run() {
 						try {
-							ActorGateway testActor = new AkkaActorGateway(getTestActor(), null);
+							ActorGateway testActor = new AkkaActorGateway(getTestActor(), HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 							int maxAttempts = 10;
 							int sleepTime = 100;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActor.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.client;
 
 import akka.actor.ActorRef;
+import akka.actor.Cancellable;
 import akka.actor.PoisonPill;
 import akka.actor.Status;
 import akka.actor.Terminated;
@@ -36,6 +37,7 @@ import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.util.Preconditions;
 import scala.concurrent.duration.FiniteDuration;
 
+import java.util.Objects;
 import java.util.UUID;
 
 
@@ -66,6 +68,10 @@ public abstract class JobClientActor extends FlinkUntypedActor implements Leader
 	/** The client which the actor is responsible for */
 	protected ActorRef client;
 
+	private Cancellable connectionTimeout;
+
+	private UUID connectionTimeoutId;
+
 	public JobClientActor(
 			LeaderRetrievalService leaderRetrievalService,
 			FiniteDuration timeout,
@@ -73,6 +79,11 @@ public abstract class JobClientActor extends FlinkUntypedActor implements Leader
 		this.leaderRetrievalService = Preconditions.checkNotNull(leaderRetrievalService);
 		this.timeout = Preconditions.checkNotNull(timeout);
 		this.sysoutUpdates = sysoutUpdates;
+		this.jobManager = ActorRef.noSender();
+		this.leaderSessionID = null;
+
+		connectionTimeout = null;
+		connectionTimeoutId = null;
 	}
 
 	@Override
@@ -146,6 +157,9 @@ public abstract class JobClientActor extends FlinkUntypedActor implements Leader
 							getSelf().tell(decorateMessage(new JobManagerActorRef(result)), ActorRef.noSender());
 						}
 					}, getContext().dispatcher());
+			} else if (isClientConnected() && connectionTimeoutId == null) {
+				// msg.address == null means that the leader has lost its leadership
+				registerConnectionTimeout();
 			}
 		} else if (message instanceof JobManagerActorRef) {
 			// Resolved JobManager ActorRef
@@ -184,36 +198,35 @@ public abstract class JobClientActor extends FlinkUntypedActor implements Leader
 					jobManager.path());
 				disconnectFromJobManager();
 
-				// we only issue a connection timeout if we have submitted a job before
-				// otherwise, we might have some more time to find another job manager
-				// Important: The ConnectionTimeout message is filtered out in case that we are
-				// notified about a new leader by setting the new leader session ID, because
-				// ConnectionTimeout extends RequiresLeaderSessionID
 				if (isClientConnected()) {
-					getContext().system().scheduler().scheduleOnce(
-						timeout,
-						getSelf(),
-						decorateMessage(JobClientMessages.getConnectionTimeout()),
-						getContext().dispatcher(),
-						ActorRef.noSender());
+					if (connectionTimeoutId == null) {
+						// only register a connection timeout if we haven't done this before
+						registerConnectionTimeout();
+					}
 				}
 			} else {
 				LOG.warn("Received 'Terminated' for unknown actor " + target);
 			}
 		}
-		else if (JobClientMessages.getConnectionTimeout().equals(message)) {
-			// check if we haven't found a job manager yet
-			if (!isJobManagerConnected()) {
-				final JobClientActorConnectionTimeoutException errorMessage =
-					new JobClientActorConnectionTimeoutException("Lost connection to the JobManager.");
-				final Object replyMessage = decorateMessage(new Status.Failure(errorMessage));
-				if (isClientConnected()) {
-					client.tell(
-						replyMessage,
-						getSelf());
+		else if (message instanceof JobClientMessages.ConnectionTimeout) {
+			JobClientMessages.ConnectionTimeout timeoutMessage = (JobClientMessages.ConnectionTimeout) message;
+
+			if (Objects.equals(connectionTimeoutId, timeoutMessage.id())) {
+				// check if we haven't found a job manager yet
+				if (!isJobManagerConnected()) {
+					final JobClientActorConnectionTimeoutException errorMessage =
+						new JobClientActorConnectionTimeoutException("Lost connection to the JobManager.");
+					final Object replyMessage = decorateMessage(new Status.Failure(errorMessage));
+					if (isClientConnected()) {
+						client.tell(
+							replyMessage,
+							getSelf());
+					}
+					// Connection timeout reached, let's terminate
+					terminate();
 				}
-				// Connection timeout reached, let's terminate
-				terminate();
+			} else {
+				LOG.debug("Received outdated connection timeout.");
 			}
 		}
 
@@ -225,13 +238,10 @@ public abstract class JobClientActor extends FlinkUntypedActor implements Leader
 				message);
 			// We want to submit/attach to a job, but we haven't found a job manager yet.
 			// Let's give him another chance to find a job manager within the given timeout.
-			getContext().system().scheduler().scheduleOnce(
-				timeout,
-				getSelf(),
-				decorateMessage(JobClientMessages.getConnectionTimeout()),
-				getContext().dispatcher(),
-				ActorRef.noSender()
-			);
+			if (connectionTimeoutId == null) {
+				// only register the connection timeout once
+				registerConnectionTimeout();
+			}
 			handleCustomMessage(message);
 		}
 		else {
@@ -304,6 +314,8 @@ public abstract class JobClientActor extends FlinkUntypedActor implements Leader
 			getContext().unwatch(jobManager);
 			jobManager = ActorRef.noSender();
 		}
+
+		leaderSessionID = null;
 	}
 
 	private void connectToJobManager(ActorRef jobManager) {
@@ -316,6 +328,8 @@ public abstract class JobClientActor extends FlinkUntypedActor implements Leader
 
 		this.jobManager = jobManager;
 		getContext().watch(jobManager);
+
+		unregisterConnectionTimeout();
 	}
 
 	protected void terminate() {
@@ -331,6 +345,30 @@ public abstract class JobClientActor extends FlinkUntypedActor implements Leader
 
 	protected boolean isClientConnected() {
 		return client != ActorRef.noSender();
+	}
+
+	private void registerConnectionTimeout() {
+		if (connectionTimeout != null) {
+			connectionTimeout.cancel();
+		}
+
+		connectionTimeoutId = UUID.randomUUID();
+
+		connectionTimeout = getContext().system().scheduler().scheduleOnce(
+			timeout,
+			getSelf(),
+			decorateMessage(new JobClientMessages.ConnectionTimeout(connectionTimeoutId)),
+			getContext().dispatcher(),
+			ActorRef.noSender()
+		);
+	}
+
+	private void unregisterConnectionTimeout() {
+		if (connectionTimeout != null) {
+			connectionTimeout.cancel();
+			connectionTimeout = null;
+			connectionTimeoutId = null;
+		}
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/FlinkResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/FlinkResourceManager.java
@@ -410,9 +410,9 @@ public abstract class FlinkResourceManager<WorkerType extends ResourceIDRetrieva
 		// disconnect from the current leader (no-op if no leader yet)
 		jobManagerLostLeadership();
 
-		// a null leader address means that only a leader disconnect
+		// a null leader session id means that only a leader disconnect
 		// happened, without a new leader yet
-		if (leaderAddress != null) {
+		if (leaderSessionID != null && leaderAddress != null) {
 			// the leaderSessionID implicitly filters out success and failure messages
 			// that come after leadership changed again
 			this.leaderSessionID = leaderSessionID;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/AkkaActorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/AkkaActorGateway.java
@@ -24,6 +24,7 @@ import akka.util.Timeout;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.messages.LeaderSessionMessageDecorator;
 import org.apache.flink.runtime.messages.MessageDecorator;
+import org.apache.flink.util.Preconditions;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
@@ -48,8 +49,8 @@ public class AkkaActorGateway implements ActorGateway, Serializable {
 	private final MessageDecorator decorator;
 
 	public AkkaActorGateway(ActorRef actor, UUID leaderSessionID) {
-		this.actor = actor;
-		this.leaderSessionID = leaderSessionID;
+		this.actor = Preconditions.checkNotNull(actor);
+		this.leaderSessionID = Preconditions.checkNotNull(leaderSessionID);
 		// we want to wrap RequiresLeaderSessionID messages in a LeaderSessionMessage
 		this.decorator = new LeaderSessionMessageDecorator(leaderSessionID);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionService.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.leaderelection;
 
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.util.Preconditions;
 
 import java.util.UUID;
@@ -42,7 +43,7 @@ public class StandaloneLeaderElectionService implements LeaderElectionService {
 		contender = Preconditions.checkNotNull(newContender);
 
 		// directly grant leadership to the given contender
-		contender.grantLeadership(null);
+		contender.grantLeadership(HighAvailabilityServices.DEFAULT_LEADER_ID);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/StandaloneLeaderRetrievalService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/StandaloneLeaderRetrievalService.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.leaderretrieval;
 
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+
 import java.util.UUID;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -54,7 +56,7 @@ public class StandaloneLeaderRetrievalService implements LeaderRetrievalService 
 	@Deprecated
 	public StandaloneLeaderRetrievalService(String leaderAddress) {
 		this.leaderAddress = checkNotNull(leaderAddress);
-		this.leaderId = null;
+		this.leaderId = HighAvailabilityServices.DEFAULT_LEADER_ID;
 	}
 
 	/**

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobClientMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobClientMessages.scala
@@ -66,10 +66,13 @@ object JobClientMessages {
   /** Message which is triggered when the JobClient registration at the JobManager times out */
   case object RegistrationTimeout extends RequiresLeaderSessionID
 
-  /** Message which is triggered when the connection timeout has been reached. */
-  case object ConnectionTimeout extends RequiresLeaderSessionID
+  /**
+    * Message which is triggered when the connection timeout has been reached.
+    *
+    * @param id Timeout id which identifies the concurrent timeouts
+    */
+  case class ConnectionTimeout(id: UUID)
 
   def getSubmissionTimeout(): AnyRef = SubmissionTimeout
   def getRegistrationTimeout(): AnyRef = RegistrationTimeout
-  def getConnectionTimeout(): AnyRef = ConnectionTimeout
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
@@ -45,7 +45,7 @@ object JobManagerMessages {
     * [[RequiresLeaderSessionID]] interface and have to be wrapped in a [[LeaderSessionMessage]],
     * which also contains the current leader session ID.
     *
-    * @param leaderSessionID Current leader session ID or null, if no leader session ID was set
+    * @param leaderSessionID Current leader session ID
     * @param message [[RequiresLeaderSessionID]] message to be wrapped in a [[LeaderSessionMessage]]
     */
   case class LeaderSessionMessage(leaderSessionID: UUID, message: Any)

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1434,7 +1434,10 @@ class TaskManager(
     this.jobManagerAkkaURL = Option(newJobManagerAkkaURL)
     this.leaderSessionID = Option(leaderSessionID)
 
-    triggerTaskManagerRegistration()
+    if (this.leaderSessionID.isDefined) {
+      // only trigger the registration if we have obtained a valid leader id (!= null)
+      triggerTaskManagerRegistration()
+    }
   }
 
   /** Starts the TaskManager's registration process to connect to the JobManager.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorTest.java
@@ -28,6 +28,7 @@ import akka.util.Timeout;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.FlinkUntypedActor;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.leaderelection.TestingLeaderRetrievalService;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -73,7 +74,7 @@ public class JobClientActorTest extends TestLogger {
 	 */
 	@Test(expected=JobClientActorSubmissionTimeoutException.class)
 	public void testSubmissionTimeout() throws Exception {
-		FiniteDuration jobClientActorTimeout = new FiniteDuration(5, TimeUnit.SECONDS);
+		FiniteDuration jobClientActorTimeout = new FiniteDuration(1L, TimeUnit.SECONDS);
 		FiniteDuration timeout = jobClientActorTimeout.$times(2);
 
 		UUID leaderSessionID = UUID.randomUUID();
@@ -112,7 +113,7 @@ public class JobClientActorTest extends TestLogger {
 	 */
 	@Test(expected=JobClientActorRegistrationTimeoutException.class)
 	public void testRegistrationTimeout() throws Exception {
-		FiniteDuration jobClientActorTimeout = new FiniteDuration(5, TimeUnit.SECONDS);
+		FiniteDuration jobClientActorTimeout = new FiniteDuration(1L, TimeUnit.SECONDS);
 		FiniteDuration timeout = jobClientActorTimeout.$times(2);
 
 		UUID leaderSessionID = UUID.randomUUID();
@@ -142,17 +143,19 @@ public class JobClientActorTest extends TestLogger {
 		Await.result(jobExecutionResult, timeout);
 	}
 
-	/** Tests that a {@link org.apache.flink.runtime.client.JobClientActorConnectionTimeoutException}
+	/** Tests that a {@link JobClientActorConnectionTimeoutException}
 	 * is thrown when the JobSubmissionClientActor wants to submit a job but has not connected to a JobManager.
 	 *
 	 * @throws Exception
 	 */
 	@Test(expected=JobClientActorConnectionTimeoutException.class)
 	public void testConnectionTimeoutWithoutJobManagerForSubmission() throws Exception {
-		FiniteDuration jobClientActorTimeout = new FiniteDuration(5, TimeUnit.SECONDS);
+		FiniteDuration jobClientActorTimeout = new FiniteDuration(1L, TimeUnit.SECONDS);
 		FiniteDuration timeout = jobClientActorTimeout.$times(2);
 
-		TestingLeaderRetrievalService testingLeaderRetrievalService = new TestingLeaderRetrievalService();
+		TestingLeaderRetrievalService testingLeaderRetrievalService = new TestingLeaderRetrievalService(
+			"localhost",
+			HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 		Props jobClientActorProps = JobSubmissionClientActor.createActorProps(
 			testingLeaderRetrievalService,
@@ -170,16 +173,18 @@ public class JobClientActorTest extends TestLogger {
 		Await.result(jobExecutionResult, timeout);
 	}
 
-	/** Tests that a {@link org.apache.flink.runtime.client.JobClientActorConnectionTimeoutException}
+	/** Tests that a {@link JobClientActorConnectionTimeoutException}
 	 * is thrown when the JobAttachmentClientActor attach to a job at the JobManager
 	 * but has not connected to a JobManager.
 	 */
 	@Test(expected=JobClientActorConnectionTimeoutException.class)
 	public void testConnectionTimeoutWithoutJobManagerForRegistration() throws Exception {
-		FiniteDuration jobClientActorTimeout = new FiniteDuration(5, TimeUnit.SECONDS);
+		FiniteDuration jobClientActorTimeout = new FiniteDuration(1L, TimeUnit.SECONDS);
 		FiniteDuration timeout = jobClientActorTimeout.$times(2);
 
-		TestingLeaderRetrievalService testingLeaderRetrievalService = new TestingLeaderRetrievalService();
+		TestingLeaderRetrievalService testingLeaderRetrievalService = new TestingLeaderRetrievalService(
+			"localhost",
+			HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 		Props jobClientActorProps = JobAttachmentClientActor.createActorProps(
 			testingLeaderRetrievalService,
@@ -203,7 +208,7 @@ public class JobClientActorTest extends TestLogger {
 	 */
 	@Test(expected=JobClientActorConnectionTimeoutException.class)
 	public void testConnectionTimeoutAfterJobSubmission() throws Exception {
-		FiniteDuration jobClientActorTimeout = new FiniteDuration(5, TimeUnit.SECONDS);
+		FiniteDuration jobClientActorTimeout = new FiniteDuration(1L, TimeUnit.SECONDS);
 		FiniteDuration timeout = jobClientActorTimeout.$times(2);
 
 		UUID leaderSessionID = UUID.randomUUID();
@@ -245,8 +250,8 @@ public class JobClientActorTest extends TestLogger {
 	 */
 	@Test(expected=JobClientActorConnectionTimeoutException.class)
 	public void testConnectionTimeoutAfterJobRegistration() throws Exception {
-		FiniteDuration jobClientActorTimeout = new FiniteDuration(5, TimeUnit.SECONDS);
-		FiniteDuration timeout = jobClientActorTimeout.$times(2);
+		FiniteDuration jobClientActorTimeout = new FiniteDuration(1L, TimeUnit.SECONDS);
+		FiniteDuration timeout = jobClientActorTimeout.$times(2L);
 
 		UUID leaderSessionID = UUID.randomUUID();
 
@@ -287,7 +292,7 @@ public class JobClientActorTest extends TestLogger {
 	 */
 	@Test
 	public void testGuaranteedAnswerIfJobClientDies() throws Exception {
-		FiniteDuration timeout = new FiniteDuration(2, TimeUnit.SECONDS);
+		FiniteDuration timeout = new FiniteDuration(2L, TimeUnit.SECONDS);
 
 			UUID leaderSessionID = UUID.randomUUID();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.restart.FixedDelayRestartStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.instance.InstanceManager;
@@ -166,7 +167,9 @@ public class JobManagerHARecoveryTest {
 			CheckpointIDCounter checkpointCounter = new StandaloneCheckpointIDCounter();
 			CheckpointRecoveryFactory checkpointStateFactory = new MyCheckpointRecoveryFactory(checkpointStore, checkpointCounter);
 			TestingLeaderElectionService myLeaderElectionService = new TestingLeaderElectionService();
-			TestingLeaderRetrievalService myLeaderRetrievalService = new TestingLeaderRetrievalService();
+			TestingLeaderRetrievalService myLeaderRetrievalService = new TestingLeaderRetrievalService(
+				"localhost",
+				HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 			InstanceManager instanceManager = new InstanceManager();
 			instanceManager.addInstanceListener(scheduler);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -86,6 +87,7 @@ import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.BlockingNoOpInvokable;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.StoppableInvokable;
+import org.apache.flink.util.TestLogger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -120,7 +122,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class JobManagerTest {
+public class JobManagerTest extends TestLogger {
 
 	@Rule
 	public TemporaryFolder tmpFolder = new TemporaryFolder();
@@ -183,7 +185,7 @@ public class JobManagerTest {
 							TestingUtils.TESTING_DURATION());
 
 						// we can set the leader session ID to None because we don't use this gateway to send messages
-						final ActorGateway testActorGateway = new AkkaActorGateway(getTestActor(), null);
+						final ActorGateway testActorGateway = new AkkaActorGateway(getTestActor(), HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 						// Submit the job and wait for all vertices to be running
 						jobManagerGateway.tell(
@@ -304,7 +306,7 @@ public class JobManagerTest {
 							TestingUtils.TESTING_DURATION());
 
 						// we can set the leader session ID to None because we don't use this gateway to send messages
-						final ActorGateway testActorGateway = new AkkaActorGateway(getTestActor(), null);
+						final ActorGateway testActorGateway = new AkkaActorGateway(getTestActor(), HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 						// Submit the job and wait for all vertices to be running
 						jobManagerGateway.tell(
@@ -395,7 +397,7 @@ public class JobManagerTest {
 							TestingUtils.TESTING_DURATION());
 
 						// we can set the leader session ID to None because we don't use this gateway to send messages
-						final ActorGateway testActorGateway = new AkkaActorGateway(getTestActor(), null);
+						final ActorGateway testActorGateway = new AkkaActorGateway(getTestActor(), HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 						// Submit the job and wait for all vertices to be running
 						jobManagerGateway.tell(
@@ -478,7 +480,7 @@ public class JobManagerTest {
 						final ActorGateway jobManagerGateway = cluster.getLeaderGateway(TestingUtils.TESTING_DURATION());
 
 						// we can set the leader session ID to None because we don't use this gateway to send messages
-						final ActorGateway testActorGateway = new AkkaActorGateway(getTestActor(), null);
+						final ActorGateway testActorGateway = new AkkaActorGateway(getTestActor(), HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 						// Submit the job and wait for all vertices to be running
 						jobManagerGateway.tell(
@@ -530,7 +532,7 @@ public class JobManagerTest {
 						final ActorGateway jobManagerGateway = cluster.getLeaderGateway(TestingUtils.TESTING_DURATION());
 
 						// we can set the leader session ID to None because we don't use this gateway to send messages
-						final ActorGateway testActorGateway = new AkkaActorGateway(getTestActor(), null);
+						final ActorGateway testActorGateway = new AkkaActorGateway(getTestActor(), HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 						// Submit the job and wait for all vertices to be running
 						jobManagerGateway.tell(
@@ -572,7 +574,6 @@ public class JobManagerTest {
 		Configuration config = new Configuration();
 		config.setString(ConfigConstants.AKKA_ASK_TIMEOUT, "100ms");
 
-		UUID leaderSessionId = null;
 		ActorGateway jobManager = new AkkaActorGateway(
 				JobManager.startJobManagerActors(
 					config,
@@ -581,7 +582,7 @@ public class JobManagerTest {
 					TestingUtils.defaultExecutor(),
 					TestingJobManager.class,
 					MemoryArchivist.class)._1(),
-				leaderSessionId);
+				HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 		LeaderRetrievalService leaderRetrievalService = new StandaloneLeaderRetrievalService(
 				AkkaUtils.getAkkaURL(system, jobManager.actor()));
@@ -794,8 +795,8 @@ public class JobManagerTest {
 				TestingJobManager.class,
 				TestingMemoryArchivist.class);
 
-			jobManager = new AkkaActorGateway(master._1(), null);
-			archiver = new AkkaActorGateway(master._2(), null);
+			jobManager = new AkkaActorGateway(master._1(), HighAvailabilityServices.DEFAULT_LEADER_ID);
+			archiver = new AkkaActorGateway(master._2(), HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 			ActorRef taskManagerRef = TaskManager.startTaskManagerComponentsAndActor(
 					config,
@@ -807,7 +808,7 @@ public class JobManagerTest {
 					true,
 					TestingTaskManager.class);
 
-			taskManager = new AkkaActorGateway(taskManagerRef, null);
+			taskManager = new AkkaActorGateway(taskManagerRef, HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 			// Wait until connected
 			Object msg = new TestingTaskManagerMessages.NotifyWhenRegisteredAtJobManager(jobManager.actor());
@@ -920,8 +921,8 @@ public class JobManagerTest {
 				TestingJobManager.class,
 				TestingMemoryArchivist.class);
 
-			jobManager = new AkkaActorGateway(master._1(), null);
-			archiver = new AkkaActorGateway(master._2(), null);
+			jobManager = new AkkaActorGateway(master._1(), HighAvailabilityServices.DEFAULT_LEADER_ID);
+			archiver = new AkkaActorGateway(master._2(), HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 			ActorRef taskManagerRef = TaskManager.startTaskManagerComponentsAndActor(
 				config,
@@ -933,7 +934,7 @@ public class JobManagerTest {
 				true,
 				TestingTaskManager.class);
 
-			taskManager = new AkkaActorGateway(taskManagerRef, null);
+			taskManager = new AkkaActorGateway(taskManagerRef, HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 			// Wait until connected
 			Object msg = new TestingTaskManagerMessages.NotifyWhenRegisteredAtJobManager(jobManager.actor());
@@ -1026,8 +1027,8 @@ public class JobManagerTest {
 				TestingJobManager.class,
 				TestingMemoryArchivist.class);
 
-			jobManager = new AkkaActorGateway(master._1(), null);
-			archiver = new AkkaActorGateway(master._2(), null);
+			jobManager = new AkkaActorGateway(master._1(), HighAvailabilityServices.DEFAULT_LEADER_ID);
+			archiver = new AkkaActorGateway(master._2(), HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 			ActorRef taskManagerRef = TaskManager.startTaskManagerComponentsAndActor(
 					config,
@@ -1039,7 +1040,7 @@ public class JobManagerTest {
 					true,
 					TestingTaskManager.class);
 
-			taskManager = new AkkaActorGateway(taskManagerRef, null);
+			taskManager = new AkkaActorGateway(taskManagerRef, HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 			// Wait until connected
 			Object msg = new TestingTaskManagerMessages.NotifyWhenRegisteredAtJobManager(jobManager.actor());
@@ -1126,8 +1127,8 @@ public class JobManagerTest {
 				TestingJobManager.class,
 				TestingMemoryArchivist.class);
 
-			jobManager = new AkkaActorGateway(master._1(), null);
-			archiver = new AkkaActorGateway(master._2(), null);
+			jobManager = new AkkaActorGateway(master._1(), HighAvailabilityServices.DEFAULT_LEADER_ID);
+			archiver = new AkkaActorGateway(master._2(), HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 			Configuration tmConfig = new Configuration();
 			tmConfig.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 4);
@@ -1142,7 +1143,7 @@ public class JobManagerTest {
 					true,
 					TestingTaskManager.class);
 
-			taskManager = new AkkaActorGateway(taskManagerRef, null);
+			taskManager = new AkkaActorGateway(taskManagerRef, HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 			// Wait until connected
 			Object msg = new TestingTaskManagerMessages.NotifyWhenRegisteredAtJobManager(jobManager.actor());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -64,7 +64,9 @@ public class JobMasterTest extends TestLogger {
 	@Test
 	public void testHeartbeatTimeoutWithTaskManager() throws Exception {
 		final TestingHighAvailabilityServices haServices = new TestingHighAvailabilityServices();
-		final TestingLeaderRetrievalService rmLeaderRetrievalService = new TestingLeaderRetrievalService();
+		final TestingLeaderRetrievalService rmLeaderRetrievalService = new TestingLeaderRetrievalService(
+			null,
+			null);
 		haServices.setResourceManagerLeaderRetriever(rmLeaderRetrievalService);
 		haServices.setCheckpointRecoveryFactory(mock(CheckpointRecoveryFactory.class));
 		final TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionRetrievalTestingCluster.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionRetrievalTestingCluster.java
@@ -53,8 +53,8 @@ public class LeaderElectionRetrievalTestingCluster extends TestingCluster {
 		this.userConfiguration = userConfiguration;
 		this.useSingleActorSystem = singleActorSystem;
 
-		leaderElectionServices = new ArrayList<TestingLeaderElectionService>();
-		leaderRetrievalServices = new ArrayList<TestingLeaderRetrievalService>();
+		leaderElectionServices = new ArrayList<>();
+		leaderRetrievalServices = new ArrayList<>();
 	}
 
 	@Override
@@ -78,7 +78,9 @@ public class LeaderElectionRetrievalTestingCluster extends TestingCluster {
 
 	@Override
 	public LeaderRetrievalService createLeaderRetrievalService() {
-		leaderRetrievalServices.add(new TestingLeaderRetrievalService());
+		leaderRetrievalServices.add(new TestingLeaderRetrievalService(
+			null,
+			null));
 
 		return leaderRetrievalServices.get(leaderRetrievalServices.size() - 1);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.leaderelection;
 
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.leaderretrieval.StandaloneLeaderRetrievalService;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
@@ -46,12 +47,12 @@ public class StandaloneLeaderElectionTest extends TestLogger {
 			contender.waitForLeader(1000l);
 
 			assertTrue(contender.isLeader());
-			assertEquals(null, contender.getLeaderSessionID());
+			assertEquals(HighAvailabilityServices.DEFAULT_LEADER_ID, contender.getLeaderSessionID());
 
 			testingListener.waitForNewLeader(1000l);
 
 			assertEquals(TEST_URL, testingListener.getAddress());
-			assertEquals(null, testingListener.getLeaderSessionID());
+			assertEquals(HighAvailabilityServices.DEFAULT_LEADER_ID, testingListener.getLeaderSessionID());
 		} finally {
 			leaderElectionService.stop();
 			leaderRetrievalService.stop();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderRetrievalService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderRetrievalService.java
@@ -35,10 +35,6 @@ public class TestingLeaderRetrievalService implements LeaderRetrievalService {
 
 	private volatile LeaderRetrievalListener listener;
 
-	public TestingLeaderRetrievalService() {
-		this(null, null);
-	}
-
 	public TestingLeaderRetrievalService(String leaderAddress, UUID leaderSessionID) {
 		this.leaderAddress = leaderAddress;
 		this.leaderSessionID = leaderSessionID;
@@ -48,7 +44,7 @@ public class TestingLeaderRetrievalService implements LeaderRetrievalService {
 	public void start(LeaderRetrievalListener listener) throws Exception {
 		this.listener = Preconditions.checkNotNull(listener);
 
-		if (leaderAddress != null) {
+		if (leaderSessionID != null && leaderAddress != null) {
 			listener.notifyLeaderAddress(leaderAddress, leaderSessionID);
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/TaskManagerMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/TaskManagerMetricsTest.java
@@ -25,6 +25,7 @@ import akka.testkit.JavaTestKit;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobmanager.JobManager;
 import org.apache.flink.runtime.jobmanager.MemoryArchivist;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
@@ -109,7 +110,11 @@ public class TaskManagerMetricsTest {
 						expectMsgEquals(TaskManagerMessages.getRegisteredAtJobManagerMessage());
 
 						// trigger re-registration of TM; this should include a disconnect from the current JM
-						taskManager.tell(new TaskManagerMessages.JobManagerLeaderAddress(jobManager.path().toString(), null), jobManager);
+						taskManager.tell(
+							new TaskManagerMessages.JobManagerLeaderAddress(
+								jobManager.path().toString(),
+								HighAvailabilityServices.DEFAULT_LEADER_ID),
+							jobManager);
 
 						// wait for re-registration to be completed
 						taskManager.tell(TaskManagerMessages.getNotifyWhenRegisteredAtJobManagerMessage(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/JobLeaderIdServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/JobLeaderIdServiceTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.leaderelection.TestingLeaderRetrievalService;
 import org.apache.flink.util.TestLogger;
@@ -64,7 +65,9 @@ public class JobLeaderIdServiceTest extends TestLogger {
 		final String address = "foobar";
 		final UUID leaderId = UUID.randomUUID();
 		TestingHighAvailabilityServices highAvailabilityServices = new TestingHighAvailabilityServices();
-		TestingLeaderRetrievalService leaderRetrievalService = new TestingLeaderRetrievalService();
+		TestingLeaderRetrievalService leaderRetrievalService = new TestingLeaderRetrievalService(
+			null,
+			null);
 
 		highAvailabilityServices.setJobMasterLeaderRetriever(jobId, leaderRetrievalService);
 
@@ -98,7 +101,7 @@ public class JobLeaderIdServiceTest extends TestLogger {
 	public void testRemovingJob() throws Exception {
 		final JobID jobId = new JobID();
 		TestingHighAvailabilityServices highAvailabilityServices = new TestingHighAvailabilityServices();
-		TestingLeaderRetrievalService leaderRetrievalService = new TestingLeaderRetrievalService();
+		TestingLeaderRetrievalService leaderRetrievalService = new TestingLeaderRetrievalService(null, null);
 
 		highAvailabilityServices.setJobMasterLeaderRetriever(jobId, leaderRetrievalService);
 
@@ -139,7 +142,9 @@ public class JobLeaderIdServiceTest extends TestLogger {
 	public void testInitialJobTimeout() throws Exception {
 		final JobID jobId = new JobID();
 		TestingHighAvailabilityServices highAvailabilityServices = new TestingHighAvailabilityServices();
-		TestingLeaderRetrievalService leaderRetrievalService = new TestingLeaderRetrievalService();
+		TestingLeaderRetrievalService leaderRetrievalService = new TestingLeaderRetrievalService(
+			null,
+			null);
 
 		highAvailabilityServices.setJobMasterLeaderRetriever(jobId, leaderRetrievalService);
 
@@ -181,7 +186,9 @@ public class JobLeaderIdServiceTest extends TestLogger {
 		final String address = "foobar";
 		final UUID leaderId = UUID.randomUUID();
 		TestingHighAvailabilityServices highAvailabilityServices = new TestingHighAvailabilityServices();
-		TestingLeaderRetrievalService leaderRetrievalService = new TestingLeaderRetrievalService();
+		TestingLeaderRetrievalService leaderRetrievalService = new TestingLeaderRetrievalService(
+			null,
+			null);
 
 		highAvailabilityServices.setJobMasterLeaderRetriever(jobId, leaderRetrievalService);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.resourcemanager;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterRegistrationSuccess;
@@ -112,7 +113,9 @@ public class ResourceManagerJobMasterTest {
 		String jobMasterAddress = "/jobMasterAddress1";
 		JobID jobID = mockJobMaster(jobMasterAddress);
 		TestingLeaderElectionService resourceManagerLeaderElectionService = new TestingLeaderElectionService();
-		TestingLeaderRetrievalService jobMasterLeaderRetrievalService = new TestingLeaderRetrievalService();
+		TestingLeaderRetrievalService jobMasterLeaderRetrievalService = new TestingLeaderRetrievalService(
+			"localhost",
+			HighAvailabilityServices.DEFAULT_LEADER_ID);
 		TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
 		final ResourceManager resourceManager = createAndStartResourceManager(resourceManagerLeaderElectionService, jobID, jobMasterLeaderRetrievalService, testingFatalErrorHandler);
 		final UUID rmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
@@ -136,7 +139,9 @@ public class ResourceManagerJobMasterTest {
 		String jobMasterAddress = "/jobMasterAddress1";
 		JobID jobID = mockJobMaster(jobMasterAddress);
 		TestingLeaderElectionService resourceManagerLeaderElectionService = new TestingLeaderElectionService();
-		TestingLeaderRetrievalService jobMasterLeaderRetrievalService = new TestingLeaderRetrievalService();
+		TestingLeaderRetrievalService jobMasterLeaderRetrievalService = new TestingLeaderRetrievalService(
+			"localhost",
+			HighAvailabilityServices.DEFAULT_LEADER_ID);
 		TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
 		final ResourceManager resourceManager = createAndStartResourceManager(resourceManagerLeaderElectionService, jobID, jobMasterLeaderRetrievalService, testingFatalErrorHandler);
 		final UUID rmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
@@ -160,7 +165,9 @@ public class ResourceManagerJobMasterTest {
 		String jobMasterAddress = "/jobMasterAddress1";
 		JobID jobID = mockJobMaster(jobMasterAddress);
 		TestingLeaderElectionService resourceManagerLeaderElectionService = new TestingLeaderElectionService();
-		TestingLeaderRetrievalService jobMasterLeaderRetrievalService = new TestingLeaderRetrievalService();
+		TestingLeaderRetrievalService jobMasterLeaderRetrievalService = new TestingLeaderRetrievalService(
+			"localhost",
+			HighAvailabilityServices.DEFAULT_LEADER_ID);
 		TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
 		final ResourceManager resourceManager = createAndStartResourceManager(resourceManagerLeaderElectionService, jobID, jobMasterLeaderRetrievalService, testingFatalErrorHandler);
 		final UUID rmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -83,7 +83,7 @@ public class TaskExecutorITCase {
 		final ResourceID taskManagerResourceId = new ResourceID("foobar");
 		final UUID rmLeaderId = UUID.randomUUID();
 		final TestingLeaderElectionService rmLeaderElectionService = new TestingLeaderElectionService();
-		final TestingLeaderRetrievalService rmLeaderRetrievalService = new TestingLeaderRetrievalService();
+		final TestingLeaderRetrievalService rmLeaderRetrievalService = new TestingLeaderRetrievalService(null, null);
 		final String rmAddress = "rm";
 		final String jmAddress = "jm";
 		final UUID jmLeaderId = UUID.randomUUID();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -119,8 +119,12 @@ public class TaskExecutorTest extends TestLogger {
 		final TestingSerialRpcService rpc = new TestingSerialRpcService();
 		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation);
 		final TestingHighAvailabilityServices haServices = new TestingHighAvailabilityServices();
-		final TestingLeaderRetrievalService rmLeaderRetrievalService = new TestingLeaderRetrievalService();
-		final TestingLeaderRetrievalService jmLeaderRetrievalService = new TestingLeaderRetrievalService();
+		final TestingLeaderRetrievalService rmLeaderRetrievalService = new TestingLeaderRetrievalService(
+			null,
+			null);
+		final TestingLeaderRetrievalService jmLeaderRetrievalService = new TestingLeaderRetrievalService(
+			null,
+			null);
 		haServices.setJobMasterLeaderRetriever(jobId, jmLeaderRetrievalService);
 		haServices.setResourceManagerLeaderRetriever(rmLeaderRetrievalService);
 
@@ -296,7 +300,9 @@ public class TaskExecutorTest extends TestLogger {
 			rpc.registerGateway(address1, rmGateway1);
 			rpc.registerGateway(address2, rmGateway2);
 
-			TestingLeaderRetrievalService testLeaderService = new TestingLeaderRetrievalService();
+			TestingLeaderRetrievalService testLeaderService = new TestingLeaderRetrievalService(
+				null,
+				null);
 
 			TestingHighAvailabilityServices haServices = new TestingHighAvailabilityServices();
 			haServices.setResourceManagerLeaderRetriever(testLeaderService);
@@ -514,8 +520,12 @@ public class TaskExecutorTest extends TestLogger {
 		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation);
 		final TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
 
-		final TestingLeaderRetrievalService resourceManagerLeaderRetrievalService = new TestingLeaderRetrievalService();
-		final TestingLeaderRetrievalService jobManagerLeaderRetrievalService = new TestingLeaderRetrievalService();
+		final TestingLeaderRetrievalService resourceManagerLeaderRetrievalService = new TestingLeaderRetrievalService(
+			null,
+			null);
+		final TestingLeaderRetrievalService jobManagerLeaderRetrievalService = new TestingLeaderRetrievalService(
+			null,
+			null);
 		haServices.setResourceManagerLeaderRetriever(resourceManagerLeaderRetrievalService);
 		haServices.setJobMasterLeaderRetriever(jobId, jobManagerLeaderRetrievalService);
 
@@ -735,7 +745,9 @@ public class TaskExecutorTest extends TestLogger {
 			ResourceManagerGateway rmGateway1 = mock(ResourceManagerGateway.class);
 			rpc.registerGateway(address1, rmGateway1);
 
-			TestingLeaderRetrievalService testLeaderService = new TestingLeaderRetrievalService();
+			TestingLeaderRetrievalService testLeaderService = new TestingLeaderRetrievalService(
+				"localhost",
+				HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 			TestingHighAvailabilityServices haServices = new TestingHighAvailabilityServices();
 			haServices.setResourceManagerLeaderRetriever(testLeaderService);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager;
 import org.apache.flink.runtime.clusterframework.standalone.StandaloneResourceManager;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.jobmanager.JobManager;
@@ -567,7 +568,7 @@ public class TaskManagerRegistrationTest extends TestLogger {
 				final ActorRef taskManager = taskManagerGateway.actor();
 
 				final UUID falseLeaderSessionID = UUID.randomUUID();
-				final UUID trueLeaderSessionID = null;
+				final UUID trueLeaderSessionID = HighAvailabilityServices.DEFAULT_LEADER_ID;
 
 				new Within(timeout) {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -46,6 +46,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.JobInformation;
 import org.apache.flink.runtime.executiongraph.TaskInformation;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.instance.InstanceID;
@@ -125,7 +126,7 @@ public class TaskManagerTest extends TestLogger {
 
 	private static ActorSystem system;
 
-	final static UUID leaderSessionID = null;
+	final static UUID leaderSessionID = HighAvailabilityServices.DEFAULT_LEADER_ID;
 
 	@BeforeClass
 	public static void setup() {
@@ -1165,8 +1166,8 @@ public class TaskManagerTest extends TestLogger {
 
 			// We need this to be a JM that answers to update messages for
 			// robustness on Travis (if jobs need to be resubmitted in (4)).
-			ActorRef jm = system.actorOf(Props.create(new SimpleLookupJobManagerCreator(null)));
-			ActorGateway jobManagerActorGateway = new AkkaActorGateway(jm, null);
+			ActorRef jm = system.actorOf(Props.create(new SimpleLookupJobManagerCreator(leaderSessionID)));
+			ActorGateway jobManagerActorGateway = new AkkaActorGateway(jm, leaderSessionID);
 
 			final ActorGateway testActorGateway = new AkkaActorGateway(
 					getTestActor(),

--- a/flink-runtime/src/test/resources/log4j-test.properties
+++ b/flink-runtime/src/test/resources/log4j-test.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-log4j.rootLogger=OFF, console
+log4j.rootLogger=INFO, console
 
 # -----------------------------------------------------------------------------
 # Console (use 'console')

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/ScalaTestingUtils.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/ScalaTestingUtils.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.testingUtils
 
 import akka.actor.ActorRef
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices
 import org.apache.flink.runtime.instance.{ActorGateway, AkkaActorGateway}
 
 /** Mixing for testing utils
@@ -32,6 +33,6 @@ trait ScalaTestingUtils {
     * @return [[ActorGateway]] encapsulating the given [[ActorRef]]
     */
   implicit def actorRef2InstanceGateway(actor: ActorRef): ActorGateway = {
-    new AkkaActorGateway(actor, null)
+    new AkkaActorGateway(actor, HighAvailabilityServices.DEFAULT_LEADER_ID)
   }
 }

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.flink.runtime.client.JobClient
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager
 import org.apache.flink.runtime.clusterframework.types.ResourceID
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices
 import org.apache.flink.runtime.instance.{ActorGateway, AkkaActorGateway}
 import org.apache.flink.runtime.jobgraph.JobGraph
 import org.apache.flink.runtime.jobmanager.{JobManager, MemoryArchivist}
@@ -45,7 +46,7 @@ import org.apache.flink.runtime.{FlinkActor, LeaderSessionMessageFilter, LogMess
 
 import scala.concurrent.duration.TimeUnit
 import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContextExecutor, Await, ExecutionContext}
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor}
 import scala.language.postfixOps
 
 /**
@@ -326,7 +327,7 @@ object TestingUtils {
       Await.ready(notificationResult, TESTING_DURATION)
     }
 
-    new AkkaActorGateway(taskManager, null)
+    new AkkaActorGateway(taskManager, HighAvailabilityServices.DEFAULT_LEADER_ID)
   }
 
   /** Stops the given actor by sending it a Kill message
@@ -456,7 +457,7 @@ object TestingUtils {
         jobManagerClass,
         classOf[MemoryArchivist])
 
-    new AkkaActorGateway(actor, null)
+    new AkkaActorGateway(actor, HighAvailabilityServices.DEFAULT_LEADER_ID)
   }
 
   /** Creates a forwarding JobManager which sends all received message to the forwarding target.
@@ -478,7 +479,7 @@ object TestingUtils {
           Props(
             classOf[ForwardingActor],
             forwardingTarget,
-            None),
+            Option(HighAvailabilityServices.DEFAULT_LEADER_ID)),
           name
         )
       case None =>
@@ -486,11 +487,11 @@ object TestingUtils {
           Props(
             classOf[ForwardingActor],
             forwardingTarget,
-            None)
+            Option(HighAvailabilityServices.DEFAULT_LEADER_ID))
         )
     }
 
-    new AkkaActorGateway(actor, null)
+    new AkkaActorGateway(actor, HighAvailabilityServices.DEFAULT_LEADER_ID)
   }
 
   def submitJobAndWait(
@@ -537,7 +538,7 @@ object TestingUtils {
       LeaderRetrievalUtils.createLeaderRetrievalService(configuration, jobManager),
       classOf[TestingResourceManager])
 
-    new AkkaActorGateway(actor, null)
+    new AkkaActorGateway(actor, HighAvailabilityServices.DEFAULT_LEADER_ID)
   }
 
 

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
@@ -24,6 +24,7 @@ import akka.testkit.JavaTestKit;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.messages.JobManagerMessages;
@@ -75,7 +76,7 @@ public class LocalFlinkMiniClusterITCase {
 			final ActorGateway jmGateway = miniCluster.getLeaderGateway(TestingUtils.TESTING_DURATION());
 
 			new JavaTestKit(system) {{
-				final ActorGateway selfGateway = new AkkaActorGateway(getRef(), null);
+				final ActorGateway selfGateway = new AkkaActorGateway(getRef(), HighAvailabilityServices.DEFAULT_LEADER_ID);
 
 				new Within(TestingUtils.TESTING_DURATION()) {
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/UtilsTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/UtilsTest.java
@@ -93,7 +93,9 @@ public class UtilsTest extends TestLogger {
 
 			Configuration flinkConfig = new Configuration();
 			YarnConfiguration yarnConfig = new YarnConfiguration();
-			TestingLeaderRetrievalService leaderRetrievalService = new TestingLeaderRetrievalService();
+			TestingLeaderRetrievalService leaderRetrievalService = new TestingLeaderRetrievalService(
+				null,
+				null);
 			String applicationMasterHostName = "localhost";
 			String webInterfaceURL = "foobar";
 			ContaineredTaskManagerParameters taskManagerParameters = new ContaineredTaskManagerParameters(


### PR DESCRIPTION
Before the default leader session id was null in the standalone case. However, in the ZooKeeper
case null indicated that there was no active leader available. With this commit, the default
leader id will be set to UUID(0L, 0L). This allows the uniform treatment of null denoting that
there is no active leader across the standalone and the ZooKeeper case.

With this change, the FlinkActors will now ignore all LeaderSessionMessages if the actor's
leader id field is null. This indicates that the FlinkActor does not know the current leader.
