### PR TITLE
[FLINK-6120][Distributed Coordinator]Implement heartbeat logic between JobManager and ResourceManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -153,7 +153,10 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 	private final MetricGroup jobMetricGroup;
 
 	/** The heartbeat manager with task managers */
-	private final HeartbeatManager<Void, Void> heartbeatManager;
+	private final HeartbeatManager<Void, Void> taskManagerHeartbeatManager;
+
+	/** The heartbeat manager with resource manager */
+	private final HeartbeatManager<Void, Void> resourceManagerHeartbeatManager;
 
 	/** The execution context which is used to execute futures */
 	private final Executor executor;
@@ -215,11 +218,17 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 		this.errorHandler = checkNotNull(errorHandler);
 		this.userCodeLoader = checkNotNull(userCodeLoader);
 
-		this.heartbeatManager = heartbeatServices.createHeartbeatManagerSender(
+		this.taskManagerHeartbeatManager = heartbeatServices.createHeartbeatManagerSender(
 			resourceId,
 			new TaskManagerHeartbeatListener(),
 			rpcService.getScheduledExecutor(),
 			log);
+
+		this.resourceManagerHeartbeatManager = heartbeatServices.createHeartbeatManager(
+				resourceId,
+				new ResourceManagerHeartbeatListener(),
+				rpcService.getScheduledExecutor(),
+				log);
 
 		final String jobName = jobGraph.getName();
 		final JobID jid = jobGraph.getJobID();
@@ -306,7 +315,8 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 	 */
 	@Override
 	public void shutDown() throws Exception {
-		heartbeatManager.stop();
+		taskManagerHeartbeatManager.stop();
+		resourceManagerHeartbeatManager.stop();
 
 		// make sure there is a graceful exit
 		getSelf().suspendExecution(new Exception("JobManager is shutting down."));
@@ -404,7 +414,7 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 		slotPoolGateway.suspend();
 
 		// disconnect from resource manager:
-		closeResourceManagerConnection();
+		closeResourceManagerConnection(new Exception(cause.getMessage()));
 	}
 
 	//----------------------------------------------------------------------------------------------
@@ -531,7 +541,7 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 
 	@RpcMethod
 	public void disconnectTaskManager(final ResourceID resourceID, final Exception cause) {
-		heartbeatManager.unmonitorTarget(resourceID);
+		taskManagerHeartbeatManager.unmonitorTarget(resourceID);
 		slotPoolGateway.releaseTaskManager(resourceID);
 
 		Tuple2<TaskManagerLocation, TaskExecutorGateway> taskManagerConnection = registeredTaskManagers.remove(resourceID);
@@ -763,7 +773,7 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 					registeredTaskManagers.put(taskManagerId, Tuple2.of(taskManagerLocation, taskExecutorGateway));
 
 					// monitor the task manager as heartbeat target
-					heartbeatManager.monitorTarget(taskManagerId, new HeartbeatTarget<Void>() {
+					taskManagerHeartbeatManager.monitorTarget(taskManagerId, new HeartbeatTarget<Void>() {
 						@Override
 						public void receiveHeartbeat(ResourceID resourceID, Void payload) {
 							// the task manager will not request heartbeat, so this method will never be called currently
@@ -785,13 +795,24 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 	public void disconnectResourceManager(
 			final UUID jobManagerLeaderId,
 			final UUID resourceManagerLeaderId,
-			final Exception cause) {
-		// TODO: Implement disconnect behaviour
+			final Exception cause) throws Exception {
+
+		validateLeaderSessionId(jobManagerLeaderId);
+
+		if (resourceManagerConnection != null
+				&& resourceManagerConnection.getTargetLeaderId().equals(resourceManagerLeaderId)) {
+			closeResourceManagerConnection(cause);
+		}
 	}
 
 	@RpcMethod
 	public void heartbeatFromTaskManager(final ResourceID resourceID) {
-		heartbeatManager.receiveHeartbeat(resourceID, null);
+		taskManagerHeartbeatManager.receiveHeartbeat(resourceID, null);
+	}
+
+	@RpcMethod
+	public void heartbeatFromResourceManager(final ResourceID resourceID) {
+		resourceManagerHeartbeatManager.requestHeartbeat(resourceID, null);
 	}
 
 	//----------------------------------------------------------------------------------------------
@@ -869,56 +890,79 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 		}
 	}
 
-	private void notifyOfNewResourceManagerLeader(
-			final String resourceManagerAddress, final UUID resourceManagerLeaderId)
-	{
-		validateRunsInMainThread();
-
+	private void notifyOfNewResourceManagerLeader(final String resourceManagerAddress, final UUID resourceManagerLeaderId) {
 		if (resourceManagerConnection != null) {
 			if (resourceManagerAddress != null) {
 				if (resourceManagerAddress.equals(resourceManagerConnection.getTargetAddress())
-						&& resourceManagerLeaderId.equals(resourceManagerConnection.getTargetLeaderId())) {
+					&& resourceManagerLeaderId.equals(resourceManagerConnection.getTargetLeaderId())) {
 					// both address and leader id are not changed, we can keep the old connection
 					return;
 				}
+
+				closeResourceManagerConnection(new Exception(
+					"ResourceManager leader changed to new address " + resourceManagerAddress));
+
 				log.info("ResourceManager leader changed from {} to {}. Registering at new leader.",
-						resourceManagerConnection.getTargetAddress(), resourceManagerAddress);
+					resourceManagerConnection.getTargetAddress(), resourceManagerAddress);
 			} else {
 				log.info("Current ResourceManager {} lost leader status. Waiting for new ResourceManager leader.",
-						resourceManagerConnection.getTargetAddress());
+					resourceManagerConnection.getTargetAddress());
 			}
 		}
 
-		closeResourceManagerConnection();
-
 		if (resourceManagerAddress != null) {
 			log.info("Attempting to register at ResourceManager {}", resourceManagerAddress);
+
 			resourceManagerConnection = new ResourceManagerConnection(
-					log, jobGraph.getJobID(), getAddress(), leaderSessionID,
-					resourceManagerAddress, resourceManagerLeaderId, executor);
+				log,
+				jobGraph.getJobID(),
+				resourceId,
+				getAddress(),
+				leaderSessionID,
+				resourceManagerAddress,
+				resourceManagerLeaderId,
+				executor);
+
 			resourceManagerConnection.start();
 		}
 	}
 
-	private void onResourceManagerRegistrationSuccess(final JobMasterRegistrationSuccess success) {
-		validateRunsInMainThread();
+	private void establishResourceManagerConnection(final JobMasterRegistrationSuccess success) {
+		final UUID resourceManagerLeaderId = success.getResourceManagerLeaderId();
 	
 		// verify the response with current connection
 		if (resourceManagerConnection != null
-				&& resourceManagerConnection.getTargetLeaderId().equals(success.getResourceManagerLeaderId()))
-		{
-			log.info("JobManager successfully registered at ResourceManager, leader id: {}.",
-					success.getResourceManagerLeaderId());
+				&& resourceManagerConnection.getTargetLeaderId().equals(resourceManagerLeaderId)) {
 
-			slotPoolGateway.connectToResourceManager(
-					success.getResourceManagerLeaderId(), resourceManagerConnection.getTargetGateway());
+			log.info("JobManager successfully registered at ResourceManager, leader id: {}.", resourceManagerLeaderId);
+
+			final ResourceManagerGateway resourceManagerGateway = resourceManagerConnection.getTargetGateway();
+
+			slotPoolGateway.connectToResourceManager(resourceManagerLeaderId, resourceManagerGateway);
+
+			resourceManagerHeartbeatManager.monitorTarget(success.getResourceManagerResourceId(), new HeartbeatTarget<Void>() {
+				@Override
+				public void receiveHeartbeat(ResourceID resourceID, Void payload) {
+					resourceManagerGateway.heartbeatFromJobManager(resourceID);
+				}
+
+				@Override
+				public void requestHeartbeat(ResourceID resourceID, Void payload) {
+					// request heartbeat will never be called on the job manager side
+				}
+			});
 		}
 	}
 
-	private void closeResourceManagerConnection() {
-		validateRunsInMainThread();
-
+	private void closeResourceManagerConnection(Exception cause) {
 		if (resourceManagerConnection != null) {
+			log.info("Close ResourceManager connection {}.", resourceManagerConnection.getResourceManagerResourceID(), cause);
+
+			resourceManagerHeartbeatManager.unmonitorTarget(resourceManagerConnection.getResourceManagerResourceID());
+
+			ResourceManagerGateway resourceManagerGateway = resourceManagerConnection.getTargetGateway();
+			resourceManagerGateway.disconnectJobManager(resourceManagerConnection.getJobID(), cause);
+
 			resourceManagerConnection.close();
 			resourceManagerConnection = null;
 		}
@@ -961,13 +1005,18 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 	{
 		private final JobID jobID;
 
+		private final ResourceID jobManagerResourceID;
+
 		private final String jobManagerRpcAddress;
 
 		private final UUID jobManagerLeaderID;
 
+		private ResourceID resourceManagerResourceID;
+
 		ResourceManagerConnection(
 				final Logger log,
 				final JobID jobID,
+				final ResourceID jobManagerResourceID,
 				final String jobManagerRpcAddress,
 				final UUID jobManagerLeaderID,
 				final String resourceManagerAddress,
@@ -976,6 +1025,7 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 		{
 			super(log, resourceManagerAddress, resourceManagerLeaderID, executor);
 			this.jobID = checkNotNull(jobID);
+			this.jobManagerResourceID = checkNotNull(jobManagerResourceID);
 			this.jobManagerRpcAddress = checkNotNull(jobManagerRpcAddress);
 			this.jobManagerLeaderID = checkNotNull(jobManagerLeaderID);
 		}
@@ -995,6 +1045,7 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 					return gateway.registerJobManager(
 						leaderId,
 						jobManagerLeaderID,
+						jobManagerResourceID,
 						jobManagerRpcAddress,
 						jobID,
 						timeout);
@@ -1007,7 +1058,8 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 			runAsync(new Runnable() {
 				@Override
 				public void run() {
-					onResourceManagerRegistrationSuccess(success);
+					resourceManagerResourceID = success.getResourceManagerResourceId();
+					establishResourceManagerConnection(success);
 				}
 			});
 		}
@@ -1015,6 +1067,14 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 		@Override
 		protected void onRegistrationFailure(final Throwable failure) {
 			handleFatalError(failure);
+		}
+
+		public ResourceID getResourceManagerResourceID() {
+			return resourceManagerResourceID;
+		}
+
+		public JobID getJobID() {
+			return jobID;
 		}
 	}
 
@@ -1053,6 +1113,33 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 		@Override
 		public void reportPayload(ResourceID resourceID, Void payload) {
 			// nothing to do since there is no payload
+		}
+
+		@Override
+		public Future<Void> retrievePayload() {
+			return FlinkCompletableFuture.completed(null);
+		}
+	}
+
+	private class ResourceManagerHeartbeatListener implements HeartbeatListener<Void, Void> {
+
+		@Override
+		public void notifyHeartbeatTimeout(final ResourceID resourceId) {
+			runAsync(new Runnable() {
+				@Override
+				public void run() {
+					log.info("The heartbeat of ResourceManager with id {} timed out.", resourceId);
+
+					closeResourceManagerConnection(
+						new TimeoutException(
+							"The heartbeat of ResourceManager with id " + resourceId + " timed out."));
+				}
+			});
+		}
+
+		@Override
+		public void reportPayload(ResourceID resourceID, Void payload) {
+			// nothing to do since the payload is of type Void
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -226,4 +226,11 @@ public interface JobMasterGateway extends CheckpointCoordinatorGateway {
 	 * @param resourceID unique id of the task manager
 	 */
 	void heartbeatFromTaskManager(final ResourceID resourceID);
+
+	/**
+	 * Heartbeat request from the resource manager
+	 *
+	 * @param resourceID unique id of the resource manager
+	 */
+	void heartbeatFromResourceManager(final ResourceID resourceID);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterRegistrationSuccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterRegistrationSuccess.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmaster;
 
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 
 import java.util.UUID;
@@ -35,9 +36,15 @@ public class JobMasterRegistrationSuccess extends RegistrationResponse.Success {
 
 	private final UUID resourceManagerLeaderId;
 
-	public JobMasterRegistrationSuccess(final long heartbeatInterval, final UUID resourceManagerLeaderId) {
+	private final ResourceID resourceManagerResourceId;
+
+	public JobMasterRegistrationSuccess(
+			final long heartbeatInterval,
+			final UUID resourceManagerLeaderId,
+			final ResourceID resourceManagerResourceId) {
 		this.heartbeatInterval = heartbeatInterval;
 		this.resourceManagerLeaderId = checkNotNull(resourceManagerLeaderId);
+		this.resourceManagerResourceId = checkNotNull(resourceManagerResourceId);
 	}
 
 	/**
@@ -53,11 +60,16 @@ public class JobMasterRegistrationSuccess extends RegistrationResponse.Success {
 		return resourceManagerLeaderId;
 	}
 
+	public ResourceID getResourceManagerResourceId() {
+		return resourceManagerResourceId;
+	}
+
 	@Override
 	public String toString() {
 		return "JobMasterRegistrationSuccess{" +
 			"heartbeatInterval=" + heartbeatInterval +
 			", resourceManagerLeaderId=" + resourceManagerLeaderId +
+			", resourceManagerResourceId=" + resourceManagerResourceId +
 			'}';
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -44,6 +44,7 @@ public interface ResourceManagerGateway extends RpcGateway {
 	 *
 	 * @param resourceManagerLeaderId The fencing token for the ResourceManager leader
 	 * @param jobMasterLeaderId The fencing token for the JobMaster leader
+	 * @param jobMasterResourceId   The resource ID of the JobMaster that registers
 	 * @param jobMasterAddress        The address of the JobMaster that registers
 	 * @param jobID                   The Job ID of the JobMaster that registers
 	 * @param timeout                 Timeout for the future to complete
@@ -52,10 +53,10 @@ public interface ResourceManagerGateway extends RpcGateway {
 	Future<RegistrationResponse> registerJobManager(
 		UUID resourceManagerLeaderId,
 		UUID jobMasterLeaderId,
+		ResourceID jobMasterResourceId,
 		String jobMasterAddress,
 		JobID jobID,
 		@RpcTimeout Time timeout);
-
 
 	/**
 	 * Requests a slot from the resource manager.
@@ -139,10 +140,25 @@ public interface ResourceManagerGateway extends RpcGateway {
 	void heartbeatFromTaskManager(final ResourceID heartbeatOrigin);
 
 	/**
+	 * Sends the heartbeat to resource manager from job manager
+	 *
+	 * @param heartbeatOrigin unique id of the job manager
+	 */
+	void heartbeatFromJobManager(final ResourceID heartbeatOrigin);
+
+	/**
 	 * Disconnects a TaskManager specified by the given resourceID from the {@link ResourceManager}.
 	 *
 	 * @param resourceID identifying the TaskManager to disconnect
 	 * @param cause for the disconnection of the TaskManager
 	 */
 	void disconnectTaskManager(ResourceID resourceID, Exception cause);
+
+	/**
+	 * Disconnects a JobManager specified by the given resourceID from the {@link ResourceManager}.
+	 *
+	 * @param jobId JobID for which the JobManager was the leader
+	 * @param cause for the disconnection of the JobManager
+	 */
+	void disconnectJobManager(JobID jobId, Exception cause);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/JobManagerRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/JobManagerRegistration.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager.registration;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.util.Preconditions;
 
@@ -30,21 +31,29 @@ import java.util.UUID;
 public class JobManagerRegistration {
 	private final JobID jobID;
 
+	private final ResourceID jobManagerResourceID;
+
 	private final UUID leaderID;
 
 	private final JobMasterGateway jobManagerGateway;
 
 	public JobManagerRegistration(
 			JobID jobID,
+			ResourceID jobManagerResourceID,
 			UUID leaderID,
 			JobMasterGateway jobManagerGateway) {
 		this.jobID = Preconditions.checkNotNull(jobID);
+		this.jobManagerResourceID = Preconditions.checkNotNull(jobManagerResourceID);
 		this.leaderID = Preconditions.checkNotNull(leaderID);
 		this.jobManagerGateway = Preconditions.checkNotNull(jobManagerGateway);
 	}
 
 	public JobID getJobID() {
 		return jobID;
+	}
+
+	public ResourceID getJobManagerResourceID() {
+		return jobManagerResourceID;
 	}
 
 	public UUID getLeaderID() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ResourceManagerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.clusterframework;
 
 import akka.actor.ActorSystem;
 import akka.testkit.JavaTestKit;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -37,7 +38,10 @@ import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+import org.apache.flink.runtime.jobmaster.JobMasterRegistrationSuccess;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
+import org.apache.flink.runtime.leaderelection.TestingLeaderRetrievalService;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.metrics.MetricRegistry;
@@ -394,7 +398,8 @@ public class ResourceManagerTest extends TestLogger {
 
 		try {
 			final StandaloneResourceManager resourceManager = new StandaloneResourceManager(
-				rpcService, resourceManagerResourceID,
+				rpcService,
+				resourceManagerResourceID,
 				resourceManagerConfiguration,
 				highAvailabilityServices,
 				heartbeatServices,
@@ -410,27 +415,32 @@ public class ResourceManagerTest extends TestLogger {
 
 			final SlotReport slotReport = new SlotReport();
 			// test registration response successful and it will trigger monitor heartbeat target, schedule heartbeat request at interval time
-			Future<RegistrationResponse> successfulFuture =
-					resourceManager.registerTaskExecutor(rmLeaderSessionId, taskManagerAddress, taskManagerResourceID, slotReport);
+			Future<RegistrationResponse> successfulFuture = resourceManager.registerTaskExecutor(
+				rmLeaderSessionId,
+				taskManagerAddress,
+				taskManagerResourceID,
+				slotReport);
 			RegistrationResponse response = successfulFuture.get(5, TimeUnit.SECONDS);
 			assertTrue(response instanceof TaskExecutorRegistrationSuccess);
 
 			ArgumentCaptor<Runnable> heartbeatRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
-			verify(scheduledExecutor, times(1)).scheduleAtFixedRate(
+			verify(scheduledExecutor, times(2)).scheduleAtFixedRate(
 				heartbeatRunnableCaptor.capture(),
 				eq(0L),
 				eq(heartbeatInterval),
 				eq(TimeUnit.MILLISECONDS));
 
-			Runnable heartbeatRunnable = heartbeatRunnableCaptor.getValue();
+			List<Runnable> heartbeatRunnable = heartbeatRunnableCaptor.getAllValues();
 
 			ArgumentCaptor<Runnable> timeoutRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
 			verify(scheduledExecutor).schedule(timeoutRunnableCaptor.capture(), eq(heartbeatTimeout), eq(TimeUnit.MILLISECONDS));
 
 			Runnable timeoutRunnable = timeoutRunnableCaptor.getValue();
 
-			// run the first heartbeat request
-			heartbeatRunnable.run();
+			// run all the heartbeat requests
+			for (Runnable runnable : heartbeatRunnable) {
+				runnable.run();
+			}
 
 			verify(taskExecutorGateway, times(1)).heartbeatFromResourceManager(eq(resourceManagerResourceID));
 
@@ -438,6 +448,100 @@ public class ResourceManagerTest extends TestLogger {
 			timeoutRunnable.run();
 
 			verify(taskExecutorGateway).disconnectResourceManager(any(TimeoutException.class));
+
+		} finally {
+			rpcService.stopService();
+		}
+	}
+
+	@Test
+	public void testHeartbeatTimeoutWithJobManager() throws Exception {
+		final String jobMasterAddress = "jm";
+		final ResourceID jmResourceId = new ResourceID(jobMasterAddress);
+		final ResourceID rmResourceId = ResourceID.generate();
+		final UUID rmLeaderId = UUID.randomUUID();
+		final UUID jmLeaderId = UUID.randomUUID();
+		final JobID jobId = new JobID();
+
+		final JobMasterGateway jobMasterGateway = mock(JobMasterGateway.class);
+
+		final TestingSerialRpcService rpcService = new TestingSerialRpcService();
+		rpcService.registerGateway(jobMasterAddress, jobMasterGateway);
+
+		final ResourceManagerConfiguration resourceManagerConfiguration = new ResourceManagerConfiguration(
+			Time.seconds(5L),
+			Time.seconds(5L));
+
+		final TestingLeaderElectionService rmLeaderElectionService = new TestingLeaderElectionService();
+		final TestingLeaderRetrievalService jmLeaderRetrievalService = new TestingLeaderRetrievalService(jobMasterAddress, jmLeaderId);
+		final TestingHighAvailabilityServices highAvailabilityServices = new TestingHighAvailabilityServices();
+		highAvailabilityServices.setResourceManagerLeaderElectionService(rmLeaderElectionService);
+		highAvailabilityServices.setJobMasterLeaderRetriever(jobId, jmLeaderRetrievalService);
+
+		final long heartbeatInterval = 1L;
+		final long heartbeatTimeout = 5L;
+		final ScheduledExecutor scheduledExecutor = mock(ScheduledExecutor.class);
+		final HeartbeatServices heartbeatServices = new TestingHeartbeatServices(heartbeatInterval, heartbeatTimeout, scheduledExecutor);
+
+		final TestingSlotManagerFactory slotManagerFactory = new TestingSlotManagerFactory();
+		final MetricRegistry metricRegistry = mock(MetricRegistry.class);
+		final JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(
+			highAvailabilityServices,
+			rpcService.getScheduledExecutor(),
+			Time.minutes(5L));
+		final TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
+
+		try {
+			final StandaloneResourceManager resourceManager = new StandaloneResourceManager(
+				rpcService,
+				rmResourceId,
+				resourceManagerConfiguration,
+				highAvailabilityServices,
+				heartbeatServices,
+				slotManagerFactory,
+				metricRegistry,
+				jobLeaderIdService,
+				testingFatalErrorHandler);
+
+			resourceManager.start();
+
+			rmLeaderElectionService.isLeader(rmLeaderId);
+
+			// test registration response successful and it will trigger monitor heartbeat target, schedule heartbeat request at interval time
+			Future<RegistrationResponse> successfulFuture = resourceManager.registerJobManager(
+				rmLeaderId,
+				jmLeaderId,
+				jmResourceId,
+				jobMasterAddress,
+				jobId);
+			RegistrationResponse response = successfulFuture.get(5, TimeUnit.SECONDS);
+			assertTrue(response instanceof JobMasterRegistrationSuccess);
+
+			ArgumentCaptor<Runnable> heartbeatRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+			verify(scheduledExecutor, times(2)).scheduleAtFixedRate(
+				heartbeatRunnableCaptor.capture(),
+				eq(0L),
+				eq(heartbeatInterval),
+				eq(TimeUnit.MILLISECONDS));
+
+			List<Runnable> heartbeatRunnable = heartbeatRunnableCaptor.getAllValues();
+
+			ArgumentCaptor<Runnable> timeoutRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+			verify(scheduledExecutor).schedule(timeoutRunnableCaptor.capture(), eq(heartbeatTimeout), eq(TimeUnit.MILLISECONDS));
+
+			Runnable timeoutRunnable = timeoutRunnableCaptor.getValue();
+
+			// run all the heartbeat requests
+			for (Runnable runnable : heartbeatRunnable) {
+				runnable.run();
+			}
+
+			verify(jobMasterGateway, times(1)).heartbeatFromResourceManager(eq(rmResourceId));
+
+			// run the timeout runnable to simulate a heartbeat timeout
+			timeoutRunnable.run();
+
+			verify(jobMasterGateway).disconnectResourceManager(eq(jmLeaderId), eq(rmLeaderId), any(TimeoutException.class));
 
 		} finally {
 			rpcService.stopService();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -18,11 +18,13 @@
 
 package org.apache.flink.runtime.jobmaster;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoader;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory;
@@ -32,6 +34,8 @@ import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
 import org.apache.flink.runtime.leaderelection.TestingLeaderRetrievalService;
+import org.apache.flink.runtime.registration.RegistrationResponse;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rpc.TestingSerialRpcService;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
@@ -52,9 +56,8 @@ import java.util.concurrent.TimeoutException;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(BlobLibraryCacheManager.class)
@@ -135,6 +138,86 @@ public class JobMasterTest extends TestLogger {
 			timeoutRunnable.run();
 
 			verify(taskExecutorGateway).disconnectJobManager(eq(jobGraph.getJobID()), any(TimeoutException.class));
+
+			// check if a concurrent error occurred
+			testingFatalErrorHandler.rethrowError();
+
+		} finally {
+			rpc.stopService();
+		}
+	}
+
+	@Test
+	public void testHeartbeatTimeoutWithResourceManager() throws Exception {
+		final String resourceManagerAddress = "rm";
+		final String jobManagerAddress = "jm";
+		final UUID rmLeaderId = UUID.randomUUID();
+		final UUID jmLeaderId = UUID.randomUUID();
+		final ResourceID rmResourceId = new ResourceID(resourceManagerAddress);
+		final ResourceID jmResourceId = new ResourceID(jobManagerAddress);
+		final JobGraph jobGraph = new JobGraph();
+
+		final TestingHighAvailabilityServices haServices = new TestingHighAvailabilityServices();
+		final TestingLeaderRetrievalService rmLeaderRetrievalService = new TestingLeaderRetrievalService(
+			null,
+			null);
+		haServices.setResourceManagerLeaderRetriever(rmLeaderRetrievalService);
+		haServices.setCheckpointRecoveryFactory(mock(CheckpointRecoveryFactory.class));
+
+		final long heartbeatInterval = 1L;
+		final long heartbeatTimeout = 5L;
+		final ScheduledExecutor scheduledExecutor = mock(ScheduledExecutor.class);
+		final HeartbeatServices heartbeatServices = new TestingHeartbeatServices(heartbeatInterval, heartbeatTimeout, scheduledExecutor);
+
+		final ResourceManagerGateway resourceManagerGateway = mock(ResourceManagerGateway.class);
+		when(resourceManagerGateway.registerJobManager(
+			any(UUID.class),
+			any(UUID.class),
+			any(ResourceID.class),
+			anyString(),
+			any(JobID.class),
+			any(Time.class)
+		)).thenReturn(FlinkCompletableFuture.<RegistrationResponse>completed(new JobMasterRegistrationSuccess(
+			heartbeatInterval, rmLeaderId, rmResourceId)));
+
+		final TestingSerialRpcService rpc = new TestingSerialRpcService();
+		rpc.registerGateway(resourceManagerAddress, resourceManagerGateway);
+
+		final TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
+
+		try {
+			final JobMaster jobMaster = new JobMaster(
+				jmResourceId,
+				jobGraph,
+				new Configuration(),
+				rpc,
+				haServices,
+				heartbeatServices,
+				Executors.newScheduledThreadPool(1),
+				mock(BlobLibraryCacheManager.class),
+				mock(RestartStrategyFactory.class),
+				Time.of(10, TimeUnit.SECONDS),
+				null,
+				mock(OnCompletionActions.class),
+				testingFatalErrorHandler,
+				new FlinkUserCodeClassLoader(new URL[0]));
+
+			jobMaster.start(jmLeaderId);
+
+			// define a leader and see that a registration happens
+			rmLeaderRetrievalService.notifyListener(resourceManagerAddress, rmLeaderId);
+
+			// register job manager success will trigger monitor heartbeat target between jm and rm
+			verify(resourceManagerGateway).registerJobManager(
+				eq(rmLeaderId),
+				eq(jmLeaderId),
+				eq(jmResourceId),
+				anyString(),
+				eq(jobGraph.getJobID()),
+				any(Time.class));
+
+			// heartbeat timeout should trigger disconnect JobManager from ResourceManager
+			verify(resourceManagerGateway, timeout(heartbeatTimeout * 50L)).disconnectJobManager(eq(jobGraph.getJobID()), any(TimeoutException.class));
 
 			// check if a concurrent error occurred
 			testingFatalErrorHandler.rethrowError();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -69,13 +69,19 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 		JobID jobID = mockJobMaster(jobMasterAddress);
 		TestingLeaderElectionService resourceManagerLeaderElectionService = new TestingLeaderElectionService();
 		UUID jmLeaderID = UUID.randomUUID();
+		final ResourceID jmResourceId = new ResourceID(jobMasterAddress);
 		TestingLeaderRetrievalService jobMasterLeaderRetrievalService = new TestingLeaderRetrievalService(jobMasterAddress, jmLeaderID);
 		TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
 		final ResourceManager resourceManager = createAndStartResourceManager(resourceManagerLeaderElectionService, jobID, jobMasterLeaderRetrievalService, testingFatalErrorHandler);
 		final UUID rmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
 
 		// test response successful
-		Future<RegistrationResponse> successfulFuture = resourceManager.registerJobManager(rmLeaderSessionId, jmLeaderID, jobMasterAddress, jobID);
+		Future<RegistrationResponse> successfulFuture = resourceManager.registerJobManager(
+			rmLeaderSessionId,
+			jmLeaderID,
+			jmResourceId,
+			jobMasterAddress,
+			jobID);
 		RegistrationResponse response = successfulFuture.get(5L, TimeUnit.SECONDS);
 		assertTrue(response instanceof JobMasterRegistrationSuccess);
 
@@ -93,6 +99,7 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 		JobID jobID = mockJobMaster(jobMasterAddress);
 		TestingLeaderElectionService resourceManagerLeaderElectionService = new TestingLeaderElectionService();
 		UUID jmLeaderID = UUID.randomUUID();
+		final ResourceID jmResourceId = new ResourceID(jobMasterAddress);
 		TestingLeaderRetrievalService jobMasterLeaderRetrievalService = new TestingLeaderRetrievalService(jobMasterAddress, jmLeaderID);
 		TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
 		final ResourceManager resourceManager = createAndStartResourceManager(resourceManagerLeaderElectionService, jobID, jobMasterLeaderRetrievalService, testingFatalErrorHandler);
@@ -100,7 +107,12 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 
 		// test throw exception when receive a registration from job master which takes unmatched leaderSessionId
 		UUID differentLeaderSessionID = UUID.randomUUID();
-		Future<RegistrationResponse> unMatchedLeaderFuture = resourceManager.registerJobManager(differentLeaderSessionID, jmLeaderID, jobMasterAddress, jobID);
+		Future<RegistrationResponse> unMatchedLeaderFuture = resourceManager.registerJobManager(
+			differentLeaderSessionID,
+			jmLeaderID,
+			jmResourceId,
+			jobMasterAddress,
+			jobID);
 		assertTrue(unMatchedLeaderFuture.get(5, TimeUnit.SECONDS) instanceof RegistrationResponse.Decline);
 
 		if (testingFatalErrorHandler.hasExceptionOccurred()) {
@@ -123,10 +135,16 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 		final ResourceManager resourceManager = createAndStartResourceManager(resourceManagerLeaderElectionService, jobID, jobMasterLeaderRetrievalService, testingFatalErrorHandler);
 		final UUID rmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
 		final UUID jmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
+		final ResourceID jmResourceId = new ResourceID(jobMasterAddress);
 
 		// test throw exception when receive a registration from job master which takes unmatched leaderSessionId
 		UUID differentLeaderSessionID = UUID.randomUUID();
-		Future<RegistrationResponse> unMatchedLeaderFuture = resourceManager.registerJobManager(rmLeaderSessionId, differentLeaderSessionID, jobMasterAddress, jobID);
+		Future<RegistrationResponse> unMatchedLeaderFuture = resourceManager.registerJobManager(
+			rmLeaderSessionId,
+			differentLeaderSessionID,
+			jmResourceId,
+			jobMasterAddress,
+			jobID);
 		assertTrue(unMatchedLeaderFuture.get(5, TimeUnit.SECONDS) instanceof RegistrationResponse.Decline);
 
 		if (testingFatalErrorHandler.hasExceptionOccurred()) {
@@ -149,10 +167,16 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 		final ResourceManager resourceManager = createAndStartResourceManager(resourceManagerLeaderElectionService, jobID, jobMasterLeaderRetrievalService, testingFatalErrorHandler);
 		final UUID rmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
 		final UUID jmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
+		final ResourceID jmResourceId = new ResourceID(jobMasterAddress);
 
 		// test throw exception when receive a registration from job master which takes invalid address
 		String invalidAddress = "/jobMasterAddress2";
-		Future<RegistrationResponse> invalidAddressFuture = resourceManager.registerJobManager(rmLeaderSessionId, jmLeaderSessionId, invalidAddress, jobID);
+		Future<RegistrationResponse> invalidAddressFuture = resourceManager.registerJobManager(
+			rmLeaderSessionId,
+			jmLeaderSessionId,
+			jmResourceId,
+			invalidAddress,
+			jobID);
 		assertTrue(invalidAddressFuture.get(5, TimeUnit.SECONDS) instanceof RegistrationResponse.Decline);
 
 		if (testingFatalErrorHandler.hasExceptionOccurred()) {
@@ -175,10 +199,16 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 		final ResourceManager resourceManager = createAndStartResourceManager(resourceManagerLeaderElectionService, jobID, jobMasterLeaderRetrievalService, testingFatalErrorHandler);
 		final UUID rmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
 		final UUID jmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
+		final ResourceID jmResourceId = new ResourceID(jobMasterAddress);
 
 		JobID unknownJobIDToHAServices = new JobID();
 		// verify return RegistrationResponse.Decline when failed to start a job master Leader retrieval listener
-		Future<RegistrationResponse> declineFuture = resourceManager.registerJobManager(rmLeaderSessionId, jmLeaderSessionId, jobMasterAddress, unknownJobIDToHAServices);
+		Future<RegistrationResponse> declineFuture = resourceManager.registerJobManager(
+			rmLeaderSessionId,
+			jmLeaderSessionId,
+			jmResourceId,
+			jobMasterAddress,
+			unknownJobIDToHAServices);
 		RegistrationResponse response = declineFuture.get(5, TimeUnit.SECONDS);
 		assertTrue(response instanceof RegistrationResponse.Decline);
 
@@ -204,7 +234,7 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 		highAvailabilityServices.setResourceManagerLeaderElectionService(resourceManagerLeaderElectionService);
 		highAvailabilityServices.setJobMasterLeaderRetriever(jobID, jobMasterLeaderRetrievalService);
 
-		HeartbeatServices heartbeatServices = mock(HeartbeatServices.class);
+		HeartbeatServices heartbeatServices = new HeartbeatServices(5L, 5L);
 
 		ResourceManagerConfiguration resourceManagerConfiguration = new ResourceManagerConfiguration(
 			Time.seconds(5L),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
@@ -100,6 +100,7 @@ public class SlotProtocolTest extends TestLogger {
 		final String jmAddress = "/jm1";
 		final JobID jobID = new JobID();
 		final ResourceID rmResourceId = new ResourceID(rmAddress);
+		final ResourceID jmResourceId = new ResourceID(jmAddress);
 
 		testRpcService.registerGateway(jmAddress, mock(JobMasterGateway.class));
 
@@ -137,7 +138,7 @@ public class SlotProtocolTest extends TestLogger {
 		rmLeaderElectionService.isLeader(rmLeaderID);
 
 		Future<RegistrationResponse> registrationFuture =
-			resourceManager.registerJobManager(rmLeaderID, jmLeaderID, jmAddress, jobID);
+			resourceManager.registerJobManager(rmLeaderID, jmLeaderID, jmResourceId, jmAddress, jobID);
 		try {
 			registrationFuture.get(5, TimeUnit.SECONDS);
 		} catch (Exception e) {
@@ -206,6 +207,7 @@ public class SlotProtocolTest extends TestLogger {
 		final String tmAddress = "/tm1";
 		final JobID jobID = new JobID();
 		final ResourceID rmResourceId = new ResourceID(rmAddress);
+		final ResourceID jmResourceId = new ResourceID(jmAddress);
 
 		testRpcService.registerGateway(jmAddress, mock(JobMasterGateway.class));
 
@@ -251,7 +253,7 @@ public class SlotProtocolTest extends TestLogger {
 		Thread.sleep(1000);
 
 		Future<RegistrationResponse> registrationFuture =
-			resourceManager.registerJobManager(rmLeaderID, jmLeaderID, jmAddress, jobID);
+			resourceManager.registerJobManager(rmLeaderID, jmLeaderID, jmResourceId, jmAddress, jobID);
 		try {
 			registrationFuture.get(5L, TimeUnit.SECONDS);
 		} catch (Exception e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -88,6 +88,7 @@ public class TaskExecutorITCase {
 		final String jmAddress = "jm";
 		final UUID jmLeaderId = UUID.randomUUID();
 		final ResourceID rmResourceId = new ResourceID(rmAddress);
+		final ResourceID jmResourceId = new ResourceID(jmAddress);
 		final JobID jobId = new JobID();
 		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
 
@@ -176,7 +177,12 @@ public class TaskExecutorITCase {
 			// notify the TM about the new RM leader
 			rmLeaderRetrievalService.notifyListener(rmAddress, rmLeaderId);
 
-			Future<RegistrationResponse> registrationResponseFuture = resourceManager.registerJobManager(rmLeaderId, jmLeaderId, jmAddress, jobId);
+			Future<RegistrationResponse> registrationResponseFuture = resourceManager.registerJobManager(
+				rmLeaderId,
+				jmLeaderId,
+				jmResourceId,
+				jmAddress,
+				jobId);
 
 			RegistrationResponse registrationResponse = registrationResponseFuture.get();
 


### PR DESCRIPTION
It is part of work for Flip-6.

The `HeartbeatManager` is mainly used for monitoring heartbeat target and reporting payloads.

For `ResourceManager` side, it would trigger monitor the `HeartbeatTarget` when receive registration from `JobManager`, and schedule a task to `requestHeartbeat` at interval time. If not receive heartbeat response within duration time, the `HeartbeatListener` will notify heartbeat timeout, then the `ResourceManager` will remove the internal connection with `JobManager` and also notify the `JobManager` to close the corresponding connection via RPC.

For `JobManger` side, it would trigger monitor the `HeartbeatTarget` when receive registration success from `ResourceManager`. It will also be notified heartbeat timeout if not receive heartbeat request from `ResourceManager` within duration time and close connection as a result.

The current implementation will not interact payloads via heartbeat, and it can be added if needed future.
