### PR TITLE
[FLINK-4545] replace the network buffers parameter

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -78,13 +78,13 @@ without explicit scheme definition, such as `/user/USERNAME/in.txt`, is going to
 
 ### Managed Memory
 
-By default, Flink allocates a fraction of `0.7` of the total memory configured via `taskmanager.heap.mb` for its managed memory. Managed memory helps Flink to run the batch operators efficiently. It prevents `OutOfMemoryException`s because Flink knows how much memory it can use to execute operations. If Flink runs out of managed memory, it utilizes disk space. Using managed memory, some operations can be performed directly on the raw data without having to deserialize the data to convert it into Java objects. All in all, managed memory improves the robustness and speed of the system.
+By default, Flink allocates a fraction of `0.7` of the free memory (total memory configured via `taskmanager.heap.mb` minus memory used for network buffers) for its managed memory. Managed memory helps Flink to run the batch operators efficiently. It prevents `OutOfMemoryException`s because Flink knows how much memory it can use to execute operations. If Flink runs out of managed memory, it utilizes disk space. Using managed memory, some operations can be performed directly on the raw data without having to deserialize the data to convert it into Java objects. All in all, managed memory improves the robustness and speed of the system.
 
 The default fraction for managed memory can be adjusted using the `taskmanager.memory.fraction` parameter. An absolute value may be set using `taskmanager.memory.size` (overrides the fraction parameter). If desired, the managed memory may be allocated outside the JVM heap. This may improve performance in setups with large memory sizes.
 
 - `taskmanager.memory.size`: The amount of memory (in megabytes) that the task manager reserves on-heap or off-heap (depending on `taskmanager.memory.off-heap`) for sorting, hash tables, and caching of intermediate results. If unspecified (-1), the memory manager will take a fixed ratio with respect to the size of the task manager JVM as specified by `taskmanager.memory.fraction`. (DEFAULT: -1)
 
-- `taskmanager.memory.fraction`: The relative amount of memory (with respect to `taskmanager.heap.mb`) that the task manager reserves for sorting, hash tables, and caching of intermediate results. For example, a value of `0.8` means that a task manager reserves 80% of its memory (on-heap or off-heap depending on `taskmanager.memory.off-heap`) for internal data buffers, leaving 20% of free memory for the task manager's heap for objects created by user-defined functions. (DEFAULT: 0.7) This parameter is only evaluated, if `taskmanager.memory.size` is not set.
+- `taskmanager.memory.fraction`: The relative amount of memory (with respect to `taskmanager.heap.mb`, after subtracting the amount of memory used by network buffers) that the task manager reserves for sorting, hash tables, and caching of intermediate results. For example, a value of `0.8` means that a task manager reserves 80% of its memory (on-heap or off-heap depending on `taskmanager.memory.off-heap`) for internal data buffers, leaving 20% of free memory for the task manager's heap for objects created by user-defined functions. (DEFAULT: 0.7) This parameter is only evaluated, if `taskmanager.memory.size` is not set.
 
 - `taskmanager.memory.off-heap`: If set to `true`, the task manager allocates memory which is used for sorting, hash tables, and caching of intermediate results outside of the JVM heap. For setups with larger quantities of memory, this can improve the efficiency of the operations performed on the memory (DEFAULT: false).
 
@@ -170,7 +170,11 @@ will be used under the directory specified by jobmanager.web.tmpdir.
 
 - `fs.output.always-create-directory`: File writers running with a parallelism larger than one create a directory for the output file path and put the different result files (one per parallel writer task) into that directory. If this option is set to *true*, writers with a parallelism of 1 will also create a directory and place a single result file into it. If the option is set to *false*, the writer will directly create the file directly at the output path, without creating a containing directory. (DEFAULT: false)
 
-- `taskmanager.network.numberOfBuffers`: The number of buffers available to the network stack. This number determines how many streaming data exchange channels a TaskManager can have at the same time and how well buffered the channels are. If a job is rejected or you get a warning that the system has not enough buffers available, increase this value (DEFAULT: 2048).
+- `taskmanager.network.memory.fraction`: Fraction of JVM memory to use for network buffers. This determines how many streaming data exchange channels a TaskManager can have at the same time and how well buffered the channels are. If a job is rejected or you get a warning that the system has not enough buffers available, increase this value or the min/max values below. (DEFAULT: 0.1)
+
+- `taskmanager.network.memory.min`: Minimum memory size for network buffers in bytes (DEFAULT: 64 MB)
+
+- `taskmanager.network.memory.max`: Maximum memory size for network buffers in bytes (DEFAULT: 1 GB)
 
 - `state.backend`: The backend that will be used to store operator state checkpoints if checkpointing is enabled. Supported backends:
    -  `jobmanager`: In-memory state, backup to JobManager's/ZooKeeper's memory. Should be used only for minimal state (Kafka offsets) or testing and local debugging.
@@ -253,11 +257,17 @@ The following parameters configure Flink's JobManager and TaskManagers.
 
 - `taskmanager.tmp.dirs`: The directory for temporary files, or a list of directories separated by the system's directory delimiter (for example ':' (colon) on Linux/Unix). If multiple directories are specified, then the temporary files will be distributed across the directories in a round robin fashion. The I/O manager component will spawn one reading and one writing thread per directory. A directory may be listed multiple times to have the I/O manager use multiple threads for it (for example if it is physically stored on a very fast disc or RAID) (DEFAULT: **The system's tmp dir**).
 
-- `taskmanager.network.numberOfBuffers`: The number of buffers available to the network stack. This number determines how many streaming data exchange channels a TaskManager can have at the same time and how well buffered the channels are. If a job is rejected or you get a warning that the system has not enough buffers available, increase this value (DEFAULT: **2048**).
+- `taskmanager.network.memory.fraction`: Fraction of JVM memory to use for network buffers. This determines how many streaming data exchange channels a TaskManager can have at the same time and how well buffered the channels are. If a job is rejected or you get a warning that the system has not enough buffers available, increase this value or the min/max values below. Also note, that `taskmanager.network.memory.min` and `taskmanager.network.memory.max` may override this fraction. (DEFAULT: **0.1**)
+
+- `taskmanager.network.memory.min`: Minimum memory size for network buffers in bytes (DEFAULT: **64 MB**). Previously, this was determined from `taskmanager.network.numberOfBuffers` and `taskmanager.memory.segment-size`.
+
+- `taskmanager.network.memory.max`: Maximum memory size for network buffers in bytes (DEFAULT: **1 GB**). Previously, this was determined from `taskmanager.network.numberOfBuffers` and `taskmanager.memory.segment-size`.
+
+- `taskmanager.network.numberOfBuffers` (deprecated, replaced by the three parameters above): The number of buffers available to the network stack. This number determines how many streaming data exchange channels a TaskManager can have at the same time and how well buffered the channels are. If a job is rejected or you get a warning that the system has not enough buffers available, increase this value (DEFAULT: **2048**). If set, it will be mapped to `taskmanager.network.memory.min` and `taskmanager.network.memory.max` based on `taskmanager.memory.segment-size`.
 
 - `taskmanager.memory.size`: The amount of memory (in megabytes) that the task manager reserves on the JVM's heap space for sorting, hash tables, and caching of intermediate results. If unspecified (-1), the memory manager will take a fixed ratio of the heap memory available to the JVM, as specified by `taskmanager.memory.fraction`. (DEFAULT: **-1**)
 
-- `taskmanager.memory.fraction`: The relative amount of memory that the task manager reserves for sorting, hash tables, and caching of intermediate results. For example, a value of 0.8 means that TaskManagers reserve 80% of the JVM's heap space for internal data buffers, leaving 20% of the JVM's heap space free for objects created by user-defined functions. (DEFAULT: **0.7**) This parameter is only evaluated, if `taskmanager.memory.size` is not set.
+- `taskmanager.memory.fraction`: The relative amount of memory (with respect to `taskmanager.heap.mb`, after subtracting the amount of memory used by network buffers) that the task manager reserves for sorting, hash tables, and caching of intermediate results. For example, a value of `0.8` means that a task manager reserves 80% of its memory (on-heap or off-heap depending on `taskmanager.memory.off-heap`) for internal data buffers, leaving 20% of free memory for the task manager's heap for objects created by user-defined functions. (DEFAULT: 0.7) This parameter is only evaluated, if `taskmanager.memory.size` is not set.
 
 - `taskmanager.debug.memory.startLogThread`: Causes the TaskManagers to periodically log memory and Garbage collection statistics. The statistics include current heap-, off-heap, and other memory pool utilization, as well as the time spent on garbage collection, by heap memory pool.
 
@@ -602,9 +612,54 @@ You have to configure `jobmanager.archive.fs.dir` in order to archive terminated
 
 ## Background
 
+
 ### Configuring the Network Buffers
 
