### PR TITLE
[FLINK-5752] [table] Support push down projections for HBaseTableSource (Ram)

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/logical/PushProjectIntoTableSourceScanRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/logical/PushProjectIntoTableSourceScanRule.scala
@@ -34,6 +34,7 @@ class PushProjectIntoTableSourceScanRule extends RelOptRule(
     val scan: FlinkLogicalTableSourceScan = call.rel(1).asInstanceOf[FlinkLogicalTableSourceScan]
     scan.tableSource match {
       case _: ProjectableTableSource[_] => true
+      case _: NestedFieldsProjectableTableSource[_] => true
       case _ => false
     }
   }


### PR DESCRIPTION
Ran mvn clean verify -DskipTests
In this patch 
`Arrays.sort(nestedFields[i]);`

Am doing this before doing addColumns for the new projected table source, because here the cols appears in a reverse sorted way and when we apply that for the new projected table source it creates an assertion error while creating the new calcite program with the projected cols
`assert expr.getType().getFieldList().get(field.getIndex()) == field;`
{edit} the above line is in RexFieldAccess
So doing this sort helps in correcting those issues and the tests run fine. But this nestedFields that is being passed to the projectNestedFields() API is created by
`def getProjectedFields: Array[Array[String]] ` under RexProgramExtractor. Trying to understand what it does. 

