### PR TITLE
Update TimeWindow.java

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/TimeWindow.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/TimeWindow.java
@@ -82,7 +82,17 @@ public class TimeWindow extends Window {
 	public long maxTimestamp() {
 		return end - 1;
 	}
-
+	
+	/**
+     * Updates window max timestamp
+     * @param timestamp
+     */
+  public void update(long timestamp) {
+    if (this.end < timestamp) {
+      this.end = timestamp;
+    }
+  }
+	
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {


### PR DESCRIPTION
A method to update the time window max timestamp would be useful when we need control the max timestamp based on events. For instance a session time window may end after the gap or when an event with a given record arives.