-If you ever see the Exception `java.io.IOException: Insufficient number of network buffers`, please use the following formula to adjust the number of network buffers:
+If you ever see the Exception `java.io.IOException: Insufficient number of network buffers`, you
+need to adapt the amount of memory used for network buffers in order for your program to run on your
+task managers.
+
+Network buffers are a critical resource for the communication layers. They are used to buffer
+records before transmission over a network, and to buffer incoming data before dissecting it into
+records and handing them to the application. A sufficient number of network buffers is critical to
+achieve a good throughput.
+
+<div class="alert alert-info">
+Since Flink 1.3, you may follow the idiom "more is better" without any penalty on the latency (we
+prevent excessive buffering in each outgoing and incoming channel, i.e. *buffer bloat*, by limiting
+the actual number of buffers used by each channel).
+</div>
+
+In general, configure the task manager to have enough buffers that each logical network connection
+you expect to be open at the same time has a dedicated buffer. A logical network connection exists
+for each point-to-point exchange of data over the network, which typically happens at
+repartitioning or broadcasting steps (shuffle phase). In those, each parallel task inside the
+TaskManager has to be able to talk to all other parallel tasks.
+
+#### Setting Memory Fractions
+
+Previously, the number of network buffers was set manually which became a quite error-prone task
+(see below). Since Flink 1.3, it is possible to define a fraction of memory that is being used for
+network buffers with the following configuration parameters:
+
+- `taskmanager.network.memory.fraction`: Fraction of JVM memory to use for network buffers (DEFAULT: 0.1),
+- `taskmanager.network.memory.min`: Minimum memory size for network buffers in bytes (DEFAULT: 64 MB),
+- `taskmanager.network.memory.max`: Maximum memory size for network buffers in bytes (DEFAULT: 1 GB), and
+- `taskmanager.memory.segment-size`: Size of memory buffers used by the memory manager and the
+network stack in bytes (DEFAULT: 32768 (= 32 KiBytes)).
+
+#### Setting the Number of Network Buffers directly
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> This way of configuring the amount of memory used for network buffers is deprecated. Please consider using the method above by defining a fraction of memory to use.
+</div>
+
+The required number of buffers on a task manager is
+*total-degree-of-parallelism* (number of targets) \* *intra-node-parallelism* (number of sources in one task manager) \* *n*
+with *n* being a constant that defines how many repartitioning-/broadcasting steps you expect to be
+active at the same time. Since the *intra-node-parallelism* is typically the number of cores, and
+more than 4 repartitioning or broadcasting channels are rarely active in parallel, it frequently
+boils down to
 
 ```
 #slots-per-TM^2 * #TMs * 4
@@ -612,16 +667,11 @@ If you ever see the Exception `java.io.IOException: Insufficient number of netwo
 
 Where `#slots per TM` are the [number of slots per TaskManager](#configuring-taskmanager-processing-slots) and `#TMs` are the total number of task managers.
 
-Network buffers are a critical resource for the communication layers. They are used to buffer records before transmission over a network, and to buffer incoming data before dissecting it into records and handing them to the
-application. A sufficient number of network buffers is critical to achieve a good throughput.
+To support, for example, a cluster of 20 8-slot machines, you should use roughly 5000 network
+buffers for optimal throughput.
 
-In general, configure the task manager to have enough buffers that each logical network connection you expect to be open at the same time has a dedicated buffer. A logical network connection exists for each point-to-point exchange of data over the network, which typically happens at repartitioning- or broadcasting steps (shuffle phase). In those, each parallel task inside the TaskManager has to be able to talk to all other parallel tasks. Hence, the required number of buffers on a task manager is *total-degree-of-parallelism* (number of targets) \* *intra-node-parallelism* (number of sources in one task manager) \* *n*. Here, *n* is a constant that defines how many repartitioning-/broadcasting steps you expect to be active at the same time.
-
-Since the *intra-node-parallelism* is typically the number of cores, and more than 4 repartitioning or broadcasting channels are rarely active in parallel, it frequently boils down to `#slots-per-TM^2 * #TMs * 4`.
-
-To support for example a cluster of 20 8-slot machines, you should use roughly 5000 network buffers for optimal throughput.
-
-Each network buffer has by default a size of 32 KiBytes. In the above example, the system would allocate roughly 300 MiBytes for network buffers.
+Each network buffer has by default a size of 32 KiBytes. In the example above, the system would thus
+allocate roughly 300 MiBytes for network buffers.
 
 The number and size of network buffers can be configured with the following parameters:
 

--- a/docs/setup/yarn_setup.md
+++ b/docs/setup/yarn_setup.md
@@ -122,7 +122,7 @@ The system will use the configuration in `conf/flink-conf.yaml`. Please follow o
 
 Flink on YARN will overwrite the following configuration parameters `jobmanager.rpc.address` (because the JobManager is always allocated at different machines), `taskmanager.tmp.dirs` (we are using the tmp directories given by YARN) and `parallelism.default` if the number of slots has been specified.
 
-If you don't want to change the configuration file to set configuration parameters, there is the option to pass dynamic properties via the `-D` flag. So you can pass parameters this way: `-Dfs.overwrite-files=true -Dtaskmanager.network.numberOfBuffers=16368`.
+If you don't want to change the configuration file to set configuration parameters, there is the option to pass dynamic properties via the `-D` flag. So you can pass parameters this way: `-Dfs.overwrite-files=true -Dtaskmanager.network.memory.min=536346624`.
 
 The example invocation starts 11 containers (even though only 10 containers were requested), since there is one additional container for the ApplicationMaster and Job Manager.
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -450,7 +450,7 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 		}
 		catch (Throwable t) {
 			if (LOG.isErrorEnabled()) {
-				LOG.error("Unexpected problen while getting the file statistics for file '" + this.filePath + "': "
+				LOG.error("Unexpected problem while getting the file statistics for file '" + this.filePath + "': "
 						+ t.getMessage(), t);
 			}
 		} finally {

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -80,10 +80,29 @@ public class TaskManagerOptions {
 	/**
 	 * Number of buffers used in the network stack. This defines the number of possible tasks and
 	 * shuffles.
+	 *
+	 * @deprecated use {@link #NETWORK_BUFFERS_MEMORY_FRACTION}, {@link #NETWORK_BUFFERS_MEMORY_MIN},
+	 * and {@link #NETWORK_BUFFERS_MEMORY_MAX} instead
 	 */
+	@Deprecated
 	public static final ConfigOption<Integer> NETWORK_NUM_BUFFERS =
 			key("taskmanager.network.numberOfBuffers")
 			.defaultValue(2048);
+
+	/** Fraction of JVM memory to use for network buffers. */
+	public static final ConfigOption<Float> NETWORK_BUFFERS_MEMORY_FRACTION =
+			key("taskmanager.network.memory.fraction")
+			.defaultValue(0.1f);
+
+	/** Minimum memory size for network buffers (in bytes) */
+	public static final ConfigOption<Long> NETWORK_BUFFERS_MEMORY_MIN =
+			key("taskmanager.network.memory.min")
+			.defaultValue(64L << 20); // 64 MB
+
+	/** Maximum memory size for network buffers (in bytes) */
+	public static final ConfigOption<Long> NETWORK_BUFFERS_MEMORY_MAX =
+			key("taskmanager.network.memory.max")
+			.defaultValue(1024L << 20); // 1 GB
 
 
 	/** Minimum backoff for partition requests of input channels. */
@@ -95,6 +114,7 @@ public class TaskManagerOptions {
 	public static final ConfigOption<Integer> NETWORK_REQUEST_BACKOFF_MAX =
 			key("taskmanager.net.request-backoff.max")
 			.defaultValue(10000);
+
 
 	/**
 	 * Number of network buffers to use for each outgoing/ingoing channel (subpartition/input channel).

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -234,6 +234,16 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 		<!-- end optional Flink libraries -->
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- end test dependencies -->
 	</dependencies>
 
 	<profiles>
@@ -291,6 +301,20 @@ under the License.
 
 	<build>
 		<plugins>
+
+			<!--unit tests-->
+			<!--plugin must appear BEFORE the shade-plugin to not mess up package order and include the non-uber JAR into the assembly-->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<reuseForks>false</reuseForks>
+					<!-- <workingDirectory>${project.build.testOutputDirectory}</workingDirectory> -->
+					<systemPropertyVariables>
+						<log.level>WARN</log.level>
+					</systemPropertyVariables>
+				</configuration>
+			</plugin>
 
 			<!-- binary compatibility checks -->
 			<plugin>

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -96,6 +96,11 @@ KEY_TASKM_MEM_MANAGED_FRACTION="taskmanager.memory.fraction"
 KEY_TASKM_OFFHEAP="taskmanager.memory.off-heap"
 KEY_TASKM_MEM_PRE_ALLOCATE="taskmanager.memory.preallocate"
 
+KEY_TASKM_NET_BUF_FRACTION="taskmanager.network.memory.fraction"
+KEY_TASKM_NET_BUF_MIN="taskmanager.network.memory.min"
+KEY_TASKM_NET_BUF_MAX="taskmanager.network.memory.max"
+KEY_TASKM_NET_BUF_NR="taskmanager.network.numberOfBuffers" # fallback
+
 KEY_TASKM_COMPUTE_NUMA="taskmanager.compute.numa"
 
 KEY_ENV_PID_DIR="env.pid.dir"
@@ -218,6 +223,31 @@ fi
 if [ -z "${FLINK_TM_MEM_PRE_ALLOCATE}" ]; then
     FLINK_TM_MEM_PRE_ALLOCATE=$(readFromConfig ${KEY_TASKM_MEM_PRE_ALLOCATE} "false" "${YAML_CONF}")
 fi
+
+
+# Define FLINK_TM_NET_BUF_FRACTION if it is not already set
+if [ -z "${FLINK_TM_NET_BUF_FRACTION}" ]; then
+    FLINK_TM_NET_BUF_FRACTION=$(readFromConfig ${KEY_TASKM_NET_BUF_FRACTION} 0.1 "${YAML_CONF}")
+fi
+
+# Define FLINK_TM_NET_BUF_MIN and FLINK_TM_NET_BUF_MAX if not already set (as a fallback)
+if [ -z "${FLINK_TM_NET_BUF_MIN}" -a -z "${FLINK_TM_NET_BUF_MAX}" ]; then
+    FLINK_TM_NET_BUF_MIN=$(readFromConfig ${KEY_TASKM_NET_BUF_NR} -1 "${YAML_CONF}")
+    FLINK_TM_NET_BUF_MAX=${FLINK_TM_NET_BUF_MIN}
+fi
+
+# Define FLINK_TM_NET_BUF_MIN if it is not already set
+if [ -z "${FLINK_TM_NET_BUF_MIN}" -o "${FLINK_TM_NET_BUF_MIN}" = "-1" ]; then
+    # default: 64MB = 67108864 bytes (same as the previous default with 2048 buffers of 32k each)
+    FLINK_TM_NET_BUF_MIN=$(readFromConfig ${KEY_TASKM_NET_BUF_MIN} 67108864 "${YAML_CONF}")
+fi
+
+# Define FLINK_TM_NET_BUF_MAX if it is not already set
+if [ -z "${FLINK_TM_NET_BUF_MAX}" -o "${FLINK_TM_NET_BUF_MAX}" = "-1" ]; then
+    # default: 1GB = 1073741824 bytes
+    FLINK_TM_NET_BUF_MAX=$(readFromConfig ${KEY_TASKM_NET_BUF_MAX} 1073741824 "${YAML_CONF}")
+fi
+
 
 # Verify that NUMA tooling is available
 command -v numactl >/dev/null 2>&1
@@ -397,4 +427,107 @@ readSlaves() {
 
 useOffHeapMemory() {
     [[ "`echo ${FLINK_TM_OFFHEAP} | tr '[:upper:]' '[:lower:]'`" == "true" ]]
+}
+
+HAVE_AWK=
+# same as org.apache.flink.runtime.taskexecutor.TaskManagerServices.calculateNetworkBuf(long totalJavaMemorySize, Configuration config)
+calculateNetworkBuf() {
+    local network_buffers_bytes
+    if [ "${FLINK_TM_HEAP}" -le "0" ]; then
+        echo "Variable 'FLINK_TM_HEAP' not set (usually read from '${KEY_TASKM_MEM_SIZE}' in ${FLINK_CONF_FILE})."
+        exit 1
+    fi
+
+    if [[ "${FLINK_TM_NET_BUF_MIN}" = "${FLINK_TM_NET_BUF_MAX}" ]]; then
+        # fix memory size for network buffers
+        network_buffers_bytes=${FLINK_TM_NET_BUF_MIN}
+    else
+        if [[ "${FLINK_TM_NET_BUF_MIN}" -gt "${FLINK_TM_NET_BUF_MAX}" ]]; then
+            echo "[ERROR] Configured TaskManager network buffer memory min/max '${FLINK_TM_NET_BUF_MIN}'/'${FLINK_TM_NET_BUF_MAX}' are not valid."
+            echo "Min must be less than or equal to max."
+            echo "Please set '${KEY_TASKM_NET_BUF_MIN}' and '${KEY_TASKM_NET_BUF_MAX}' in ${FLINK_CONF_FILE}."
+            exit 1
+        fi
+
+        # Bash only performs integer arithmetic so floating point computation is performed using awk
+        if [[ -z "${HAVE_AWK}" ]] ; then
+            command -v awk >/dev/null 2>&1
+            if [[ $? -ne 0 ]]; then
+                echo "[ERROR] Program 'awk' not found."
+                echo "Please install 'awk' or define '${KEY_TASKM_NET_BUF_MIN}' and '${KEY_TASKM_NET_BUF_MAX}' instead of '${KEY_TASKM_NET_BUF_FRACTION}' in ${FLINK_CONF_FILE}."
+                exit 1
+            fi
+            HAVE_AWK=true
+        fi
+
+        # We calculate the memory using a fraction of the total memory
+        if [[ `awk '{ if ($1 > 0.0 && $1 < 1.0) print "1"; }' <<< "${FLINK_TM_NET_BUF_FRACTION}"` != "1" ]]; then
+            echo "[ERROR] Configured TaskManager network buffer memory fraction '${FLINK_TM_NET_BUF_FRACTION}' is not a valid value."
+            echo "It must be between 0.0 and 1.0."
+            echo "Please set '${KEY_TASKM_NET_BUF_FRACTION}' in ${FLINK_CONF_FILE}."
+            exit 1
+        fi
+
+        network_buffers_bytes=`awk "BEGIN { x = lshift(${FLINK_TM_HEAP},20) * ${FLINK_TM_NET_BUF_FRACTION}; netbuf = x > ${FLINK_TM_NET_BUF_MAX} ? ${FLINK_TM_NET_BUF_MAX} : x < ${FLINK_TM_NET_BUF_MIN} ? ${FLINK_TM_NET_BUF_MIN} : x; printf \"%.0f\n\", netbuf }"`
+    fi
+
+    # recalculate the JVM heap memory by taking the network buffers into account
+    local tm_heap_size_bytes=$((${FLINK_TM_HEAP} << 20)) # megabytes to bytes
+    if [[ "${tm_heap_size_bytes}" -le "${network_buffers_bytes}" ]]; then
+        echo "[ERROR] Configured TaskManager memory size (${FLINK_TM_HEAP} MB, from '${KEY_TASKM_MEM_SIZE}') must be larger than the network buffer memory size (${network_buffers_bytes} bytes, from: '${KEY_TASKM_NET_BUF_FRACTION}', '${KEY_TASKM_NET_BUF_MIN}', '${KEY_TASKM_NET_BUF_MAX}', and '${KEY_TASKM_NET_BUF_NR}')."
+        exit 1
+    fi
+
+    echo ${network_buffers_bytes}
+}
+
+# same as org.apache.flink.runtime.taskexecutor.TaskManagerServices.calculateHeapSizeMB(long totalJavaMemorySizeMB, Configuration config)
+calculateTaskManagerHeapSizeMB() {
+    if [ "${FLINK_TM_HEAP}" -le "0" ]; then
+        echo "Variable 'FLINK_TM_HEAP' not set (usually read from '${KEY_TASKM_MEM_SIZE}' in ${FLINK_CONF_FILE})."
+        exit 1
+    fi
+
+    local tm_heap_size_mb=${FLINK_TM_HEAP}
+
+    if useOffHeapMemory; then
+
+        local network_buffers_mb=$(($(calculateNetworkBuf) >> 20)) # bytes to megabytes
+        tm_heap_size_mb=$((tm_heap_size_mb - network_buffers_mb))
+
+        if [[ "${FLINK_TM_MEM_MANAGED_SIZE}" -gt "0" ]]; then
+            # We split up the total memory in heap and off-heap memory
+            if [[ "${tm_heap_size_mb}" -le "${FLINK_TM_MEM_MANAGED_SIZE}" ]]; then
+                echo "[ERROR] Remaining TaskManager memory size (${tm_heap_size_mb} MB, from: '${KEY_TASKM_MEM_SIZE}' (${FLINK_TM_HEAP} MB) minus network buffer memory size (${network_buffers_mb} MB, from: '${KEY_TASKM_NET_BUF_FRACTION}', '${KEY_TASKM_NET_BUF_MIN}', '${KEY_TASKM_NET_BUF_MAX}', and '${KEY_TASKM_NET_BUF_NR}')) must be larger than the managed memory size (${FLINK_TM_MEM_MANAGED_SIZE} MB, from: '${KEY_TASKM_MEM_MANAGED_SIZE}')."
+                exit 1
+            fi
+
+            tm_heap_size_mb=$((tm_heap_size_mb - FLINK_TM_MEM_MANAGED_SIZE))
+        else
+            # Bash only performs integer arithmetic so floating point computation is performed using awk
+            if [[ -z "${HAVE_AWK}" ]] ; then
+                command -v awk >/dev/null 2>&1
+                if [[ $? -ne 0 ]]; then
+                    echo "[ERROR] Program 'awk' not found."
+                    echo "Please install 'awk' or define '${KEY_TASKM_MEM_MANAGED_SIZE}' instead of '${KEY_TASKM_MEM_MANAGED_FRACTION}' in ${FLINK_CONF_FILE}."
+                    exit 1
+                fi
+                HAVE_AWK=true
+            fi
+
+            # We calculate the memory using a fraction of the total memory
+            if [[ `awk '{ if ($1 > 0.0 && $1 < 1.0) print "1"; }' <<< "${FLINK_TM_MEM_MANAGED_FRACTION}"` != "1" ]]; then
+                echo "[ERROR] Configured TaskManager managed memory fraction '${FLINK_TM_MEM_MANAGED_FRACTION}' is not a valid value."
+                echo "It must be between 0.0 and 1.0."
+                echo "Please set '${KEY_TASKM_MEM_MANAGED_FRACTION}' in ${FLINK_CONF_FILE}."
+                exit 1
+            fi
+
+            # recalculate the JVM heap memory by taking the off-heap ratio into account
+            local offheap_managed_memory_size=`awk "BEGIN { printf \"%.0f\n\", ${tm_heap_size_mb} * ${FLINK_TM_MEM_MANAGED_FRACTION} }"`
+            tm_heap_size_mb=$((tm_heap_size_mb - offheap_managed_memory_size))
+        fi
+    fi
+
+    echo ${tm_heap_size_mb}
 }

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -430,8 +430,8 @@ useOffHeapMemory() {
 }
 
 HAVE_AWK=
-# same as org.apache.flink.runtime.taskexecutor.TaskManagerServices.calculateNetworkBuf(long totalJavaMemorySize, Configuration config)
-calculateNetworkBuf() {
+# same as org.apache.flink.runtime.taskexecutor.TaskManagerServices.calculateNetworkBufferMemory(long totalJavaMemorySize, Configuration config)
+calculateNetworkBufferMemory() {
     local network_buffers_bytes
     if [ "${FLINK_TM_HEAP}" -le "0" ]; then
         echo "Variable 'FLINK_TM_HEAP' not set (usually read from '${KEY_TASKM_MEM_SIZE}' in ${FLINK_CONF_FILE})."
@@ -492,7 +492,7 @@ calculateTaskManagerHeapSizeMB() {
 
     if useOffHeapMemory; then
 
-        local network_buffers_mb=$(($(calculateNetworkBuf) >> 20)) # bytes to megabytes
+        local network_buffers_mb=$(($(calculateNetworkBufferMemory) >> 20)) # bytes to megabytes
         tm_heap_size_mb=$((tm_heap_size_mb - network_buffers_mb))
 
         if [[ "${FLINK_TM_MEM_MANAGED_SIZE}" -gt "0" ]]; then

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -57,38 +57,9 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
 
     if [ "${FLINK_TM_HEAP}" -gt "0" ]; then
 
-        TM_HEAP_SIZE=${FLINK_TM_HEAP}
+        TM_HEAP_SIZE=$(calculateTaskManagerHeapSizeMB)
         # Long.MAX_VALUE in TB: This is an upper bound, much less direct memory will be used
         TM_MAX_OFFHEAP_SIZE="8388607T"
-
-        if useOffHeapMemory; then
-            if [[ "${FLINK_TM_MEM_MANAGED_SIZE}" -gt "0" ]]; then
-                # We split up the total memory in heap and off-heap memory
-                if [[ "${FLINK_TM_HEAP}" -le "${FLINK_TM_MEM_MANAGED_SIZE}" ]]; then
-                    echo "[ERROR] Configured TaskManager memory size ('${KEY_TASKM_MEM_SIZE}') must be larger than the managed memory size ('${KEY_TASKM_MEM_MANAGED_SIZE}')."
-                    exit 1
-                fi
-                TM_HEAP_SIZE=$((FLINK_TM_HEAP - FLINK_TM_MEM_MANAGED_SIZE))
-            else
-                # Bash only performs integer arithmetic so floating point computation is performed using awk
-                command -v awk >/dev/null 2>&1
-                if [[ $? -ne 0 ]]; then
-                    echo "[ERROR] Program 'awk' not found."
-                    echo "Please install 'awk' or define '${KEY_TASKM_MEM_MANAGED_SIZE}' instead of '${KEY_TASKM_MEM_MANAGED_FRACTION}' in ${FLINK_CONF_FILE}."
-                    exit 1
-                fi
-                # We calculate the memory using a fraction of the total memory
-                if [[ `awk '{ if ($1 > 0.0 && $1 < 1.0) print "1"; }' <<< "${FLINK_TM_MEM_MANAGED_FRACTION}"` != "1" ]]; then
-                    echo "[ERROR] Configured TaskManager managed memory fraction '${FLINK_TM_MEM_MANAGED_FRACTION}' is not a valid value."
-                    echo "It must be between 0.0 and 1.0."
-                    echo "Please set '${KEY_TASKM_MEM_MANAGED_FRACTION}' in ${FLINK_CONF_FILE}."
-                    exit 1
-                fi
-                # recalculate the JVM heap memory by taking the off-heap ratio into account
-                OFFHEAP_MANAGED_MEMORY_SIZE=`awk "BEGIN { printf \"%.0f\n\", ${FLINK_TM_HEAP} * ${FLINK_TM_MEM_MANAGED_FRACTION} }"`
-                TM_HEAP_SIZE=$((FLINK_TM_HEAP - OFFHEAP_MANAGED_MEMORY_SIZE))
-            fi
-        fi
 
         export JVM_ARGS="${JVM_ARGS} -Xms${TM_HEAP_SIZE}M -Xmx${TM_HEAP_SIZE}M -XX:MaxDirectMemorySize=${TM_MAX_OFFHEAP_SIZE}"
 

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -18,7 +18,7 @@
 ################################################################################
 
 # Start/stop a Flink TaskManager.
-USAGE="Usage: taskmanager.sh start|start-foreground|stop|stop-all)"
+USAGE="Usage: taskmanager.sh (start|start-foreground|stop|stop-all)"
 
 STARTSTOP=$1
 

--- a/flink-dist/src/test/bin/calcTMHeapSizeMB.sh
+++ b/flink-dist/src/test/bin/calcTMHeapSizeMB.sh
@@ -18,17 +18,20 @@
 ################################################################################
 
 # Wrapper script to compare the TM heap size calculation of config.sh with Java
-USAGE="Usage: calculateTaskManagerNetworkBuf.sh <memTotal> <netBufFrac> <netBufMin> <netBufMax>"
+USAGE="Usage: calcTMHeapSizeMB.sh <memTotal> <offHeap> <netBufFrac> <netBufMin> <netBufMax> <managedMemMB> <managedMemFrac>"
 
 bin=`dirname "$0"`
 bin=`cd "$bin"; pwd`
 
 FLINK_TM_HEAP=$1
-FLINK_TM_NET_BUF_FRACTION=$2
-FLINK_TM_NET_BUF_MIN=$3
-FLINK_TM_NET_BUF_MAX=$4
+FLINK_TM_OFFHEAP=$2
+FLINK_TM_NET_BUF_FRACTION=$3
+FLINK_TM_NET_BUF_MIN=$4
+FLINK_TM_NET_BUF_MAX=$5
+FLINK_TM_MEM_MANAGED_SIZE=$6
+FLINK_TM_MEM_MANAGED_FRACTION=$7
 
-if [[ -z "${FLINK_TM_NET_BUF_MAX}" ]]; then
+if [[ -z "${FLINK_TM_MEM_MANAGED_FRACTION}" ]]; then
   echo "$USAGE"
   exit 1
 fi
@@ -36,4 +39,4 @@ fi
 FLINK_CONF_DIR=${bin}/../../main/resources
 . ${bin}/../../main/flink-bin/bin/config.sh
 
-calculateNetworkBuf
+calculateTaskManagerHeapSizeMB

--- a/flink-dist/src/test/bin/calcTMNetBufMem.sh
+++ b/flink-dist/src/test/bin/calcTMNetBufMem.sh
@@ -18,20 +18,17 @@
 ################################################################################
 
 # Wrapper script to compare the TM heap size calculation of config.sh with Java
-USAGE="Usage: calculateTaskManagerHeapSizeMB.sh <memTotal> <offHeap> <netBufFrac> <netBufMin> <netBufMax> <managedMemMB> <managedMemFrac>"
+USAGE="Usage: calcTMNetBufMem.sh <memTotal> <netBufFrac> <netBufMin> <netBufMax>"
 
 bin=`dirname "$0"`
 bin=`cd "$bin"; pwd`
 
 FLINK_TM_HEAP=$1
-FLINK_TM_OFFHEAP=$2
-FLINK_TM_NET_BUF_FRACTION=$3
-FLINK_TM_NET_BUF_MIN=$4
-FLINK_TM_NET_BUF_MAX=$5
-FLINK_TM_MEM_MANAGED_SIZE=$6
-FLINK_TM_MEM_MANAGED_FRACTION=$7
+FLINK_TM_NET_BUF_FRACTION=$2
+FLINK_TM_NET_BUF_MIN=$3
+FLINK_TM_NET_BUF_MAX=$4
 
-if [[ -z "${FLINK_TM_MEM_MANAGED_FRACTION}" ]]; then
+if [[ -z "${FLINK_TM_NET_BUF_MAX}" ]]; then
   echo "$USAGE"
   exit 1
 fi
@@ -39,4 +36,4 @@ fi
 FLINK_CONF_DIR=${bin}/../../main/resources
 . ${bin}/../../main/flink-bin/bin/config.sh
 
-calculateTaskManagerHeapSizeMB
+calculateNetworkBufferMemory

--- a/flink-dist/src/test/bin/calculateTaskManagerHeapSizeMB.sh
+++ b/flink-dist/src/test/bin/calculateTaskManagerHeapSizeMB.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Wrapper script to compare the TM heap size calculation of config.sh with Java
+USAGE="Usage: calculateTaskManagerHeapSizeMB.sh <memTotal> <offHeap> <netBufFrac> <netBufMin> <netBufMax> <managedMemMB> <managedMemFrac>"
+
+bin=`dirname "$0"`
+bin=`cd "$bin"; pwd`
+
+FLINK_TM_HEAP=$1
+FLINK_TM_OFFHEAP=$2
+FLINK_TM_NET_BUF_FRACTION=$3
+FLINK_TM_NET_BUF_MIN=$4
+FLINK_TM_NET_BUF_MAX=$5
+FLINK_TM_MEM_MANAGED_SIZE=$6
+FLINK_TM_MEM_MANAGED_FRACTION=$7
+
+if [[ -z "${FLINK_TM_MEM_MANAGED_FRACTION}" ]]; then
+  echo "$USAGE"
+  exit 1
+fi
+
+FLINK_CONF_DIR=${bin}/../../main/resources
+. ${bin}/../../main/flink-bin/bin/config.sh
+
+calculateTaskManagerHeapSizeMB

--- a/flink-dist/src/test/bin/calculateTaskManagerNetworkBuf.sh
+++ b/flink-dist/src/test/bin/calculateTaskManagerNetworkBuf.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Wrapper script to compare the TM heap size calculation of config.sh with Java
+USAGE="Usage: calculateTaskManagerNetworkBuf.sh <memTotal> <netBufFrac> <netBufMin> <netBufMax>"
+
+bin=`dirname "$0"`
+bin=`cd "$bin"; pwd`
+
+FLINK_TM_HEAP=$1
+FLINK_TM_NET_BUF_FRACTION=$2
+FLINK_TM_NET_BUF_MIN=$3
+FLINK_TM_NET_BUF_MAX=$4
+
+if [[ -z "${FLINK_TM_NET_BUF_MAX}" ]]; then
+  echo "$USAGE"
+  exit 1
+fi
+
+FLINK_CONF_DIR=${bin}/../../main/resources
+. ${bin}/../../main/flink-bin/bin/config.sh
+
+calculateNetworkBuf

--- a/flink-dist/src/test/java/org/apache/flink/dist/TaskManagerHeapSizeCalculationJavaBashTest.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/TaskManagerHeapSizeCalculationJavaBashTest.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.dist;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
+import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.TestLogger;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Random;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Unit test that verifies that the task manager heap size calculation used by the bash script
+ * <tt>taskmanager.sh</tt> returns the same values as the heap size calculation of
+ * {@link TaskManagerServices#calculateHeapSizeMB(long, Configuration)}.
+ *
+ * NOTE: the shell script uses <tt>awk</tt> to perform floating-point arithmetic which uses
+ * <tt>double</tt> precision but our Java code restrains to <tt>float</tt> because we actually do
+ * not need high precision.
+ */
+public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
+
+	/** Key that is used by <tt>config.sh</tt>. */
+	private static final String KEY_TASKM_MEM_SIZE = "taskmanager.heap.mb";
+
+	/**
+	 * Number of tests with random values.
+	 *
+	 * NOTE: calling the external test script is slow and thus low numbers are preferred for general
+	 * testing.
+	 */
+	private static final int NUM_RANDOM_TESTS = 20;
+
+	@Before
+	public void checkOperatingSystem() {
+		Assume.assumeTrue("This test checks shell scripts not available on Windows.",
+			!OperatingSystem.isWindows());
+	}
+
+	/**
+	 * Tests that {@link TaskManagerServices#calculateNetworkBuf(long, Configuration)} has the same
+	 * result as the shell script.
+	 */
+	@Test
+	public void compareNetworkBufShellScriptWithJava() throws Exception {
+		int managedMemSize = TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue().intValue();
+		float managedMemFrac = TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue();
+
+		// manual tests from org.apache.flink.runtime.taskexecutor.TaskManagerServices.calculateHeapSizeMB()
+
+		compareNetworkBufJavaVsScript(
+			getConfig(1000, false, 0.1f, 64L << 20, 1L << 30, managedMemSize, managedMemFrac), 0.0f);
+
+		compareNetworkBufJavaVsScript(
+			getConfig(1000, true, 0.1f, 64L << 20, 1L << 30, 10 /*MB*/, managedMemFrac), 0.0f);
+
+		compareNetworkBufJavaVsScript(
+			getConfig(1000, true, 0.1f, 64L << 20, 1L << 30, managedMemSize, 0.1f), 0.0f);
+
+		// some automated tests with random (but valid) values
+
+		Random ran = new Random();
+		for (int i = 0; i < NUM_RANDOM_TESTS; ++i) {
+			// tolerate that values differ by 1% (due to different floating point precisions)
+			compareNetworkBufJavaVsScript(getRandomConfig(ran), 0.01f);
+		}
+	}
+
+	/**
+	 * Tests that {@link TaskManagerServices#calculateHeapSizeMB(long, Configuration)} has the same
+	 * result as the shell script.
+	 */
+	@Test
+	public void compareHeapSizeShellScriptWithJava() throws Exception {
+		int managedMemSize = TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue().intValue();
+		float managedMemFrac = TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue();
+
+		// manual tests from org.apache.flink.runtime.taskexecutor.TaskManagerServices.calculateHeapSizeMB()
+
+		compareHeapSizeJavaVsScript(
+			getConfig(1000, false, 0.1f, 64L << 20, 1L << 30, managedMemSize, managedMemFrac), 0.0f);
+
+		compareHeapSizeJavaVsScript(
+			getConfig(1000, true, 0.1f, 64L << 20, 1L << 30, 10 /*MB*/, managedMemFrac), 0.0f);
+
+		compareHeapSizeJavaVsScript(
+			getConfig(1000, true, 0.1f, 64L << 20, 1L << 30, managedMemSize, 0.1f), 0.0f);
+
+		// some automated tests with random (but valid) values
+
+		Random ran = new Random();
+		for (int i = 0; i < NUM_RANDOM_TESTS; ++i) {
+			// tolerate that values differ by 1% (due to different floating point precisions)
+			compareHeapSizeJavaVsScript(getRandomConfig(ran), 0.01f);
+		}
+	}
+
+	/**
+	 * Returns a flink configuration object with the given values.
+	 *
+	 * @param javaMemMB
+	 * 		total JVM memory to use (in megabytes)
+	 * @param useOffHeap
+	 * 		whether to use off-heap memory (<tt>true</tt>) or not (<tt>false</tt>)
+	 * @param netBufMemFrac
+	 * 		fraction of JVM memory to use for network buffers
+	 * @param netBufMemMin
+	 * 		minimum memory size for network buffers (in bytes)
+	 * @param netBufMemMax
+	 * 		maximum memory size for network buffers (in bytes)
+	 * @param managedMemSizeMB
+	 * 		amount of managed memory (in megabytes)
+	 * @param managedMemFrac
+	 * 		fraction of free memory to use for managed memory (if <tt>managedMemSizeMB</tt> is
+	 * 		<tt>-1</tt>)
+	 *
+	 * @return flink configuration
+	 */
+	private static Configuration getConfig(
+			final int javaMemMB, final boolean useOffHeap, final float netBufMemFrac,
+			final long netBufMemMin, final long netBufMemMax, final int managedMemSizeMB,
+			final float managedMemFrac) {
+
+		Configuration config = new Configuration();
+
+		config.setLong(KEY_TASKM_MEM_SIZE, javaMemMB);
+		config.setBoolean(TaskManagerOptions.MEMORY_OFF_HEAP, useOffHeap);
+
+		config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, netBufMemFrac);
+		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, netBufMemMin);
+		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, netBufMemMax);
+
+		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, managedMemSizeMB);
+		config.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, managedMemFrac);
+
+		return config;
+	}
+
+	/**
+	 * Returns a flink configuration object with random values (only those relevant to the tests in
+	 * this class.
+	 *
+	 * @param ran  random number generator
+	 *
+	 * @return flink configuration
+	 */
+	private static Configuration getRandomConfig(final Random ran) {
+
+		float frac = Math.max(ran.nextFloat(), Float.MIN_VALUE);
+
+//		long min = Math.max(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue(), ran.nextLong());
+		long min = TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue() + ran.nextInt(Integer.MAX_VALUE);
+
+//		long max = Math.max(min, ran.nextLong());
+		long max = ran.nextInt(Integer.MAX_VALUE) + min;
+
+		int javaMemMB = Math.max((int) (max >> 20), ran.nextInt(Integer.MAX_VALUE)) + 1;
+		boolean useOffHeap = ran.nextBoolean();
+
+		int managedMemSize = TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue().intValue();
+		float managedMemFrac = TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue();
+
+		if (ran.nextBoolean()) {
+			// use fixed-size managed memory
+			Configuration config = getConfig(javaMemMB, useOffHeap, frac, min, max, managedMemSize, managedMemFrac);
+			long totalJavaMemorySize = ((long) javaMemMB) << 20; // megabytes to bytes
+			final int networkBufMB =
+				(int) (TaskManagerServices.calculateNetworkBuf(totalJavaMemorySize, config) >> 20);
+			// max (exclusive): total - netbuf
+			managedMemSize = Math.min(javaMemMB - networkBufMB - 1, ran.nextInt(Integer.MAX_VALUE));
+		} else {
+			// use fraction of given memory
+			managedMemFrac = Math.max(ran.nextFloat(), Float.MIN_VALUE);
+		}
+
+		return getConfig(javaMemMB, useOffHeap, frac, min, max, managedMemSize, managedMemFrac);
+	}
+
+	// Helper functions
+
+	/**
+	 * Calculates the heap size via
+	 * {@link TaskManagerServices#calculateHeapSizeMB(long, Configuration)} and the shell script
+	 * and verifies that these are equal.
+	 *
+	 * @param config     flink configuration
+	 * @param tolerance  tolerate values that are off by this factor (0.01 = 1%)
+	 */
+	private void compareNetworkBufJavaVsScript(final Configuration config, final float tolerance)
+			throws IOException {
+
+		final long totalJavaMemorySizeMB = config.getLong(KEY_TASKM_MEM_SIZE, 0L);
+
+		long javaNetworkBufMem = TaskManagerServices.calculateNetworkBuf(totalJavaMemorySizeMB << 20, config);
+
+		String[] command = {"src/test/bin/calculateTaskManagerNetworkBuf.sh",
+			String.valueOf(totalJavaMemorySizeMB),
+			String.valueOf(config.getFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION)),
+			String.valueOf(config.getLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN)),
+			String.valueOf(config.getLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX))};
+		String scriptOutput = executeScript(command);
+
+		long absoluteTolerance = (long) (javaNetworkBufMem * tolerance);
+		if (absoluteTolerance < 1) {
+			assertEquals(
+				"Different network buffer memory sizes with configuration: " + config.toString(),
+				String.valueOf(javaNetworkBufMem), scriptOutput);
+		} else {
+			Long scriptNetworkBufMem = Long.valueOf(scriptOutput);
+			assertThat(
+				"Different network buffer memory sizes (Java: " + javaNetworkBufMem + ", Script: " + scriptNetworkBufMem +
+					") with configuration: " + config.toString(), scriptNetworkBufMem,
+				allOf(greaterThanOrEqualTo(javaNetworkBufMem - absoluteTolerance),
+					lessThanOrEqualTo(javaNetworkBufMem + absoluteTolerance)));
+		}
+	}
+
+	/**
+	 * Calculates the heap size via
+	 * {@link TaskManagerServices#calculateHeapSizeMB(long, Configuration)} and the shell script
+	 * and verifies that these are equal.
+	 *
+	 * @param config     flink configuration
+	 * @param tolerance  tolerate values that are off by this factor (0.01 = 1%)
+	 */
+	private void compareHeapSizeJavaVsScript(final Configuration config, float tolerance)
+			throws IOException {
+
+		final long totalJavaMemorySizeMB = config.getLong(KEY_TASKM_MEM_SIZE, 0L);
+
+		long javaHeapSizeMB = TaskManagerServices.calculateHeapSizeMB(totalJavaMemorySizeMB, config);
+
+		String[] command = {"src/test/bin/calculateTaskManagerHeapSizeMB.sh",
+			String.valueOf(totalJavaMemorySizeMB),
+			String.valueOf(config.getBoolean(TaskManagerOptions.MEMORY_OFF_HEAP)),
+			String.valueOf(config.getFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION)),
+			String.valueOf(config.getLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN)),
+			String.valueOf(config.getLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX)),
+			String.valueOf(config.getLong(TaskManagerOptions.MANAGED_MEMORY_SIZE)),
+			String.valueOf(config.getFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION))};
+		String scriptOutput = executeScript(command);
+
+		long absoluteTolerance = (long) (javaHeapSizeMB * tolerance);
+		if (absoluteTolerance < 1) {
+			assertEquals("Different heap sizes with configuration: " + config.toString(),
+				String.valueOf(javaHeapSizeMB), scriptOutput);
+		} else {
+			Long scriptHeapSizeMB = Long.valueOf(scriptOutput);
+			assertThat(
+				"Different heap sizes (Java: " + javaHeapSizeMB + ", Script: " + scriptHeapSizeMB +
+					") with configuration: " + config.toString(), scriptHeapSizeMB,
+				allOf(greaterThanOrEqualTo(javaHeapSizeMB - absoluteTolerance),
+					lessThanOrEqualTo(javaHeapSizeMB + absoluteTolerance)));
+		}
+	}
+
+	/**
+	 * Executes the given shell script wrapper and returns its output.
+	 *
+	 * @param command  command to run
+	 *
+	 * @return raw script output
+	 */
+	private String executeScript(final String[] command) throws IOException {
+		ProcessBuilder pb = new ProcessBuilder(command);
+		pb.redirectErrorStream(true);
+		Process process = pb.start();
+		BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+		StringBuilder sb = new StringBuilder();
+		String s;
+		while ((s = reader.readLine()) != null) {
+			sb.append(s);
+		}
+		return sb.toString();
+	}
+
+}

