### PR TITLE
[FLINK-6090] [table] Add RetractionRule at the stage of decoration

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCorrelate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCorrelate.scala
@@ -36,14 +36,14 @@ import org.apache.flink.types.Row
 class DataStreamCorrelate(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
-    inputNode: RelNode,
+    input: RelNode,
     scan: LogicalTableFunctionScan,
     condition: Option[RexNode],
     relRowType: RelDataType,
     joinRowType: RelDataType,
     joinType: SemiJoinType,
     ruleDescription: String)
-  extends SingleRel(cluster, traitSet, inputNode)
+  extends SingleRel(cluster, traitSet, input)
   with CommonCorrelate
   with DataStreamRel {
 
@@ -84,7 +84,7 @@ class DataStreamCorrelate(
     val config = tableEnv.getConfig
 
     // we do not need to specify input type
-    val inputDS = inputNode.asInstanceOf[DataStreamRel].translateToPlan(tableEnv)
+    val inputDS = getInput.asInstanceOf[DataStreamRel].translateToPlan(tableEnv)
 
     val funcRel = scan.asInstanceOf[LogicalTableFunctionScan]
     val rexCall = funcRel.getCall.asInstanceOf[RexCall]

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupAggregate.scala
@@ -57,6 +57,12 @@ class DataStreamGroupAggregate(
 
   override def deriveRowType() = rowRelDataType
 
+  override def needsUpdatesAsRetraction = true
+
+  override def producesUpdates = true
+
+  override def consumesRetractions = true
+
   override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
     new DataStreamGroupAggregate(
       cluster,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupWindowAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupWindowAggregate.scala
@@ -54,6 +54,10 @@ class DataStreamGroupWindowAggregate(
 
   override def deriveRowType(): RelDataType = rowRelDataType
 
+  override def needsUpdatesAsRetraction = true
+
+  override def consumesRetractions = true
+
   override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
     new DataStreamGroupWindowAggregate(
       window,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamOverAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamOverAggregate.scala
@@ -51,6 +51,10 @@ class DataStreamOverAggregate(
 
   override def deriveRowType(): RelDataType = rowRelDataType
 
+  override def needsUpdatesAsRetraction = true
+
+  override def consumesRetractions = true
+
   override def copy(traitSet: RelTraitSet, inputs: JList[RelNode]): RelNode = {
     new DataStreamOverAggregate(
       logicWindow,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamRel.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamRel.scala
@@ -34,5 +34,23 @@ trait DataStreamRel extends RelNode with FlinkRel {
     */
   def translateToPlan(tableEnv: StreamTableEnvironment) : DataStream[Row]
 
+  /**
+    * Whether a [[DataStreamRel]] requires that update and delete changes are sent with retraction
+    * messages.
+    */
+  def needsUpdatesAsRetraction: Boolean = false
+
+  /**
+    * Whether a [[DataStreamRel]] produces update and delete changes.
+    */
+  def producesUpdates: Boolean = false
+
+  /**
+    * Wheter a [[DataStreamRel]] consumes retraction messages instead of forwarding them.
+    * The node might or might not produce new retraction messages.
+    * This is checked by [[DataStreamRetractionRule]].
+    */
+  def consumesRetractions: Boolean = false
+
 }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamRetractionRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamRetractionRule.scala
@@ -1,0 +1,341 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.datastream
+
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
+import org.apache.calcite.plan.RelOptRule._
+import org.apache.calcite.plan.hep.HepRelVertex
+import org.apache.calcite.rel.RelNode
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
+
+/**
+  * Collection of retraction rules that apply various transformations on DataStreamRel trees.
+  * Currently, there are three transformations: InitProcessRule, NeedToRetractProcessRule and
+  * AccModeProcessRule. Note: these rules must be called in order (InitProcessRule ->
+  * NeedToRetractProcessRule -> AccModeProcessRule).
+  */
+object DataStreamRetractionRule {
+
+  /**
+    * Singleton rule that init retraction trait inside a [[DataStreamRel]]
+    */
+  val INIT_INSTANCE = new InitProcessRule()
+
+  /**
+    * Singleton rule that decide needToRetract property inside a [[DataStreamRel]]
+    */
+  val NEEDTORETRACT_INSTANCE = new NeedToRetractProcessRule()
+
+  /**
+    * Singleton rule that decide accMode inside a [[DataStreamRel]]
+    */
+  val ACCMODE_INSTANCE = new AccModeProcessRule()
+
+  /**
+    * Get all child RelNodes of a RelNode
+    * @param topRel The input RelNode
+    * @return All child nodes
+    */
+  def getChildRelNodes(topRel: RelNode): ListBuffer[RelNode] = {
+    val topRelInputs = new ListBuffer[RelNode]()
+    topRelInputs.++=(topRel.getInputs.asScala)
+    topRelInputs.transform(e => e.asInstanceOf[HepRelVertex].getCurrentRel)
+  }
+
+  def traitSetContainNeedToRetract(traitSet: RelTraitSet): Boolean = {
+    val retractionTrait = traitSet.getTrait(RetractionTraitDef.INSTANCE)
+    if (null == retractionTrait) {
+      false
+    } else {
+      retractionTrait.getNeedToRetract
+    }
+  }
+
+
+  /**
+    * Find all needToRetract nodes. A node needs to retract means that there are downstream
+    * nodes need retraction from it. Currently, [[DataStreamOverAggregate]] and
+    * [[DataStreamGroupWindowAggregate]] need retraction from upstream nodes, besides, a
+    * needToRetract node also need retraction from it's upstream nodes.
+    */
+  class NeedToRetractProcessRule extends RelOptRule(
+    operand(
+      classOf[DataStreamRel], none()),
+    "NeedToRetractProcessRule") {
+
+    /**
+      * Return true if bottom RelNode does not contain needToRetract and top RelNode need
+      * retraction from bottom RelNode. Currently, operators which contain aggregations need
+      * retraction from upstream nodes, besides, a needToRetract node also needs retraction from
+      * it's upstream nodes.
+      */
+    def bottomNeedToRetract(topRel: RelNode, bottomRel: RelNode): Boolean = {
+      val bottomTraits = bottomRel.getTraitSet
+      if(!traitSetContainNeedToRetract(bottomTraits)){
+        topRel match {
+          case _: DataStreamGroupAggregate => true
+          case _: DataStreamGroupWindowAggregate => true
+          case _: DataStreamOverAggregate => true
+          case _ if traitSetContainNeedToRetract(topRel.getTraitSet) => true
+          case _ => false
+        }
+      } else {
+        false
+      }
+    }
+
+    /**
+      * Add needToRetract for the input RelNode
+      */
+    def addNeedToRetract(relNode: RelNode): RelNode = {
+      val traitSet = relNode.getTraitSet
+      var retractionTrait = traitSet.getTrait(RetractionTraitDef.INSTANCE)
+      if (null == retractionTrait) {
+        retractionTrait = new RetractionTrait(true, AccMode.Acc)
+      } else {
+        retractionTrait = new RetractionTrait(true, retractionTrait.getAccMode)
+      }
+
+      relNode.copy(traitSet.plus(retractionTrait), relNode.getInputs)
+    }
+
+    /**
+      * Returns a new topRel and a needTransform flag for a given topRel and bottomRels. The new
+      * topRel contains new bottomRels with needToRetract properly marked. The needTransform flag
+      * will be true if any transformation has been done.
+      *
+      * @param topRel The input top RelNode.
+      * @param bottomRels The input bottom RelNodes.
+      * @return A tuple holding a new top RelNode and a needTransform flag
+      */
+    def needToRetractProcess(
+        topRel: RelNode,
+        bottomRels: ListBuffer[RelNode])
+    : (RelNode, Boolean) = {
+
+      var needTransform = false
+      var i = 0
+      while(i < bottomRels.size) {
+        val bottomRel = bottomRels(i)
+        if(bottomNeedToRetract(topRel, bottomRel)) {
+          needTransform = true
+          bottomRels(i) = addNeedToRetract(bottomRel)
+        }
+        i += 1
+      }
+      val newTopRel = topRel.copy(topRel.getTraitSet, bottomRels.asJava)
+      (newTopRel, needTransform)
+    }
+
+    override def onMatch(call: RelOptRuleCall): Unit = {
+      val topRel = call.rel(0).asInstanceOf[DataStreamRel]
+
+      // get bottom relnodes
+      val bottomRels = getChildRelNodes(topRel)
+
+      // process bottom relnodes
+      val (newTopRel, needTransform) = needToRetractProcess(topRel, bottomRels)
+
+      if (needTransform) {
+        call.transformTo(newTopRel)
+      }
+    }
+
+  }
+
+
+  /**
+    * Find all AccRetract nodes. A node in AccRetract Mode means that the operator may generate
+    * or forward an additional retraction message.
+    *
+    */
+  class AccModeProcessRule extends RelOptRule(
+    operand(
+      classOf[DataStreamRel], none()),
+    "AccModeProcessRule") {
+
+
+    /**
+      * Return true if result table is a replace table
+      */
+    def resultTableIsReplaceTable(relNode: RelNode): Boolean = {
+      relNode match {
+        case _: DataStreamGroupAggregate => true
+        case _ => false
+      }
+    }
+
+
+    def traitSetContainAccRetract(traitSet: RelTraitSet): Boolean = {
+      val retractionTrait = traitSet.getTrait(RetractionTraitDef.INSTANCE)
+      if (null == retractionTrait) {
+        false
+      } else {
+        retractionTrait.getAccMode == AccMode.AccRetract
+      }
+    }
+
+    /**
+      * Return true if the result table of input RelNode is a replace table and the input RelNode
+      * is under AccMode with needToRetract.
+      */
+    def needSetAccRetract(relNode: RelNode): Boolean = {
+      val traitSet = relNode.getTraitSet
+      if (traitSetContainNeedToRetract(traitSet)
+        && resultTableIsReplaceTable(relNode)
+        && !traitSetContainAccRetract(traitSet)) {
+        true
+      } else {
+        false
+      }
+    }
+
+    /**
+      * Set AccMode to AccRetract for the input RelNode
+      */
+    def setAccRetract(relNode: RelNode): RelNode = {
+      val traitSet = relNode.getTraitSet
+      var retractionTrait = traitSet.getTrait(RetractionTraitDef.INSTANCE)
+      if (null == retractionTrait) {
+        retractionTrait = new RetractionTrait(false, AccMode.AccRetract)
+      } else {
+        retractionTrait = new RetractionTrait(retractionTrait.getNeedToRetract,
+                                              AccMode.AccRetract)
+      }
+      relNode.copy(traitSet.plus(retractionTrait), relNode.getInputs)
+    }
+
+    /**
+      * Currently, window (including group window and over window) does not contain early firing,
+      * so [[DataStreamGroupWindowAggregate]] and [[DataStreamOverAggregate]] will digest
+      * retraction messages. [[DataStreamGroupAggregate]] can also digest retraction because
+      * it digests retraction first then generate new retraction messages by itself.
+      */
+    def canDigestRetraction(relNode: RelNode): Boolean = {
+      relNode match {
+        case _: DataStreamGroupAggregate => true
+        case _: DataStreamGroupWindowAggregate => true
+        case _: DataStreamOverAggregate => true
+        case _ => false
+      }
+    }
+
+    /**
+      * Return true if topRel needs to work under AccRetract
+      */
+    def topRelNeedSetAccRetract(topRel: RelNode, bottomRels: ListBuffer[RelNode]): Boolean = {
+      var needSet: Boolean = false
+      var bottomRelsUnderAccRetract: Boolean = false
+      val traitSet = topRel.getTraitSet
+
+      // check if top RelNode needs to work under AccRetract by itself
+      needSet = needSetAccRetract(topRel)
+
+      // check if there is a bottom RelNode working under AccRetract
+      var i = 0
+      while(i < bottomRels.size) {
+        if (traitSetContainAccRetract(bottomRels(i).getTraitSet)) {
+          bottomRelsUnderAccRetract = true
+        }
+        i += 1
+      }
+
+      // Return true
+      // if topRel needs to work under AccRetract by itself
+      // or bottom relNodes make topRel to work under AccRetract
+      needSet ||
+        (bottomRelsUnderAccRetract
+          && !canDigestRetraction(topRel)
+          && !traitSetContainAccRetract(traitSet))
+    }
+
+    /**
+      * Returns a new topRel and a needTransform flag for a given topRel and bottomRels. The new
+      * topRel contains new bottomRels with AccMode properly setted. The needTransform flag
+      * will be true if any transformation has been done.
+      *
+      * @param topRel The input top RelNode.
+      * @param bottomRels The input bottom RelNodes.
+      * @return A tuple holding a new top RelNode and a needTransform flag
+      */
+    def accModeProcess(topRel: RelNode, bottomRels: ListBuffer[RelNode]): (RelNode, Boolean) = {
+      var needTransform = false
+      var i = 0
+      var newTopRel = topRel
+
+      // process bottom RelNodes
+      while (i < bottomRels.size) {
+        val bottomRel = bottomRels(i)
+        if(needSetAccRetract(bottomRel)) {
+          needTransform = true
+          bottomRels(i) = setAccRetract(bottomRel)
+        }
+        i += 1
+      }
+
+      // process top RelNode
+      if (topRelNeedSetAccRetract(topRel, bottomRels)) {
+        needTransform = true
+        newTopRel = setAccRetract(topRel)
+      }
+
+      newTopRel = newTopRel.copy(newTopRel.getTraitSet, bottomRels.asJava)
+      (newTopRel, needTransform)
+    }
+
+    override def onMatch(call: RelOptRuleCall): Unit = {
+      val topRel = call.rel(0).asInstanceOf[DataStreamRel]
+
+      // get bottom relnodes
+      val bottomRels = getChildRelNodes(topRel)
+
+      // process bottom and top relnodes
+      val (newTopRel, needTransform) = accModeProcess(topRel, bottomRels)
+
+      if (needTransform) {
+        call.transformTo(newTopRel)
+      }
+    }
+  }
+
+
+  /**
+    * Rule that init retraction trait inside a [[DataStreamRel]]. If a [[DataStreamRel]] does not
+    * contain retraction trait, initialize one for the [[DataStreamRel]]. After
+    * initiallization, needToRetract will be set to false and AccMode will be set to Acc.
+    */
+  class InitProcessRule extends RelOptRule(
+    operand(
+      classOf[DataStreamRel], none()),
+    "InitProcessRule") {
+
+    override def onMatch(call: RelOptRuleCall): Unit = {
+      val rel = call.rel(0).asInstanceOf[DataStreamRel]
+      var retractionTrait = rel.getTraitSet.getTrait(RetractionTraitDef.INSTANCE)
+      if (null == retractionTrait) {
+        retractionTrait = new RetractionTrait(false, AccMode.Acc)
+        call.transformTo(rel.copy(rel.getTraitSet.plus(retractionTrait), rel.getInputs))
+      }
+    }
+  }
+}
+
+

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/RetractionTrait.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/RetractionTrait.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.datastream
+
+import org.apache.calcite.plan.{RelOptPlanner, RelTrait, RelTraitDef}
+import org.apache.flink.table.plan.nodes.datastream.AccMode.AccMode
+
+/**
+  * Used to store retraction related properties which is used during rule optimization.
+  */
+class RetractionTrait extends RelTrait {
+
+  /**
+    * Defines whether downstream operator need retraction. Please note that needToRetract is
+    * different from needRetraction. NeedToRetract is a property particular for each operator,
+    * while NeedRetraction is a property for each input. Most of operators have only one input,
+    * some operators may have more than one inputs (e.g., join, union), and the property of the
+    * NeedRetraction could be different across different inputs of the same operator
+    */
+  private var needToRetract: Boolean = false
+
+  /**
+    * Defines the accumulating mode for a operator. Basically there are two modes for each
+    * operator: Accumulating Mode (Acc) and Accumulating and Retracting Mode (AccRetract).
+    */
+  private var accMode = AccMode.Acc
+
+
+  def this(needToRetract: Boolean, accMode: AccMode) {
+    this()
+    this.needToRetract = needToRetract
+    this.accMode = accMode
+  }
+
+  def getNeedToRetract = needToRetract
+
+  def getAccMode = accMode
+
+
+  override def register(planner: RelOptPlanner): Unit = { }
+
+  override def getTraitDef: RelTraitDef[_ <: RelTrait] = RetractionTraitDef.INSTANCE
+
+  override def satisfies(`trait`: RelTrait): Boolean = {
+    this.equals(`trait`)
+  }
+
+  override def toString: String = {
+    s"(${needToRetract.toString}, ${accMode.toString})"
+  }
+
+}
+
+object RetractionTrait {
+  val DEFAULT = new RetractionTrait(false, AccMode.Acc)
+}
+
+
+/**
+  * Use this property to indicates how the accumulating works in an operator. In AccMode, all the
+  * inputs of an operator will be just simply accumulated to the existing state and generate an
+  * accumulating message to the downstream, while in AccRetractMode besides accumulating message
+  * the operator may generate or forward an additional retraction message
+  */
+object AccMode extends Enumeration {
+  type AccMode = Value
+  val Acc, AccRetract = Value
+}
+
+

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/RetractionTraitDef.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/RetractionTraitDef.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.datastream
+
+import org.apache.calcite.plan.{RelOptPlanner, RelTraitDef}
+import org.apache.calcite.rel.RelNode
+
+/**
+  * Definition of the retraction trait.
+  */
+class RetractionTraitDef extends RelTraitDef[RetractionTrait] {
+  override def convert(
+      planner: RelOptPlanner,
+      rel: RelNode,
+      toTrait: RetractionTrait,
+      allowInfiniteCostConverters: Boolean): RelNode = {
+
+    rel.copy(rel.getTraitSet.plus(toTrait), rel.getInputs)
+  }
+
+  override def canConvert(
+      planner: RelOptPlanner,
+      fromTrait: RetractionTrait,
+      toTrait: RetractionTrait): Boolean = true
+
+  override def getTraitClass: Class[RetractionTrait] = classOf[RetractionTrait]
+
+  override def getSimpleName: String = this.getClass.getSimpleName
+
+  override def getDefault: RetractionTrait = {
+    RetractionTrait.DEFAULT
+  }
+}
+
+object RetractionTraitDef {
+  val INSTANCE = new RetractionTraitDef
+}
+

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.plan.rules
 import org.apache.calcite.rel.rules._
 import org.apache.calcite.tools.{RuleSet, RuleSets}
 import org.apache.flink.table.calcite.rules.FlinkAggregateExpandDistinctAggregatesRule
+import org.apache.flink.table.plan.nodes.datastream.DataStreamRetractionRule
 import org.apache.flink.table.plan.rules.dataSet._
 import org.apache.flink.table.plan.rules.datastream._
 
@@ -195,6 +196,10 @@ object FlinkRuleSets {
   val DATASTREAM_DECO_RULES: RuleSet = RuleSets.ofList(
     // rules
 
+    // retraction rules
+    DataStreamRetractionRule.INIT_INSTANCE,
+    DataStreamRetractionRule.NEEDTORETRACT_INSTANCE,
+    DataStreamRetractionRule.ACCMODE_INSTANCE
   )
 
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/CalciteConfigBuilderTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/CalciteConfigBuilderTest.scala
@@ -22,6 +22,7 @@ import org.apache.calcite.rel.rules._
 import org.apache.calcite.sql.fun.{OracleSqlOperatorTable, SqlStdOperatorTable}
 import org.apache.calcite.tools.RuleSets
 import org.apache.flink.table.calcite.{CalciteConfig, CalciteConfigBuilder}
+import org.apache.flink.table.plan.nodes.datastream.DataStreamRetractionRule
 import org.junit.Assert._
 import org.junit.Test
 
@@ -50,7 +51,7 @@ class CalciteConfigBuilderTest {
     val cc: CalciteConfig = new CalciteConfigBuilder()
       .addNormRuleSet(RuleSets.ofList(ReduceExpressionsRule.FILTER_INSTANCE))
       .replaceOptRuleSet(RuleSets.ofList(FilterMergeRule.INSTANCE))
-      .replaceDecoRuleSet(RuleSets.ofList(ReduceExpressionsRule.FILTER_INSTANCE))
+      .replaceDecoRuleSet(RuleSets.ofList(DataStreamRetractionRule.INIT_INSTANCE))
       .build()
 
     assertFalse(cc.replacesNormRuleSet)
@@ -191,62 +192,62 @@ class CalciteConfigBuilderTest {
   def testReplaceDecorationRules(): Unit = {
 
     val cc: CalciteConfig = new CalciteConfigBuilder()
-      .replaceDecoRuleSet(RuleSets.ofList(ReduceExpressionsRule.FILTER_INSTANCE))
+      .replaceDecoRuleSet(RuleSets.ofList(DataStreamRetractionRule.INIT_INSTANCE))
       .build()
 
     assertEquals(true, cc.replacesDecoRuleSet)
     assertTrue(cc.getDecoRuleSet.isDefined)
     val cSet = cc.getDecoRuleSet.get.iterator().asScala.toSet
     assertEquals(1, cSet.size)
-    assertTrue(cSet.contains(ReduceExpressionsRule.FILTER_INSTANCE))
+    assertTrue(cSet.contains(DataStreamRetractionRule.INIT_INSTANCE))
   }
 
   @Test
   def testReplaceDecorationAddRules(): Unit = {
 
     val cc: CalciteConfig = new CalciteConfigBuilder()
-      .replaceDecoRuleSet(RuleSets.ofList(ReduceExpressionsRule.FILTER_INSTANCE))
-      .addDecoRuleSet(RuleSets.ofList(ReduceExpressionsRule.PROJECT_INSTANCE))
+      .replaceDecoRuleSet(RuleSets.ofList(DataStreamRetractionRule.INIT_INSTANCE))
+      .addDecoRuleSet(RuleSets.ofList(DataStreamRetractionRule.NEEDTORETRACT_INSTANCE))
       .build()
 
     assertEquals(true, cc.replacesDecoRuleSet)
     assertTrue(cc.getDecoRuleSet.isDefined)
     val cSet = cc.getDecoRuleSet.get.iterator().asScala.toSet
     assertEquals(2, cSet.size)
-    assertTrue(cSet.contains(ReduceExpressionsRule.FILTER_INSTANCE))
-    assertTrue(cSet.contains(ReduceExpressionsRule.PROJECT_INSTANCE))
+    assertTrue(cSet.contains(DataStreamRetractionRule.INIT_INSTANCE))
+    assertTrue(cSet.contains(DataStreamRetractionRule.NEEDTORETRACT_INSTANCE))
   }
 
   @Test
   def testAddDecorationRules(): Unit = {
 
     val cc: CalciteConfig = new CalciteConfigBuilder()
-      .addDecoRuleSet(RuleSets.ofList(ReduceExpressionsRule.FILTER_INSTANCE))
+      .addDecoRuleSet(RuleSets.ofList(DataStreamRetractionRule.INIT_INSTANCE))
       .build()
 
     assertEquals(false, cc.replacesDecoRuleSet)
     assertTrue(cc.getDecoRuleSet.isDefined)
     val cSet = cc.getDecoRuleSet.get.iterator().asScala.toSet
     assertEquals(1, cSet.size)
-    assertTrue(cSet.contains(ReduceExpressionsRule.FILTER_INSTANCE))
+    assertTrue(cSet.contains(DataStreamRetractionRule.INIT_INSTANCE))
   }
 
   @Test
   def testAddAddDecorationRules(): Unit = {
 
     val cc: CalciteConfig = new CalciteConfigBuilder()
-      .addDecoRuleSet(RuleSets.ofList(ReduceExpressionsRule.FILTER_INSTANCE))
-      .addDecoRuleSet(RuleSets.ofList(ReduceExpressionsRule.PROJECT_INSTANCE,
-                                      ReduceExpressionsRule.CALC_INSTANCE))
+      .addDecoRuleSet(RuleSets.ofList(DataStreamRetractionRule.INIT_INSTANCE))
+      .addDecoRuleSet(RuleSets.ofList(DataStreamRetractionRule.NEEDTORETRACT_INSTANCE,
+                                      DataStreamRetractionRule.ACCMODE_INSTANCE))
       .build()
 
     assertEquals(false, cc.replacesDecoRuleSet)
     assertTrue(cc.getDecoRuleSet.isDefined)
     val cList = cc.getDecoRuleSet.get.iterator().asScala.toList
     assertEquals(3, cList.size)
-    assertEquals(cList.head, ReduceExpressionsRule.FILTER_INSTANCE)
-    assertEquals(cList(1), ReduceExpressionsRule.PROJECT_INSTANCE)
-    assertEquals(cList(2), ReduceExpressionsRule.CALC_INSTANCE)
+    assertEquals(cList.head, DataStreamRetractionRule.INIT_INSTANCE)
+    assertEquals(cList(1), DataStreamRetractionRule.NEEDTORETRACT_INSTANCE)
+    assertEquals(cList(2), DataStreamRetractionRule.ACCMODE_INSTANCE)
   }
 
   @Test

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/rules/RetractionRulesTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/rules/RetractionRulesTest.scala
@@ -1,0 +1,334 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules
+
+import org.apache.calcite.rel.RelNode
+import org.apache.flink.table.api.Table
+import org.apache.flink.table.plan.nodes.datastream.{AccMode, RetractionTrait, RetractionTraitDef}
+import org.apache.flink.table.utils.{StreamTableTestUtil, TableTestBase}
+import org.apache.flink.table.utils.TableTestUtil._
+import org.junit.Assert._
+import org.junit.Test
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+
+
+class RetractionRulesTest extends TableTestBase {
+
+  def streamTestForRetractionUtil(): StreamTableTestForRetractionUtil = {
+    new StreamTableTestForRetractionUtil()
+  }
+
+  @Test
+  def testSelect(): Unit = {
+    val util = streamTestForRetractionUtil()
+    val table = util.addTable[(String, Int)]('word, 'number)
+    val defaultStatus = RetractionTrait.DEFAULT.toString
+
+    val resultTable = table.select('word, 'number)
+
+    val expected = s"DataStreamScan(${defaultStatus})"
+
+    util.verifyTableTrait(resultTable, expected)
+  }
+
+  // one level unbounded groupBy
+  @Test
+  def testGroupBy(): Unit = {
+    val util = streamTestForRetractionUtil()
+    val table = util.addTable[(String, Int)]('word, 'number)
+    val defaultStatus = RetractionTrait.DEFAULT.toString
+
+    val resultTable = table
+      .groupBy('word)
+      .select('number.count)
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamGroupAggregate",
+          unaryNode(
+            "DataStreamCalc",
+            s"DataStreamScan(${new RetractionTrait(true, AccMode.Acc).toString})",
+            new RetractionTrait(true, AccMode.Acc).toString
+          ),
+          s"${defaultStatus}"
+        ),
+        s"${defaultStatus}"
+      )
+
+    util.verifyTableTrait(resultTable, expected)
+  }
+
+
+  // two level unbounded groupBy
+  @Test
+  def testTwoGroupBy(): Unit = {
+    val util = streamTestForRetractionUtil()
+    val table = util.addTable[(String, Int)]('word, 'number)
+    val defaultStatus = RetractionTrait.DEFAULT.toString
+
+    val resultTable = table
+      .groupBy('word)
+      .select('word, 'number.count as 'count)
+      .groupBy('count)
+      .select('count, 'count.count as 'frequency)
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamGroupAggregate",
+          unaryNode(
+            "DataStreamCalc",
+            unaryNode(
+              "DataStreamGroupAggregate",
+              s"DataStreamScan(${new RetractionTrait(true, AccMode.Acc).toString})",
+              new RetractionTrait(true, AccMode.AccRetract).toString
+            ),
+            new RetractionTrait(true, AccMode.AccRetract).toString
+          ),
+          s"${defaultStatus}"
+        ),
+        s"${defaultStatus}"
+      )
+
+    util.verifyTableTrait(resultTable, expected)
+  }
+
+
+  // group window
+  @Test
+  def testGroupWindow(): Unit = {
+    val util = streamTestForRetractionUtil()
+    val table = util.addTable[(String, Int)]('word, 'number)
+    val defaultStatus = RetractionTrait.DEFAULT.toString
+
+    val resultTable = table
+      .window(Tumble over 50.milli as 'w)
+      .groupBy('w, 'word)
+      .select('word, 'number.count as 'count)
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamGroupWindowAggregate",
+          s"DataStreamScan(${new RetractionTrait(true, AccMode.Acc).toString})",
+          s"${defaultStatus}"
+        ),
+        s"${defaultStatus}"
+      )
+
+    util.verifyTableTrait(resultTable, expected)
+  }
+
+
+
+  // group window after unbounded groupBy
+  @Test
+  def testGroupWindowAfterGroupBy(): Unit = {
+    val util = streamTestForRetractionUtil()
+    val table = util.addTable[(String, Int)]('word, 'number)
+    val defaultStatus = RetractionTrait.DEFAULT.toString
+
+    val resultTable = table
+      .groupBy('word)
+      .select('word, 'number.count as 'count)
+      .window(Tumble over 50.milli as 'w)
+      .groupBy('w, 'count)
+      .select('count, 'count.count as 'frequency)
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamGroupWindowAggregate",
+          unaryNode(
+            "DataStreamCalc",
+            unaryNode(
+              "DataStreamGroupAggregate",
+              s"DataStreamScan(${new RetractionTrait(true, AccMode.Acc).toString})",
+              new RetractionTrait(true, AccMode.AccRetract).toString
+            ),
+            new RetractionTrait(true, AccMode.AccRetract).toString
+          ),
+          s"${defaultStatus}"
+        ),
+        s"${defaultStatus}"
+      )
+
+    util.verifyTableTrait(resultTable, expected)
+  }
+
+
+  // over window
+  @Test
+  def testOverWindow(): Unit = {
+    val util = streamTestForRetractionUtil()
+    util.addTable[(String, Int)]("T1", 'word, 'number)
+    val defaultStatus = RetractionTrait.DEFAULT.toString
+
+    val sqlQuery =
+      "SELECT " +
+        "word, count(number) " +
+        "OVER (PARTITION BY word ORDER BY ProcTime() " +
+        "ROWS BETWEEN UNBOUNDED preceding AND CURRENT ROW)" +
+        "FROM T1"
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamOverAggregate",
+          unaryNode(
+            "DataStreamCalc",
+            s"DataStreamScan(${new RetractionTrait(true, AccMode.Acc).toString})",
+            new RetractionTrait(true, AccMode.Acc).toString
+          ),
+          s"${defaultStatus}"
+        ),
+        s"${defaultStatus}"
+      )
+
+    util.verifySqlTrait(sqlQuery, expected)
+  }
+
+
+  // over window after unbounded groupBy
+  @Test
+  def testOverWindowAfterGroupBy(): Unit = {
+    val util = streamTestForRetractionUtil()
+    util.addTable[(String, Int)]("T1", 'word, 'number)
+    val defaultStatus = RetractionTrait.DEFAULT.toString
+
+    val sqlQuery =
+      "SELECT " +
+        "_count, count(word) " +
+        "OVER (PARTITION BY _count ORDER BY ProcTime() " +
+        "ROWS BETWEEN UNBOUNDED preceding AND CURRENT ROW)" +
+        "FROM " +
+        "(SELECT word, count(number) as _count FROM T1 GROUP BY word) "
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamOverAggregate",
+          unaryNode(
+            "DataStreamCalc",
+            unaryNode(
+              "DataStreamGroupAggregate",
+              s"DataStreamScan(${new RetractionTrait(true, AccMode.Acc).toString})",
+              new RetractionTrait(true, AccMode.AccRetract).toString
+            ),
+            new RetractionTrait(true, AccMode.AccRetract).toString
+          ),
+          s"${defaultStatus}"
+        ),
+        s"${defaultStatus}"
+      )
+
+    util.verifySqlTrait(sqlQuery, expected)
+  }
+
+  // test binaryNode
+  @Test
+  def testBinaryNode(): Unit = {
+    val util = streamTestForRetractionUtil()
+    val lTable = util.addTable[(String, Int)]('word, 'number)
+    val rTable = util.addTable[(String, Long)]('word_r, 'count_r)
+    val defaultStatus = RetractionTrait.DEFAULT.toString
+
+    val resultTable = lTable
+      .groupBy('word)
+      .select('word, 'number.count as 'count)
+      .unionAll(rTable)
+      .groupBy('count)
+      .select('count, 'count.count as 'frequency)
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamGroupAggregate",
+          unaryNode(
+            "DataStreamCalc",
+            binaryNode(
+              "DataStreamUnion",
+              unaryNode(
+                "DataStreamCalc",
+                unaryNode(
+                  "DataStreamGroupAggregate",
+                  s"DataStreamScan(${new RetractionTrait(true, AccMode.Acc).toString})",
+                  new RetractionTrait(true, AccMode.AccRetract).toString
+                ),
+                new RetractionTrait(true, AccMode.AccRetract).toString
+              ),
+              s"DataStreamScan(${new RetractionTrait(true, AccMode.Acc).toString})",
+              new RetractionTrait(true, AccMode.AccRetract).toString
+            ),
+            new RetractionTrait(true, AccMode.AccRetract).toString
+          ),
+          s"${defaultStatus}"
+        ),
+        s"${defaultStatus}"
+      )
+
+    util.verifyTableTrait(resultTable, expected)
+  }
+}
+
+
+class StreamTableTestForRetractionUtil extends StreamTableTestUtil {
+
+  def verifySqlTrait(query: String, expected: String): Unit = {
+    verifyTableTrait(tEnv.sql(query), expected)
+  }
+
+  def verifyTableTrait(resultTable: Table, expected: String): Unit = {
+    val relNode = resultTable.getRelNode
+    val optimized = tEnv.optimize(relNode)
+    val actual = TraitUtil.toString(optimized)
+    assertEquals(
+      expected.split("\n").map(_.trim).mkString("\n"),
+      actual.split("\n").map(_.trim).mkString("\n"))
+  }
+}
+
+
+object TraitUtil {
+  def toString(rel: RelNode): String = {
+    val className = rel.getClass.getSimpleName
+    var childString: String = ""
+    var i = 0
+    while (i < rel.getInputs.size()) {
+      childString += TraitUtil.toString(rel.getInput(i))
+      i += 1
+    }
+
+    val traitSting = rel.getTraitSet.getTrait(RetractionTraitDef.INSTANCE).toString
+
+    s"""${className}(${traitSting})
+       |${childString}
+       |""".stripMargin.stripLineEnd
+  }
+}
+


### PR DESCRIPTION
Add RetractionRules at the stage of decoration. These rules can derive NeedRetraction property and accumulating mode. There are three rules:
1.InitProcessRule. This rule inits NeedRetraction property and AccMode for DatastreamRels.
2.NeedToRetractProcessRule. This rule derives NeedRetraction property.
3.AccModeProcessRule.Find all AccRetract nodes. This rule derives accumulating mode.

- [x] General
  - The pull request references the related JIRA issue  [FLINK-6090] Add RetractionRule at the stage of decoration
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
