### PR TITLE
[FLINK-6211] [kinesis] Validation error in Kinesis Consumer when using AT_TIMESTAMP as start position

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -226,12 +226,15 @@ public class KinesisConfigUtil {
 		if (config.containsKey(key)) {
 			try {
 				initTimestampDateFormat.parse(config.getProperty(key));
-				double value = Double.parseDouble(config.getProperty(key));
-				if (value < 0) {
-					throw new NumberFormatException();
+			} catch (ParseException parseException) {
+				try {
+					double value = Double.parseDouble(config.getProperty(key));
+					if (value < 0) {
+						throw new NumberFormatException();
+					}
+				} catch (NumberFormatException numberFormatException){
+					throw new IllegalArgumentException(message);
 				}
-			} catch (ParseException | NumberFormatException e) {
-				throw new IllegalArgumentException(message);
 			}
 		}
 	}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
@@ -40,12 +40,14 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Suite of FlinkKinesisConsumer tests for the methods called throughout the source life cycle.
@@ -162,6 +164,69 @@ public class FlinkKinesisConsumerTest {
 		testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP, "unparsableDate");
 
 		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+	}
+
+	@Test
+	public void testIllegalValueForInitialTimestampInConfig() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Invalid value given for initial timestamp for AT_TIMESTAMP initial position in stream.");
+
+		Properties testConfig = new Properties();
+		testConfig.setProperty(ConsumerConfigConstants.AWS_REGION, "us-east-1");
+		testConfig.setProperty(ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
+		testConfig.setProperty(ConsumerConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
+		testConfig.setProperty(ConsumerConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
+		testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_POSITION, "AT_TIMESTAMP");
+		testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP, "-1.0");
+
+		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+	}
+
+	@Test
+	public void testDateStringInValidateOptionDatePropertyForInitialTimestampInConfig() {
+		String timestamp = "2016-04-04T19:58:46.480-00:00";
+
+		Properties testConfig = new Properties();
+		testConfig.setProperty(ConsumerConfigConstants.AWS_REGION, "us-east-1");
+		testConfig.setProperty(ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
+		testConfig.setProperty(ConsumerConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
+		testConfig.setProperty(ConsumerConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
+		testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_POSITION, "AT_TIMESTAMP");
+		testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP, timestamp);
+
+		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+
+		try {
+			KinesisConfigUtil.initTimestampDateFormat.parse(timestamp);
+		} catch (ParseException e){
+			e.printStackTrace();
+			fail();
+		}
+	}
+
+	@Test
+	public void testUnixTimestampInValidateOptionDatePropertyForInitialTimestampInConfig() {
+		String unixTimestamp = "1459799926.480";
+
+		Properties testConfig = new Properties();
+		testConfig.setProperty(ConsumerConfigConstants.AWS_REGION, "us-east-1");
+		testConfig.setProperty(ConsumerConfigConstants.AWS_CREDENTIALS_PROVIDER, "BASIC");
+		testConfig.setProperty(ConsumerConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
+		testConfig.setProperty(ConsumerConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
+		testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_POSITION, "AT_TIMESTAMP");
+		testConfig.setProperty(ConsumerConfigConstants.STREAM_INITIAL_TIMESTAMP, unixTimestamp);
+
+		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
+
+		try{
+			double value = Double.parseDouble(unixTimestamp);
+			if (value < 0) {
+				throw new NumberFormatException();
+			}
+		} catch (Exception e){
+			e.printStackTrace();
+			fail();
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Address the bug in validation function to check if the date string is well formed when using AT_TIMESTAMP as start position.

This function needs to check if one of the two conditions is passed, but I made a mistake to check all conditions should be passed. That causes the problem.