### PR TITLE
[FLINK-6046] Add support for oversized messages during deployment

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -488,6 +488,8 @@ May be set to -1 to disable this feature.
   - `none` (default): No high availability. A single JobManager runs and no JobManager state is checkpointed.
   - `zookeeper`: Supports the execution of multiple JobManagers and JobManager state checkpointing. Among the group of JobManagers, ZooKeeper elects one of them as the leader which is responsible for the cluster execution. In case of a JobManager failure, a standby JobManager will be elected as the new leader and is given the last checkpointed JobManager state. In order to use the 'zookeeper' mode, it is mandatory to also define the `high-availability.zookeeper.quorum` configuration value.
 
+- `high-availability.cluster-id`: (Default `/default_ns` in standalone cluster mode, or the <yarn-application-id> under YARN) Defines the subdirectory under the root dir where the ZooKeeper HA mode will create znodes. This allows to isolate multiple applications on the same ZooKeeper. Previously this key was named `recovery.zookeeper.path.namespace` and `high-availability.zookeeper.path.namespace`.
+
 Previously this key was named `recovery.mode` and the default value was `standalone`.
 
 #### ZooKeeper-based HA Mode
@@ -495,8 +497,6 @@ Previously this key was named `recovery.mode` and the default value was `standal
 - `high-availability.zookeeper.quorum`: Defines the ZooKeeper quorum URL which is used to connect to the ZooKeeper cluster when the 'zookeeper' HA mode is selected. Previously this key was named `recovery.zookeeper.quorum`.
 
 - `high-availability.zookeeper.path.root`: (Default `/flink`) Defines the root dir under which the ZooKeeper HA mode will create namespace directories. Previously this ket was named `recovery.zookeeper.path.root`.
-
-- `high-availability.cluster-id`: (Default `/default_ns` in standalone cluster mode, or the <yarn-application-id> under YARN) Defines the subdirectory under the root dir where the ZooKeeper HA mode will create znodes. This allows to isolate multiple applications on the same ZooKeeper. Previously this key was named `recovery.zookeeper.path.namespace` and `high-availability.zookeeper.path.namespace`.
 
 - `high-availability.zookeeper.path.latch`: (Default `/leaderlatch`) Defines the znode of the leader latch which is used to elect the leader. Previously this key was named `recovery.zookeeper.path.latch`.
 

--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -496,13 +496,13 @@ Previously this key was named `recovery.mode` and the default value was `standal
 
 - `high-availability.zookeeper.path.root`: (Default `/flink`) Defines the root dir under which the ZooKeeper HA mode will create namespace directories. Previously this ket was named `recovery.zookeeper.path.root`.
 
-- `high-availability.zookeeper.path.namespace`: (Default `/default_ns` in standalone cluster mode, or the <yarn-application-id> under YARN) Defines the subdirectory under the root dir where the ZooKeeper HA mode will create znodes. This allows to isolate multiple applications on the same ZooKeeper. Previously this key was named `recovery.zookeeper.path.namespace`.
+- `high-availability.cluster-id`: (Default `/default_ns` in standalone cluster mode, or the <yarn-application-id> under YARN) Defines the subdirectory under the root dir where the ZooKeeper HA mode will create znodes. This allows to isolate multiple applications on the same ZooKeeper. Previously this key was named `recovery.zookeeper.path.namespace` and `high-availability.zookeeper.path.namespace`.
 
 - `high-availability.zookeeper.path.latch`: (Default `/leaderlatch`) Defines the znode of the leader latch which is used to elect the leader. Previously this key was named `recovery.zookeeper.path.latch`.
 
 - `high-availability.zookeeper.path.leader`: (Default `/leader`) Defines the znode of the leader which contains the URL to the leader and the current leader session ID. Previously this key was named `recovery.zookeeper.path.leader`.
 
-- `high-availability.zookeeper.storageDir`: Defines the directory in the state backend where the JobManager metadata will be stored (ZooKeeper only keeps pointers to it). Required for HA. Previously this key was named `recovery.zookeeper.storageDir`.
+- `high-availability.storageDir`: Defines the directory in the state backend where the JobManager metadata will be stored (ZooKeeper only keeps pointers to it). Required for HA. Previously this key was named `recovery.zookeeper.storageDir` and `high-availability.zookeeper.storageDir`.
 
 - `high-availability.zookeeper.client.session-timeout`: (Default `60000`) Defines the session timeout for the ZooKeeper session in ms. Previously this key was named `recovery.zookeeper.client.session-timeout`
 

--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -291,6 +291,8 @@ The following parameters configure Flink's JobManager and TaskManagers.
 
 - `akka.framesize`: Maximum size of messages which are sent between the JobManager and the TaskManagers. If Flink fails because messages exceed this limit, then you should increase it. The message size requires a size-unit specifier (DEFAULT: **10485760b**).
 
+- `akka.rpc.offload.minsize`: Maximum size of binary blobs to still transmit them through Akka (larger blobs may be offloaded to the BLOB server) (DEFAULT: **1 KiB**).
+
 - `akka.watch.heartbeat.interval`: Heartbeat interval for Akka's DeathWatch mechanism to detect dead TaskManagers. If TaskManagers are wrongly marked dead because of lost or delayed heartbeat messages, then you should increase this value. A thorough description of Akka's DeathWatch can be found [here](http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector) (DEFAULT: **10 s**).
 
 - `akka.watch.heartbeat.pause`: Acceptable heartbeat pause for Akka's DeathWatch mechanism. A low value does not allow a irregular heartbeat. A thorough description of Akka's DeathWatch can be found [here](http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector) (DEFAULT: **60 s**).

