### PR TITLE
[FLINK-6213] [yarn] terminate resource manager itself when shutting down application

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkResourceManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.yarn;
 
 import akka.actor.ActorRef;
+import akka.actor.PoisonPill;
 import akka.actor.Props;
 
 import org.apache.flink.configuration.ConfigConstants;
@@ -300,6 +301,8 @@ public class YarnFlinkResourceManager extends FlinkResourceManager<RegisteredYar
 		} catch (Throwable t) {
 			LOG.error("Could not cleanly shut down the Node Manager Client", t);
 		}
+
+		self().tell(decorateMessage(PoisonPill.getInstance()), self());
 	}
 
 	@Override


### PR DESCRIPTION
When number of failed containers exceeds maximum failed containers, `YarnFlinkResourceManager` will receive msg `StopCluster` and then invoke `shutdownApplication`. In this method, it calls `amrmclient.unregisterApplicationMaster` to finish the application. But the AM container is not released until 10 minutes later triggered by RM ping check timeout. 
I fix this issue by terminating resource manager itself after unregistering application master, then the process will exit and the container will be released.
