### PR TITLE
[FLINK-6280] [scripts] Allow logging with Java flags

### DIFF
--- a/docs/monitoring/application_profiling.md
+++ b/docs/monitoring/application_profiling.md
@@ -27,8 +27,8 @@ under the License.
 
 ## Overview of Custom Logging with Apache Flink
 
-The standalone JobManager, TaskManager, HistoryServer, and ZooKeeper daemons by write `stdout` and `stderr` to files
-with a `.out` filename suffix and write internal logging to files with a `.log` suffix. Java options configured by the
+Each standalone JobManager, TaskManager, HistoryServer, and ZooKeeper daemon redirects `stdout` and `stderr` to a file
+with a `.out` filename suffix and writes internal logging to a file with a `.log` suffix. Java options configured by the
 user in `env.java.opts`, `env.java.opts.jobmanager`, and `env.java.opts.taskmanager` can likewise define log files with
 use of the script variable `LOG_PREFIX` and by enclosing the options in double quotes for late evaluation. Log files
 using `LOG_PREFIX` are rotated along with the default `.out` and `.log` files.

--- a/docs/monitoring/application_profiling.md
+++ b/docs/monitoring/application_profiling.md
@@ -1,0 +1,54 @@
+---
+title: "Application Profiling"
+nav-parent_id: monitoring
+nav-pos: 15
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+* ToC
+{:toc}
+
+## Overview of Custom Logging with Apache Flink
+
+The standalone JobManager, TaskManager, HistoryServer, and ZooKeeper daemons by write `stdout` and `stderr` to files
+with a `.out` filename suffix and write internal logging to files with a `.log` suffix. Java options configured by the
+user in `env.java.opts`, `env.java.opts.jobmanager`, and `env.java.opts.taskmanager` can likewise define log files with
+use of the script variable `LOG_PREFIX` and by enclosing the options in double quotes for late evaluation. Log files
+using `LOG_PREFIX` are rotated along with the default `.out` and `.log` files.
+
+# Profiling with Java Flight Recorder 
+ 
+Java Flight Recorder is a profiling and event collection framework built into the Oracle JDK.
+[Java Mission Control](http://www.oracle.com/technetwork/java/javaseproducts/mission-control/java-mission-control-1998576.html)
+is an advanced set of tools that enables efficient and detailed analysis of the extensive of data collected by Java Flight Recorder.
+Example configuration:
+
+~~~
+env.java.opts: "-XX:+UnlockCommercialFeatures -XX:+UnlockDiagnosticVMOptions -XX:+FlightRecorder -XX:+DebugNonSafepoints -XX:FlightRecorderOptions=defaultrecording=true,dumponexit=true,dumponexitpath=${LOG_PREFIX}.jfr"
+~~~
+
+# Profiling with JITWatch
+
+[JITWatch](https://github.com/AdoptOpenJDK/jitwatch/wiki) is a log analyser and visualizer for the Java HotSpot JIT
+compiler used to inspect inlining decisions, hot methods, bytecode, and assembly. Example configuration:
+
+~~~
+env.java.opts: "-XX:+UnlockDiagnosticVMOptions -XX:+TraceClassLoading -XX:+LogCompilation -XX:LogFile=${LOG_PREFIX}.jit -XX:+PrintAssembly"
+~~~

--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -42,7 +42,11 @@ The configuration files for the TaskManagers can be different, Flink does not as
 
 - `env.java.home`: The path to the Java installation to use (DEFAULT: system's default Java installation, if found). Needs to be specified if the startup scripts fail to automatically resolve the java home directory. Can be specified to point to a specific java installation or version. If this option is not specified, the startup scripts also evaluate the `$JAVA_HOME` environment variable.
 
-- `env.java.opts`: Set custom JVM options. This value is respected by Flink's start scripts, both JobManager and TaskManager, and Flink's YARN client. This can be used to set different garbage collectors or to include remote debuggers into the JVMs running Flink's services. Use `env.java.opts.jobmanager` and `env.java.opts.taskmanager` for JobManager or TaskManager-specific options, respectively.
+- `env.java.opts`: Set custom JVM options. This value is respected by Flink's start scripts, both JobManager and
+TaskManager, and Flink's YARN client. This can be used to set different garbage collectors or to include remote
+debuggers into the JVMs running Flink's services. Enclosing options in double quotes delays parameter substitution
+allowing access to variables from Flink's startup scripts, for example `LOG_PREFIX`. Use `env.java.opts.jobmanager` and
+`env.java.opts.taskmanager` for JobManager or TaskManager-specific options, respectively.
 
 - `env.java.opts.jobmanager`: JobManager-specific JVM options. These are used in addition to the regular `env.java.opts`.
 
@@ -535,6 +539,8 @@ Previously this key was named `recovery.mode` and the default value was `standal
 ### Environment
 
 - `env.log.dir`: (Defaults to the `log` directory under Flink's home) Defines the directory where the Flink logs are saved. It has to be an absolute path.
+
+- `env.log.max`: (Default: `5`) The maximum number of old log files to keep.`
 
 - `env.ssh.opts`: Additional command line options passed to SSH clients when starting or stopping JobManager, TaskManager, and Zookeeper services (start-cluster.sh, stop-cluster.sh, start-zookeeper-quorum.sh, stop-zookeeper-quorum.sh).
 

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -331,7 +331,15 @@ extractHostName() {
     echo $SLAVE
 }
 
-# Auxilliary function for log file rotation
+# Auxilliary functions for log file rotation
+rotateLogFilesWithPrefix() {
+    dir=$1
+    prefix=$2
+    while read -r log ; do
+        rotateLogFile $log
+    done < <(find "$dir" ! -type d -path "${prefix}*" | sed -E s/\.[0-9]+$// | sort | uniq)
+}
+
 rotateLogFile() {
     log=$1;
     num=$MAX_LOG_FILE_NUMBER

--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -78,8 +78,9 @@ fi
 # This allows us to start multiple daemon of each type.
 id=$([ -f "$pid" ] && echo $(wc -l < $pid) || echo "0")
 
-log="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-${DAEMON}-${id}-${HOSTNAME}.log"
-out="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-${DAEMON}-${id}-${HOSTNAME}.out"
+LOG_PREFIX="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-${DAEMON}-${id}-${HOSTNAME}"
+log="${LOG_PREFIX}.log"
+out="${LOG_PREFIX}.out"
 
 log_setting=("-Dlog.file=${log}" "-Dlog4j.configuration=file:${FLINK_CONF_DIR}/log4j.properties" "-Dlogback.configurationFile=file:${FLINK_CONF_DIR}/logback.xml")
 
@@ -96,8 +97,7 @@ case $STARTSTOP in
 
     (start)
         # Rotate log files
-        rotateLogFile $log
-        rotateLogFile $out
+        rotateLogFilesWithPrefix $FLINK_LOG_DIR $LOG_PREFIX
 
         # Print a warning if daemons are already running on host
         if [ -f $pid ]; then
@@ -115,6 +115,9 @@ case $STARTSTOP in
             echo "[INFO] $count instance(s) of $DAEMON are already running on $HOSTNAME."
           fi
         fi
+
+        # Evaluate user options for local variable expansion
+        FLINK_ENV_JAVA_OPTS=$(eval echo ${FLINK_ENV_JAVA_OPTS})
 
         echo "Starting $DAEMON daemon on host $HOSTNAME."
         $JAVA_RUN $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "`manglePathList "$FLINK_TM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" ${CLASS_TO_RUN} "${ARGS[@]}" > "$out" 200<&- 2>&1 < /dev/null &


### PR DESCRIPTION
Evaluate user-defined Java options immediately before starting services and rotate all log files.