### PR TITLE
[FLINK-6205] [FLINK-6069] [cep] Correct watermark/late events in side-output

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/KeyedCEPPatternOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/KeyedCEPPatternOperator.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -46,9 +47,10 @@ public class KeyedCEPPatternOperator<IN, KEY> extends AbstractKeyedCEPPatternOpe
 			KeySelector<IN, KEY> keySelector,
 			TypeSerializer<KEY> keySerializer,
 			NFACompiler.NFAFactory<IN> nfaFactory,
+			OutputTag<IN> lateDataOutputTag,
 			boolean migratingFromOldKeyedOperator) {
 
-		super(inputSerializer, isProcessingTime, keySelector, keySerializer, nfaFactory, migratingFromOldKeyedOperator);
+		super(inputSerializer, isProcessingTime, keySelector, keySerializer, nfaFactory, lateDataOutputTag, migratingFromOldKeyedOperator);
 	}
 
 	@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/TimeoutKeyedCEPPatternOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/TimeoutKeyedCEPPatternOperator.java
@@ -25,6 +25,7 @@ import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.types.Either;
+import org.apache.flink.util.OutputTag;
 
 import java.util.Collection;
 import java.util.Map;
@@ -46,9 +47,10 @@ public class TimeoutKeyedCEPPatternOperator<IN, KEY> extends AbstractKeyedCEPPat
 			KeySelector<IN, KEY> keySelector,
 			TypeSerializer<KEY> keySerializer,
 			NFACompiler.NFAFactory<IN> nfaFactory,
+			OutputTag<IN> lateDataOutputTag,
 			boolean migratingFromOldKeyedOperator) {
 
-		super(inputSerializer, isProcessingTime, keySelector, keySerializer, nfaFactory, migratingFromOldKeyedOperator);
+		super(inputSerializer, isProcessingTime, keySelector, keySerializer, nfaFactory, lateDataOutputTag, migratingFromOldKeyedOperator);
 	}
 
 	@Override

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigration11to13Test.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigration11to13Test.java
@@ -103,6 +103,7 @@ public class CEPMigration11to13Test {
 								keySelector,
 								IntSerializer.INSTANCE,
 								new NFAFactory(),
+								null,
 								true),
 						keySelector,
 						BasicTypeInfo.INT_TYPE_INFO);
@@ -177,6 +178,7 @@ public class CEPMigration11to13Test {
 								keySelector,
 								ByteSerializer.INSTANCE,
 								new NFAFactory(),
+								null,
 								false),
 						keySelector,
 						BasicTypeInfo.BYTE_TYPE_INFO);

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigration12to13Test.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigration12to13Test.java
@@ -118,6 +118,7 @@ public class CEPMigration12to13Test {
 					keySelector,
 					IntSerializer.INSTANCE,
 					new NFAFactory(),
+					null,
 					true),
 				keySelector,
 				BasicTypeInfo.INT_TYPE_INFO);
@@ -233,6 +234,7 @@ public class CEPMigration12to13Test {
 					keySelector,
 					IntSerializer.INSTANCE,
 					new NFAFactory(),
+					null,
 					true),
 				keySelector,
 				BasicTypeInfo.INT_TYPE_INFO);
@@ -353,6 +355,7 @@ public class CEPMigration12to13Test {
 					keySelector,
 					IntSerializer.INSTANCE,
 					new SinglePatternNFAFactory(),
+					null,
 					true),
 				keySelector,
 				BasicTypeInfo.INT_TYPE_INFO);

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
@@ -225,6 +225,7 @@ public class CEPOperatorTest extends TestLogger {
 				keySelector,
 				IntSerializer.INSTANCE,
 				new NFAFactory(true),
+				null,
 				true),
 			keySelector,
 			BasicTypeInfo.INT_TYPE_INFO);
@@ -482,6 +483,7 @@ public class CEPOperatorTest extends TestLogger {
 			keySelector,
 			IntSerializer.INSTANCE,
 			new NFAFactory(),
+			null,
 			true);
 	}
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPRescalingTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPRescalingTest.java
@@ -346,6 +346,7 @@ public class CEPRescalingTest {
 				keySelector,
 				BasicTypeInfo.INT_TYPE_INFO.createSerializer(new ExecutionConfig()),
 				new NFAFactory(),
+				null,
 				true),
 			keySelector,
 			BasicTypeInfo.INT_TYPE_INFO,


### PR DESCRIPTION
With this, the CEP library assumes correctness of the watermark
and considers as late, events that arrive having a timestamp
smaller than that of the last seen watermark. Late events are not
silently dropped, but the user can specify to send them to a side
output.