### PR TITLE
[FLINK-6011] Support TUMBLE, HOP, SESSION window in streaming SQL.

### DIFF
--- a/docs/dev/table_api.md
+++ b/docs/dev/table_api.md
@@ -1418,9 +1418,45 @@ val result2 = tableEnv.sql(
 </div>
 </div>
 
+#### Group windows
+
+Streaming SQL supports aggregation on group windows by specifying the windows in the `GROUP BY` clause. The following table describes the syntax of the group windows:
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th><code>GROUP BY</code> clause</th>
+      <th class="text-left">Description</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><code>TUMBLE(mode, interval)</code></td>
+      <td>A tumbling window over the time period specified by <code>interval</code>.</td>
+    </tr>
+    <tr>
+      <td><code>HOP(mode, slide, size)</code></td>
+      <td>A sliding window with the length of <code>size</code> and moves every <code>slide</code>.</td>
+    </tr>
+    <tr>
+      <td><code>SESSION(mode, gap)</code></td>
+      <td>A session window that has <code>gap</code> as the gap between two windows.</td>
+    </tr>
+  </tbody>
+</table>
+
+The parameters `interval`, `slide`, `size`, `gap` must be constant time intervals. The `mode` can be either `proctime()` or `rowtime()`, which specifies the window is over the processing time or the event time.
+
+As an example, the following SQL computes the total number of records over a 15 minute tumbling window over processing time:
+
+```
+SELECT COUNT(*) FROM $table GROUP BY TUMBLE(proctime(), INTERVAL '15' MINUTE)
+```
+
 #### Limitations
 
-The current version of streaming SQL only supports `SELECT`, `FROM`, `WHERE`, and `UNION` clauses. Aggregations or joins are not supported yet.
+The current version of streaming SQL only supports `SELECT`, `FROM`, `WHERE`, and `UNION` clauses. Aggregations or joins are not fully supported yet.
 
 {% top %}
 
@@ -5093,8 +5129,7 @@ The following operations are not supported yet:
 - Collection functions
 - Aggregate functions like STDDEV_xxx, VAR_xxx, and REGR_xxx
 - Distinct aggregate functions like COUNT DISTINCT
-- Window functions
-- Grouping functions
+- Row windows
 
 
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/LogicalWindowAggregateRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/LogicalWindowAggregateRule.scala
@@ -17,23 +17,25 @@
  */
 package org.apache.flink.table.plan.rules.datastream
 
+import java.math.BigDecimal
+
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.avatica.util.TimeUnitRange
 import org.apache.calcite.plan._
 import org.apache.calcite.plan.hep.HepRelVertex
 import org.apache.calcite.rel.logical.{LogicalAggregate, LogicalProject}
 import org.apache.calcite.rex.{RexCall, RexLiteral, RexNode}
-import org.apache.calcite.sql.fun.SqlFloorFunction
+import org.apache.calcite.sql.fun.{SqlFloorFunction, SqlStdOperatorTable}
 import org.apache.calcite.util.ImmutableBitSet
-import org.apache.flink.table.api.scala.Tumble
-import org.apache.flink.table.api.{EventTimeWindow, TableException, TumblingWindow, Window}
+import org.apache.flink.table.api.scala.{Session, Slide, Tumble}
+import org.apache.flink.table.api._
 import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.TimeModeTypes
 import org.apache.flink.table.plan.logical.rel.LogicalWindowAggregate
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo
 
-import scala.collection.JavaConversions._
+import _root_.scala.collection.JavaConversions._
 
 class LogicalWindowAggregateRule
   extends RelOptRule(
@@ -117,46 +119,86 @@ class LogicalWindowAggregateRule
   }
 
   private def identifyWindow(field: RexNode): Option[Window] = {
-    // Detects window expressions by pattern matching
-    //   supported patterns: FLOOR(time AS xxx) and CEIL(time AS xxx),
-    //   with time being equal to proctime() or rowtime()
     field match {
       case call: RexCall =>
         call.getOperator match {
-          case _: SqlFloorFunction =>
-            val operand = call.getOperands.get(1).asInstanceOf[RexLiteral]
-            val unit: TimeUnitRange = operand.getValue.asInstanceOf[TimeUnitRange]
-            val w = LogicalWindowAggregateRule.timeUnitRangeToTumbleWindow(unit)
-            call.getType match {
-              case TimeModeTypes.PROCTIME =>
-                return Some(w)
-              case TimeModeTypes.ROWTIME =>
-                return Some(w.on("rowtime"))
-              case _ =>
-            }
-          case _ =>
+          case _: SqlFloorFunction => FloorWindowTranslator(call).toWindow
+          case SqlStdOperatorTable.TUMBLE => TumbleWindowTranslator(call).toWindow
+          case SqlStdOperatorTable.HOP => SlidingWindowTranslator(call).toWindow
+          case SqlStdOperatorTable.SESSION => SessionWindowTranslator(call).toWindow
+          case _ => None
         }
-      case _ =>
+      case _ => None
     }
-    None
   }
+}
 
