### PR TITLE
[FLINK-6300] Use 'exec' in start-foreground calls

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/flink-console.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-console.sh
@@ -62,4 +62,4 @@ if [[ ${JAVA_VERSION} =~ ${IS_NUMBER} ]]; then
 fi
 
 echo "Starting $SERVICE as a console application on host $HOSTNAME."
-$JAVA_RUN $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "`manglePathList "$FLINK_TM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" ${CLASS_TO_RUN} "${ARGS[@]}"
+exec $JAVA_RUN $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "`manglePathList "$FLINK_TM_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" ${CLASS_TO_RUN} "${ARGS[@]}"

--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -76,7 +76,7 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
 fi
 
 if [[ $STARTSTOP == "start-foreground" ]]; then
-    "${FLINK_BIN_DIR}"/flink-console.sh jobmanager "${args[@]}"
+    exec "${FLINK_BIN_DIR}"/flink-console.sh jobmanager "${args[@]}"
 else
     "${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP jobmanager "${args[@]}"
 fi

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -102,7 +102,7 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
 fi
 
 if [[ $STARTSTOP == "start-foreground" ]]; then
-    "${FLINK_BIN_DIR}"/flink-console.sh taskmanager "${args[@]}"
+    exec "${FLINK_BIN_DIR}"/flink-console.sh taskmanager "${args[@]}"
 else
     TM_COMMAND="${FLINK_BIN_DIR}/flink-daemon.sh $STARTSTOP taskmanager ${args[@]}"
     


### PR DESCRIPTION
To avoid signal-handling issues in Docker, applications need to run as
a single executable or use a process manager that forwards signals
correctly, in either case running as PID 1.

Since Flink uses a number of chained scripts before the ultimate call
to `java`, we need to use `exec` so that the script executable is
replaced, ultimately resulting in a single `java` process as PID 1.

There's no need to run a process manager since Flink only actually
requires a single process.

**Note:** As there has not been a Flink release since these codepaths were introduced, I'm comfortable with merging this change for 1.2.1 since my manual testing was successful.