### PR TITLE
[FLINK-5047] [table] Add count sliding group-windows for batch tables

### DIFF
--- a/docs/dev/table_api.md
+++ b/docs/dev/table_api.md
@@ -1274,11 +1274,159 @@ A session window is defined by using the `Session` class as follows:
 
 #### Limitations
 
-Currently the following features are not supported yet:
+The following table summarizes available windows:
 
-- Row-count windows on event-time
-- Non-grouped session windows on batch tables
-- Sliding windows on batch tables
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 15%">Batch or streaming</th>
+      <th class="text-left" style="width: 15%">Table API</th>
+      <th class="text-left" style="width: 15%">Time</th>
+      <th class="text-left" style="width: 15%">Time or count interval</th>
+      <th class="text-left" style="width: 15%">Grouped or ungrouped</th>
+      <th class="text-left" style="width: 15%">Supported?</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>Batch</td>
+      <td>Tumble</td>
+      <td>Event-time</td>
+      <td>Count</td>
+      <td>Grouped</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <td>Batch</td>
+      <td>Tumble</td>
+      <td>Event-time</td>
+      <td>Count</td>
+      <td>Ungrouped</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Batch</td>
+      <td>Tumble</td>
+      <td>Event-time</td>
+      <td>Time</td>
+      <td>Both</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <td>Batch</td>
+      <td>Tumble</td>
+      <td>Processing-time</td>
+      <td>Both</td>
+      <td>Both</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Batch</td>
+      <td>Slide</td>
+      <td>Event-time</td>
+      <td>Count</td>
+      <td>Grouped</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <td>Batch</td>
+      <td>Slide</td>
+      <td>Event-time</td>
+      <td>Count</td>
+      <td>Ungrouped</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Batch</td>
+      <td>Slide</td>
+      <td>Event-time</td>
+      <td>Time</td>
+      <td>Both</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <td>Batch</td>
+      <td>Slide</td>
+      <td>Processing-time</td>
+      <td>Both</td>
+      <td>Both</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Batch</td>
+      <td>Session</td>
+      <td>Event-time</td>
+      <td>Time</td>
+      <td>Both</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <td>Batch</td>
+      <td>Session</td>
+      <td>Event-time</td>
+      <td>Count</td>
+      <td>Both</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Batch</td>
+      <td>Session</td>
+      <td>Processing-time</td>
+      <td>Both</td>
+      <td>Both</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Streaming</td>
+      <td>Tumble</td>
+      <td>Both</td>
+      <td>Time</td>
+      <td>Both</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <td>Streaming</td>
+      <td>Tumble</td>
+      <td>Both</td>
+      <td>Count</td>
+      <td>Both</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Streaming</td>
+      <td>Slide</td>
+      <td>Time</td>
+      <td>Both</td>
+      <td>Both</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <td>Streaming</td>
+      <td>Slide</td>
+      <td>Count</td>
+      <td>Both</td>
+      <td>Both</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>Streaming</td>
+      <td>Session</td>
+      <td>Time</td>
+      <td>Both</td>
+      <td>Both</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <td>Streaming</td>
+      <td>Session</td>
+      <td>Count</td>
+      <td>Both</td>
+      <td>Both</td>
+      <td>No</td>
+    </tr>
+  </tbody>
+</table>
 
 SQL
 ----

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
@@ -226,6 +226,18 @@ object AggregateUtil {
           asLong(slide),
           returnType)
 
