### PR TITLE
[FLINK-6197] [cep] Add support for iterative conditions.

### DIFF
--- a/docs/dev/libs/cep.md
+++ b/docs/dev/libs/cep.md
@@ -146,11 +146,10 @@ start.where(new IterativeCondition<SubEvent>() {
             return false;
         }
         
-        double sum = 0.0;
+        double sum = value.getPrice();
         for (Event event : ctx.getEventsForPattern("middle")) {
             sum += event.getPrice();
         }
-        sum += value.getPrice();
         return Double.compare(sum, 5.0) < 0;
     }
 });
@@ -161,16 +160,8 @@ start.where(new IterativeCondition<SubEvent>() {
 {% highlight scala %}
 start.where(
     (value, ctx) => {
-        var res = value.getName.startsWith("foo")
-        if (res) {
-            var sum = 0.0
-            for (e: Event <- ctx.getEventsForPattern("middle")) {
-                sum += e.getPrice
-            }
-            sum += value.getPrice
-            res = res && sum < 5.0
-        }
-        res
+        lazy val sum = ctx.getEventsForPattern("middle").asScala.map(_.getPrice).sum
+        value.getName.startsWith("foo") && sum + value.getPrice < 5.0
     }
 )
 {% endhighlight %}

--- a/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/pattern/Pattern.scala
+++ b/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/pattern/Pattern.scala
@@ -17,8 +17,9 @@
  */
 package org.apache.flink.cep.scala.pattern
 
-import org.apache.flink.api.common.functions.FilterFunction
 import org.apache.flink.cep
+import org.apache.flink.cep.pattern.conditions.IterativeCondition
+import org.apache.flink.cep.pattern.conditions.IterativeCondition.Context
 import org.apache.flink.cep.pattern.{Quantifier, Pattern => JPattern}
 import org.apache.flink.streaming.api.windowing.time.Time
 
@@ -67,8 +68,8 @@ class Pattern[T , F <: T](jPattern: JPattern[T, F]) {
     *
     * @return Filter condition for an event to be matched
     */
-  def getFilterFunction(): Option[FilterFunction[F]] = {
-    Option(jPattern.getFilterFunction())
+  def getCondition(): Option[IterativeCondition[F]] = {
+    Option(jPattern.getCondition())
   }
 
   /**
@@ -127,7 +128,7 @@ class Pattern[T , F <: T](jPattern: JPattern[T, F]) {
     * @param filter Filter condition
     * @return The same pattern operator where the new filter condition is set
     */
-  def where(filter: FilterFunction[F]): Pattern[T, F] = {
+  def where(filter: IterativeCondition[F]): Pattern[T, F] = {
     jPattern.where(filter)
     this
   }
@@ -138,7 +139,7 @@ class Pattern[T , F <: T](jPattern: JPattern[T, F]) {
     * @param filter Or filter function
     * @return The same pattern operator where the new filter condition is set
     */
-  def or(filter: FilterFunction[F]): Pattern[T, F] = {
+  def or(filter: IterativeCondition[F]): Pattern[T, F] = {
     jPattern.or(filter)
     this
   }
@@ -149,11 +150,26 @@ class Pattern[T , F <: T](jPattern: JPattern[T, F]) {
     * @param filterFun Filter condition
     * @return The same pattern operator where the new filter condition is set
     */
-  def where(filterFun: F => Boolean): Pattern[T, F] = {
-    val filter = new FilterFunction[F] {
+  def where(filterFun: (F, Context[F]) => Boolean): Pattern[T, F] = {
+    val filter = new IterativeCondition[F] {
       val cleanFilter = cep.scala.cleanClosure(filterFun)
 
-      override def filter(value: F): Boolean = cleanFilter(value)
+      override def filter(value: F, ctx: Context[F]): Boolean = cleanFilter(value, ctx)
+    }
+    where(filter)
+  }
+
+  /**
+    * Specifies a filter condition which has to be fulfilled by an event in order to be matched.
+    *
+    * @param filterFun Filter condition
+    * @return The same pattern operator where the new filter condition is set
+    */
+  def where(filterFun: F => Boolean): Pattern[T, F] = {
+    val filter = new IterativeCondition[F] {
+      val cleanFilter = cep.scala.cleanClosure(filterFun)
+
+      override def filter(value: F, ctx: Context[F]): Boolean = cleanFilter(value)
     }
     where(filter)
   }

--- a/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/pattern/Pattern.scala
+++ b/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/pattern/Pattern.scala
@@ -145,6 +145,21 @@ class Pattern[T , F <: T](jPattern: JPattern[T, F]) {
   }
 
   /**
+    * Specifies a filter condition which is ORed with an existing filter function.
+    *
+    * @param filterFun Or filter function
+    * @return The same pattern operator where the new filter condition is set
+    */
+  def or(filterFun: (F, Context[F]) => Boolean): Pattern[T, F] = {
+    val filter = new IterativeCondition[F] {
+      val cleanFilter = cep.scala.cleanClosure(filterFun)
+
+      override def filter(value: F, ctx: Context[F]): Boolean = cleanFilter(value, ctx)
+    }
+    or(filter)
+  }
+
+  /**
     * Specifies a filter condition which has to be fulfilled by an event in order to be matched.
     *
     * @param filterFun Filter condition

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -92,7 +92,7 @@ public class NFA<T> implements Serializable {
 	private final NonDuplicatingTypeSerializer<T> nonDuplicatingTypeSerializer;
 
 	/**
-	 * 	Used only for backward compatibility. Buffer used to store the matched events.
+	 * Used only for backwards compatibility. Buffer used to store the matched events.
 	 */
 	private final SharedBuffer<State<T>, T> sharedBuffer = null;
 
@@ -575,7 +575,7 @@ public class NFA<T> implements Serializable {
 				computationState.getVersion());
 
 		// for a given computation state, we cannot have more than one matching patterns.
-		Preconditions.checkArgument(paths.size() <= 1);
+		Preconditions.checkState(paths.size() <= 1);
 
 		TypeSerializer<T> serializer = nonDuplicatingTypeSerializer.getTypeSerializer();
 
@@ -609,7 +609,7 @@ public class NFA<T> implements Serializable {
 			computationState.getVersion());
 
 		// for a given computation state, we cannot have more than one matching patterns.
-		Preconditions.checkArgument(paths.size() <= 1);
+		Preconditions.checkState(paths.size() <= 1);
 
 		List<Map<String, T>> result = new ArrayList<>();
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/State.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/State.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.cep.nfa;
 
-import org.apache.flink.api.common.functions.FilterFunction;
+import org.apache.flink.cep.pattern.conditions.IterativeCondition;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -66,29 +66,29 @@ public class State<T> implements Serializable {
 	}
 
 	private void addStateTransition(
-		final StateTransitionAction action,
-		final State<T> targetState,
-		final FilterFunction<T> condition) {
+			final StateTransitionAction action,
+			final State<T> targetState,
+			final IterativeCondition<T> condition) {
 		stateTransitions.add(new StateTransition<T>(this, action, targetState, condition));
 	}
 
-	public void addIgnore(final FilterFunction<T> condition) {
+	public void addIgnore(final IterativeCondition<T> condition) {
 		addStateTransition(StateTransitionAction.IGNORE, this, condition);
 	}
 
-	public void addIgnore(final State<T> targetState,final FilterFunction<T> condition) {
+	public void addIgnore(final State<T> targetState,final IterativeCondition<T> condition) {
 		addStateTransition(StateTransitionAction.IGNORE, targetState, condition);
 	}
 
-	public void addTake(final State<T> targetState, final FilterFunction<T> condition) {
+	public void addTake(final State<T> targetState, final IterativeCondition<T> condition) {
 		addStateTransition(StateTransitionAction.TAKE, targetState, condition);
 	}
 
-	public void addProceed(final State<T> targetState, final FilterFunction<T> condition) {
+	public void addProceed(final State<T> targetState, final IterativeCondition<T> condition) {
 		addStateTransition(StateTransitionAction.PROCEED, targetState, condition);
 	}
 
-	public void addTake(final FilterFunction<T> condition) {
+	public void addTake(final IterativeCondition<T> condition) {
 		addStateTransition(StateTransitionAction.TAKE, this, condition);
 	}
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/AndFilterFunction.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/AndFilterFunction.java
@@ -21,11 +21,15 @@ package org.apache.flink.cep.pattern;
 import org.apache.flink.api.common.functions.FilterFunction;
 
 /**
- * A filter function which combines two filter functions with a logical and. Thus, the filter
+ * @deprecated This is only used when migrating from an older Flink version.
+ * Use the {@link org.apache.flink.cep.pattern.conditions.AndCondition} instead.
+ *
+ * <p>A filter function which combines two filter functions with a logical and. Thus, the filter
  * function only returns true, iff both filters return true.
  *
  * @param <T> Type of the element to filter
  */
+@Deprecated
 public class AndFilterFunction<T> implements FilterFunction<T> {
 	private static final long serialVersionUID = -2109562093871155005L;
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/AndCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/AndCondition.java
@@ -16,41 +16,42 @@
  * limitations under the License.
  */
 
-package org.apache.flink.cep.pattern;
-
-import org.apache.flink.api.common.functions.FilterFunction;
+package org.apache.flink.cep.pattern.conditions;
 
 /**
- * @deprecated This is only used when migrating from an older Flink version.
- * Use the {@link org.apache.flink.cep.pattern.conditions.OrCondition} instead.
- *
- * <p>A filter function which combines two filter functions with a logical or. Thus, the filter
- * function only returns true, iff at least one of the filter functions holds true.
+ * A {@link IterativeCondition condition} which combines two conditions with a logical
+ * {@code AND} and returns {@code true} if both are {@code true}.
  *
  * @param <T> Type of the element to filter
  */
-@Deprecated
-public class OrFilterFunction<T> implements FilterFunction<T> {
-	private static final long serialVersionUID = -2109562093871155005L;
+public class AndCondition<T> extends IterativeCondition<T> {
 
-	private final FilterFunction<T> left;
-	private final FilterFunction<T> right;
+	private static final long serialVersionUID = -2471892317390197319L;
 
-	public OrFilterFunction(final FilterFunction<T> left, final FilterFunction<T> right) {
+	private final IterativeCondition<T> left;
+	private final IterativeCondition<T> right;
+
+	public AndCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
 		this.left = left;
 		this.right = right;
 	}
 
 	@Override
-	public boolean filter(T value) throws Exception {
-		return left.filter(value) || right.filter(value);
+	public boolean filter(T value, Context<T> ctx) throws Exception {
+		return left.filter(value, ctx) && right.filter(value, ctx);
 	}
 
-	public FilterFunction<T> getLeft() {
+	/**
+	 * @return One of the {@link IterativeCondition conditions} combined in this condition.
+	 */
+	public IterativeCondition<T> getLeft() {
 		return left;
 	}
 
-	public FilterFunction<T> getRight() {
+	/**
+	 * @return One of the {@link IterativeCondition conditions} combined in this condition.
+	 */
+	public IterativeCondition<T> getRight() {
 		return right;
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/BooleanConditions.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/BooleanConditions.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.cep.pattern.conditions;
+
+/**
+ * Utility class containing an {@link IterativeCondition} that always returns
+ * {@code true} and one that always returns {@code false}.
+ */
+public class BooleanConditions {
+
+	/**
+	 * @return An {@link IterativeCondition} that always returns {@code true}.
+	 */
+	public static <T> IterativeCondition<T> trueFunction()  {
+		return new SimpleCondition<T>() {
+			private static final long serialVersionUID = 8379409657655181451L;
+
+			@Override
+			public boolean filter(T value) throws Exception {
+				return true;
+			}
+		};
+	}
+
+	/**
+	 * @return An {@link IterativeCondition} that always returns {@code false}.
+	 */
+	public static <T> IterativeCondition<T> falseFunction()  {
+		return new SimpleCondition<T>() {
+			private static final long serialVersionUID = -823981593720949910L;
+
+			@Override
+			public boolean filter(T value) throws Exception {
+				return false;
+			}
+		};
+	}
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/IterativeCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/IterativeCondition.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep.pattern.conditions;
+
+import org.apache.flink.api.common.functions.Function;
+
+import java.io.Serializable;
+
+/**
+ * A user-defined condition that decides if an element should be accepted in the pattern or not.
+ * Accepting an element also signals a state transition for the corresponding {@link org.apache.flink.cep.nfa.NFA}.
+ *
+ * <p>A condition can be a simple filter or a more complex condition that iterates over the previously accepted
+ * elements in the pattern and decides to accept a new element or not based on some statistic over these elements.
+ * In the former case, the condition should extend the {@link SimpleCondition} class. In the later, the condition
+ * should extend this class, which gives you also access to the previously accepted elements through a {@link Context}.
+ *
+ * <p>An iterative condition that accepts an element if i) its name is middle, and ii) the sum of the prices of all
+ * accepted elements is less than {@code 5} would look like:
+ *
+ * <pre>
+ * {@code
+ * private class MyCondition extends IterativeCondition<Event> {
+ *
+ * 		@Override
+ *     	public boolean filter(Event value, Context<Event> ctx) throws Exception {
+ *     		if (!value.getName().equals("middle")) {
+ *     			return false;
+ *     		}
+ *
+ *     		double sum = 0.0;
+ *     		for (Event e: ctx.getEventsForPattern("middle")) {
+ *     			sum += e.getPrice();
+ *     		}
+ *     		sum += value.getPrice();
+ *     		return Double.compare(sum, 5.0) <= 0;
+ *     	}
+ *    }
+ * }
+ * </pre>
+ *
+ * <b>ATTENTION: </b> The call to {@link Context#getEventsForPattern(String) getEventsForPattern(...)} has to find
+ * the elements that belong to the pattern among the elements stored by the NFA. The cost of this operation can vary,
+ * so when implementing your condition, try to minimize the times the method is called.
+ */
+public abstract class IterativeCondition<T> implements Function, Serializable {
+
+	private static final long serialVersionUID = 7067817235759351255L;
+
+	/**
+	 * The filter function that evaluates the predicate.
+	 * <p>
+	 * <strong>IMPORTANT:</strong> The system assumes that the function does not
+	 * modify the elements on which the predicate is applied. Violating this assumption
+	 * can lead to incorrect results.
+	 *
+	 * @param value The value to be tested.
+	 * @param ctx The {@link Context} used for the evaluation of the function and provides access to
+	 *            the already accepted events in the pattern (see {@link Context#getEventsForPattern(String)}).
+	 * @return {@code true} for values that should be retained, {@code false}
+	 * for values to be filtered out.
+	 *
+	 * @throws Exception This method may throw exceptions. Throwing an exception will cause the operation
+	 *                   to fail and may trigger recovery.
+	 */
+	public abstract boolean filter(T value, Context<T> ctx) throws Exception;
+
+	/**
+	 * The context used when evaluating the {@link IterativeCondition condition}.
+	 */
+	public interface Context<T> extends Serializable {
+
+		/**
+		 * @return An {@link Iterable} over the already accepted elements
+		 * for a given pattern. Elements are iterated in the order the were
+		 * inserted in the pattern.
+		 *
+		 * @param name The name of the pattern.
+		 */
+		Iterable<T> getEventsForPattern(String name);
+	}
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/IterativeCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/IterativeCondition.java
@@ -88,7 +88,7 @@ public abstract class IterativeCondition<T> implements Function, Serializable {
 
 		/**
 		 * @return An {@link Iterable} over the already accepted elements
-		 * for a given pattern. Elements are iterated in the order the were
+		 * for a given pattern. Elements are iterated in the order they were
 		 * inserted in the pattern.
 		 *
 		 * @param name The name of the pattern.

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/NotCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/NotCondition.java
@@ -15,30 +15,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.cep.pattern;
 
-import org.apache.flink.api.common.functions.FilterFunction;
+package org.apache.flink.cep.pattern.conditions;
 
-public class FilterFunctions<T> {
+/**
+ * A {@link IterativeCondition condition} which negates the condition it wraps
+ * and returns {@code true} if the original condition returns {@code false}.
+ *
+ * @param <T> Type of the element to filter
+ */
+public class NotCondition<T> extends IterativeCondition<T> {
+	private static final long serialVersionUID = -2109562093871155005L;
 
-	private FilterFunctions() {
+	private final IterativeCondition<T> original;
+
+	public NotCondition(final IterativeCondition<T> original) {
+		this.original = original;
 	}
 
-	public static <T> FilterFunction<T> trueFunction()  {
-		return new FilterFunction<T>() {
-			@Override
-			public boolean filter(T value) throws Exception {
-				return true;
-			}
-		};
-	}
-
-	public static <T> FilterFunction<T> falseFunction()  {
-		return new FilterFunction<T>() {
-			@Override
-			public boolean filter(T value) throws Exception {
-				return false;
-			}
-		};
+	@Override
+	public boolean filter(T value, Context<T> ctx) throws Exception {
+		return !original.filter(value, ctx);
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/OrCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/OrCondition.java
@@ -16,41 +16,42 @@
  * limitations under the License.
  */
 
-package org.apache.flink.cep.pattern;
-
-import org.apache.flink.api.common.functions.FilterFunction;
+package org.apache.flink.cep.pattern.conditions;
 
 /**
- * @deprecated This is only used when migrating from an older Flink version.
- * Use the {@link org.apache.flink.cep.pattern.conditions.OrCondition} instead.
- *
- * <p>A filter function which combines two filter functions with a logical or. Thus, the filter
- * function only returns true, iff at least one of the filter functions holds true.
+ * A {@link IterativeCondition condition} which combines two conditions with a logical
+ * {@code OR} and returns {@code true} if at least one is {@code true}.
  *
  * @param <T> Type of the element to filter
  */
-@Deprecated
-public class OrFilterFunction<T> implements FilterFunction<T> {
-	private static final long serialVersionUID = -2109562093871155005L;
+public class OrCondition<T> extends IterativeCondition<T> {
 
-	private final FilterFunction<T> left;
-	private final FilterFunction<T> right;
+	private static final long serialVersionUID = 2554610954278485106L;
 
-	public OrFilterFunction(final FilterFunction<T> left, final FilterFunction<T> right) {
+	private final IterativeCondition<T> left;
+	private final IterativeCondition<T> right;
+
+	public OrCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
 		this.left = left;
 		this.right = right;
 	}
 
 	@Override
-	public boolean filter(T value) throws Exception {
-		return left.filter(value) || right.filter(value);
+	public boolean filter(T value, Context<T> ctx) throws Exception {
+		return left.filter(value, ctx) || right.filter(value, ctx);
 	}
 
-	public FilterFunction<T> getLeft() {
+	/**
+	 * @return One of the {@link IterativeCondition conditions} combined in this condition.
+	 */
+	public IterativeCondition<T> getLeft() {
 		return left;
 	}
 
-	public FilterFunction<T> getRight() {
+	/**
+	 * @return One of the {@link IterativeCondition conditions} combined in this condition.
+	 */
+	public IterativeCondition<T> getRight() {
 		return right;
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/SimpleCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/SimpleCondition.java
@@ -16,32 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.flink.cep.pattern;
+package org.apache.flink.cep.pattern.conditions;
 
 import org.apache.flink.api.common.functions.FilterFunction;
 
 /**
- * @deprecated This is only used when migrating from an older Flink version.
- * Use the {@link org.apache.flink.cep.pattern.conditions.SubtypeCondition} instead.
+ *  A user-defined condition that decides if an element should be accepted in the pattern or not.
+ * Accepting an element also signals a state transition for the corresponding {@link org.apache.flink.cep.nfa.NFA}.
  *
- * <p>A filter function which filters elements of the given type. A element if filtered out iff it
- * is not assignable to the given subtype of T.
- *
- * @param <T> Type of the elements to be filtered
+ * <p>Contrary to the {@link IterativeCondition}, conditions that extend this class do not have access to the
+ * previously accepted elements in the pattern. Conditions that extend this class are simple {@code filter(...)}
+ * functions that decide based on the properties of the element at hand.
  */
-@Deprecated
-public class SubtypeFilterFunction<T> implements FilterFunction<T> {
-	private static final long serialVersionUID = -2990017519957561355L;
+public abstract class SimpleCondition<T> extends IterativeCondition<T> implements FilterFunction<T> {
 
-	// subtype to filter for
-	private final Class<? extends T> subtype;
-
-	public SubtypeFilterFunction(final Class<? extends T> subtype) {
-		this.subtype = subtype;
-	}
+	private static final long serialVersionUID = 4942618239408140245L;
 
 	@Override
-	public boolean filter(T value) throws Exception {
-		return subtype.isAssignableFrom(value.getClass());
+	public boolean filter(T value, Context<T> ctx) throws Exception {
+		return filter(value);
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/SubtypeCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/SubtypeCondition.java
@@ -16,27 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.cep.pattern;
-
-import org.apache.flink.api.common.functions.FilterFunction;
+package org.apache.flink.cep.pattern.conditions;
 
 /**
- * A filter function which negates filter function.
+ * A {@link IterativeCondition condition} which filters elements of the given type.
+ * An element is filtered out iff it is not assignable to the given subtype of {@code T}.
  *
- * @param <T> Type of the element to filter
+ * @param <T> Type of the elements to be filtered
  */
-public class NotFilterFunction<T> implements FilterFunction<T> {
-	private static final long serialVersionUID = -2109562093871155005L;
+public class SubtypeCondition<T> extends SimpleCondition<T> {
+	private static final long serialVersionUID = -2990017519957561355L;
 
-	private final FilterFunction<T> original;
+	/** The subtype to filter for. */
+	private final Class<? extends T> subtype;
 
-	public NotFilterFunction(final FilterFunction<T> original) {
-		this.original = original;
+	public SubtypeCondition(final Class<? extends T> subtype) {
+		this.subtype = subtype;
 	}
 
 	@Override
 	public boolean filter(T value) throws Exception {
-		return !original.filter(value);
+		return subtype.isAssignableFrom(value.getClass());
 	}
-
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
@@ -18,11 +18,11 @@
 
 package org.apache.flink.cep;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.cep.pattern.Pattern;
+import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -81,7 +81,7 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 			new Event(8, "end", 1.0)
 		);
 
-		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new FilterFunction<Event>() {
+		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new SimpleCondition<Event>() {
 
 			@Override
 			public boolean filter(Event value) throws Exception {
@@ -89,7 +89,7 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 			}
 		})
 		.followedBy("middle").subtype(SubEvent.class).where(
-				new FilterFunction<SubEvent>() {
+				new SimpleCondition<SubEvent>() {
 
 					@Override
 					public boolean filter(SubEvent value) throws Exception {
@@ -97,7 +97,7 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 					}
 				}
 			)
-		.followedBy("end").where(new FilterFunction<Event>() {
+		.followedBy("end").where(new SimpleCondition<Event>() {
 
 			@Override
 			public boolean filter(Event value) throws Exception {
@@ -156,7 +156,7 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 			}
 		});
 
-		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new FilterFunction<Event>() {
+		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new SimpleCondition<Event>() {
 
 			@Override
 			public boolean filter(Event value) throws Exception {
@@ -164,7 +164,7 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 			}
 		})
 			.followedBy("middle").subtype(SubEvent.class).where(
-				new FilterFunction<SubEvent>() {
+				new SimpleCondition<SubEvent>() {
 
 					@Override
 					public boolean filter(SubEvent value) throws Exception {
@@ -172,7 +172,7 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 					}
 				}
 			)
-			.followedBy("end").where(new FilterFunction<Event>() {
+			.followedBy("end").where(new SimpleCondition<Event>() {
 
 				@Override
 				public boolean filter(Event value) throws Exception {
@@ -236,19 +236,19 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 			}
 		});
 
-		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new FilterFunction<Event>() {
+		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new SimpleCondition<Event>() {
 
 			@Override
 			public boolean filter(Event value) throws Exception {
 				return value.getName().equals("start");
 			}
-		}).followedBy("middle").where(new FilterFunction<Event>() {
+		}).followedBy("middle").where(new SimpleCondition<Event>() {
 
 			@Override
 			public boolean filter(Event value) throws Exception {
 				return value.getName().equals("middle");
 			}
-		}).followedBy("end").where(new FilterFunction<Event>() {
+		}).followedBy("end").where(new SimpleCondition<Event>() {
 
 			@Override
 			public boolean filter(Event value) throws Exception {
@@ -325,19 +325,19 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 			}
 		});
 
-		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new FilterFunction<Event>() {
+		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new SimpleCondition<Event>() {
 
 			@Override
 			public boolean filter(Event value) throws Exception {
 				return value.getName().equals("start");
 			}
-		}).followedBy("middle").where(new FilterFunction<Event>() {
+		}).followedBy("middle").where(new SimpleCondition<Event>() {
 
 			@Override
 			public boolean filter(Event value) throws Exception {
 				return value.getName().equals("middle");
 			}
-		}).followedBy("end").where(new FilterFunction<Event>() {
+		}).followedBy("end").where(new SimpleCondition<Event>() {
 
 			@Override
 			public boolean filter(Event value) throws Exception {
@@ -378,7 +378,7 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 
 		Pattern<Tuple2<Integer, Integer>, ?> pattern =
 			Pattern.<Tuple2<Integer, Integer>>begin("start")
-				.where(new FilterFunction<Tuple2<Integer, Integer>>() {
+				.where(new SimpleCondition<Tuple2<Integer, Integer>>() {
 					@Override
 					public boolean filter(Tuple2<Integer, Integer> rec) throws Exception {
 						return rec.f1 == 1;
@@ -456,19 +456,19 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 			}
 		});
 
-		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new FilterFunction<Event>() {
+		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new SimpleCondition<Event>() {
 
 			@Override
 			public boolean filter(Event value) throws Exception {
 				return value.getName().equals("start");
 			}
-		}).followedBy("middle").where(new FilterFunction<Event>() {
+		}).followedBy("middle").where(new SimpleCondition<Event>() {
 
 			@Override
 			public boolean filter(Event value) throws Exception {
 				return value.getName().equals("middle");
 			}
-		}).followedBy("end").where(new FilterFunction<Event>() {
+		}).followedBy("end").where(new SimpleCondition<Event>() {
 
 			@Override
 			public boolean filter(Event value) throws Exception {
@@ -524,26 +524,26 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 		);
 
 		Pattern<Event, ?> pattern = Pattern.<Event>begin("start")
-			.where(new FilterFunction<Event>() {
+			.where(new SimpleCondition<Event>() {
 				@Override
 				public boolean filter(Event value) throws Exception {
 					return value.getName().equals("start");
 				}
 			})
 			.followedBy("middle")
-			.where(new FilterFunction<Event>() {
+			.where(new SimpleCondition<Event>() {
 				@Override
 				public boolean filter(Event value) throws Exception {
 					return value.getPrice() == 2.0;
 				}
 			})
-			.or(new FilterFunction<Event>() {
+			.or(new SimpleCondition<Event>() {
 				@Override
 				public boolean filter(Event value) throws Exception {
 					return value.getPrice() == 5.0;
 				}
 			})
-			.followedBy("end").where(new FilterFunction<Event>() {
+			.followedBy("end").where(new SimpleCondition<Event>() {
 
 				@Override
 				public boolean filter(Event value) throws Exception {

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFATest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFATest.java
@@ -19,9 +19,9 @@
 package org.apache.flink.cep.nfa;
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.cep.Event;
-import org.apache.flink.cep.pattern.FilterFunctions;
+import org.apache.flink.cep.pattern.conditions.BooleanConditions;
+import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
@@ -58,7 +58,7 @@ public class NFATest extends TestLogger {
 
 		startState.addTake(
 			endState,
-			new FilterFunction<Event>() {
+			new SimpleCondition<Event>() {
 				private static final long serialVersionUID = -4869589195918650396L;
 
 				@Override
@@ -68,7 +68,7 @@ public class NFATest extends TestLogger {
 			});
 		endState.addTake(
 			endingState,
-			new FilterFunction<Event>() {
+			new SimpleCondition<Event>() {
 				private static final long serialVersionUID = 2979804163709590673L;
 
 				@Override
@@ -76,7 +76,7 @@ public class NFATest extends TestLogger {
 					return value.getName().equals("end");
 				}
 			});
-		endState.addIgnore(FilterFunctions.<Event>trueFunction());
+		endState.addIgnore(BooleanConditions.<Event>trueFunction());
 
 		nfa.addState(startState);
 		nfa.addState(endState);
@@ -241,7 +241,7 @@ public class NFATest extends TestLogger {
 
 		startState.addTake(
 			endState,
-			new FilterFunction<Event>() {
+			new SimpleCondition<Event>() {
 				private static final long serialVersionUID = -4869589195918650396L;
 
 				@Override
@@ -251,7 +251,7 @@ public class NFATest extends TestLogger {
 			});
 		endState.addTake(
 			endingState,
-			new FilterFunction<Event>() {
+			new SimpleCondition<Event>() {
 				private static final long serialVersionUID = 2979804163709590673L;
 
 				@Override
@@ -259,7 +259,7 @@ public class NFATest extends TestLogger {
 					return value.getName().equals("end");
 				}
 			});
-		endState.addIgnore(FilterFunctions.<Event>trueFunction());
+		endState.addIgnore(BooleanConditions.<Event>trueFunction());
 
 		nfa.addState(startState);
 		nfa.addState(endState);
@@ -268,7 +268,7 @@ public class NFATest extends TestLogger {
 		return nfa;
 	}
 
-	private static class NameFilter implements FilterFunction<Event> {
+	private static class NameFilter extends SimpleCondition<Event> {
 
 		private static final long serialVersionUID = 7472112494752423802L;
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/SharedBufferTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/SharedBufferTest.java
@@ -84,11 +84,16 @@ public class SharedBufferTest extends TestLogger {
 		sharedBuffer.put("b", events[7], timestamp, "a[]", events[6], timestamp, DeweyNumber.fromString("1.1.0"));
 
 		Collection<LinkedHashMultimap<String, Event>> patterns3 = sharedBuffer.extractPatterns("b", events[7], timestamp, DeweyNumber.fromString("1.1.0"));
-		sharedBuffer.remove("b", events[7], timestamp);
+		sharedBuffer.release("b", events[7], timestamp);
 		Collection<LinkedHashMultimap<String, Event>> patterns4 = sharedBuffer.extractPatterns("b", events[7], timestamp, DeweyNumber.fromString("1.1.0"));
 		Collection<LinkedHashMultimap<String, Event>> patterns1 = sharedBuffer.extractPatterns("b", events[5], timestamp, DeweyNumber.fromString("2.0.0"));
 		Collection<LinkedHashMultimap<String, Event>> patterns2 = sharedBuffer.extractPatterns("b", events[5], timestamp, DeweyNumber.fromString("1.0.0"));
-		sharedBuffer.remove("b", events[5], timestamp);
+		sharedBuffer.release("b", events[5], timestamp);
+
+		assertEquals(1L, patterns3.size());
+		assertEquals(0L, patterns4.size());
+		assertEquals(1L, patterns1.size());
+		assertEquals(1L, patterns2.size());
 
 		assertTrue(sharedBuffer.isEmpty());
 		assertTrue(patterns4.isEmpty());

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/compiler/NFACompilerTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/compiler/NFACompilerTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.cep.nfa.compiler;
 
 import com.google.common.collect.Sets;
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
@@ -32,6 +31,7 @@ import org.apache.flink.cep.nfa.StateTransition;
 import org.apache.flink.cep.nfa.StateTransitionAction;
 import org.apache.flink.cep.pattern.MalformedPatternException;
 import org.apache.flink.cep.pattern.Pattern;
+import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.util.TestLogger;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertTrue;
 
 public class NFACompilerTest extends TestLogger {
 
-	private static final FilterFunction<Event> startFilter = new FilterFunction<Event>() {
+	private static final SimpleCondition<Event> startFilter = new SimpleCondition<Event>() {
 		private static final long serialVersionUID = 3314714776170474221L;
 
 		@Override
@@ -57,7 +57,7 @@ public class NFACompilerTest extends TestLogger {
 		}
 	};
 
-	private static final FilterFunction<Event> endFilter = new FilterFunction<Event>() {
+	private static final SimpleCondition<Event> endFilter = new SimpleCondition<Event>() {
 		private static final long serialVersionUID = 3990995859716364087L;
 
 		@Override
@@ -91,7 +91,7 @@ public class NFACompilerTest extends TestLogger {
 	 * A filter implementation to test invalid pattern specification with
 	 * duplicate pattern names. Check {@link #testNFACompilerUniquePatternName()}.
 	 */
-	private static class TestFilter implements FilterFunction<Event> {
+	private static class TestFilter extends SimpleCondition<Event> {
 
 		private static final long serialVersionUID = -3863103355752267133L;
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigration11to13Test.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigration11to13Test.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.cep.operator;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.ByteSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
@@ -29,6 +28,7 @@ import org.apache.flink.cep.SubEvent;
 import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.cep.pattern.Pattern;
+import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -239,7 +239,7 @@ public class CEPMigration11to13Test {
 		}
 	}
 
-	private static class StartFilter implements FilterFunction<Event> {
+	private static class StartFilter extends SimpleCondition<Event> {
 		private static final long serialVersionUID = 5726188262756267490L;
 
 		@Override
@@ -248,7 +248,7 @@ public class CEPMigration11to13Test {
 		}
 	}
 
-	private static class MiddleFilter implements FilterFunction<SubEvent> {
+	private static class MiddleFilter extends SimpleCondition<SubEvent> {
 		private static final long serialVersionUID = 6215754202506583964L;
 
 		@Override
@@ -257,7 +257,7 @@ public class CEPMigration11to13Test {
 		}
 	}
 
-	private static class EndFilter implements FilterFunction<Event> {
+	private static class EndFilter extends SimpleCondition<Event> {
 		private static final long serialVersionUID = 7056763917392056548L;
 
 		@Override

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigration12to13Test.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigration12to13Test.java
@@ -17,7 +17,6 @@
  */
 package org.apache.flink.cep.operator;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -26,6 +25,7 @@ import org.apache.flink.cep.SubEvent;
 import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.cep.pattern.Pattern;
+import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
@@ -448,7 +448,7 @@ public class CEPMigration12to13Test {
 		}
 	}
 
-	private static class StartFilter implements FilterFunction<Event> {
+	private static class StartFilter extends SimpleCondition<Event> {
 		private static final long serialVersionUID = 5726188262756267490L;
 
 		@Override
@@ -457,7 +457,7 @@ public class CEPMigration12to13Test {
 		}
 	}
 
-	private static class MiddleFilter implements FilterFunction<SubEvent> {
+	private static class MiddleFilter extends SimpleCondition<SubEvent> {
 		private static final long serialVersionUID = 6215754202506583964L;
 
 		@Override
@@ -466,7 +466,7 @@ public class CEPMigration12to13Test {
 		}
 	}
 
-	private static class EndFilter implements FilterFunction<Event> {
+	private static class EndFilter extends SimpleCondition<Event> {
 		private static final long serialVersionUID = 7056763917392056548L;
 
 		@Override

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.cep.operator;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -30,6 +29,7 @@ import org.apache.flink.cep.SubEvent;
 import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.cep.pattern.Pattern;
+import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -434,7 +434,7 @@ public class CEPOperatorTest extends TestLogger {
 
 		harness.close();
 	}
-
+	
 	private void verifyWatermark(Object outputObject, long timestamp) {
 		assertTrue(outputObject instanceof Watermark);
 		assertEquals(timestamp, ((Watermark) outputObject).getTimestamp());
@@ -512,7 +512,7 @@ public class CEPOperatorTest extends TestLogger {
 		@Override
 		public NFA<Event> createNFA() {
 
-			Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new FilterFunction<Event>() {
+			Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new SimpleCondition<Event>() {
 						private static final long serialVersionUID = 5726188262756267490L;
 
 						@Override
@@ -520,7 +520,7 @@ public class CEPOperatorTest extends TestLogger {
 							return value.getName().equals("start");
 						}
 					})
-					.followedBy("middle").subtype(SubEvent.class).where(new FilterFunction<SubEvent>() {
+					.followedBy("middle").subtype(SubEvent.class).where(new SimpleCondition<SubEvent>() {
 						private static final long serialVersionUID = 6215754202506583964L;
 
 						@Override
@@ -528,7 +528,7 @@ public class CEPOperatorTest extends TestLogger {
 							return value.getVolume() > 5.0;
 						}
 					})
-					.followedBy("end").where(new FilterFunction<Event>() {
+					.followedBy("end").where(new SimpleCondition<Event>() {
 						private static final long serialVersionUID = 7056763917392056548L;
 
 						@Override

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPRescalingTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPRescalingTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.cep.operator;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.cep.Event;
@@ -27,6 +26,7 @@ import org.apache.flink.cep.SubEvent;
 import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.cep.pattern.Pattern;
+import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.time.Time;
@@ -371,7 +371,7 @@ public class CEPRescalingTest {
 		@Override
 		public NFA<Event> createNFA() {
 
-			Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new FilterFunction<Event>() {
+			Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new SimpleCondition<Event>() {
 				private static final long serialVersionUID = 5726188262756267490L;
 
 				@Override
@@ -379,7 +379,7 @@ public class CEPRescalingTest {
 					return value.getName().equals("start");
 				}
 			})
-				.followedBy("middle").subtype(SubEvent.class).where(new FilterFunction<SubEvent>() {
+				.followedBy("middle").subtype(SubEvent.class).where(new SimpleCondition<SubEvent>() {
 					private static final long serialVersionUID = 6215754202506583964L;
 
 					@Override
@@ -387,7 +387,7 @@ public class CEPRescalingTest {
 						return value.getVolume() > 5.0;
 					}
 				})
-				.followedBy("end").where(new FilterFunction<Event>() {
+				.followedBy("end").where(new SimpleCondition<Event>() {
 					private static final long serialVersionUID = 7056763917392056548L;
 
 					@Override

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/pattern/PatternTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/pattern/PatternTest.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.cep.pattern;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.cep.Event;
 import org.apache.flink.cep.SubEvent;
+import org.apache.flink.cep.pattern.conditions.OrCondition;
+import org.apache.flink.cep.pattern.conditions.SimpleCondition;
+import org.apache.flink.cep.pattern.conditions.SubtypeCondition;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
@@ -66,14 +68,14 @@ public class PatternTest extends TestLogger {
 
 	@Test
 	public void testStrictContiguityWithCondition() {
-		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").next("next").where(new FilterFunction<Event>() {
+		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").next("next").where(new SimpleCondition<Event>() {
 			private static final long serialVersionUID = -7657256242101104925L;
 
 			@Override
 			public boolean filter(Event value) throws Exception {
 				return value.getName().equals("foobar");
 			}
-		}).next("end").where(new FilterFunction<Event>() {
+		}).next("end").where(new SimpleCondition<Event>() {
 			private static final long serialVersionUID = -7597452389191504189L;
 
 			@Override
@@ -89,9 +91,9 @@ public class PatternTest extends TestLogger {
 		assertNotNull(previous2 = previous.getPrevious());
 		assertNull(previous2.getPrevious());
 
-		assertNotNull(pattern.getFilterFunction());
-		assertNotNull(previous.getFilterFunction());
-		assertNull(previous2.getFilterFunction());
+		assertNotNull(pattern.getCondition());
+		assertNotNull(previous.getCondition());
+		assertNull(previous2.getCondition());
 
 		assertEquals(pattern.getName(), "end");
 		assertEquals(previous.getName(), "next");
@@ -109,8 +111,8 @@ public class PatternTest extends TestLogger {
 		assertNotNull(previous2 = previous.getPrevious());
 		assertNull(previous2.getPrevious());
 
-		assertNotNull(previous.getFilterFunction());
-		assertTrue(previous.getFilterFunction() instanceof SubtypeFilterFunction);
+		assertNotNull(previous.getCondition());
+		assertTrue(previous.getCondition() instanceof SubtypeCondition);
 
 		assertEquals(pattern.getName(), "end");
 		assertEquals(previous.getName(), "subevent");
@@ -119,7 +121,7 @@ public class PatternTest extends TestLogger {
 
 	@Test
 	public void testPatternWithSubtypingAndFilter() {
-		Pattern<Event, Event> pattern = Pattern.<Event>begin("start").next("subevent").subtype(SubEvent.class).where(new FilterFunction<SubEvent>() {
+		Pattern<Event, Event> pattern = Pattern.<Event>begin("start").next("subevent").subtype(SubEvent.class).where(new SimpleCondition<SubEvent>() {
 			private static final long serialVersionUID = -4118591291880230304L;
 
 			@Override
@@ -136,7 +138,7 @@ public class PatternTest extends TestLogger {
 		assertNull(previous2.getPrevious());
 
 		assertTrue(pattern instanceof FollowedByPattern);
-		assertNotNull(previous.getFilterFunction());
+		assertNotNull(previous.getCondition());
 
 		assertEquals(pattern.getName(), "end");
 		assertEquals(previous.getName(), "subevent");
@@ -145,21 +147,21 @@ public class PatternTest extends TestLogger {
 
 	@Test
 	public void testPatternWithOrFilter() {
-		Pattern<Event, Event> pattern = Pattern.<Event>begin("start").where(new FilterFunction<Event>() {
+		Pattern<Event, Event> pattern = Pattern.<Event>begin("start").where(new SimpleCondition<Event>() {
 			private static final long serialVersionUID = 3518061453394250543L;
 
 			@Override
 			public boolean filter(Event value) throws Exception {
 				return false;
 			}
-		}).or(new FilterFunction<Event>() {
+		}).or(new SimpleCondition<Event>() {
 			private static final long serialVersionUID = 947463545810023841L;
 
 			@Override
 			public boolean filter(Event value) throws Exception {
 				return false;
 			}
-		}).next("or").or(new FilterFunction<Event>() {
+		}).next("or").or(new SimpleCondition<Event>() {
 			private static final long serialVersionUID = -2775487887505922250L;
 
 			@Override
@@ -176,8 +178,8 @@ public class PatternTest extends TestLogger {
 		assertNull(previous2.getPrevious());
 
 		assertTrue(pattern instanceof FollowedByPattern);
-		assertFalse(previous.getFilterFunction() instanceof OrFilterFunction);
-		assertTrue(previous2.getFilterFunction() instanceof OrFilterFunction);
+		assertFalse(previous.getCondition() instanceof OrCondition);
+		assertTrue(previous2.getCondition() instanceof OrCondition);
 
 		assertEquals(pattern.getName(), "end");
 		assertEquals(previous.getName(), "or");
@@ -187,7 +189,9 @@ public class PatternTest extends TestLogger {
 	@Test(expected = MalformedPatternException.class)
 	public void testPatternCanHaveQuantifierSpecifiedOnce1() throws Exception {
 
-		Pattern.begin("start").where(new FilterFunction<Object>() {
+		Pattern.begin("start").where(new SimpleCondition<Object>() {
+			private static final long serialVersionUID = 8876425689668531458L;
+
 			@Override
 			public boolean filter(Object value) throws Exception {
 				return true;
@@ -198,7 +202,9 @@ public class PatternTest extends TestLogger {
 	@Test(expected = MalformedPatternException.class)
 	public void testPatternCanHaveQuantifierSpecifiedOnce2() throws Exception {
 
-		Pattern.begin("start").where(new FilterFunction<Object>() {
+		Pattern.begin("start").where(new SimpleCondition<Object>() {
+			private static final long serialVersionUID = 8311890695733430258L;
+
 			@Override
 			public boolean filter(Object value) throws Exception {
 				return true;
@@ -209,7 +215,9 @@ public class PatternTest extends TestLogger {
 	@Test(expected = MalformedPatternException.class)
 	public void testPatternCanHaveQuantifierSpecifiedOnce3() throws Exception {
 
-		Pattern.begin("start").where(new FilterFunction<Object>() {
+		Pattern.begin("start").where(new SimpleCondition<Object>() {
+			private static final long serialVersionUID = 8093713196099078214L;
+
 			@Override
 			public boolean filter(Object value) throws Exception {
 				return true;
@@ -220,7 +228,9 @@ public class PatternTest extends TestLogger {
 	@Test(expected = MalformedPatternException.class)
 	public void testPatternCanHaveQuantifierSpecifiedOnce4() throws Exception {
 
-		Pattern.begin("start").where(new FilterFunction<Object>() {
+		Pattern.begin("start").where(new SimpleCondition<Object>() {
+			private static final long serialVersionUID = -2995187062849334113L;
+
 			@Override
 			public boolean filter(Object value) throws Exception {
 				return true;
@@ -231,7 +241,9 @@ public class PatternTest extends TestLogger {
 	@Test(expected = MalformedPatternException.class)
 	public void testPatternCanHaveQuantifierSpecifiedOnce5() throws Exception {
 
-		Pattern.begin("start").where(new FilterFunction<Object>() {
+		Pattern.begin("start").where(new SimpleCondition<Object>() {
+			private static final long serialVersionUID = -2205071036073867531L;
+
 			@Override
 			public boolean filter(Object value) throws Exception {
 				return true;


### PR DESCRIPTION
So far, the where clause only supported simple FilterFunction
conditions. With this, we add support for conditions where an
event is accepted not only based on its own properties, e.g.
name, as it was before, but also based on some statistic
computed over previously accepted events in the pattern, e.g.
if the price is higher than the average of the prices of the
previously accepted events.