--- a/flink-dist/src/test/resources/log4j-test.properties
+++ b/flink-dist/src/test/resources/log4j-test.properties
@@ -1,0 +1,35 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=OFF, console
+
+# -----------------------------------------------------------------------------
+# Console (use 'console')
+# -----------------------------------------------------------------------------
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+# -----------------------------------------------------------------------------
+# File (use 'file')
+# -----------------------------------------------------------------------------
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.file=${log.dir}/${mvn.forkNumber}.log
+log4j.appender.file.append=false
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -304,7 +304,7 @@ public class BootstrapTools {
 	 * Get an instance of the dynamic properties option.
 	 *
 	 * Dynamic properties allow the user to specify additional configuration values with -D, such as
-	 *  -Dfs.overwrite-files=true  -Dtaskmanager.network.numberOfBuffers=16368
+	 * <tt> -Dfs.overwrite-files=true  -Dtaskmanager.network.memory.min=536346624</tt>
      */
 	public static Option newDynamicPropertiesOption() {
 		return new Option(DYNAMIC_PROPERTIES_OPT, true, "Dynamic properties");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -194,12 +194,15 @@ public class NetworkBufferPool implements BufferPoolFactory {
 			if (numTotalRequiredBuffers + numRequiredBuffers > totalNumberOfMemorySegments) {
 				throw new IOException(String.format("Insufficient number of network buffers: " +
 								"required %d, but only %d available. The total number of network " +
-								"buffers is currently set to %d. You can increase this " +
-								"number by setting the configuration key '%s'.",
+								"buffers is currently set to %d of %d bytes each. You can increase this " +
+								"number by setting the configuration keys '%s', '%s', and '%s'.",
 						numRequiredBuffers,
 						totalNumberOfMemorySegments - numTotalRequiredBuffers,
 						totalNumberOfMemorySegments,
-						TaskManagerOptions.NETWORK_NUM_BUFFERS.key()));
+						memorySegmentSize,
+						TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION.key(),
+						TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN.key(),
+						TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.key()));
 			}
 
 			this.numTotalRequiredBuffers += numRequiredBuffers;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -53,8 +53,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>Since the network buffer pool size for outgoing partitions is usually
  * quite small, e.g. via the {@link TaskManagerOptions#NETWORK_BUFFERS_PER_CHANNEL}
  * and {@link TaskManagerOptions#NETWORK_EXTRA_BUFFERS_PER_GATE} parameters
- * for bounded channels or from the default value of
- * {@link TaskManagerOptions#NETWORK_NUM_BUFFERS}, most spillable partitions
+ * for bounded channels or from the default values of
+ * {@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_FRACTION},
+ * {@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MIN}, and
+ * {@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MAX}, most spillable partitions
  * will be spilled for real-world data sets.
  */
 class SpillableSubpartition extends ResultSubpartition {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import scala.concurrent.duration.FiniteDuration;
 
@@ -190,7 +191,7 @@ public class MiniClusterConfiguration {
 	 * 3. Distribute the available free memory equally among all components (JMs, RMs and TMs) and
 	 * calculate the managed memory from the share of memory for a single task manager.
 	 *
-	 * @return
+	 * @return size of managed memory per task manager (in megabytes)
 	 */
 	private long getOrCalculateManagedMemoryPerTaskManager() {
 		if (managedMemoryPerTaskManager == -1) {
@@ -206,9 +207,6 @@ public class MiniClusterConfiguration {
 				// share the available memory among all running components
 
 				float memoryFraction = config.getFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION);
-				long networkBuffersMemory =
-					(long) config.getInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS) *
-						(long) config.getInteger(TaskManagerOptions.MEMORY_SEGMENT_SIZE);
 
 				long freeMemory = EnvironmentInformation.getSizeOfFreeHeapMemoryWithDefrag();
 
@@ -217,12 +215,13 @@ public class MiniClusterConfiguration {
 				long memoryPerComponent = freeMemory / (numTaskManagers + numResourceManagers + numJobManagers);
 
 				// subtract the network buffer memory
+				long networkBuffersMemory = TaskManagerServices.calculateNetworkBuf(memoryPerComponent, config);
 				long memoryMinusNetworkBuffers = memoryPerComponent - networkBuffersMemory;
 
 				// calculate the managed memory size
 				long managedMemoryBytes = (long) (memoryMinusNetworkBuffers * memoryFraction);
 
-				return managedMemoryBytes >>> 20;
+				return managedMemoryBytes >> 20; // bytes to megabytes
 			} else {
 				return memorySize;
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -215,7 +215,7 @@ public class MiniClusterConfiguration {
 				long memoryPerComponent = freeMemory / (numTaskManagers + numResourceManagers + numJobManagers);
 
 				// subtract the network buffer memory
-				long networkBuffersMemory = TaskManagerServices.calculateNetworkBuf(memoryPerComponent, config);
+				long networkBuffersMemory = TaskManagerServices.calculateNetworkBufferMemory(memoryPerComponent, config);
 				long memoryMinusNetworkBuffers = memoryPerComponent - networkBuffersMemory;
 
 				// calculate the managed memory size

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -257,7 +257,7 @@ public class TaskManagerServices {
 			}
 			memorySize = configuredMemory << 20; // megabytes to bytes
 		} else {
-			// similar to #calculateNetworkBuf(TaskManagerServicesConfiguration tmConfig)
+			// similar to #calculateNetworkBufferMemory(TaskManagerServicesConfiguration tmConfig)
 			float memoryFraction = taskManagerServicesConfiguration.getMemoryFraction();
 
 			if (memType == MemoryType.HEAP) {
@@ -327,7 +327,7 @@ public class TaskManagerServices {
 
 		NetworkEnvironmentConfiguration networkEnvironmentConfiguration = taskManagerServicesConfiguration.getNetworkConfig();
 
-		final long networkBuf = calculateNetworkBuf(taskManagerServicesConfiguration);
+		final long networkBuf = calculateNetworkBufferMemory(taskManagerServicesConfiguration);
 		int segmentSize = networkEnvironmentConfiguration.networkBufferSize();
 
 		// tolerate offcuts between intended and allocated memory due to segmentation (will be available to the user-space memory)
@@ -411,8 +411,8 @@ public class TaskManagerServices {
 	 * @return memory to use for network buffers (in bytes)
 	 */
 	@SuppressWarnings("deprecation")
-	public static long calculateNetworkBuf(long totalJavaMemorySize, Configuration config) {
-		assert totalJavaMemorySize > 0;
+	public static long calculateNetworkBufferMemory(long totalJavaMemorySize, Configuration config) {
+		Preconditions.checkArgument(totalJavaMemorySize > 0);
 
 		int segmentSize = config.getInteger(TaskManagerOptions.MEMORY_SEGMENT_SIZE);
 
@@ -475,7 +475,7 @@ public class TaskManagerServices {
 	 *
 	 * @return memory to use for network buffers (in bytes)
 	 */
-	public static long calculateNetworkBuf(TaskManagerServicesConfiguration tmConfig) {
+	public static long calculateNetworkBufferMemory(TaskManagerServicesConfiguration tmConfig) {
 		final NetworkEnvironmentConfiguration networkConfig = tmConfig.getNetworkConfig();
 
 		final float networkBufFraction = networkConfig.networkBufFraction();
@@ -564,7 +564,7 @@ public class TaskManagerServices {
 	 * @return heap memory to use (in megabytes)
 	 */
 	public static long calculateHeapSizeMB(long totalJavaMemorySizeMB, Configuration config) {
-		assert totalJavaMemorySizeMB > 0;
+		Preconditions.checkArgument(totalJavaMemorySizeMB > 0);
 
 		final long totalJavaMemorySize = totalJavaMemorySizeMB << 20; // megabytes to bytes
 
@@ -576,7 +576,7 @@ public class TaskManagerServices {
 		if (useOffHeap) {
 
 			// subtract the Java memory used for network buffers
-			final long networkBufMB = calculateNetworkBuf(totalJavaMemorySize, config) >> 20; // bytes to megabytes
+			final long networkBufMB = calculateNetworkBufferMemory(totalJavaMemorySize, config) >> 20; // bytes to megabytes
 			final long remainingJavaMemorySizeMB = totalJavaMemorySizeMB - networkBufMB;
 
 			long offHeapSize = config.getLong(TaskManagerOptions.MANAGED_MEMORY_SIZE);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -46,7 +48,6 @@ import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.util.Preconditions;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -256,9 +257,11 @@ public class TaskManagerServices {
 			}
 			memorySize = configuredMemory << 20; // megabytes to bytes
 		} else {
+			// similar to #calculateNetworkBuf(TaskManagerServicesConfiguration tmConfig)
 			float memoryFraction = taskManagerServicesConfiguration.getMemoryFraction();
 
 			if (memType == MemoryType.HEAP) {
+				// network buffers already allocated -> use memoryFraction of the remaining heap:
 				long relativeMemSize = (long) (EnvironmentInformation.getSizeOfFreeHeapMemoryWithDefrag() * memoryFraction);
 				if (preAllocateMemory) {
 					LOG.info("Using {} of the currently free heap space for managed heap memory ({} MB)." ,
@@ -269,7 +272,10 @@ public class TaskManagerServices {
 				}
 				memorySize = relativeMemSize;
 			} else if (memType == MemoryType.OFF_HEAP) {
-				// The maximum heap memory has been adjusted according to the fraction
+				// The maximum heap memory has been adjusted according to the fraction (see
+				// calculateHeapSizeMB(long totalJavaMemorySizeMB, Configuration config)), i.e.
+				// maxJvmHeap = jvmHeapNoNet - jvmHeapNoNet * memoryFraction = jvmHeapNoNet * (1 - memoryFraction)
+				// directMemorySize = jvmHeapNoNet * memoryFraction
 				long maxMemory = EnvironmentInformation.getMaxJvmHeapMemory();
 				long directMemorySize = (long) (maxMemory / (1.0 - memoryFraction) * memoryFraction);
 				if (preAllocateMemory) {
@@ -321,9 +327,19 @@ public class TaskManagerServices {
 
 		NetworkEnvironmentConfiguration networkEnvironmentConfiguration = taskManagerServicesConfiguration.getNetworkConfig();
 
+		final long networkBuf = calculateNetworkBuf(taskManagerServicesConfiguration);
+		int segmentSize = networkEnvironmentConfiguration.networkBufferSize();
+
+		// tolerate offcuts between intended and allocated memory due to segmentation (will be available to the user-space memory)
+		final long numNetBuffersLong = networkBuf / segmentSize;
+		if (numNetBuffersLong > Integer.MAX_VALUE) {
+			throw new IllegalArgumentException("The given number of memory bytes (" + networkBuf
+				+ ") corresponds to more than MAX_INT pages.");
+		}
+
 		NetworkBufferPool networkBufferPool = new NetworkBufferPool(
-			networkEnvironmentConfiguration.numNetworkBuffers(),
-			networkEnvironmentConfiguration.networkBufferSize(),
+			(int) numNetBuffersLong,
+			segmentSize,
 			networkEnvironmentConfiguration.memoryType());
 
 		ConnectionManager connectionManager;
@@ -373,6 +389,169 @@ public class TaskManagerServices {
 			networkEnvironmentConfiguration.partitionRequestMaxBackoff(),
 			networkEnvironmentConfiguration.networkBuffersPerChannel(),
 			networkEnvironmentConfiguration.extraNetworkBuffersPerGate());
+	}
+
+	/**
+	 * Calculates the amount of memory used for network buffers based on the total memory to use and
+	 * the according configuration parameters.
+	 *
+	 * The following configuration parameters are involved:
+	 * <ul>
+	 *  <li>{@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_FRACTION},</li>
+	 * 	<li>{@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MIN},</li>
+	 * 	<li>{@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MAX}, and</li>
+	 *  <li>{@link TaskManagerOptions#NETWORK_NUM_BUFFERS} (fallback if the ones above do not exist)</li>
+	 * </ul>.
+	 *
+	 * @param totalJavaMemorySize
+	 * 		overall available memory to use (heap and off-heap, in bytes)
+	 * @param config
+	 * 		configuration object
+	 *
+	 * @return memory to use for network buffers (in bytes)
+	 */
+	public static long calculateNetworkBuf(long totalJavaMemorySize, Configuration config) {
+		final long networkBufBytes;
+		if (TaskManagerServicesConfiguration.hasNewNetworkBufConf(config)) {
+			// new configuration based on fractions of available memory with selectable min and max
+			float networkBufFraction = config.getFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION);
+			long networkBufMin = config.getLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN);
+			long networkBufMax = config.getLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX);
+
+			networkBufBytes = Math.min(networkBufMax, Math.max(networkBufMin,
+				(long) (networkBufFraction * totalJavaMemorySize)));
+		} else {
+			// use old (deprecated) network buffers parameter
+			@SuppressWarnings("deprecation")
+			long numNetworkBuffers = config.getInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS);
+			int segmentSize = config.getInteger(TaskManagerOptions.MEMORY_SEGMENT_SIZE);
+
+			networkBufBytes = numNetworkBuffers * (long) segmentSize;
+		}
+		return networkBufBytes;
+	}
+
+	/**
+	 * Calculates the amount of memory used for network buffers inside the current JVM instance
+	 * based on the available heap or the max heap size and the according configuration parameters.
+	 *
+	 * For containers or when started via scripts, if started with a memory limit and set to use
+	 * off-heap memory, the maximum heap size for the JVM is adjusted accordingly and we are able
+	 * to extract the intended values from this.
+	 *
+	 * The following configuration parameters are involved:
+	 * <ul>
+	 *  <li>{@link TaskManagerOptions#MANAGED_MEMORY_FRACTION},</li>
+	 *  <li>{@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_FRACTION},</li>
+	 * 	<li>{@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MIN},</li>
+	 * 	<li>{@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MAX}, and</li>
+	 *  <li>{@link TaskManagerOptions#NETWORK_NUM_BUFFERS} (fallback if the ones above do not exist)</li>
+	 * </ul>.
+	 *
+	 * @param tmConfig task manager services configuration object
+	 *
+	 * @return memory to use for network buffers (in bytes)
+	 */
+	public static long calculateNetworkBuf(TaskManagerServicesConfiguration tmConfig) {
+		final NetworkEnvironmentConfiguration networkConfig = tmConfig.getNetworkConfig();
+
+		final float networkBufFraction = networkConfig.networkBufFraction();
+		final long networkBufMin = networkConfig.networkBufMin();
+		final long networkBufMax = networkConfig.networkBufMax();
+
+		if (networkBufMin == networkBufMax) {
+			// fixed network buffer pool size
+			return networkBufMin;
+		}
+
+		// relative network buffer pool size using the fraction
+
+		final MemoryType memType = networkConfig.memoryType();
+
+		final long networkBufBytes;
+		if (memType == MemoryType.HEAP) {
+			// use fraction parts of the available heap memory
+
+			final long relativeMemSize = EnvironmentInformation.getSizeOfFreeHeapMemoryWithDefrag();
+			networkBufBytes = Math.min(networkBufMax, Math.max(networkBufMin,
+				(long) (networkBufFraction * relativeMemSize)));
+		} else if (memType == MemoryType.OFF_HEAP) {
+			// The maximum heap memory has been adjusted accordingly as in
+			// calculateHeapSizeMB(long totalJavaMemorySizeMB, Configuration config))
+			// and we need to invert these calculations.
+
+			final long maxMemory = EnvironmentInformation.getMaxJvmHeapMemory();
+
+			// check if a value has been configured
+			long configuredMemory = tmConfig.getConfiguredMemory() << 20; // megabytes to bytes
+
+			final long jvmHeapNoNet;
+			if (configuredMemory > 0) {
+				// The maximum heap memory has been adjusted according to configuredMemory, i.e.
+				// maxJvmHeap = jvmHeapNoNet - configuredMemory
+
+				jvmHeapNoNet = maxMemory + configuredMemory;
+			} else {
+				// The maximum heap memory has been adjusted according to the fraction, i.e.
+				// maxJvmHeap = jvmHeapNoNet - jvmHeapNoNet * managedFraction = jvmHeapNoNet * (1 - managedFraction)
+
+				final float managedFraction = tmConfig.getMemoryFraction();
+				jvmHeapNoNet = (long) (maxMemory / (1.0 - managedFraction));
+			}
+
+			// finally extract the network buffer memory size again from:
+			// jvmHeapNoNet = jvmHeap - networkBufBytes
+			//              = jvmHeap - Math.min(networkBufMax, Math.max(networkBufMin, jvmHeap * netFraction)
+			networkBufBytes = Math.min(networkBufMax, Math.max(networkBufMin,
+				(long) (jvmHeapNoNet / (1.0 - networkBufFraction) * networkBufFraction)));
+		} else {
+			throw new RuntimeException("No supported memory type detected.");
+		}
+
+		return networkBufBytes;
+	}
+
+	/**
+	 * Calculates the amount of heap memory to use (to set via <tt>-Xmx</tt> and <tt>-Xms</tt>)
+	 * based on the total memory to use and the given configuration parameters.
+	 *
+	 * @param totalJavaMemorySizeMB
+	 * 		overall available memory to use (heap and off-heap)
+	 * @param config
+	 * 		configuration object
+	 *
+	 * @return heap memory to use (in megabytes)
+	 */
+	public static long calculateHeapSizeMB(long totalJavaMemorySizeMB, Configuration config) {
+
+
+		final long totalJavaMemorySize = totalJavaMemorySizeMB << 20; // megabytes to bytes
+
+		// split the available Java memory between heap and off-heap
+
+		final boolean useOffHeap = config.getBoolean(TaskManagerOptions.MEMORY_OFF_HEAP);
+
+		final long heapSizeMB;
+		if (useOffHeap) {
+
+			// subtract the Java memory used for network buffers
+			final long networkBufMB = calculateNetworkBuf(totalJavaMemorySize, config) >> 20; // bytes to megabytes
+			final long remainingJavaMemorySizeMB = totalJavaMemorySizeMB - networkBufMB;
+
+			long offHeapSize = config.getLong(TaskManagerOptions.MANAGED_MEMORY_SIZE);
+
+			if (offHeapSize <= 0) {
+				// calculate off-heap section via fraction
+				double fraction = config.getFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION);
+				offHeapSize = (long) (fraction * remainingJavaMemorySizeMB);
+			}
+
+			heapSizeMB = remainingJavaMemorySizeMB - offHeapSize;
+		} else {
+			heapSizeMB = totalJavaMemorySizeMB;
+		}
+
+		return heapSizeMB;
 	}
 
 	/**

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
@@ -353,11 +353,6 @@ class LocalFlinkMiniCluster(
     if (config.getLong(TaskManagerOptions.MANAGED_MEMORY_SIZE) ==
         TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()) {
 
-      val bufferSize: Int = config.getInteger(TaskManagerOptions.MEMORY_SEGMENT_SIZE)
-
-      val bufferMem: Long = config.getInteger(
-        TaskManagerOptions.NETWORK_NUM_BUFFERS).toLong * bufferSize.toLong
-
       val numTaskManager = config.getInteger(
         ConfigConstants.LOCAL_NUMBER_TASK_MANAGER,
         ConfigConstants.DEFAULT_LOCAL_NUMBER_TASK_MANAGER)
@@ -371,10 +366,10 @@ class LocalFlinkMiniCluster(
       // each TaskManagers and each JobManager
       memorySize /= numTaskManager + 1 // the +1 is the job manager
 
-      // for each TaskManager, subtract the memory needed for memory buffers
-      memorySize -= bufferMem
+      // for each TaskManager, subtract the memory needed for network memory buffers
+      memorySize -= TaskManagerServices.calculateNetworkBuf(memorySize, config)
       memorySize = (memorySize * memoryFraction).toLong
-      memorySize >>>= 20 // bytes to megabytes
+      memorySize >>= 20 // bytes to megabytes
       config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, memorySize)
     }
   }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
@@ -367,7 +367,7 @@ class LocalFlinkMiniCluster(
       memorySize /= numTaskManager + 1 // the +1 is the job manager
 
       // for each TaskManager, subtract the memory needed for network memory buffers
-      memorySize -= TaskManagerServices.calculateNetworkBuf(memorySize, config)
+      memorySize -= TaskManagerServices.calculateNetworkBufferMemory(memorySize, config)
       memorySize = (memorySize * memoryFraction).toLong
       memorySize >>= 20 // bytes to megabytes
       config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, memorySize)

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/NetworkEnvironmentConfiguration.scala
@@ -23,7 +23,9 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager.IOMode
 import org.apache.flink.runtime.io.network.netty.NettyConfig
 
 case class NetworkEnvironmentConfiguration(
-    numNetworkBuffers: Int,
+    networkBufFraction: Float,
+    networkBufMin: Long,
+    networkBufMax: Long,
     networkBufferSize: Int,
     memoryType: MemoryType,
     ioMode: IOMode,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfigurationTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit test for {@link TaskManagerServicesConfiguration}.
+ */
+public class TaskManagerServicesConfigurationTest {
+	/**
+	 * Verifies that {@link TaskManagerServicesConfiguration#hasNewNetworkBufConf(Configuration)}
+	 * returns the correct result for old configurations via
+	 * {@link TaskManagerOptions#NETWORK_NUM_BUFFERS}.
+	 */
+	@SuppressWarnings("deprecation")
+	@Test
+	public void hasNewNetworkBufConfOld() throws Exception {
+		Configuration config = new Configuration();
+		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 1);
+
+		assertFalse(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
+	}
+
+	/**
+	 * Verifies that {@link TaskManagerServicesConfiguration#hasNewNetworkBufConf(Configuration)}
+	 * returns the correct result for new configurations via
+	 * {@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_FRACTION},
+	 * {@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MIN} and {@link
+	 * TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MAX}.
+	 */
+	@Test
+	public void hasNewNetworkBufConfNew() throws Exception {
+		Configuration config = new Configuration();
+		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
+
+		// fully defined:
+		config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
+		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, 1024);
+		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 2048);
+
+		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
+
+		// partly defined:
+		config = new Configuration();
+		config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
+		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
+		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 1024);
+		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
+
+		config = new Configuration();
+		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, 1024);
+		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
+		config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
+		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
+
+		config = new Configuration();
+		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 1024);
+		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
+		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, 1024);
+		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
+	}
+
+	/**
+	 * Verifies that {@link TaskManagerServicesConfiguration#hasNewNetworkBufConf(Configuration)}
+	 * returns the correct result for mixed old/new configurations.
+	 */
+	@SuppressWarnings("deprecation")
+	@Test
+	public void hasNewNetworkBufConfMixed() throws Exception {
+		Configuration config = new Configuration();
+		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
+
+		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 1);
+		assertFalse(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
+
+		// old + 1 new parameter = new:
+		Configuration config1 = config.clone();
+		config1.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
+		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config1));
+
+		config1 = config.clone();
+		config1.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, 1024);
+		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config1));
+
+		config1 = config.clone();
+		config1.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 1024);
+		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config1));
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesTest.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.memory.MemoryType;
+import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
+import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
+import org.apache.flink.runtime.util.EnvironmentInformation;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.net.InetAddress;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Unit test for {@link TaskManagerServices}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(EnvironmentInformation.class)
+public class TaskManagerServicesTest {
+
+	/**
+	 * Test for {@link TaskManagerServices#calculateNetworkBuf(long, Configuration)} using old
+	 * configurations via {@link TaskManagerOptions#NETWORK_NUM_BUFFERS}.
+	 */
+	@SuppressWarnings("deprecation")
+	@Test
+	public void calculateNetworkBufOld() throws Exception {
+		Configuration config = new Configuration();
+		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 1);
+
+		// note: actual network buffer memory size is independent of the totalJavaMemorySize
+		assertEquals(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue().longValue(),
+			TaskManagerServices.calculateNetworkBuf(10L << 20, config));
+		assertEquals(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue().longValue(),
+			TaskManagerServices.calculateNetworkBuf(64L << 20, config));
+
+		// test integer overflow in the memory size
+		int numBuffers = (int) ((2L << 32) / TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue()); // 2^33
+		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, numBuffers);
+		assertEquals(2L << 32, TaskManagerServices.calculateNetworkBuf(2L << 33, config));
+	}
+
+	/**
+	 * Test for {@link TaskManagerServices#calculateNetworkBuf(long, Configuration)} using new
+	 * configurations via {@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_FRACTION},
+	 * {@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MIN} and
+	 * {@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MAX}.
+	 */
+	@Test
+	public void calculateNetworkBufNew() throws Exception {
+		Configuration config = new Configuration();
+
+		// (1) defaults
+		final Float defaultFrac = TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION.defaultValue();
+		final Long defaultMin = TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN.defaultValue();
+		final Long defaultMax = TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.defaultValue();
+		assertEquals(Math.min(defaultMax, Math.max(defaultMin, (long) (defaultFrac * (10L << 20)))),
+			TaskManagerServices.calculateNetworkBuf((64L << 20 + 1), config));
+		assertEquals(Math.min(defaultMax, Math.max(defaultMin, (long) (defaultFrac * (10L << 30)))),
+			TaskManagerServices.calculateNetworkBuf((10L << 30), config));
+
+		calculateNetworkBufNew(config);
+	}
+
+	/**
+	 * Helper to test {@link TaskManagerServices#calculateNetworkBuf(long, Configuration)} with the
+	 * new configuration parameters.
+	 *
+	 * @param config configuration object
+	 */
+	private static void calculateNetworkBufNew(final Configuration config) {
+		// (2) fixed size memory
+		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, 1L << 20); // 1MB
+		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 1L << 20); // 1MB
+
+		// note: actual network buffer memory size is independent of the totalJavaMemorySize
+		assertEquals(1 << 20, TaskManagerServices.calculateNetworkBuf(10L << 20, config));
+		assertEquals(1 << 20, TaskManagerServices.calculateNetworkBuf(64L << 20, config));
+		assertEquals(1 << 20, TaskManagerServices.calculateNetworkBuf(1L << 30, config));
+
+		// (3) random fraction, min, and max values
+		Random ran = new Random();
+		for (int i = 0; i < 1_000; ++i){
+			float frac = Math.max(ran.nextFloat(), Float.MIN_VALUE);
+			config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, frac);
+
+			long min = Math.max(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue(), ran.nextLong());
+			config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, min);
+
+			long max = Math.max(min, ran.nextLong());
+			config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, max);
+
+			long javaMem = Math.max(max + 1, ran.nextLong());
+
+			final long networkBufMem = TaskManagerServices.calculateNetworkBuf(javaMem, config);
+			assertTrue(networkBufMem >= min);
+			assertTrue(networkBufMem <= max);
+			if (networkBufMem > min && networkBufMem < max) {
+				assertEquals((long) (javaMem * frac), networkBufMem);
+			}
+		}
+	}
+
+	/**
+	 * Test for {@link TaskManagerServices#calculateNetworkBuf(long, Configuration)} using mixed
+	 * old/new configurations.
+	 */
+	@SuppressWarnings("deprecation")
+	@Test
+	public void calculateNetworkBufMixed() throws Exception {
+		Configuration config = new Configuration();
+		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 1);
+
+		final Float defaultFrac = TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION.defaultValue();
+		final Long defaultMin = TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN.defaultValue();
+		final Long defaultMax = TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.defaultValue();
+
+		// old + 1 new parameter = new:
+		Configuration config1 = config.clone();
+		config1.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
+		assertEquals(Math.min(defaultMax, Math.max(defaultMin, (long) (0.1f * (10L << 20)))),
+			TaskManagerServices.calculateNetworkBuf((64L << 20 + 1), config1));
+		assertEquals(Math.min(defaultMax, Math.max(defaultMin, (long) (0.1f * (10L << 30)))),
+			TaskManagerServices.calculateNetworkBuf((10L << 30), config1));
+
+		config1 = config.clone();
+		long newMin = TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue(); // smallest value possible
+		config1.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, newMin);
+		assertEquals(Math.min(defaultMax, Math.max(newMin, (long) (defaultFrac * (10L << 20)))),
+			TaskManagerServices.calculateNetworkBuf((10L << 20), config1));
+		assertEquals(Math.min(defaultMax, Math.max(newMin, (long) (defaultFrac * (10L << 30)))),
+			TaskManagerServices.calculateNetworkBuf((10L << 30), config1));
+
+		config1 = config.clone();
+		long newMax = Math.max(64L << 20 + 1, TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN.defaultValue());
+		config1.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, newMax);
+		assertEquals(Math.min(newMax, Math.max(defaultMin, (long) (defaultFrac * (10L << 20)))),
+			TaskManagerServices.calculateNetworkBuf((64L << 20 + 1), config1));
+		assertEquals(Math.min(newMax, Math.max(defaultMin, (long) (defaultFrac * (10L << 30)))),
+			TaskManagerServices.calculateNetworkBuf((10L << 30), config1));
+		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config1));
+
+		// old + any new parameter = new:
+		calculateNetworkBufNew(config);
+	}
+
+	/**
+	 * Test for {@link TaskManagerServices#calculateNetworkBuf(TaskManagerServicesConfiguration)}
+	 * using the same (manual) test cases as in {@link #calculateHeapSizeMB()}.
+	 */
+	@Test
+	public void calculateNetworkBufFromHeapSize() throws Exception {
+		PowerMockito.mockStatic(EnvironmentInformation.class);
+		// some defaults:
+		when(EnvironmentInformation.getSizeOfFreeHeapMemoryWithDefrag()).thenReturn(1000L << 20); // 1000MB
+		when(EnvironmentInformation.getMaxJvmHeapMemory()).thenReturn(1000L << 20); // 1000MB
+
+		TaskManagerServicesConfiguration tmConfig;
+
+		tmConfig = getTmConfig(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue(),
+			TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
+			0.1f, 60L << 20, 1L << 30, MemoryType.HEAP);
+		when(EnvironmentInformation.getSizeOfFreeHeapMemoryWithDefrag()).thenReturn(1000L << 20); // 1000MB
+		assertEquals(100L << 20, TaskManagerServices.calculateNetworkBuf(tmConfig));
+
+		tmConfig = getTmConfig(10, TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
+			0.1f, 60L << 20, 1L << 30, MemoryType.OFF_HEAP);
+		when(EnvironmentInformation.getMaxJvmHeapMemory()).thenReturn(890L << 20); // 890MB
+		assertEquals((100L << 20) + 1 /* one too many due to floating point imprecision */,
+			TaskManagerServices.calculateNetworkBuf(tmConfig));
+
+		tmConfig = getTmConfig(-1, 0.1f,
+			0.1f, 60L << 20, 1L << 30, MemoryType.OFF_HEAP);
+		when(EnvironmentInformation.getMaxJvmHeapMemory()).thenReturn(810L << 20); // 810MB
+		assertEquals((100L << 20) + 1 /* one too many due to floating point imprecision */,
+			TaskManagerServices.calculateNetworkBuf(tmConfig));
+	}
+
+	/**
+	 * Returns a task manager services configuration for the tests
+	 *
+	 * @param managedMemory         see {@link TaskManagerOptions#MANAGED_MEMORY_SIZE}
+	 * @param managedMemoryFraction see {@link TaskManagerOptions#MANAGED_MEMORY_FRACTION}
+	 * @param networkBufFraction	see {@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_FRACTION}
+	 * @param networkBufMin			see {@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MIN}
+	 * @param networkBufMax			see {@link TaskManagerOptions#NETWORK_BUFFERS_MEMORY_MAX}
+	 * @param memType				on-heap or off-heap
+	 *
+	 * @return configuration object
+	 */
+	private static TaskManagerServicesConfiguration getTmConfig(
+		final long managedMemory, final float managedMemoryFraction, float networkBufFraction,
+		long networkBufMin, long networkBufMax,
+		final MemoryType memType) {
+
+		final NetworkEnvironmentConfiguration networkConfig = new NetworkEnvironmentConfiguration(
+			networkBufFraction,
+			networkBufMin,
+			networkBufMax,
+			TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue(),
+			memType,
+			null,
+			TaskManagerOptions.NETWORK_REQUEST_BACKOFF_INITIAL.defaultValue(),
+			TaskManagerOptions.NETWORK_REQUEST_BACKOFF_MAX.defaultValue(),
+			TaskManagerOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue(),
+			TaskManagerOptions.NETWORK_EXTRA_BUFFERS_PER_GATE.defaultValue(),
+			null);
+
+		return new TaskManagerServicesConfiguration(
+			mock(InetAddress.class),
+			new String[] {},
+			networkConfig,
+			QueryableStateConfiguration.disabled(),
+			1,
+			managedMemory,
+			false,
+			managedMemoryFraction,
+			mock(MetricRegistryConfiguration.class),
+			0);
+	}
+
+	/**
+	 * Test for {@link TaskManagerServices#calculateHeapSizeMB(long, Configuration)} with some
+	 * manually calculated scenarios.
+	 */
+	@Test
+	public void calculateHeapSizeMB() throws Exception {
+		Configuration config = new Configuration();
+		config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
+		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, 64L << 20); // 64MB
+		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 1L << 30); // 1GB
+
+		config.setBoolean(TaskManagerOptions.MEMORY_OFF_HEAP, false);
+		assertEquals(1000, TaskManagerServices.calculateHeapSizeMB(1000, config));
+
+		config.setBoolean(TaskManagerOptions.MEMORY_OFF_HEAP, true);
+		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 10); // 10MB
+		assertEquals(890, TaskManagerServices.calculateHeapSizeMB(1000, config));
+
+		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, -1); // use fraction of given memory
+		config.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, 0.1f); // 10%
+		assertEquals(810, TaskManagerServices.calculateHeapSizeMB(1000, config));
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
@@ -112,18 +112,21 @@ public class TaskManagerComponentsStartupShutdownTest {
 				config,
 				false); // exit-jvm-on-fatal-error
 