+      case EventTimeSlidingGroupWindow(_, _, size, slide) =>
+        // sliding count-window for partial aggregations
+        val preTumblingSize = determineLargestTumblingSize(asLong(size), asLong(slide))
+
+        new DataSetSlideCountWindowAggReduceGroupFunction(
+          aggregates,
+          groupings.length,
+          preTumblingSize,
+          asLong(size),
+          asLong(slide),
+          returnType)
+
       case _ =>
         throw new UnsupportedOperationException(s"$window is currently not supported on batch.")
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSlideCountWindowAggReduceGroupFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSlideCountWindowAggReduceGroupFunction.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.runtime.aggregate
+
+import java.lang.Iterable
+import java.util.{ArrayList => JArrayList}
+
+import org.apache.flink.api.common.functions.{CombineFunction, RichGroupReduceFunction}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow
+import org.apache.flink.table.functions.{Accumulator, AggregateFunction}
+import org.apache.flink.types.Row
+import org.apache.flink.util.{Collector, Preconditions}
+
+/**
+  * It is used for sliding windows on batch for count-windows. It takes a prepared input row,
+  * pre-aggregates (pre-tumbles) rows, aligns the window start, and replicates or omits records
+  * for different panes of a sliding window.
+  *
+  * This function is similar to [[DataSetTumbleCountWindowAggReduceGroupFunction]], however,
+  * it does no final aggregate evaluation.
+  *
+  * @param aggregates aggregate functions
+  * @param groupingKeysLength number of grouping keys
+  * @param preTumblingSize number of records to be aggregated (tumbled) before emission
+  * @param windowSize window size of the sliding window
+  * @param windowSlide window slide of the sliding window
+  * @param returnType return type of this function
+  */
+class DataSetSlideCountWindowAggReduceGroupFunction(
+    private val aggregates: Array[AggregateFunction[_ <: Any]],
+    private val groupingKeysLength: Int,
+    private val preTumblingSize: Long,
+    private val windowSize: Long,
+    private val windowSlide: Long,
+    @transient private val returnType: TypeInformation[Row])
+  extends RichGroupReduceFunction[Row, Row]
+  with ResultTypeQueryable[Row] {
+
+  Preconditions.checkNotNull(aggregates)
+
+  protected var intermediateRow: Row = _
+  // add one field to store window start
+  protected val intermediateRowArity: Int = groupingKeysLength + aggregates.length + 1
+  protected val accumulatorList: Array[JArrayList[Accumulator]] = Array.fill(aggregates.length) {
+    new JArrayList[Accumulator](2)
+  }
+  private val intermediateWindowStartPos: Int = intermediateRowArity - 1
+
+  override def open(config: Configuration) {
+    intermediateRow = new Row(intermediateRowArity)
+
+    // init lists with two empty accumulators
+    var i = 0
+    while (i < aggregates.length) {
+      val accumulator = aggregates(i).createAccumulator()
+      accumulatorList(i).add(accumulator)
+      accumulatorList(i).add(accumulator)
+      i += 1
+    }
+  }
+
+  override def reduce(records: Iterable[Row], out: Collector[Row]): Unit = {
+    var count: Long = 0
+
+    val iterator = records.iterator()
+
+    var i = 0
+    while (iterator.hasNext) {
+
+      val record = iterator.next()
+
+      // reset first accumulators after completed tumbling
+      if (count % preTumblingSize == 0) {
+        var i = 0
+        while (i < aggregates.length) {
+          val accumulator = aggregates(i).createAccumulator()
+          accumulatorList(i).set(0, accumulator)
+          i += 1
+        }
+      }
+
+      // accumulate
+      i = 0
+      while (i < aggregates.length) {
+        // insert received accumulator into acc list
+        val newAcc = record.getField(groupingKeysLength + i).asInstanceOf[Accumulator]
+        accumulatorList(i).set(1, newAcc)
+        // merge acc list
+        val retAcc = aggregates(i).merge(accumulatorList(i))
+        // insert result into acc list
+        accumulatorList(i).set(0, retAcc)
+        i += 1
+      }
+
+      count += 1
+
+      // trigger tumbling evaluation
+      if (count % preTumblingSize == 0) {
+        val windowStart = count
+
+        // adopted from SlidingEventTimeWindows.assignWindows
+        var start: Long = TimeWindow.getWindowStartWithOffset(windowStart, 0, windowSlide)
+
+        // skip preparing output if it is not necessary
+        if (start > windowStart - windowSize && start >= windowSlide) {
+
+          // set group keys
+          i = 0
+          while (i < groupingKeysLength) {
+            intermediateRow.setField(i, record.getField(i))
+            i += 1
+          }
+
+          // set accumulators
+          i = 0
+          while (i < aggregates.length) {
+            intermediateRow.setField(groupingKeysLength + i, accumulatorList(i).get(0))
+            i += 1
+          }
+
+          // adopted from SlidingEventTimeWindows.assignWindows
+          while (start > windowStart - windowSize && start >= windowSlide) {
+            intermediateRow.setField(intermediateWindowStartPos, start)
+            out.collect(intermediateRow)
+            start -= windowSlide
+          }
+        }
+      }
+    }
+  }
+
+  override def getProducedType: TypeInformation[Row] = {
+    returnType
+  }
+}


### PR DESCRIPTION
This PR adds the missing sliding group-windows for row intervals. I also added an additional table to the documentation to make it more transparent what is supported.