### PR TITLE
[FLINK-6315] Notify on checkpoint timeout

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -365,7 +365,7 @@ public class CheckpointCoordinator {
 
 	@VisibleForTesting
 	CheckpointTriggerResult triggerCheckpoint(
-			long timestamp,
+			final long timestamp,
 			CheckpointProperties props,
 			String targetDirectory,
 			boolean isPeriodic) {
@@ -505,6 +505,13 @@ public class CheckpointCoordinator {
 							checkpoint.abortExpired();
 							pendingCheckpoints.remove(checkpointID);
 							rememberRecentCheckpointId(checkpointID);
+
+							for (ExecutionVertex ev : tasksToCommitTo) {
+								Execution ee = ev.getCurrentExecutionAttempt();
+								if (ee != null) {
+									ee.notifyCheckpointTimeout(checkpointID, timestamp);
+								}
+							}
 
 							triggerQueuedRequests();
 						}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -671,6 +671,19 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		}
 	}
 
+	public void notifyCheckpointTimeout(long checkpointId, long timestamp) {
+		final SimpleSlot slot = assignedResource;
+
+		if (slot != null) {
+			final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
+
+			taskManagerGateway.notifyCheckpointTimeout(attemptId, getVertex().getJobId(), checkpointId, timestamp);
+		} else {
+			LOG.debug("The execution has no slot assigned. This indicates that the execution is " +
+				"no longer running.");
+		}
+	}
+
 	/**
 	 * Trigger a new checkpoint on the task of this execution.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/StatefulTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/StatefulTask.java
@@ -85,4 +85,13 @@ public interface StatefulTask {
 	 * @throws Exception The notification method may forward its exceptions.
 	 */
 	void notifyCheckpointComplete(long checkpointId) throws Exception;
+
+	/**
+	 * Invoked when a checkpoint has timed out, i.e., when the checkpoint coordinator has
+	 * not received the notification from all participating tasks within the allowed time frame.
+	 *
+	 * @param checkpointId The ID of the checkpoint that is complete..
+	 * @throws Exception The notification method may forward its exceptions.
+	 */
+	void notifyCheckpointTimeout(long checkpointId) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/ActorTaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/ActorTaskManagerGateway.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.messages.StackTraceSampleResponse;
 import org.apache.flink.runtime.messages.TaskManagerMessages;
 import org.apache.flink.runtime.messages.TaskMessages;
 import org.apache.flink.runtime.messages.checkpoint.NotifyCheckpointComplete;
+import org.apache.flink.runtime.messages.checkpoint.NotifyCheckpointTimeout;
 import org.apache.flink.runtime.messages.checkpoint.TriggerCheckpoint;
 import org.apache.flink.util.Preconditions;
 import scala.concurrent.duration.FiniteDuration;
