### PR TITLE
[FLINK-6268] [core] Object reuse for Either type

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializer.java
@@ -92,12 +92,12 @@ public class EitherSerializer<L, R> extends TypeSerializer<Either<L, R>> {
 	@Override
 	public Either<L, R> copy(Either<L, R> from, Either<L, R> reuse) {
 		if (from.isLeft()) {
-			Left<L, R> to = Either.asLeft(reuse, leftSerializer);
+			Left<L, R> to = Either.obtainLeft(reuse, leftSerializer);
 			L left = leftSerializer.copy(from.left(), to.left());
 			to.setValue(left);
 			return to;
 		} else {
-			Right<L, R> to = Either.asRight(reuse, rightSerializer);
+			Right<L, R> to = Either.obtainRight(reuse, rightSerializer);
 			R right = rightSerializer.copy(from.right(), to.right());
 			to.setValue(right);
 			return to;
@@ -136,12 +136,12 @@ public class EitherSerializer<L, R> extends TypeSerializer<Either<L, R>> {
 	public Either<L, R> deserialize(Either<L, R> reuse, DataInputView source) throws IOException {
 		boolean isLeft = source.readBoolean();
 		if (isLeft) {
-			Left<L, R> to = Either.asLeft(reuse, leftSerializer);
+			Left<L, R> to = Either.obtainLeft(reuse, leftSerializer);
 			L left = leftSerializer.deserialize(to.left(), source);
 			to.setValue(left);
 			return to;
 		} else {
-			Right<L, R> to = Either.asRight(reuse, rightSerializer);
+			Right<L, R> to = Either.obtainRight(reuse, rightSerializer);
 			R right = rightSerializer.deserialize(to.right(), source);
 			to.setValue(right);
 			return to;

--- a/flink-core/src/main/java/org/apache/flink/types/Either.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Either.java
@@ -20,7 +20,9 @@ package org.apache.flink.types;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.EitherTypeInfoFactory;
+import org.apache.flink.api.java.typeutils.runtime.EitherSerializer;
 
 /**
  * This type represents a value of one two possible types, Left or Right (a
@@ -92,7 +94,9 @@ public abstract class Either<L, R> {
 	 *            the type of Right
 	 */
 	public static class Left<L, R> extends Either<L, R> {
-		private final L value;
+		private L value;
+
+		private Right<L, R> right;
 
 		public Left(L value) {
 			this.value = java.util.Objects.requireNonNull(value);
@@ -106,6 +110,15 @@ public abstract class Either<L, R> {
 		@Override
 		public R right() {
 			throw new IllegalStateException("Cannot retrieve Right value on a Left");
+		}
+
+		/**
+		 * Sets the encapsulated value to another value
+		 *
+		 * @param value the new value of the encapsulated value
+		 */
+		public void setValue(L value) {
+			this.value = value;
 		}
 
 		@Override
@@ -145,7 +158,9 @@ public abstract class Either<L, R> {
 	 *            the type of Right
 	 */
 	public static class Right<L, R> extends Either<L, R> {
-		private final R value;
+		private R value;
+
+		private Left<L, R> left;
 
 		public Right(R value) {
 			this.value = java.util.Objects.requireNonNull(value);
@@ -159,6 +174,15 @@ public abstract class Either<L, R> {
 		@Override
 		public R right() {
 			return value;
+		}
+
+		/**
+		 * Sets the encapsulated value to another value
+		 *
+		 * @param value the new value of the encapsulated value
+		 */
+		public void setValue(R value) {
+			this.value = value;
 		}
 
 		@Override
@@ -186,6 +210,62 @@ public abstract class Either<L, R> {
 		 */
 		public static <L, R> Right<L, R> of(R right) {
 			return new Right<L, R>(right);
+		}
+	}
+
+	/**
+	 * Utility function for {@link EitherSerializer} to support object reuse.
+	 *
+	 * To support object reuse both subclasses of Either contain a reference to
+	 * an instance of the other type. This method provides access to and
+	 * initializes the cross-reference.
+	 *
+	 * @param input container for Left or Right value
+	 * @param leftSerializer for creating an instance of the left type
+	 * @param <L>
+	 *            the type of Left
+	 * @param <R>
+	 *            the type of Right
+	 * @return input if Left type else input's Left reference
+	 */
+	public static <L, R> Left<L, R> asLeft(Either<L, R> input, TypeSerializer<L> leftSerializer) {
+		if (input.isLeft()) {
+			return (Left<L, R>) input;
+		} else {
+			Right<L, R> right = (Right<L, R>) input;
+			if (right.left == null) {
+				right.left = Left.of(leftSerializer.createInstance());
+				right.left.right = right;
+			}
+			return right.left;
+		}
+	}
+
+	/**
+	 * Utility function for {@link EitherSerializer} to support object reuse.
+	 *
+	 * To support object reuse both subclasses of Either contain a reference to
+	 * an instance of the other type. This method provides access to and
+	 * initializes the cross-reference.
+	 *
+	 * @param input container for Left or Right value
+	 * @param rightSerializer for creating an instance of the right type
+	 * @param <L>
+	 *            the type of Left
+	 * @param <R>
+	 *            the type of Right
+	 * @return input if Right type else input's Right reference
+	 */
+	public static <L, R> Right<L, R> asRight(Either<L, R> input, TypeSerializer<R> rightSerializer) {
+		if (input.isRight()) {
+			return (Right<L, R>) input;
+		} else {
+			Left<L, R> left = (Left<L, R>) input;
+			if (left.right == null) {
+				left.right = Right.of(rightSerializer.createInstance());
+				left.right.left = left;
+			}
+			return left.right;
 		}
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/Either.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Either.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.types;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.typeinfo.TypeInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -228,7 +229,8 @@ public abstract class Either<L, R> {
 	 *            the type of Right
 	 * @return input if Left type else input's Left reference
 	 */
-	public static <L, R> Left<L, R> asLeft(Either<L, R> input, TypeSerializer<L> leftSerializer) {
+	@Internal
+	public static <L, R> Left<L, R> obtainLeft(Either<L, R> input, TypeSerializer<L> leftSerializer) {
 		if (input.isLeft()) {
 			return (Left<L, R>) input;
 		} else {
@@ -256,7 +258,8 @@ public abstract class Either<L, R> {
 	 *            the type of Right
 	 * @return input if Right type else input's Right reference
 	 */
-	public static <L, R> Right<L, R> asRight(Either<L, R> input, TypeSerializer<R> rightSerializer) {
+	@Internal
+	public static <L, R> Right<L, R> obtainRight(Either<L, R> input, TypeSerializer<R> rightSerializer) {
 		if (input.isRight()) {
 			return (Right<L, R>) input;
 		} else {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializerTest.java
@@ -143,20 +143,17 @@ public class EitherSerializerTest {
 		// the first copy creates a new instance of Left
 		Either<LongValue, DoubleValue> copy0 = eitherSerializer.copy(left, right);
 
-		// and the second copy creates a new instance of Right
-		Either<LongValue, DoubleValue> copy1 = eitherSerializer.copy(right, copy0);
-
 		// then the cross-references are used for future copies
+		Either<LongValue, DoubleValue> copy1 = eitherSerializer.copy(right, copy0);
 		Either<LongValue, DoubleValue> copy2 = eitherSerializer.copy(left, copy1);
-		Either<LongValue, DoubleValue> copy3 = eitherSerializer.copy(right, copy2);
 
 		// validate reference equality
+		assertSame(right, copy1);
 		assertSame(copy0, copy2);
-		assertSame(copy1, copy3);
 
 		// validate reference equality of contained objects
+		assertSame(right.right(), copy1.right());
 		assertSame(copy0.left(), copy2.left());
-		assertSame(copy1.right(), copy3.right());
 	}
 
 	@Test
@@ -182,20 +179,17 @@ public class EitherSerializerTest {
 		// the first deserialization creates a new instance of Left
 		Either<LongValue, DoubleValue> copy0 = eitherSerializer.deserialize(right, in);
 
-		// and the second deserialization creates a new instance of Right
-		Either<LongValue, DoubleValue> copy1 = eitherSerializer.deserialize(copy0, in);
-
 		// then the cross-references are used for future copies
+		Either<LongValue, DoubleValue> copy1 = eitherSerializer.deserialize(copy0, in);
 		Either<LongValue, DoubleValue> copy2 = eitherSerializer.deserialize(copy1, in);
-		Either<LongValue, DoubleValue> copy3 = eitherSerializer.deserialize(copy2, in);
 
 		// validate reference equality
+		assertSame(right, copy1);
 		assertSame(copy0, copy2);
-		assertSame(copy1, copy3);
 
 		// validate reference equality of contained objects
+		assertSame(right.right(), copy1.right());
 		assertSame(copy0.left(), copy2.left());
-		assertSame(copy1.right(), copy3.right());
 	}
 
 	/**

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializerTest.java
@@ -18,20 +18,29 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-import static org.apache.flink.types.Either.Left;
-import static org.apache.flink.types.Either.Right;
-
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.ComparatorTestBase.TestInputView;
+import org.apache.flink.api.common.typeutils.ComparatorTestBase.TestOutputView;
 import org.apache.flink.api.common.typeutils.SerializerTestInstance;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.types.Either;
 import org.apache.flink.api.java.typeutils.EitherTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.api.java.typeutils.ValueTypeInfo;
+import org.apache.flink.types.DoubleValue;
+import org.apache.flink.types.Either;
+import org.apache.flink.types.LongValue;
+import org.apache.flink.types.StringValue;
 import org.junit.Test;
+
+import java.io.IOException;
+
+import static junit.framework.TestCase.assertSame;
+import static org.apache.flink.types.Either.Left;
+import static org.apache.flink.types.Either.Right;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 public class EitherSerializerTest {
 
@@ -53,6 +62,26 @@ public class EitherSerializerTest {
 	SerializerTestInstance<Either<String, Double>> testInstance =
 			new EitherSerializerTestInstance<Either<String, Double>>(eitherSerializer, eitherTypeInfo.getTypeClass(), -1, testData);
 	testInstance.testAll();
+	}
+
+	@Test
+	public void testStringValueDoubleValueEither() {
+		@SuppressWarnings("unchecked")
+		Either<StringValue, DoubleValue>[] testData = new Either[] {
+			Left(new StringValue("banana")),
+			Left.of(new StringValue("apple")),
+			new Left(new StringValue("")),
+			Right(new DoubleValue(32.0)),
+			Right.of(new DoubleValue(Double.MIN_VALUE)),
+			new Right(new DoubleValue(Double.MAX_VALUE))};
+
+		EitherTypeInfo<StringValue, DoubleValue> eitherTypeInfo = new EitherTypeInfo<>(
+			ValueTypeInfo.STRING_VALUE_TYPE_INFO, ValueTypeInfo.DOUBLE_VALUE_TYPE_INFO);
+		EitherSerializer<StringValue, DoubleValue> eitherSerializer =
+			(EitherSerializer<StringValue, DoubleValue>) eitherTypeInfo.createSerializer(new ExecutionConfig());
+		SerializerTestInstance<Either<StringValue, DoubleValue>> testInstance =
+			new EitherSerializerTestInstance<>(eitherSerializer, eitherTypeInfo.getTypeClass(), -1, testData);
+		testInstance.testAll();
 	}
 
 	@SuppressWarnings("unchecked")
@@ -78,6 +107,97 @@ public class EitherSerializerTest {
 	testInstance.testAll();
 	}
 
+	@Test
+	public void testEitherWithTupleValues() {
+		@SuppressWarnings("unchecked")
+		Either<Tuple2<LongValue, LongValue>, DoubleValue>[] testData = new Either[] {
+			Left(new Tuple2<>(new LongValue(2L), new LongValue(9L))),
+			new Left<>(new Tuple2<>(new LongValue(Long.MIN_VALUE), new LongValue(Long.MAX_VALUE))),
+			new Right<>(new DoubleValue(32.0)),
+			Right(new DoubleValue(Double.MIN_VALUE)),
+			Right(new DoubleValue(Double.MAX_VALUE))};
+
+		EitherTypeInfo<Tuple2<LongValue, LongValue>, DoubleValue> eitherTypeInfo = new EitherTypeInfo<>(
+			new TupleTypeInfo<Tuple2<LongValue, LongValue>>(ValueTypeInfo.LONG_VALUE_TYPE_INFO, ValueTypeInfo.LONG_VALUE_TYPE_INFO),
+			ValueTypeInfo.DOUBLE_VALUE_TYPE_INFO);
+		EitherSerializer<Tuple2<LongValue, LongValue>, DoubleValue> eitherSerializer =
+			(EitherSerializer<Tuple2<LongValue, LongValue>, DoubleValue>) eitherTypeInfo.createSerializer(new ExecutionConfig());
+		SerializerTestInstance<Either<Tuple2<LongValue, LongValue>, DoubleValue>> testInstance =
+			new EitherSerializerTestInstance<>(eitherSerializer, eitherTypeInfo.getTypeClass(), -1, testData);
+		testInstance.testAll();
+	}
+
+	@Test
+	public void testEitherWithObjectReuse() {
+		EitherTypeInfo<LongValue, DoubleValue> eitherTypeInfo = new EitherTypeInfo<>(
+			ValueTypeInfo.LONG_VALUE_TYPE_INFO, ValueTypeInfo.DOUBLE_VALUE_TYPE_INFO);
+		EitherSerializer<LongValue, DoubleValue> eitherSerializer =
+			(EitherSerializer<LongValue, DoubleValue>) eitherTypeInfo.createSerializer(new ExecutionConfig());
+
+		LongValue lv = new LongValue();
+		DoubleValue dv = new DoubleValue();
+
+		Either<LongValue, DoubleValue> left = Left(lv);
+		Either<LongValue, DoubleValue> right = Right(dv);
+
+		// the first copy creates a new instance of Left
+		Either<LongValue, DoubleValue> copy0 = eitherSerializer.copy(left, right);
+
+		// and the second copy creates a new instance of Right
+		Either<LongValue, DoubleValue> copy1 = eitherSerializer.copy(right, copy0);
+
+		// then the cross-references are used for future copies
+		Either<LongValue, DoubleValue> copy2 = eitherSerializer.copy(left, copy1);
+		Either<LongValue, DoubleValue> copy3 = eitherSerializer.copy(right, copy2);
+
+		// validate reference equality
+		assertSame(copy0, copy2);
+		assertSame(copy1, copy3);
+
+		// validate reference equality of contained objects
+		assertSame(copy0.left(), copy2.left());
+		assertSame(copy1.right(), copy3.right());
+	}
+
+	@Test
+	public void testSerializeIndividually() throws IOException {
+		EitherTypeInfo<LongValue, DoubleValue> eitherTypeInfo = new EitherTypeInfo<>(
+			ValueTypeInfo.LONG_VALUE_TYPE_INFO, ValueTypeInfo.DOUBLE_VALUE_TYPE_INFO);
+		EitherSerializer<LongValue, DoubleValue> eitherSerializer =
+			(EitherSerializer<LongValue, DoubleValue>) eitherTypeInfo.createSerializer(new ExecutionConfig());
+
+		LongValue lv = new LongValue();
+		DoubleValue dv = new DoubleValue();
+
+		Either<LongValue, DoubleValue> left = Left(lv);
+		Either<LongValue, DoubleValue> right = Right(dv);
+
+		TestOutputView out = new TestOutputView();
+		eitherSerializer.serialize(left, out);
+		eitherSerializer.serialize(right, out);
+		eitherSerializer.serialize(left, out);
+		eitherSerializer.serialize(right, out);
+
+		TestInputView in = out.getInputView();
+		// the first deserialization creates a new instance of Left
+		Either<LongValue, DoubleValue> copy0 = eitherSerializer.deserialize(right, in);
+
+		// and the second deserialization creates a new instance of Right
+		Either<LongValue, DoubleValue> copy1 = eitherSerializer.deserialize(copy0, in);
+
+		// then the cross-references are used for future copies
+		Either<LongValue, DoubleValue> copy2 = eitherSerializer.deserialize(copy1, in);
+		Either<LongValue, DoubleValue> copy3 = eitherSerializer.deserialize(copy2, in);
+
+		// validate reference equality
+		assertSame(copy0, copy2);
+		assertSame(copy1, copy3);
+
+		// validate reference equality of contained objects
+		assertSame(copy0.left(), copy2.left());
+		assertSame(copy1.right(), copy3.right());
+	}
+
 	/**
 	 * {@link org.apache.flink.api.common.typeutils.SerializerTestBase#testInstantiate()}
 	 * checks that the type of the created instance is the same as the type class parameter.
@@ -98,7 +218,7 @@ public class EitherSerializerTest {
 
 				T instance = serializer.createInstance();
 				assertNotNull("The created instance must not be null.", instance);
-				
+
 				Class<T> type = getTypeClass();
 				assertNotNull("The test is corrupt: type class is null.", type);
 			}
@@ -108,6 +228,6 @@ public class EitherSerializerTest {
 				fail("Exception in test: " + e.getMessage());
 			}
 		}
-		
+
 	}
 }


### PR DESCRIPTION
Implement object reuse for Flink's Either type by storing a reference to Right in Left and Left in Right. These references are private and remain null until set by EitherSerializer when copying or deserializing with object reuse.