+private abstract class WindowTranslator {
+  val call: RexCall
+
+  protected def unwrapLiteral[T](node: RexNode): T =
+    node.asInstanceOf[RexLiteral].getValue.asInstanceOf[T]
+
+  protected def getOperandAsLong(idx: Int): Long =
+    unwrapLiteral[BigDecimal](call.getOperands.get(idx)).longValue()
+
+  def toWindow: Option[Window]
+}
+
+private case class FloorWindowTranslator(call: RexCall) extends WindowTranslator {
+  override def toWindow: Option[Window] = {
+    val range = unwrapLiteral[TimeUnitRange](call.getOperands.get(1))
+    val w = Tumble.over(Literal(range.startUnit.multiplier.longValue(),
+      TimeIntervalTypeInfo.INTERVAL_MILLIS))
+    call.getType match {
+      case TimeModeTypes.PROCTIME => Some(w)
+      case TimeModeTypes.ROWTIME => Some(w.on("rowtime"))
+      case _ => None
+    }
+  }
+}
+
+private case class TumbleWindowTranslator(call: RexCall) extends WindowTranslator {
+  override def toWindow: Option[Window] = {
+    val interval = getOperandAsLong(1)
+    val w = Tumble.over(Literal(interval, TimeIntervalTypeInfo.INTERVAL_MILLIS))
+    call.getType match {
+      case TimeModeTypes.PROCTIME => Some(w)
+      case TimeModeTypes.ROWTIME => Some(w.on("rowtime"))
+      case _ => None
+    }
+  }
+}
+
+private case class SlidingWindowTranslator(call: RexCall) extends WindowTranslator {
+  override def toWindow: Option[Window] = {
+    val (slide, size) = (getOperandAsLong(1), getOperandAsLong(2))
+    val w = Slide
+      .over(Literal(size, TimeIntervalTypeInfo.INTERVAL_MILLIS))
+      .every(Literal(slide, TimeIntervalTypeInfo.INTERVAL_MILLIS))
+    call.getType match {
+      case TimeModeTypes.PROCTIME => Some(w)
+      case TimeModeTypes.ROWTIME => Some(w.on("rowtime"))
+      case _ => None
+    }
+  }
+}
+
+private case class SessionWindowTranslator(call: RexCall) extends WindowTranslator {
+  override def toWindow: Option[Window] = {
+    val gap = getOperandAsLong(1)
+    val w = Session.withGap(Literal(gap, TimeIntervalTypeInfo.INTERVAL_MILLIS))
+    call.getType match {
+      case TimeModeTypes.PROCTIME => Some(w)
+      case TimeModeTypes.ROWTIME => Some(w.on("rowtime"))
+      case _ => None
+    }
+  }
 }
 
 object LogicalWindowAggregateRule {
-
   private[flink] val LOGICAL_WINDOW_PREDICATE = RelOptRule.operand(classOf[LogicalAggregate],
     RelOptRule.operand(classOf[LogicalProject], RelOptRule.none()))
 
   private[flink] val INSTANCE = new LogicalWindowAggregateRule
-
-  private def timeUnitRangeToTumbleWindow(range: TimeUnitRange): TumblingWindow = {
-    intervalToTumbleWindow(range.startUnit.multiplier.longValue())
-  }
-
-  private def intervalToTumbleWindow(size: Long): TumblingWindow = {
-    Tumble over Literal(size, TimeIntervalTypeInfo.INTERVAL_MILLIS)
-  }
-
 }
