### PR TITLE
[FLINK-4848] [ssl] Throw meaningful exception when SSL is misconfigured

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
@@ -141,6 +141,9 @@ public class SSLUtils {
 				ConfigConstants.SECURITY_SSL_PROTOCOL,
 				ConfigConstants.DEFAULT_SECURITY_SSL_PROTOCOL);
 
+			Preconditions.checkNotNull(trustStoreFilePath, ConfigConstants.SECURITY_SSL_TRUSTSTORE + " was not configured.");
+			Preconditions.checkNotNull(trustStorePassword, ConfigConstants.SECURITY_SSL_TRUSTSTORE_PASSWORD + " was not configured.");
+
 			KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
 
 			FileInputStream trustStoreFile = null;
@@ -197,6 +200,10 @@ public class SSLUtils {
 			String sslProtocolVersion = sslConfig.getString(
 				ConfigConstants.SECURITY_SSL_PROTOCOL,
 				ConfigConstants.DEFAULT_SECURITY_SSL_PROTOCOL);
+
+			Preconditions.checkNotNull(keystoreFilePath, ConfigConstants.SECURITY_SSL_KEYSTORE + " was not configured.");
+			Preconditions.checkNotNull(keystorePassword, ConfigConstants.SECURITY_SSL_KEYSTORE_PASSWORD + " was not configured.");
+			Preconditions.checkNotNull(certPassword, ConfigConstants.SECURITY_SSL_KEY_PASSWORD + " was not configured.");
 
 			KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
 			FileInputStream keyStoreFile = null;


### PR DESCRIPTION
This PR provides better error messages when SSL is enabled but is missing crucial configuration options.