### PR TITLE
[FLINK-5005] WIP: publish scala 2.12 artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
     - jdk: "oraclejdk8"
       env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis -Dmaven.javadoc.skip=true"
 
-  exclude:
   # Always run test groups A and B together
     - jdk: "oraclejdk8"
       env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis,jdk8 -Dmaven.javadoc.skip=true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
       env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis -Dmaven.javadoc.skip=true"
     - jdk: "oraclejdk8"
       env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis -Dmaven.javadoc.skip=true"
+    - jdk: "oraclejdk8"
+      env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-c,include-kinesis -Dmaven.javadoc.skip=true"
 
   # Always run test groups A and B together
     - jdk: "oraclejdk8"
@@ -28,11 +30,18 @@ matrix:
       env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-c,include-kinesis,jdk8 -Dmaven.javadoc.skip=true"
 
     - jdk: "oraclejdk8"
-      env: PROFILE="-Dhadoop.version=2.6.3 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis -Dmaven.javadoc.skip=true"
+      env: PROFILE="-Dhadoop.version=2.6.3 -Dscala-2.10 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis -Dmaven.javadoc.skip=true"
     - jdk: "oraclejdk8"
-      env: PROFILE="-Dhadoop.version=2.6.3 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis -Dmaven.javadoc.skip=true"
+      env: PROFILE="-Dhadoop.version=2.6.3 -Dscala-2.10 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis -Dmaven.javadoc.skip=true"
     - jdk: "oraclejdk8"
-      env: PROFILE="-Dhadoop.version=2.6.3 -Pinclude-yarn-tests,flink-fast-tests-c,include-kinesis -Dmaven.javadoc.skip=true"
+      env: PROFILE="-Dhadoop.version=2.6.3 -Dscala-2.10 -Pinclude-yarn-tests,flink-fast-tests-c,include-kinesis -Dmaven.javadoc.skip=true"
+
+    - jdk: "openjdk7"
+      env: PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis"
+    - jdk: "openjdk7"
+      env: PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis"
+    - jdk: "openjdk7"
+      env: PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-c,include-kinesis"
 
     - jdk: "openjdk7"
       env: PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis"
@@ -42,11 +51,11 @@ matrix:
       env: PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-c,include-kinesis"
 
     - jdk: "oraclejdk7"
-      env: PROFILE="-Dhadoop.version=2.3.0 -Pflink-fast-tests-a,include-kinesis"
+      env: PROFILE="-Dhadoop.version=2.3.0 -Dscala-2.10 -Pflink-fast-tests-a,include-kinesis"
     - jdk: "oraclejdk7"
-      env: PROFILE="-Dhadoop.version=2.3.0 -Pflink-fast-tests-b,include-kinesis"
+      env: PROFILE="-Dhadoop.version=2.3.0 -Dscala-2.10 -Pflink-fast-tests-b,include-kinesis"
     - jdk: "oraclejdk7"
-      env: PROFILE="-Dhadoop.version=2.3.0 -Pflink-fast-tests-c,include-kinesis"
+      env: PROFILE="-Dhadoop.version=2.3.0 -Dscala-2.10 -Pflink-fast-tests-c,include-kinesis"
 
 
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ language: java
 matrix:
   include:
     - jdk: "oraclejdk8"
-      env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis -Dmaven.javadoc.skip=true"
+      env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis,jdk8 -Dmaven.javadoc.skip=true"
     - jdk: "oraclejdk8"
-      env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis -Dmaven.javadoc.skip=true"
+      env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis,jdk8 -Dmaven.javadoc.skip=true"
     - jdk: "oraclejdk8"
-      env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-c,include-kinesis -Dmaven.javadoc.skip=true"
+      env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-c,include-kinesis,jdk8 -Dmaven.javadoc.skip=true"
 
   # Always run test groups A and B together
     - jdk: "oraclejdk8"
@@ -36,12 +36,12 @@ matrix:
     - jdk: "oraclejdk8"
       env: PROFILE="-Dhadoop.version=2.6.3 -Dscala-2.10 -Pinclude-yarn-tests,flink-fast-tests-c,include-kinesis -Dmaven.javadoc.skip=true"
 
-    - jdk: "openjdk7"
-      env: PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis"
-    - jdk: "openjdk7"
-      env: PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis"
-    - jdk: "openjdk7"
-      env: PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-c,include-kinesis"
+    - jdk: "oraclejdk8"
+      env: PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis,jdk8"
+    - jdk: "oraclejdk8"
+      env: PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis,jdk8"
+    - jdk: "oraclejdk8"
+      env: PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-c,include-kinesis,jdk8"
 
     - jdk: "openjdk7"
       env: PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ language: java
 #See https://issues.apache.org/jira/browse/FLINK-1072
 matrix:
   include:
+    - jdk: "oraclejdk8"
+      env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis -Dmaven.javadoc.skip=true"
+    - jdk: "oraclejdk8"
+      env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.12 -Pinclude-yarn-tests,flink-fast-tests-b,include-kinesis -Dmaven.javadoc.skip=true"
+
+  exclude:
   # Always run test groups A and B together
     - jdk: "oraclejdk8"
       env: PROFILE="-Dhadoop.version=2.7.2 -Dscala-2.11 -Pinclude-yarn-tests,flink-fast-tests-a,include-kinesis,jdk8 -Dmaven.javadoc.skip=true"
@@ -46,7 +52,6 @@ matrix:
 
 git:
   depth: 100
-
 
 env:
     global:

--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -194,7 +194,7 @@ under the License.
 			<activation>
 				<property>
 					<!-- this is the default scala profile -->
-					<name>!scala-2.11</name>
+					<name>scala-2.12</name>
 				</property>
 			</activation>
 			<dependencies>
@@ -206,6 +206,12 @@ under the License.
 		</profile>
 		<profile>
 			<id>scala</id>
+			<activation>
+				<property>
+					<!-- this is the default scala profile -->
+					<name>!scala-2.12</name>
+				</property>
+			</activation>
 			<dependencies>
 				<dependency>
 					<groupId>com.data-artisans</groupId>

--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -76,12 +76,7 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-		
-		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-testkit_${scala.binary.version}</artifactId>
-			<scope>test</scope>
-		</dependency>
+
 	</dependencies>
 
 	<!-- More information on this:
@@ -192,4 +187,31 @@ under the License.
 			</plugins>
 		</pluginManagement>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>scala-2.12</id>
+			<activation>
+				<property>
+					<!-- this is the default scala profile -->
+					<name>!scala-2.11</name>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>com.typesafe.akka</groupId>
+					<artifactId>akka-testkit_2.12</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>scala</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.data-artisans</groupId>
+					<artifactId>flakka-testkit_${scala.binary.version}</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 </project>

--- a/flink-connectors/flink-connector-kafka-0.10/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.10/pom.xml
@@ -37,7 +37,7 @@ under the License.
 
 	<!-- Allow users to pass custom connector versions -->
 	<properties>
-		<kafka.version>0.10.0.1</kafka.version>
+		<kafka.version>0.10.1.1</kafka.version>
 	</properties>
 
 	<dependencies>

--- a/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import kafka.admin.AdminUtils;
 import kafka.common.KafkaException;
+import kafka.metrics.KafkaMetricsReporter;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
 import kafka.utils.SystemTime$;
@@ -42,6 +43,7 @@ import org.apache.kafka.common.protocol.SecurityProtocol;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.collection.Seq$;
 
 import java.io.File;
 import java.net.BindException;
@@ -381,7 +383,9 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 
 			try {
 				scala.Option<String> stringNone = scala.Option.apply(null);
-				KafkaServer server = new KafkaServer(kafkaConfig, SystemTime$.MODULE$, stringNone);
+				scala.collection.Seq emptyReporter =
+					Seq$.MODULE$.<KafkaMetricsReporter>empty();
+				KafkaServer server = new KafkaServer(kafkaConfig, SystemTime$.MODULE$, stringNone, emptyReporter);
 				server.startup();
 				return server;
 			}

--- a/flink-connectors/flink-connector-kafka-base/pom.xml
+++ b/flink-connectors/flink-connector-kafka-base/pom.xml
@@ -37,7 +37,7 @@ under the License.
 
 	<!-- Allow users to pass custom connector versions -->
 	<properties>
-		<kafka.version>0.8.2.2</kafka.version>
+		<kafka.version>0.10.1.1</kafka.version>
 	</properties>
 
 	<dependencies>

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -42,8 +42,6 @@ under the License.
 		<module>flink-hbase</module>
 		<module>flink-hcatalog</module>
 		<module>flink-connector-kafka-base</module>
-		<module>flink-connector-kafka-0.8</module>
-		<module>flink-connector-kafka-0.9</module>
 		<module>flink-connector-kafka-0.10</module>
 		<module>flink-connector-elasticsearch-base</module>
 		<module>flink-connector-elasticsearch</module>
@@ -98,6 +96,20 @@ under the License.
 			</activation>
 			<modules>
 				<module>flink-connector-elasticsearch5</module>
+			</modules>
+		</profile>
+
+		<profile>
+			<id>scala-2.12</id>
+			<properties>
+				<kafka.version>0.10.1.1</kafka.version>
+			</properties>
+		</profile>
+		<profile>
+			<id>scala</id>
+			<modules>
+				<module>flink-connector-kafka-0.8</module>
+				<module>flink-connector-kafka-0.9</module>
 			</modules>
 		</profile>
 	</profiles>

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -107,6 +107,11 @@ under the License.
 		</profile>
 		<profile>
 			<id>scala</id>
+			<activation>
+				<property>
+					<name>!scala-2.12</name>
+				</property>
+			</activation>
 			<modules>
 				<module>flink-connector-kafka-0.8</module>
 				<module>flink-connector-kafka-0.9</module>

--- a/flink-contrib/flink-streaming-contrib/pom.xml
+++ b/flink-contrib/flink-streaming-contrib/pom.xml
@@ -100,13 +100,6 @@ under the License.
 						<jvmArg>-Xms128m</jvmArg>
 						<jvmArg>-Xmx512m</jvmArg>
 					</jvmArgs>
-					<compilerPlugins combine.children="append">
-						<compilerPlugin>
-							<groupId>org.scalamacros</groupId>
-							<artifactId>paradise_${scala.version}</artifactId>
-							<version>${scala.macros.version}</version>
-						</compilerPlugin>
-					</compilerPlugins>
 				</configuration>
 			</plugin>
 
@@ -184,4 +177,60 @@ under the License.
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>scala</id>
+			<activation>
+				<property>
+					<name>!scala-2.12</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+				
+			<!-- Scala Compiler -->
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<executions>
+					<!-- Run scala compiler in the process-resources phase, so that dependencies on
+						scala classes can be resolved later in the (Java) compile phase -->
+					<execution>
+						<id>scala-compile-first</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+
+					<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+						 scala classes can be resolved later in the (Java) test-compile phase -->
+					<execution>
+						<id>scala-test-compile</id>
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<jvmArgs>
+						<jvmArg>-Xms128m</jvmArg>
+						<jvmArg>-Xmx512m</jvmArg>
+					</jvmArgs>
+					<compilerPlugins combine.children="append">
+						<compilerPlugin>
+							<groupId>org.scalamacros</groupId>
+							<artifactId>paradise_${scala.version}</artifactId>
+							<version>${scala.macros.version}</version>
+						</compilerPlugin>
+					</compilerPlugins>
+				</configuration>
+			</plugin>
+
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/flink-contrib/flink-streaming-contrib/pom.xml
+++ b/flink-contrib/flink-streaming-contrib/pom.xml
@@ -193,32 +193,7 @@ under the License.
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>
 				<artifactId>scala-maven-plugin</artifactId>
-				<executions>
-					<!-- Run scala compiler in the process-resources phase, so that dependencies on
-						scala classes can be resolved later in the (Java) compile phase -->
-					<execution>
-						<id>scala-compile-first</id>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-
-					<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
-						 scala classes can be resolved later in the (Java) test-compile phase -->
-					<execution>
-						<id>scala-test-compile</id>
-						<phase>process-test-resources</phase>
-						<goals>
-							<goal>testCompile</goal>
-						</goals>
-					</execution>
-				</executions>
 				<configuration>
-					<jvmArgs>
-						<jvmArg>-Xms128m</jvmArg>
-						<jvmArg>-Xmx512m</jvmArg>
-					</jvmArgs>
 					<compilerPlugins combine.children="append">
 						<compilerPlugin>
 							<groupId>org.scalamacros</groupId>

