### PR TITLE
[FLINK-6295]Update suspended ExecutionGraph to lower latency

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/ExecutionGraphHolder.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/ExecutionGraphHolder.java
@@ -61,29 +61,23 @@ public class ExecutionGraphHolder {
 			.build(new CacheLoader<JobID, AccessExecutionGraph>() {
 				@Override
 				public AccessExecutionGraph load(JobID jobID) throws Exception {
-					try {
-						if (jobManagerRef.get() != null) {
-							Future<Object> future = jobManagerRef.get().ask(new JobManagerMessages.RequestJob(jobID), timeout);
-							Object result = Await.result(future, timeout);
+					if (jobManagerRef.get() != null) {
+						Future<Object> future = jobManagerRef.get().ask(new JobManagerMessages.RequestJob(jobID), timeout);
+						Object result = Await.result(future, timeout);
 
-							if (result instanceof JobManagerMessages.JobNotFound) {
-								return null;
-							}
-							else if (result instanceof JobManagerMessages.JobFound) {
-								AccessExecutionGraph eg = ((JobManagerMessages.JobFound) result).executionGraph();
-								return eg;
-							}
-							else {
-								throw new RuntimeException("Unknown response from JobManager / Archive: " + result);
-							}
-						}
-						else {
-							LOG.warn("No connection to the leading JobManager.");
+						if (result instanceof JobManagerMessages.JobNotFound) {
 							return null;
 						}
+						else if (result instanceof JobManagerMessages.JobFound) {
+							AccessExecutionGraph eg = ((JobManagerMessages.JobFound) result).executionGraph();
+							return eg;
+						}
+						else {
+							throw new RuntimeException("Unknown response from JobManager / Archive: " + result);
+						}
 					}
-					catch (Exception e) {
-						throw new RuntimeException("Error requesting execution graph", e);
+					else {
+						throw new RuntimeException("No connection to the leading JobManager.");
 					}
 				}
 			});


### PR DESCRIPTION
Now in ExecutionGraphHolder, which is used in many handlers, we use a WeakHashMap to cache ExecutionGraph(s), which is only sensitive to garbage collection.

The latency is too high when JVM do GC rarely, which will make status of jobs or its tasks unmatched with the real ones. (WE once observed that the web still shows tasks cancelled/failed, after the actual states of tasks coming back to normal for **30+ mins,** until a gc happened)

LoadingCache is a common used cache implementation from guava lib, we can use its time based eviction to lower latency of status update.