### PR TITLE
[FLINK-6215] Make the StatefulSequenceSource scalable.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ListCheckpointed.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ListCheckpointed.java
@@ -67,7 +67,7 @@ import java.util.List;
  * +----+   +----+   +----+   +----+   +----+
  * </pre>
  
- * Recovering the checkpoint with <i>parallelism = 5</i> yields the following state assignment:
+ * Recovering the checkpoint with <i>parallelism = 2</i> yields the following state assignment:
  * <pre>
  *      func_1          func_2
  * +----+----+----+   +----+----+

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/StatefulSequenceSourceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/StatefulSequenceSourceTest.java
@@ -39,7 +39,8 @@ public class StatefulSequenceSourceTest {
 
 	@Test
 	public void testCheckpointRestore() throws Exception {
-		final int initElement = 0;
+		final int maxParallelism = 5;
+		final int initElement = -101;
 		final int maxElement = 100;
 
 		final Set<Long> expectedOutput = new HashSet<>();
@@ -57,14 +58,14 @@ public class StatefulSequenceSourceTest {
 		StreamSource<Long, StatefulSequenceSource> src1 = new StreamSource<>(source1);
 
 		final AbstractStreamOperatorTestHarness<Long> testHarness1 =
-			new AbstractStreamOperatorTestHarness<>(src1, 2, 2, 0);
+			new AbstractStreamOperatorTestHarness<>(src1, maxParallelism, 2, 0);
 		testHarness1.open();
 
 		final StatefulSequenceSource source2 = new StatefulSequenceSource(initElement, maxElement);
 		StreamSource<Long, StatefulSequenceSource> src2 = new StreamSource<>(source2);
 
 		final AbstractStreamOperatorTestHarness<Long> testHarness2 =
-			new AbstractStreamOperatorTestHarness<>(src2, 2, 2, 1);
+			new AbstractStreamOperatorTestHarness<>(src2, maxParallelism, 2, 1);
 		testHarness2.open();
 
 		final Throwable[] error = new Throwable[3];
@@ -117,7 +118,7 @@ public class StatefulSequenceSourceTest {
 		StreamSource<Long, StatefulSequenceSource> src3 = new StreamSource<>(source3);
 
 		final AbstractStreamOperatorTestHarness<Long> testHarness3 =
-			new AbstractStreamOperatorTestHarness<>(src3, 2, 1, 0);
+			new AbstractStreamOperatorTestHarness<>(src3, maxParallelism, 1, 0);
 		testHarness3.setup();
 		testHarness3.initializeState(snapshot);
 		testHarness3.open();


### PR DESCRIPTION
So far this source was computing all the elements to
be emitted and stored them in memory. This could lead
to out-of-memory problems for large deployments. Now
we split the range of elements into partitions that
can be re-shuffled upon rescaling and we just store
the next offset and the end of each one of them upon
checkpointing.

The current version of the PR has no backwards compatibility,
as this becomes tricky given that we change the semantics
of the state that we store.

I believe that this is ok, given that it is a fix that has to go in
the 1.3 and we are not sure if people are actually using it in 
production, i.e. in settings that need backwards compatibility.

What do you think @aljoscha @StephanEwen ?

