### PR TITLE
[FLINK-6312]update curator version to 2.12.0 to avoid potential block

### DIFF
--- a/flink-contrib/flink-storm-examples/pom.xml
+++ b/flink-contrib/flink-storm-examples/pom.xml
@@ -84,6 +84,10 @@ under the License.
 					<groupId>org.apache.storm</groupId>
 					<artifactId>storm-core</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.curator</groupId>
+					<artifactId>curator-framework</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -22,7 +22,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.BackgroundCallback;
 import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.curator.framework.api.CuratorEventType;
-import org.apache.curator.framework.api.Pathable;
+import org.apache.curator.framework.api.ErrorListenerPathable;
 import org.apache.curator.utils.EnsurePath;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.concurrent.Executors;
@@ -127,12 +127,12 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 				.delete()
 				.deletingChildrenIfNeeded()
 				.inBackground(any(BackgroundCallback.class), any(Executor.class))
-		).thenAnswer(new Answer<Pathable<Void>>() {
+		).thenAnswer(new Answer<ErrorListenerPathable<Void>>() {
 			@Override
-			public Pathable<Void> answer(InvocationOnMock invocation) throws Throwable {
+			public ErrorListenerPathable<Void> answer(InvocationOnMock invocation) throws Throwable {
 				final BackgroundCallback callback = (BackgroundCallback) invocation.getArguments()[0];
 
-				Pathable<Void> result = mock(Pathable.class);
+				ErrorListenerPathable<Void> result = mock(ErrorListenerPathable.class);
 
 				when(result.forPath(anyString())).thenAnswer(new Answer<Void>() {
 					@Override

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ under the License.
 		<chill.version>0.7.4</chill.version>
 		<asm.version>5.0.4</asm.version>
 		<zookeeper.version>3.4.6</zookeeper.version>
-		<curator.version>2.8.0</curator.version>
+		<curator.version>2.12.0</curator.version>
 		<jackson.version>2.7.4</jackson.version>
 		<metrics.version>3.1.0</metrics.version>
 		<junit.version>4.12</junit.version>


### PR DESCRIPTION
As there's a Major bug([CURATOR-344](https://issues.apache.org/jira/browse/CURATOR-344)) in curator release used by flink, we need to update the release to 2.12.0 to avoid potential block in flink.

 (flink use recipes in checkpoint coordinator and we have already occurred problem in zookeeper failover when we're trying to fix [FLINK-6174](https://issues.apache.org/jira/browse/FLINK-6174))