### PR TITLE
[FLINK-6306] [filesystem-connectors] Sink for eventually consistent file systems

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
@@ -222,7 +222,7 @@ public class BucketingSink<T>
 	/**
 	 * The default prefix for part files.
 	 */
-	private final String DEFAULT_PART_REFIX = "part";
+	private final String DEFAULT_PART_PREFIX = "part";
 
 	/**
 	 * The default timeout for asynchronous operations such as recoverLease and truncate (in {@code ms}).
@@ -260,7 +260,7 @@ public class BucketingSink<T>
 	private String validLengthSuffix = DEFAULT_VALID_SUFFIX;
 	private String validLengthPrefix= DEFAULT_VALID_PREFIX;
 
-	private String partPrefix = DEFAULT_PART_REFIX;
+	private String partPrefix = DEFAULT_PART_PREFIX;
 
 	/**
 	 * The timeout for asynchronous operations such as recoverLease and truncate (in {@code ms}).

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/consistent/CheckpointWithTimestampBucketer.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/consistent/CheckpointWithTimestampBucketer.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.fs.consistent;
+
+import org.apache.hadoop.fs.Path;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * An {@link EventuallyConsistentBucketer} that assigns to buckets based on
+ * the checkpoint id and the time at which that checkpoint was initiated.
+ *
+ * <p>
+ * The {@code CheckpointWithTimestampBucketer} will create directories of the following form:
+ * {@code /{basePath}/{dateTimePath}/{checkpointId}}. The {@code basePath} is the path
+ * that was specified as a base path when creating the
+ * {@link EventuallyConsistentBucketer}. The {@code dateTimePath}
+ * is determined based on the time the checkpoint was initiated
+ * and the user provided format string.
+ *
+ * <p>
+ * {@link SimpleDateFormat} is used to derive a date string from the current system time and
+ * the date format string. The default format string is {@code "yyyy-MM-dd/HH-mm"} so the rolling
+ * files will have a granularity of minutes. <b>NOTE: </b> it is important that your timestamp
+ * is more fine-grained then checkpoint frequency for exactly once writes to be guaranteed.
+ *
+ */
+public class CheckpointWithTimestampBucketer implements EventuallyConsistentBucketer {
+
+	private static final String DEFAULT_FORMAT_STRING = "yyyy-MM-dd/HH-mm";
+
+	private transient SimpleDateFormat dateFormatter;
+
+	private String formatString;
+
+	public CheckpointWithTimestampBucketer() {
+		this(DEFAULT_FORMAT_STRING);
+	}
+
+	public CheckpointWithTimestampBucketer(String formatString) {
+		this.formatString = formatString;
+		this.dateFormatter = new SimpleDateFormat(formatString);
+	}
+
+	@Override
+	public Path getEventualConsistencyPath(Path basePath, long checkpointId, long timestamp) {
+		String newDateTimeString = dateFormatter.format(new Date(timestamp));
+		return new Path(basePath + "/" + newDateTimeString + "/" + checkpointId);
+	}
+}

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/consistent/CheckpointWithTimestampBucketer.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/consistent/CheckpointWithTimestampBucketer.java
@@ -61,6 +61,6 @@ public class CheckpointWithTimestampBucketer implements EventuallyConsistentBuck
 	@Override
 	public Path getEventualConsistencyPath(Path basePath, long checkpointId, long timestamp) {
 		String newDateTimeString = dateFormatter.format(new Date(timestamp));
-		return new Path(basePath + "/" + newDateTimeString + "/" + checkpointId);
+		return new Path(basePath, "/" + newDateTimeString + "/" + checkpointId);
 	}
 }

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/consistent/EventuallyConsistentBucketer.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/consistent/EventuallyConsistentBucketer.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.fs.consistent;
+
+import org.apache.hadoop.fs.Path;
+
+import java.io.Serializable;
+
+/**
+ * The eventual consistency bucketer is used with a {@code EventuallyConsistentBucketingSink }
+ * to generate a unique path for each checkpoint based on the timestamp that the
+ * checkpoint was initiated by the job manager.
+ *
+ * It is important that if {@code EventuallyConsistentBucketer#getEventualConsistencyPath}
+ * is called twice with the same checkpoint id but different timestamps that different
+ * final paths are returned. Otherwise, exactly once cannot be guaranteed.
+ */
+public interface EventuallyConsistentBucketer extends Serializable {
+	Path getEventualConsistencyPath(Path basePath, long checkpointId, long timestamp);
+}

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/consistent/EventuallyConsistentBucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/consistent/EventuallyConsistentBucketingSink.java
@@ -1,0 +1,682 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.fs.consistent;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
+import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.connectors.fs.StringWriter;
+import org.apache.flink.streaming.connectors.fs.Writer;
+import org.apache.flink.streaming.connectors.fs.bucketing.Bucketer;
+import org.apache.flink.util.Preconditions;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.security.action.GetPropertyAction;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.Serializable;
+import java.security.AccessController;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Sink that emits its input elements its input elements to a {@link FileSystem } with eventual consistency semantics
+ * such as Amazon's S3. This is integrated with the checkpointing mechanism to provide either exactly once or at least
+ * once semantics depending on the level of cooperation put forth by the consuming processes.
+ *
+ * <p>
+ * When creating the sink a {@code basePath} must be specified. The base directory contains one directory for every
+ * checkpoint. The checkpoint directories themselves contain several part files, at least one for every parallel subtask
+ * of the sink. These part files contain the actual output data.
+ *
+ * <p>
+ * The sink uses a {@link EventuallyConsistentBucketer} to determine which directory each file should be written to
+ * inside the base directory. The {@code EventuallyConsistentBucketer} must take into account both the checkpoint id
+ * as well as the checkpoint timestamp to otherwise exactly once output will not be guaranteed. The default
+ * {@code EventuallyConsistentBucketer} is a {@link CheckpointWithTimestampBucketer} or you can specify a custom
+ * one using {@link #setEventuallyConsistentBucketer(EventuallyConsistentBucketer)}.
+ *
+ * <p>
+ * The filenames of the part files contain the part prefix, the parallel subtask index of the sink
+ * and a rolling counter. For example the file {@code "part-1-1"} contains the data from
+ * {@code subtask 1} of the sink and is the {@code 1st} file created by that subtask. Per default
+ * the part prefix is {@code "part"} but this can be configured using {@link #setPartPrefix(String)}.
+ *
+ * <p>
+ * An eventually consistent filesystem typically provides weak guarantee's about what operations can be performed in
+ * a stable manner. In general, {@code PUT} is the only operation considered always consistent. This sink will buffer
+ * data either on local disk, or another consistent file system such as {@code HDFS} and then copy all files to the
+ * final destination once per checkpoint.
+ *
+ * <p>
+ * Because {@code DELETE} operations are not permitted, if a checkpoint fails
+ * then invalid files are not removed. Instead directories containing all valid files will be marked with an empty flagFile
+ * file. The default flagFile file is {@code _DONE} but you can specify a custom one using {@link #setFlagFile(String)}.
+ * It is then up to consuming processes to choose their guarantees. They can either achieve exactly once semantics by
+ * only consuming directories with flagFile files or at least once semantics by consuming all files.
+ *
+ * <p>
+ * <b>NOTE:</b>
+ * <ol>
+ *     <li>
+ *         If checkpointing is not enabled the buffered files on disk will never be moved to their final location. In
+ *         the case of data be buffered on local disk this will result in data being written until all disk space is
+ *         consumed.
+ *     </li>
+ *	    <li>
+ *         The part files are written using an instance of {@link Writer}. By default, a
+ *         {@link StringWriter} is used, which writes the result of {@code toString()} for
+ *         every element, separated by newlines. You can configure the writer using the
+ *         {@link #setWriter(Writer)}. For example, {@link org.apache.flink.streaming.connectors.fs.AvroKeyValueSinkWriter.AvroKeyValueWriter}
+ *         can be used to write Hadoop {@code AvroKeyValueSinkWriter}.
+ *     </li>
+ * </ol>
+ * </ol>
+ * @param <T>
+ */
+public class EventuallyConsistentBucketingSink<T>
+	extends RichSinkFunction<T>
+	implements InputTypeConfigurable, CheckpointedFunction, CheckpointListener {
+
+	private static final long serialVersionUID = 1L;
+
+	private static Logger LOG = LoggerFactory.getLogger(EventuallyConsistentBucketingSink.class);
+
+	/**
+	 * The default maximum size of part files (currently {@code 384 MB}).
+	 */
+	private final long DEFAULT_BATCH_SIZE = 1024L * 1024L * 384L;
+
+	/**
+	 * The default prefix for part files.
+	 */
+	private final String DEFAULT_PART_PREFIX = "part";
+
+	/**
+	 * The default flagFile file for denoting consistent buckets
+	 */
+	private final String DEFAULT_FLAG_FILE = "_DONE";
+
+	/**
+	 * The consistent file system directory where files are buffered
+	 * before being copied to their final location. The default
+	 * location is platform dependent tmp directory on local disk.
+	 */
+	private String consistentFsDir;
+
+	/**
+	 * The base {@code Path} that stores all bucket directories.
+	 */
+	private final String basePath;
+
+	/**
+	 * The {@code EventuallyConsistentBucketer} that is used to determine the path of bucket directories.
+	 */
+	private EventuallyConsistentBucketer bucketer;
+
+	/**
+	 * We have a template and call duplicate() for each parallel writer in open() to get the actual
+	 * writer that is used for the part files.
+	 */
+	private Writer<T> writerTemplate;
+
+	private String flagFile = DEFAULT_FLAG_FILE;
+
+	private String partPrefix = DEFAULT_PART_PREFIX;
+
+	private long batchSize = DEFAULT_BATCH_SIZE;
+
+	/**
+	 * User-defined FileSystem parameters
+	 */
+	private Configuration fsConfig;
+
+	/**
+	 * User-defined FileSystem parameters for the buffer remoteFileSystem
+	 */
+	private Configuration consistentFsConfig;
+
+	/**
+	 * The FileSystem reference.
+	 */
+	private transient FileSystem remoteFileSystem;
+
+	private transient State<T> state;
+
+	/**
+	 * Store path to unwritten but required flag files
+	 * in case the job fails between a checkpoint completing
+	 * and the operator being notified.
+	 */
+	private transient ListState<String> completedBucketState;
+
+	public EventuallyConsistentBucketingSink(String basePath) {
+		this.consistentFsDir = new File(AccessController.doPrivileged(new GetPropertyAction("java.io.tmpdir"))).getPath();
+		this.basePath = basePath;
+		this.bucketer = new FineGrainedBucketer();
+		this.writerTemplate = new StringWriter<>();
+	}
+
+	/**
+	 * Specify a custom {@code Configuration} that will be used when creating
+	 * the {@link FileSystem} for writing.
+	 */
+	public EventuallyConsistentBucketingSink<T> setFSConfig(Configuration config) {
+		this.fsConfig = new Configuration();
+		fsConfig.addAll(config);
+		return this;
+	}
+
+	/**
+	 * Sets the prefix of part files.  The default is {@code "part"}.
+	 */
+	public EventuallyConsistentBucketingSink<T> setPartPrefix(String partPrefix) {
+		this.partPrefix = partPrefix;
+		return this;
+	}
+
+	/**
+	 * Sets the maximum bucket size in bytes.
+	 *
+	 * <p>
+	 * When a bucket part file becomes larger than this size a new bucket part file is started and
+	 * the old one is closed. The name of the bucket files depends on the {@link Bucketer}.
+	 *
+	 * @param batchSize The bucket part file size in bytes.
+	 */
+	public EventuallyConsistentBucketingSink<T> setBatchSize(long batchSize) {
+		this.batchSize = batchSize;
+		return this;
+	}
+
+	/**
+	 * Specify a custom {@code Configuration} that will be used when creating
+	 * the {@link FileSystem} for writing.
+	 */
+	public EventuallyConsistentBucketingSink<T> setFSConfig(org.apache.hadoop.conf.Configuration config) {
+		this.fsConfig = new Configuration();
+		for(Map.Entry<String, String> entry : config) {
+			fsConfig.setString(entry.getKey(), entry.getValue());
+		}
+		return this;
+	}
+
+	/**
+	 * Specify a custom {@code Configuration} that will be used when creating
+	 * the {@link FileSystem} for writing buffer files.
+	 */
+	public EventuallyConsistentBucketingSink<T> setBufferFSConfig(Configuration config) {
+		this.consistentFsConfig = new Configuration();
+		consistentFsConfig.addAll(config);
+		return this;
+	}
+
+	/**
+	 * Specify a custom {@code Configuration} that will be used when creating
+	 * the {@link FileSystem} for writing buffer files.
+	 */
+	public EventuallyConsistentBucketingSink<T> setBufferFSConfig(org.apache.hadoop.conf.Configuration config) {
+		this.consistentFsConfig = new Configuration();
+		for(Map.Entry<String, String> entry : config) {
+			consistentFsConfig.setString(entry.getKey(), entry.getValue());
+		}
+		return this;
+	}
+
+	public EventuallyConsistentBucketingSink<T> setEventuallyConsistentBucketer(EventuallyConsistentBucketer bucketer) {
+		this.bucketer = bucketer;
+		return this;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public void setInputType(TypeInformation<?> type, ExecutionConfig executionConfig) {
+		if (this.writerTemplate instanceof InputTypeConfigurable) {
+			((InputTypeConfigurable) writerTemplate).setInputType(type, executionConfig);
+		}
+	}
+
+	/**
+	 * Sets the {@link Writer} to be used for writing the incoming elements to bucket files.
+	 *
+	 * @param writer The {@code Writer} to use.
+	 */
+	public EventuallyConsistentBucketingSink<T> setWriter(Writer<T> writer) {
+		this.writerTemplate = writer;
+		return this;
+	}
+
+	/**
+	 * Sets the local directory where buffers will be written.
+	 * The default is the local os specific temporary directory.
+	 */
+	public EventuallyConsistentBucketingSink<T> setBufferDirectory(String path) {
+		this.consistentFsDir = path;
+		return this;
+	}
+
+	/**
+	 * Sets the name of the flagFile file for marking buckets as being
+	 * available for exactly once reading. The default is {@code _DONE}.
+	 * @param flag The name of the flagFile file to use.
+	 */
+	public EventuallyConsistentBucketingSink<T> setFlagFile(String flag) {
+		this.flagFile = flag;
+		return this;
+	}
+
+	@Override
+	public void open(Configuration configuration) throws Exception {
+		if (state == null) {
+			state = new State<>(writerTemplate, partPrefix, getRuntimeContext().getIndexOfThisSubtask());
+		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		state.cleanup();
+		remoteFileSystem.close();
+	}
+
+	@Override
+	public void invoke(T value) throws Exception {
+		if (state.isWriterOpen && state.currentBucket.writer.getPos() > batchSize) {
+			state.closeFile();
+		}
+
+		if (!state.isWriterOpen) {
+			state.openFile();
+		}
+
+		state.currentBucket.writer.write(value);
+	}
+
+	@Override
+	public void initializeState(FunctionInitializationContext context) throws Exception {
+		if (state == null) {
+			state = new State<>(writerTemplate, partPrefix, getRuntimeContext().getIndexOfThisSubtask());
+		}
+		try {
+			state.initFileSystem(consistentFsConfig, consistentFsDir);
+			initFileSystem();
+		} catch (IOException e) {
+			LOG.error("Error while creating FileSystem when initializing the status of the EventuallyConsistentBucketingSink.", e);
+			throw new RuntimeException("Error while creating FileSystem when initializing the status of the EventuallyConsistentBucketingSink.", e);
+		}
+
+		completedBucketState = context.getOperatorStateStore().getSerializableListState("completed-buckets");
+
+		if (context.isRestored()) {
+			for (String flag : completedBucketState.get()) {
+				Path flagPath = new Path(flag);
+
+				// this may not be the first time
+				// we've restarted from this checkpoint
+				if (!remoteFileSystem.exists(flagPath)) {
+					remoteFileSystem.create(flagPath).close();
+				}
+			}
+
+			RemoteIterator<LocatedFileStatus> oldBufferFiles = state.fileOnPath();
+
+			while (oldBufferFiles.hasNext()) {
+				LocatedFileStatus bufferFile = oldBufferFiles.next();
+				if (bufferFile.isFile() && bufferFile.getPath().getName().startsWith(partPrefix)) {
+					try {
+						state.consistentFileSystem.delete(bufferFile.getPath(), true);
+					} catch (FileNotFoundException ignore) {
+						LOG.info("Attempted to delete a non-existent file, ignoring");
+					} catch (IOException e) {
+						LOG.error("Error while deleting old buffer file when restoring the status of the EventuallyConsistentBucketingSink.", e);
+						throw new RuntimeException("Error while deleting old buffer file when restoring the status of the EventuallyConsistentBucketingSink.", e);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Create a file system with the user-defined {@code HDFS} configuration.
+	 * @throws IOException
+	 */
+	private void initFileSystem() throws IOException {
+		if (remoteFileSystem != null) {
+			return;
+		}
+		org.apache.hadoop.conf.Configuration hadoopConf = HadoopFileSystem.getHadoopConfiguration();
+		if (fsConfig != null) {
+			String disableCacheName = String.format("remoteFileSystem.%s.impl.disable.cache", new Path(basePath).toUri().getScheme());
+			hadoopConf.setBoolean(disableCacheName, true);
+			for (String key : fsConfig.keySet()) {
+				hadoopConf.set(key, fsConfig.getString(key, null));
+			}
+		}
+
+		remoteFileSystem = new Path(basePath).getFileSystem(hadoopConf);
+	}
+
+	@Override
+	public void snapshotState(FunctionSnapshotContext context) throws Exception {
+		completedBucketState.clear();
+
+		if (state.isWriterOpen) {
+			state.closeFile();
+		}
+
+		Path bucketPath = bucketer.getEventualConsistencyPath(new Path(basePath), context.getCheckpointId(), context.getCheckpointTimestamp());
+		state.rollBucket(context.getCheckpointId(), bucketPath);
+
+		synchronized (state.pendingBuckets) {
+			Iterator<Map.Entry<Long, BucketState<T>>> buckets = state.pendingBuckets.entrySet().iterator();
+
+			while (buckets.hasNext()) {
+				Map.Entry<Long, BucketState<T>> entry = buckets.next();
+				final BucketState<T> bucket = entry.getValue();
+
+				if (bucket.status == UploadStatus.Completed) {
+					continue;
+				}
+
+				bucket.status = UploadStatus.InProgress;
+
+				Iterator<Path> files = bucket.bufferFiles.iterator();
+				while (files.hasNext()) {
+					Path file = files.next();
+					remoteFileSystem.copyFromLocalFile(file, new Path(bucket.remotePath, file.getName()));
+
+					Path uploaded = file.suffix("." + Long.toString(context.getCheckpointId()) + ".uploaded");
+					state.consistentFileSystem.rename(file, uploaded);
+
+					synchronized (bucket.uploadedFiles) {
+						bucket.uploadedFiles.add(uploaded);
+						files.remove();
+					}
+				}
+
+				bucket.status = UploadStatus.Completed;
+
+				synchronized (state.completedBuckets) {
+					state.completedBuckets.put(entry.getKey(), bucket);
+				}
+
+				if (state.subtaskIndex == 0) {
+					// only store a single instance per job
+					Path flagFilePath = new Path(bucket.remotePath, flagFile);
+					bucket.flagFile = flagFilePath;
+					completedBucketState.add(flagFilePath.toString());
+				}
+
+				buckets.remove();
+			}
+		}
+	}
+
+	@Override
+	public void notifyCheckpointComplete(long checkpointId) throws Exception {
+		synchronized (state.completedBuckets) {
+			Iterator<Map.Entry<Long, BucketState<T>>> buckets = state.completedBuckets.entrySet().iterator();
+
+			while (buckets.hasNext()) {
+				Map.Entry<Long, BucketState<T>> entry = buckets.next();
+
+				if (checkpointId < entry.getKey()) {
+					continue;
+				}
+
+				Iterator<Path> localFiles = entry.getValue().uploadedFiles.iterator();
+
+				while (localFiles.hasNext()) {
+					Path file = localFiles.next();
+					state.consistentFileSystem.delete(file, true);
+					localFiles.remove();
+				}
+
+				if (state.subtaskIndex == 0) {
+					remoteFileSystem.create(entry.getValue().flagFile, true).close();
+				}
+
+				buckets.remove();
+			}
+		}
+	}
+
+	enum UploadStatus implements Serializable {
+		NotStarted,
+		InProgress,
+		Completed
+	}
+
+	static class State<T> implements Serializable {
+		private static final long serialVersionUID = 1L;
+
+		private transient boolean isWriterOpen;
+
+		private transient BucketState<T> currentBucket;
+
+		private final transient Map<Long, BucketState<T>> pendingBuckets;
+
+		private final transient Map<Long, BucketState<T>> completedBuckets;
+
+		private transient FileSystem consistentFileSystem;
+
+		private transient Path consistentFsPath;
+
+		private Writer<T> writerTemplate;
+
+		private int subtaskIndex;
+
+		String partPrefix;
+
+		State(Writer<T> writerTemplate, String partPrefix, int subtaskIndex) {
+			this.isWriterOpen = false;
+			this.currentBucket = new BucketState<>();
+			this.pendingBuckets = new HashMap<>();
+			this.completedBuckets = new HashMap<>();
+
+			this.writerTemplate = writerTemplate;
+			this.subtaskIndex = subtaskIndex;
+			this.partPrefix = partPrefix;
+		}
+
+		private void openFile() throws IOException {
+			if (isWriterOpen) {
+				throw new IOException("Invalid operation; cannot open a file if the writer is already open");
+			}
+
+			isWriterOpen = true;
+			currentBucket.open(writerTemplate, consistentFsPath, partPrefix, subtaskIndex, consistentFileSystem);
+		}
+
+		private void closeFile() throws IOException {
+			if (!isWriterOpen) {
+				throw new IOException("Invalid operation; cannot close a file that is not open");
+			}
+
+			currentBucket.close();
+			isWriterOpen = false;
+		}
+
+		private void rollBucket(long checkpointId, Path remotePath) {
+			Preconditions.checkArgument(!isWriterOpen, "Cannot roll a bucket if it has an open writer");
+
+			synchronized (pendingBuckets) {
+				currentBucket.remotePath = remotePath;
+				pendingBuckets.put(checkpointId, currentBucket);
+				currentBucket = new BucketState<>();
+			}
+		}
+
+		RemoteIterator<LocatedFileStatus> fileOnPath() throws IOException {
+			return consistentFileSystem.listFiles(consistentFsPath, true);
+		}
+
+		/**
+		 * Create a buffer file system with the user-defined {@code HDFS} configuration.
+		 * @throws IOException
+		 */
+		private void initFileSystem(Configuration consistentFsConfig, String consistentFsDir) throws IOException {
+			if (consistentFileSystem != null) {
+				return;
+			}
+
+			org.apache.hadoop.conf.Configuration hadoopConf = HadoopFileSystem.getHadoopConfiguration();
+			if (consistentFsConfig != null) {
+				String disableCacheName = String.format("remoteFileSystem.%s.impl.disable.cache", new Path(consistentFsDir).toUri().getScheme());
+				hadoopConf.setBoolean(disableCacheName, true);
+				for (String key : consistentFsConfig.keySet()) {
+					hadoopConf.set(key, consistentFsConfig.getString(key, null));
+				}
+			}
+
+			consistentFsPath = new Path(consistentFsDir, "flink-ecs-dir/" + Integer.toString(subtaskIndex));
+			consistentFileSystem = consistentFsPath.getFileSystem(hadoopConf);
+
+			if (consistentFileSystem.exists(consistentFsPath)) {
+				consistentFileSystem.delete(consistentFsPath, true);
+			} else if (!consistentFileSystem.mkdirs(consistentFsPath)) {
+				LOG.error("Failed to create buffer directory %s", consistentFsPath.toString());
+				throw new RuntimeException(String.format("Failed to create buffer directory %s", consistentFsPath.toString()));
+			}
+		}
+
+		private void cleanup() throws IOException {
+			if (isWriterOpen) {
+				currentBucket.close();
+			}
+
+			consistentFileSystem.delete(new Path(consistentFsPath, currentBucket.subdir), true);
+			for (BucketState<T> bucket : pendingBuckets.values()) {
+				consistentFileSystem.delete(new Path(consistentFsPath, bucket.subdir), true);
+			}
+
+			for (BucketState<T> bucket : completedBuckets.values()) {
+				consistentFileSystem.delete(new Path(consistentFsPath, bucket.subdir), true);
+			}
+
+			consistentFileSystem.close();
+		}
+	}
+
+	static class BucketState<T> implements Serializable {
+		/**
+		 * Closed buffer files that **have not** been
+		 * uploaded to remote
+		 */
+		final transient List<Path> bufferFiles;
+
+		/**
+		 * Closed buffer files that **have** been uploaded
+		 * to remote but have not been deleted from local
+		 * disk.
+		 */
+		final transient List<Path> uploadedFiles;
+
+		/**
+		 * The remote path for this checkpoint
+		 * as designated by the bucketer
+		 */
+		transient Path remotePath;
+
+		/**
+		 * The remote path to the flag
+		 * file that will mark this
+		 * bucket as consistent.
+		 */
+		transient Path flagFile;
+
+		/**
+		 * Upload status of this bucket
+		 */
+		transient UploadStatus status;
+
+		/**
+		 * For counting the part files inside a bucket directory. Part files follow the pattern
+		 * {@code "{part-prefix}-{subtask}-{count}"}. When creating new part files we increase the counter.
+		 */
+		int partCounter;
+
+
+		/**
+		 * The unique sub directory that
+		 * scopes the files for this particular
+		 * bucket
+		 */
+		String subdir;
+
+
+		/**
+		 * The actual writer that we user for writing the part files.
+		 */
+		private transient Writer<T> writer;
+
+		/**
+		 * The currentBucket path being written to by the writer
+ 		 */
+		private transient Path currentPath;
+
+		BucketState() {
+			this.status = UploadStatus.NotStarted;
+			this.bufferFiles = new ArrayList<>();
+			this.uploadedFiles = new ArrayList<>();
+			this.subdir = Long.toString(Math.abs(UUID.randomUUID().getMostSignificantBits()));
+		}
+
+		void open(Writer<T> writerTemplate, Path consistentFsPath, String partPrefix, int subtaskIndex, FileSystem consistentFileSystem) throws IOException {
+			try {
+				writer = writerTemplate.duplicate();
+				String fileName = subdir + "/" + partPrefix + "-" + subtaskIndex + "-" + this.partCounter;
+				currentPath = new Path(consistentFsPath, fileName);
+				this.partCounter++;
+				writer.open(consistentFileSystem, currentPath);
+			} catch(IOException e) {
+				LOG.error("Failed to open buffer file {} for writing", currentPath, e);
+				throw new IOException("Failed to open buffer file " + currentPath + " for writing", e);
+			}
+		}
+
+		void close() throws IOException {
+			try {
+				writer.close();
+			} catch (IOException e) {
+				LOG.error("Unable to close buffer part file in EventuallyConsistentBucketingSink", e);
+				throw new IOException("Unable to close buffer part file in EventuallyConsistentBucketingSink", e);
+			}
+
+			bufferFiles.add(currentPath);
+			currentPath = null;
+		}
+	}
+}

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/consistent/FineGrainedBucketer.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/consistent/FineGrainedBucketer.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.fs.consistent;
+
+import org.apache.hadoop.fs.Path;
+
+/**
+ * A {@link EventuallyConsistentBucketer} that assigns to buckets based on
+ * the checkpoint id and the time at which that checkpoint was initiated.
+ * The timestamp is printed as milliseconds since the epoch so this is always
+ * guaranteed to be a consistent bucketing scheme.
+ */
+public class FineGrainedBucketer implements EventuallyConsistentBucketer {
+	@Override
+	public Path getEventualConsistencyPath(Path basePath, long checkpointId, long timestamp) {
+		return new Path(basePath, Long.toString(checkpointId) + "/" +  Long.toString(timestamp));
+	}
+}

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/consistent/EventuallyConsistentSinkFaultToleranceITCase.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/consistent/EventuallyConsistentSinkFaultToleranceITCase.java
@@ -1,0 +1,300 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.fs.consistent;
+
+import com.google.common.collect.Sets;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.test.checkpointing.StreamFaultToleranceTestBase;
+import org.apache.flink.util.NetUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link EventuallyConsistentBucketingSink}.
+ *
+ * <p>
+ * This test only verifies the exactly once behaviour of the sink. Another test tests the
+ * rolling behaviour.
+ */
+public class EventuallyConsistentSinkFaultToleranceITCase extends StreamFaultToleranceTestBase {
+
+	final long NUM_STRINGS = 16_000;
+
+	@ClassRule
+	public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+	private static MiniDFSCluster hdfsCluster;
+	private static org.apache.hadoop.fs.FileSystem dfs;
+
+	private static String outPath;
+
+	@BeforeClass
+	public static void createHDFS() throws IOException {
+		Configuration conf = new Configuration();
+
+		File dataDir = tempFolder.newFolder();
+
+		conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, dataDir.getAbsolutePath());
+		MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(conf);
+		hdfsCluster = builder.build();
+
+		dfs = hdfsCluster.getFileSystem();
+
+		outPath = "hdfs://"
+			+ NetUtils.hostAndPortToUrlString(hdfsCluster.getURI().getHost(), hdfsCluster.getNameNodePort())
+			+ "/buckets";
+	}
+
+	@AfterClass
+	public static void destroyHDFS() {
+		if (hdfsCluster != null) {
+			hdfsCluster.shutdown();
+		}
+	}
+
+	@Override
+	public void testProgram(StreamExecutionEnvironment env) {
+		assertTrue("Broken test setup", NUM_STRINGS % 40 == 0);
+
+		System.out.println("Outputting to " + outPath);
+
+		int PARALLELISM = 12;
+
+		env.enableCheckpointing(20);
+		env.setParallelism(PARALLELISM);
+		env.disableOperatorChaining();
+
+		DataStream<String> stream = env.addSource(new StringGeneratingSourceFunction(NUM_STRINGS)).startNewChain();
+
+		DataStream<String> mapped = stream
+			.map(new OnceFailingIdentityMapper(NUM_STRINGS));
+
+		EventuallyConsistentBucketingSink<String> sink = null;
+		try {
+			sink = new EventuallyConsistentBucketingSink<String>(outPath)
+                .setBatchSize(1000)
+                .setBufferDirectory(tempFolder.newFolder().getAbsolutePath())
+                .setEventuallyConsistentBucketer(new FineGrainedBucketer());
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to instantiate test", e);
+		}
+
+		mapped.addSink(sink);
+
+	}
+
+	@Override
+	public void postSubmit() throws Exception {
+
+		Pattern messageRegex = Pattern.compile("message (\\d*)");
+
+		// Keep a set of the message IDs that we read. The size must equal the read count and
+		// the NUM_STRINGS. If numRead is bigger than the size of the set we have seen some
+		// elements twice.
+		Set<Integer> readNumbers = Sets.newHashSet();
+
+		HashSet<String> uniqMessagesRead = new HashSet<>();
+		HashSet<String> messagesInCommittedFiles = new HashSet<>();
+
+		RemoteIterator<LocatedFileStatus> outterBucketFiles = dfs.listFiles(new Path(
+			outPath), false);
+
+		while (outterBucketFiles.hasNext()) {
+			LocatedFileStatus outerBucket = outterBucketFiles.next();
+			if (dfs.isDirectory(outerBucket.getPath())) {
+				if (!dfs.exists(outerBucket.getPath().suffix("_DONE"))) {
+					continue;
+				}
+
+				RemoteIterator<LocatedFileStatus> files = dfs.listFiles(outerBucket.getPath(), false);
+				while (files.hasNext()) {
+					LocatedFileStatus file = files.next();
+					if (file.getPath().getName().startsWith("_DONE")) {
+						System.out.println("Found _DONE file");
+						continue;
+					}
+
+					int validLength = (int)file.getLen();
+					FSDataInputStream inStream = dfs.open(file.getPath());
+					byte[] buffer = new byte[validLength];
+					inStream.readFully(0, buffer, 0, validLength);
+					inStream.close();
+
+					ByteArrayInputStream bais = new ByteArrayInputStream(buffer);
+
+					InputStreamReader inStreamReader = new InputStreamReader(bais);
+					BufferedReader br = new BufferedReader(inStreamReader);
+
+					String line = br.readLine();
+					while (line != null) {
+						Matcher matcher = messageRegex.matcher(line);
+						if (matcher.matches()) {
+							uniqMessagesRead.add(line);
+
+							// check that in the committed to files there are no duplicates
+							if (!messagesInCommittedFiles.add(line)) {
+								Assert.fail("Duplicate entry in committed bucket.");
+							}
+
+							int messageId = Integer.parseInt(matcher.group(1));
+							readNumbers.add(messageId);
+						} else {
+							Assert.fail("Read line does not match expected pattern.");
+						}
+						line = br.readLine();
+					}
+					br.close();
+					inStreamReader.close();
+					bais.close();
+				}
+			}
+
+			// Verify that we read all strings (at-least-once)
+			Assert.assertEquals(NUM_STRINGS, readNumbers.size());
+
+			// Verify that we don't have duplicates (boom!, exactly-once)
+			Assert.assertEquals(NUM_STRINGS, uniqMessagesRead.size());
+		}
+	}
+
+	private static class OnceFailingIdentityMapper extends RichMapFunction<String, String> {
+		private static final long serialVersionUID = 1L;
+
+		private static volatile boolean hasFailed = false;
+
+		private final long numElements;
+
+		private long failurePos;
+		private long count;
+
+
+		OnceFailingIdentityMapper(long numElements) {
+			this.numElements = numElements;
+		}
+
+		@Override
+		public void open(org.apache.flink.configuration.Configuration parameters) throws IOException {
+			long failurePosMin = (long) (0.7 * numElements / getRuntimeContext().getNumberOfParallelSubtasks());
+			long failurePosMax = (long) (0.9 * numElements / getRuntimeContext().getNumberOfParallelSubtasks());
+
+			failurePos = (new Random().nextLong() % (failurePosMax - failurePosMin)) + failurePosMin;
+			count = 0;
+		}
+
+		@Override
+		public String map(String value) throws Exception {
+			count++;
+			if (!hasFailed && count >= failurePos) {
+				hasFailed = true;
+				throw new Exception("Test Failure");
+			}
+
+			return value;
+		}
+	}
+
+	private static class StringGeneratingSourceFunction extends RichParallelSourceFunction<String>
+		implements ListCheckpointed<Integer> {
+
+		private static final long serialVersionUID = 1L;
+
+		private final long numElements;
+
+		private int index;
+
+		private volatile boolean isRunning = true;
+
+		StringGeneratingSourceFunction(long numElements) {
+			this.numElements = numElements;
+		}
+
+		@Override
+		public void run(SourceContext<String> ctx) throws Exception {
+			final Object lockingObject = ctx.getCheckpointLock();
+
+			final int step = getRuntimeContext().getNumberOfParallelSubtasks();
+
+			if (index == 0) {
+				index = getRuntimeContext().getIndexOfThisSubtask();
+			}
+
+			while (isRunning && index < numElements) {
+
+				Thread.sleep(1);
+				synchronized (lockingObject) {
+					ctx.collect("message " + index);
+					index += step;
+				}
+			}
+		}
+
+		@Override
+		public void cancel() {
+			isRunning = false;
+		}
+
+		@Override
+		public List<Integer> snapshotState(long checkpointId, long timestamp) throws Exception {
+			return Collections.singletonList(index);
+		}
+
+		@Override
+		public void restoreState(List<Integer> state) throws Exception {
+			if (state.isEmpty() || state.size() > 1) {
+				throw new RuntimeException("Test failed due to unexpected recovered state size " + state.size());
+			}
+			this.index = state.get(0);
+		}
+	}
+
+	static class FineGrainedBucketer implements EventuallyConsistentBucketer {
+		@Override
+		// We need a very fine grained bucketer because this test checkpoints every 20 ms
+		public Path getEventualConsistencyPath(Path basePath, long checkpointId, long timestamp) {
+			return new Path(basePath, Long.toString(checkpointId) + "/" + Long.toString(timestamp));
+		}
+	}
+}

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/consistent/EventuallyConsistentSinkFaultToleranceITCase.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/consistent/EventuallyConsistentSinkFaultToleranceITCase.java
@@ -289,12 +289,4 @@ public class EventuallyConsistentSinkFaultToleranceITCase extends StreamFaultTol
 			this.index = state.get(0);
 		}
 	}
-
-	static class FineGrainedBucketer implements EventuallyConsistentBucketer {
-		@Override
-		// We need a very fine grained bucketer because this test checkpoints every 20 ms
-		public Path getEventualConsistencyPath(Path basePath, long checkpointId, long timestamp) {
-			return new Path(basePath, Long.toString(checkpointId) + "/" + Long.toString(timestamp));
-		}
-	}
 }

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/consistent/EventuallyConsistentSinkTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/consistent/EventuallyConsistentSinkTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.connectors.fs.consistent;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.flink.streaming.api.operators.StreamSink;
+import org.apache.flink.streaming.connectors.fs.StringWriter;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+public class EventuallyConsistentSinkTest {
+	@ClassRule
+	public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+	private static MiniDFSCluster hdfsCluster;
+
+	private OneInputStreamOperatorTestHarness<String, Object> createTestSink(File bufferDir, File dataDir, int totalParallelism, int taskIdx) throws Exception {
+		EventuallyConsistentBucketingSink<String> sink = new EventuallyConsistentBucketingSink<String>(dataDir.getAbsolutePath())
+			.setWriter(new StringWriter<String>())
+			.setBufferDirectory(bufferDir.getAbsolutePath());
+
+		return createTestSink(sink, totalParallelism, taskIdx);
+	}
+
+	private <T> OneInputStreamOperatorTestHarness<T, Object> createTestSink(
+		EventuallyConsistentBucketingSink<T> sink, int totalParallelism, int taskIdx) throws Exception {
+		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), 10, totalParallelism, taskIdx);
+	}
+
+	@BeforeClass
+	public static void createHDFS() throws IOException {
+		Configuration conf = new Configuration();
+
+		File dataDir = tempFolder.newFolder();
+
+		conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, dataDir.getAbsolutePath());
+		MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(conf);
+		hdfsCluster = builder.build();
+
+	}
+
+	@AfterClass
+	public static void destroyHDFS() {
+		hdfsCluster.shutdown();
+	}
+
+	@Test
+	public void testEventualConsistencySink() throws Exception {
+		final File bufferDir = tempFolder.newFolder();
+		final File outDir = tempFolder.newFolder();
+
+		OneInputStreamOperatorTestHarness<String, Object> testHarness = createTestSink(bufferDir, outDir, 1, 0);
+		testHarness.setup();
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>("test1", 1L));
+		testHarness.processElement(new StreamRecord<>("test2", 1L));
+
+		testHarness.snapshot(0, 2);
+		testHarness.notifyOfCompletedCheckpoint(0);
+
+		testHarness.processElement(new StreamRecord<>("test3", 3L));
+		testHarness.processElement(new StreamRecord<>("test4", 3L));
+
+		testHarness.snapshot(1, 4);
+		testHarness.notifyOfCompletedCheckpoint(1);
+
+		testHarness.close();
+
+		checkFs(outDir, 2, 2);
+	}
+
+	@Test
+	public void testEventualConsistencySinkWithTimedOutCheckpoints() throws Exception {
+		final File bufferDir = tempFolder.newFolder();
+		final File outDir = tempFolder.newFolder();
+
+		OneInputStreamOperatorTestHarness<String, Object> testHarness = createTestSink(bufferDir, outDir, 1, 0);
+		testHarness.setup();
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>("test1", 1L));
+		testHarness.processElement(new StreamRecord<>("test2", 1L));
+
+		testHarness.snapshot(0, 2);
+		//Do not notify checkpoint complete
+
+		testHarness.processElement(new StreamRecord<>("test3", 3L));
+		testHarness.processElement(new StreamRecord<>("test4", 3L));
+
+		testHarness.snapshot(1, 4);
+		testHarness.notifyOfCompletedCheckpoint(1);
+
+		testHarness.close();
+
+		checkFs(outDir, 2, 2);
+	}
+
+	@Test
+	public void testEventualConsistencySinkWithConcurrentCheckpoints() throws Exception {
+		final File bufferDir = tempFolder.newFolder();
+		final File outDir = tempFolder.newFolder();
+
+		OneInputStreamOperatorTestHarness<String, Object> testHarness = createTestSink(bufferDir, outDir, 1, 0);
+		testHarness.setup();
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>("test1", 1L));
+		testHarness.processElement(new StreamRecord<>("test2", 1L));
+
+		testHarness.snapshot(0, 2);
+		testHarness.processElement(new StreamRecord<>("test3", 3L));
+
+		testHarness.snapshot(1, 4);
+		testHarness.processElement(new StreamRecord<>("test4", 3L));
+
+		testHarness.notifyOfCompletedCheckpoint(0);
+		testHarness.notifyOfCompletedCheckpoint(1);
+
+		testHarness.close();
+
+		checkFs(outDir, 2, 2);
+	}
+
+	private void checkFs(File outDir, int done, int numFiles) throws IOException {
+		int countDone = 0;
+		int countPart = 0;
+
+		for (File file : FileUtils.listFiles(outDir, null, true)) {
+			if (file.getAbsolutePath().endsWith("crc")) {
+				continue;
+			}
+
+			String path = file.getPath();
+			if (path.endsWith("_DONE")) {
+				countDone++;
+			} else if (path.contains("part")) {
+				countPart++;
+			}
+		}
+
+		Assert.assertEquals(done, countDone);
+		Assert.assertEquals(numFiles, countPart);
+	}
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-6306

This PR introduces a bucketer for eventually consistent file systems such as Amazon S3, guaranteeing exactly once output across failure and concurrent checkpoints (thank you @StephanEwen). I have attempted to keep the api as similar the the BucketingSink as possible including the shared use of writers for specifying output format. 

Currently there is documentation in the form of javadoc, once the api is settled I will make another PR with updated documentation.  