### PR TITLE
[FLINK-6279] [table] fix bug: the digest of VolcanoRuleMatch matched …

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/TableSourceScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/TableSourceScan.scala
@@ -55,7 +55,15 @@ abstract class TableSourceScan(
   }
 
   override def toString: String = {
-    s"Source(from: (${getRowType.getFieldNames.asScala.toList.mkString(", ")}))"
+    val tableName = getTable.getQualifiedName
+    val s = s"table:$tableName, fields:(${getRowType.getFieldNames.asScala.toList.mkString(", ")})"
+
+    val sourceDesc = tableSource.explainSource()
+    if (sourceDesc.nonEmpty) {
+      s"Scan($s, source:$sourceDesc)"
+    } else {
+      s"Scan($s)"
+    }
   }
 
   def copy(traitSet: RelTraitSet, tableSource: TableSource[_]): TableSourceScan

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/TableSourceTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/TableSourceTest.scala
@@ -31,6 +31,35 @@ class TableSourceTest extends TableTestBase {
   private val projectedFields: Array[String] = Array("last", "id", "score")
   private val noCalcFields: Array[String] = Array("id", "score", "first")
 
+  @Test
+  def testTableSourceScanToString(): Unit = {
+    val (tableSource1, _) = filterableTableSource
+    val (tableSource2, _) = filterableTableSource
+    val util = batchTestUtil()
+    val tEnv = util.tEnv
+
+    tEnv.registerTableSource("table1", tableSource1)
+    tEnv.registerTableSource("table2", tableSource2)
+
+    val table1 = tEnv.scan("table1").where("amount > 2")
+    val table2 = tEnv.scan("table2").where("amount > 2")
+    val result = table1.unionAll(table2)
+
+    val expected = binaryNode(
+      "DataSetUnion",
+      batchFilterableSourceTableNode(
+        "table1",
+        Array("name", "id", "amount", "price"),
+        "'amount > 2"),
+      batchFilterableSourceTableNode(
+        "table2",
+        Array("name", "id", "amount", "price"),
+        "'amount > 2"),
+      term("union", "name, id, amount, price")
+    )
+    util.verifyTable(result, expected)
+  }
+
   // batch plan
 
   @Test


### PR DESCRIPTION
`toString` of `TableSourceScan` should contain table name and result of `explainSource` to distinguish the difference of table sources with same field names. Otherwise the digest of `VolcanoRuleMatch` matched those table sources may be same.