### PR TITLE
[FLINK-6162]Fix bug in ByteArrayOutputStreamWithPos#setPosition

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayInputStreamWithPos.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayInputStreamWithPos.java
@@ -119,7 +119,7 @@ public class ByteArrayInputStreamWithPos extends InputStream {
 	}
 
 	public void setPosition(int pos) {
-		Preconditions.checkArgument(pos < count, "Position out of bounds.");
+		Preconditions.checkArgument(pos >=0 && pos <= count, "Position out of bounds.");
 		this.position = pos;
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayInputStreamWithPos.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayInputStreamWithPos.java
@@ -118,7 +118,8 @@ public class ByteArrayInputStreamWithPos extends InputStream {
 		return position;
 	}
 
-	public void setPos(int pos) {
+	public void setPosition(int pos) {
+		Preconditions.checkArgument(pos < count, "Position out of bounds.");
 		this.position = pos;
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPos.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPos.java
@@ -101,16 +101,13 @@ public class ByteArrayOutputStreamWithPos extends OutputStream {
 		return new String(buffer, 0, count, ConfigConstants.DEFAULT_CHARSET);
 	}
 
-	private int getEndPosition() {
-		return buffer.length;
-	}
-
 	public int getPosition() {
 		return count;
 	}
 
 	public void setPosition(int position) {
-		Preconditions.checkArgument(position <= getEndPosition(), "Position out of bounds.");
+		Preconditions.checkArgument(position >=0, "Position out of bounds.");
+		ensureCapacity(position + 1);
 		count = position;
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPos.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPos.java
@@ -110,7 +110,7 @@ public class ByteArrayOutputStreamWithPos extends OutputStream {
 	}
 
 	public void setPosition(int position) {
-		Preconditions.checkArgument(position < getEndPosition(), "Position out of bounds.");
+		Preconditions.checkArgument(position <= getEndPosition(), "Position out of bounds.");
 		count = position;
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayInputStreamWithPosTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayInputStreamWithPosTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.memory;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ByteArrayInputStreamWithPosTest {
+
+	/**
+	 *  This tests setting position on a {@link ByteArrayInputStreamWithPos}
+	 */
+	@Test
+	public void testSetPosition() throws Exception {
+		byte[] data = new byte[] {'0','1','2','3','4','5','6','7','8','9'};
+		ByteArrayInputStreamWithPos inputStreamWithPos = new ByteArrayInputStreamWithPos(data);
+		inputStreamWithPos.setPosition(1);
+		Assert.assertEquals('1', inputStreamWithPos.read());
+		inputStreamWithPos.setPosition(3);
+		Assert.assertEquals('3', inputStreamWithPos.read());
+	}
+
+	/**
+	 * This tests that the expected position exceeds the capacity of the byte array.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testSetErrorPosition() throws Exception {
+		byte[] data = new byte[] {'0','1','2','3','4','5','6','7','8','9'};
+		ByteArrayInputStreamWithPos inputStreamWithPos = new ByteArrayInputStreamWithPos(data);
+		inputStreamWithPos.setPosition(data.length);
+		Assert.fail("Should not reach here !!!!");
+	}
+
+}

--- a/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayInputStreamWithPosTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayInputStreamWithPosTest.java
@@ -36,9 +36,14 @@ public class ByteArrayInputStreamWithPosTest {
 		byte[] data = new byte[] {'0','1','2','3','4','5','6','7','8','9'};
 		ByteArrayInputStreamWithPos inputStreamWithPos = new ByteArrayInputStreamWithPos(data);
 		inputStreamWithPos.setPosition(1);
+		Assert.assertEquals(data.length - 1, inputStreamWithPos.available());
 		Assert.assertEquals('1', inputStreamWithPos.read());
 		inputStreamWithPos.setPosition(3);
+		Assert.assertEquals(data.length - 3, inputStreamWithPos.available());
 		Assert.assertEquals('3', inputStreamWithPos.read());
+		inputStreamWithPos.setPosition(data.length);
+		Assert.assertEquals(0, inputStreamWithPos.available());
+		Assert.assertEquals(-1, inputStreamWithPos.read());
 	}
 
 	/**
@@ -50,7 +55,7 @@ public class ByteArrayInputStreamWithPosTest {
 		thrown.expectMessage("Position out of bounds.");
 		byte[] data = new byte[] {'0','1','2','3','4','5','6','7','8','9'};
 		ByteArrayInputStreamWithPos inputStreamWithPos = new ByteArrayInputStreamWithPos(data);
-		inputStreamWithPos.setPosition(data.length);
+		inputStreamWithPos.setPosition(data.length + 1);
 		Assert.fail("Should not reach here !!!!");
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayInputStreamWithPosTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayInputStreamWithPosTest.java
@@ -19,9 +19,14 @@
 package org.apache.flink.core.memory;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class ByteArrayInputStreamWithPosTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
 
 	/**
 	 *  This tests setting position on a {@link ByteArrayInputStreamWithPos}
@@ -39,11 +44,26 @@ public class ByteArrayInputStreamWithPosTest {
 	/**
 	 * This tests that the expected position exceeds the capacity of the byte array.
 	 */
-	@Test(expected = IllegalArgumentException.class)
-	public void testSetErrorPosition() throws Exception {
+	@Test
+	public void testSetTooLargePosition() throws Exception {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("Position out of bounds.");
 		byte[] data = new byte[] {'0','1','2','3','4','5','6','7','8','9'};
 		ByteArrayInputStreamWithPos inputStreamWithPos = new ByteArrayInputStreamWithPos(data);
 		inputStreamWithPos.setPosition(data.length);
+		Assert.fail("Should not reach here !!!!");
+	}
+
+	/**
+	 * This tests setting a negative position
+	 */
+	@Test
+	public void testSetNegativePosition() throws Exception {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("Position out of bounds.");
+		byte[] data = new byte[] {'0','1','2','3','4','5','6','7','8','9'};
+		ByteArrayInputStreamWithPos inputStreamWithPos = new ByteArrayInputStreamWithPos(data);
+		inputStreamWithPos.setPosition(-1);
 		Assert.fail("Should not reach here !!!!");
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
@@ -39,7 +39,7 @@ public class ByteArrayOutputStreamWithPosTest {
 
 		stream.setPosition(initBufferSize);
 
-		// confirm current position is at where we expects.
+		// confirm current position is at where we expect.
 		Assert.assertEquals(initBufferSize, stream.getPosition());
 
 	}

--- a/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.core.memory;
+
+import org.junit.Test;
+
+public class ByteArrayOutputStreamWithPosTest {
+	@Test
+	public void setPositionWhenBufferIsFull() throws Exception {
+		ByteArrayOutputStreamWithPos stream = new ByteArrayOutputStreamWithPos();
+		stream.write(new byte[64]);
+		stream.setPosition(stream.getPosition());
+	}
+
+}

--- a/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
@@ -18,14 +18,30 @@
 
 package org.apache.flink.core.memory;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 public class ByteArrayOutputStreamWithPosTest {
 	@Test
 	public void setPositionWhenBufferIsFull() throws Exception {
-		ByteArrayOutputStreamWithPos stream = new ByteArrayOutputStreamWithPos(32);
-		stream.write(new byte[32]);
-		stream.setPosition(stream.getPosition());
+
+		int initBufferSize = 32;
+
+		ByteArrayOutputStreamWithPos stream = new ByteArrayOutputStreamWithPos(initBufferSize);
+
+		stream.write(new byte[initBufferSize]);
+
+		// check whether the buffer is filled fully
+		Assert.assertEquals(initBufferSize, stream.getBuf().length);
+
+		// check current position is the end of the buffer
+		Assert.assertEquals(initBufferSize, stream.getPosition());
+
+		stream.setPosition(initBufferSize);
+
+		// confirm current position is at where we expects.
+		Assert.assertEquals(initBufferSize, stream.getPosition());
+
 	}
 
 }

--- a/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.core.memory;
 
 import org.junit.Test;

--- a/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
@@ -89,11 +89,11 @@ public class ByteArrayOutputStreamWithPosTest {
 
 		Assert.assertEquals(initBufferSize, stream.getBuf().length);
 
-		stream.setPosition(33);
+		stream.setPosition(initBufferSize + 1);
 
-		Assert.assertEquals(64, stream.getBuf().length);
+		Assert.assertEquals(initBufferSize * 2, stream.getBuf().length);
 
-		Assert.assertEquals(33, stream.getPosition());
+		Assert.assertEquals(initBufferSize + 1, stream.getPosition());
 	}
 
 	/**

--- a/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
@@ -23,8 +23,8 @@ import org.junit.Test;
 public class ByteArrayOutputStreamWithPosTest {
 	@Test
 	public void setPositionWhenBufferIsFull() throws Exception {
-		ByteArrayOutputStreamWithPos stream = new ByteArrayOutputStreamWithPos();
-		stream.write(new byte[64]);
+		ByteArrayOutputStreamWithPos stream = new ByteArrayOutputStreamWithPos(32);
+		stream.write(new byte[32]);
 		stream.setPosition(stream.getPosition());
 	}
 


### PR DESCRIPTION
Currently the precondition check in setPosition will fail when the buffer is full: 
{{Preconditions.checkArgument(position < getEndPosition(), "Position out of bounds.");}}
We should allow the expected position to be the end position

I have added a test on the fix.
