### PR TITLE
[FLINK-6286] Fix the hbase command not found error

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -311,7 +311,12 @@ INTERNAL_HADOOP_CLASSPATHS="${HADOOP_CLASSPATH}:${HADOOP_CONF_DIR}:${YARN_CONF_D
 
 if [ -n "${HBASE_CONF_DIR}" ]; then
     # Setup the HBase classpath.
-    INTERNAL_HADOOP_CLASSPATHS="${INTERNAL_HADOOP_CLASSPATHS}:`hbase classpath`"
+    HBASE_IN_PATH=$(PATH="${HBASE_HOME}/bin:$PATH" \
+        which hbase 2>/dev/null)
+    if [ -f "${HBASE_IN_PATH}" ]; then
+        INTERNAL_HADOOP_CLASSPATHS="${INTERNAL_HADOOP_CLASSPATHS}:`${HBASE_IN_PATH} classpath`"
+        echo $INTERNAL_HADOOP_CLASSPATHS
+    fi
 
     # We add the HBASE_CONF_DIR last to ensure the right config directory is used.
     INTERNAL_HADOOP_CLASSPATHS="${INTERNAL_HADOOP_CLASSPATHS}:${HBASE_CONF_DIR}"


### PR DESCRIPTION
Fix the hbase command not found error.
https://issues.apache.org/jira/browse/FLINK-6286