### PR TITLE
[FLINK-6182] Fix possible NPE in SourceStreamTask

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -58,6 +58,8 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 	
 	@Override
 	protected void cancelTask() throws Exception {
-		headOperator.cancel();
+		if (headOperator != null) {
+			headOperator.cancel();
+		}
 	}
 }


### PR DESCRIPTION
A user ran into this and reported confusing NPEs in the logs. This could only happen if a source task is cancelled before it was invoked.