+			final int networkBufNum = 32;
+			// note: the network buffer memory configured here is not actually used below but set
+			// accordingly to be consistent
 			final NetworkEnvironmentConfiguration netConf = new NetworkEnvironmentConfiguration(
-					32, BUFFER_SIZE, MemoryType.HEAP, IOManager.IOMode.SYNC,
+					0.1f, networkBufNum * BUFFER_SIZE, networkBufNum * BUFFER_SIZE, BUFFER_SIZE, MemoryType.HEAP, IOManager.IOMode.SYNC,
 					0, 0, 2, 8, null);
 
 			ResourceID taskManagerId = ResourceID.generate();
 			
 			final TaskManagerLocation connectionInfo = new TaskManagerLocation(taskManagerId, InetAddress.getLocalHost(), 10000);
 
-			final MemoryManager memManager = new MemoryManager(32 * BUFFER_SIZE, 1, BUFFER_SIZE, MemoryType.HEAP, false);
+			final MemoryManager memManager = new MemoryManager(networkBufNum * BUFFER_SIZE, 1, BUFFER_SIZE, MemoryType.HEAP, false);
 			final IOManager ioManager = new IOManagerAsync(TMP_DIR);
 			final NetworkEnvironment network = new NetworkEnvironment(
-				new NetworkBufferPool(netConf.numNetworkBuffers(), netConf.networkBufferSize(), netConf.memoryType()),
+				new NetworkBufferPool(32, netConf.networkBufferSize(), netConf.memoryType()),
 				new LocalConnectionManager(),
 				new ResultPartitionManager(),
 				new TaskEventDispatcher(),

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
@@ -101,6 +101,8 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 2);
 		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, PARALLELISM / 2);
 		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 48L);