--- a/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
@@ -55,4 +55,12 @@ public class AkkaOptions {
 	public static final ConfigOption<String> AKKA_WATCH_HEARTBEAT_PAUSE = ConfigOptions
 		.key("akka.watch.heartbeat.pause")
 		.defaultValue("60 s");
+
+	/**
+	 * The maximum size of binary blobs to still transmit them through Akka. Larger blobs may be
+	 * offloaded to the BLOB server.
+	 */
+	public static final ConfigOption<Integer> AKKA_RPC_OFFLOAD_MINSIZE = ConfigOptions
+		.key("akka.rpc.offload.minsize")
+		.defaultValue(1_024); // 1KiB by default
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
@@ -367,13 +367,13 @@ public final class BlobCache implements BlobService {
 	 *         the BLOB server or if the BLOB server cannot delete the file
 	 */
 	public void deleteGlobal(JobID jobId, String key) throws IOException {
-		BlobClient bc = createClient();
-		try {
-			delete(jobId, key);
+		// delete locally
+		delete(jobId, key);
+		// then delete on the BLOB server
+		// (don't use the distributed storage directly - this way the blob
+		// server is aware of the delete operation, too)
+		try (BlobClient bc = createClient()) {
 			bc.delete(jobId, key);
-		}
-		finally {
-			bc.close();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
@@ -302,8 +302,8 @@ public final class BlobCache implements BlobService {
 	public void delete(BlobKey key) {
 		final File localFile = BlobUtils.getStorageLocation(storageDir, key);
 
-		if (localFile.exists() && !localFile.delete()) {
-			LOG.warn("Failed to delete locally cached BLOB {} at {}" + key, localFile.getAbsolutePath());
+		if (!localFile.delete() && localFile.exists()) {
+			LOG.warn("Failed to delete locally cached BLOB {} at {}", key, localFile.getAbsolutePath());
 		}
 	}
 
@@ -317,7 +317,7 @@ public final class BlobCache implements BlobService {
 	public void delete(JobID jobId, String key) {
 		final File localFile = BlobUtils.getStorageLocation(storageDir, jobId, key);
 
-		if (localFile.exists() && !localFile.delete()) {
+		if (!localFile.delete() && localFile.exists()) {
 			LOG.warn("Failed to delete locally cached BLOB {}/{} at {}", jobId, key, localFile.getAbsolutePath());
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -231,6 +232,20 @@ public final class BlobCache implements BlobService {
 
 		if (localFile.exists() && !localFile.delete()) {
 			LOG.warn("Failed to delete locally cached BLOB " + key + " at " + localFile.getAbsolutePath());
+		}
+	}
+
+	/**
+	 * Deletes all files associated with the given job id from the BLOB cache.
+	 *
+	 * @param jobId     JobID of the file in the blob store
+	 */
+	@Override
+	public void deleteAll(JobID jobId) {
+		try {
+			BlobUtils.deleteJobDirectory(storageDir, jobId);
+		} catch (IOException e) {
+			LOG.warn("Failed to delete local BLOB storage dir {}.", BlobUtils.getJobDirectory(storageDir, jobId));
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
@@ -22,7 +22,6 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.util.FileUtils;
-import org.apache.flink.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -180,78 +179,45 @@ public final class BlobCache implements BlobService {
 
 		// fallback: download from the BlobServer
 		final byte[] buf = new byte[BlobServerProtocol.BUFFER_SIZE];
+		LOG.info("Downloading {} from {}", requiredBlob, serverAddress);
 
 		// loop over retries
 		int attempt = 0;
 		while (true) {
-
-			if (attempt == 0) {
-				LOG.info("Downloading {} from {}", requiredBlob, serverAddress);
-			} else {
-				LOG.info("Downloading {} from {} (retry {})", requiredBlob, serverAddress, attempt);
-			}
-
-			try {
-				BlobClient bc = null;
-				InputStream is = null;
-				OutputStream os = null;
-
-				try {
-					bc = new BlobClient(serverAddress, blobClientConfig);
-					is = bc.get(requiredBlob);
-					os = new FileOutputStream(localJarFile);
-
-					while (true) {
-						final int read = is.read(buf);
-						if (read < 0) {
-							break;
-						}
-						os.write(buf, 0, read);
+			try (
+				final BlobClient bc = new BlobClient(serverAddress, blobClientConfig);
+				final InputStream is = bc.get(requiredBlob);
+				final OutputStream os = new FileOutputStream(localJarFile)
+			) {
+				while (true) {
+					final int read = is.read(buf);
+					if (read < 0) {
+						break;
 					}
-
-					// we do explicitly not use a finally block, because we want the closing
-					// in the regular case to throw exceptions and cause the writing to fail.
-					// But, the closing on exception should not throw further exceptions and
-					// let us keep the root exception
-					os.close();
-					os = null;
-					is.close();
-					is = null;
-					bc.close();
-					bc = null;
-
-					// success, we finished
-					return localJarFile.toURI().toURL();
+					os.write(buf, 0, read);
 				}
-				catch (Throwable t) {
-					// we use "catch (Throwable)" to keep the root exception. Otherwise that exception
-					// it would be replaced by any exception thrown in the finally block
-					IOUtils.closeQuietly(os);
-					IOUtils.closeQuietly(is);
-					IOUtils.closeQuietly(bc);
 
-					if (t instanceof IOException) {
-						throw (IOException) t;
-					} else {
-						throw new IOException(t.getMessage(), t);
-					}
-				}
+				// success, we finished
+				return localJarFile.toURI().toURL();
 			}
-			catch (IOException e) {
+			catch (Throwable t) {
 				String message = "Failed to fetch BLOB " + requiredBlob + " from " + serverAddress +
 					" and store it under " + localJarFile.getAbsolutePath();
 				if (attempt < numFetchRetries) {
-					attempt++;
 					if (LOG.isDebugEnabled()) {
-						LOG.debug(message + " Retrying...", e);
+						LOG.debug(message + " Retrying...", t);
 					} else {
 						LOG.error(message + " Retrying...");
 					}
 				}
 				else {
-					LOG.error(message + " No retries left.", e);
-					throw new IOException(message, e);
+					LOG.error(message + " No retries left.", t);
+					throw new IOException(message, t);
 				}
+
+				// retry
+				++attempt;
+				LOG.info("Downloading {} from {} (retry {})", requiredBlob, serverAddress, attempt);
 			}
 		} // end loop over retries
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -64,6 +64,7 @@ import static org.apache.flink.runtime.blob.BlobServerProtocol.RETURN_OKAY;
 import static org.apache.flink.runtime.blob.BlobUtils.readFully;
 import static org.apache.flink.runtime.blob.BlobUtils.readLength;
 import static org.apache.flink.runtime.blob.BlobUtils.writeLength;
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * The BLOB client can communicate with the BLOB server and either upload (PUT), download (GET),
@@ -594,9 +595,7 @@ public final class BlobClient implements Closeable {
 	 *         the BLOB server or if the BLOB server cannot delete the file
 	 */
 	public void delete(BlobKey key) throws IOException {
-		if (key == null) {
-			throw new IllegalArgumentException("BLOB key must not be null");
-		}
+		checkArgument(key != null, "BLOB key must not be null.");
 
 		deleteInternal(null, null, key);
 	}
@@ -612,12 +611,9 @@ public final class BlobClient implements Closeable {
 	 *         thrown if an I/O error occurs while transferring the request to the BLOB server
 	 */
 	public void delete(JobID jobId, String key) throws IOException {
-		if (jobId == null) {
-			throw new IllegalArgumentException("JobID must not be null");
-		}
-		if (key == null) {
-			throw new IllegalArgumentException("Key must not be null");
-		}
+		checkArgument(jobId != null, "Job id must not be null.");
+		checkArgument(key != null, "BLOB name must not be null.");
+		
 		if (key.length() > MAX_KEY_LENGTH) {
 			throw new IllegalArgumentException("Keys must not be longer than " + MAX_KEY_LENGTH);
 		}
@@ -634,9 +630,7 @@ public final class BlobClient implements Closeable {
 	 *         thrown if an I/O error occurs while transferring the request to the BLOB server
 	 */
 	public void deleteAll(JobID jobId) throws IOException {
-		if (jobId == null) {
-			throw new IllegalArgumentException("Argument jobID must not be null");
-		}
+		checkArgument(jobId != null, "Job id must not be null.");
 
 		deleteInternal(jobId, null, null);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -409,10 +409,8 @@ public class BlobServer extends Thread implements BlobService {
 
 		final File localFile = BlobUtils.getStorageLocation(storageDir, key);
 
-		if (localFile.exists()) {
-			if (!localFile.delete()) {
-				LOG.warn("Failed to delete locally BLOB " + key + " at " + localFile.getAbsolutePath());
-			}
+		if (!localFile.delete() && localFile.exists()) {
+			LOG.warn("Failed to delete locally BLOB " + key + " at " + localFile.getAbsolutePath());
 		}
 
 		blobStore.delete(key);
@@ -452,7 +450,7 @@ public class BlobServer extends Thread implements BlobService {
 
 		try {
 			BlobUtils.deleteJobDirectory(storageDir, jobId);
-		} catch (IOException e) {
+		} catch (Exception e) {
 			LOG.warn("Failed to delete local BLOB storage dir {}.", BlobUtils.getJobDirectory(storageDir, jobId));
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -481,6 +481,15 @@ public class BlobServer extends Thread implements BlobService {
 	}
 
 	/**
+	 * Returns the configuration used by the BLOB server.
+	 *
+	 * @return configuration
+	 */
+	public final Configuration getConfiguration() {
+		return blobServiceConfiguration;
+	}
+
+	/**
 	 * Returns the port on which the server is listening.
 	 *
 	 * @return port on which the server is listening

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -347,18 +347,19 @@ public class BlobServer extends Thread implements BlobService {
 	 * 		if set, any existing file under the given name will be overwritten, otherwise nothing is
 	 * 		done
 	 *
-	 * @return whether the file has been successfully written or was skipped due to an existing file
+	 * @return whether the file has been successfully written (<tt>true</tt>) or was skipped due to an existing file
+	 * 			(<tt>false</tt>)
 	 */
 	public boolean putObject(Object data, JobID jobId, String key, boolean overwriteExisting) throws IOException {
 		File storageFile = getStorageLocation(jobId, key);
 
 		// already existing file that is not to be overwritten?
-		if (storageFile.exists() && !overwriteExisting) {
+		if (!overwriteExisting && storageFile.exists()) {
 			return false;
 		}
 
 		// temporary file during transfer:
-		File incomingFile = new File(storageFile.getParent(), "." + storageFile.getName());
+		File incomingFile = createTemporaryFilename();
 		try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(incomingFile))) {
 			oos.writeObject(data);
 			oos.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -214,18 +214,6 @@ public class BlobServer extends Thread implements BlobService {
 	}
 
 	/**
-	 * Method which deletes all files associated with the given jobID.
-	 *
-	 * <p><strong>This is only called from the {@link BlobServerConnection}</strong>
-	 *
-	 * @param jobID all files associated to this jobID will be deleted
-	 * @throws IOException
-	 */
-	void deleteJobDirectory(JobID jobID) throws IOException {
-		BlobUtils.deleteJobDirectory(storageDir, jobID);
-	}
-
-	/**
 	 * Returns a temporary file inside the BLOB server's incoming directory.
 	 *
 	 * @return a temporary file inside the BLOB server's incoming directory
@@ -398,6 +386,22 @@ public class BlobServer extends Thread implements BlobService {
 		}
 
 		blobStore.delete(key);
+	}
+
+	/**
+	 * Deletes all files associated with the given job id from the storage.
+	 *
+	 * @param jobId     JobID of the files in the blob store
+	 */
+	@Override
+	public void deleteAll(final JobID jobId) {
+		try {
+			BlobUtils.deleteJobDirectory(storageDir, jobId);
+		} catch (IOException e) {
+			LOG.warn("Failed to delete local BLOB storage dir {}.", BlobUtils.getJobDirectory(storageDir, jobId));
+		}
+
+		blobStore.deleteAll(jobId);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
@@ -397,12 +397,7 @@ class BlobServerConnection extends Thread {
 
 			if (type == CONTENT_ADDRESSABLE) {
 				BlobKey key = BlobKey.readFromInputStream(inputStream);
-				File blobFile = this.blobServer.getStorageLocation(key);
-				if (blobFile.exists() && !blobFile.delete()) {
-					throw new IOException("Cannot delete BLOB file " + blobFile.getAbsolutePath());
-				}
-
-				blobStore.delete(key);
+				blobServer.delete(key);
 			}
 			else if (type == NAME_ADDRESSABLE) {
 				byte[] jidBytes = new byte[JobID.SIZE];
@@ -411,12 +406,7 @@ class BlobServerConnection extends Thread {
 
 				String key = readKey(buf, inputStream);
 
-				File blobFile = this.blobServer.getStorageLocation(jobID, key);
-				if (blobFile.exists() && !blobFile.delete()) {
-					throw new IOException("Cannot delete BLOB file " + blobFile.getAbsolutePath());
-				}
-
-				blobStore.delete(jobID, key);
+				blobServer.delete(jobID, key);
 			}
 			else if (type == JOB_ID_SCOPE) {
 				byte[] jidBytes = new byte[JobID.SIZE];

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
@@ -423,9 +423,7 @@ class BlobServerConnection extends Thread {
 				readFully(inputStream, jidBytes, 0, JobID.SIZE, "JobID");
 				JobID jobID = JobID.fromByteArray(jidBytes);
 
-				blobServer.deleteJobDirectory(jobID);
-
-				blobStore.deleteAll(jobID);
+				blobServer.deleteAll(jobID);
 			}
 			else {
 				throw new IOException("Unrecognized addressing type: " + type);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
@@ -33,19 +33,37 @@ public interface BlobService {
 	 *
 	 * @param key blob key associated with the requested file
 	 * @return The URL to the file.
-	 * @throws java.io.FileNotFoundException when the path does not exist;
+	 * @throws java.io.FileNotFoundException if the path does not exist;
 	 * @throws IOException if any other error occurs when retrieving the file
 	 */
 	URL getURL(BlobKey key) throws IOException;
+
+	/**
+	 * Returns the URL of the file associated with the provided parameters.
+	 *
+	 * @param jobId     JobID of the file in the blob store
+	 * @param key       String key of the file in the blob store
+	 * @return The URL to the file.
+	 * @throws java.io.FileNotFoundException if the path does not exist;
+	 * @throws IOException if any other error occurs when retrieving the file
+	 */
+	URL getURL(JobID jobId, String key) throws IOException;
 
 
 	/**
 	 * Deletes the file associated with the provided blob key.
 	 *
 	 * @param key associated with the file to be deleted
-	 * @throws IOException
 	 */
-	void delete(BlobKey key) throws IOException;
+	void delete(BlobKey key);
+
+	/**
+	 * Deletes the file associated with the provided parameters.
+	 *
+	 * @param jobId     JobID of the file in the blob store
+	 * @param key       String key of the file in the blob store
+	 */
+	void delete(JobID jobId, String key);
 
 	/**
 	 * Deletes all files associated with the given job id.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
@@ -27,11 +27,12 @@ import java.net.URL;
 public interface BlobService {
 
 	/**
-	 * This method returns the URL of the file associated with the provided blob key.
+	 * Returns the URL of the file associated with the provided blob key.
 	 *
 	 * @param key blob key associated with the requested file
 	 * @return The URL to the file.
-	 * @throws IOException
+	 * @throws java.io.FileNotFoundException when the path does not exist;
+	 * @throws IOException if any other error occurs when retrieving the file
 	 */
 	URL getURL(BlobKey key) throws IOException;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.api.common.JobID;
+
 import java.io.IOException;
 import java.net.URL;
 
@@ -38,12 +40,19 @@ public interface BlobService {
 
 
 	/**
-	 * This method deletes the file associated with the provided blob key.
+	 * Deletes the file associated with the provided blob key.
 	 *
 	 * @param key associated with the file to be deleted
 	 * @throws IOException
 	 */
 	void delete(BlobKey key) throws IOException;
+
+	/**
+	 * Deletes all files associated with the given job id.
+	 *
+	 * @param jobId     JobID of the files in the blob store
+	 */
+	void deleteAll(JobID jobId);
 
 	/**
 	 * Returns the port of the blob service.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -193,7 +193,7 @@ public class BlobUtils {
 	static File getJobDirectory(File storageDir, JobID jobID) {
 		final File jobDirectory = new File(storageDir, JOB_DIR_PREFIX + jobID.toString());
 
-		if (!jobDirectory.exists() && !jobDirectory.mkdirs()) {
+		if (!jobDirectory.mkdirs() && !jobDirectory.exists()) {
 			throw new RuntimeException("Could not create jobId directory '" + jobDirectory.getAbsolutePath() + "'.");
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -190,7 +190,7 @@ public class BlobUtils {
 	 *        the ID of the job to return the storage directory for
 	 * @return the storage directory for BLOBs belonging to the job with the given ID
 	 */
-	private static File getJobDirectory(File storageDir, JobID jobID) {
+	static File getJobDirectory(File storageDir, JobID jobID) {
 		final File jobDirectory = new File(storageDir, JOB_DIR_PREFIX + jobID.toString());
 
 		if (!jobDirectory.exists() && !jobDirectory.mkdirs()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -206,11 +206,6 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 		}
 	}
 
-	@Override
-	public BlobService getBlobService() {
-		return blobService;
-	}
-
 	/**
 	 * Returns a file handle to the file identified by the blob key.
 	 * <p>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -150,6 +150,11 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 	@Override
 	public void unregisterJob(JobID id) {
 		unregisterTask(id, JOB_ATTEMPT_ID);
+
+		synchronized (lockObject) {
+			// delete all NAME_ADDRESSABLE BLOBs
+			blobService.deleteAll(id);
+		}
 	}
 	
 	@Override
@@ -189,6 +194,11 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 				throw new IllegalStateException("No libraries are registered for job " + id);
 			}
 		}
+	}
+
+	@Override
+	public BlobService getBlobService() {
+		return blobService;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -48,6 +48,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * a set of libraries (typically JAR files) which the job requires to run. The library cache manager
  * caches library files in order to avoid unnecessary retransmission of data. It is based on a singleton
  * programming pattern, so there exists at most one library manager at a time.
+ * <p>
+ * All files registered via {@link #registerJob(JobID, Collection, Collection)} are reference-counted
+ * and are removed by a timer-based cleanup task if their reference counter is zero.
+ * <strong>NOTE:</strong> this does not apply to files that enter the blob service via
+ * {@link #getFile(BlobKey)}!
  */
 public final class BlobLibraryCacheManager extends TimerTask implements LibraryCacheManager {
 
@@ -73,6 +78,12 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 	
 	// --------------------------------------------------------------------------------------------
 
+	/**
+	 * Creates the blob library cache manager.
+	 *
+	 * @param blobService blob file retrieval service to use
+	 * @param cleanupInterval cleanup interval in milliseconds
+	 */
 	public BlobLibraryCacheManager(BlobService blobService, long cleanupInterval) {
 		this.blobService = checkNotNull(blobService);
 
@@ -201,6 +212,17 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 		return blobService;
 	}
 
+	/**
+	 * Returns a file handle to the file identified by the blob key.
+	 * <p>
+	 * <strong>NOTE:</strong> if not already registered during
+	 * {@link #registerJob(JobID, Collection, Collection)}, files that enter the library cache /
+	 * backing blob store using this method will not be reference-counted and garbage-collected!
+	 *
+	 * @param blobKey identifying the requested file
+	 * @return File handle
+	 * @throws IOException if any error occurs when retrieving the file
+	 */
 	@Override
 	public File getFile(BlobKey blobKey) throws IOException {
 		return new File(blobService.getURL(blobKey).getFile());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -224,7 +224,11 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 
 	@Override
 	public File getFile(JobID jobId, String key) throws IOException {
-		return new File(blobService.getURL(jobId, key).getFile());
+		// There is a concurrency issue between the BlobService's deleteAll and getURL methods (FLINK-6380)
+		// -> serialize these two for now to be on the safe side.
+		synchronized (lockObject) {
+			return new File(blobService.getURL(jobId, key).getFile());
+		}
 	}
 
 	public BlobService getBlobService() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -227,6 +227,10 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 		return new File(blobService.getURL(jobId, key).getFile());
 	}
 
+	public BlobService getBlobService() {
+		return blobService;
+	}
+
 	public int getBlobServerPort() {
 		return blobService.getPort();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FallbackLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FallbackLibraryCacheManager.java
@@ -51,6 +51,11 @@ public class FallbackLibraryCacheManager implements LibraryCacheManager {
 	}
 
 	@Override
+	public File getFile(final JobID jobId, final String key) throws IOException {
+		throw new IOException("There is no file associated to the job id " + jobId + " and name " + key);
+	}
+
+	@Override
 	public void registerJob(JobID id, Collection<BlobKey> requiredJarFiles, Collection<URL> requiredClasspaths) {
 		LOG.warn("FallbackLibraryCacheManager cannot download files associated with blob keys.");
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FallbackLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FallbackLibraryCacheManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.execution.librarycache;
 
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.BlobService;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.api.common.JobID;
 import org.slf4j.Logger;
@@ -36,6 +37,12 @@ public class FallbackLibraryCacheManager implements LibraryCacheManager {
 	@Override
 	public ClassLoader getClassLoader(JobID id) {
 		return getClass().getClassLoader();
+	}
+
+	@Override
+	public BlobService getBlobService() {
+		LOG.warn("FallbackLibraryCacheManager does not have a backing blob storage.");
+		return null;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FallbackLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FallbackLibraryCacheManager.java
@@ -18,10 +18,9 @@
 
 package org.apache.flink.runtime.execution.librarycache;
 
-import org.apache.flink.runtime.blob.BlobKey;
-import org.apache.flink.runtime.blob.BlobService;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,12 +36,6 @@ public class FallbackLibraryCacheManager implements LibraryCacheManager {
 	@Override
 	public ClassLoader getClassLoader(JobID id) {
 		return getClass().getClassLoader();
-	}
-
-	@Override
-	public BlobService getBlobService() {
-		LOG.warn("FallbackLibraryCacheManager does not have a backing blob storage.");
-		return null;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
@@ -18,10 +18,9 @@
 
 package org.apache.flink.runtime.execution.librarycache;
 
-import org.apache.flink.runtime.blob.BlobKey;
-import org.apache.flink.runtime.blob.BlobService;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,13 +35,6 @@ public interface LibraryCacheManager {
 	 * @return ClassLoader which can load the user code
 	 */
 	ClassLoader getClassLoader(JobID id);
-
-	/**
-	 * Returns the blob storage service that is being used
-	 *
-	 * @return blob storage service
-	 */
-	BlobService getBlobService();
 
 	/**
 	 * Returns a file handle to the file identified by the blob key.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
@@ -49,7 +49,7 @@ public interface LibraryCacheManager {
 	 *
 	 * @param blobKey identifying the requested file
 	 * @return File handle
-	 * @throws IOException
+	 * @throws IOException if any error occurs when retrieving the file
 	 */
 	File getFile(BlobKey blobKey) throws IOException;
 
@@ -59,7 +59,9 @@ public interface LibraryCacheManager {
 	 * @param id job ID
 	 * @param requiredJarFiles collection of blob keys identifying the required jar files
 	 * @param requiredClasspaths collection of classpaths that are added to the user code class loader
-	 * @throws IOException
+	 * @throws IOException if any error occurs when retrieving the required jar files
+	 *
+	 * @see #unregisterJob(JobID) counterpart of this method
 	 */
 	void registerJob(JobID id, Collection<BlobKey> requiredJarFiles, Collection<URL> requiredClasspaths)
 			throws IOException;
@@ -71,21 +73,36 @@ public interface LibraryCacheManager {
 	 * @param requiredJarFiles collection of blob keys identifying the required jar files
 	 * @param requiredClasspaths collection of classpaths that are added to the user code class loader
 	 * @throws IOException
+	 *
+	 * @see #unregisterTask(JobID, ExecutionAttemptID) counterpart of this method
 	 */
 	void registerTask(JobID id, ExecutionAttemptID execution, Collection<BlobKey> requiredJarFiles,
 			Collection<URL> requiredClasspaths) throws IOException;
 
 	/**
-	 * Unregisters a job from the library cache manager.
+	 * Unregisters a job task execution from the library cache manager.
+	 * <p>
+	 * <strong>Note:</strong> this is the counterpart of {@link #registerTask(JobID,
+	 * ExecutionAttemptID, Collection, Collection)} and it will not remove any job added via
+	 * {@link #registerJob(JobID, Collection, Collection)}!
 	 *
 	 * @param id job ID
+	 *
+	 * @see #registerTask(JobID, ExecutionAttemptID, Collection, Collection) counterpart of this method
 	 */
 	void unregisterTask(JobID id, ExecutionAttemptID execution);
-	
+
 	/**
-	 * Unregisters a job from the library cache manager and initiates the cleanup of stored resources.
+	 * Unregisters a job from the library cache manager and initiates the cleanup of stored
+	 * resources.
+	 * <p>
+	 * <strong>Note:</strong> this is the counterpart of {@link #registerJob(JobID, Collection,
+	 * Collection)} and it will not remove any job task execution added via {@link
+	 * #registerTask(JobID, ExecutionAttemptID, Collection, Collection)}!
 	 *
 	 * @param id job ID
+	 *
+	 * @see #registerJob(JobID, Collection, Collection) counterpart of this method
 	 */
 	void unregisterJob(JobID id);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
@@ -54,6 +54,19 @@ public interface LibraryCacheManager {
 	File getFile(BlobKey blobKey) throws IOException;
 
 	/**
+	 * Returns a file handle to the file identified by a job id.
+	 * <p>
+	 * <strong>Note:</strong> these files will be cleaned up when the last job (task execution)
+	 * with the given jobId is removed from this cache manager.
+	 *
+	 * @param jobId   JobID of the requested file
+	 * @param key     String key of the requested file
+	 * @return File handle
+	 * @throws IOException if any error occurs when retrieving the file
+	 */
+	File getFile(JobID jobId, String key) throws IOException;
+
+	/**
 	 * Registers a job with its required jar files and classpaths. The jar files are identified by their blob keys.
 	 *
 	 * @param id job ID

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.execution.librarycache;
 
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.BlobService;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.api.common.JobID;
 
@@ -35,6 +36,13 @@ public interface LibraryCacheManager {
 	 * @return ClassLoader which can load the user code
 	 */
 	ClassLoader getClassLoader(JobID id);
+
+	/**
+	 * Returns the blob storage service that is being used
+	 *
+	 * @return blob storage service
+	 */
+	BlobService getBlobService();
 
 	/**
 	 * Returns a file handle to the file identified by the blob key.
@@ -75,7 +83,7 @@ public interface LibraryCacheManager {
 	void unregisterTask(JobID id, ExecutionAttemptID execution);
 	
 	/**
-	 * Unregisters a job from the library cache manager.
+	 * Unregisters a job from the library cache manager and initiates the cleanup of stored resources.
 	 *
 	 * @param id job ID
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -1045,7 +1045,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 			if (error == null) {
 				LOG.info("{} ({}) switched from {} to {}.", getVertex().getTaskNameWithSubtaskIndex(), getAttemptId(), currentState, targetState);
 			} else {
-				LOG.info("{} ({}) switched from {} to {}.", getVertex().getTaskNameWithSubtaskIndex(), getAttemptId(), currentState, targetState, error);
+				LOG.info("{} ({}) switched from {} to {} with {}.", getVertex().getTaskNameWithSubtaskIndex(), getAttemptId(), currentState, targetState, error);
 			}
 
 			// make sure that the state transition completes normally.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -253,6 +253,25 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 			Time timeout,
 			RestartStrategy restartStrategy,
 			SlotProvider slotProvider) {
+
+		this(futureExecutor, ioExecutor, jobId, jobName, jobConfig, serializedConfig, timeout,
+			restartStrategy, slotProvider, null);
+	}
+
+	/**
+	 * This constructor is for tests only, because it does not include class loading information.
+	 */
+	ExecutionGraph(
+			ScheduledExecutorService futureExecutor,
+			Executor ioExecutor,
+			JobID jobId,
+			String jobName,
+			Configuration jobConfig,
+			SerializedValue<ExecutionConfig> serializedConfig,
+			Time timeout,
+			RestartStrategy restartStrategy,
+			SlotProvider slotProvider,
+			BlobServer blobServer) {
 		this(
 			futureExecutor,
 			ioExecutor,
@@ -266,7 +285,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 			Collections.<URL>emptyList(),
 			slotProvider,
 			ExecutionGraph.class.getClassLoader(),
-			null
+			blobServer
 		);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -27,10 +27,11 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
-import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsTracker;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.executiongraph.metrics.DownTimeGauge;
@@ -80,6 +81,7 @@ public class ExecutionGraphBuilder {
 			RestartStrategy restartStrategy,
 			MetricGroup metrics,
 			int parallelismForAutoMax,
+			BlobServer blobServer,
 			Logger log)
 		throws JobExecutionException, JobException {
 
@@ -102,7 +104,8 @@ public class ExecutionGraphBuilder {
 						jobGraph.getUserJarBlobKeys(),
 						jobGraph.getClasspaths(),
 						slotProvider,
-						classLoader);
+						classLoader,
+						blobServer);
 
 		// set the basic properties
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -308,6 +308,8 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 	public SerializedValue<TaskInformation> getSerializedTaskInformation() throws IOException {
 
 		if (null == serializedTaskInformation) {
+			// TODO: actually, at the moment, multiple threads may enter this code
+			// -> we may be able to avoid some unnecessary work here
 
 			int parallelism = getParallelism();
 			int maxParallelism = getMaxParallelism();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -28,6 +28,7 @@ import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
@@ -95,7 +96,6 @@ import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.SerializedThrowable;
 import org.apache.flink.util.InstantiationUtil;
-
 import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
@@ -265,6 +265,7 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 			restartStrategy,
 			jobMetricGroup,
 			-1,
+			(BlobServer) libraryCacheManager.getBlobService(),
 			log);
 
 		// register self as job status change listener

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -507,7 +507,7 @@ public class Task implements Runnable, TaskActions {
 	}
 
 	/**
-	 * The core work method that bootstraps the task and executes it code
+	 * The core work method that bootstraps the task and executes its code
 	 */
 	@Override
 	public void run() {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1791,7 +1791,7 @@ class JobManager(
       libraryCacheManager.unregisterJob(jobID)
     } catch {
       case t: Throwable =>
-        log.error(s"Could not properly unregister job $jobID form the library cache.", t)
+        log.error(s"Could not properly unregister job $jobID from the library cache.", t)
     }
     jobManagerMetricGroup.foreach(_.removeJob(jobID))
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1307,6 +1307,7 @@ class JobManager(
           restartStrategy,
           jobMetrics,
           numSlots,
+          libraryCacheManager.getBlobService.asInstanceOf[BlobServer],
           log.logger)
         
         if (registerNewGraph) {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1305,6 +1305,9 @@ class TaskManager(
         s"${task.getExecutionState} to JobManager for task ${task.getTaskInfo.getTaskName} " +
         s"(${task.getExecutionId})")
 
+      // delete all NAME_ADDRESSABLE BLOBs
+      libraryCacheManager.get.getBlobService.deleteAll(task.getJobID)
+
       val accumulators = {
         val registry = task.getAccumulatorRegistry
         registry.getSnapshot

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1305,9 +1305,6 @@ class TaskManager(
         s"${task.getExecutionState} to JobManager for task ${task.getTaskInfo.getTaskName} " +
         s"(${task.getExecutionId})")
 
-      // delete all NAME_ADDRESSABLE BLOBs
-      libraryCacheManager.get.getBlobService.deleteAll(task.getJobID)
-
       val accumulators = {
         val registry = task.getAccumulatorRegistry
         registry.getSnapshot

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Random;
 
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -41,7 +42,7 @@ public class BlobServerDeleteTest {
 	private final Random rnd = new Random();
 
 	@Test
-	public void testDeleteSingle() {
+	public void testDeleteSingleByBlobKey() {
 		BlobServer server = null;
 		BlobClient client = null;
 
@@ -59,7 +60,13 @@ public class BlobServerDeleteTest {
 			BlobKey key = client.put(data);
 			assertNotNull(key);
 
-			// issue a DELETE request
+			// second item
+			data[0] ^= 1;
+			BlobKey key2 = client.put(data);
+			assertNotNull(key2);
+			assertNotEquals(key, key2);
+
+			// issue a DELETE request via the client
 			client.delete(key);
 			client.close();
 
@@ -77,6 +84,78 @@ public class BlobServerDeleteTest {
 				fail("client should be closed after erroneous operation");
 			}
 			catch (IllegalStateException e) {
+				// expected
+			}
+
+			// delete a file directly on the server
+			server.delete(key2);
+			try {
+				server.getURL(key2);
+				fail("BLOB should have been deleted");
+			}
+			catch (IOException e) {
+				// expected
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+		finally {
+			cleanup(server, client);
+		}
+	}
+
+	@Test
+	public void testDeleteSingleByName() {
+		BlobServer server = null;
+		BlobClient client = null;
+
+		try {
+			Configuration config = new Configuration();
+			server = new BlobServer(config);
+
+			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
+			client = new BlobClient(serverAddress, config);
+
+			byte[] data = new byte[2000000];
+			rnd.nextBytes(data);
+
+			JobID jobID = new JobID();
+			String name1 = "random name";
+			String name2 = "any nyme";
+
+			client.put(jobID, name1, data);
+			client.put(jobID, name2, data);
+
+			// issue a DELETE request via the client
+			client.delete(jobID, name1);
+			client.close();
+
+			client = new BlobClient(serverAddress, config);
+			try {
+				client.get(jobID, name1);
+				fail("BLOB should have been deleted");
+			}
+			catch (IOException e) {
+				// expected
+			}
+
+			try {
+				client.put(new byte[1]);
+				fail("client should be closed after erroneous operation");
+			}
+			catch (IllegalStateException e) {
+				// expected
+			}
+
+			// delete a file directly on the server
+			server.delete(jobID, name2);
+			try {
+				server.getURL(jobID, name2);
+				fail("BLOB should have been deleted");
+			}
+			catch (IOException e) {
 				// expected
 			}
 		}
@@ -111,9 +190,15 @@ public class BlobServerDeleteTest {
 			// put content addressable (like libraries)
 			client.put(jobID, name1, data);
 			client.put(jobID, name2, new byte[712]);
+			// items for a second (different!) job ID
+			final byte[] jobIdBytes = jobID.getBytes();
+			jobIdBytes[0] ^= 1;
+			JobID jobID2 = JobID.fromByteArray(jobIdBytes);
+			client.put(jobID2, name1, data);
+			client.put(jobID2, name2, new byte[712]);
 
 
-			// issue a DELETE ALL request
+			// issue a DELETE ALL request via the client
 			client.deleteAll(jobID);
 			client.close();
 
@@ -137,6 +222,23 @@ public class BlobServerDeleteTest {
 			client = new BlobClient(serverAddress, config);
 			try {
 				client.get(jobID, name2);
+				fail("BLOB should have been deleted");
+			}
+			catch (IOException e) {
+				// expected
+			}
+
+			// delete the second set of files directly on the server
+			server.deleteAll(jobID2);
+			try {
+				server.getURL(jobID2, name1);
+				fail("BLOB should have been deleted");
+			}
+			catch (IOException e) {
+				// expected
+			}
+			try {
+				server.getURL(jobID2, name2);
 				fail("BLOB should have been deleted");
 			}
 			catch (IOException e) {
@@ -174,13 +276,16 @@ public class BlobServerDeleteTest {
 			File blobFile = server.getStorageLocation(key);
 			assertTrue(blobFile.delete());
 
-			// issue a DELETE request
+			// issue a DELETE request via the client
 			try {
 				client.delete(key);
 			}
 			catch (IOException e) {
 				fail("DELETE operation should not fail if file is already deleted");
 			}
+
+			// issue a DELETE request on the server
+			server.delete(key);
 		}
 		catch (Exception e) {
 			e.printStackTrace();
@@ -214,13 +319,16 @@ public class BlobServerDeleteTest {
 			File blobFile = server.getStorageLocation(jid, name);
 			assertTrue(blobFile.delete());
 
-			// issue a DELETE request
+			// issue a DELETE request via the client
 			try {
 				client.delete(jid, name);
 			}
 			catch (IOException e) {
 				fail("DELETE operation should not fail if file is already deleted");
 			}
+
+			// issue a DELETE request on the server
+			server.delete(jid, name);
 		}
 		catch (Exception e) {
 			e.printStackTrace();
@@ -232,12 +340,14 @@ public class BlobServerDeleteTest {
 	}
 
 	@Test
-	public void testDeleteFails() {
+	public void testDeleteFailsByBlobKey() {
 		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
 
 		BlobServer server = null;
 		BlobClient client = null;
 
+		File blobFile = null;
+		File directory = null;
 		try {
 			Configuration config = new Configuration();
 			server = new BlobServer(config);
@@ -252,30 +362,76 @@ public class BlobServerDeleteTest {
 			BlobKey key = client.put(data);
 			assertNotNull(key);
 
-			File blobFile = server.getStorageLocation(key);
-			File directory = blobFile.getParentFile();
+			blobFile = server.getStorageLocation(key);
+			directory = blobFile.getParentFile();
 
 			assertTrue(blobFile.setWritable(false, false));
 			assertTrue(directory.setWritable(false, false));
 
-			// issue a DELETE request
-			try {
-				client.delete(key);
-				fail("DELETE operation should fail if file cannot be deleted");
-			}
-			catch (IOException e) {
-				// expected
-			}
-			finally {
+			// issue a DELETE request via the client
+			client.delete(key);
+
+			// issue a DELETE request on the server
+			server.delete(key);
+
+			// the file should still be there
+			server.getURL(key);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		} finally {
+			if (blobFile != null && directory != null) {
 				blobFile.setWritable(true, false);
 				directory.setWritable(true, false);
 			}
+			cleanup(server, client);
 		}
-		catch (Exception e) {
+	}
+
+	@Test
+	public void testDeleteByNameFails() {
+		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
+
+		BlobServer server = null;
+		BlobClient client = null;
+
+		File blobFile = null;
+		File directory = null;
+		try {
+			Configuration config = new Configuration();
+			server = new BlobServer(config);
+
+			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
+			client = new BlobClient(serverAddress, config);
+
+			byte[] data = new byte[2000000];
+			rnd.nextBytes(data);
+
+			JobID jid = new JobID();
+			String name = "------------fdghljEgRJHF+##4U789Q345";
+
+			client.put(jid, name, data);
+
+			blobFile = server.getStorageLocation(jid, name);
+			directory = blobFile.getParentFile();
+
+			assertTrue(blobFile.setWritable(false, false));
+			assertTrue(directory.setWritable(false, false));
+
+			// issue a DELETE request via the client
+			client.delete(jid, name);
+
+			// issue a DELETE request on the server
+			server.delete(jid, name);
+
+			// the file should still be there
+			server.getURL(jid, name);
+		} catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
-		}
-		finally {
+		} finally {
+			blobFile.setWritable(true, false);
+			directory.setWritable(true, false);
 			cleanup(server, client);
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.blob;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.util.OperatingSystem;
 import org.junit.Test;
 
@@ -40,6 +41,110 @@ import static org.junit.Assume.assumeTrue;
 public class BlobServerPutTest {
 
 	private final Random rnd = new Random();
+
+
+	// --- concurrency tests for utility methods which could fail during the put operation ---
+
+	/**
+	 * Checked thread that calls {@link BlobServer#getStorageLocation(BlobKey)}
+	 */
+	public static class ContentAddressableGetStorageLocation extends CheckedThread {
+		private final BlobServer server;
+		private final BlobKey key;
+
+		public ContentAddressableGetStorageLocation(BlobServer server, BlobKey key) {
+			this.server = server;
+			this.key = key;
+		}
+
+		@Override
+		public void go() throws Exception {
+			server.getStorageLocation(key);
+		}
+	}
+
+	/**
+	 * Tests concurrent calls to {@link BlobServer#getStorageLocation(BlobKey)}.
+	 */
+	@Test
+	public void testServerContentAddressableGetStorageLocationConcurrent() throws Exception {
+		BlobServer server = new BlobServer(new Configuration());
+
+		try {
+			BlobKey key = new BlobKey();
+			CheckedThread[] threads = new CheckedThread[] {
+				new ContentAddressableGetStorageLocation(server, key),
+				new ContentAddressableGetStorageLocation(server, key),
+				new ContentAddressableGetStorageLocation(server, key)
+			};
+			checkedThreadSimpleTest(threads);
+		} finally {
+			server.shutdown();
+		}
+	}
+
+	/**
+	 * Helper method to first start all threads and then wait for their completion.
+	 *
+	 * @param threads threads to use
+	 * @throws Exception exceptions that are thrown from the threads
+	 */
+	protected void checkedThreadSimpleTest(CheckedThread[] threads)
+		throws Exception {
+
+		// start all threads
+		for (CheckedThread t: threads) {
+			t.start();
+		}
+
+		// wait for thread completion and check exceptions
+		for (CheckedThread t: threads) {
+			t.sync();
+		}
+	}
+
+	/**
+	 * Checked thread that calls {@link BlobServer#getStorageLocation(JobID, String)}
+	 */
+	public static class NameAddressableGetStorageLocation extends CheckedThread {
+		private final BlobServer server;
+		private final JobID jid;
+		private final String name;
+
+		public NameAddressableGetStorageLocation(BlobServer server, JobID jid, String name) {
+			this.server = server;
+			this.jid = jid;
+			this.name = name;
+		}
+
+		@Override
+		public void go() throws Exception {
+			server.getStorageLocation(jid, name);
+		}
+	}
+
+	/**
+	 * Tests concurrent calls to {@link BlobServer#getStorageLocation(JobID, String)}.
+	 */
+	@Test
+	public void testServerNameAddressableGetStorageLocationConcurrent() throws Exception {
+		BlobServer server = new BlobServer(new Configuration());
+
+		try {
+			JobID jid = new JobID();
+			String stringKey = "my test key";
+			CheckedThread[] threads = new CheckedThread[] {
+				new NameAddressableGetStorageLocation(server, jid, stringKey),
+				new NameAddressableGetStorageLocation(server, jid, stringKey),
+				new NameAddressableGetStorageLocation(server, jid, stringKey)
+			};
+			checkedThreadSimpleTest(threads);
+		} finally {
+			server.shutdown();
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
 
 	@Test
 	public void testPutBufferSuccessful() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -94,7 +94,8 @@ public class ExecutionGraphCheckpointCoordinatorTest {
 			Collections.<BlobKey>emptyList(),
 			Collections.<URL>emptyList(),
 			new Scheduler(TestingUtils.defaultExecutionContext()),
-			ClassLoader.getSystemClassLoader());
+			ClassLoader.getSystemClassLoader(),
+			null);
 
 		executionGraph.enableCheckpointing(
 				100,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -73,6 +73,8 @@ public class TaskDeploymentDescriptorTest {
 			final TaskStateHandles taskStateHandles = new TaskStateHandles();
 
 			final TaskDeploymentDescriptor orig = new TaskDeploymentDescriptor(
+				jobID,
+				vertexID,
 				serializedJobInformation,
 				serializedJobVertexInformation,
 				execId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -63,6 +63,7 @@ public class BlobLibraryCacheManagerTest {
 			keys.add(bc.put(buf));
 			buf[0] += 1;
 			keys.add(bc.put(buf));
+			bc.put(jid, "test", buf);
 
 			long cleanupInterval = 1000l;
 			libraryCacheManager = new BlobLibraryCacheManager(server, cleanupInterval);
@@ -84,7 +85,7 @@ public class BlobLibraryCacheManagerTest {
 			{
 				long deadline = System.currentTimeMillis() + 30000;
 				do {
-					Thread.sleep(500);
+					Thread.sleep(100);
 				}
 				while (libraryCacheManager.getNumberOfCachedLibraries() > 0 &&
 						System.currentTimeMillis() < deadline);
@@ -106,6 +107,13 @@ public class BlobLibraryCacheManagerTest {
 			}
 
 			assertEquals(2, caughtExceptions);
+
+			try {
+				bc.get(jid, "test");
+				fail("name-addressable BLOB should have been deleted");
+			} catch (IOException e) {
+				// expected
+			}
 
 			bc.close();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -44,8 +44,12 @@ import java.util.List;
 
 public class BlobLibraryCacheManagerTest {
 
+	/**
+	 * Tests that the {@link BlobLibraryCacheManager} cleans up after calling {@link
+	 * BlobLibraryCacheManager#unregisterJob(JobID)}.
+	 */
 	@Test
-	public void testLibraryCacheManagerCleanup() {
+	public void testLibraryCacheManagerJobCleanup() {
 
 		JobID jid = new JobID();
 		List<BlobKey> keys = new ArrayList<BlobKey>();
@@ -69,16 +73,133 @@ public class BlobLibraryCacheManagerTest {
 			libraryCacheManager = new BlobLibraryCacheManager(server, cleanupInterval);
 			libraryCacheManager.registerJob(jid, keys, Collections.<URL>emptyList());
 
-			List<File> files = new ArrayList<File>();
-
-			for (BlobKey key : keys) {
-				files.add(libraryCacheManager.getFile(key));
-			}
-
-			assertEquals(2, files.size());
-			files.clear();
+			assertEquals(2, checkFilesExist(keys, libraryCacheManager, true));
+			assertEquals(2, libraryCacheManager.getNumberOfCachedLibraries());
+			assertEquals(1, libraryCacheManager.getNumberOfReferenceHolders(jid));
 
 			libraryCacheManager.unregisterJob(jid);
+
+			// because we cannot guarantee that there are not thread races in the build system, we
+			// loop for a certain while until the references disappear
+			{
+				long deadline = System.currentTimeMillis() + 30000;
+				do {
+					Thread.sleep(100);
+				}
+				while (libraryCacheManager.getNumberOfCachedLibraries() > 0 &&
+					System.currentTimeMillis() < deadline);
+			}
+
+			// this fails if we exited via a timeout
+			assertEquals(0, libraryCacheManager.getNumberOfCachedLibraries());
+			assertEquals(0, libraryCacheManager.getNumberOfReferenceHolders(jid));
+
+			// the blob cache should no longer contain the files
+			assertEquals(0, checkFilesExist(keys, libraryCacheManager, false));
+
+			try {
+				bc.get(jid, "test");
+				fail("name-addressable BLOB should have been deleted");
+			} catch (IOException e) {
+				// expected
+			}
+
+			bc.close();
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+		finally {
+			if (server != null) {
+				server.shutdown();
+			}
+
+			if (libraryCacheManager != null) {
+				try {
+					libraryCacheManager.shutdown();
+				}
+				catch (IOException e) {
+					e.printStackTrace();
+				}
+			}
+		}
+	}
+
+	/**
+	 * Checks how many of the files given by blob keys are accessible.
+	 *
+	 * @param keys
+	 * 		blob keys to check
+	 * @param libraryCacheManager
+	 * 		cache manager to use
+	 * @param doThrow
+	 * 		whether exceptions should be ignored (<tt>false</tt>), or throws (<tt>true</tt>)
+	 *
+	 * @return number of files we were able to retrieve via {@link BlobLibraryCacheManager#getFile(BlobKey)}
+	 */
+	private int checkFilesExist(
+			List<BlobKey> keys, BlobLibraryCacheManager libraryCacheManager, boolean doThrow)
+			throws IOException {
+		int numFiles = 0;
+
+		for (BlobKey key : keys) {
+			try {
+				libraryCacheManager.getFile(key);
+				++numFiles;
+			} catch (IOException e) {
+				if (doThrow) {
+					throw e;
+				}
+			}
+		}
+
+		return numFiles;
+	}
+
+	/**
+	 * Tests that the {@link BlobLibraryCacheManager} cleans up after calling {@link
+	 * BlobLibraryCacheManager#unregisterTask(JobID, ExecutionAttemptID)}.
+	 */
+	@Test
+	public void testLibraryCacheManagerTaskCleanup() {
+
+		JobID jid = new JobID();
+		ExecutionAttemptID executionId1 = new ExecutionAttemptID();
+		ExecutionAttemptID executionId2 = new ExecutionAttemptID();
+		List<BlobKey> keys = new ArrayList<BlobKey>();
+		BlobServer server = null;
+		BlobLibraryCacheManager libraryCacheManager = null;
+
+		final byte[] buf = new byte[128];
+
+		try {
+			Configuration config = new Configuration();
+			server = new BlobServer(config);
+			InetSocketAddress blobSocketAddress = new InetSocketAddress(server.getPort());
+			BlobClient bc = new BlobClient(blobSocketAddress, config);
+
+			keys.add(bc.put(buf));
+			buf[0] += 1;
+			keys.add(bc.put(buf));
+			bc.put(jid, "test", buf);
+
+			long cleanupInterval = 1000l;
+			libraryCacheManager = new BlobLibraryCacheManager(server, cleanupInterval);
+			libraryCacheManager.registerTask(jid, executionId1, keys, Collections.<URL>emptyList());
+			libraryCacheManager.registerTask(jid, executionId2, keys, Collections.<URL>emptyList());
+
+			assertEquals(2, checkFilesExist(keys, libraryCacheManager, true));
+			assertEquals(2, libraryCacheManager.getNumberOfCachedLibraries());
+			assertEquals(2, libraryCacheManager.getNumberOfReferenceHolders(jid));
+
+			libraryCacheManager.unregisterTask(jid, executionId1);
+
+			assertEquals(2, checkFilesExist(keys, libraryCacheManager, true));
+			assertEquals(2, libraryCacheManager.getNumberOfCachedLibraries());
+			assertEquals(1, libraryCacheManager.getNumberOfReferenceHolders(jid));
+
+			libraryCacheManager.unregisterTask(jid, executionId2);
 
 			// because we cannot guarantee that there are not thread races in the build system, we
 			// loop for a certain while until the references disappear
@@ -93,20 +214,10 @@ public class BlobLibraryCacheManagerTest {
 
 			// this fails if we exited via a timeout
 			assertEquals(0, libraryCacheManager.getNumberOfCachedLibraries());
+			assertEquals(0, libraryCacheManager.getNumberOfReferenceHolders(jid));
 
-			int caughtExceptions = 0;
-
-			for (BlobKey key : keys) {
-				// the blob cache should no longer contain the files
-				try {
-					files.add(libraryCacheManager.getFile(key));
-				}
-				catch (IOException ioe) {
-					caughtExceptions++;
-				}
-			}
-
-			assertEquals(2, caughtExceptions);
+			// the blob cache should no longer contain the files
+			assertEquals(0, checkFilesExist(keys, libraryCacheManager, false));
 
 			try {
 				bc.get(jid, "test");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.SimpleSlot;
@@ -108,7 +109,7 @@ public class ExecutionGraphDeploymentTest {
 				TestingUtils.defaultExecutor(),
 				TestingUtils.defaultExecutor(),
 				jobId, 
-				"some job", 
+				"some job",
 				new Configuration(),
 				new SerializedValue<>(new ExecutionConfig()),
 				AkkaUtils.getDefaultTimeout(),
@@ -514,8 +515,8 @@ public class ExecutionGraphDeploymentTest {
 			new DirectScheduledExecutorService(),
 			TestingUtils.defaultExecutor(),
 			jobId, 
-			"some job", 
-			new Configuration(), 
+			"some job",
+			new Configuration(),
 			new SerializedValue<>(new ExecutionConfig()),
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
@@ -584,6 +585,7 @@ public class ExecutionGraphDeploymentTest {
 			new NoRestartStrategy(),
 			new UnregisteredMetricsGroup(),
 			1,
+			null,
 			LoggerFactory.getLogger(getClass()));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentWithBlobServerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentWithBlobServerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests {@link ExecutionGraph} deployment when offloading job and task information into the BLOB
+ * server.
+ */
+public class ExecutionGraphDeploymentWithBlobServerTest extends ExecutionGraphDeploymentTest {
+
+	@Before
+	public void setupBlobServer() throws IOException {
+		Configuration config = new Configuration();
+		// always offload the serialized job and task information
+		config.setInteger(AkkaOptions.AKKA_RPC_OFFLOAD_MINSIZE, 0);
+		blobServer = new BlobServer(config);
+	}
+
+	@After
+	public void shutdownBlobServer() {
+		if (blobServer != null) {
+			blobServer.shutdown();
+		}
+	}
+
+	@Override
+	protected void checkJobOffloaded(ExecutionGraph eg) throws Exception {
+		assertTrue(eg.hasJobInformationAtBlobStore());
+
+		final String fileKey = ExecutionGraph.getOffloadedJobInfoFileName();
+		// must not throw:
+		blobServer.getURL(eg.getJobID(), fileKey);
+	}
+
+	@Override
+	protected void checkTaskOffloaded(ExecutionGraph eg, JobVertexID jobVertexId) throws Exception {
+		assertTrue(eg.getJobVertex(jobVertexId).hasTaskInformationAtBlobStore());
+
+		final String fileKey = ExecutionJobVertex.getOffloadedTaskInfoFileName(jobVertexId);
+		// must not throw:
+		blobServer.getURL(eg.getJobID(), fileKey);
+	}
+
+	// TODO: test cleanup with failures?
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphMetricsTest.java
@@ -136,7 +136,8 @@ public class ExecutionGraphMetricsTest extends TestLogger {
 				Collections.<BlobKey>emptyList(),
 				Collections.<URL>emptyList(),
 				scheduler,
-				getClass().getClassLoader());
+				getClass().getClassLoader(),
+				null);
 
 			RestartTimeGauge restartingTime = new RestartTimeGauge(executionGraph);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
@@ -568,6 +568,7 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 			new NoRestartStrategy(),
 			new UnregisteredMetricsGroup(),
 			1,
+			null,
 			log);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexLocalityTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexLocalityTest.java
@@ -218,6 +218,7 @@ public class ExecutionVertexLocalityTest extends TestLogger {
 			new FixedDelayRestartStrategy(10, 0L),
 			new UnregisteredMetricsGroup(),
 			1,
+			null,
 			log);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -509,6 +509,8 @@ public class TaskExecutorTest extends TestLogger {
 		SerializedValue<TaskInformation> serializedJobVertexInformation = new SerializedValue<>(taskInformation);
 
 		final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
+				jobId,
+				jobVertexId,
 				serializedJobInformation,
 				serializedJobVertexInformation,
 				new ExecutionAttemptID(),
@@ -1053,6 +1055,8 @@ public class TaskExecutorTest extends TestLogger {
 			SerializedValue<TaskInformation> serializedJobVertexInformation = new SerializedValue<>(taskInformation);
 
 			final TaskDeploymentDescriptor tdd = new TaskDeploymentDescriptor(
+				jobId,
+				jobVertexId,
 				serializedJobInformation,
 				serializedJobVertexInformation,
 				new ExecutionAttemptID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -2060,6 +2060,8 @@ public class TaskManagerTest extends TestLogger {
 		SerializedValue<TaskInformation> serializedJobVertexInformation = new SerializedValue<>(taskInformation);
 
 		return new TaskDeploymentDescriptor(
+			jobId,
+			jobVertexId,
 			serializedJobInformation,
 			serializedJobVertexInformation,
 			executionAttemptId,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
@@ -150,7 +150,8 @@ public class RescalePartitionerTest extends TestLogger {
 			new ArrayList<BlobKey>(),
 			new ArrayList<URL>(),
 			new Scheduler(TestingUtils.defaultExecutionContext()),
-			ExecutionGraph.class.getClassLoader());
+			ExecutionGraph.class.getClassLoader(),
+			null);
 		try {
 			eg.attachJobGraph(jobVertices);
 		}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -102,7 +102,6 @@ import static org.apache.flink.runtime.messages.JobManagerMessages.getDisposeSav
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -313,7 +312,9 @@ public class SavepointITCase extends TestLogger {
 			// - Verification START -------------------------------------------
 
 			String errMsg = "Error during gathering of TaskDeploymentDescriptors";
-			assertNull(errMsg, error[0]);
+			if (error[0] != null) {
+				throw new AssertionError(errMsg, error[0]);
+			}
 
 			// Verify that all tasks, which are part of the savepoint
 			// have a matching task deployment descriptor.


### PR DESCRIPTION
(builds upon #3512)

This adds offloading of large data from the `TaskDeploymentDescriptor` to the `BlobServer`, i.e. `serializedJobInformation` and `serializedTaskInformation`, in case they are larger than the new `akka.rpc.offload.minsize` config parameter. Both fields are offloaded only once for all parallel instances which does not only frees use from the akka message size restriction but should also speed up massive deployments by leveraging any distributed file system used for the blob server.

Future extensions may keep this information stored in the blob store (and not clean up immediately after a job finishes in `BlobLibraryCacheManager`) and use the same blobs for re-deployments, e.g. in case of failures.

Compared to the JIRA description, this PR already implements one of the extensions: the separation of the serialized job information and task information and the re-use of them for all parallel instances.