-

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/LogicalWindowAggregateRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/LogicalWindowAggregateRule.scala
@@ -27,8 +27,8 @@ import org.apache.calcite.rel.logical.{LogicalAggregate, LogicalProject}
 import org.apache.calcite.rex.{RexCall, RexLiteral, RexNode}
 import org.apache.calcite.sql.fun.{SqlFloorFunction, SqlStdOperatorTable}
 import org.apache.calcite.util.ImmutableBitSet
-import org.apache.flink.table.api.scala.{Session, Slide, Tumble}
 import org.apache.flink.table.api._
+import org.apache.flink.table.api.scala.{Session, Slide, Tumble}
 import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.TimeModeTypes
@@ -140,7 +140,10 @@ private abstract class WindowTranslator {
     node.asInstanceOf[RexLiteral].getValue.asInstanceOf[T]
 
   protected def getOperandAsLong(idx: Int): Long =
-    unwrapLiteral[BigDecimal](call.getOperands.get(idx)).longValue()
+    call.getOperands.get(idx) match {
+      case v : RexLiteral => v.getValue.asInstanceOf[BigDecimal].longValue()
+      case _ => throw new TableException("Only constant window descriptors are supported")
+    }
 
   def toWindow: Option[Window]
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -350,7 +350,16 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     SqlStdOperatorTable.EXISTS,
     // EXTENSIONS
     EventTimeExtractor,
-    ProcTimeExtractor
+    ProcTimeExtractor,
+    SqlStdOperatorTable.TUMBLE,
+    SqlStdOperatorTable.TUMBLE_START,
+    SqlStdOperatorTable.TUMBLE_END,
+    SqlStdOperatorTable.HOP,
+    SqlStdOperatorTable.HOP_START,
+    SqlStdOperatorTable.HOP_END,
+    SqlStdOperatorTable.SESSION,
+    SqlStdOperatorTable.SESSION_START,
+    SqlStdOperatorTable.SESSION_END
   )
 
   builtInSqlOperators.foreach(register)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -352,14 +352,8 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     EventTimeExtractor,
     ProcTimeExtractor,
     SqlStdOperatorTable.TUMBLE,
-    SqlStdOperatorTable.TUMBLE_START,
-    SqlStdOperatorTable.TUMBLE_END,
     SqlStdOperatorTable.HOP,
-    SqlStdOperatorTable.HOP_START,
-    SqlStdOperatorTable.HOP_END,
-    SqlStdOperatorTable.SESSION,
-    SqlStdOperatorTable.SESSION_START,
-    SqlStdOperatorTable.SESSION_END
+    SqlStdOperatorTable.SESSION
   )
 
   builtInSqlOperators.foreach(register)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/sql/WindowAggregateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/sql/WindowAggregateTest.scala
@@ -249,6 +249,13 @@ class WindowAggregateTest extends TableTestBase {
     streamUtil.verifySql(sql, expected)
   }
 
+  @Test(expected = classOf[TableException])
+  def testNonconstantWindowSize() = {
+    val sql = "SELECT COUNT(*) FROM MyTable GROUP BY TUMBLE(proctime(), c * INTERVAL '1' MINUTE)"
+    val expected = ""
+    streamUtil.verifySql(sql, expected)
+  }
+
   @Test
   def testUnboundPartitionedProcessingWindowWithRange() = {
     val sql = "SELECT " +


### PR DESCRIPTION
This PR adds supports for the `TUMBLE`, `HOP`, and `SESSION` windows in Flink.

The work of supporting WindowStart and WindowEnd expressions will be deferred to FLINK-6012.