### PR TITLE
Change to validateOptionalDatePropery method

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -224,15 +224,24 @@ public class KinesisConfigUtil {
 
 	private static void validateOptionalDateProperty(Properties config, String key, String message) {
 		if (config.containsKey(key)) {
-			try {
-				initTimestampDateFormat.parse(config.getProperty(key));
-				double value = Double.parseDouble(config.getProperty(key));
-				if (value < 0) {
-					throw new NumberFormatException();
+			try{
+				if(!validateDateFormat(config, key)){
+					double value = Double.parseDouble(config.getProperty(key));
+					if (value < 0) {
+						throw new NumberFormatException();
+					}
 				}
-			} catch (ParseException | NumberFormatException e) {
+			} catch(NumberFormatException){
 				throw new IllegalArgumentException(message);
 			}
+		}
+	}
+	public static boolean validateDateFormat(Properties config, String key){
+		try {
+			initTimestampDateFormat.parse(config.getProperty(key));
+			return true;
+		} catch (ParseException) {
+			return false;
 		}
 	}
 }


### PR DESCRIPTION
Current version of validateoptionaldateproperty will fail because it will check for date first and if it passes it will fail to get parsed as a double and so it will fail the next step. Please let me know if this is an accurate statement. I just made a small change, may not follow to the pertaining code format though.

Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [ ] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
