### PR TITLE
[FLINK-6298]Local execution is not setting RuntimeContext for RichOutputFormat

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/OutputFormatSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/OutputFormatSinkFunction.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.io.CleanupWhenUnsuccessful;
 import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.api.common.io.RichOutputFormat;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
 import org.apache.flink.configuration.Configuration;
@@ -58,6 +59,14 @@ public class OutputFormatSinkFunction<IN> extends RichSinkFunction<IN> implement
 		int indexInSubtaskGroup = context.getIndexOfThisSubtask();
 		int currentNumberOfSubtasks = context.getNumberOfParallelSubtasks();
 		format.open(indexInSubtaskGroup, currentNumberOfSubtasks);
+	}
+
+	@Override
+	public void setRuntimeContext(RuntimeContext context) {
+		super.setRuntimeContext(context);
+		if(format instanceof RichOutputFormat) {
+			((RichOutputFormat) format).setRuntimeContext(context);
+		}
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/OutputFormatSinkFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/OutputFormatSinkFunctionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.sink;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.api.common.io.RichOutputFormat;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class OutputFormatSinkFunctionTest {
+
+	@Test
+	public void setRuntimeContext() throws Exception {
+
+		// Make sure setRuntimeContext of the rich output format is called
+		RichOutputFormat<Object> mockRichOutputFormat = Mockito.mock(RichOutputFormat.class);
+		OutputFormatSinkFunction<Object> objectOutputFormatSinkFunction = new OutputFormatSinkFunction<>(mockRichOutputFormat);
+		RuntimeContext mockContext = Mockito.mock(RuntimeContext.class);
+		objectOutputFormatSinkFunction.setRuntimeContext(mockContext);
+		Mockito.verify(mockRichOutputFormat, Mockito.times(1)).setRuntimeContext(Mockito.eq(mockContext));
+
+		// Make sure setRuntimeContext work well when output format is not RichOutputFormat
+		OutputFormat<Object> mockNonRichOutputFormat = Mockito.mock(OutputFormat.class);
+		objectOutputFormatSinkFunction = new OutputFormatSinkFunction<>(mockNonRichOutputFormat);
+		objectOutputFormatSinkFunction.setRuntimeContext(mockContext);
+
+	}
+
+}


### PR DESCRIPTION
call set RuntimeContext OutputFormat when the OutputFormat is RichOutputFormat