### PR TITLE
[FLINK-6286] [script] Fix the hbase command not found error

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -310,11 +310,15 @@ fi
 INTERNAL_HADOOP_CLASSPATHS="${HADOOP_CLASSPATH}:${HADOOP_CONF_DIR}:${YARN_CONF_DIR}"
 
 if [ -n "${HBASE_CONF_DIR}" ]; then
-    # Setup the HBase classpath.
+    # Search hbase command in PATH.
     HBASE_IN_PATH=$(PATH="${HBASE_HOME}/bin:$PATH" \
         which hbase 2>/dev/null)
+    # Whether the hbase command is found.
     if [ -f "${HBASE_IN_PATH}" ]; then
+        # The hbase command is found, then setup the HBase classpath.
         INTERNAL_HADOOP_CLASSPATHS="${INTERNAL_HADOOP_CLASSPATHS}:`${HBASE_IN_PATH} classpath`"
+    else
+        echo "The HBASE_IN_PATH is setted but can't setup HBase classpath. Please verify hbase command exists."
     fi
 
     # We add the HBASE_CONF_DIR last to ensure the right config directory is used.

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -311,7 +311,11 @@ INTERNAL_HADOOP_CLASSPATHS="${HADOOP_CLASSPATH}:${HADOOP_CONF_DIR}:${YARN_CONF_D
 
 if [ -n "${HBASE_CONF_DIR}" ]; then
     # Setup the HBase classpath.
-    INTERNAL_HADOOP_CLASSPATHS="${INTERNAL_HADOOP_CLASSPATHS}:`hbase classpath`"
+    HBASE_IN_PATH=$(PATH="${HBASE_HOME}/bin:$PATH" \
+        which hbase 2>/dev/null)
+    if [ -f "${HBASE_IN_PATH}" ]; then
+        INTERNAL_HADOOP_CLASSPATHS="${INTERNAL_HADOOP_CLASSPATHS}:`${HBASE_IN_PATH} classpath`"
+    fi
 
     # We add the HBASE_CONF_DIR last to ensure the right config directory is used.
     INTERNAL_HADOOP_CLASSPATHS="${INTERNAL_HADOOP_CLASSPATHS}:${HBASE_CONF_DIR}"

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -318,7 +318,7 @@ if [ -n "${HBASE_CONF_DIR}" ]; then
         # The hbase command is found, then setup the HBase classpath.
         INTERNAL_HADOOP_CLASSPATHS="${INTERNAL_HADOOP_CLASSPATHS}:`${HBASE_IN_PATH} classpath`"
     else
-        echo "The HBASE_IN_PATH is setted but can't setup HBase classpath. Please verify hbase command exists."
+        echo "HBASE_CONF_DIR="${HBASE_CONF_DIR}" is set but 'hbase' command was not found in "${PATH}", so classpath could not be updated."
     fi
 
     # We add the HBASE_CONF_DIR last to ensure the right config directory is used.


### PR DESCRIPTION
When using flink with the HBASE_CONF_DIR env variable and don't install hbase, then will get the "hbase command not found" error.

https://issues.apache.org/jira/browse/FLINK-6286