### PR TITLE
[FLINK-6152] [yarn] don't throw exception if client can't receive cluster status

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
@@ -245,7 +245,8 @@ public class YarnClusterClient extends ClusterClient {
 					akkaDuration);
 			return (GetClusterStatusResponse) Await.result(clusterStatusOption, akkaDuration);
 		} catch (Exception e) {
-			throw new RuntimeException("Unable to get ClusterClient status from Application Client", e);
+			LOG.warn("Unable to get ClusterClient status from Application Client", e);
+			return null;
 		}
 	}
 


### PR DESCRIPTION
Currently if client can't get jobmanager status, it will throw exception and trigger shutdown hook. In the shutdown hook method, config file, keytab file and properties file will all be deleted. As result, AM restarting will fail. 
I fix this issue by only responding cluster status failure from yarn client, which tolerates am restarting.