### PR TITLE
[FLINK-6341]Don't let JM fall into infinite loop

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/messages/ReconnectResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/messages/ReconnectResourceManager.java
@@ -35,11 +35,11 @@ public class ReconnectResourceManager implements RequiresLeaderSessionID, java.i
 
 	private final ActorRef resourceManager;
 
-	private final UUID connID;
+	private final UUID currentConnID;
 
-	public ReconnectResourceManager(ActorRef resourceManager, UUID connID) {
+	public ReconnectResourceManager(ActorRef resourceManager, UUID currentConnID) {
 		this.resourceManager = Preconditions.checkNotNull(resourceManager);
-		this.connID = Preconditions.checkNotNull(connID);
+		this.currentConnID = Preconditions.checkNotNull(currentConnID);
 	}
 	
 	public ActorRef resourceManager() {
@@ -47,7 +47,7 @@ public class ReconnectResourceManager implements RequiresLeaderSessionID, java.i
 	}
 
 	public UUID connID() {
-		return connID;
+		return currentConnID;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/messages/ReconnectResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/messages/ReconnectResourceManager.java
@@ -22,6 +22,8 @@ import akka.actor.ActorRef;
 import org.apache.flink.runtime.messages.RequiresLeaderSessionID;
 import org.apache.flink.util.Preconditions;
 
+import java.util.UUID;
+
 /**
  * This message signals that the ResourceManager should reconnect to the JobManager. It is processed
  * by the JobManager if it fails to register resources with the ResourceManager. The JobManager wants
@@ -33,12 +35,19 @@ public class ReconnectResourceManager implements RequiresLeaderSessionID, java.i
 
 	private final ActorRef resourceManager;
 
-	public ReconnectResourceManager(ActorRef resourceManager) {
+	private final UUID connID;
+
+	public ReconnectResourceManager(ActorRef resourceManager, UUID connID) {
 		this.resourceManager = Preconditions.checkNotNull(resourceManager);
+		this.connID = Preconditions.checkNotNull(connID);
 	}
 	
 	public ActorRef resourceManager() {
 		return resourceManager;
+	}
+
+	public UUID connID() {
+		return connID;
 	}
 
 	@Override

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -356,7 +356,12 @@ class JobManager(
         msg.resourceManager() ! decorateMessage(new TriggerRegistrationAtJobManager(self))
         // try again after some delay
         context.system.scheduler.scheduleOnce(2 seconds) {
-          self ! decorateMessage(msg)
+          currentResourceManager match {
+            case None =>
+              self ! decorateMessage (msg)
+            case Some(rm) =>
+              log.info("Do not trigger Flink Resource Manager registration as it has done.")
+          }
         }(context.dispatcher)
       }
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -359,7 +359,7 @@ class JobManager(
         msg.resourceManager() ! decorateMessage(new TriggerRegistrationAtJobManager(self))
         // try again after some delay
         context.system.scheduler.scheduleOnce(2 seconds) {
-          self ! decorateMessage (msg)
+          self ! decorateMessage(msg)
         }(context.dispatcher)
       }
 


### PR DESCRIPTION
When TaskManager register to JobManager, JM will send a "NotifyResourceStarted" message to kick off Resource Manager, then trigger a reconnection to resource manager through sending a "TriggerRegistrationAtJobManager".

When the ref of resource manager in JobManager is not None and the reconnection is to same resource manager, JobManager will go to a infinite message sending loop which will always sending himself a "ReconnectResourceManager" every 2 seconds.

We have already observed that phonomenon. More details, check how JobManager handles `ReconnectResourceManager`.