### PR TITLE
[FLINK-6175] Harden HistoryServerTest#testFullArchiveLifecycle

### DIFF
--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.runtime.webmonitor.history;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
+import akka.testkit.TestActorRef;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
@@ -38,10 +39,12 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import scala.Option;
 
 public class HistoryServerTest {
@@ -62,42 +65,31 @@ public class HistoryServerTest {
 		config.setString(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_DIRS, jmDirectory.toURI().toString());
 		config.setString(HistoryServerOptions.HISTORY_SERVER_WEB_DIR, hsDirectory.getAbsolutePath());
 
+		config.setInteger(HistoryServerOptions.HISTORY_SERVER_WEB_PORT, 0);
+
 		ActorSystem actorSystem = AkkaUtils.createLocalActorSystem(config);
 		Option<Path> archivePath = Option.apply(new Path(jmDirectory.toURI().toString()));
 
-		ActorRef memoryArchivist = actorSystem.actorOf(JobManager.getArchiveProps(MemoryArchivist.class, 1, archivePath));
+		ActorRef memoryArchivist = TestActorRef.apply(JobManager.getArchiveProps(MemoryArchivist.class, 1, archivePath), actorSystem);
 		memoryArchivist.tell(new ArchiveMessages.ArchiveExecutionGraph(graph.getJobID(), graph), null);
 
 		File archive = new File(jmDirectory, graph.getJobID().toString());
-		for (int x = 0; x < 10 && !archive.exists(); x++) {
-			Thread.sleep(50);
-		}
 		Assert.assertTrue(archive.exists());
 
-		HistoryServer hs = new HistoryServer(config);
+		CountDownLatch numFinishedPolls = new CountDownLatch(1);
+
+		HistoryServer hs = new HistoryServer(config, numFinishedPolls);
 		try {
 			hs.start();
+			String baseUrl = "http://localhost:" + hs.getWebPort();
+			numFinishedPolls.await(10L, TimeUnit.SECONDS);
+
 			ObjectMapper mapper = new ObjectMapper();
-			JsonNode overview = null;
-			for (int x = 0; x < 20; x++) {
-				Thread.sleep(50);
-				String response = getFromHTTP("http://localhost:8082/joboverview");
-				if (response.contains("404 Not Found")) {
-					// file may not be written yet
-					continue;
-				} else {
-					try {
-						overview = mapper.readTree(response);
-						break;
-					} catch (IOException ignored) {
-						// while the file may exist the contents may not have been written yet
-						continue;
-					}
-				}
-			}
-			Assert.assertNotNull("/joboverview.json did not contain valid json", overview);
+			String response = getFromHTTP(baseUrl + "/joboverview");
+			JsonNode overview = mapper.readTree(response);
+
 			String jobID = overview.get("finished").get(0).get("jid").asText();
-			JsonNode jobDetails = mapper.readTree(getFromHTTP("http://localhost:8082/jobs/" + jobID));
+			JsonNode jobDetails = mapper.readTree(getFromHTTP(baseUrl + "/jobs/" + jobID));
 			Assert.assertNotNull(jobDetails.get("jid"));
 		} finally {
 			hs.stop();


### PR DESCRIPTION
This PR hardens the `testFullArchiveLifecycle` test by introducing an optional `CountdownLatch` argument to the HistoryServer constructor This latch is updated after each finished archive poll, regardless of whether it failed or not.

This simplifies the test and removes edge cases where the requested file already exists but the contents weren't written yet.