### PR TITLE
[FLINK-6173] [build] Move gelly-examples jar from opt to examples

### DIFF
--- a/docs/dev/libs/gelly/index.md
+++ b/docs/dev/libs/gelly/index.md
@@ -71,24 +71,22 @@ The remaining sections provide a description of available methods and present se
 Running Gelly Examples
 ----------------------
 
-The Gelly library and examples jars are provided in the [Flink distribution](https://flink.apache.org/downloads.html "Apache Flink: Downloads")
+The Gelly library jars are provided in the [Flink distribution](https://flink.apache.org/downloads.html "Apache Flink: Downloads")
 in the folder **opt** (for versions older than Flink 1.2 these can be manually downloaded from
-[Maven Central](http://search.maven.org/#search|ga|1|flink%20gelly)).
-
-To run the Gelly examples the **flink-gelly** (for Java) or **flink-gelly-scala** (for Scala) jar must be copied to
-Flink's **lib** directory.
+[Maven Central](http://search.maven.org/#search|ga|1|flink%20gelly)). To run the Gelly examples the **flink-gelly** (for
+Java) or **flink-gelly-scala** (for Scala) jar must be copied to Flink's **lib** directory.
 
 ~~~bash
 cp opt/flink-gelly_*.jar lib/
 cp opt/flink-gelly-scala_*.jar lib/
 ~~~
 
-Gelly's examples jar includes drivers for each of the library methods. After configuring and starting the cluster, list
-the available algorithm classes:
+Gelly's examples jar includes drivers for each of the library methods and is provided in the **examples** folder. After
+configuring and starting the cluster, list the available algorithm classes:
 
 ~~~bash
 ./bin/start-cluster.sh
-./bin/flink run opt/flink-gelly-examples_*.jar
+./bin/flink run examples/flink-gelly-examples_*.jar
 ~~~
 
 The Gelly drivers can generate graph data or read the edge list from a CSV file (each node in a cluster must have access
@@ -96,13 +94,13 @@ to the input file). The algorithm description, available inputs and outputs, and
 algorithm is selected. Print usage for [JaccardIndex](./library_methods.html#jaccard-index):
 
 ~~~bash
-./bin/flink run opt/flink-gelly-examples_*.jar --algorithm JaccardIndex
+./bin/flink run examples/flink-gelly-examples_*.jar --algorithm JaccardIndex
 ~~~
 
 Display [graph metrics](./library_methods.html#metric) for a million vertex graph:
 
 ~~~bash
-./bin/flink run opt/flink-gelly-examples_*.jar \
+./bin/flink run examples/flink-gelly-examples_*.jar \
     --algorithm GraphMetrics --order directed \
     --input RMatGraph --type integer --scale 20 --simplify directed \
     --output print
@@ -119,17 +117,17 @@ Run a few algorithms and monitor the job progress in Flink's Web UI:
 ~~~bash
 wget -O - http://snap.stanford.edu/data/bigdata/communities/com-lj.ungraph.txt.gz | gunzip -c > com-lj.ungraph.txt
 
-./bin/flink run -q opt/flink-gelly-examples_*.jar \
+./bin/flink run -q examples/flink-gelly-examples_*.jar \
     --algorithm GraphMetrics --order undirected \
     --input CSV --type integer --simplify undirected --input_filename com-lj.ungraph.txt --input_field_delimiter $'\t' \
     --output print
 
-./bin/flink run -q opt/flink-gelly-examples_*.jar \
+./bin/flink run -q examples/flink-gelly-examples_*.jar \
     --algorithm ClusteringCoefficient --order undirected \
     --input CSV --type integer --simplify undirected --input_filename com-lj.ungraph.txt --input_field_delimiter $'\t' \
     --output hash
 
-./bin/flink run -q opt/flink-gelly-examples_*.jar \
+./bin/flink run -q examples/flink-gelly-examples_*.jar \
     --algorithm JaccardIndex \
     --input CSV --type integer --simplify undirected --input_filename com-lj.ungraph.txt --input_field_delimiter $'\t' \
     --output hash

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -156,6 +156,19 @@ under the License.
 		</dependency>
 
 		<!--
+			The following dependencies are packaged in 'examples/'
+			The scope of these dependencies needs to be 'provided' so that
+			they are not included into the 'flink-dist' uber jar.
+		-->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-gelly-examples_2.10</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!--
 			The following dependencies are packaged in 'opt/' 
 			The scope of these dependencies needs to be 'provided' so that
 			they are not included into the 'flink-dist' uber jar.
@@ -216,13 +229,6 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-gelly-scala_2.10</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-gelly-examples_2.10</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -59,6 +59,14 @@ under the License.
 			<outputDirectory>conf</outputDirectory>
 			<fileMode>0644</fileMode>
 		</file>
+
+		<!-- copy jar file of the Gelly examples -->
+		<file>
+			<source>../flink-libraries/flink-gelly-examples/target/flink-gelly-examples_2.10-${project.version}.jar</source>
+			<outputDirectory>examples/</outputDirectory>
+			<destName>flink-gelly-examples_2.10-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
 	</files>
 
 	<fileSets>

--- a/flink-dist/src/main/assemblies/opt.xml
+++ b/flink-dist/src/main/assemblies/opt.xml
@@ -53,13 +53,6 @@
 		</file>
 
 		<file>
-			<source>../flink-libraries/flink-gelly-examples/target/flink-gelly-examples_2.10-${project.version}.jar</source>
-			<outputDirectory>opt/</outputDirectory>
-			<destName>flink-gelly-examples_2.10-${project.version}.jar</destName>
-			<fileMode>0644</fileMode>
-		</file>
-
-		<file>
 			<source>../flink-libraries/flink-gelly-scala/target/flink-gelly-scala_2.10-${project.version}-jar-with-dependencies.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-gelly-scala_2.10-${project.version}.jar</destName>

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/Runner.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/Runner.java
@@ -108,7 +108,7 @@ public class Runner {
 
 		strBuilder
 			.appendNewLine()
-			.appendln("Select an algorithm to view usage: flink run opt/flink-gelly-examples_<version>.jar --algorithm <algorithm>")
+			.appendln("Select an algorithm to view usage: flink run examples/flink-gelly-examples_<version>.jar --algorithm <algorithm>")
 			.appendNewLine()
 			.appendln("Available algorithms:");
 
@@ -139,7 +139,7 @@ public class Runner {
 			.appendNewLine()
 			.appendln(algorithm.getLongDescription())
 			.appendNewLine()
-			.append("usage: flink run opt/flink-gelly-examples_<version>.jar --algorithm ")
+			.append("usage: flink run examples/flink-gelly-examples_<version>.jar --algorithm ")
 			.append(algorithmName)
 			.append(" [algorithm options] --input <input> [input options] --output <output> [output options]")
 			.appendNewLine()

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/EdgeList.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/EdgeList.java
@@ -18,7 +18,11 @@
 
 package org.apache.flink.graph.drivers;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.api.java.typeutils.ValueTypeInfo;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.asm.dataset.ChecksumHashCode;
@@ -28,11 +32,17 @@ import org.apache.flink.graph.drivers.output.CSV;
 import org.apache.flink.graph.drivers.output.Hash;
 import org.apache.flink.graph.drivers.output.Print;
 import org.apache.flink.graph.drivers.parameter.ParameterizedBase;
+import org.apache.flink.graph.utils.EdgeToTuple2Map;
+import org.apache.flink.types.NullValue;
 
 import java.util.List;
 
 /**
  * Convert a {@link Graph} to the {@link DataSet} of {@link Edge}s.
+ *
+ * @param <K> graph ID type
+ * @param <VV> vertex value type
+ * @param <EV> edge value type
  */
 public class EdgeList<K, VV, EV>
 extends ParameterizedBase
@@ -77,16 +87,45 @@ implements Driver<K, VV, EV>, CSV, Hash, Print {
 		// Refactored due to openjdk7 compile error: https://travis-ci.org/greghogan/flink/builds/200487761
 		List<Edge<K, EV>> records = collector.run(edges).execute(executionName);
 
-		for (Edge<K, EV> result : records) {
-			System.out.println(result);
+		if (hasNullValueEdges(edges)) {
+			for (Edge<K, EV> result : records) {
+				System.out.println("(" + result.f0 + "," + result.f1 + ")");
+			}
+		} else {
+			for (Edge<K, EV> result : records) {
+				System.out.println(result);
+			}
 		}
-
 	}
 
 	@Override
 	public void writeCSV(String filename, String lineDelimiter, String fieldDelimiter) {
-		edges
-			.writeAsCsv(filename, lineDelimiter, fieldDelimiter)
-				.name("CSV: " + filename);
+		if (hasNullValueEdges(edges)) {
+			edges
+				.map(new EdgeToTuple2Map<K, EV>())
+					.name("Edge to Tuple2")
+				.writeAsCsv(filename, lineDelimiter, fieldDelimiter)
+					.name("CSV: " + filename);
+		} else {
+			edges
+				.writeAsCsv(filename, lineDelimiter, fieldDelimiter)
+					.name("CSV: " + filename);
+		}
+	}
+
+	/**
+	 * Check whether the edge type of the {@link DataSet} is {@link NullValue}.
+	 *
+	 * @param edges data set for introspection
+	 * @param <T> graph ID type
+	 * @param <ET> edge value type
+	 * @return whether the edge type of the {@link DataSet} is {@link NullValue}
+	 */
+	private static <T, ET> boolean hasNullValueEdges(DataSet<Edge<T, ET>> edges) {
+		TypeInformation<?> genericTypeInfo = edges.getType();
+		@SuppressWarnings("unchecked")
+		TupleTypeInfo<Tuple3<T, T, ET>> tupleTypeInfo = (TupleTypeInfo<Tuple3<T, T, ET>>) genericTypeInfo;
+
+		return tupleTypeInfo.getTypeAt(2).equals(ValueTypeInfo.NULL_VALUE_TYPE_INFO);
 	}
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/EdgeToTuple2Map.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/EdgeToTuple2Map.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.utils;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFields;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.graph.Edge;
+
+/**
+ * Create a Tuple2 DataSet from the vertices of an Edge DataSet
+ *
+ * @param <K> edge ID type
+ * @param <EV> edge value type
+ */
+@ForwardedFields("f0; f1")
+public class EdgeToTuple2Map<K, EV> implements MapFunction<Edge<K, EV>, Tuple2<K, K>> {
+
+	private static final long serialVersionUID = 1L;
+
+	private Tuple2<K, K> output = new Tuple2<>();
+
+	@Override
+	public Tuple2<K, K> map(Edge<K, EV> edge) {
+		output.f0 = edge.f0;
+		output.f1 = edge.f1;
+		return output;
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/AsmTestBase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/AsmTestBase.java
@@ -102,15 +102,17 @@ public class AsmTestBase {
 			.generate();
 
 		/*
-			./bin/flink run -c org.apache.flink.graph.drivers.Graph500 flink-gelly-examples_2.10-1.2-SNAPSHOT.jar \
-				--directed true --simplify true --scale 10 --edge_factor 16 --output csv --filename directedRMatGraph.csv
+		   ./bin/flink run examples/flink-gelly-examples_*.jar --algorithm EdgeList \
+		       --input RMatGraph --type long --simplify directed --scale 10 --edge_factor 16 \
+		       --output csv --output_filename directedRMatGraph.csv
 		 */
 		directedRMatGraph = rmatGraph
 			.run(new org.apache.flink.graph.asm.simple.directed.Simplify<LongValue, NullValue, NullValue>());
 
 		/*
-			./bin/flink run -c org.apache.flink.graph.drivers.Graph500 flink-gelly-examples_2.10-1.2-SNAPSHOT.jar \
-				--directed false --simplify true --scale 10 --edge_factor 16 --output csv --filename undirectedRMatGraph.csv
+		   ./bin/flink run examples/flink-gelly-examples_*.jar --algorithm EdgeList \
+		       --input RMatGraph --type long --simplify undirected --scale 10 --edge_factor 16 \
+		       --output csv --output_filename undirectedRMatGraph.csv
 		 */
 		undirectedRMatGraph = rmatGraph
 			.run(new org.apache.flink.graph.asm.simple.undirected.Simplify<LongValue, NullValue, NullValue>(false));


### PR DESCRIPTION
The opt directory should be reserved for Flink JARs which users may optionally move to lib to be loaded by the runtime. flink-gelly-examples is a user program so is being moved to the examples folder.