@@ -190,6 +191,14 @@ public class ActorTaskManagerGateway implements TaskManagerGateway {
 		Preconditions.checkNotNull(jobId);
 
 		actorGateway.tell(new NotifyCheckpointComplete(jobId, executionAttemptID, checkpointId, timestamp));
+	}
+
+	@Override
+	public void notifyCheckpointTimeout(ExecutionAttemptID executionAttemptID, JobID jobId, long checkpointId, long timestamp) {
+		Preconditions.checkNotNull(executionAttemptID);
+		Preconditions.checkNotNull(jobId);
+
+		actorGateway.tell(new NotifyCheckpointTimeout(jobId, executionAttemptID, checkpointId, timestamp));
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
@@ -155,6 +155,20 @@ public interface TaskManagerGateway {
 		long timestamp);
 
 	/**
+	 * Notify the given task about a checkpoint timeout.
+	 *
+	 * @param executionAttemptID identifying the task
+	 * @param jobId identifying the job to which the task belongs
+	 * @param checkpointId of the completed checkpoint
+	 * @param timestamp of the completed checkpoint
+	 */
+	void notifyCheckpointTimeout(
+		ExecutionAttemptID executionAttemptID,
+		JobID jobId,
+		long checkpointId,
+		long timestamp);
+
+	/**
 	 * Trigger for the given task a checkpoint.
 	 *
 	 * @param executionAttemptID identifying the task

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
@@ -124,6 +124,11 @@ public class RpcTaskManagerGateway implements TaskManagerGateway {
 	}
 
 	@Override
+	public void notifyCheckpointTimeout(ExecutionAttemptID executionAttemptID, JobID jobId, long checkpointId, long timestamp) {
+		throw new UnsupportedOperationException("Operation is not yet supported.");
+	}
+
+	@Override
 	public void triggerCheckpoint(ExecutionAttemptID executionAttemptID, JobID jobId, long checkpointId, long timestamp, CheckpointOptions checkpointOptions) {
 //		taskExecutorGateway.triggerCheckpoint(executionAttemptID, jobId, checkpointId, timestamp);
 		throw new UnsupportedOperationException("Operation is not yet supported.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/NotifyCheckpointTimeout.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/NotifyCheckpointTimeout.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.messages.checkpoint;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+
+/**
+ * This message is sent from the {@link org.apache.flink.runtime.jobmanager.JobManager} to the
+ * {@link org.apache.flink.runtime.taskmanager.TaskManager} to tell a task that the checkpoint
+ * has timed out and any partial state changes to the outside world should be rolled back or
+ * ignored.
+ */
+public class NotifyCheckpointTimeout extends AbstractCheckpointMessage implements java.io.Serializable {
+
+	private static final long serialVersionUID = 2094094662279578953L;
+
+	/** The timestamp associated with the checkpoint */
+	private final long timestamp;
+
+	public NotifyCheckpointTimeout(JobID job, ExecutionAttemptID taskExecutionId, long checkpointId, long timestamp) {
+		super(job, taskExecutionId, checkpointId);
+		this.timestamp = timestamp;
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public int hashCode() {
+		return super.hashCode() + (int) (timestamp ^ (timestamp >>> 32));
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		else if (o instanceof NotifyCheckpointTimeout) {
+			NotifyCheckpointTimeout that = (NotifyCheckpointTimeout) o;
+			return this.timestamp == that.timestamp && super.equals(o);
+		}
+		else {
+			return false;
+		}
+	}
+
+	@Override
+	public String toString() {
+		return String.format("ConfirmCheckpoint %d for (%s/%s)",
+			getCheckpointId(), getJob(), getTaskExecutionId());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointTimeoutListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointTimeoutListener.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state;
+
+
+/**
+ * This interface must be implemented by functions/operations that want to receive
+ * a notification if a checkpoint has been {@link org.apache.flink.runtime.checkpoint.CheckpointCoordinator}
+ */
+public interface CheckpointTimeoutListener {
+
+	/**
+	 * This method is called as a notification if a distributed checkpoint has been timed out.
+	 *
+	 * @param checkpointId The ID of the checkpoint that has been timed out.
+	 * @throws Exception
+	 */
+	void notifyCheckpointTimeout(long checkpointId) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -554,6 +554,24 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 		}
 	}
 
+	@RpcMethod
+	public Acknowledge timeoutCheckpoint(ExecutionAttemptID executionAttemptID, long checkpointId, long checkpointTimestamp) throws CheckpointException {
+		log.debug("Notify checkpoint timeout {}@{} for {}.", checkpointId, checkpointTimestamp, executionAttemptID);
+
+		final Task task = taskSlotTable.getTask(executionAttemptID);
+
+		if (task != null) {
+			task.notifyCheckpointTimeout(checkpointId);
+
+			return Acknowledge.get();
+		} else {
+			final String message = "TaskManager received a checkpoint timeout notification for unknown task " + executionAttemptID + '.';
+
+			log.debug(message);
+			throw new CheckpointException(message);
+		}
+	}
+
 	// ----------------------------------------------------------------------
 	// Slot allocation RPCs
 	// ----------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -116,6 +116,17 @@ public interface TaskExecutorGateway extends RpcGateway {
 	Future<Acknowledge> confirmCheckpoint(ExecutionAttemptID executionAttemptID, long checkpointId, long checkpointTimestamp);
 
 	/**
+	 * Notify a given task that a checkpoint has timed out. The checkpoint is identified by the checkpoint ID
+	 * and the checkpoint timestamp.
+	 *
+	 * @param executionAttemptID identifying the task
+	 * @param checkpointId unique id for the checkpoint
+	 * @param checkpointTimestamp is the timestamp when the checkpoint has been initiated
+	 * @return Future acknowledge if the checkpoint time out has been successfully confirmed
+	 */
+	Future<Acknowledge> timeoutCheckpoint(ExecutionAttemptID executionAttemptID, long checkpointId, long checkpointTimestamp);
+
+	/**
 	 * Stop the given task.
 	 *
 	 * @param executionAttemptID identifying the task

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -650,6 +650,11 @@ public class JobManagerHARecoveryTest {
 			}
 		}
 
+		@Override
+		public void notifyCheckpointTimeout(long checkpointId) throws Exception {
+
+		}
+
 		public static void initializeStaticHelpers(int numSubtasks) {
 			completedCheckpointsLatch = new CountDownLatch(numSubtasks);
 			recoveredStates = new long[numSubtasks];

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/messages/CheckpointMessagesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/messages/CheckpointMessagesTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.messages.checkpoint.NotifyCheckpointComplete;
+import org.apache.flink.runtime.messages.checkpoint.NotifyCheckpointTimeout;
 import org.apache.flink.runtime.messages.checkpoint.TriggerCheckpoint;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.StreamStateHandle;
@@ -49,6 +50,9 @@ public class CheckpointMessagesTest {
 		try {
 			NotifyCheckpointComplete cc = new NotifyCheckpointComplete(new JobID(), new ExecutionAttemptID(), 45287698767345L, 467L);
 			testSerializabilityEqualsHashCode(cc);
+
+			NotifyCheckpointTimeout ct = new NotifyCheckpointTimeout(new JobID(), new ExecutionAttemptID(), 23987201839L, 92318L);
+			testSerializabilityEqualsHashCode(ct);
 
 			TriggerCheckpoint tc = new TriggerCheckpoint(new JobID(), new ExecutionAttemptID(), 347652734L, 7576752L, CheckpointOptions.forFullCheckpoint());
 			testSerializabilityEqualsHashCode(tc);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -262,5 +262,10 @@ public class TaskAsyncCallTest {
 				}
 			}
 		}
+
+		@Override
+		public void notifyCheckpointTimeout(long checkpointId) throws Exception {
+			throw new UnsupportedOperationException("Should not be called");
+		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -495,6 +495,9 @@ public abstract class AbstractStreamOperator<OUT>
 	@Override
 	public void notifyOfCompletedCheckpoint(long checkpointId) throws Exception {}
 
+	@Override
+	public void notifyOfTimedOutCheckpoint(long checkpointId) throws Exception {}
+
 	/**
 	 * Returns a checkpoint stream factory for the provided options.
 	 *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.runtime.state.CheckpointTimeoutListener;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.Checkpointed;
@@ -187,6 +188,15 @@ public abstract class AbstractUdfStreamOperator<OUT, F extends Function>
 
 		if (userFunction instanceof CheckpointListener) {
 			((CheckpointListener) userFunction).notifyCheckpointComplete(checkpointId);
+		}
+	}
+
+	@Override
+	public void notifyOfTimedOutCheckpoint(long checkpointId) throws Exception {
+		super.notifyOfTimedOutCheckpoint(checkpointId);
+
+		if (userFunction instanceof CheckpointTimeoutListener) {
+			((CheckpointTimeoutListener) userFunction).notifyCheckpointTimeout(checkpointId);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
@@ -136,6 +136,16 @@ public interface StreamOperator<OUT> extends Serializable {
 	 */
 	void notifyOfCompletedCheckpoint(long checkpointId) throws Exception;
 
+	/**
+	 * Called when the checkpoint with the given ID is timed out by the checkpoint coordinator.
+	 *
+	 * @param checkpointId The ID of the checkpoint that has been timed out.
+	 *
+	 * @throws Exception Exceptions during checkpoint timeout acknowledgement may be forwarded and will cause
+	 *                   the program to fail and enter recovery.
+	 */
+	void notifyOfTimedOutCheckpoint(long checkpointId) throws Exception;
+
 	// ------------------------------------------------------------------------
 	//  miscellaneous
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
@@ -253,6 +253,9 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 		}
 	}
 
+	@Override
+	public void notifyOfTimedOutCheckpoint(long checkpointId) throws Exception {}
+
 	/**
 	 * Write the given element into the backend.
 	 *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -642,6 +642,25 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		}
 	}
 
+	@Override
+	public void notifyCheckpointTimeout(long checkpointId) throws Exception {
+		synchronized (lock) {
+			if (isRunning) {
+				LOG.debug("Notification of checkpoint timeout for task {}", getName());
+
+				for (StreamOperator<?> operator : operatorChain.getAllOperators()) {
+					if (operator != null) {
+						operator.notifyOfTimedOutCheckpoint(checkpointId);
+					}
+				}
+			}
+			else {
+				LOG.debug("Ignoring notification of checkpoint timeout for not-running task {}", getName());
+			}
+		}
+	}
+
+
 	private void checkpointState(
 			CheckpointMetaData checkpointMetaData,
 			CheckpointOptions checkpointOptions,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
@@ -84,7 +84,7 @@ public class AbstractUdfStreamOperatorLifecycleTest {
 
 	private static final String ALL_METHODS_STREAM_OPERATOR = "[close[], dispose[], getChainingStrategy[], " +
 			"getMetricGroup[], initializeState[class org.apache.flink.streaming.runtime.tasks.OperatorStateHandles], " +
-			"notifyOfCompletedCheckpoint[long], open[], setChainingStrategy[class " +
+			"notifyOfCompletedCheckpoint[long], notifyOfTimedOutCheckpoint[long], open[], setChainingStrategy[class " +
 			"org.apache.flink.streaming.api.operators.ChainingStrategy], setKeyContextElement1[class " +
 			"org.apache.flink.streaming.runtime.streamrecord.StreamRecord], " +
 			"setKeyContextElement2[class org.apache.flink.streaming.runtime.streamrecord.StreamRecord], " +

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferTest.java
@@ -1513,6 +1513,11 @@ public class BarrierBufferTest {
 		public void notifyCheckpointComplete(long checkpointId) throws Exception {
 			throw new UnsupportedOperationException("should never be called");
 		}
+
+		@Override
+		public void notifyCheckpointTimeout(long checkpointId) throws Exception {
+			throw new UnsupportedOperationException("should never be called");
+		}
 	}
 
 	private static class CheckpointMatcher extends BaseMatcher<CheckpointMetaData> {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierTrackerTest.java
@@ -536,5 +536,10 @@ public class BarrierTrackerTest {
 		public void notifyCheckpointComplete(long checkpointId) throws Exception {
 			throw new UnsupportedOperationException("should never be called");
 		}
+
+		@Override
+		public void notifyCheckpointTimeout(long checkpointId) throws Exception {
+			throw new UnsupportedOperationException("should never be called");
+		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -545,6 +545,13 @@ public class AbstractStreamOperatorTestHarness<OUT> {
 	}
 
 	/**
+	 * Calls {@link org.apache.flink.streaming.api.operators.StreamOperator#notifyOfTimedOutCheckpoint(long)} ()}
+	 */
+	public void notifyOfTimedOutCheckpoint(long checkpointId) throws Exception {
+		operator.notifyOfTimedOutCheckpoint(checkpointId);
+	}
+
+	/**
 	 * Calls {@link StreamCheckpointedOperator#restoreState(FSDataInputStream)} if
 	 * the operator implements this interface.
 	 */

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointTimeOutNotifierITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointTimeOutNotifierITCase.java
@@ -1,0 +1,498 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.functions.RichFilterFunction;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.functions.RichReduceFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.runtime.state.CheckpointTimeoutListener;
+import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.co.RichCoFlatMapFunction;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
+import org.apache.flink.util.Collector;
+
+import org.junit.Test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Integration test for the {@link CheckpointTimeoutListener} interface. The test ensures that
+ * {@link CheckpointTimeoutListener#notifyCheckpointTimeout(long)} is called for timed out
+ * checkpoints, that it is called at most once for any checkpoint id and that it is not
+ * called for successul checkpoints. 
+ *
+ * <p>
+ * The topology tested here includes a number of {@link OneInputStreamOperator}s and a
+ * {@link TwoInputStreamOperator}.
+ *
+ * <p>
+ * Note that as a result of doing the checks on the task level there is no way to verify
+ * that the {@link CheckpointTimeoutListener#notifyCheckpointTimeout(long)} is called for every
+ * successfully completed checkpoint.
+ */
+@SuppressWarnings("serial")
+public class StreamCheckpointTimeOutNotifierITCase extends StreamingMultipleProgramsTestBase {
+
+	private static final Logger LOG = LoggerFactory.getLogger(StreamCheckpointTimeOutNotifierITCase.class);
+
+	private static final int PARALLELISM = 4;
+
+	private static final long CHECKPOINT_TIMEOUT = 1000; 
+	
+	/**
+	 * Runs the following program:
+	 *
+	 * <pre>
+	 *     [ (source)->(filter) ] -> [ (co-map) ] -> [ (map) ] -> [ (groupBy/reduce)->(sink) ]
+	 * </pre>
+	 */
+	@Test
+	public void testProgram() {
+		try {
+			final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.getCheckpointConfig().setCheckpointTimeout(CHECKPOINT_TIMEOUT);
+			
+			assertEquals("test setup broken", PARALLELISM, env.getParallelism());
+			assertEquals("test setup broken", CHECKPOINT_TIMEOUT, env.getCheckpointConfig().getCheckpointTimeout());
+
+			env.enableCheckpointing(500);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 0L));
+
+			final int numElements = 10000;
+			final int numTaskTotal = PARALLELISM * 5;
+
+			DataStream<Long> stream = env.addSource(new GeneratingSourceFunction(numElements, numTaskTotal));
+
+			stream
+				// -------------- first vertex, chained to the src ----------------
+				.filter(new LongRichFilterFunction())
+
+				// -------------- second vertex, applying the co-map ----------------
+				.connect(stream).flatMap(new LeftIdentityCoRichFlatMapFunction())
+
+				// -------------- third vertex - the stateful one that also fails ----------------
+				.map(new IdentityMapFunction())
+				.startNewChain()
+
+				// -------------- fourth vertex - reducer and the sink ----------------
+				.keyBy(0)
+				.reduce(new OnceFailingReducer(numElements))
+
+				.addSink(new DiscardingSink<Tuple1<Long>>());
+
+			env.execute();
+
+			final long timedoutCheckpointID = OnceFailingReducer.timedoutCheckpointID;
+			assertNotEquals(0L, timedoutCheckpointID);
+
+			List<Long[]> allLists = Arrays.asList(
+				GeneratingSourceFunction.timedoutCheckpoints,
+				LongRichFilterFunction.timedoutCheckpoints,
+				LeftIdentityCoRichFlatMapFunction.timedoutCheckpoints,
+				IdentityMapFunction.timedoutCheckpoints,
+				OnceFailingReducer.timedoutCheckpoints
+			);
+
+			for (Long[] parallelNotifications : allLists) {
+				for (Long notification : parallelNotifications) {
+
+					assertTrue("No checkpoint timeout was received.",
+						notification > 0);
+
+					assertTrue("Timed out checkpoint was not marked.",
+						notification == timedoutCheckpointID);
+				}
+			}
+
+			List<List<Long>[]> allCompletedLists = Arrays.asList(
+				GeneratingSourceFunction.completedCheckpoints,
+				LongRichFilterFunction.completedCheckpoints,
+				LeftIdentityCoRichFlatMapFunction.completedCheckpoints,
+				IdentityMapFunction.completedCheckpoints,
+				OnceFailingReducer.completedCheckpoints
+			);
+
+			for (List<Long>[] parallelNotifications : allCompletedLists) {
+				for (List<Long> notifications : parallelNotifications) {
+
+					assertTrue("No checkpoint notification was received.",
+						notifications.size() > 0);
+
+					assertFalse("Failure checkpoint was marked as completed.",
+						notifications.contains(timedoutCheckpointID));
+
+					assertFalse("No checkpoint received after time out.",
+						notifications.get(notifications.size() - 1) == timedoutCheckpointID);
+
+					assertTrue("Checkpoint notification was received multiple times",
+						notifications.size() == new HashSet<Long>(notifications).size());
+				}
+			}
+		}
+
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	static List<Long>[] createCheckpointLists(int parallelism) {
+		@SuppressWarnings({"unchecked", "rawtypes"})
+		List<Long>[] lists = new List[parallelism];
+		for (int i = 0; i < parallelism; i++) {
+			lists[i] = new ArrayList<>();
+		}
+		return lists;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Custom Functions
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Generates some Long values and as an implementation for the {@link CheckpointTimeoutListener} 
+	 * interface it stores timed out the checkpoint id it has sees in a static list.
+	 */
+	private static class GeneratingSourceFunction extends RichSourceFunction<Long>
+		implements ParallelSourceFunction<Long>, CheckpointListener, CheckpointTimeoutListener, ListCheckpointed<Integer>
+	{
+
+		static final List<Long>[] completedCheckpoints = createCheckpointLists(PARALLELISM);
+
+		static final Long[] timedoutCheckpoints = new Long[PARALLELISM];
+
+		static AtomicLong numPostTimeoutNotifications = new AtomicLong();
+
+		// operator behaviour
+		private final long numElements;
+
+		private final int notificationsToWaitFor;
+
+		private int index;
+		private int step;
+
+		private volatile boolean timedoutAlready;
+
+		private volatile boolean isRunning = true;
+
+		GeneratingSourceFunction(long numElements, int notificationsToWaitFor) {
+			this.numElements = numElements;
+			this.notificationsToWaitFor = notificationsToWaitFor;
+		}
+
+		@Override
+		public void open(Configuration parameters) throws IOException {
+			step = getRuntimeContext().getNumberOfParallelSubtasks();
+
+			// if index has been restored, it is not 0 any more
+			if (index == 0)
+				index = getRuntimeContext().getIndexOfThisSubtask();
+		}
+
+		@Override
+		public void run(SourceContext<Long> ctx) throws Exception {
+			final Object lockingObject = ctx.getCheckpointLock();
+
+			while (isRunning && index < numElements) {
+				long result = index % 10;
+
+				synchronized (lockingObject) {
+					index += step;
+					ctx.collect(result);
+				}
+			}
+
+			// if the program goes fast and no notifications come through, we
+			// wait until all tasks had a chance to see a notification
+			while (isRunning && numPostTimeoutNotifications.get() < notificationsToWaitFor) {
+				Thread.sleep(50);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			isRunning = false;
+		}
+
+		@Override
+		public List<Integer> snapshotState(long checkpointId, long timestamp) throws Exception {
+			return Collections.singletonList(this.index);
+		}
+
+		@Override
+		public void restoreState(List<Integer> state) throws Exception {
+			if (state.isEmpty() || state.size() > 1) {
+				throw new RuntimeException("Test failed due to unexpected recovered state size " + state.size());
+			}
+			this.index = state.get(0);
+		}
+
+		@Override
+		public void notifyCheckpointComplete(long checkpointId) {
+			// record the ID of the completed checkpoint
+			int partition = getRuntimeContext().getIndexOfThisSubtask();
+			completedCheckpoints[partition].add(checkpointId);
+		}
+
+		@Override
+		public void notifyCheckpointTimeout(long checkpointId) throws Exception {
+			// record the ID of the completed checkpoint
+			int partition = getRuntimeContext().getIndexOfThisSubtask();
+			timedoutCheckpoints[partition] = checkpointId;
+
+			// if this is the first time we get a timeout since,
+			// tell the source function
+			if (OnceFailingReducer.hasTimedout && !timedoutAlready) {
+				timedoutAlready = true;
+				GeneratingSourceFunction.numPostTimeoutNotifications.incrementAndGet();
+			}
+		}
+	}
+
+	/**
+	 * Identity transform on Long values wrapping the output in a tuple. As an implementation
+	 * for the {@link CheckpointTimeoutListener} interface it stores timed out the checkpoint id it has sees in 
+	 * a static list.
+	 */
+	private static class IdentityMapFunction extends RichMapFunction<Long, Tuple1<Long>>
+		implements CheckpointListener, CheckpointTimeoutListener {
+
+		static final List<Long>[] completedCheckpoints = createCheckpointLists(PARALLELISM);
+
+		static final Long[] timedoutCheckpoints = new Long[PARALLELISM];
+		
+		private volatile boolean timedoutAlready;
+
+		@Override
+		public Tuple1<Long> map(Long value) throws Exception {
+			return Tuple1.of(value);
+		}
+
+		@Override
+		public void notifyCheckpointComplete(long checkpointId) {
+			// record the ID of the completed checkpoint
+			int partition = getRuntimeContext().getIndexOfThisSubtask();
+			completedCheckpoints[partition].add(checkpointId);
+		}
+
+		@Override
+		public void notifyCheckpointTimeout(long checkpointId) throws Exception {
+			// record the ID of the completed checkpoint
+			int partition = getRuntimeContext().getIndexOfThisSubtask(); 
+			timedoutCheckpoints[partition] = checkpointId;
+
+			// if this is the first time we get a timeout since,
+			// tell the source function
+			if (OnceFailingReducer.hasTimedout && !timedoutAlready) {
+				timedoutAlready = true;
+				GeneratingSourceFunction.numPostTimeoutNotifications.incrementAndGet();
+			}
+		}
+	}
+
+	/**
+	 * Filter on Long values supposedly letting all values through. As an implementation
+	 * for the {@link CheckpointTimeoutListener} interface it stores timed out the checkpoint id it has sees in 
+	 * a static list.
+	 */
+	private static class LongRichFilterFunction extends RichFilterFunction<Long>
+		implements CheckpointTimeoutListener, CheckpointListener
+	{
+
+		static final List<Long>[] completedCheckpoints = createCheckpointLists(PARALLELISM);
+
+		static final Long[] timedoutCheckpoints = new Long[PARALLELISM];
+
+		private volatile boolean timedoutAlready;
+
+		@Override
+		public boolean filter(Long value) {
+			return value < 100;
+		}
+
+		@Override
+		public void notifyCheckpointComplete(long checkpointId) {
+			// record the ID of the completed checkpoint
+			int partition = getRuntimeContext().getIndexOfThisSubtask();
+			completedCheckpoints[partition].add(checkpointId);
+		}
+
+		@Override
+		public void notifyCheckpointTimeout(long checkpointId) throws Exception {
+			// record the ID of the completed checkpoint
+			int partition = getRuntimeContext().getIndexOfThisSubtask();
+			timedoutCheckpoints[partition] = checkpointId;
+
+			// if this is the first time we get a timeout since,
+			// tell the source function
+			if (OnceFailingReducer.hasTimedout && !timedoutAlready) {
+				timedoutAlready = true;
+				GeneratingSourceFunction.numPostTimeoutNotifications.incrementAndGet();
+			}
+		}
+	}
+
+	/**
+	 * CoFlatMap on Long values as identity transform on the left input, while ignoring the right.
+	 * As an implementation for the {@link CheckpointTimeoutListener} interface it stores timed out 
+	 * the checkpoint id it has sees in a static list.
+	 */
+	private static class LeftIdentityCoRichFlatMapFunction extends RichCoFlatMapFunction<Long, Long, Long>
+		implements CheckpointTimeoutListener, CheckpointListener
+	{
+
+		static final List<Long>[] completedCheckpoints = createCheckpointLists(PARALLELISM);
+
+		static final Long[] timedoutCheckpoints = new Long[PARALLELISM];
+
+		private volatile boolean timedoutAlready;
+
+		@Override
+		public void flatMap1(Long value, Collector<Long> out) {
+			out.collect(value);
+		}
+
+		@Override
+		public void flatMap2(Long value, Collector<Long> out) {
+			// we ignore the values from the second input
+		}
+
+		@Override
+		public void notifyCheckpointComplete(long checkpointId) {
+			// record the ID of the completed checkpoint
+			int partition = getRuntimeContext().getIndexOfThisSubtask();
+			completedCheckpoints[partition].add(checkpointId);
+		}
+
+		@Override
+		public void notifyCheckpointTimeout(long checkpointId) throws Exception {
+			// record the ID of the completed checkpoint
+			int partition = getRuntimeContext().getIndexOfThisSubtask();
+			timedoutCheckpoints[partition] = checkpointId;
+
+			// if this is the first time we get a timeout since,
+			// tell the source function
+			if (OnceFailingReducer.hasTimedout && !timedoutAlready) {
+				timedoutAlready = true;
+				GeneratingSourceFunction.numPostTimeoutNotifications.incrementAndGet();
+			}
+		}
+	}
+
+	/**
+	 * Reducer that causes one timeout between seeing 40% to 70% of the records.
+	 */
+	private static class OnceFailingReducer extends RichReduceFunction<Tuple1<Long>>
+		implements ListCheckpointed<Long>, CheckpointTimeoutListener, CheckpointListener
+	{
+		static volatile boolean hasTimedout = false;
+		static volatile long timedoutCheckpointID;
+
+		static final List<Long>[] completedCheckpoints = createCheckpointLists(PARALLELISM);
+
+		static final Long[] timedoutCheckpoints = new Long[PARALLELISM];
+
+		private final long failurePos;
+
+		private volatile long count;
+
+		private volatile boolean timedoutAlready;
+
+		OnceFailingReducer(long numElements) {
+			this.failurePos = (long) (0.5 * numElements / PARALLELISM);
+		}
+
+		@Override
+		public Tuple1<Long> reduce(Tuple1<Long> value1, Tuple1<Long> value2) {
+			count++;
+			if (count >= failurePos && getRuntimeContext().getIndexOfThisSubtask() == 0) {
+				LOG.info(">>>>>>>>>>>>>>>>> Reached timeout position <<<<<<<<<<<<<<<<<<<<<");
+			}
+
+			value1.f0 += value2.f0;
+			return value1;
+		}
+
+		@Override
+		public List<Long> snapshotState(long checkpointId, long timestamp) throws Exception {
+			if (!hasTimedout && count >= failurePos && getRuntimeContext().getIndexOfThisSubtask() == 0) {
+				LOG.info(">>>>>>>>>>>>>>>>> Timing Out Checkpoint <<<<<<<<<<<<<<<<<<<<<");
+				hasTimedout = true;
+				timedoutCheckpointID = checkpointId;
+				Thread.sleep(CHECKPOINT_TIMEOUT + 100L);
+			}
+			return Collections.singletonList(this.count);
+		}
+
+		@Override
+		public void restoreState(List<Long> state) throws Exception {
+			if (state.isEmpty() || state.size() > 1) {
+				throw new RuntimeException("Test failed due to unexpected recovered state size " + state.size());
+			}
+			this.count = state.get(0);
+		}
+
+		@Override
+		public void notifyCheckpointComplete(long checkpointId) {
+			// record the ID of the completed checkpoint
+			int partition = getRuntimeContext().getIndexOfThisSubtask();
+			completedCheckpoints[partition].add(checkpointId);
+		}
+
+		@Override
+		public void notifyCheckpointTimeout(long checkpointId) throws Exception {
+			// record the ID of the completed checkpoint
+			int partition = getRuntimeContext().getIndexOfThisSubtask();
+			timedoutCheckpoints[partition] = checkpointId;
+
+			// if this is the first time we get a timeout since,
+			// tell the source function
+			if (OnceFailingReducer.hasTimedout && !timedoutAlready) {
+				timedoutAlready = true;
+				GeneratingSourceFunction.numPostTimeoutNotifications.incrementAndGet();
+			}
+		}
+	}
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-6315

A common use case when writing a custom operator that outputs data to some third party location to partially output on checkpoint and then commit on notifyCheckpointComplete. If that external system does not gracefully handle rollbacks (such as Amazon S3 not allowing consistent delete operations) then that data needs to be handled by the next checkpoint.
The idea is to add a new interface similar to CheckpointListener that provides a callback when the CheckpointCoordinator times out a checkpoint

This is required for the eventually consistent sink coming in FLINK-6306 to be able to differentiate between concurrent checkpoints and timed out checkpoints. 