### PR TITLE
[Flink-6072] TestCase CheckpointStateRestoreTest::testSetState should be fail

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskState.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.runtime.state.ChainedStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StateUtil;
@@ -83,6 +84,14 @@ public class SubtaskState implements StateObject {
 		this.managedKeyedState = managedKeyedState;
 		this.rawKeyedState = rawKeyedState;
 
+		if (this.managedKeyedState != null && this.rawKeyedState != null){
+			KeyGroupRange keyGroupRange1 = this.managedKeyedState.getKeyGroupRange();
+			KeyGroupRange keyGroupRange2 = this.rawKeyedState.getKeyGroupRange();
+			if (!keyGroupRange1.equals(keyGroupRange2)){
+				throw new IllegalArgumentException("ManagedKeyedState's KeyRange " + keyGroupRange1 +
+					" is different with RawKeyedState's KeyRange " + keyGroupRange2);
+			}
+		}
 		try {
 			long calculateStateSize = getSizeNullSafe(legacyOperatorState);
 			calculateStateSize += getSizeNullSafe(managedOperatorState);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/SubtaskStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/SubtaskStateTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+
+import org.apache.flink.runtime.state.ChainedStateHandle;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
+import org.apache.flink.runtime.state.KeyGroupsStateHandle;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class SubtaskStateTest {
+
+	@Test
+	public void testDifferentKeyRange(){
+		ChainedStateHandle<StreamStateHandle> legacyOperatorState =
+			(ChainedStateHandle<StreamStateHandle>) mock(ChainedStateHandle.class);
+
+		KeyGroupsStateHandle managedKeyedState = mock(KeyGroupsStateHandle.class);
+		KeyGroupsStateHandle rawKeyedState = mock(KeyGroupsStateHandle.class);
+		KeyGroupRange managedKeyGroupRange = KeyGroupRange.of(0,9);
+		KeyGroupRange rawKeyGroupRange = KeyGroupRange.of(10,19);
+
+		when(managedKeyedState.getKeyGroupRange()).thenReturn(managedKeyGroupRange);
+		when(rawKeyedState.getKeyGroupRange()).thenReturn(rawKeyGroupRange);
+
+		try {
+			new SubtaskState(legacyOperatorState, null, null, managedKeyedState, rawKeyedState);
+			fail("Did not throw expected Exception");
+		}catch(Exception expected){
+			assertTrue(expected.getMessage().contains("is different with"));
+		}
+	}
+
+	@Test
+	public void testSameKeyRange(){
+		ChainedStateHandle<StreamStateHandle> legacyOperatorState =
+			(ChainedStateHandle<StreamStateHandle>) mock(ChainedStateHandle.class);
+
+		KeyGroupsStateHandle managedKeyedState = mock(KeyGroupsStateHandle.class);
+		KeyGroupsStateHandle rawKeyedState = mock(KeyGroupsStateHandle.class);
+		KeyGroupRange managedKeyGroupRange = KeyGroupRange.of(0,9);
+		KeyGroupRange rawKeyGroupRange = KeyGroupRange.of(0,9);
+
+		when(managedKeyedState.getKeyGroupRange()).thenReturn(managedKeyGroupRange);
+		when(rawKeyedState.getKeyGroupRange()).thenReturn(rawKeyGroupRange);
+
+		try {
+			new SubtaskState(legacyOperatorState, null, null, managedKeyedState, rawKeyedState);
+		}catch(Exception unExpected){
+			fail("Throw unExpected Exception");
+		}
+	}
+
+	@Test
+	public void testOnlyHasKeyedState(){
+		ChainedStateHandle<StreamStateHandle> legacyOperatorState =
+			(ChainedStateHandle<StreamStateHandle>) mock(ChainedStateHandle.class);
+
+		KeyGroupsStateHandle managedKeyedState = mock(KeyGroupsStateHandle.class);
+		KeyGroupRange managedKeyGroupRange = KeyGroupRange.of(0,9);
+		KeyGroupRangeOffsets managedKeyGroupRangeOffsets = mock(KeyGroupRangeOffsets.class);
+
+		when(managedKeyedState.getKeyGroupRange()).thenReturn(managedKeyGroupRange);
+
+		try {
+			new SubtaskState(legacyOperatorState, null, null, managedKeyedState, null);
+		}catch(Exception unExpected){
+			fail("Throw unExpected Exception");
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TaskStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TaskStateTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupsStateHandle;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TaskStateTest {
+
+	@Test
+	public void testNoOverlapKeyRange(){
+		JobVertexID jobVertexId = new JobVertexID();
+		TaskState taskState = new TaskState(jobVertexId,3,128,3);
+
+		SubtaskState subTaskState0 = mock(SubtaskState.class);
+		/* KeyGroupStateHandel0 [0,9] */
+		KeyGroupsStateHandle keyGroupsStateHandle0 = mock(KeyGroupsStateHandle.class);
+		KeyGroupRange keyGroupRange0 = KeyGroupRange.of(0,9);
+		when(keyGroupsStateHandle0.getKeyGroupRange()).thenReturn(keyGroupRange0);
+		when(subTaskState0.getManagedKeyedState()).thenReturn(keyGroupsStateHandle0);
+
+		SubtaskState subTaskState1 = mock(SubtaskState.class);
+		/* KeyGroupStateHandel1 [10,19] */
+		KeyGroupsStateHandle keyGroupsStateHandle1 = mock(KeyGroupsStateHandle.class);
+		KeyGroupRange keyGroupRange1 = KeyGroupRange.of(10,19);
+		when(keyGroupsStateHandle1.getKeyGroupRange()).thenReturn(keyGroupRange1);
+		when(subTaskState1.getManagedKeyedState()).thenReturn(keyGroupsStateHandle1);
+
+
+
+		taskState.putState(0, subTaskState0);
+		taskState.putState(1, subTaskState1);
+
+		SubtaskState subTaskState2 = mock(SubtaskState.class);
+		/* KeyGroupStateHandel1 [20,29] */
+		KeyGroupsStateHandle keyGroupsStateHandle2 = mock(KeyGroupsStateHandle.class);
+		KeyGroupRange keyGroupRange2 = KeyGroupRange.of(20,29);
+		when(keyGroupsStateHandle2.getKeyGroupRange()).thenReturn(keyGroupRange2);
+		when(subTaskState2.getManagedKeyedState()).thenReturn(keyGroupsStateHandle2);
+
+		taskState.putState(2, subTaskState2);
+
+		assertEquals(3, taskState.getNumberCollectedStates());
+
+	}
+
+	@Test
+	public void testOverlapKeyRange(){
+		JobVertexID jobVertexId = new JobVertexID();
+		TaskState taskState = new TaskState(jobVertexId,3,128,3);
+
+		SubtaskState subTaskState0 = mock(SubtaskState.class);
+		/* KeyGroupStateHandel0 [0,9] */
+		KeyGroupsStateHandle keyGroupsStateHandle0 = mock(KeyGroupsStateHandle.class);
+		KeyGroupRange keyGroupRange0 = KeyGroupRange.of(0,9);
+		when(keyGroupsStateHandle0.getKeyGroupRange()).thenReturn(keyGroupRange0);
+		when(subTaskState0.getManagedKeyedState()).thenReturn(keyGroupsStateHandle0);
+
+		SubtaskState subTaskState1 = mock(SubtaskState.class);
+		/* KeyGroupStateHandel1 [10,19] */
+		KeyGroupsStateHandle keyGroupsStateHandle1 = mock(KeyGroupsStateHandle.class);
+		KeyGroupRange keyGroupRange1 = KeyGroupRange.of(10,19);
+		when(keyGroupsStateHandle1.getKeyGroupRange()).thenReturn(keyGroupRange1);
+		when(subTaskState1.getManagedKeyedState()).thenReturn(keyGroupsStateHandle1);
+
+
+
+		taskState.putState(0, subTaskState0);
+		taskState.putState(1, subTaskState1);
+
+
+		SubtaskState subTaskState2 = mock(SubtaskState.class);
+		/* KeyGroupStateHandel1 [15,29] */
+		KeyGroupsStateHandle keyGroupsStateHandle2 = mock(KeyGroupsStateHandle.class);
+		KeyGroupRange keyGroupRange2 = KeyGroupRange.of(15,29);
+		when(keyGroupsStateHandle2.getKeyGroupRange()).thenReturn(keyGroupRange2);
+		when(subTaskState2.getManagedKeyedState()).thenReturn(keyGroupsStateHandle2);
+
+		try {
+			taskState.putState(2, subTaskState2);
+			fail("Did not throw expected Exception");
+		}catch (Exception expected){
+			assertTrue(expected.getMessage().contains("has overlap with"));
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV1Test.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV1Test.java
@@ -128,14 +128,14 @@ public class SavepointV1Test {
 
 				if (hasKeyedBackend) {
 					keyedStateBackend = new KeyGroupsStateHandle(
-							new KeyGroupRangeOffsets(1, 1, new long[]{42}),
+							new KeyGroupRangeOffsets(subtaskIdx, subtaskIdx, new long[]{42}),
 							new TestByteStreamStateHandleDeepCompare("c", "Hello"
 								.getBytes(ConfigConstants.DEFAULT_CHARSET)));
 				}
 
 				if (hasKeyedStream) {
 					keyedStateStream = new KeyGroupsStateHandle(
-							new KeyGroupRangeOffsets(1, 1, new long[]{23}),
+							new KeyGroupRangeOffsets(subtaskIdx, subtaskIdx, new long[]{23}),
 							new TestByteStreamStateHandleDeepCompare("d", "World"
 								.getBytes(ConfigConstants.DEFAULT_CHARSET)));
 				}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -949,8 +949,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 						checkpointMetaData.getCheckpointId());
 				}
 			} catch (Exception e) {
-				e.printStackTrace();;
-				System.err.println("we are exception"+e);
 				// the state is completed if an exception occurred in the acknowledgeCheckpoint call
 				// in order to clean up, we have to set it to RUNNING again.
 				asyncCheckpointState.compareAndSet(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -949,6 +949,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 						checkpointMetaData.getCheckpointId());
 				}
 			} catch (Exception e) {
+				e.printStackTrace();;
+				System.err.println("we are exception"+e);
 				// the state is completed if an exception occurred in the acknowledgeCheckpoint call
 				// in order to clean up, we have to set it to RUNNING again.
 				asyncCheckpointState.compareAndSet(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -463,6 +463,9 @@ public class StreamTaskTest extends TestLogger {
 		OperatorStateHandle managedOperatorStateHandle = mock(OperatorStateHandle.class);
 		OperatorStateHandle rawOperatorStateHandle = mock(OperatorStateHandle.class);
 
+		when(managedKeyedStateHandle.getKeyGroupRange()).thenReturn(KeyGroupRange.of(0,0));
+		when(rawKeyedStateHandle.getKeyGroupRange()).thenReturn(KeyGroupRange.of(0,0));
+
 		OperatorSnapshotResult operatorSnapshotResult = new OperatorSnapshotResult(
 			new DoneFuture<>(managedKeyedStateHandle),
 			new DoneFuture<>(rawKeyedStateHandle),
@@ -578,6 +581,9 @@ public class StreamTaskTest extends TestLogger {
 		KeyedStateHandle rawKeyedStateHandle = mock(KeyedStateHandle.class);
 		OperatorStateHandle managedOperatorStateHandle = mock(OperatorStateHandle.class);
 		OperatorStateHandle rawOperatorStateHandle = mock(OperatorStateHandle.class);
+
+		when(managedKeyedStateHandle.getKeyGroupRange()).thenReturn(KeyGroupRange.of(0,0));
+		when(rawKeyedStateHandle.getKeyGroupRange()).thenReturn(KeyGroupRange.of(0,0));
 
 		OperatorSnapshotResult operatorSnapshotResult = new OperatorSnapshotResult(
 			new DoneFuture<>(managedKeyedStateHandle),


### PR DESCRIPTION
This case should be fail because three `KeyGroupStateHandles` which have same `KeyGroupRange[0,0]` are received by `CheckpointCoordinator`.

This pull request includes:
1. Use three different `KeyGroupRange`s in the test case.
2. Check whether the `KeyGroupRange` of `TaskState` has overlap.
3. Check whether the `KeyGroupRange` of `SubTaskState` is different.