+		// the default network buffers size (10% of heap max =~ 150MB) seems to much for this test case
+		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 80L << 20); // 80 MB
 
 		cluster = new LocalFlinkMiniCluster(config, false);
 		cluster.start();

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnCLI.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnCLI.java
@@ -67,7 +67,7 @@ public class FlinkYarnCLI implements CustomCommandLine<YarnClusterClientV2> {
 
 	/**
 	 * Dynamic properties allow the user to specify additional configuration values with -D, such as
-	 *  -D fs.overwrite-files=true  -D taskmanager.network.numberOfBuffers=16368
+	 * <tt> -Dfs.overwrite-files=true  -Dtaskmanager.network.memory.min=536346624</tt>
 	 */
 	private final Option DYNAMIC_PROPERTIES;
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -119,7 +119,7 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 
 	/**
 	 * Dynamic properties allow the user to specify additional configuration values with -D, such as
-	 *  -D fs.overwrite-files=true  -D taskmanager.network.numberOfBuffers=16368
+	 * <tt> -Dfs.overwrite-files=true  -Dtaskmanager.network.memory.min=536346624</tt>
 	 */
 	private final Option DYNAMIC_PROPERTIES;
 


### PR DESCRIPTION
(based on #3708 and #3713)

Instead, allow the configuration with the following three new (more flexible) parameters:
* `taskmanager.network.memory.fraction`: fraction of JVM memory to use for network buffers (default: 0.1)
* `taskmanager.network.memory.min`: minimum memory size for network buffers (default: 64 MB)
* `taskmanager.network.memory.max`: maximum memory size for network buffers (default: 1 GB)

Note that I needed to adapt two unit tests which would have been killed on Travis CI because these defaults result in ~150MB memory being used for network buffers which apparently was too much there.