### PR TITLE
[FLINK-6317] Fix wrong default directory for history server

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -138,7 +138,7 @@ public class HistoryServer {
 
 		String webDirectory = config.getString(HistoryServerOptions.HISTORY_SERVER_WEB_DIR);
 		if (webDirectory == null) {
-			webDirectory = System.getProperty("java.io.tmpdir") + "flink-web-history-" + UUID.randomUUID();
+			webDirectory = System.getProperty("java.io.tmpdir") + File.separator + "flink-web-history-" + UUID.randomUUID();
 		}
 		webDir = new File(webDirectory);
 


### PR DESCRIPTION
This PR will fix the issue with the missing file separator when using the default Java temp directory for the history server.