### PR TITLE
[FLINK-6327] [table] Bug in CommonCalc's estimateRowCount() method

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/CommonCalc.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/CommonCalc.scala
@@ -177,7 +177,7 @@ trait CommonCalc {
 
     if (calcProgram.getCondition != null) {
       // we reduce the result card to push filters down
-      (rowCnt * 0.75).min(1.0)
+      (rowCnt * 0.75).max(1.0)
     } else {
       rowCnt
     }


### PR DESCRIPTION
(rowCnt * 0.75).min(1.0) should be changed to (rowCnt * 0.75).max(1.0)