### PR TITLE
[FLINK-6273] [core] don't convert hostname to lower cases to prevent akka connection failure

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/NetUtils.java
@@ -130,7 +130,7 @@ public class NetUtils {
 		if (host == null) {
 			host = InetAddress.getLoopbackAddress().getHostAddress();
 		} else {
-			host = host.trim().toLowerCase();
+			host = host.trim();
 		}
 
 		// normalize and valid address


### PR DESCRIPTION
For akka `Address`, the host part is case sensitive, So if we build remote jobmanager url with lower case hostname, akka will reject message.
I fix this issue by removing `toLowerCase` when building actor url.