--- a/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/graph/DeltaPageRank.scala
+++ b/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/graph/DeltaPageRank.scala
@@ -77,7 +77,7 @@ object DeltaPageRank {
       (solutionSet, workset) =>
         {
           val deltas = workset.join(adjacency).where(0).equalTo(0) {
-            (lastDeltas, adj, out: Collector[Page]) =>
+            (lastDeltas: (Long, Double), adj: (Long, Array[Long]), out: Collector[Page]) =>
               {
                 val targets = adj._2
                 val deltaPerTarget = DAMPENING_FACTOR * lastDeltas._2 / targets.length
@@ -88,7 +88,7 @@ object DeltaPageRank {
               }
           }
             .groupBy(0).sum(1)
-            .filter(x => Math.abs(x._2) > THRESHOLD)
+            .filter((x: (Long, Double)) => Math.abs(x._2) > THRESHOLD)
 
           val rankUpdates = solutionSet.join(deltas).where(0).equalTo(0) {
             (current, delta) => (current._1, current._2 + delta._2)

--- a/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/graph/PageRankBasic.scala
+++ b/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/graph/PageRankBasic.scala
@@ -114,7 +114,7 @@ object PageRankBasic {
           // collect ranks and sum them up
           .groupBy("pageId").aggregate(SUM, "rank")
           // apply dampening factor
-          .map { p =>
+          .map { p: Page =>
             Page(p.pageId, (p.rank * DAMPENING_FACTOR) + ((1 - DAMPENING_FACTOR) / numPages))
           }.withForwardedFields("pageId")
 

--- a/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/graph/TransitiveClosureNaive.scala
+++ b/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/graph/TransitiveClosureNaive.scala
@@ -58,7 +58,7 @@ object TransitiveClosureNaive {
       val nextPaths = prevPaths
         .join(edges)
         .where(1).equalTo(0) {
-          (left, right) => (left._1,right._2)
+          (left: (Long, Long), right: (Long, Long)) => (left._1,right._2)
         }.withForwardedFieldsFirst("_1").withForwardedFieldsSecond("_2")
         .union(prevPaths)
         .groupBy(0, 1)
@@ -67,7 +67,8 @@ object TransitiveClosureNaive {
       val terminate = prevPaths
         .coGroup(nextPaths)
         .where(0).equalTo(0) {
-          (prev, next, out: Collector[(Long, Long)]) => {
+          (prev: Iterator[(Long, Long)], next: Iterator[(Long, Long)],
+           out: Collector[(Long, Long)]) => {
             val prevPaths = prev.toSet
             for (n <- next)
               if (!prevPaths.contains(n)) out.collect(n)

--- a/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/relational/WebLogAnalysis.scala
+++ b/flink-examples/flink-examples-batch/src/main/scala/org/apache/flink/examples/scala/relational/WebLogAnalysis.scala
@@ -105,20 +105,22 @@ object WebLogAnalysis {
     val visits = getVisitsDataSet(env, params)
 
     val filteredDocs = documents
-      .filter(doc => doc._2.contains(" editors ") && doc._2.contains(" oscillations "))
+      .filter((doc: (String, String)) =>
+        doc._2.contains(" editors ") && doc._2.contains(" oscillations "))
 
     val filteredRanks = ranks
-      .filter(rank => rank._1 > 40)
+      .filter((rank: (Int, String, Int)) => rank._1 > 40)
 
     val filteredVisits = visits
-      .filter(visit => visit._2.substring(0, 4).toInt == 2007)
+      .filter((visit: (String, String)) => visit._2.substring(0, 4).toInt == 2007)
 
     val joinDocsRanks = filteredDocs.join(filteredRanks).where(0).equalTo(1) {
-      (doc, rank) => rank
+      (doc: (String, String), rank: (Int, String, Int)) => rank
     }.withForwardedFieldsSecond("*")
 
     val result = joinDocsRanks.coGroup(filteredVisits).where(1).equalTo(0) {
-      (ranks, visits, out: Collector[(Int, String, Int)]) =>
+      (ranks: Iterator[(Int, String, Int)], visits: Iterator[(String, String)],
+       out: Collector[(Int, String, Int)]) =>
         if (visits.isEmpty) for (rank <- ranks) out.collect(rank)
     }.withForwardedFieldsFirst("*")
 

--- a/flink-libraries/flink-gelly-examples/pom.xml
+++ b/flink-libraries/flink-gelly-examples/pom.xml
@@ -94,45 +94,6 @@
 
 	<build>
 		<plugins>
-			<!-- Scala Compiler -->
-			<plugin>
-				<groupId>net.alchim31.maven</groupId>
-				<artifactId>scala-maven-plugin</artifactId>
-				<executions>
-					<!-- Run scala compiler in the process-resources phase, so that dependencies on
-                        scala classes can be resolved later in the (Java) compile phase -->
-					<execution>
-						<id>scala-compile-first</id>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-
-					<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
-                         scala classes can be resolved later in the (Java) test-compile phase -->
-					<execution>
-						<id>scala-test-compile</id>
-						<phase>process-test-resources</phase>
-						<goals>
-							<goal>testCompile</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<jvmArgs>
-						<jvmArg>-Xms128m</jvmArg>
-						<jvmArg>-Xmx512m</jvmArg>
-					</jvmArgs>
-					<compilerPlugins combine.children="append">
-						<compilerPlugin>
-							<groupId>org.scalamacros</groupId>
-							<artifactId>paradise_${scala.version}</artifactId>
-							<version>${scala.macros.version}</version>
-						</compilerPlugin>
-					</compilerPlugins>
-				</configuration>
-			</plugin>
 
 			<!-- Eclipse Integration -->
 			<plugin>
@@ -222,4 +183,108 @@
 		</plugins>
 	</build>
 
+
+	<profiles>
+		<profile>
+			<id>scala</id>
+			<activation>
+				<property>
+					<name>!scala-2.12</name>
+				</property>
+			</activation>
+
+			<build>
+				<plugins>
+					<!-- Scala Compiler -->
+					<plugin>
+						<groupId>net.alchim31.maven</groupId>
+						<artifactId>scala-maven-plugin</artifactId>
+						<executions>
+							<!-- Run scala compiler in the process-resources phase, so that dependencies on
+                                scala classes can be resolved later in the (Java) compile phase -->
+							<execution>
+								<id>scala-compile-first</id>
+								<phase>process-resources</phase>
+								<goals>
+									<goal>compile</goal>
+								</goals>
+							</execution>
+
+							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+                                 scala classes can be resolved later in the (Java) test-compile phase -->
+							<execution>
+								<id>scala-test-compile</id>
+								<phase>process-test-resources</phase>
+								<goals>
+									<goal>testCompile</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<jvmArgs>
+								<jvmArg>-Xms128m</jvmArg>
+								<jvmArg>-Xmx512m</jvmArg>
+							</jvmArgs>
+							<compilerPlugins combine.children="append">
+								<compilerPlugin>
+									<groupId>org.scalamacros</groupId>
+									<artifactId>paradise_${scala.version}</artifactId>
+									<version>${scala.macros.version}</version>
+								</compilerPlugin>
+							</compilerPlugins>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+
+		</profile>
+		<profile>
+			<id>scala-2.12</id>
+			<activation>
+				<property>
+					<name>!scala-2.10</name>
+				</property>
+			</activation>
+
+			<build>
+				<plugins>
+					<!-- Scala Compiler -->
+					<plugin>
+						<groupId>net.alchim31.maven</groupId>
+						<artifactId>scala-maven-plugin</artifactId>
+						<executions>
+							<!-- Run scala compiler in the process-resources phase, so that dependencies on
+                                scala classes can be resolved later in the (Java) compile phase -->
+							<execution>
+								<id>scala-compile-first</id>
+								<phase>process-resources</phase>
+								<goals>
+									<goal>compile</goal>
+								</goals>
+							</execution>
+
+							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+                                 scala classes can be resolved later in the (Java) test-compile phase -->
+							<execution>
+								<id>scala-test-compile</id>
+								<phase>process-test-resources</phase>
+								<goals>
+									<goal>testCompile</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<jvmArgs>
+								<jvmArg>-Xms128m</jvmArg>
+								<jvmArg>-Xmx512m</jvmArg>
+							</jvmArgs>
+						</configuration>
+					</plugin>
+
+				</plugins>
+			</build>
+
+		</profile>
+	</profiles>
+	
 </project>

--- a/flink-libraries/flink-gelly-examples/pom.xml
+++ b/flink-libraries/flink-gelly-examples/pom.xml
@@ -94,7 +94,39 @@
 
 	<build>
 		<plugins>
+			<!-- Scala Compiler -->
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<executions>
+					<!-- Run scala compiler in the process-resources phase, so that dependencies on
+                        scala classes can be resolved later in the (Java) compile phase -->
+					<execution>
+						<id>scala-compile-first</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
 
+					<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+                         scala classes can be resolved later in the (Java) test-compile phase -->
+					<execution>
+						<id>scala-test-compile</id>
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<jvmArgs>
+						<jvmArg>-Xms128m</jvmArg>
+						<jvmArg>-Xmx512m</jvmArg>
+					</jvmArgs>
+				</configuration>
+			</plugin>
+			
 			<!-- Eclipse Integration -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -199,32 +231,7 @@
 					<plugin>
 						<groupId>net.alchim31.maven</groupId>
 						<artifactId>scala-maven-plugin</artifactId>
-						<executions>
-							<!-- Run scala compiler in the process-resources phase, so that dependencies on
-                                scala classes can be resolved later in the (Java) compile phase -->
-							<execution>
-								<id>scala-compile-first</id>
-								<phase>process-resources</phase>
-								<goals>
-									<goal>compile</goal>
-								</goals>
-							</execution>
-
-							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
-                                 scala classes can be resolved later in the (Java) test-compile phase -->
-							<execution>
-								<id>scala-test-compile</id>
-								<phase>process-test-resources</phase>
-								<goals>
-									<goal>testCompile</goal>
-								</goals>
-							</execution>
-						</executions>
 						<configuration>
-							<jvmArgs>
-								<jvmArg>-Xms128m</jvmArg>
-								<jvmArg>-Xmx512m</jvmArg>
-							</jvmArgs>
 							<compilerPlugins combine.children="append">
 								<compilerPlugin>
 									<groupId>org.scalamacros</groupId>
@@ -236,54 +243,6 @@
 					</plugin>
 				</plugins>
 			</build>
-
-		</profile>
-		<profile>
-			<id>scala-2.12</id>
-			<activation>
-				<property>
-					<name>!scala-2.10</name>
-				</property>
-			</activation>
-
-			<build>
-				<plugins>
-					<!-- Scala Compiler -->
-					<plugin>
-						<groupId>net.alchim31.maven</groupId>
-						<artifactId>scala-maven-plugin</artifactId>
-						<executions>
-							<!-- Run scala compiler in the process-resources phase, so that dependencies on
-                                scala classes can be resolved later in the (Java) compile phase -->
-							<execution>
-								<id>scala-compile-first</id>
-								<phase>process-resources</phase>
-								<goals>
-									<goal>compile</goal>
-								</goals>
-							</execution>
-
-							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
-                                 scala classes can be resolved later in the (Java) test-compile phase -->
-							<execution>
-								<id>scala-test-compile</id>
-								<phase>process-test-resources</phase>
-								<goals>
-									<goal>testCompile</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<jvmArgs>
-								<jvmArg>-Xms128m</jvmArg>
-								<jvmArg>-Xmx512m</jvmArg>
-							</jvmArgs>
-						</configuration>
-					</plugin>
-
-				</plugins>
-			</build>
-
 		</profile>
 	</profiles>
 	

--- a/flink-libraries/flink-gelly-scala/pom.xml
+++ b/flink-libraries/flink-gelly-scala/pom.xml
@@ -103,45 +103,6 @@ under the License.
 
     <build>
         <plugins>
-            <!-- Scala Compiler -->
-            <plugin>
-                <groupId>net.alchim31.maven</groupId>
-                <artifactId>scala-maven-plugin</artifactId>
-                <executions>
-                    <!-- Run scala compiler in the process-resources phase, so that dependencies on
-                        scala classes can be resolved later in the (Java) compile phase -->
-                    <execution>
-                        <id>scala-compile-first</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-
-                    <!-- Run scala compiler in the process-test-resources phase, so that dependencies on
-                         scala classes can be resolved later in the (Java) test-compile phase -->
-                    <execution>
-                        <id>scala-test-compile</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <jvmArgs>
-                        <jvmArg>-Xms128m</jvmArg>
-                        <jvmArg>-Xmx512m</jvmArg>
-                    </jvmArgs>
-                    <compilerPlugins combine.children="append">
-                        <compilerPlugin>
-                            <groupId>org.scalamacros</groupId>
-                            <artifactId>paradise_${scala.version}</artifactId>
-                            <version>${scala.macros.version}</version>
-                        </compilerPlugin>
-                    </compilerPlugins>
-                </configuration>
-            </plugin>
 
             <!-- Eclipse Integration -->
             <plugin>
@@ -237,4 +198,106 @@ under the License.
         </plugins>
     </build>
 
+	<profiles>
+		<profile>
+			<id>scala</id>
+			<activation>
+				<property>
+					<name>!scala-2.12</name>
+				</property>
+			</activation>
+
+			<build>
+				<plugins>
+					<!-- Scala Compiler -->
+					<plugin>
+						<groupId>net.alchim31.maven</groupId>
+						<artifactId>scala-maven-plugin</artifactId>
+						<executions>
+							<!-- Run scala compiler in the process-resources phase, so that dependencies on
+                                scala classes can be resolved later in the (Java) compile phase -->
+							<execution>
+								<id>scala-compile-first</id>
+								<phase>process-resources</phase>
+								<goals>
+									<goal>compile</goal>
+								</goals>
+							</execution>
+
+							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+                                 scala classes can be resolved later in the (Java) test-compile phase -->
+							<execution>
+								<id>scala-test-compile</id>
+								<phase>process-test-resources</phase>
+								<goals>
+									<goal>testCompile</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<jvmArgs>
+								<jvmArg>-Xms128m</jvmArg>
+								<jvmArg>-Xmx512m</jvmArg>
+							</jvmArgs>
+							<compilerPlugins combine.children="append">
+								<compilerPlugin>
+									<groupId>org.scalamacros</groupId>
+									<artifactId>paradise_${scala.version}</artifactId>
+									<version>${scala.macros.version}</version>
+								</compilerPlugin>
+							</compilerPlugins>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+
+		</profile>
+		<profile>
+			<id>scala-2.12</id>
+			<activation>
+				<property>
+					<name>!scala-2.10</name>
+				</property>
+			</activation>
+
+			<build>
+				<plugins>
+					<!-- Scala Compiler -->
+					<plugin>
+						<groupId>net.alchim31.maven</groupId>
+						<artifactId>scala-maven-plugin</artifactId>
+						<executions>
+							<!-- Run scala compiler in the process-resources phase, so that dependencies on
+                                scala classes can be resolved later in the (Java) compile phase -->
+							<execution>
+								<id>scala-compile-first</id>
+								<phase>process-resources</phase>
+								<goals>
+									<goal>compile</goal>
+								</goals>
+							</execution>
+
+							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+                                 scala classes can be resolved later in the (Java) test-compile phase -->
+							<execution>
+								<id>scala-test-compile</id>
+								<phase>process-test-resources</phase>
+								<goals>
+									<goal>testCompile</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<jvmArgs>
+								<jvmArg>-Xms128m</jvmArg>
+								<jvmArg>-Xmx512m</jvmArg>
+							</jvmArgs>
+						</configuration>
+					</plugin>
+
+				</plugins>
+			</build>
+
+		</profile>
+	</profiles>
 </project>

--- a/flink-libraries/flink-gelly-scala/pom.xml
+++ b/flink-libraries/flink-gelly-scala/pom.xml
@@ -18,91 +18,91 @@ specific language governing permissions and limitations
 under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <groupId>org.apache.flink</groupId>
-        <artifactId>flink-libraries</artifactId>
-        <version>1.3-SNAPSHOT</version>
-        <relativePath>..</relativePath>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-libraries</artifactId>
+		<version>1.3-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
 
-    <artifactId>flink-gelly-scala_2.10</artifactId>
-    <name>flink-gelly-scala</name>
+	<artifactId>flink-gelly-scala_2.10</artifactId>
+	<name>flink-gelly-scala</name>
 
-    <packaging>jar</packaging>
+	<packaging>jar</packaging>
 
-    <dependencies>
-        
-        <!-- core dependencies -->
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-scala_2.10</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
+	<dependencies>
 
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-clients_2.10</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
+		<!-- core dependencies -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-scala_2.10</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-gelly_2.10</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-clients_2.10</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 
-        <!-- the dependencies below are already provided in Flink -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-gelly_2.10</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-reflect</artifactId>
-            <scope>provided</scope>
-        </dependency>
+		<!-- the dependencies below are already provided in Flink -->
 
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <scope>provided</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-reflect</artifactId>
+			<scope>provided</scope>
+		</dependency>
 
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-compiler</artifactId>
-            <scope>provided</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-library</artifactId>
+			<scope>provided</scope>
+		</dependency>
 
-        <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
-            <version>${asm.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        
-        <!-- test dependencies -->
-        
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-tests_2.10</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-            <type>test-jar</type>
-        
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-test-utils_2.10</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-compiler</artifactId>
+			<scope>provided</scope>
+		</dependency>
 
-    <build>
-        <plugins>
+		<dependency>
+			<groupId>org.ow2.asm</groupId>
+			<artifactId>asm</artifactId>
+			<version>${asm.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-tests_2.10</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils_2.10</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
 			<!-- Scala Compiler -->
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>
@@ -135,69 +135,69 @@ under the License.
 					</jvmArgs>
 				</configuration>
 			</plugin>
-            <!-- Eclipse Integration -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-eclipse-plugin</artifactId>
-                <version>2.8</version>
-                <configuration>
-                    <downloadSources>true</downloadSources>
-                    <projectnatures>
-                        <projectnature>org.scala-ide.sdt.core.scalanature</projectnature>
-                        <projectnature>org.eclipse.jdt.core.javanature</projectnature>
-                    </projectnatures>
-                    <buildcommands>
-                        <buildcommand>org.scala-ide.sdt.core.scalabuilder</buildcommand>
-                    </buildcommands>
-                    <classpathContainers>
-                        <classpathContainer>org.scala-ide.sdt.launching.SCALA_CONTAINER</classpathContainer>
-                        <classpathContainer>org.eclipse.jdt.launching.JRE_CONTAINER</classpathContainer>
-                    </classpathContainers>
-                    <excludes>
-                        <exclude>org.scala-lang:scala-library</exclude>
-                        <exclude>org.scala-lang:scala-compiler</exclude>
-                    </excludes>
-                    <sourceIncludes>
-                        <sourceInclude>**/*.scala</sourceInclude>
-                        <sourceInclude>**/*.java</sourceInclude>
-                    </sourceIncludes>
-                </configuration>
-            </plugin>
+			<!-- Eclipse Integration -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-eclipse-plugin</artifactId>
+				<version>2.8</version>
+				<configuration>
+					<downloadSources>true</downloadSources>
+					<projectnatures>
+						<projectnature>org.scala-ide.sdt.core.scalanature</projectnature>
+						<projectnature>org.eclipse.jdt.core.javanature</projectnature>
+					</projectnatures>
+					<buildcommands>
+						<buildcommand>org.scala-ide.sdt.core.scalabuilder</buildcommand>
+					</buildcommands>
+					<classpathContainers>
+						<classpathContainer>org.scala-ide.sdt.launching.SCALA_CONTAINER</classpathContainer>
+						<classpathContainer>org.eclipse.jdt.launching.JRE_CONTAINER</classpathContainer>
+					</classpathContainers>
+					<excludes>
+						<exclude>org.scala-lang:scala-library</exclude>
+						<exclude>org.scala-lang:scala-compiler</exclude>
+					</excludes>
+					<sourceIncludes>
+						<sourceInclude>**/*.scala</sourceInclude>
+						<sourceInclude>**/*.java</sourceInclude>
+					</sourceIncludes>
+				</configuration>
+			</plugin>
 
-            <!-- Adding scala source directories to build path -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.7</version>
-                <executions>
-                    <!-- Add src/main/scala to eclipse build path -->
-                    <execution>
-                        <id>add-source</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>src/main/scala</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                    <!-- Add src/test/scala to eclipse build path -->
-                    <execution>
-                        <id>add-test-source</id>
-                        <phase>generate-test-sources</phase>
-                        <goals>
-                            <goal>add-test-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>src/test/scala</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+			<!-- Adding scala source directories to build path -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>1.7</version>
+				<executions>
+					<!-- Add src/main/scala to eclipse build path -->
+					<execution>
+						<id>add-source</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>src/main/scala</source>
+							</sources>
+						</configuration>
+					</execution>
+					<!-- Add src/test/scala to eclipse build path -->
+					<execution>
+						<id>add-test-source</id>
+						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>add-test-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>src/test/scala</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 
 			<!-- Scala Code Style, most of the configuration done via plugin management -->
 			<plugin>
@@ -208,26 +208,26 @@ under the License.
 				</configuration>
 			</plugin>
 
-            <!-- build a jar-with-dependencies, to be included in the 'opt' build folder -->
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+			<!-- build a jar-with-dependencies, to be included in the 'opt' build folder -->
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+				</configuration>
+				<executions>
+					<execution>
+						<id>make-assembly</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
 	<profiles>
 		<profile>

--- a/flink-libraries/flink-gelly-scala/pom.xml
+++ b/flink-libraries/flink-gelly-scala/pom.xml
@@ -103,7 +103,38 @@ under the License.
 
     <build>
         <plugins>
+			<!-- Scala Compiler -->
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<executions>
+					<!-- Run scala compiler in the process-resources phase, so that dependencies on
+                        scala classes can be resolved later in the (Java) compile phase -->
+					<execution>
+						<id>scala-compile-first</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
 
+					<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+                         scala classes can be resolved later in the (Java) test-compile phase -->
+					<execution>
+						<id>scala-test-compile</id>
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<jvmArgs>
+						<jvmArg>-Xms128m</jvmArg>
+						<jvmArg>-Xmx512m</jvmArg>
+					</jvmArgs>
+				</configuration>
+			</plugin>
             <!-- Eclipse Integration -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -213,32 +244,7 @@ under the License.
 					<plugin>
 						<groupId>net.alchim31.maven</groupId>
 						<artifactId>scala-maven-plugin</artifactId>
-						<executions>
-							<!-- Run scala compiler in the process-resources phase, so that dependencies on
-                                scala classes can be resolved later in the (Java) compile phase -->
-							<execution>
-								<id>scala-compile-first</id>
-								<phase>process-resources</phase>
-								<goals>
-									<goal>compile</goal>
-								</goals>
-							</execution>
-
-							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
-                                 scala classes can be resolved later in the (Java) test-compile phase -->
-							<execution>
-								<id>scala-test-compile</id>
-								<phase>process-test-resources</phase>
-								<goals>
-									<goal>testCompile</goal>
-								</goals>
-							</execution>
-						</executions>
 						<configuration>
-							<jvmArgs>
-								<jvmArg>-Xms128m</jvmArg>
-								<jvmArg>-Xmx512m</jvmArg>
-							</jvmArgs>
 							<compilerPlugins combine.children="append">
 								<compilerPlugin>
 									<groupId>org.scalamacros</groupId>
@@ -248,53 +254,6 @@ under the License.
 							</compilerPlugins>
 						</configuration>
 					</plugin>
-				</plugins>
-			</build>
-
-		</profile>
-		<profile>
-			<id>scala-2.12</id>
-			<activation>
-				<property>
-					<name>!scala-2.10</name>
-				</property>
-			</activation>
-
-			<build>
-				<plugins>
-					<!-- Scala Compiler -->
-					<plugin>
-						<groupId>net.alchim31.maven</groupId>
-						<artifactId>scala-maven-plugin</artifactId>
-						<executions>
-							<!-- Run scala compiler in the process-resources phase, so that dependencies on
-                                scala classes can be resolved later in the (Java) compile phase -->
-							<execution>
-								<id>scala-compile-first</id>
-								<phase>process-resources</phase>
-								<goals>
-									<goal>compile</goal>
-								</goals>
-							</execution>
-
-							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
-                                 scala classes can be resolved later in the (Java) test-compile phase -->
-							<execution>
-								<id>scala-test-compile</id>
-								<phase>process-test-resources</phase>
-								<goals>
-									<goal>testCompile</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<jvmArgs>
-								<jvmArg>-Xms128m</jvmArg>
-								<jvmArg>-Xmx512m</jvmArg>
-							</jvmArgs>
-						</configuration>
-					</plugin>
-
 				</plugins>
 			</build>
 

--- a/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
+++ b/flink-libraries/flink-gelly-scala/src/main/scala/org/apache/flink/graph/scala/Graph.scala
@@ -109,8 +109,8 @@ object Graph {
   def fromTupleDataSet[K: TypeInformation : ClassTag, VV: TypeInformation : ClassTag, EV:
   TypeInformation : ClassTag](vertices: DataSet[(K, VV)], edges: DataSet[(K, K, EV)],
                               env: ExecutionEnvironment): Graph[K, VV, EV] = {
-    val javaTupleVertices = vertices.map(v => new jtuple.Tuple2(v._1, v._2)).javaSet
-    val javaTupleEdges = edges.map(v => new jtuple.Tuple3(v._1, v._2, v._3)).javaSet
+    val javaTupleVertices = vertices.map((v: (K, VV)) => new jtuple.Tuple2(v._1, v._2)).javaSet
+    val javaTupleEdges = edges.map((v: (K, K, EV)) => new jtuple.Tuple3(v._1, v._2, v._3)).javaSet
     wrapGraph(jg.Graph.fromTupleDataSet[K, VV, EV](javaTupleVertices, javaTupleEdges,
       env.getJavaEnv))
   }
@@ -124,7 +124,7 @@ object Graph {
    */
   def fromTupleDataSet[K: TypeInformation : ClassTag, EV: TypeInformation : ClassTag]
   (edges: DataSet[(K, K, EV)], env: ExecutionEnvironment): Graph[K, NullValue, EV] = {
-    val javaTupleEdges = edges.map(v => new jtuple.Tuple3(v._1, v._2, v._3)).javaSet
+    val javaTupleEdges = edges.map((v: (K, K, EV)) => new jtuple.Tuple3(v._1, v._2, v._3)).javaSet
     wrapGraph(jg.Graph.fromTupleDataSet[K, EV](javaTupleEdges, env.getJavaEnv))
   }
 
@@ -139,7 +139,7 @@ object Graph {
   def fromTupleDataSet[K: TypeInformation : ClassTag, VV: TypeInformation : ClassTag, EV:
   TypeInformation : ClassTag](edges: DataSet[(K, K, EV)],
   vertexValueInitializer: MapFunction[K, VV], env: ExecutionEnvironment): Graph[K, VV, EV] = {
-    val javaTupleEdges = edges.map(v => new jtuple.Tuple3(v._1, v._2, v._3)).javaSet
+    val javaTupleEdges = edges.map((v: (K, K, EV)) => new jtuple.Tuple3(v._1, v._2, v._3)).javaSet
     wrapGraph(jg.Graph.fromTupleDataSet[K, VV, EV](javaTupleEdges, vertexValueInitializer,
       env.getJavaEnv))
   }
@@ -152,7 +152,7 @@ object Graph {
    */
   def fromTuple2DataSet[K: TypeInformation : ClassTag](edges: DataSet[(K, K)],
   env: ExecutionEnvironment): Graph[K, NullValue, NullValue] = {
-    val javaTupleEdges = edges.map(v => new jtuple.Tuple2(v._1, v._2)).javaSet
+    val javaTupleEdges = edges.map((v: (K, K)) => new jtuple.Tuple2(v._1, v._2)).javaSet
     wrapGraph(jg.Graph.fromTuple2DataSet[K](javaTupleEdges, env.getJavaEnv))
   }
 
@@ -166,7 +166,7 @@ object Graph {
   def fromTuple2DataSet[K: TypeInformation : ClassTag, VV: TypeInformation : ClassTag]
   (edges: DataSet[(K, K)], vertexValueInitializer: MapFunction[K, VV],
   env: ExecutionEnvironment): Graph[K, VV, NullValue] = {
-    val javaTupleEdges = edges.map(v => new jtuple.Tuple2(v._1, v._2)).javaSet
+    val javaTupleEdges = edges.map((v: (K, K)) => new jtuple.Tuple2(v._1, v._2)).javaSet
     wrapGraph(jg.Graph.fromTuple2DataSet[K, VV](javaTupleEdges, vertexValueInitializer,
       env.getJavaEnv))
   }
@@ -259,7 +259,7 @@ object Graph {
         ignoreCommentsEdges,
         lenientEdges,
         includedFieldsEdges)
-        .map(edge => (edge._1, edge._2, NullValue.getInstance))
+        .map((edge: (K, K)) => (edge._1, edge._2, NullValue.getInstance))
         .asInstanceOf[DataSet[(K, K, EV)]]
     } else {
       env.readCsvFile[(K, K, EV)](
@@ -331,14 +331,16 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * @return the vertex DataSet as Tuple2.
    */
   def getVerticesAsTuple2(): DataSet[(K, VV)] = {
-    wrap(jgraph.getVerticesAsTuple2).map(jtuple => (jtuple.f0, jtuple.f1))
+    wrap(jgraph.getVerticesAsTuple2).map((javatuple: jtuple.Tuple2[K, VV])
+    => (javatuple.f0, javatuple.f1))
   }
 
   /**
    * @return the edge DataSet as Tuple3.
    */
   def getEdgesAsTuple3(): DataSet[(K, K, EV)] = {
-    wrap(jgraph.getEdgesAsTuple3).map(jtuple => (jtuple.f0, jtuple.f1, jtuple.f2))
+    wrap(jgraph.getEdgesAsTuple3).map((javatuple: jtuple.Tuple3[K, K, EV])
+    => (javatuple.f0, javatuple.f1, javatuple.f2))
   }
 
   /**
@@ -508,7 +510,7 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    */
   def joinWithVertices[T: TypeInformation](inputDataSet: DataSet[(K, T)],
   vertexJoinFunction: VertexJoinFunction[VV, T]): Graph[K, VV, EV] = {
-    val javaTupleSet = inputDataSet.map(scalatuple => new jtuple.Tuple2(scalatuple._1,
+    val javaTupleSet = inputDataSet.map((scalatuple: (K, T)) => new jtuple.Tuple2(scalatuple._1,
       scalatuple._2)).javaSet
     wrapGraph(jgraph.joinWithVertices[T](javaTupleSet, vertexJoinFunction))
   }
@@ -537,7 +539,7 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
         cleanFun(vertexValue, inputValue)
       }
     }
-    val javaTupleSet = inputDataSet.map(scalatuple => new jtuple.Tuple2(scalatuple._1,
+    val javaTupleSet = inputDataSet.map((scalatuple: (K, T)) => new jtuple.Tuple2(scalatuple._1,
       scalatuple._2)).javaSet
     wrapGraph(jgraph.joinWithVertices[T](javaTupleSet, newVertexJoin))
   }
@@ -559,8 +561,8 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    */
   def joinWithEdges[T: TypeInformation](inputDataSet: DataSet[(K, K, T)],
   edgeJoinFunction: EdgeJoinFunction[EV, T]): Graph[K, VV, EV] = {
-    val javaTupleSet = inputDataSet.map(scalatuple => new jtuple.Tuple3(scalatuple._1,
-      scalatuple._2, scalatuple._3)).javaSet
+    val javaTupleSet = inputDataSet.map((scalatuple: (K, K, T)) =>
+      new jtuple.Tuple3(scalatuple._1, scalatuple._2, scalatuple._3)).javaSet
     wrapGraph(jgraph.joinWithEdges[T](javaTupleSet, edgeJoinFunction))
   }
 
@@ -588,8 +590,8 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
         cleanFun(edgeValue, inputValue)
       }
     }
-    val javaTupleSet = inputDataSet.map(scalatuple => new jtuple.Tuple3(scalatuple._1,
-      scalatuple._2, scalatuple._3)).javaSet
+    val javaTupleSet = inputDataSet.map((scalatuple: (K, K, T)) =>
+      new jtuple.Tuple3(scalatuple._1, scalatuple._2, scalatuple._3)).javaSet
     wrapGraph(jgraph.joinWithEdges[T](javaTupleSet, newEdgeJoin))
   }
 
@@ -611,7 +613,7 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    */
   def joinWithEdgesOnSource[T: TypeInformation](inputDataSet: DataSet[(K, T)],
   edgeJoinFunction: EdgeJoinFunction[EV, T]): Graph[K, VV, EV] = {
-    val javaTupleSet = inputDataSet.map(scalatuple => new jtuple.Tuple2(scalatuple._1,
+    val javaTupleSet = inputDataSet.map((scalatuple: (K, T)) => new jtuple.Tuple2(scalatuple._1,
       scalatuple._2)).javaSet
     wrapGraph(jgraph.joinWithEdgesOnSource[T](javaTupleSet, edgeJoinFunction))
   }
@@ -641,7 +643,7 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
         cleanFun(edgeValue, inputValue)
       }
     }
-    val javaTupleSet = inputDataSet.map(scalatuple => new jtuple.Tuple2(scalatuple._1,
+    val javaTupleSet = inputDataSet.map((scalatuple: (K, T)) => new jtuple.Tuple2(scalatuple._1,
       scalatuple._2)).javaSet
     wrapGraph(jgraph.joinWithEdgesOnSource[T](javaTupleSet, newEdgeJoin))
   }
@@ -664,7 +666,7 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    */
   def joinWithEdgesOnTarget[T: TypeInformation](inputDataSet: DataSet[(K, T)],
   edgeJoinFunction: EdgeJoinFunction[EV, T]): Graph[K, VV, EV] = {
-    val javaTupleSet = inputDataSet.map(scalatuple => new jtuple.Tuple2(scalatuple._1,
+    val javaTupleSet = inputDataSet.map((scalatuple: (K, T)) => new jtuple.Tuple2(scalatuple._1,
       scalatuple._2)).javaSet
     wrapGraph(jgraph.joinWithEdgesOnTarget[T](javaTupleSet, edgeJoinFunction))
   }
@@ -694,7 +696,7 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
         cleanFun(edgeValue, inputValue)
       }
     }
-    val javaTupleSet = inputDataSet.map(scalatuple => new jtuple.Tuple2(scalatuple._1,
+    val javaTupleSet = inputDataSet.map((scalatuple: (K, T)) => new jtuple.Tuple2(scalatuple._1,
       scalatuple._2)).javaSet
     wrapGraph(jgraph.joinWithEdgesOnTarget[T](javaTupleSet, newEdgeJoin))
   }
@@ -799,7 +801,8 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * @return A DataSet of Tuple2<vertexId, inDegree>
    */
   def inDegrees(): DataSet[(K, LongValue)] = {
-    wrap(jgraph.inDegrees).map(javatuple => (javatuple.f0, javatuple.f1))
+    wrap(jgraph.inDegrees).map((javatuple: jtuple.Tuple2[K, LongValue]) =>
+      (javatuple.f0, javatuple.f1))
   }
 
   /**
@@ -808,7 +811,8 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * @return A DataSet of Tuple2<vertexId, outDegree>
    */
   def outDegrees(): DataSet[(K, LongValue)] = {
-    wrap(jgraph.outDegrees).map(javatuple => (javatuple.f0, javatuple.f1))
+    wrap(jgraph.outDegrees).map((javatuple: jtuple.Tuple2[K, LongValue]) =>
+      (javatuple.f0, javatuple.f1))
   }
 
   /**
@@ -817,7 +821,8 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * @return A DataSet of Tuple2<vertexId, degree>
    */
   def getDegrees(): DataSet[(K, LongValue)] = {
-    wrap(jgraph.getDegrees).map(javatuple => (javatuple.f0, javatuple.f1))
+    wrap(jgraph.getDegrees).map((javatuple: jtuple.Tuple2[K, LongValue]) =>
+      (javatuple.f0, javatuple.f1))
   }
 
   /**
@@ -927,7 +932,8 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    * @return The IDs of the edges as DataSet
    */
   def getEdgeIds(): DataSet[(K, K)] = {
-    wrap(jgraph.getEdgeIds).map(jtuple => (jtuple.f0, jtuple.f1))
+    wrap(jgraph.getEdgeIds).map((javatuple: jtuple.Tuple2[K, K]) =>
+      (javatuple.f0, javatuple.f1))
   }
 
   /**
@@ -1083,8 +1089,8 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    */
   def reduceOnNeighbors(reduceNeighborsFunction: ReduceNeighborsFunction[VV], direction:
   EdgeDirection): DataSet[(K, VV)] = {
-    wrap(jgraph.reduceOnNeighbors(reduceNeighborsFunction, direction)).map(jtuple => (jtuple
-      .f0, jtuple.f1))
+    wrap(jgraph.reduceOnNeighbors(reduceNeighborsFunction, direction))
+      .map((javatuple: jtuple.Tuple2[K, VV]) => (javatuple.f0, javatuple.f1))
   }
 
   /**
@@ -1102,8 +1108,8 @@ TypeInformation : ClassTag](jgraph: jg.Graph[K, VV, EV]) {
    */
   def reduceOnEdges(reduceEdgesFunction: ReduceEdgesFunction[EV], direction: EdgeDirection):
   DataSet[(K, EV)] = {
-    wrap(jgraph.reduceOnEdges(reduceEdgesFunction, direction)).map(jtuple => (jtuple.f0,
-      jtuple.f1))
+    wrap(jgraph.reduceOnEdges(reduceEdgesFunction, direction))
+      .map((javatuple: jtuple.Tuple2[K, EV]) => (javatuple.f0, javatuple.f1))
   }
 
   /**

--- a/flink-libraries/flink-ml/pom.xml
+++ b/flink-libraries/flink-ml/pom.xml
@@ -34,7 +34,7 @@
 	<packaging>jar</packaging>
 
 	<properties>
-		<breeze.version>0.12</breeze.version>
+		<breeze.version>0.13</breeze.version>
 	</properties>
 	<dependencies>
 
@@ -123,13 +123,6 @@
 			<properties>
 				<suffix.test>(?&lt;!(IT|Integration))(Test|Suite|Case)</suffix.test>
 				<suffix.it>(IT|Integration)(Test|Suite|Case)</suffix.it>
-			</properties>
-		</profile>
-
-		<profile>
-			<id>scala-2.12</id>
-			<properties>
-				<breeze.version>0.13</breeze.version>
 			</properties>
 		</profile>
 	</profiles>

--- a/flink-libraries/flink-ml/pom.xml
+++ b/flink-libraries/flink-ml/pom.xml
@@ -33,6 +33,9 @@
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<breeze.version>0.12</breeze.version>
+	</properties>
 	<dependencies>
 
 		<!-- core dependencies -->
@@ -47,7 +50,7 @@
 		<dependency>
 			<groupId>org.scalanlp</groupId>
 			<artifactId>breeze_${scala.binary.version}</artifactId>
-			<version>0.12</version>
+			<version>${breeze.version}</version>
 		</dependency>
 
 		<!-- the dependencies below are already provided in Flink -->
@@ -120,6 +123,13 @@
 			<properties>
 				<suffix.test>(?&lt;!(IT|Integration))(Test|Suite|Case)</suffix.test>
 				<suffix.it>(IT|Integration)(Test|Suite|Case)</suffix.it>
+			</properties>
+		</profile>
+
+		<profile>
+			<id>scala-2.12</id>
+			<properties>
+				<breeze.version>0.13</breeze.version>
 			</properties>
 		</profile>
 	</profiles>
@@ -201,4 +211,5 @@
 			</plugin>
 		</plugins>
 	</build>
+
 </project>

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/classification/SVM.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/classification/SVM.scala
@@ -349,7 +349,7 @@ object SVM{
 
         // Count the number of vectors, but keep the value in a DataSet to broadcast it later
         // TODO: Once efficient count and intermediate result partitions are implemented, use count
-        val numberVectors = input map { x => 1 } reduce { _ + _ }
+        val numberVectors: DataSet[Int] = input map { x: LabeledVector => 1 } reduce { _ + _ }
 
         // Group the input data into blocks in round robin fashion
         val blockedInputNumberElements = FlinkMLTools.block(
@@ -357,7 +357,7 @@ object SVM{
           blocks,
           Some(ModuloKeyPartitioner)).
           cross(numberVectors).
-          map { x => x }
+          map { (x: (Block[LabeledVector], Int)) => x }
 
         val resultingWeights = initialWeights.iterate(iterations) {
           weights => {

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/common/FlinkMLTools.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/common/FlinkMLTools.scala
@@ -376,7 +376,7 @@ object FlinkMLTools {
     partitionerOption: Option[Partitioner[Int]] = None)
   : DataSet[Block[T]] = {
     val blockIDInput = input map {
-      element =>
+      (element: T) =>
         val blockID = element.hashCode() % numBlocks
 
         val blockIDResult = if(blockID < 0){

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/nn/KNN.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/nn/KNN.scala
@@ -227,7 +227,8 @@ object KNN {
 
             // join input and training set
             val crossed = crossTuned.mapPartition {
-              (iter, out: Collector[(FlinkVector, FlinkVector, Long, Double)]) => {
+              (iter: Iterator[(Block[FlinkVector], Block[(Long, T)])],
+               out: Collector[(FlinkVector, FlinkVector, Long, Double)]) => {
                 for ((training, testing) <- iter) {
                   // use a quadtree if (4 ^ dim) * Ntest * log(Ntrain)
                   // < Ntest * Ntrain, and distance is Euclidean
@@ -252,7 +253,8 @@ object KNN {
 
             // group by input vector id and pick k nearest neighbor for each group
             val result = crossed.groupBy(2).sortGroup(3, Order.ASCENDING).reduceGroup {
-              (iter, out: Collector[(FlinkVector, Array[FlinkVector])]) => {
+              (iter: Iterator[(FlinkVector, FlinkVector, Long, Double)],
+               out: Collector[(FlinkVector, Array[FlinkVector])]) => {
                 if (iter.hasNext) {
                   val head = iter.next()
                   val key = head._2

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/outlier/StochasticOutlierSelection.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/outlier/StochasticOutlierSelection.scala
@@ -197,7 +197,7 @@ object StochasticOutlierSelection extends WithParameters {
         val resultingParameters = instance.parameters ++ transformParameters
 
         // Map to the right format
-        val vectorsWithIndex = input.zipWithUniqueId.map(vector => {
+        val vectorsWithIndex = input.zipWithUniqueId.map((vector: (Long, T)) => {
           BreezeLabeledVector(vector._1.toInt, vector._2.asBreeze)
         })
 

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/MinMaxScaler.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/MinMaxScaler.scala
@@ -149,7 +149,7 @@ object MinMaxScaler {
   : DataSet[(linalg.Vector[Double], linalg.Vector[Double])] = {
 
     val minMax = dataSet.map {
-      v => (v.asBreeze, v.asBreeze)
+      v: T => (v.asBreeze, v.asBreeze)
     }.reduce {
       (minMax1, minMax2) => {
 

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/PolynomialFeatures.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/PolynomialFeatures.scala
@@ -116,7 +116,7 @@ object PolynomialFeatures{
         val degree = resultingParameters(Degree)
 
         input.map {
-          vector => {
+          vector: T => {
             calculatePolynomial(degree, vector)
           }
         }

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/Splitter.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/Splitter.scala
@@ -76,7 +76,7 @@ object Splitter {
       }
     }
 
-    val leftSplitLight = leftSplit.map(o => (o._1, false))
+    val leftSplitLight = leftSplit.map((o: (Long, T)) => (o._1, false))
 
     val rightSplit: DataSet[T] = indexedInput.leftOuterJoin[(Long, Boolean)](leftSplitLight)
       .where(0)
@@ -87,7 +87,7 @@ object Splitter {
         }
     }
 
-    Array(leftSplit.map(o => o._2), rightSplit)
+    Array(leftSplit.map((o: (Long, T)) => o._2), rightSplit)
   }
 
   // --------------------------------------------------------------------------------------------
@@ -117,14 +117,14 @@ object Splitter {
 
     eid.reseedRandomGenerator(seed)
 
-    val tempDS: DataSet[(Int,T)] = input.map(o => (eid.sample, o))
+    val tempDS: DataSet[(Int,T)] = input.map((o: T) => (eid.sample, o))
 
     val splits = fracArray.length
     val outputArray = new Array[DataSet[T]]( splits )
 
     for (k <- 0 to splits-1){
-      outputArray(k) = tempDS.filter(o => o._1 == k)
-                             .map(o => o._2)
+      outputArray(k) = tempDS.filter((o: (Int, T)) => o._1 == k)
+                             .map((o: (Int, T)) => o._2)
     }
 
     outputArray

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/StandardScaler.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/StandardScaler.scala
@@ -158,7 +158,7 @@ object StandardScaler {
           fitParameters: ParameterMap,
           input: DataSet[(T, Double)])
       : Unit = {
-        val vectorDS = input.map(_._1)
+        val vectorDS = input.map((i: (T, Double)) => i._1)
         val metrics = extractFeatureMetrics(vectorDS)
 
         instance.metricsOption = Some(metrics)
@@ -180,7 +180,7 @@ object StandardScaler {
   private def extractFeatureMetrics[T <: Vector](dataSet: DataSet[T])
   : DataSet[(linalg.Vector[Double], linalg.Vector[Double])] = {
     val metrics = dataSet.map{
-      v => (1.0, v.asBreeze, linalg.Vector.zeros[Double](v.size))
+      (v: T) => (1.0, v.asBreeze, linalg.Vector.zeros[Double](v.size))
     }.reduce{
       (metrics1, metrics2) => {
         /* We use formula 1.5b of the cited technical report for the combination of partial

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
@@ -210,7 +210,7 @@ class ALS extends Predictor[ALS] {
         val predictions = data.join(userFactors, JoinHint.REPARTITION_HASH_SECOND).where(0)
           .equalTo(0).join(itemFactors, JoinHint.REPARTITION_HASH_SECOND).where("_1._2")
           .equalTo(0).map {
-          triple => {
+          (triple: (((Long, Long), ALS.Factors), ALS.Factors)) => {
             val (((uID, iID), uFactors), iFactors) = triple
 
             val uFactorsVector = uFactors.factors
@@ -404,7 +404,7 @@ object ALS {
         case Some((userFactors, itemFactors)) => {
           input.join(userFactors, JoinHint.REPARTITION_HASH_SECOND).where(0).equalTo(0)
             .join(itemFactors, JoinHint.REPARTITION_HASH_SECOND).where("_1._2").equalTo(0).map {
-            triple => {
+            (triple: (((Long, Long), ALS.Factors), ALS.Factors)) => {
               val (((uID, iID), uFactors), iFactors) = triple
 
               val uFactorsVector = uFactors.factors

--- a/flink-mesos/pom.xml
+++ b/flink-mesos/pom.xml
@@ -267,7 +267,7 @@ under the License.
 			<activation>
 				<property>
 					<!-- this is the default scala profile -->
-					<name>!scala-2.11</name>
+					<name>scala-2.12</name>
 				</property>
 			</activation>
 			<dependencies>
@@ -291,6 +291,12 @@ under the License.
 		</profile>
 		<profile>
 			<id>scala</id>
+			<activation>
+				<property>
+					<!-- this is the default scala profile -->
+					<name>!scala-2.12</name>
+				</property>
+			</activation>
 			<dependencies>
 				<dependency>
 					<groupId>com.data-artisans</groupId>

--- a/flink-mesos/pom.xml
+++ b/flink-mesos/pom.xml
@@ -61,28 +61,6 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-actor_${scala.binary.version}</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-remote_${scala.binary.version}</artifactId>
-			<exclusions>
-				<!-- exclude protobuf here to allow the mesos library to provide it -->
-				<exclusion>
-					<groupId>com.google.protobuf</groupId>
-					<artifactId>protobuf-java</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-
-		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-slf4j_${scala.binary.version}</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apache.mesos</groupId>
 			<artifactId>mesos</artifactId>
 			<version>${mesos.version}</version>
@@ -119,12 +97,6 @@ under the License.
 			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-test</artifactId>
 			<version>${curator.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-testkit_${scala.binary.version}</artifactId>
 			<scope>test</scope>
 		</dependency>
 
@@ -287,4 +259,59 @@ under the License.
 			</plugin>
 		</plugins>
 	</build>
+
+
+	<profiles>
+		<profile>
+			<id>scala-2.12</id>
+			<activation>
+				<property>
+					<!-- this is the default scala profile -->
+					<name>!scala-2.11</name>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>com.typesafe.akka</groupId>
+					<artifactId>akka-actor_2.12</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>com.typesafe.akka</groupId>
+					<artifactId>akka-slf4j_2.12</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>com.typesafe.akka</groupId>
+					<artifactId>akka-remote_2.12</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>com.typesafe.akka</groupId>
+					<artifactId>akka-testkit_2.12</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>scala</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.data-artisans</groupId>
+					<artifactId>flakka-actor_${scala.binary.version}</artifactId>
+				</dependency>
+
+				<dependency>
+					<groupId>com.data-artisans</groupId>
+					<artifactId>flakka-remote_${scala.binary.version}</artifactId>
+				</dependency>
+
+				<dependency>
+					<groupId>com.data-artisans</groupId>
+					<artifactId>flakka-slf4j_${scala.binary.version}</artifactId>
+				</dependency>
+
+				<dependency>
+					<groupId>com.data-artisans</groupId>
+					<artifactId>flakka-testkit_${scala.binary.version}</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 </project>

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -126,7 +126,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		}
 
 		@Override
-		public Map<String, NamedResourceSetRequest> getCustomNamedResources() {
+		public Map<String, TaskRequest.NamedResourceSetRequest> getCustomNamedResources() {
 			return Collections.emptyMap();
 		}
 
@@ -141,12 +141,12 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		}
 
 		@Override
-		public void setAssignedResources(AssignedResources assignedResources) {
+		public void setAssignedResources(TaskRequest.AssignedResources assignedResources) {
 			this.assignedResources.set(assignedResources);
 		}
 
 		@Override
-		public AssignedResources getAssignedResources() {
+		public TaskRequest.AssignedResources getAssignedResources() {
 			return assignedResources.get();
 		}
 

--- a/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/LaunchCoordinatorTest.scala
+++ b/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/LaunchCoordinatorTest.scala
@@ -21,29 +21,29 @@ package org.apache.flink.mesos.scheduler
 import java.util.{Collections, UUID}
 import java.util.concurrent.atomic.AtomicReference
 
+import akka.actor.ActorSystem
 import akka.actor.FSM.StateTimeout
 import akka.testkit._
 import com.netflix.fenzo.TaskRequest.{AssignedResources, NamedResourceSetRequest}
 import com.netflix.fenzo._
 import com.netflix.fenzo.functions.{Action1, Action2}
 import com.netflix.fenzo.plugins.VMLeaseObject
-import org.apache.flink.api.java.tuple.{Tuple2=>FlinkTuple2}
+import org.apache.flink.api.java.tuple.{Tuple2 => FlinkTuple2}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.mesos.scheduler.LaunchCoordinator._
 import org.apache.flink.mesos.scheduler.messages._
 import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.mesos.Protos.{SlaveID, TaskInfo}
-import org.apache.mesos.{SchedulerDriver, Protos}
+import org.apache.mesos.{Protos, SchedulerDriver}
 import org.junit.runner.RunWith
 import org.mockito.Mockito.{verify, _}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.mockito.{Matchers => MM, Mockito}
+import org.mockito.{Mockito, Matchers => MM}
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
 import scala.collection.JavaConverters._
-
 import org.apache.flink.mesos.Utils.range
 import org.apache.flink.mesos.Utils.ranges
 import org.apache.flink.mesos.Utils.scalar
@@ -57,7 +57,7 @@ class LaunchCoordinatorTest
     with BeforeAndAfterAll {
 
   lazy val config = new Configuration()
-  implicit lazy val system = AkkaUtils.createLocalActorSystem(config)
+  implicit lazy val system: ActorSystem = AkkaUtils.createLocalActorSystem(config)
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)

--- a/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/ReconciliationCoordinatorTest.scala
+++ b/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/ReconciliationCoordinatorTest.scala
@@ -20,14 +20,14 @@ package org.apache.flink.mesos.scheduler
 
 import java.util.UUID
 
-import akka.actor.FSM
+import akka.actor.{ActorSystem, FSM}
 import akka.testkit._
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.mesos.Matchers._
 import org.apache.flink.mesos.scheduler.messages.{Connected, Disconnected, StatusUpdate}
 import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.mesos.Protos.TaskState._
-import org.apache.mesos.{SchedulerDriver, Protos}
+import org.apache.mesos.{Protos, SchedulerDriver}
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.Mockito._
@@ -45,7 +45,7 @@ class ReconciliationCoordinatorTest
   import ReconciliationCoordinator._
 
   lazy val config = new Configuration()
-  implicit lazy val system = AkkaUtils.createLocalActorSystem(config)
+  implicit lazy val system: ActorSystem = AkkaUtils.createLocalActorSystem(config)
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)

--- a/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/TaskMonitorTest.scala
+++ b/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/TaskMonitorTest.scala
@@ -20,14 +20,15 @@ package org.apache.flink.mesos.scheduler
 
 import java.util.UUID
 
+import akka.actor.ActorSystem
 import akka.actor.FSM.StateTimeout
 import akka.testkit._
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.mesos.TestFSMUtils
 import org.apache.flink.mesos.scheduler.ReconciliationCoordinator.Reconcile
-import org.apache.flink.mesos.scheduler.messages.{Disconnected, Connected, StatusUpdate}
+import org.apache.flink.mesos.scheduler.messages.{Connected, Disconnected, StatusUpdate}
 import org.apache.flink.runtime.akka.AkkaUtils
-import org.apache.mesos.{SchedulerDriver, Protos}
+import org.apache.mesos.{Protos, SchedulerDriver}
 import org.apache.mesos.Protos.TaskState._
 import org.junit.runner.RunWith
 import org.mockito.Mockito
@@ -46,7 +47,7 @@ class TaskMonitorTest
   import TaskMonitor._
 
   lazy val config = new Configuration()
-  implicit lazy val system = AkkaUtils.createLocalActorSystem(config)
+  implicit lazy val system: ActorSystem = AkkaUtils.createLocalActorSystem(config)
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)

--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -134,7 +134,7 @@ under the License.
 			<activation>
 				<property>
 					<!-- this is the default scala profile -->
-					<name>!scala-2.11</name>
+					<name>scala-2.12</name>
 				</property>
 			</activation>
 			<dependencies>
@@ -146,6 +146,12 @@ under the License.
 		</profile>
 		<profile>
 			<id>scala</id>
+			<activation>
+				<property>
+					<!-- this is the default scala profile -->
+					<name>!scala-2.12</name>
+				</property>
+			</activation>
 			<dependencies>
 
 				<dependency>

--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -91,11 +91,6 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-testkit_${scala.binary.version}</artifactId>
-			<scope>test</scope>
-		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -132,5 +127,33 @@ under the License.
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>scala-2.12</id>
+			<activation>
+				<property>
+					<!-- this is the default scala profile -->
+					<name>!scala-2.11</name>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>com.typesafe.akka</groupId>
+					<artifactId>akka-testkit_2.12</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>scala</id>
+			<dependencies>
+
+				<dependency>
+					<groupId>com.data-artisans</groupId>
+					<artifactId>flakka-testkit_${scala.binary.version}</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 	
 </project>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -95,22 +95,7 @@ under the License.
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-library</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-actor_${scala.binary.version}</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-remote_${scala.binary.version}</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-slf4j_${scala.binary.version}</artifactId>
-		</dependency>
-
+		
 		<dependency>
 			<groupId>org.clapper</groupId>
 			<artifactId>grizzled-slf4j_${scala.binary.version}</artifactId>
@@ -184,10 +169,6 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-testkit_${scala.binary.version}</artifactId>
-		</dependency>
 
 		<dependency>
 			<groupId>org.reflections</groupId>
@@ -395,4 +376,58 @@ under the License.
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>scala-2.12</id>
+			<activation>
+				<property>
+					<!-- this is the default scala profile -->
+					<name>!scala-2.11</name>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>com.typesafe.akka</groupId>
+					<artifactId>akka-actor_2.12</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>com.typesafe.akka</groupId>
+					<artifactId>akka-slf4j_2.12</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>com.typesafe.akka</groupId>
+					<artifactId>akka-remote_2.12</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>com.typesafe.akka</groupId>
+					<artifactId>akka-testkit_2.12</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>scala</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.data-artisans</groupId>
+					<artifactId>flakka-actor_${scala.binary.version}</artifactId>
+				</dependency>
+
+				<dependency>
+					<groupId>com.data-artisans</groupId>
+					<artifactId>flakka-remote_${scala.binary.version}</artifactId>
+				</dependency>
+
+				<dependency>
+					<groupId>com.data-artisans</groupId>
+					<artifactId>flakka-slf4j_${scala.binary.version}</artifactId>
+				</dependency>
+
+				<dependency>
+					<groupId>com.data-artisans</groupId>
+					<artifactId>flakka-testkit_${scala.binary.version}</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 </project>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -383,7 +383,7 @@ under the License.
 			<activation>
 				<property>
 					<!-- this is the default scala profile -->
-					<name>!scala-2.11</name>
+					<name>scala-2.12</name>
 				</property>
 			</activation>
 			<dependencies>
@@ -407,6 +407,12 @@ under the License.
 		</profile>
 		<profile>
 			<id>scala</id>
+			<activation>
+				<property>
+					<!-- this is the default scala profile -->
+					<name>!scala-2.12</name>
+				</property>
+			</activation>
 			<dependencies>
 				<dependency>
 					<groupId>com.data-artisans</groupId>

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1350,8 +1350,8 @@ class TaskManager(
             accumulatorEvents.append(accumulators)
           } catch {
             case e: Exception =>
-              log.warn("Failed to take accumulator snapshot for task {}.",
-                execID, ExceptionUtils.getRootCause(e))
+              log.warn(s"Failed to take accumulator snapshot for task $execID.",
+                ExceptionUtils.getRootCause(e))
           }
       }
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerLike.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerLike.scala
@@ -68,7 +68,7 @@ trait TestingJobManagerLike extends FlinkActor {
   val waitForNumRegisteredTaskManagers = mutable.PriorityQueue.newBuilder(
     new Ordering[(Int, ActorRef)] {
       override def compare(x: (Int, ActorRef), y: (Int, ActorRef)): Int = y._1 - x._1
-    })
+    }).result()
 
   val waitForClient = scala.collection.mutable.HashSet[ActorRef]()
 

--- a/flink-scala-shell/pom.xml
+++ b/flink-scala-shell/pom.xml
@@ -16,7 +16,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -39,7 +39,7 @@ under the License.
 		<!-- scala command line parsing -->
 		<dependency>
 			<groupId>com.github.scopt</groupId>
-            <artifactId>scopt_${scala.binary.version}</artifactId>
+			<artifactId>scopt_${scala.binary.version}</artifactId>
 		</dependency>
 
 		<dependency>
@@ -205,24 +205,11 @@ under the License.
 	<profiles>
 		<profile>
 			<id>scala-2.10</id>
-			<build>
-			<!-- Scala Compiler -->
-			<plugins>
-			<plugin>
-				<groupId>net.alchim31.maven</groupId>
-				<artifactId>scala-maven-plugin</artifactId>
-				<configuration>
-					<compilerPlugins combine.children="append">
-						<compilerPlugin>
-							<groupId>org.scalamacros</groupId>
-							<artifactId>paradise_${scala.version}</artifactId>
-							<version>${scala.macros.version}</version>
-						</compilerPlugin>
-					</compilerPlugins>
-				</configuration>
-			</plugin>
-			</plugins>
-			</build>
+			<activation>
+				<property>
+					<name>scala-2.10</name>
+				</property>
+			</activation>
 			<dependencies>
 				<dependency>
 					<groupId>org.scalamacros</groupId>
@@ -238,25 +225,30 @@ under the License.
 			</dependencies>
 		</profile>
 		<profile>
-			<id>scala-2.11</id>
+			<id>scala</id>
+			<activation>
+				<property>
+					<name>!scala-2.12</name>
+				</property>
+			</activation>
 			<!-- Scala Compiler -->
-		<build>
-		<plugins>
-			<plugin>
-				<groupId>net.alchim31.maven</groupId>
-				<artifactId>scala-maven-plugin</artifactId>
-				<configuration>
-					<compilerPlugins combine.children="append">
-						<compilerPlugin>
-							<groupId>org.scalamacros</groupId>
-							<artifactId>paradise_${scala.version}</artifactId>
-							<version>${scala.macros.version}</version>
-						</compilerPlugin>
-					</compilerPlugins>
-				</configuration>
-			</plugin>
-		</plugins>
-		</build>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>net.alchim31.maven</groupId>
+						<artifactId>scala-maven-plugin</artifactId>
+						<configuration>
+							<compilerPlugins combine.children="append">
+								<compilerPlugin>
+									<groupId>org.scalamacros</groupId>
+									<artifactId>paradise_${scala.version}</artifactId>
+									<version>${scala.macros.version}</version>
+								</compilerPlugin>
+							</compilerPlugins>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 
 	</profiles>

--- a/flink-scala-shell/pom.xml
+++ b/flink-scala-shell/pom.xml
@@ -121,13 +121,6 @@ under the License.
 						<jvmArg>-Xms128m</jvmArg>
 						<jvmArg>-Xmx512m</jvmArg>
 					</jvmArgs>
-					<compilerPlugins combine.children="append">
-						<compilerPlugin>
-							<groupId>org.scalamacros</groupId>
-							<artifactId>paradise_${scala.version}</artifactId>
-							<version>${scala.macros.version}</version>
-						</compilerPlugin>
-					</compilerPlugins>
 				</configuration>
 			</plugin>
 
@@ -212,12 +205,24 @@ under the License.
 	<profiles>
 		<profile>
 			<id>scala-2.10</id>
-			<activation>
-				<property>
-					<!-- this is the default scala profile -->
-					<name>!scala-2.11</name>
-				</property>
-			</activation>
+			<build>
+			<!-- Scala Compiler -->
+			<plugins>
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<configuration>
+					<compilerPlugins combine.children="append">
+						<compilerPlugin>
+							<groupId>org.scalamacros</groupId>
+							<artifactId>paradise_${scala.version}</artifactId>
+							<version>${scala.macros.version}</version>
+						</compilerPlugin>
+					</compilerPlugins>
+				</configuration>
+			</plugin>
+			</plugins>
+			</build>
 			<dependencies>
 				<dependency>
 					<groupId>org.scalamacros</groupId>
@@ -232,6 +237,28 @@ under the License.
 				</dependency>
 			</dependencies>
 		</profile>
+		<profile>
+			<id>scala-2.11</id>
+			<!-- Scala Compiler -->
+		<build>
+		<plugins>
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<configuration>
+					<compilerPlugins combine.children="append">
+						<compilerPlugin>
+							<groupId>org.scalamacros</groupId>
+							<artifactId>paradise_${scala.version}</artifactId>
+							<version>${scala.macros.version}</version>
+						</compilerPlugin>
+					</compilerPlugins>
+				</configuration>
+			</plugin>
+		</plugins>
+		</build>
+		</profile>
+
 	</profiles>
 
 </project>

--- a/flink-scala-shell/src/main/scala-2.12/org/apache/flink/api/scala/ILoopCompat.scala
+++ b/flink-scala-shell/src/main/scala-2.12/org/apache/flink/api/scala/ILoopCompat.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.scala
+
+import java.io.BufferedReader
+
+import _root_.scala.tools.nsc.interpreter._
+import _root_.scala.io.AnsiColor.{MAGENTA, RESET}
+
+class ILoopCompat(
+                   in0: Option[BufferedReader],
+                   out0: JPrintWriter)
+  extends ILoop(in0, out0) {
+
+  override def prompt = {
+    val promptStr = "Scala-Flink> "
+    s"$MAGENTA$promptStr$RESET"
+  }
+
+  protected def addThunk(f: => Unit): Unit = f
+}

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -106,46 +106,6 @@ under the License.
 				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 			</plugin>
-
-			<!-- Scala Compiler -->
-			<plugin>
-				<groupId>net.alchim31.maven</groupId>
-				<artifactId>scala-maven-plugin</artifactId>
-				<executions>
-					<!-- Run scala compiler in the process-resources phase, so that dependencies on
-						scala classes can be resolved later in the (Java) compile phase -->
-					<execution>
-						<id>scala-compile-first</id>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
- 
-					<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
-						 scala classes can be resolved later in the (Java) test-compile phase -->
-					<execution>
-						<id>scala-test-compile</id>
-						<phase>process-test-resources</phase>
-						<goals>
-							<goal>testCompile</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<jvmArgs>
-						<jvmArg>-Xms128m</jvmArg>
-						<jvmArg>-Xmx512m</jvmArg>
-					</jvmArgs>
-					<compilerPlugins combine.children="append">
-					   <compilerPlugin>
-						   <groupId>org.scalamacros</groupId>
-						   <artifactId>paradise_${scala.version}</artifactId>
-						   <version>${scala.macros.version}</version>
-					   </compilerPlugin>
-				   </compilerPlugins>
-				</configuration>
-			</plugin>
 			
 			<!-- Eclipse Integration -->
 			<plugin>
@@ -228,8 +188,7 @@ under the License.
 			<id>scala-2.10</id>
 			<activation>
 				<property>
-					<!-- this is the default scala profile -->
-					<name>!scala-2.11</name>
+					<name>!scala-2.12</name>
 				</property>
 			</activation>
 			<dependencies>
@@ -239,7 +198,100 @@ under the License.
 					<version>${scala.macros.version}</version>
 				</dependency>
 			</dependencies>
+
+			<build>
+				<plugins>
+					<!-- Scala Compiler -->
+					<plugin>
+						<groupId>net.alchim31.maven</groupId>
+						<artifactId>scala-maven-plugin</artifactId>
+						<executions>
+							<!-- Run scala compiler in the process-resources phase, so that dependencies on
+                                scala classes can be resolved later in the (Java) compile phase -->
+							<execution>
+								<id>scala-compile-first</id>
+								<phase>process-resources</phase>
+								<goals>
+									<goal>compile</goal>
+								</goals>
+							</execution>
+
+							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+                                 scala classes can be resolved later in the (Java) test-compile phase -->
+							<execution>
+								<id>scala-test-compile</id>
+								<phase>process-test-resources</phase>
+								<goals>
+									<goal>testCompile</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<jvmArgs>
+								<jvmArg>-Xms128m</jvmArg>
+								<jvmArg>-Xmx512m</jvmArg>
+							</jvmArgs>
+							<compilerPlugins combine.children="append">
+								<compilerPlugin>
+									<groupId>org.scalamacros</groupId>
+									<artifactId>paradise_${scala.version}</artifactId>
+									<version>${scala.macros.version}</version>
+								</compilerPlugin>
+							</compilerPlugins>
+						</configuration>
+					</plugin>
+
+				</plugins>
+			</build>
+
 		</profile>
-	</profiles>
+		<profile>
+			<id>scala-2.12</id>
+			<activation>
+				<property>
+					<name>!scala-2.10</name>
+				</property>
+			</activation>
+
+			<build>
+				<plugins>
+					<!-- Scala Compiler -->
+					<plugin>
+						<groupId>net.alchim31.maven</groupId>
+						<artifactId>scala-maven-plugin</artifactId>
+						<executions>
+							<!-- Run scala compiler in the process-resources phase, so that dependencies on
+                                scala classes can be resolved later in the (Java) compile phase -->
+							<execution>
+								<id>scala-compile-first</id>
+								<phase>process-resources</phase>
+								<goals>
+									<goal>compile</goal>
+								</goals>
+							</execution>
+
+							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+                                 scala classes can be resolved later in the (Java) test-compile phase -->
+							<execution>
+								<id>scala-test-compile</id>
+								<phase>process-test-resources</phase>
+								<goals>
+									<goal>testCompile</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<jvmArgs>
+								<jvmArg>-Xms128m</jvmArg>
+								<jvmArg>-Xmx512m</jvmArg>
+							</jvmArgs>
+						</configuration>
+					</plugin>
+
+				</plugins>
+			</build>
+
+		</profile>
+	</profiles>   
 
 </project>

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -106,6 +106,39 @@ under the License.
 				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 			</plugin>
+
+			<!-- Scala Compiler -->
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<executions>
+					<!-- Run scala compiler in the process-resources phase, so that dependencies on
+                        scala classes can be resolved later in the (Java) compile phase -->
+					<execution>
+						<id>scala-compile-first</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+
+					<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+                         scala classes can be resolved later in the (Java) test-compile phase -->
+					<execution>
+						<id>scala-test-compile</id>
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<jvmArgs>
+						<jvmArg>-Xms128m</jvmArg>
+						<jvmArg>-Xmx512m</jvmArg>
+					</jvmArgs>
+				</configuration>
+			</plugin>
 			
 			<!-- Eclipse Integration -->
 			<plugin>
@@ -188,7 +221,7 @@ under the License.
 			<id>scala-2.10</id>
 			<activation>
 				<property>
-					<name>!scala-2.12</name>
+					<name>scala-2.10</name>
 				</property>
 			</activation>
 			<dependencies>
@@ -198,6 +231,14 @@ under the License.
 					<version>${scala.macros.version}</version>
 				</dependency>
 			</dependencies>
+		</profile>
+		<profile>
+			<id>scala</id>
+			<activation>
+				<property>
+					<name>!scala-2.12</name>
+				</property>
+			</activation>
 
 			<build>
 				<plugins>
@@ -205,32 +246,7 @@ under the License.
 					<plugin>
 						<groupId>net.alchim31.maven</groupId>
 						<artifactId>scala-maven-plugin</artifactId>
-						<executions>
-							<!-- Run scala compiler in the process-resources phase, so that dependencies on
-                                scala classes can be resolved later in the (Java) compile phase -->
-							<execution>
-								<id>scala-compile-first</id>
-								<phase>process-resources</phase>
-								<goals>
-									<goal>compile</goal>
-								</goals>
-							</execution>
-
-							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
-                                 scala classes can be resolved later in the (Java) test-compile phase -->
-							<execution>
-								<id>scala-test-compile</id>
-								<phase>process-test-resources</phase>
-								<goals>
-									<goal>testCompile</goal>
-								</goals>
-							</execution>
-						</executions>
 						<configuration>
-							<jvmArgs>
-								<jvmArg>-Xms128m</jvmArg>
-								<jvmArg>-Xmx512m</jvmArg>
-							</jvmArgs>
 							<compilerPlugins combine.children="append">
 								<compilerPlugin>
 									<groupId>org.scalamacros</groupId>
@@ -244,52 +260,6 @@ under the License.
 				</plugins>
 			</build>
 
-		</profile>
-		<profile>
-			<id>scala-2.12</id>
-			<activation>
-				<property>
-					<name>!scala-2.10</name>
-				</property>
-			</activation>
-
-			<build>
-				<plugins>
-					<!-- Scala Compiler -->
-					<plugin>
-						<groupId>net.alchim31.maven</groupId>
-						<artifactId>scala-maven-plugin</artifactId>
-						<executions>
-							<!-- Run scala compiler in the process-resources phase, so that dependencies on
-                                scala classes can be resolved later in the (Java) compile phase -->
-							<execution>
-								<id>scala-compile-first</id>
-								<phase>process-resources</phase>
-								<goals>
-									<goal>compile</goal>
-								</goals>
-							</execution>
-
-							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
-                                 scala classes can be resolved later in the (Java) test-compile phase -->
-							<execution>
-								<id>scala-test-compile</id>
-								<phase>process-test-resources</phase>
-								<goals>
-									<goal>testCompile</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<jvmArgs>
-								<jvmArg>-Xms128m</jvmArg>
-								<jvmArg>-Xmx512m</jvmArg>
-							</jvmArgs>
-						</configuration>
-					</plugin>
-
-				</plugins>
-			</build>
 
 		</profile>
 	</profiles>   

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ClosureCleaner.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ClosureCleaner.scala
@@ -259,7 +259,8 @@ class ReturnStatementFinder extends ClassVisitor(ASM5) {
   }
 }
 
-private class LambdaReturnStatementFinder(targetMethodName: String) extends ClassVisitor(ASM5) {
+private[flink]
+class LambdaReturnStatementFinder(targetMethodName: String) extends ClassVisitor(ASM5) {
   override def visitMethod(
                             access: Int,
                             name: String,

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ClosureCleaner.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ClosureCleaner.scala
@@ -262,7 +262,7 @@ class FieldAccessFinder(output: Map[Class[_], Set[String]]) extends ClassVisitor
       }
 
       override def visitMethodInsn(op: Int, owner: String, name: String,
-                                   desc: String) {
+                                   desc: String, itf: Boolean) {
         // Check for calls a getter method for a variable in an interpreter wrapper object.
         // This means that the corresponding field will be accessed, so we should save it.
         if (op == INVOKEVIRTUAL && owner.endsWith("$iwC") && !name.endsWith("$outer")) {
@@ -288,7 +288,7 @@ private[flink] class InnerClosureFinder(output: Set[Class[_]]) extends ClassVisi
                            sig: String, exceptions: Array[String]): MethodVisitor = {
     new MethodVisitor(ASM5) {
       override def visitMethodInsn(op: Int, owner: String, name: String,
-                                   desc: String) {
+                                   desc: String, itf: Boolean) {
         val argTypes = Type.getArgumentTypes(desc)
         if (op == INVOKESPECIAL && name == "<init>" && argTypes.nonEmpty
           && argTypes(0).toString.startsWith("L") // is it an object?

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnDataSet.scala
@@ -20,6 +20,7 @@ package org.apache.flink.api.scala.extensions.impl.acceptPartialFunctions
 import org.apache.flink.annotation.PublicEvolving
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala.{DataSet, GroupedDataSet}
+import org.apache.flink.util.Collector
 
 import scala.reflect.ClassTag
 
@@ -53,7 +54,7 @@ class OnDataSet[T](ds: DataSet[T]) {
   @PublicEvolving
   def mapPartitionWith[R: TypeInformation: ClassTag](fun: Stream[T] => R): DataSet[R] =
     ds.mapPartition {
-      (it, out) =>
+      (it: Iterator[T], out: Collector[R]) =>
         out.collect(fun(it.toStream))
     }
 
@@ -100,7 +101,7 @@ class OnDataSet[T](ds: DataSet[T]) {
   @PublicEvolving
   def reduceGroupWith[R: TypeInformation: ClassTag](fun: Stream[T] => R): DataSet[R] =
     ds.reduceGroup {
-      (it, out) =>
+      (it: Iterator[T], out: Collector[R]) =>
         out.collect(fun(it.toStream))
     }
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnGroupedDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/extensions/impl/acceptPartialFunctions/OnGroupedDataSet.scala
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.PublicEvolving
 import org.apache.flink.api.common.operators.Order
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala.{DataSet, GroupedDataSet}
+import org.apache.flink.util.Collector
 
 import scala.reflect.ClassTag
 
@@ -65,7 +66,7 @@ class OnGroupedDataSet[T](ds: GroupedDataSet[T]) {
   @PublicEvolving
   def reduceGroupWith[R: TypeInformation: ClassTag](fun: Stream[T] => R): DataSet[R] =
     ds.reduceGroup {
-      (it, out) =>
+      (it: Iterator[T], out: Collector[R]) =>
         out.collect(fun(it.toStream))
     }
 
@@ -80,7 +81,7 @@ class OnGroupedDataSet[T](ds: GroupedDataSet[T]) {
   @PublicEvolving
   def combineGroupWith[R: TypeInformation: ClassTag](fun: Stream[T] => R): DataSet[R] =
     ds.combineGroup {
-      (it, out) =>
+      (it: Iterator[T], out: Collector[R]) =>
         out.collect(fun(it.toStream))
     }
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/LambdaClosureCleaner.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/LambdaClosureCleaner.scala
@@ -1,0 +1,76 @@
+package org.apache.flink.api.scala.utils
+
+import java.lang.reflect.Method
+
+import org.apache.flink.api.scala.{ClosureCleaner, LambdaReturnStatementFinder}
+import org.slf4j.LoggerFactory
+
+ object LambdaClosureCleaner {
+
+  def getSparkClassLoader: ClassLoader = getClass.getClassLoader
+
+  def getContextOrSparkClassLoader: ClassLoader =
+    Option(Thread.currentThread().getContextClassLoader).getOrElse(getSparkClassLoader)
+
+  /** Preferred alternative to Class.forName(className) */
+  def classForName(className: String): Class[_] = {
+    Class.forName(className, true, getContextOrSparkClassLoader)
+    // scalastyle:on classforname
+  }
+
+  val LOG = LoggerFactory.getLogger(this.getClass)
+
+  def clean(closure: AnyRef): Unit = {
+    val writeReplaceMethod: Method = try {
+      closure.getClass.getDeclaredMethod("writeReplace")
+    } catch {
+      case e: java.lang.NoSuchMethodException =>
+        LOG.warn("Expected a Java lambda; got " + closure.getClass.getName)
+        return
+    }
+
+    writeReplaceMethod.setAccessible(true)
+    // Because we still need to support Java 7, we must use reflection here.
+    val serializedLambda: AnyRef = writeReplaceMethod.invoke(closure)
+    if (serializedLambda.getClass.getName != "java.lang.invoke.SerializedLambda") {
+      LOG.warn("Closure's writeReplace() method " +
+        s"returned ${serializedLambda.getClass.getName}, not SerializedLambda")
+      return
+    }
+
+    val serializedLambdaClass = classForName("java.lang.invoke.SerializedLambda")
+
+    val implClassName = serializedLambdaClass
+      .getDeclaredMethod("getImplClass").invoke(serializedLambda).asInstanceOf[String]
+    // TODO: we do not want to unconditionally strip this suffix.
+    val implMethodName = {
+      serializedLambdaClass
+        .getDeclaredMethod("getImplMethodName").invoke(serializedLambda).asInstanceOf[String]
+        .stripSuffix("$adapted")
+    }
+    val implMethodSignature = serializedLambdaClass
+      .getDeclaredMethod("getImplMethodSignature").invoke(serializedLambda).asInstanceOf[String]
+    val capturedArgCount = serializedLambdaClass
+      .getDeclaredMethod("getCapturedArgCount").invoke(serializedLambda).asInstanceOf[Int]
+    val capturedArgs = (0 until capturedArgCount).map { argNum: Int =>
+      serializedLambdaClass
+        .getDeclaredMethod("getCapturedArg", java.lang.Integer.TYPE)
+        .invoke(serializedLambda, argNum.asInstanceOf[Object])
+    }
+    assert(capturedArgs.size == capturedArgCount)
+    val implClass = classForName(implClassName.replaceAllLiterally("/", "."))
+
+    // Fail fast if we detect return statements in closures.
+    // TODO: match the impl method based on its type signature as well, not just its name.
+    ClosureCleaner
+      .getClassReader(implClass)
+      .accept(new LambdaReturnStatementFinder(implMethodName), 0)
+
+    // Check serializable TODO: add flag
+    ClosureCleaner.ensureSerializable(closure)
+    capturedArgs.foreach(ClosureCleaner.clean(_))
+
+    // TODO: null fields to render the closure serializable?
+  }
+}
+

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/LambdaClosureCleaner.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/LambdaClosureCleaner.scala
@@ -5,16 +5,16 @@ import java.lang.reflect.Method
 import org.apache.flink.api.scala.{ClosureCleaner, LambdaReturnStatementFinder}
 import org.slf4j.LoggerFactory
 
- object LambdaClosureCleaner {
+object LambdaClosureCleaner {
 
-  def getSparkClassLoader: ClassLoader = getClass.getClassLoader
+  def getFlinkClassLoader: ClassLoader = getClass.getClassLoader
 
-  def getContextOrSparkClassLoader: ClassLoader =
-    Option(Thread.currentThread().getContextClassLoader).getOrElse(getSparkClassLoader)
+  def getContextOrFlinkClassLoader: ClassLoader =
+    Option(Thread.currentThread().getContextClassLoader).getOrElse(getFlinkClassLoader)
 
   /** Preferred alternative to Class.forName(className) */
   def classForName(className: String): Class[_] = {
-    Class.forName(className, true, getContextOrSparkClassLoader)
+    Class.forName(className, true, getContextOrFlinkClassLoader)
     // scalastyle:on classforname
   }
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/LambdaClosureCleaner.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/LambdaClosureCleaner.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.flink.api.scala.utils
 
 import java.lang.reflect.Method

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/package.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/package.scala
@@ -31,7 +31,7 @@ import org.apache.flink.api.java.operators.PartitionOperator
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.{DataSetUtils => jutils}
 import org.apache.flink.util.AbstractID
-
+import org.apache.flink.api.java.tuple.Tuple2
 import _root_.scala.language.implicitConversions
 import _root_.scala.reflect.ClassTag
 
@@ -72,7 +72,8 @@ package object utils {
         BasicTypeInfo.LONG_TYPE_INFO.asInstanceOf[TypeInformation[Long]],
         implicitly[TypeInformation[T]]
       )
-      wrap(jutils.zipWithIndex(self.javaSet)).map { t => (t.f0.toLong, t.f1) }
+      wrap(jutils.zipWithIndex(self.javaSet))
+        .map { t: Tuple2[java.lang.Long, T] => (t.f0.toLong, t.f1) }
     }
 
     /**
@@ -85,7 +86,8 @@ package object utils {
         BasicTypeInfo.LONG_TYPE_INFO.asInstanceOf[TypeInformation[Long]],
         implicitly[TypeInformation[T]]
       )
-      wrap(jutils.zipWithUniqueId(self.javaSet)).map { t => (t.f0.toLong, t.f1) }
+      wrap(jutils.zipWithUniqueId(self.javaSet))
+        .map { t: Tuple2[java.lang.Long, T] => (t.f0.toLong, t.f1) }
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -118,7 +118,40 @@ under the License.
 
 	<build>
 		<plugins>
+			
+			<!-- Scala Compiler -->
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<executions>
+					<!-- Run scala compiler in the process-resources phase, so that dependencies on
+                        scala classes can be resolved later in the (Java) compile phase -->
+					<execution>
+						<id>scala-compile-first</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
 
+					<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+                         scala classes can be resolved later in the (Java) test-compile phase -->
+					<execution>
+						<id>scala-test-compile</id>
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<jvmArgs>
+						<jvmArg>-Xms128m</jvmArg>
+						<jvmArg>-Xmx512m</jvmArg>
+					</jvmArgs>
+				</configuration>
+			</plugin>
+			
 			<!-- Eclipse Integration -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -235,7 +268,7 @@ under the License.
 			<id>scala-2.10</id>
 			<activation>
 				<property>
-					<name>!scala-2.12</name>
+					<name>scala-2.10</name>
 				</property>
 			</activation>
 			<dependencies>
@@ -245,93 +278,21 @@ under the License.
 					<version>${scala.macros.version}</version>
 				</dependency>
 			</dependencies>
-
-			<build>
-				<plugins>
-					<!-- Scala Compiler -->
-					<plugin>
-						<groupId>net.alchim31.maven</groupId>
-						<artifactId>scala-maven-plugin</artifactId>
-						<executions>
-							<!-- Run scala compiler in the process-resources phase, so that dependencies on
-                                scala classes can be resolved later in the (Java) compile phase -->
-							<execution>
-								<id>scala-compile-first</id>
-								<phase>process-resources</phase>
-								<goals>
-									<goal>compile</goal>
-								</goals>
-							</execution>
-
-							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
-                                 scala classes can be resolved later in the (Java) test-compile phase -->
-							<execution>
-								<id>scala-test-compile</id>
-								<phase>process-test-resources</phase>
-								<goals>
-									<goal>testCompile</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<jvmArgs>
-								<jvmArg>-Xms128m</jvmArg>
-								<jvmArg>-Xmx512m</jvmArg>
-							</jvmArgs>
-							<compilerPlugins combine.children="append">
-								<compilerPlugin>
-									<groupId>org.scalamacros</groupId>
-									<artifactId>paradise_${scala.version}</artifactId>
-									<version>${scala.macros.version}</version>
-								</compilerPlugin>
-							</compilerPlugins>
-						</configuration>
-					</plugin>
-
-				</plugins>
-			</build>
-
 		</profile>
 		<profile>
-			<id>scala-2.11</id>
+			<id>scala</id>
 			<activation>
 				<property>
 					<name>!scala-2.12</name>
 				</property>
 			</activation>
-
 			<build>
 				<plugins>
 					<!-- Scala Compiler -->
 					<plugin>
 						<groupId>net.alchim31.maven</groupId>
 						<artifactId>scala-maven-plugin</artifactId>
-						<executions>
-							<!-- Run scala compiler in the process-resources phase, so that dependencies on
-                                scala classes can be resolved later in the (Java) compile phase -->
-							<execution>
-								<id>scala-compile-first</id>
-								<phase>process-resources</phase>
-								<goals>
-									<goal>compile</goal>
-								</goals>
-							</execution>
-
-							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
-                                 scala classes can be resolved later in the (Java) test-compile phase -->
-							<execution>
-								<id>scala-test-compile</id>
-								<phase>process-test-resources</phase>
-								<goals>
-									<goal>testCompile</goal>
-								</goals>
-							</execution>
-						</executions>
 						<configuration>
-							<jvmArgs>
-								<jvmArg>-Xms128m</jvmArg>
-								<jvmArg>-Xmx512m</jvmArg>
-							</jvmArgs>
 							<compilerPlugins combine.children="append">
 								<compilerPlugin>
 									<groupId>org.scalamacros</groupId>
@@ -339,53 +300,6 @@ under the License.
 									<version>${scala.macros.version}</version>
 								</compilerPlugin>
 							</compilerPlugins>
-						</configuration>
-					</plugin>
-
-				</plugins>
-			</build>
-
-		</profile>
-		<profile>
-			<id>scala-2.12</id>
-			<activation>
-				<property>
-					<name>!scala-2.10</name>
-				</property>
-			</activation>
-
-			<build>
-				<plugins>
-					<!-- Scala Compiler -->
-					<plugin>
-						<groupId>net.alchim31.maven</groupId>
-						<artifactId>scala-maven-plugin</artifactId>
-						<executions>
-							<!-- Run scala compiler in the process-resources phase, so that dependencies on
-                                scala classes can be resolved later in the (Java) compile phase -->
-							<execution>
-								<id>scala-compile-first</id>
-								<phase>process-resources</phase>
-								<goals>
-									<goal>compile</goal>
-								</goals>
-							</execution>
-
-							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
-                                 scala classes can be resolved later in the (Java) test-compile phase -->
-							<execution>
-								<id>scala-test-compile</id>
-								<phase>process-test-resources</phase>
-								<goals>
-									<goal>testCompile</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<jvmArgs>
-								<jvmArg>-Xms128m</jvmArg>
-								<jvmArg>-Xmx512m</jvmArg>
-							</jvmArgs>
 						</configuration>
 					</plugin>
 
@@ -394,5 +308,4 @@ under the License.
 
 		</profile>
 	</profiles>
-	
 </project>

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -118,45 +118,6 @@ under the License.
 
 	<build>
 		<plugins>
-			<!-- Scala Compiler -->
-			<plugin>
-				<groupId>net.alchim31.maven</groupId>
-				<artifactId>scala-maven-plugin</artifactId>
-				<executions>
-					<!-- Run scala compiler in the process-resources phase, so that dependencies on
-						scala classes can be resolved later in the (Java) compile phase -->
-					<execution>
-						<id>scala-compile-first</id>
-						<phase>process-resources</phase>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
- 
-					<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
-						 scala classes can be resolved later in the (Java) test-compile phase -->
-					<execution>
-						<id>scala-test-compile</id>
-						<phase>process-test-resources</phase>
-						<goals>
-							<goal>testCompile</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<jvmArgs>
-						<jvmArg>-Xms128m</jvmArg>
-						<jvmArg>-Xmx512m</jvmArg>
-					</jvmArgs>
-					<compilerPlugins combine.children="append">
-					   <compilerPlugin>
-						   <groupId>org.scalamacros</groupId>
-						   <artifactId>paradise_${scala.version}</artifactId>
-						   <version>${scala.macros.version}</version>
-					   </compilerPlugin>
-				   </compilerPlugins>
-				</configuration>
-			</plugin>
 
 			<!-- Eclipse Integration -->
 			<plugin>
@@ -268,4 +229,170 @@ under the License.
 		</plugins>
 	</build>
 
+
+	<profiles>
+		<profile>
+			<id>scala-2.10</id>
+			<activation>
+				<property>
+					<name>!scala-2.12</name>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>org.scalamacros</groupId>
+					<artifactId>quasiquotes_${scala.binary.version}</artifactId>
+					<version>${scala.macros.version}</version>
+				</dependency>
+			</dependencies>
+
+			<build>
+				<plugins>
+					<!-- Scala Compiler -->
+					<plugin>
+						<groupId>net.alchim31.maven</groupId>
+						<artifactId>scala-maven-plugin</artifactId>
+						<executions>
+							<!-- Run scala compiler in the process-resources phase, so that dependencies on
+                                scala classes can be resolved later in the (Java) compile phase -->
+							<execution>
+								<id>scala-compile-first</id>
+								<phase>process-resources</phase>
+								<goals>
+									<goal>compile</goal>
+								</goals>
+							</execution>
+
+							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+                                 scala classes can be resolved later in the (Java) test-compile phase -->
+							<execution>
+								<id>scala-test-compile</id>
+								<phase>process-test-resources</phase>
+								<goals>
+									<goal>testCompile</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<jvmArgs>
+								<jvmArg>-Xms128m</jvmArg>
+								<jvmArg>-Xmx512m</jvmArg>
+							</jvmArgs>
+							<compilerPlugins combine.children="append">
+								<compilerPlugin>
+									<groupId>org.scalamacros</groupId>
+									<artifactId>paradise_${scala.version}</artifactId>
+									<version>${scala.macros.version}</version>
+								</compilerPlugin>
+							</compilerPlugins>
+						</configuration>
+					</plugin>
+
+				</plugins>
+			</build>
+
+		</profile>
+		<profile>
+			<id>scala-2.11</id>
+			<activation>
+				<property>
+					<name>!scala-2.12</name>
+				</property>
+			</activation>
+
+			<build>
+				<plugins>
+					<!-- Scala Compiler -->
+					<plugin>
+						<groupId>net.alchim31.maven</groupId>
+						<artifactId>scala-maven-plugin</artifactId>
+						<executions>
+							<!-- Run scala compiler in the process-resources phase, so that dependencies on
+                                scala classes can be resolved later in the (Java) compile phase -->
+							<execution>
+								<id>scala-compile-first</id>
+								<phase>process-resources</phase>
+								<goals>
+									<goal>compile</goal>
+								</goals>
+							</execution>
+
+							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+                                 scala classes can be resolved later in the (Java) test-compile phase -->
+							<execution>
+								<id>scala-test-compile</id>
+								<phase>process-test-resources</phase>
+								<goals>
+									<goal>testCompile</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<jvmArgs>
+								<jvmArg>-Xms128m</jvmArg>
+								<jvmArg>-Xmx512m</jvmArg>
+							</jvmArgs>
+							<compilerPlugins combine.children="append">
+								<compilerPlugin>
+									<groupId>org.scalamacros</groupId>
+									<artifactId>paradise_${scala.version}</artifactId>
+									<version>${scala.macros.version}</version>
+								</compilerPlugin>
+							</compilerPlugins>
+						</configuration>
+					</plugin>
+
+				</plugins>
+			</build>
+
+		</profile>
+		<profile>
+			<id>scala-2.12</id>
+			<activation>
+				<property>
+					<name>!scala-2.10</name>
+				</property>
+			</activation>
+
+			<build>
+				<plugins>
+					<!-- Scala Compiler -->
+					<plugin>
+						<groupId>net.alchim31.maven</groupId>
+						<artifactId>scala-maven-plugin</artifactId>
+						<executions>
+							<!-- Run scala compiler in the process-resources phase, so that dependencies on
+                                scala classes can be resolved later in the (Java) compile phase -->
+							<execution>
+								<id>scala-compile-first</id>
+								<phase>process-resources</phase>
+								<goals>
+									<goal>compile</goal>
+								</goals>
+							</execution>
+
+							<!-- Run scala compiler in the process-test-resources phase, so that dependencies on
+                                 scala classes can be resolved later in the (Java) test-compile phase -->
+							<execution>
+								<id>scala-test-compile</id>
+								<phase>process-test-resources</phase>
+								<goals>
+									<goal>testCompile</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<jvmArgs>
+								<jvmArg>-Xms128m</jvmArg>
+								<jvmArg>-Xmx512m</jvmArg>
+							</jvmArgs>
+						</configuration>
+					</plugin>
+
+				</plugins>
+			</build>
+
+		</profile>
+	</profiles>
+	
 </project>

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/AllWindowTranslationTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/AllWindowTranslationTest.scala
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.functions.KeySelector
 import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
-import org.apache.flink.streaming.api.scala.function.{AllWindowFunction, ProcessAllWindowFunction, WindowFunction}
+import org.apache.flink.streaming.api.scala.function.{AllWindowFunction, ProcessAllWindowFunction}
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
 import org.apache.flink.streaming.api.windowing.assigners._
 import org.apache.flink.streaming.api.windowing.evictors.CountEvictor
@@ -484,7 +484,8 @@ class AllWindowTranslationTest {
       .windowAll(TumblingEventTimeWindows.of(Time.seconds(1)))
       .reduce(
         { (x, _) => x },
-        { (_, in, out: Collector[(String, Int)]) => in foreach { x => out.collect(x)} })
+        { (_: TimeWindow, in: Iterable[(String, Int)], out: Collector[(String, Int)]) =>
+          in foreach { x => out.collect(x)} })
 
     val transform = window1
       .javaStream
@@ -721,7 +722,7 @@ class AllWindowTranslationTest {
       .windowAll(TumblingEventTimeWindows.of(Time.seconds(1)))
       .aggregate(
         new DummyAggregator(),
-        { (_, in: Iterable[(String, Int)], out: Collector[(String, Int)]) => {
+        { (_: TimeWindow, in: Iterable[(String, Int)], out: Collector[(String, Int)]) => {
           in foreach { x => out.collect(x)}
         } })
 
@@ -1069,7 +1070,7 @@ class AllWindowTranslationTest {
       .fold(
         ("", "", 1),
         { (acc: (String, String, Int), _) => acc },
-        { (_, in: Iterable[(String, String, Int)], out: Collector[(String, Int)]) =>
+        { (_: TimeWindow, in: Iterable[(String, String, Int)], out: Collector[(String, Int)]) =>
           in foreach { x => out.collect((x._1, x._3)) }
         })
 

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
@@ -54,7 +54,7 @@ class DataStreamTest extends StreamingMultipleProgramsTestBase {
 
     val dataStream2 = env.generateSequence(0, 0).name("testSource2")
       .keyBy(x=>x)
-      .reduce((x, y) => 0)
+      .reduce((x, y) => 0L)
       .name("testReduce")
     assert("testReduce" == dataStream2.getName)
 

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/WindowTranslationTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/WindowTranslationTest.scala
@@ -547,7 +547,8 @@ class WindowTranslationTest {
       .window(TumblingEventTimeWindows.of(Time.seconds(1)))
       .reduce(
         { (x, _) => x },
-        { (_, _, in, out: Collector[(String, Int)]) => in foreach { x => out.collect(x)} })
+        { (_: String, _: TimeWindow, in: Iterable[(String, Int)], out: Collector[(String, Int)])
+          => in foreach { x => out.collect(x)} })
 
     val transform = window1
       .javaStream
@@ -790,7 +791,8 @@ class WindowTranslationTest {
       .keyBy(_._1)
       .window(TumblingEventTimeWindows.of(Time.seconds(1)))
       .aggregate(new DummyAggregator(),
-        { (_, _, in: Iterable[(String, Int)], out: Collector[(String, Int)]) => {
+        { (_: String, _: TimeWindow, in: Iterable[(String, Int)], out: Collector[(String, Int)]) =>
+        {
           in foreach { x => out.collect(x)}
         } })
 
@@ -1197,7 +1199,8 @@ class WindowTranslationTest {
       .fold(
         ("", "", 1),
         { (acc: (String, String, Int), _) => acc },
-        { (_, _, in: Iterable[(String, String, Int)], out: Collector[(String, Int)]) =>
+        { (_: String, _: TimeWindow, in: Iterable[(String, String, Int)],
+           out: Collector[(String, Int)]) =>
           in foreach { x => out.collect((x._1, x._3)) }
         })
 

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -610,7 +610,7 @@ under the License.
 			<activation>
 				<property>
 					<!-- this is the default scala profile -->
-					<name>!scala-2.11</name>
+					<name>scala-2.12</name>
 				</property>
 			</activation>
 			<dependencies>
@@ -624,6 +624,12 @@ under the License.
 		
 		<profile>
 			<id>scala</id>
+			<activation>
+				<property>
+					<!-- this is the default scala profile -->
+					<name>!scala-2.12</name>
+				</property>
+			</activation>
 			<dependencies>
 				<dependency>
 					<groupId>com.data-artisans</groupId>

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -621,6 +621,7 @@ under the License.
 				</dependency>
 			</dependencies>
 		</profile>
+		
 		<profile>
 			<id>scala</id>
 			<dependencies>

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -166,11 +166,6 @@ under the License.
 			<artifactId>scalatest_${scala.binary.version}</artifactId>
 			<scope>test</scope>
 		</dependency>
-
-		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-testkit_${scala.binary.version}</artifactId>
-		</dependency>
 		
 		<dependency>
 			<groupId>joda-time</groupId>
@@ -608,4 +603,32 @@ under the License.
 			</plugins>
 		</pluginManagement>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>scala-2.12</id>
+			<activation>
+				<property>
+					<!-- this is the default scala profile -->
+					<name>!scala-2.11</name>
+				</property>
+			</activation>
+			<dependencies>
+
+				<dependency>
+					<groupId>com.typesafe.akka</groupId>
+					<artifactId>akka-testkit_2.12</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>scala</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.data-artisans</groupId>
+					<artifactId>flakka-testkit_${scala.binary.version}</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 </project>

--- a/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/GroupCombineITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/GroupCombineITCase.java
@@ -51,7 +51,7 @@ import java.util.List;
  */
 public class GroupCombineITCase extends MultipleProgramsTestBase {
 
-	public GroupCombineITCase(TestExecutionMode mode) {
+	public GroupCombineITCase(MultipleProgramsTestBase.TestExecutionMode mode) {
 		super(mode);
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
@@ -25,8 +25,8 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
@@ -34,13 +34,13 @@ import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 import scala.concurrent.ExecutionContext$;
-import scala.concurrent.forkjoin.ForkJoinPool;
 import scala.concurrent.impl.ExecutionContextImpl;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
 
 import static org.junit.Assert.fail;
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/hadoop/mapred/WordCountMapredITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/hadoop/mapred/WordCountMapredITCase.scala
@@ -65,7 +65,7 @@ class WordCountMapredITCase extends JavaProgramTestBase {
       .sum(1)
 
     val words = counts
-      .map( t => (new Text(t._1), new LongWritable(t._2)) )
+      .map( (t: (String, Int)) => (new Text(t._1), new LongWritable(t._2)) )
 
     val hadoopOutputFormat = new HadoopOutputFormat[Text, LongWritable](
       new TextOutputFormat[Text, LongWritable],

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/hadoop/mapreduce/WordCountMapreduceITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/hadoop/mapreduce/WordCountMapreduceITCase.scala
@@ -75,7 +75,7 @@ class WordCountMapreduceITCase extends JavaProgramTestBase {
       .sum(1)
 
     val words = counts
-      .map( t => (new Text(t._1), new LongWritable(t._2)) )
+      .map( (t: (String, Int)) => (new Text(t._1), new LongWritable(t._2)) )
 
     val job = Job.getInstance()
     val hadoopOutputFormat = new HadoopOutputFormat[Text, LongWritable](

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/AggregateITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/AggregateITCase.scala
@@ -61,7 +61,7 @@ class AggregateITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(
       .aggregate(Aggregations.SUM,0)
       .and(Aggregations.MAX, 1)
       // Ensure aggregate operator correctly copies other fields
-      .filter(_._3 != null)
+      .filter((in: (Int, Long, String)) => in._3 != null)
       .map{ t => (t._1, t._2) }
 
     aggregateDs.writeAsCsv(resultPath, writeMode = WriteMode.OVERWRITE)
@@ -81,7 +81,7 @@ class AggregateITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(
       .groupBy(1)
       .aggregate(Aggregations.SUM, 0)
       // Ensure aggregate operator correctly copies other fields
-      .filter(_._3 != null)
+      .filter((in: (Int, Long, String)) => in._3 != null)
       .map { t => (t._2, t._1) }
 
     aggregateDs.writeAsCsv(resultPath, writeMode = WriteMode.OVERWRITE)
@@ -102,7 +102,7 @@ class AggregateITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(
       .aggregate(Aggregations.MIN, 0)
       .aggregate(Aggregations.MIN, 0)
       // Ensure aggregate operator correctly copies other fields
-      .filter(_._3 != null)
+      .filter((in: (Int, Long, String)) => in._3 != null)
       .map { t => new Tuple1(t._1) }
 
     aggregateDs.writeAsCsv(resultPath, writeMode = WriteMode.OVERWRITE)

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/CoGroupITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/CoGroupITCase.scala
@@ -108,7 +108,8 @@ class CoGroupITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mo
     val ds = CollectionDataSets.get3TupleDataSet(env)
     val ds2 = CollectionDataSets.get3TupleDataSet(env)
     val coGroupDs = ds.coGroup(ds2).where(0).equalTo(0) {
-      (first, second, out: Collector[(Int, Long, String)] ) =>
+      (first: Iterator[(Int, Long, String)], second: Iterator[(Int, Long, String)],
+       out: Collector[(Int, Long, String)] ) =>
         for (t <- first) {
           if (t._1 < 6) {
             out.collect(t)
@@ -127,7 +128,9 @@ class CoGroupITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mo
     val ds = CollectionDataSets.get5TupleDataSet(env)
     val ds2 = CollectionDataSets.get5TupleDataSet(env)
     val coGroupDs = ds.coGroup(ds2).where(0).equalTo(0) {
-      (first, second, out: Collector[(Int, Long, Int, String, Long)]) =>
+      (first: Iterator[(Int, Long, Int, String, Long)],
+       second: Iterator[(Int, Long, Int, String, Long)],
+       out: Collector[(Int, Long, Int, String, Long)]) =>
         for (t <- second) {
           if (t._1 < 4) {
             out.collect(t)
@@ -247,7 +250,8 @@ class CoGroupITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mo
     val ds1 = CollectionDataSets.get5TupleDataSet(env)
     val ds2 = CollectionDataSets.get3TupleDataSet(env)
     val coGrouped = ds1.coGroup(ds2).where(0,4).equalTo(0, 1) {
-      (first, second, out: Collector[(Int, Long, String)]) =>
+      (first: Iterator[(Int, Long, Int, String, Long)],
+       second: Iterator[(Int, Long, String)], out: Collector[(Int, Long, String)]) =>
         val strs = first map(_._4)
         for (t <- second) {
           for (s <- strs) {
@@ -273,7 +277,8 @@ class CoGroupITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mo
     val ds2 = CollectionDataSets.get3TupleDataSet(env)
     val coGrouped = ds1.coGroup(ds2).where(t => (t._1, t._5)).equalTo(t => (t._1, t._2))
       .apply {
-      (first, second, out: Collector[(Int, Long, String)]) =>
+      (first: Iterator[(Int, Long, Int, String, Long)],
+       second: Iterator[(Int, Long, String)], out: Collector[(Int, Long, String)]) =>
         val strs = first map(_._4)
         for (t <- second) {
           for (s <- strs) {
@@ -325,7 +330,9 @@ class CoGroupITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mo
     val ds = CollectionDataSets.getSmallPojoDataSet(env)
     val ds2 = CollectionDataSets.getSmallTuplebasedPojoMatchingDataSet(env)
     val coGroupDs = ds.coGroup(ds2).where("nestedPojo.longNumber").equalTo(6) {
-      (first, second, out: Collector[CustomType]) =>
+      (first: Iterator[CollectionDataSets.POJO],
+       second: Iterator[(Int, String, Int, Int, Long, String, Long)],
+       out: Collector[CustomType]) =>
         for (p <- first) {
           for (t <- second) {
             Assert.assertTrue(p.nestedPojo.longNumber == t._7)
@@ -348,7 +355,9 @@ class CoGroupITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mo
     val ds = CollectionDataSets.getSmallPojoDataSet(env)
     val ds2 = CollectionDataSets.getSmallTuplebasedPojoMatchingDataSet(env)
     val coGroupDs = ds.coGroup(ds2).where(t => new Tuple1(t.nestedPojo.longNumber)).equalTo(6) {
-      (first, second, out: Collector[CustomType]) =>
+      (first: Iterator[CollectionDataSets.POJO],
+       second: Iterator[(Int, String, Int, Int, Long, String, Long)],
+       out: Collector[CustomType]) =>
         for (p <- first) {
           for (t <- second) {
             Assert.assertTrue(p.nestedPojo.longNumber == t._7)
@@ -371,7 +380,9 @@ class CoGroupITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mo
     val ds = CollectionDataSets.getSmallPojoDataSet(env)
     val ds2 = CollectionDataSets.getSmallTuplebasedPojoMatchingDataSet(env)
     val coGroupDs = ds.coGroup(ds2).where(_.nestedPojo.longNumber).equalTo(6) {
-      (first, second, out: Collector[CustomType]) =>
+      (first: Iterator[CollectionDataSets.POJO],
+       second: Iterator[(Int, String, Int, Int, Long, String, Long)],
+       out: Collector[CustomType]) =>
         for (p <- first) {
           for (t <- second) {
             Assert.assertTrue(p.nestedPojo.longNumber == t._7)
@@ -390,7 +401,8 @@ class CoGroupITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mo
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env)
     val ds2 = env.fromElements(0, 1, 2)
     val coGroupDs = ds1.coGroup(ds2).where(0).equalTo("*") {
-      (first, second, out: Collector[(Int, Long, String)]) =>
+      (first: Iterator[(Int, Long, String)], second: Iterator[Int],
+       out: Collector[(Int, Long, String)]) =>
         for (p <- first) {
           for (t <- second) {
             if (p._1 == t) {
@@ -411,7 +423,8 @@ class CoGroupITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(mo
     val ds1 = env.fromElements(0, 1, 2)
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env)
     val coGroupDs = ds1.coGroup(ds2).where("*").equalTo(0) {
-      (first, second, out: Collector[(Int, Long, String)]) =>
+      (first: Iterator[Int], second: Iterator[(Int, Long, String)],
+       out: Collector[(Int, Long, String)]) =>
         for (p <- first) {
           for (t <- second) {
             if (p == t._1) {

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/GroupCombineITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/GroupCombineITCase.scala
@@ -47,7 +47,7 @@ class GroupCombineITCase(mode: TestExecutionMode) extends MultipleProgramsTestBa
       .output(new DiscardingOutputFormat[Tuple1[String]])
 
     ds.combineGroup((in: Iterator[Tuple1[String]], out: Collector[Tuple1[String]]) =>
-      in.toSet foreach (out.collect(_)))
+      in.toSet foreach ((t: Tuple1[String]) => out.collect(t)))
       .output(new DiscardingOutputFormat[Tuple1[String]])
 
     // all methods on UnsortedGrouping
@@ -57,7 +57,7 @@ class GroupCombineITCase(mode: TestExecutionMode) extends MultipleProgramsTestBa
 
     ds.groupBy(0)
       .combineGroup((in: Iterator[Tuple1[String]], out: Collector[Tuple1[String]]) =>
-        in.toSet foreach (out.collect(_)))
+        in.toSet foreach ((t: Tuple1[String]) => out.collect(t)))
       .output(new DiscardingOutputFormat[Tuple1[String]])
 
     // all methods on SortedGrouping
@@ -67,7 +67,7 @@ class GroupCombineITCase(mode: TestExecutionMode) extends MultipleProgramsTestBa
 
     ds.groupBy(0).sortGroup(0, Order.ASCENDING)
       .combineGroup((in: Iterator[Tuple1[String]], out: Collector[Tuple1[String]]) =>
-        in.toSet foreach (out.collect(_)))
+        in.toSet foreach ((t: Tuple1[String]) => out.collect(t)))
       .output(new DiscardingOutputFormat[Tuple1[String]])
 
     env.execute()

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/GroupCombineITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/GroupCombineITCase.scala
@@ -46,7 +46,8 @@ class GroupCombineITCase(mode: TestExecutionMode) extends MultipleProgramsTestBa
     ds.combineGroup(new ScalaGroupCombineFunctionExample())
       .output(new DiscardingOutputFormat[Tuple1[String]])
 
-    ds.combineGroup((in, out: Collector[Tuple1[String]]) => in.toSet foreach (out.collect))
+    ds.combineGroup((in: Iterator[Tuple1[String]], out: Collector[Tuple1[String]]) =>
+      in.toSet foreach (out.collect(_)))
       .output(new DiscardingOutputFormat[Tuple1[String]])
 
     // all methods on UnsortedGrouping
@@ -55,7 +56,8 @@ class GroupCombineITCase(mode: TestExecutionMode) extends MultipleProgramsTestBa
       .output(new DiscardingOutputFormat[Tuple1[String]])
 
     ds.groupBy(0)
-      .combineGroup((in, out: Collector[Tuple1[String]]) => in.toSet foreach (out.collect))
+      .combineGroup((in: Iterator[Tuple1[String]], out: Collector[Tuple1[String]]) =>
+        in.toSet foreach (out.collect(_)))
       .output(new DiscardingOutputFormat[Tuple1[String]])
 
     // all methods on SortedGrouping
@@ -64,7 +66,8 @@ class GroupCombineITCase(mode: TestExecutionMode) extends MultipleProgramsTestBa
       .output(new DiscardingOutputFormat[Tuple1[String]])
 
     ds.groupBy(0).sortGroup(0, Order.ASCENDING)
-      .combineGroup((in, out: Collector[Tuple1[String]]) => in.toSet foreach (out.collect))
+      .combineGroup((in: Iterator[Tuple1[String]], out: Collector[Tuple1[String]]) =>
+        in.toSet foreach (out.collect(_)))
       .output(new DiscardingOutputFormat[Tuple1[String]])
 
     env.execute()

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/SumMinMaxITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/SumMinMaxITCase.scala
@@ -43,7 +43,7 @@ class SumMinMaxITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(
       .sum(0)
       .andMax(1)
       // Ensure aggregate operator correctly copies other fields
-      .filter(_._3 != null)
+      .filter((tup: (Int, Long, String)) => tup._3 != null)
       .map{ t => (t._1, t._2) }
 
 
@@ -63,7 +63,7 @@ class SumMinMaxITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(
       .groupBy(1)
       .sum(0)
       // Ensure aggregate operator correctly copies other fields
-      .filter(_._3 != null)
+      .filter((tup: (Int, Long, String)) => tup._3 != null)
       .map { t => (t._2, t._1) }
 
     val result : Seq[(Long, Int)] = aggregateDs.collect().sortWith((a, b) => a._1 < b._1)
@@ -83,7 +83,7 @@ class SumMinMaxITCase(mode: TestExecutionMode) extends MultipleProgramsTestBase(
       .min(0)
       .min(0)
       // Ensure aggregate operator correctly copies other fields
-      .filter(_._3 != null)
+      .filter((tup: (Int, Long, String)) => tup._3 != null)
       .map { t => t._1 }
 
     val result: Seq[Int] = aggregateDs.collect()

--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -229,7 +229,7 @@ under the License.
 			<activation>
 				<property>
 					<!-- this is the default scala profile -->
-					<name>!scala-2.11</name>
+					<name>scala-2.12</name>
 				</property>
 			</activation>
 			<dependencies>
@@ -253,6 +253,12 @@ under the License.
 		</profile>
 		<profile>
 			<id>scala</id>
+			<activation>
+				<property>
+					<!-- this is the default scala profile -->
+					<name>!scala-2.12</name>
+				</property>
+			</activation>
 			<dependencies>
 				<dependency>
 					<groupId>com.data-artisans</groupId>

--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -68,31 +68,11 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-actor_${scala.binary.version}</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-remote_${scala.binary.version}</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-camel_${scala.binary.version}</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>${guava.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-testkit_${scala.binary.version}</artifactId>
-			<scope>test</scope>
-		</dependency>
 
 		<!-- test dependencies -->
 
@@ -242,4 +222,58 @@ under the License.
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>scala-2.12</id>
+			<activation>
+				<property>
+					<!-- this is the default scala profile -->
+					<name>!scala-2.11</name>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>com.typesafe.akka</groupId>
+					<artifactId>akka-actor_2.12</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>com.typesafe.akka</groupId>
+					<artifactId>akka-camel_2.12</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>com.typesafe.akka</groupId>
+					<artifactId>akka-remote_2.12</artifactId>
+				</dependency>
+				<dependency>
+					<groupId>com.typesafe.akka</groupId>
+					<artifactId>akka-testkit_2.12</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>scala</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.data-artisans</groupId>
+					<artifactId>flakka-actor_${scala.binary.version}</artifactId>
+				</dependency>
+
+				<dependency>
+					<groupId>com.data-artisans</groupId>
+					<artifactId>flakka-remote_${scala.binary.version}</artifactId>
+				</dependency>
+
+				<dependency>
+					<groupId>com.data-artisans</groupId>
+					<artifactId>flakka-camel_${scala.binary.version}</artifactId>
+				</dependency>
+
+				<dependency>
+					<groupId>com.data-artisans</groupId>
+					<artifactId>flakka-testkit_${scala.binary.version}</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -395,6 +395,28 @@ under the License.
 			</dependency>
 
 			<dependency>
+				<groupId>com.typesafe.akka</groupId>
+				<artifactId>akka-actor_2.12</artifactId>
+				<version>${akka.typesafe.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.typesafe.akka</groupId>
+				<artifactId>akka-slf4j_2.12</artifactId>
+				<version>${akka.typesafe.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.typesafe.akka</groupId>
+				<artifactId>akka-remote_2.12</artifactId>
+				<version>${akka.typesafe.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.typesafe.akka</groupId>
+				<artifactId>akka-testkit_2.12</artifactId>
+				<version>${akka.typesafe.version}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
 				<groupId>org.scalatest</groupId>
 				<artifactId>scalatest_${scala.binary.version}</artifactId>
 				<version>${scalatest.version}</version>
@@ -481,12 +503,13 @@ under the License.
 			<id>scala-2.12</id>
 			<activation>
 				<property>
-					<name>!scala-2.12</name>
+					<name>scala-2.12</name>
 				</property>
 			</activation>
 			<properties>
 				<scala.version>2.12.1</scala.version>
 				<scala.binary.version>2.12</scala.binary.version>
+				<akka.typesafe.version>2.4.16</akka.typesafe.version>
 				<chill.version>0.9.0</chill.version>
 				<scalatest.version>3.0.1</scalatest.version>
 				<scopt.version>3.5.0</scopt.version>
@@ -1338,7 +1361,7 @@ under the License.
 							<!-- Don't break build on newly added maven modules -->
 							<ignoreNonResolvableArtifacts>true</ignoreNonResolvableArtifacts>
 						</parameter>
-						<skip>false</skip>
+						<skip>true</skip>
 						<dependencies>
 							<dependency>
 								<groupId>org.apache.flink</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@ under the License.
 		<scopt.version>3.5.0</scopt.version>
 		<grizzled.version>1.0.2</grizzled.version>
 		<chill.version>0.7.7</chill.version>
-		<asm.version>5.0.4</asm.version>
+		<asm.version>5.2</asm.version>
 		<zookeeper.version>3.4.6</zookeeper.version>
 		<curator.version>2.8.0</curator.version>
 		<jackson.version>2.7.4</jackson.version>
@@ -514,6 +514,7 @@ under the License.
 				</property>
 			</activation>
 			<properties>
+				<java.version>1.8</java.version>
 				<scala.version>2.12.1</scala.version>
 				<scala.binary.version>2.12</scala.binary.version>
 				<grizzled.version>1.3.0</grizzled.version>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@ under the License.
 		<log4j.configuration>log4j-test.properties</log4j.configuration>
 		<guava.version>18.0</guava.version>
 		<akka.version>2.3-custom</akka.version>
+		<akka.typesafe.version>2.4.16</akka.typesafe.version>
 		<java.version>1.7</java.version>
 		<scala.macros.version>2.0.1</scala.macros.version>
 		<!-- Default scala versions, may be overwritten by build profiles -->
@@ -515,7 +516,6 @@ under the License.
 			<properties>
 				<scala.version>2.12.1</scala.version>
 				<scala.binary.version>2.12</scala.binary.version>
-				<akka.typesafe.version>2.4.16</akka.typesafe.version>
 				<grizzled.version>1.3.0</grizzled.version>
 			</properties>
 		</profile>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ under the License.
 		<scalatest.version>3.0.1</scalatest.version>
 		<scopt.version>3.5.0</scopt.version>
 		<grizzled.version>1.0.2</grizzled.version>
-		<chill.version>0.8.1</chill.version>
+		<chill.version>0.8.3</chill.version>
 		<asm.version>5.0.4</asm.version>
 		<zookeeper.version>3.4.6</zookeeper.version>
 		<curator.version>2.8.0</curator.version>
@@ -516,7 +516,6 @@ under the License.
 				<scala.version>2.12.1</scala.version>
 				<scala.binary.version>2.12</scala.binary.version>
 				<akka.typesafe.version>2.4.16</akka.typesafe.version>
-				<chill.version>0.9.0</chill.version>
 				<grizzled.version>1.3.0</grizzled.version>
 			</properties>
 		</profile>

--- a/pom.xml
+++ b/pom.xml
@@ -473,6 +473,20 @@ under the License.
 			</properties>
 		</profile>
 
+		<!-- Profile to switch to Scala Version 2.12 -->
+		<profile>
+			<id>scala-2.12</id>
+			<activation>
+				<property>
+					<name>!scala-2.12</name>
+				</property>
+			</activation>
+			<properties>
+				<scala.version>2.12.1</scala.version>
+				<scala.binary.version>2.12</scala.binary.version>
+			</properties>
+		</profile>
+
 		<!-- Profile to deactivate the YARN tests -->
 		<profile>
 			<id>include-yarn-tests</id>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,10 @@ under the License.
 		<!-- Default scala versions, may be overwritten by build profiles -->
 		<scala.version>2.10.4</scala.version>
 		<scala.binary.version>2.10</scala.binary.version>
-		<chill.version>0.7.4</chill.version>
+		<scalatest.version>2.2.2</scalatest.version>
+		<scopt.version>3.5.0</scopt.version>
+		<grizzled.version>1.0.2</grizzled.version>
+		<chill.version>0.8.1</chill.version>
 		<asm.version>5.0.4</asm.version>
 		<zookeeper.version>3.4.6</zookeeper.version>
 		<curator.version>2.8.0</curator.version>
@@ -357,7 +360,7 @@ under the License.
 			<dependency>
 				<groupId>org.clapper</groupId>
 				<artifactId>grizzled-slf4j_${scala.binary.version}</artifactId>
-				<version>1.0.2</version>
+				<version>${grizzled.version}</version>
 			</dependency>
 
 			<dependency>
@@ -394,14 +397,14 @@ under the License.
 			<dependency>
 				<groupId>org.scalatest</groupId>
 				<artifactId>scalatest_${scala.binary.version}</artifactId>
-				<version>2.2.2</version>
+				<version>${scalatest.version}</version>
 				<scope>test</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>com.github.scopt</groupId>
 				<artifactId>scopt_${scala.binary.version}</artifactId>
-				<version>3.5.0</version>
+				<version>${scopt.version}</version>
 				<exclusions>
 					<exclusion>
 						<groupId>org.scala-lang</groupId>
@@ -484,6 +487,10 @@ under the License.
 			<properties>
 				<scala.version>2.12.1</scala.version>
 				<scala.binary.version>2.12</scala.binary.version>
+				<chill.version>0.9.0</chill.version>
+				<scalatest.version>3.0.1</scalatest.version>
+				<scopt.version>3.5.0</scopt.version>
+				<grizzled.version>1.3.0</grizzled.version>
 			</properties>
 		</profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ under the License.
 		<scalatest.version>3.0.1</scalatest.version>
 		<scopt.version>3.5.0</scopt.version>
 		<grizzled.version>1.0.2</grizzled.version>
-		<chill.version>0.8.3</chill.version>
+		<chill.version>0.7.7</chill.version>
 		<asm.version>5.0.4</asm.version>
 		<zookeeper.version>3.4.6</zookeeper.version>
 		<curator.version>2.8.0</curator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -417,6 +417,12 @@ under the License.
 			</dependency>
 
 			<dependency>
+				<groupId>com.typesafe.akka</groupId>
+				<artifactId>akka-camel_2.12</artifactId>
+				<version>${akka.typesafe.version}</version>
+			</dependency>
+
+			<dependency>
 				<groupId>org.scalatest</groupId>
 				<artifactId>scalatest_${scala.binary.version}</artifactId>
 				<version>${scalatest.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@ under the License.
 			<dependency>
 				<groupId>org.javassist</groupId>
 				<artifactId>javassist</artifactId>
-				<version>3.18.2-GA</version>
+				<version>3.20.0-GA</version>
 			</dependency>
 
 			<!-- joda time is pulled in different versions by different transitive dependencies-->

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ under the License.
 		<!-- Default scala versions, may be overwritten by build profiles -->
 		<scala.version>2.10.4</scala.version>
 		<scala.binary.version>2.10</scala.binary.version>
-		<scalatest.version>2.2.2</scalatest.version>
+		<scalatest.version>3.0.1</scalatest.version>
 		<scopt.version>3.5.0</scopt.version>
 		<grizzled.version>1.0.2</grizzled.version>
 		<chill.version>0.8.1</chill.version>
@@ -517,8 +517,6 @@ under the License.
 				<scala.binary.version>2.12</scala.binary.version>
 				<akka.typesafe.version>2.4.16</akka.typesafe.version>
 				<chill.version>0.9.0</chill.version>
-				<scalatest.version>3.0.1</scalatest.version>
-				<scopt.version>3.5.0</scopt.version>
 				<grizzled.version>1.3.0</grizzled.version>
 			</properties>
 		</profile>

--- a/tools/create_release_files.sh
+++ b/tools/create_release_files.sh
@@ -242,11 +242,16 @@ deploy_to_maven() {
   cd flink
   cp ../../deploysettings.xml .
   
+  echo "Deploying Scala 2.12 version"
+  cd tools && ./change-scala-version.sh 2.12 && cd ..
+
+  $MVN clean deploy -Prelease,docs-and-source --settings deploysettings.xml -DskipTests -Dgpg.executable=$GPG -Dgpg.keyname=$GPG_KEY -Dgpg.passphrase=$GPG_PASSPHRASE -DretryFailedDeploymentCount=10
+
   echo "Deploying Scala 2.11 version"
   cd tools && ./change-scala-version.sh 2.11 && cd ..
 
   $MVN clean deploy -Prelease,docs-and-source --settings deploysettings.xml -DskipTests -Dgpg.executable=$GPG -Dgpg.keyname=$GPG_KEY -Dgpg.passphrase=$GPG_PASSPHRASE -DretryFailedDeploymentCount=10
-  
+
   # It is important to first deploy scala 2.11 and then scala 2.10 so that the quickstarts (which are independent of the scala version)
   # are depending on scala 2.10.
   echo "Deploying Scala 2.10 version"


### PR DESCRIPTION
- [ ] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed


This is an initial approach to make flink scala 2.12 ready.

I've introduced profiles to switch between 2.12, 2.11 and 2.10. All three profiles now compile.

`mvn clean install -D$version` where $version is `scala-2.12`, `scala-2.11` or `scala-2.10`.

To overcome the `flakka` artifacts (akka2.3-custom) for scala 2.12, I've replaced them with the latest typesafe-akka artifacts when using the 2.12 profile.

TravisCI profiles are added and I've changed the initial release script to accomodate for 2.12, but this is by no means finished. 

I encountered a lot of compilation errors, because types could not be inferred. Therefore I've added types to problematic expressions.

The kafka 0.10 dependency is bumped to 0.10.1.1 since that's the first released version for 2.12. 
There is some trickery in the connector-parent-pom because only kafka-0.10 is released for 2.12, kafka-0.9 and kafka-0.8 aren't compiled for 2.12. I've to look into that a little more. 

More updated dependencies: 
javassist was bumped because of java.lang.IllegalStateException: Failed to transform class with name scala.concurrent.duration.Duration. Reason: javassist.bytecode.InterfaceMethodrefInfo cannot be cast to javassist.bytecode.MethodrefInfo. which led me to: http://stackoverflow.com/questions/31189086/powermock-and-java-8-issue-interfacemethodrefinfo-cannot-be-cast-to-methodrefin#37217871

twitter-chill was bumped to 0.7.7 version for cross-compiled versions. 

grizzled slf4j was bumped for scala 2.12 to version 1.3.0. 

scalatest was bumped for scala 2.12 to version 3.0.1

Right now I'm trying to make the travis build succeed.

I will squash all commits once this succeeds.

Any other suggestions are welcome!

