### PR TITLE
[FLINK-6201][example] move python example files from resources to the examples

### DIFF
--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -178,7 +178,17 @@ under the License.
 			<directory>../flink-libraries/flink-python/src/main/python/org/apache/flink/python/api</directory>
 			<outputDirectory>resources/python</outputDirectory>
 			<fileMode>0755</fileMode>
+			<excludes>
+				<exclude>**/example/**</exclude>
+			</excludes>
 		</fileSet>
+		<!-- copy python example to examples of dist -->
+		<fileSet>
+			<directory>../flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/example</directory>
+			<outputDirectory>examples/python</outputDirectory>
+			<fileMode>0755</fileMode>
+		</fileSet>
+
 	</fileSets>
 
 </assembly>


### PR DESCRIPTION
Python example in the resource dir is not suitable. Move them to the examples/python dir.

- [X] General
  - The pull request references the related JIRA issue ("[FLINK-6201] move python example files from resources to the examples")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [X] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [X] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
