### PR TITLE
[FLINK-1984] initial commit of hard constraint evaluator

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -446,6 +446,8 @@ use the `env.java.opts` setting, which is the `%jvmopts%` variable in the String
 
 - `mesos.initial-tasks`: The initial workers to bring up when the master starts (**DEFAULT**: The number of workers specified at cluster startup).
 
+- `mesos.constraints.hard.hostattribute`: Constraints for task placement on mesos (**DEFAULT**: None).
+
 - `mesos.maximum-failed-tasks`: The maximum number of failed workers before the cluster fails (**DEFAULT**: Number of initial workers).
 May be set to -1 to disable this feature.
 

--- a/docs/setup/mesos.md
+++ b/docs/setup/mesos.md
@@ -222,6 +222,8 @@ When running Flink with Marathon, the whole Flink cluster including the job mana
 
 `mesos.initial-tasks`: The initial workers to bring up when the master starts (**DEFAULT**: The number of workers specified at cluster startup).
 
+`mesos.constraints.hard.hostattribute`: Constraints for task placement on mesos (**DEFAULT**: None).
+
 `mesos.maximum-failed-tasks`: The maximum number of failed workers before the cluster fails (**DEFAULT**: Number of initial workers).
 May be set to -1 to disable this feature.
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -459,6 +459,11 @@ public final class ConfigConstants {
 	public static final String MESOS_INITIAL_TASKS = "mesos.initial-tasks";
 
 	/**
+	* Constraints for placement of Mesos tasks.
+	*/
+	public static final String MESOS_CONSTRAINTS = "mesos.constraints.hard.hostattribute";
+
+	/**
 	 * The maximum number of failed Mesos tasks before entirely stopping
 	 * the Mesos session / job on Mesos.
 	 *

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -132,7 +132,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 
 		@Override
 		public List<? extends ConstraintEvaluator> getHardConstraints() {
-			return null;
+			return params.constraints();
 		}
 
 		@Override

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -18,12 +18,19 @@
 
 package org.apache.flink.mesos.runtime.clusterframework;
 
+import com.netflix.fenzo.ConstraintEvaluator;
+import com.netflix.fenzo.functions.Func1;
+import com.netflix.fenzo.plugins.HostAttrValueConstraint;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import scala.Option;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.flink.configuration.ConfigOptions.key;
@@ -56,6 +63,10 @@ public class MesosTaskManagerParameters {
 		key("mesos.resourcemanager.tasks.container.image.name")
 			.noDefaultValue();
 
+	public static final ConfigOption<String> MESOS_CONSTRAINTS_HARD_HOSTATTR =
+		key("mesos.constraints.hard.hostattribute")
+			.noDefaultValue();
+
 	/**
 	 * Value for {@code MESOS_RESOURCEMANAGER_TASKS_CONTAINER_TYPE} setting. Tells to use the Mesos containerizer.
 	 */
@@ -73,16 +84,20 @@ public class MesosTaskManagerParameters {
 
 	private final ContaineredTaskManagerParameters containeredParameters;
 
+	private final List<ConstraintEvaluator> constraints;
+
 	public MesosTaskManagerParameters(
 		double cpus,
 		ContainerType containerType,
 		Option<String> containerImageName,
-		ContaineredTaskManagerParameters containeredParameters) {
+		ContaineredTaskManagerParameters containeredParameters,
+		List<ConstraintEvaluator> constraints) {
 		requireNonNull(containeredParameters);
 		this.cpus = cpus;
 		this.containerType = containerType;
 		this.containerImageName = containerImageName;
 		this.containeredParameters = containeredParameters;
+		this.constraints = constraints;
 	}
 
 	/**
@@ -115,6 +130,14 @@ public class MesosTaskManagerParameters {
 		return containeredParameters;
 	}
 
+	/**
+	 *
+	 * Get the placement constraints
+	 */
+	public List<ConstraintEvaluator> constraints() {
+		return constraints;
+	}
+
 	@Override
 	public String toString() {
 		return "MesosTaskManagerParameters{" +
@@ -122,6 +145,7 @@ public class MesosTaskManagerParameters {
 			", containerType=" + containerType +
 			", containerImageName=" + containerImageName +
 			", containeredParameters=" + containeredParameters +
+			", constraints=" + constraints +
 			'}';
 	}
 
@@ -131,6 +155,7 @@ public class MesosTaskManagerParameters {
      */
 	public static MesosTaskManagerParameters create(Configuration flinkConfig) {
 
+		List<ConstraintEvaluator> constraints = parseConstraints(flinkConfig.getString(MESOS_CONSTRAINTS_HARD_HOSTATTR));
 		// parse the common parameters
 		ContaineredTaskManagerParameters containeredParameters = ContaineredTaskManagerParameters.create(
 			flinkConfig,
@@ -166,7 +191,36 @@ public class MesosTaskManagerParameters {
 			cpus,
 			containerType,
 			Option.apply(imageName),
-			containeredParameters);
+			containeredParameters,
+			constraints);
+		}
+
+	private static List<ConstraintEvaluator> parseConstraints(String mesosConstraints) {
+		List<ConstraintEvaluator> constraints = new ArrayList<>();
+
+		if (mesosConstraints != null) {
+			for (String constraint : Arrays.asList(mesosConstraints.split(","))) {
+				if (constraint.isEmpty()) {
+					continue;
+				}
+				final List<String> constraintList = Arrays.asList(constraint.split(":"));
+				if (constraintList.size() != 2) {
+					continue;
+				}
+				addConstraint(constraints, constraintList);
+			}
+		}
+
+		return constraints;
+	}
+
+	private static void addConstraint(List<ConstraintEvaluator> constraints, final List<String> constraintList) {
+		constraints.add(new HostAttrValueConstraint(constraintList.get(0), new Func1<String, String>() {
+			@Override
+			public String call(String s) {
+				return constraintList.get(1);
+			}
+		}));
 	}
 
 	public enum ContainerType {

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
@@ -24,6 +24,7 @@ import akka.actor.ActorSystem;
 import akka.testkit.JavaTestKit;
 import akka.testkit.TestActorRef;
 import akka.testkit.TestProbe;
+import com.netflix.fenzo.ConstraintEvaluator;
 import junit.framework.AssertionFailedError;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -57,11 +58,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.*;
+
 import static java.util.Collections.singletonList;
-import java.util.HashMap;
 
 import static org.apache.flink.mesos.runtime.clusterframework.MesosFlinkResourceManager.extractGoalState;
 import static org.apache.flink.mesos.runtime.clusterframework.MesosFlinkResourceManager.extractResourceID;
@@ -198,10 +197,12 @@ public class MesosFlinkResourceManagerTest extends TestLogger {
 		 */
 		public void initialize() {
 			ContainerSpecification containerSpecification = new ContainerSpecification();
+			List<ConstraintEvaluator> constraints = new ArrayList<>();
 			ContaineredTaskManagerParameters containeredParams =
 				new ContaineredTaskManagerParameters(1024, 768, 256, 4, new HashMap<String, String>());
 			MesosTaskManagerParameters tmParams = new MesosTaskManagerParameters(
-				1.0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams);
+				1.0, MesosTaskManagerParameters.ContainerType.MESOS,
+				Option.<String>empty(), containeredParams, constraints);
 
 			TestActorRef<TestingMesosFlinkResourceManager> resourceManagerRef =
 				TestActorRef.create(system, MesosFlinkResourceManager.createActorProps(

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -1,0 +1,77 @@
+package org.apache.flink.mesos.runtime.clusterframework;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.apache.flink.configuration.Configuration;
+import org.junit.Test;
+
+import com.netflix.fenzo.ConstraintEvaluator;
+import com.netflix.fenzo.functions.Func1;
+import com.netflix.fenzo.plugins.HostAttrValueConstraint;
+
+public class MesosTaskManagerParametersTest {
+
+
+    @Test
+    public void givenTwoConstraintsInConfigShouldBeParsed() throws Exception {
+
+        MesosTaskManagerParameters mesosTaskManagerParameters = MesosTaskManagerParameters.create(withConfiguration("cluster:foo,az:eu-west-1"));
+        assertThat(mesosTaskManagerParameters.constraints().size(), is(2));
+        ConstraintEvaluator firstConstraintEvaluator = new HostAttrValueConstraint("cluster", new Func1<String, String>() {
+            @Override
+            public String call(String s) {
+                return "foo";
+            }
+        });
+        ConstraintEvaluator secondConstraintEvaluator = new HostAttrValueConstraint("az", new Func1<String, String>() {
+            @Override
+            public String call(String s) {
+                return "foo";
+            }
+        });
+        assertThat(mesosTaskManagerParameters.constraints().get(0).getName(), is(firstConstraintEvaluator.getName()));
+        assertThat(mesosTaskManagerParameters.constraints().get(1).getName(), is(secondConstraintEvaluator.getName()));
+
+    }
+
+    @Test
+    public void givenOneConstraintInConfigShouldBeParsed() throws Exception {
+
+        MesosTaskManagerParameters mesosTaskManagerParameters = MesosTaskManagerParameters.create(withConfiguration("cluster:foo"));
+        assertThat(mesosTaskManagerParameters.constraints().size(), is(1));
+        ConstraintEvaluator firstConstraintEvaluator = new HostAttrValueConstraint("cluster", new Func1<String, String>() {
+            @Override
+            public String call(String s) {
+                return "foo";
+            }
+        });
+        assertThat(mesosTaskManagerParameters.constraints().get(0).getName(), is(firstConstraintEvaluator.getName()));
+    }
+
+    @Test
+    public void givenEmptyConstraintInConfigShouldBeParsed() throws Exception {
+
+        MesosTaskManagerParameters mesosTaskManagerParameters = MesosTaskManagerParameters.create(withConfiguration(""));
+        assertThat(mesosTaskManagerParameters.constraints().size(), is(0));
+    }
+
+    @Test
+    public void givenInvalidConstraintInConfigShouldBeParsed() throws Exception {
+
+        MesosTaskManagerParameters mesosTaskManagerParameters = MesosTaskManagerParameters.create(withConfiguration(",:,"));
+        assertThat(mesosTaskManagerParameters.constraints().size(), is(0));
+    }
+
+
+    private static Configuration withConfiguration(final String configuration) {
+        return new Configuration() {
+            private static final long serialVersionUID = -3249384117909445760L;
+
+            {
+                setString(MesosTaskManagerParameters.MESOS_CONSTRAINTS_HARD_HOSTATTR, configuration);
+            }
+        };
+    }
+
+}

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.mesos.runtime.clusterframework;
 
 import static org.hamcrest.Matchers.is;


### PR DESCRIPTION
This is related to the work in FLINK-1984.  In earlier patch sets, mesos constraints were evaluated, but that appears to have been dropped in the fenzo code, and now all constraint evaluators return null.

This is a start of exposing the fenzo constraint system, and only exposes a minimal subset of that functionality for now, hopefully in a way that allows it to be extended by later authors.

Signed-off-by: Stephen Gran <stephen.gran@piksel.com>