### PR TITLE
[FLINK-6207] Duplicate TypeSerializers for async snapshots of CopyOnW…

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableTest.java
@@ -23,6 +23,10 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.ArrayListSerializer;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.RegisteredBackendStateMetaInfo;
@@ -30,6 +34,7 @@ import org.apache.flink.runtime.state.StateTransformationFunction;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -380,6 +385,77 @@ public class CopyOnWriteStateTableTest {
 		Assert.assertTrue(originalState5 == stateTable.get(5, 1));
 	}
 
+	/**
+	 * This tests that serializers used for snapshots are duplicates of the ones used in
+	 * processing to avoid race conditions in stateful serializers.
+	 */
+	@Test
+	public void testSerializerDuplicationInSnapshot() throws IOException {
+
+		final TestDuplicateSerializer namespaceSerializer = new TestDuplicateSerializer();
+		final TestDuplicateSerializer stateSerializer = new TestDuplicateSerializer();;
+		final TestDuplicateSerializer keySerializer = new TestDuplicateSerializer();;
+
+		RegisteredBackendStateMetaInfo<Integer, Integer> metaInfo =
+			new RegisteredBackendStateMetaInfo<>(
+				StateDescriptor.Type.VALUE,
+				"test",
+				namespaceSerializer,
+				stateSerializer);
+
+		final KeyGroupRange keyGroupRange = new KeyGroupRange(0, 0);
+		InternalKeyContext<Integer> mockKeyContext = new InternalKeyContext<Integer>() {
+			@Override
+			public Integer getCurrentKey() {
+				return 0;
+			}
+
+			@Override
+			public int getCurrentKeyGroupIndex() {
+				return 0;
+			}
+
+			@Override
+			public int getNumberOfKeyGroups() {
+				return 1;
+			}
+
+			@Override
+			public KeyGroupRange getKeyGroupRange() {
+				return keyGroupRange;
+			}
+
+			@Override
+			public TypeSerializer<Integer> getKeySerializer() {
+				return keySerializer;
+			}
+		};
+
+		CopyOnWriteStateTable<Integer, Integer, Integer> table =
+			new CopyOnWriteStateTable<>(mockKeyContext, metaInfo);
+
+		table.put(0, 0, 0, 0);
+		table.put(1, 0, 0, 1);
+		table.put(2, 0, 1, 2);
+
+
+		CopyOnWriteStateTableSnapshot<Integer, Integer, Integer> snapshot = table.createSnapshot();
+
+		try {
+
+			namespaceSerializer.disable();
+			keySerializer.disable();
+			stateSerializer.disable();
+
+			snapshot.writeMappingsInKeyGroup(
+				new DataOutputViewStreamWrapper(
+					new ByteArrayOutputStreamWithPos(1024)), 0);
+
+		} finally {
+			table.releaseSnapshot(snapshot);
+		}
+	}
+
 	@SuppressWarnings("unchecked")
 	private static <K, N, S> Tuple3<K, N, S>[] convert(CopyOnWriteStateTable.StateTableEntry<K, N, S>[] snapshot, int mapSize) {
 
@@ -481,6 +557,96 @@ public class CopyOnWriteStateTableTest {
 		@Override
 		public TypeSerializer<T> getKeySerializer() {
 			return serializer;
+		}
+	}
+
+	/**
+	 * Serializer that can be disabled. Duplicates are still enabled, so we can check that
+	 * serializers are duplicated.
+	 */
+	static class TestDuplicateSerializer extends TypeSerializer<Integer> {
+
+		private static final long serialVersionUID = 1L;
+
+		private static final Integer ZERO = 0;
+
+		private boolean disabled;
+
+		public TestDuplicateSerializer() {
+			this.disabled = false;
+		}
+
+		@Override
+		public boolean isImmutableType() {
+			return true;
+		}
+
+		@Override
+		public TypeSerializer<Integer> duplicate() {
+			return new TestDuplicateSerializer();
+		}
+
+		@Override
+		public Integer createInstance() {
+			return ZERO;
+		}
+
+		@Override
+		public Integer copy(Integer from) {
+			return from;
+		}
+
+		@Override
+		public Integer copy(Integer from, Integer reuse) {
+			return from;
+		}
+
+		@Override
+		public int getLength() {
+			return 4;
+		}
+
+		@Override
+		public void serialize(Integer record, DataOutputView target) throws IOException {
+			Assert.assertFalse(disabled);
+			target.writeInt(record);
+		}
+
+		@Override
+		public Integer deserialize(DataInputView source) throws IOException {
+			Assert.assertFalse(disabled);
+			return source.readInt();
+		}
+
+		@Override
+		public Integer deserialize(Integer reuse, DataInputView source) throws IOException {
+			Assert.assertFalse(disabled);
+			return deserialize(source);
+		}
+
+		@Override
+		public void copy(DataInputView source, DataOutputView target) throws IOException {
+			Assert.assertFalse(disabled);
+			target.writeInt(source.readInt());
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			return obj instanceof TestDuplicateSerializer;
+		}
+
+		@Override
+		public boolean canEqual(Object obj) {
+			return obj instanceof TestDuplicateSerializer;
+		}
+
+		@Override
+		public int hashCode() {
+			return getClass().hashCode();
+		}
+
+		public void disable() {
+			this.disabled = true;
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes a problem for stateful serializers for async snapshots in the `CopyOnWriteStateTable`. Serializers must be duplicated before they are used in the async snapshot thread.
