### PR TITLE
[FLINK-6361] [table] Refactoring the AggregateFunction interface and built-in aggregates

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/Types.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/Types.scala
@@ -17,9 +17,8 @@
  */
 package org.apache.flink.table.api
 
-import org.apache.flink.api.common.typeinfo.{Types, TypeInformation}
+import org.apache.flink.api.common.typeinfo.{Types => JTypes, TypeInformation}
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo
-import org.apache.flink.api.common.typeinfo.{Types => JTypes}
 
 /**
   * This class enumerates all supported types of the Table API.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -265,14 +265,16 @@ class CodeGenerator(
       name: String,
       generator: CodeGenerator,
       inputType: RelDataType,
-      aggregates: Array[AggregateFunction[_ <: Any]],
+      aggregates: Array[AggregateFunction[_ <: Any, _ <: Any]],
       aggFields: Array[Array[Int]],
       aggMapping: Array[Int],
       partialResults: Boolean,
       fwdMapping: Array[Int],
       mergeMapping: Option[Array[Int]],
       constantFlags: Option[Array[(Int, Boolean)]],
-      outputArity: Int)
+      outputArity: Int,
+      needRetract: Boolean,
+      needMerge: Boolean)
   : GeneratedAggregationsFunction = {
 
     // get unique function name
@@ -364,9 +366,16 @@ class CodeGenerator(
              |      ${parameters(i)});""".stripMargin
       }.mkString("\n")
 
-      j"""$sig {
-         |$retract
-         |  }""".stripMargin
+      if (needRetract) {
+        j"""
+           |$sig {
+           |$retract
+           |  }""".stripMargin
+      } else {
+        j"""
+           |$sig {
+           |  }""".stripMargin
+      }
     }
 
     def genCreateAccumulators: String = {
@@ -471,11 +480,9 @@ class CodeGenerator(
           j"""
              |    ${accTypes(i)} aAcc$i = (${accTypes(i)}) a.getField($i);
              |    ${accTypes(i)} bAcc$i = (${accTypes(i)}) b.getField(${mapping(i)});
-             |    accList$i.set(0, aAcc$i);
-             |    accList$i.set(1, bAcc$i);
-             |    a.setField(
-             |      $i,
-             |      ${aggs(i)}.merge(accList$i));
+             |    accList$i.set(0, bAcc$i);
+             |    ${aggs(i)}.merge(aAcc$i, accList$i);
+             |    a.setField($i, aAcc$i);
              """.stripMargin
       }.mkString("\n")
       val ret: String =
@@ -483,11 +490,18 @@ class CodeGenerator(
            |      return a;
            """.stripMargin
 
-      j"""
-         |$sig {
-         |$merge
-         |$ret
-         |  }""".stripMargin
+      if (needMerge) {
+        j"""
+           |$sig {
+           |$merge
+           |$ret
+           |  }""".stripMargin
+      } else {
+        j"""
+           |$sig {
+           |$ret
+           |  }""".stripMargin
+      }
     }
 
     def genMergeList: String = {
@@ -495,7 +509,7 @@ class CodeGenerator(
         for (i <- accTypes.indices) yield
           j"""
              |    private final java.util.ArrayList<${accTypes(i)}> accList$i =
-             |      new java.util.ArrayList<${accTypes(i)}>(2);
+             |      new java.util.ArrayList<${accTypes(i)}>(1);
              """.stripMargin
       }.mkString("\n")
     }
@@ -504,7 +518,6 @@ class CodeGenerator(
       {
         for (i <- accTypes.indices) yield
           j"""
-             |    accList$i.add(${aggs(i)}.createAccumulator());
              |    accList$i.add(${aggs(i)}.createAccumulator());
              """.stripMargin
       }.mkString("\n")

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/AggregateFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/AggregateFunction.scala
@@ -17,36 +17,93 @@
  */
 package org.apache.flink.table.functions
 
-import java.util.{List => JList}
-
-import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.table.api.TableException
-
 /**
   * Base class for User-Defined Aggregates.
   *
-  * @tparam T the type of the aggregation result
+  * The behavior of an [[AggregateFunction]] can be defined by implementing a series of custom
+  * methods. An [[AggregateFunction]] needs at least three methods: createAccumulator, getValue,
+  * and accumulate. There are a few other methods that can be optional to have: retract, merge,
+  * resetAccumulator, and getAccumulatorType.
+  *
+  * All these methods muse be declared publicly, not static and named exactly as the names
+  * mentioned above. The methods createAccumulator and getValue are defined in the
+  * [[AggregateFunction]] functions, while other methods are explained below.
+  *
+  *
+  * {{{
+  * Processes the input values and update the provided accumulator instance. The method
+  * accumulate can be overloaded with different custom types and arguments. This function is
+  * always a MUST to have.
+  *
+  * @param accumulator           the accumulator which contains the current aggregated results
+  * @param [user defined inputs] the input value (usually obtained from a new arrived data).
+  *
+  * def accumulate(accumulator: ACC, [user defined inputs]): Unit
+  * }}}
+  *
+  *
+  * {{{
+  * Retracts the input values from the accumulator instance. The current design assumes the
+  * inputs are the values that have been previously accumulated. The method retract can be
+  * overloaded with different custom types and arguments. This function must be implemented for
+  * datastream bounded over aggregate.
+  *
+  * @param accumulator           the accumulator which contains the current aggregated results
+  * @param [user defined inputs] the input value (usually obtained from a new arrived data).
+  *
+  * def retract(accumulator: ACC, [user defined inputs]): Unit
+  * }}}
+  *
+  *
+  * {{{
+  * Merges a group of accumulator instances into one accumulator instance. This function must be
+  * implemented for datastream session window grouping aggregate and dataset grouping aggregate.
+  *
+  * @param accumulator  the accumulator which will keep the merged aggregate results. It should
+  *                     be noted that the accumulator may contain the previous aggregated
+  *                     results. Therefore user should not replace or clean this instance in the
+  *                     custom merge method.
+  * @param its          an [[java.lang.Iterable]] pointed to a group of accumulators that will be
+  *                     merged.
+
+  * def merge(accumulator: ACC, its: java.lang.Iterable[ACC]): Unit
+  * }}}
+  *
+  *
+  * {{{
+  * Resets the accumulator for this [[AggregateFunction]]. This function must be implemented for
+  * dataset grouping aggregate.
+  *
+  * @param accumulator  the accumulator which needs to be reset
+
+  * def resetAccumulator(accumulator: ACC): Unit
+  * }}}
+  *
+  *
+  * {{{
+  * Returns the [[org.apache.flink.api.common.typeinfo.TypeInformation]] of the accumulator. This
+  * function is optional and can be implemented if the accumulator type cannot automatically
+  * inferred from the instance returned by createAccumulator method.
+  *
+  * @return  the type information for the accumulator.
+
+  * def getAccumulatorType: TypeInformation[_]
+  * }}}
+  *
+  *
+  * @tparam T   the type of the aggregation result
+  * @tparam ACC base class for aggregate Accumulator. The accumulator is used to keep the aggregated
+  *             values which are needed to compute an aggregation result. AggregateFunction
+  *             represents its state using accumulator, thereby the state of the AggregateFunction
+  *             must be put into the accumulator.
   */
-abstract class AggregateFunction[T] extends UserDefinedFunction {
+abstract class AggregateFunction[T, ACC] extends UserDefinedFunction {
   /**
     * Creates and init the Accumulator for this [[AggregateFunction]].
     *
     * @return the accumulator with the initial value
     */
-  def createAccumulator(): Accumulator
-
-  /**
-    * Retracts the input values from the accumulator instance. The current design assumes the
-    * inputs are the values that have been previously accumulated.
-    *
-    * @param accumulator the accumulator which contains the current
-    *                    aggregated results
-    * @param input       the input value (usually obtained from a new arrived data)
-    */
-  def retract(accumulator: Accumulator, input: Any): Unit = {
-    throw TableException("Retract is an optional method. There is no default implementation. You " +
-                           "must implement one for yourself.")
-  }
+  def createAccumulator(): ACC
 
   /**
     * Called every time when an aggregation result should be materialized.
@@ -58,54 +115,5 @@ abstract class AggregateFunction[T] extends UserDefinedFunction {
     *                    aggregated results
     * @return the aggregation result
     */
-  def getValue(accumulator: Accumulator): T
-
-  /**
-    * Processes the input values and update the provided accumulator instance.
-    *
-    * @param accumulator the accumulator which contains the current
-    *                    aggregated results
-    * @param input       the input value (usually obtained from a new arrived data)
-    */
-  def accumulate(accumulator: Accumulator, input: Any): Unit
-
-  /**
-    * Merges a list of accumulator instances into one accumulator instance.
-    *
-    * IMPORTANT: You may only return a new accumulator instance or the first accumulator of the
-    * input list. If you return another instance, the result of the aggregation function might be
-    * incorrect.
-    *
-    * @param accumulators the [[java.util.List]] of accumulators that will be merged
-    * @return the resulting accumulator
-    */
-  def merge(accumulators: JList[Accumulator]): Accumulator
-
-  /**
-    * Resets the Accumulator for this [[AggregateFunction]].
-    *
-    * @param accumulator the accumulator which needs to be reset
-    */
-  def resetAccumulator(accumulator: Accumulator): Unit
-
-  /**
-    * Returns the [[TypeInformation]] of the accumulator.
-    * This function is optional and can be implemented if the accumulator type cannot automatically
-    * inferred from the instance returned by [[createAccumulator()]].
-    *
-    * @return The type information for the accumulator.
-    */
-  def getAccumulatorType: TypeInformation[_] = null
+  def getValue(accumulator: ACC): T
 }
-
-/**
-  * Base class for aggregate Accumulator. The accumulator is used to keep the
-  * aggregated values which are needed to compute an aggregation result.
-  * The state of the function must be put into the accumulator.
-  *
-  * TODO: We have the plan to have the accumulator and return types of
-  * functions dynamically provided by the users. This needs the refactoring
-  * of the AggregateFunction interface with the code generation. We will remove
-  * the [[Accumulator]] once codeGen for UDAGG is completed (FLINK-5813).
-  */
-trait Accumulator

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionWithRetract.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionWithRetract.scala
@@ -18,15 +18,16 @@
 package org.apache.flink.table.functions.aggfunctions
 
 import java.math.BigDecimal
-import java.util.{HashMap => JHashMap, List => JList}
+import java.util.{HashMap => JHashMap}
+import java.lang.{Iterable => JIterable}
 
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
 import org.apache.flink.api.java.typeutils.{MapTypeInfo, TupleTypeInfo}
-import org.apache.flink.table.functions.{Accumulator, AggregateFunction}
+import org.apache.flink.table.functions.AggregateFunction
 
 /** The initial accumulator for Max with retraction aggregate function */
-class MaxWithRetractAccumulator[T] extends JTuple2[T, JHashMap[T, Long]] with Accumulator
+class MaxWithRetractAccumulator[T] extends JTuple2[T, JHashMap[T, Long]]
 
 /**
   * Base class for built-in Max with retraction aggregate function
@@ -34,110 +35,105 @@ class MaxWithRetractAccumulator[T] extends JTuple2[T, JHashMap[T, Long]] with Ac
   * @tparam T the type for the aggregation result
   */
 abstract class MaxWithRetractAggFunction[T](implicit ord: Ordering[T])
-  extends AggregateFunction[T] {
+  extends AggregateFunction[T, MaxWithRetractAccumulator[T]] {
 
-  override def createAccumulator(): Accumulator = {
+  override def createAccumulator(): MaxWithRetractAccumulator[T] = {
     val acc = new MaxWithRetractAccumulator[T]
     acc.f0 = getInitValue //max
     acc.f1 = new JHashMap[T, Long]() //store the count for each value
     acc
   }
 
-  override def accumulate(accumulator: Accumulator, value: Any): Unit = {
+  def accumulate(acc: MaxWithRetractAccumulator[T], value: Any): Unit = {
     if (value != null) {
       val v = value.asInstanceOf[T]
-      val a = accumulator.asInstanceOf[MaxWithRetractAccumulator[T]]
 
-      if (a.f1.size() == 0 || (ord.compare(a.f0, v) < 0)) {
-        a.f0 = v
+      if (acc.f1.size() == 0 || (ord.compare(acc.f0, v) < 0)) {
+        acc.f0 = v
       }
 
-      if (!a.f1.containsKey(v)) {
-        a.f1.put(v, 1L)
+      if (!acc.f1.containsKey(v)) {
+        acc.f1.put(v, 1L)
       } else {
-        var count = a.f1.get(v)
+        var count = acc.f1.get(v)
         count += 1L
-        a.f1.put(v, count)
+        acc.f1.put(v, count)
       }
     }
   }
 
-  override def retract(accumulator: Accumulator, value: Any): Unit = {
+  def retract(acc: MaxWithRetractAccumulator[T], value: Any): Unit = {
     if (value != null) {
       val v = value.asInstanceOf[T]
-      val a = accumulator.asInstanceOf[MaxWithRetractAccumulator[T]]
 
-      var count = a.f1.get(v)
+      var count = acc.f1.get(v)
       count -= 1L
       if (count == 0) {
         //remove the key v from the map if the number of appearance of the value v is 0
-        a.f1.remove(v)
+        acc.f1.remove(v)
         //if the total count is 0, we could just simply set the f0(max) to the initial value
-        if (a.f1.size() == 0) {
-          a.f0 = getInitValue
+        if (acc.f1.size() == 0) {
+          acc.f0 = getInitValue
           return
         }
         //if v is the current max value, we have to iterate the map to find the 2nd biggest
         // value to replace v as the max value
-        if (v == a.f0) {
-          val iterator = a.f1.keySet().iterator()
+        if (v == acc.f0) {
+          val iterator = acc.f1.keySet().iterator()
           var key = iterator.next()
-          a.f0 = key
+          acc.f0 = key
           while (iterator.hasNext()) {
             key = iterator.next()
-            if (ord.compare(a.f0, key) < 0) {
-              a.f0 = key
+            if (ord.compare(acc.f0, key) < 0) {
+              acc.f0 = key
             }
           }
         }
       } else {
-        a.f1.put(v, count)
+        acc.f1.put(v, count)
       }
     }
 
   }
 
-  override def getValue(accumulator: Accumulator): T = {
-    val a = accumulator.asInstanceOf[MaxWithRetractAccumulator[T]]
-    if (a.f1.size() != 0) {
-      a.f0
+  override def getValue(acc: MaxWithRetractAccumulator[T]): T = {
+    if (acc.f1.size() != 0) {
+      acc.f0
     } else {
       null.asInstanceOf[T]
     }
   }
 
-  override def merge(accumulators: JList[Accumulator]): Accumulator = {
-    val ret = accumulators.get(0).asInstanceOf[MaxWithRetractAccumulator[T]]
-    var i: Int = 1
-    while (i < accumulators.size()) {
-      val a = accumulators.get(i).asInstanceOf[MaxWithRetractAccumulator[T]]
+  def merge(acc: MaxWithRetractAccumulator[T],
+      its: JIterable[MaxWithRetractAccumulator[T]]): Unit = {
+    val iter = its.iterator()
+    while (iter.hasNext) {
+      val a = iter.next()
       if (a.f1.size() != 0) {
         // set max element
-        if (ord.compare(ret.f0, a.f0) < 0) {
-          ret.f0 = a.f0
+        if (ord.compare(acc.f0, a.f0) < 0) {
+          acc.f0 = a.f0
         }
         // merge the count for each key
         val iterator = a.f1.keySet().iterator()
         while (iterator.hasNext()) {
           val key = iterator.next()
-          if (ret.f1.containsKey(key)) {
-            ret.f1.put(key, ret.f1.get(key) + a.f1.get(key))
+          if (acc.f1.containsKey(key)) {
+            acc.f1.put(key, acc.f1.get(key) + a.f1.get(key))
           } else {
-            ret.f1.put(key, a.f1.get(key))
+            acc.f1.put(key, a.f1.get(key))
           }
         }
       }
-      i += 1
     }
-    ret
   }
 
-  override def resetAccumulator(accumulator: Accumulator): Unit = {
-    accumulator.asInstanceOf[MaxWithRetractAccumulator[T]].f0 = getInitValue
-    accumulator.asInstanceOf[MaxWithRetractAccumulator[T]].f1.clear()
+  def resetAccumulator(acc: MaxWithRetractAccumulator[T]): Unit = {
+    acc.f0 = getInitValue
+    acc.f1.clear()
   }
 
-  override def getAccumulatorType(): TypeInformation[_] = {
+  def getAccumulatorType(): TypeInformation[_] = {
     new TupleTypeInfo(
       new MaxWithRetractAccumulator[T].getClass,
       getValueTypeInfo,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.table.runtime.aggregate
 
+import java.lang.reflect.Method
 import java.util
 
 import org.apache.calcite.rel.`type`._
@@ -73,11 +74,12 @@ object AggregateUtil {
     isPartitioned: Boolean,
     isRowsClause: Boolean): ProcessFunction[Row, Row] = {
 
+    val needRetract = false
     val (aggFields, aggregates) =
       transformToAggregateFunctions(
         namedAggregates.map(_.getKey),
         inputType,
-        needRetraction = false)
+        needRetract)
 
     val aggregationStateType: RowTypeInfo =
       createDataSetAggregateBufferDataType(Array(), aggregates, inputType)
@@ -97,7 +99,9 @@ object AggregateUtil {
       forwardMapping,
       None,
       None,
-      outputArity
+      outputArity,
+      needRetract,
+      needMerge = false
     )
 
     if (isRowTimeType) {
@@ -147,11 +151,12 @@ object AggregateUtil {
     isRowsClause: Boolean,
     isRowTimeType: Boolean): ProcessFunction[Row, Row] = {
 
+    val needRetract = true
     val (aggFields, aggregates) =
       transformToAggregateFunctions(
         namedAggregates.map(_.getKey),
         inputType,
-        needRetraction = true)
+        needRetract)
 
     val aggregationStateType: RowTypeInfo = createAccumulatorRowType(aggregates)
     val inputRowType = FlinkTypeFactory.toInternalRowTypeInfo(inputType).asInstanceOf[RowTypeInfo]
@@ -171,7 +176,9 @@ object AggregateUtil {
       forwardMapping,
       None,
       None,
-      outputArity
+      outputArity,
+      needRetract,
+      needMerge = false
     )
 
     if (isRowTimeType) {
@@ -239,10 +246,11 @@ object AggregateUtil {
       isParserCaseSensitive: Boolean)
   : MapFunction[Row, Row] = {
 
+    val needRetract = false
     val (aggFieldIndexes, aggregates) = transformToAggregateFunctions(
       namedAggregates.map(_.getKey),
       inputType,
-      needRetraction = false)
+      needRetract)
 
     val mapReturnType: RowTypeInfo =
       createDataSetAggregateBufferDataType(
@@ -293,7 +301,9 @@ object AggregateUtil {
       groupings,
       None,
       None,
-      outputArity
+      outputArity,
+      needRetract,
+      needMerge = false
     )
 
     new DataSetWindowAggMapFunction(
@@ -339,10 +349,11 @@ object AggregateUtil {
       isParserCaseSensitive: Boolean)
     : RichGroupReduceFunction[Row, Row] = {
 
+    val needRetract = false
     val (aggFieldIndexes, aggregates) = transformToAggregateFunctions(
       namedAggregates.map(_.getKey),
       inputType,
-      needRetraction = false)
+      needRetract)
 
     val returnType: RowTypeInfo = createDataSetAggregateBufferDataType(
       groupings,
@@ -366,7 +377,9 @@ object AggregateUtil {
           groupings,
           Some(aggregates.indices.map(_ + groupings.length).toArray),
           None,
-          keysAndAggregatesArity + 1
+          keysAndAggregatesArity + 1,
+          needRetract,
+          needMerge = true
         )
         new DataSetSlideTimeWindowAggReduceGroupFunction(
           genFunction,
@@ -447,10 +460,11 @@ object AggregateUtil {
       isInputCombined: Boolean = false)
     : RichGroupReduceFunction[Row, Row] = {
 
+    val needRetract = false
     val (aggFieldIndexes, aggregates) = transformToAggregateFunctions(
       namedAggregates.map(_.getKey),
       inputType,
-      needRetraction = false)
+      needRetract)
 
     val aggMapping = aggregates.indices.toArray.map(_ + groupings.length)
 
@@ -465,7 +479,9 @@ object AggregateUtil {
       groupings,
       Some(aggregates.indices.map(_ + groupings.length).toArray),
       None,
-      outputType.getFieldCount
+      outputType.getFieldCount,
+      needRetract,
+      needMerge = true
     )
 
     val genFinalAggFunction = generator.generateAggregations(
@@ -479,7 +495,9 @@ object AggregateUtil {
       groupings.indices.toArray,
       Some(aggregates.indices.map(_ + groupings.length).toArray),
       None,
-      outputType.getFieldCount
+      outputType.getFieldCount,
+      needRetract,
+      needMerge = true
     )
 
     val keysAndAggregatesArity = groupings.length + namedAggregates.length
@@ -586,10 +604,11 @@ object AggregateUtil {
     inputType: RelDataType,
     groupings: Array[Int]): MapPartitionFunction[Row, Row] = {
 
+    val needRetract = false
     val (aggFieldIndexes, aggregates) = transformToAggregateFunctions(
       namedAggregates.map(_.getKey),
       inputType,
-      needRetraction = false)
+      needRetract)
 
     val aggMapping = aggregates.indices.map(_ + groupings.length).toArray
 
@@ -615,7 +634,9 @@ object AggregateUtil {
           groupings.indices.toArray,
           Some(aggregates.indices.map(_ + groupings.length).toArray),
           None,
-          groupings.length + aggregates.length + 2
+          groupings.length + aggregates.length + 2,
+          needRetract,
+          needMerge = true
         )
 
         new DataSetSessionWindowAggregatePreProcessor(
@@ -654,10 +675,11 @@ object AggregateUtil {
       groupings: Array[Int])
     : GroupCombineFunction[Row, Row] = {
 
+    val needRetract = false
     val (aggFieldIndexes, aggregates) = transformToAggregateFunctions(
       namedAggregates.map(_.getKey),
       inputType,
-      needRetraction = false)
+      needRetract)
 
     val aggMapping = aggregates.indices.map(_ + groupings.length).toArray
 
@@ -684,7 +706,9 @@ object AggregateUtil {
           groupings.indices.toArray,
           Some(aggregates.indices.map(_ + groupings.length).toArray),
           None,
-          groupings.length + aggregates.length + 2
+          groupings.length + aggregates.length + 2,
+          needRetract,
+          needMerge = true
         )
 
         new DataSetSessionWindowAggregatePreProcessor(
@@ -715,10 +739,11 @@ object AggregateUtil {
         Option[TypeInformation[Row]],
         RichGroupReduceFunction[Row, Row]) = {
 
+    val needRetract = false
     val (aggInFields, aggregates) = transformToAggregateFunctions(
       namedAggregates.map(_.getKey),
       inputType,
-      needRetraction = false)
+      needRetract)
 
     val (gkeyOutMapping, aggOutMapping) = getOutputMappings(
       namedAggregates,
@@ -760,7 +785,9 @@ object AggregateUtil {
         groupings,
         None,
         None,
-        groupings.length + aggregates.length
+        groupings.length + aggregates.length,
+        needRetract,
+        needMerge = false
       )
 
       // compute mapping of forwarded grouping keys
@@ -784,7 +811,9 @@ object AggregateUtil {
         gkeyMapping,
         Some(aggregates.indices.map(_ + groupings.length).toArray),
         constantFlags,
-        outputType.getFieldCount
+        outputType.getFieldCount,
+        needRetract,
+        needMerge = true
       )
 
       (
@@ -805,7 +834,9 @@ object AggregateUtil {
         groupings,
         None,
         constantFlags,
-        outputType.getFieldCount
+        outputType.getFieldCount,
+        needRetract,
+        needMerge = false
       )
 
       (
@@ -874,11 +905,12 @@ object AggregateUtil {
       outputType: RelDataType)
     : (DataStreamAggFunction[Row, Row, Row], RowTypeInfo, RowTypeInfo) = {
 
+    val needRetract = false
     val (aggFields, aggregates) =
       transformToAggregateFunctions(
         namedAggregates.map(_.getKey),
         inputType,
-        needRetraction = false)
+        needRetract)
 
     val aggMapping = aggregates.indices.toArray
     val outputArity = aggregates.length
@@ -894,7 +926,9 @@ object AggregateUtil {
       Array(), // no fields are forwarded
       None,
       None,
-      outputArity
+      outputArity,
+      needRetract,
+      needMerge = true
     )
 
     val aggResultTypes = namedAggregates.map(a => FlinkTypeFactory.toTypeInfo(a.left.getType))
@@ -926,7 +960,7 @@ object AggregateUtil {
     * Return true if all aggregates can be partially merged. False otherwise.
     */
   private[flink] def doAllSupportPartialMerge(
-      aggregateList: Array[TableAggregateFunction[_ <: Any]]): Boolean = {
+      aggregateList: Array[TableAggregateFunction[_ <: Any, _ <: Any]]): Boolean = {
     aggregateList.forall(ifMethodExistInFunction("merge", _))
   }
 
@@ -1033,11 +1067,11 @@ object AggregateUtil {
       aggregateCalls: Seq[AggregateCall],
       inputType: RelDataType,
       needRetraction: Boolean)
-  : (Array[Array[Int]], Array[TableAggregateFunction[_ <: Any]]) = {
+  : (Array[Array[Int]], Array[TableAggregateFunction[_ <: Any, _ <: Any]]) = {
 
     // store the aggregate fields of each aggregate function, by the same order of aggregates.
     val aggFieldIndexes = new Array[Array[Int]](aggregateCalls.size)
-    val aggregates = new Array[TableAggregateFunction[_ <: Any]](aggregateCalls.size)
+    val aggregates = new Array[TableAggregateFunction[_ <: Any, _ <: Any]](aggregateCalls.size)
 
     // create aggregate function instances by function type and aggregate field data type.
     aggregateCalls.zipWithIndex.foreach { case (aggregateCall, index) =>
@@ -1232,12 +1266,20 @@ object AggregateUtil {
   }
 
   private def createAccumulatorType(
-      aggregates: Array[TableAggregateFunction[_]]): Seq[TypeInformation[_]] = {
+      aggregates: Array[TableAggregateFunction[_,_]]): Seq[TypeInformation[_]] = {
 
     val aggTypes: Seq[TypeInformation[_]] =
       aggregates.map {
         agg =>
-          val accType = agg.getAccumulatorType
+          var accType: TypeInformation[_] = null
+          var method: Method = null
+          try {
+            val method: Method = agg.getClass.getMethod("getAccumulatorType")
+            accType = method.invoke(agg).asInstanceOf[TypeInformation[_]]
+          } catch {
+            case _: NoSuchMethodException =>
+            case ite: Throwable => throw new TableException("Unexpected exception:", ite)
+          }
           if (accType != null) {
             accType
           } else {
@@ -1259,7 +1301,7 @@ object AggregateUtil {
 
   private def createDataSetAggregateBufferDataType(
       groupings: Array[Int],
-      aggregates: Array[TableAggregateFunction[_]],
+      aggregates: Array[TableAggregateFunction[_,_]],
       inputType: RelDataType,
       windowKeyTypes: Option[Array[TypeInformation[_]]] = None): RowTypeInfo = {
 
@@ -1281,7 +1323,7 @@ object AggregateUtil {
   }
 
   private[flink] def createAccumulatorRowType(
-      aggregates: Array[TableAggregateFunction[_]]): RowTypeInfo = {
+      aggregates: Array[TableAggregateFunction[_,_]]): RowTypeInfo = {
 
     val aggTypes: Seq[TypeInformation[_]] = createAccumulatorType(aggregates)
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/AvgFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/AvgFunctionTest.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.functions.AggregateFunction
   *
   * @tparam T the type for the aggregation result
   */
-abstract class AvgAggFunctionTestBase[T: Numeric] extends AggFunctionTestBase[T] {
+abstract class AvgAggFunctionTestBase[T: Numeric, ACC] extends AggFunctionTestBase[T, ACC] {
 
   private val numeric: Numeric[T] = implicitly[Numeric[T]]
 
@@ -91,9 +91,11 @@ abstract class AvgAggFunctionTestBase[T: Numeric] extends AggFunctionTestBase[T]
     numeric.fromInt(3),
     null.asInstanceOf[T]
   )
+
+  override def retractFunc = aggregator.getClass.getMethod("retract", accType, classOf[Any])
 }
 
-class ByteAvgAggFunctionTest extends AvgAggFunctionTestBase[Byte] {
+class ByteAvgAggFunctionTest extends AvgAggFunctionTestBase[Byte, IntegralAvgAccumulator] {
 
   override def minVal = (Byte.MinValue + 1).toByte
 
@@ -102,7 +104,7 @@ class ByteAvgAggFunctionTest extends AvgAggFunctionTestBase[Byte] {
   override def aggregator = new ByteAvgAggFunction()
 }
 
-class ShortAvgAggFunctionTest extends AvgAggFunctionTestBase[Short] {
+class ShortAvgAggFunctionTest extends AvgAggFunctionTestBase[Short, IntegralAvgAccumulator] {
 
   override def minVal = (Short.MinValue + 1).toShort
 
@@ -111,7 +113,7 @@ class ShortAvgAggFunctionTest extends AvgAggFunctionTestBase[Short] {
   override def aggregator = new ShortAvgAggFunction()
 }
 
-class IntAvgAggFunctionTest extends AvgAggFunctionTestBase[Int] {
+class IntAvgAggFunctionTest extends AvgAggFunctionTestBase[Int, IntegralAvgAccumulator] {
 
   override def minVal = Int.MinValue + 1
 
@@ -120,7 +122,7 @@ class IntAvgAggFunctionTest extends AvgAggFunctionTestBase[Int] {
   override def aggregator = new IntAvgAggFunction()
 }
 
-class LongAvgAggFunctionTest extends AvgAggFunctionTestBase[Long] {
+class LongAvgAggFunctionTest extends AvgAggFunctionTestBase[Long, BigIntegralAvgAccumulator] {
 
   override def minVal = Long.MinValue + 1
 
@@ -129,7 +131,7 @@ class LongAvgAggFunctionTest extends AvgAggFunctionTestBase[Long] {
   override def aggregator = new LongAvgAggFunction()
 }
 
-class FloatAvgAggFunctionTest extends AvgAggFunctionTestBase[Float] {
+class FloatAvgAggFunctionTest extends AvgAggFunctionTestBase[Float, FloatingAvgAccumulator] {
 
   override def minVal = Float.MinValue
 
@@ -138,7 +140,7 @@ class FloatAvgAggFunctionTest extends AvgAggFunctionTestBase[Float] {
   override def aggregator = new FloatAvgAggFunction()
 }
 
-class DoubleAvgAggFunctionTest extends AvgAggFunctionTestBase[Double] {
+class DoubleAvgAggFunctionTest extends AvgAggFunctionTestBase[Double, FloatingAvgAccumulator] {
 
   override def minVal = Float.MinValue
 
@@ -147,7 +149,7 @@ class DoubleAvgAggFunctionTest extends AvgAggFunctionTestBase[Double] {
   override def aggregator = new DoubleAvgAggFunction()
 }
 
-class DecimalAvgAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
+class DecimalAvgAggFunctionTest extends AggFunctionTestBase[BigDecimal, DecimalAvgAccumulator] {
 
   override def inputValueSets: Seq[Seq[_]] = Seq(
     Seq(
@@ -182,5 +184,8 @@ class DecimalAvgAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
     null
   )
 
-  override def aggregator: AggregateFunction[BigDecimal] = new DecimalAvgAggFunction()
+  override def aggregator: AggregateFunction[BigDecimal, DecimalAvgAccumulator] =
+    new DecimalAvgAggFunction()
+
+  override def retractFunc = aggregator.getClass.getMethod("retract", accType, classOf[Any])
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/CountAggFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/CountAggFunctionTest.scala
@@ -23,7 +23,7 @@ import org.apache.flink.table.functions.AggregateFunction
 /**
   * Test case for built-in count aggregate function
   */
-class CountAggFunctionTest extends AggFunctionTestBase[Long] {
+class CountAggFunctionTest extends AggFunctionTestBase[Long, CountAccumulator] {
 
   override def inputValueSets: Seq[Seq[_]] = Seq(
     Seq("a", "b", null, "c", null, "d", "e", null, "f"),
@@ -32,5 +32,7 @@ class CountAggFunctionTest extends AggFunctionTestBase[Long] {
 
   override def expectedResults: Seq[Long] = Seq(6L, 0L)
 
-  override def aggregator: AggregateFunction[Long] = new CountAggFunction()
+  override def aggregator: AggregateFunction[Long, CountAccumulator] = new CountAggFunction()
+
+  override def retractFunc = aggregator.getClass.getMethod("retract", accType, classOf[Any])
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MaxAggFunctionTest.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.functions.AggregateFunction
   *
   * @tparam T the type for the aggregation result
   */
-abstract class MaxAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T] {
+abstract class MaxAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T, MaxAccumulator[T]] {
 
   private val numeric: Numeric[T] = implicitly[Numeric[T]]
 
@@ -61,8 +61,6 @@ abstract class MaxAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T] {
     maxVal,
     null.asInstanceOf[T]
   )
-
-  override def supportRetraction: Boolean = false
 }
 
 class ByteMaxAggFunctionTest extends MaxAggFunctionTest[Byte] {
@@ -71,7 +69,8 @@ class ByteMaxAggFunctionTest extends MaxAggFunctionTest[Byte] {
 
   override def maxVal = (Byte.MaxValue - 1).toByte
 
-  override def aggregator: AggregateFunction[Byte] = new ByteMaxAggFunction()
+  override def aggregator: AggregateFunction[Byte, MaxAccumulator[Byte]] =
+    new ByteMaxAggFunction()
 }
 
 class ShortMaxAggFunctionTest extends MaxAggFunctionTest[Short] {
@@ -80,7 +79,8 @@ class ShortMaxAggFunctionTest extends MaxAggFunctionTest[Short] {
 
   override def maxVal = (Short.MaxValue - 1).toShort
 
-  override def aggregator: AggregateFunction[Short] = new ShortMaxAggFunction()
+  override def aggregator: AggregateFunction[Short, MaxAccumulator[Short]] =
+    new ShortMaxAggFunction()
 }
 
 class IntMaxAggFunctionTest extends MaxAggFunctionTest[Int] {
@@ -89,7 +89,8 @@ class IntMaxAggFunctionTest extends MaxAggFunctionTest[Int] {
 
   override def maxVal = Int.MaxValue - 1
 
-  override def aggregator: AggregateFunction[Int] = new IntMaxAggFunction()
+  override def aggregator: AggregateFunction[Int, MaxAccumulator[Int]] =
+    new IntMaxAggFunction()
 }
 
 class LongMaxAggFunctionTest extends MaxAggFunctionTest[Long] {
@@ -98,7 +99,8 @@ class LongMaxAggFunctionTest extends MaxAggFunctionTest[Long] {
 
   override def maxVal = Long.MaxValue - 1
 
-  override def aggregator: AggregateFunction[Long] = new LongMaxAggFunction()
+  override def aggregator: AggregateFunction[Long, MaxAccumulator[Long]] =
+    new LongMaxAggFunction()
 }
 
 class FloatMaxAggFunctionTest extends MaxAggFunctionTest[Float] {
@@ -107,7 +109,8 @@ class FloatMaxAggFunctionTest extends MaxAggFunctionTest[Float] {
 
   override def maxVal = Float.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Float] = new FloatMaxAggFunction()
+  override def aggregator: AggregateFunction[Float, MaxAccumulator[Float]] =
+    new FloatMaxAggFunction()
 }
 
 class DoubleMaxAggFunctionTest extends MaxAggFunctionTest[Double] {
@@ -116,10 +119,11 @@ class DoubleMaxAggFunctionTest extends MaxAggFunctionTest[Double] {
 
   override def maxVal = Double.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Double] = new DoubleMaxAggFunction()
+  override def aggregator: AggregateFunction[Double, MaxAccumulator[Double]] =
+    new DoubleMaxAggFunction()
 }
 
-class BooleanMaxAggFunctionTest extends AggFunctionTestBase[Boolean] {
+class BooleanMaxAggFunctionTest extends AggFunctionTestBase[Boolean, MaxAccumulator[Boolean]] {
 
   override def inputValueSets: Seq[Seq[Boolean]] = Seq(
     Seq(
@@ -155,12 +159,12 @@ class BooleanMaxAggFunctionTest extends AggFunctionTestBase[Boolean] {
     null.asInstanceOf[Boolean]
   )
 
-  override def aggregator: AggregateFunction[Boolean] = new BooleanMaxAggFunction()
-
-  override def supportRetraction: Boolean = false
+  override def aggregator: AggregateFunction[Boolean, MaxAccumulator[Boolean]] =
+    new BooleanMaxAggFunction()
 }
 
-class DecimalMaxAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
+class DecimalMaxAggFunctionTest
+  extends AggFunctionTestBase[BigDecimal, MaxAccumulator[BigDecimal]] {
 
   override def inputValueSets: Seq[Seq[_]] = Seq(
     Seq(
@@ -188,12 +192,11 @@ class DecimalMaxAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
     null
   )
 
-  override def aggregator: AggregateFunction[BigDecimal] = new DecimalMaxAggFunction()
-
-  override def supportRetraction: Boolean = false
+  override def aggregator: AggregateFunction[BigDecimal, MaxAccumulator[BigDecimal]] =
+    new DecimalMaxAggFunction()
 }
 
-class StringMaxAggFunctionTest extends AggFunctionTestBase[String] {
+class StringMaxAggFunctionTest extends AggFunctionTestBase[String, MaxAccumulator[String]] {
   override def inputValueSets: Seq[Seq[_]] = Seq(
     Seq(
       new String("a"),
@@ -221,7 +224,6 @@ class StringMaxAggFunctionTest extends AggFunctionTestBase[String] {
     new String("household")
   )
 
-  override def aggregator: AggregateFunction[String] = new StringMaxAggFunction()
-
-  override def supportRetraction: Boolean = false
+  override def aggregator: AggregateFunction[String, MaxAccumulator[String]] =
+    new StringMaxAggFunction()
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MaxWithRetractAggFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MaxWithRetractAggFunctionTest.scala
@@ -25,7 +25,8 @@ import org.apache.flink.table.functions.AggregateFunction
   *
   * @tparam T the type for the aggregation result
   */
-abstract class MaxWithRetractAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T] {
+abstract class MaxWithRetractAggFunctionTest[T: Numeric]
+  extends AggFunctionTestBase[T, MaxWithRetractAccumulator[T]] {
 
   private val numeric: Numeric[T] = implicitly[Numeric[T]]
 
@@ -61,6 +62,8 @@ abstract class MaxWithRetractAggFunctionTest[T: Numeric] extends AggFunctionTest
     maxVal,
     null.asInstanceOf[T]
   )
+
+  override def retractFunc = aggregator.getClass.getMethod("retract", accType, classOf[Any])
 }
 
 class ByteMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[Byte] {
@@ -69,7 +72,8 @@ class ByteMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[By
 
   override def maxVal = (Byte.MaxValue - 1).toByte
 
-  override def aggregator: AggregateFunction[Byte] = new ByteMaxWithRetractAggFunction()
+  override def aggregator: AggregateFunction[Byte, MaxWithRetractAccumulator[Byte]] =
+    new ByteMaxWithRetractAggFunction()
 }
 
 class ShortMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[Short] {
@@ -78,7 +82,8 @@ class ShortMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[S
 
   override def maxVal = (Short.MaxValue - 1).toShort
 
-  override def aggregator: AggregateFunction[Short] = new ShortMaxWithRetractAggFunction()
+  override def aggregator: AggregateFunction[Short, MaxWithRetractAccumulator[Short]] =
+    new ShortMaxWithRetractAggFunction()
 }
 
 class IntMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[Int] {
@@ -87,7 +92,8 @@ class IntMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[Int
 
   override def maxVal = Int.MaxValue - 1
 
-  override def aggregator: AggregateFunction[Int] = new IntMaxWithRetractAggFunction()
+  override def aggregator: AggregateFunction[Int, MaxWithRetractAccumulator[Int]] =
+    new IntMaxWithRetractAggFunction()
 }
 
 class LongMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[Long] {
@@ -96,7 +102,8 @@ class LongMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[Lo
 
   override def maxVal = Long.MaxValue - 1
 
-  override def aggregator: AggregateFunction[Long] = new LongMaxWithRetractAggFunction()
+  override def aggregator: AggregateFunction[Long, MaxWithRetractAccumulator[Long]] =
+    new LongMaxWithRetractAggFunction()
 }
 
 class FloatMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[Float] {
@@ -105,7 +112,8 @@ class FloatMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[F
 
   override def maxVal = Float.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Float] = new FloatMaxWithRetractAggFunction()
+  override def aggregator: AggregateFunction[Float, MaxWithRetractAccumulator[Float]] =
+    new FloatMaxWithRetractAggFunction()
 }
 
 class DoubleMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[Double] {
@@ -114,10 +122,12 @@ class DoubleMaxWithRetractAggFunctionTest extends MaxWithRetractAggFunctionTest[
 
   override def maxVal = Double.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Double] = new DoubleMaxWithRetractAggFunction()
+  override def aggregator: AggregateFunction[Double, MaxWithRetractAccumulator[Double]] =
+    new DoubleMaxWithRetractAggFunction()
 }
 
-class BooleanMaxWithRetractAggFunctionTest extends AggFunctionTestBase[Boolean] {
+class BooleanMaxWithRetractAggFunctionTest
+  extends AggFunctionTestBase[Boolean, MaxWithRetractAccumulator[Boolean]] {
 
   override def inputValueSets: Seq[Seq[Boolean]] = Seq(
     Seq(
@@ -153,10 +163,14 @@ class BooleanMaxWithRetractAggFunctionTest extends AggFunctionTestBase[Boolean] 
     null.asInstanceOf[Boolean]
   )
 
-  override def aggregator: AggregateFunction[Boolean] = new BooleanMaxWithRetractAggFunction()
+  override def aggregator: AggregateFunction[Boolean, MaxWithRetractAccumulator[Boolean]] =
+    new BooleanMaxWithRetractAggFunction()
+
+  override def retractFunc = aggregator.getClass.getMethod("retract", accType, classOf[Any])
 }
 
-class DecimalMaxWithRetractAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
+class DecimalMaxWithRetractAggFunctionTest
+  extends AggFunctionTestBase[BigDecimal, MaxWithRetractAccumulator[BigDecimal]] {
 
   override def inputValueSets: Seq[Seq[_]] = Seq(
     Seq(
@@ -184,10 +198,14 @@ class DecimalMaxWithRetractAggFunctionTest extends AggFunctionTestBase[BigDecima
     null
   )
 
-  override def aggregator: AggregateFunction[BigDecimal] = new DecimalMaxWithRetractAggFunction()
+  override def aggregator: AggregateFunction[BigDecimal, MaxWithRetractAccumulator[BigDecimal]] =
+    new DecimalMaxWithRetractAggFunction()
+
+  override def retractFunc = aggregator.getClass.getMethod("retract", accType, classOf[Any])
 }
 
-class StringMaxWithRetractAggFunctionTest extends AggFunctionTestBase[String] {
+class StringMaxWithRetractAggFunctionTest
+  extends AggFunctionTestBase[String, MaxWithRetractAccumulator[String]] {
 
   override def inputValueSets: Seq[Seq[_]] = Seq(
     Seq(
@@ -216,5 +234,8 @@ class StringMaxWithRetractAggFunctionTest extends AggFunctionTestBase[String] {
     "x"
   )
 
-  override def aggregator: AggregateFunction[String] = new StringMaxWithRetractAggFunction()
+  override def aggregator: AggregateFunction[String, MaxWithRetractAccumulator[String]] =
+    new StringMaxWithRetractAggFunction()
+
+  override def retractFunc = aggregator.getClass.getMethod("retract", accType, classOf[Any])
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MinAggFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MinAggFunctionTest.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.functions.AggregateFunction
   *
   * @tparam T the type for the aggregation result
   */
-abstract class MinAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T] {
+abstract class MinAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T, MinAccumulator[T]] {
 
   private val numeric: Numeric[T] = implicitly[Numeric[T]]
 
@@ -61,8 +61,6 @@ abstract class MinAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T] {
     minVal,
     null.asInstanceOf[T]
   )
-
-  override def supportRetraction: Boolean = false
 }
 
 class ByteMinAggFunctionTest extends MinAggFunctionTest[Byte] {
@@ -71,7 +69,8 @@ class ByteMinAggFunctionTest extends MinAggFunctionTest[Byte] {
 
   override def maxVal = (Byte.MaxValue - 1).toByte
 
-  override def aggregator: AggregateFunction[Byte] = new ByteMinAggFunction()
+  override def aggregator: AggregateFunction[Byte, MinAccumulator[Byte]] =
+    new ByteMinAggFunction()
 }
 
 class ShortMinAggFunctionTest extends MinAggFunctionTest[Short] {
@@ -80,7 +79,8 @@ class ShortMinAggFunctionTest extends MinAggFunctionTest[Short] {
 
   override def maxVal = (Short.MaxValue - 1).toShort
 
-  override def aggregator: AggregateFunction[Short] = new ShortMinAggFunction()
+  override def aggregator: AggregateFunction[Short, MinAccumulator[Short]] =
+    new ShortMinAggFunction()
 }
 
 class IntMinAggFunctionTest extends MinAggFunctionTest[Int] {
@@ -89,7 +89,8 @@ class IntMinAggFunctionTest extends MinAggFunctionTest[Int] {
 
   override def maxVal = Int.MaxValue - 1
 
-  override def aggregator: AggregateFunction[Int] = new IntMinAggFunction()
+  override def aggregator: AggregateFunction[Int, MinAccumulator[Int]] =
+    new IntMinAggFunction()
 }
 
 class LongMinAggFunctionTest extends MinAggFunctionTest[Long] {
@@ -98,7 +99,8 @@ class LongMinAggFunctionTest extends MinAggFunctionTest[Long] {
 
   override def maxVal = Long.MaxValue - 1
 
-  override def aggregator: AggregateFunction[Long] = new LongMinAggFunction()
+  override def aggregator: AggregateFunction[Long, MinAccumulator[Long]] =
+    new LongMinAggFunction()
 }
 
 class FloatMinAggFunctionTest extends MinAggFunctionTest[Float] {
@@ -107,7 +109,8 @@ class FloatMinAggFunctionTest extends MinAggFunctionTest[Float] {
 
   override def maxVal = Float.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Float] = new FloatMinAggFunction()
+  override def aggregator: AggregateFunction[Float, MinAccumulator[Float]] =
+    new FloatMinAggFunction()
 }
 
 class DoubleMinAggFunctionTest extends MinAggFunctionTest[Double] {
@@ -116,10 +119,11 @@ class DoubleMinAggFunctionTest extends MinAggFunctionTest[Double] {
 
   override def maxVal = Double.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Double] = new DoubleMinAggFunction()
+  override def aggregator: AggregateFunction[Double, MinAccumulator[Double]] =
+    new DoubleMinAggFunction()
 }
 
-class BooleanMinAggFunctionTest extends AggFunctionTestBase[Boolean] {
+class BooleanMinAggFunctionTest extends AggFunctionTestBase[Boolean, MinAccumulator[Boolean]] {
 
   override def inputValueSets: Seq[Seq[Boolean]] = Seq(
     Seq(
@@ -155,12 +159,12 @@ class BooleanMinAggFunctionTest extends AggFunctionTestBase[Boolean] {
     null.asInstanceOf[Boolean]
   )
 
-  override def aggregator: AggregateFunction[Boolean] = new BooleanMinAggFunction()
-
-  override def supportRetraction: Boolean = false
+  override def aggregator: AggregateFunction[Boolean, MinAccumulator[Boolean]] =
+    new BooleanMinAggFunction()
 }
 
-class DecimalMinAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
+class DecimalMinAggFunctionTest
+  extends AggFunctionTestBase[BigDecimal, MinAccumulator[BigDecimal]] {
 
   override def inputValueSets: Seq[Seq[_]] = Seq(
     Seq(
@@ -188,12 +192,12 @@ class DecimalMinAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
     null
   )
 
-  override def aggregator: AggregateFunction[BigDecimal] = new DecimalMinAggFunction()
-
-  override def supportRetraction: Boolean = false
+  override def aggregator: AggregateFunction[BigDecimal, MinAccumulator[BigDecimal]] =
+    new DecimalMinAggFunction()
 }
 
-class StringMinAggFunctionTest extends AggFunctionTestBase[String] {
+class StringMinAggFunctionTest
+  extends AggFunctionTestBase[String, MinAccumulator[String]] {
   override def inputValueSets: Seq[Seq[_]] = Seq(
     Seq(
       new String("a"),
@@ -221,7 +225,6 @@ class StringMinAggFunctionTest extends AggFunctionTestBase[String] {
     new String("1House")
   )
 
-  override def aggregator: AggregateFunction[String] = new StringMinAggFunction()
-
-  override def supportRetraction: Boolean = false
+  override def aggregator: AggregateFunction[String, MinAccumulator[String]] =
+    new StringMinAggFunction()
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MinWithRetractAggFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/MinWithRetractAggFunctionTest.scala
@@ -25,7 +25,8 @@ import org.apache.flink.table.functions.AggregateFunction
   *
   * @tparam T the type for the aggregation result
   */
-abstract class MinWithRetractAggFunctionTest[T: Numeric] extends AggFunctionTestBase[T] {
+abstract class MinWithRetractAggFunctionTest[T: Numeric]
+  extends AggFunctionTestBase[T, MinWithRetractAccumulator[T]] {
 
   private val numeric: Numeric[T] = implicitly[Numeric[T]]
 
@@ -61,6 +62,8 @@ abstract class MinWithRetractAggFunctionTest[T: Numeric] extends AggFunctionTest
     minVal,
     null.asInstanceOf[T]
   )
+
+  override def retractFunc = aggregator.getClass.getMethod("retract", accType, classOf[Any])
 }
 
 class ByteMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[Byte] {
@@ -69,7 +72,8 @@ class ByteMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[By
 
   override def maxVal = (Byte.MaxValue - 1).toByte
 
-  override def aggregator: AggregateFunction[Byte] = new ByteMinWithRetractAggFunction()
+  override def aggregator: AggregateFunction[Byte, MinWithRetractAccumulator[Byte]] =
+    new ByteMinWithRetractAggFunction()
 }
 
 class ShortMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[Short] {
@@ -78,7 +82,8 @@ class ShortMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[S
 
   override def maxVal = (Short.MaxValue - 1).toShort
 
-  override def aggregator: AggregateFunction[Short] = new ShortMinWithRetractAggFunction()
+  override def aggregator: AggregateFunction[Short, MinWithRetractAccumulator[Short]] =
+    new ShortMinWithRetractAggFunction()
 }
 
 class IntMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[Int] {
@@ -87,7 +92,8 @@ class IntMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[Int
 
   override def maxVal = Int.MaxValue - 1
 
-  override def aggregator: AggregateFunction[Int] = new IntMinWithRetractAggFunction()
+  override def aggregator: AggregateFunction[Int, MinWithRetractAccumulator[Int]] =
+    new IntMinWithRetractAggFunction()
 }
 
 class LongMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[Long] {
@@ -96,7 +102,8 @@ class LongMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[Lo
 
   override def maxVal = Long.MaxValue - 1
 
-  override def aggregator: AggregateFunction[Long] = new LongMinWithRetractAggFunction()
+  override def aggregator: AggregateFunction[Long, MinWithRetractAccumulator[Long]] =
+    new LongMinWithRetractAggFunction()
 }
 
 class FloatMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[Float] {
@@ -105,7 +112,8 @@ class FloatMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[F
 
   override def maxVal = Float.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Float] = new FloatMinWithRetractAggFunction()
+  override def aggregator: AggregateFunction[Float, MinWithRetractAccumulator[Float]] =
+    new FloatMinWithRetractAggFunction()
 }
 
 class DoubleMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[Double] {
@@ -114,10 +122,12 @@ class DoubleMinWithRetractAggFunctionTest extends MinWithRetractAggFunctionTest[
 
   override def maxVal = Double.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Double] = new DoubleMinWithRetractAggFunction()
+  override def aggregator: AggregateFunction[Double, MinWithRetractAccumulator[Double]] =
+    new DoubleMinWithRetractAggFunction()
 }
 
-class BooleanMinWithRetractAggFunctionTest extends AggFunctionTestBase[Boolean] {
+class BooleanMinWithRetractAggFunctionTest
+  extends AggFunctionTestBase[Boolean, MinWithRetractAccumulator[Boolean]] {
 
   override def inputValueSets: Seq[Seq[Boolean]] = Seq(
     Seq(
@@ -153,10 +163,14 @@ class BooleanMinWithRetractAggFunctionTest extends AggFunctionTestBase[Boolean] 
     null.asInstanceOf[Boolean]
   )
 
-  override def aggregator: AggregateFunction[Boolean] = new BooleanMinWithRetractAggFunction()
+  override def aggregator: AggregateFunction[Boolean, MinWithRetractAccumulator[Boolean]] =
+    new BooleanMinWithRetractAggFunction()
+
+  override def retractFunc = aggregator.getClass.getMethod("retract", accType, classOf[Any])
 }
 
-class DecimalMinWithRetractAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
+class DecimalMinWithRetractAggFunctionTest
+  extends AggFunctionTestBase[BigDecimal, MinWithRetractAccumulator[BigDecimal]] {
 
   override def inputValueSets: Seq[Seq[_]] = Seq(
     Seq(
@@ -184,10 +198,14 @@ class DecimalMinWithRetractAggFunctionTest extends AggFunctionTestBase[BigDecima
     null
   )
 
-  override def aggregator: AggregateFunction[BigDecimal] = new DecimalMinWithRetractAggFunction()
+  override def aggregator: AggregateFunction[BigDecimal, MinWithRetractAccumulator[BigDecimal]] =
+    new DecimalMinWithRetractAggFunction()
+
+  override def retractFunc = aggregator.getClass.getMethod("retract", accType, classOf[Any])
 }
 
-class StringMinWithRetractAggFunctionTest extends AggFunctionTestBase[String] {
+class StringMinWithRetractAggFunctionTest
+  extends AggFunctionTestBase[String, MinWithRetractAccumulator[String]] {
 
   override def inputValueSets: Seq[Seq[_]] = Seq(
     Seq(
@@ -216,5 +234,8 @@ class StringMinWithRetractAggFunctionTest extends AggFunctionTestBase[String] {
     "e"
   )
 
-  override def aggregator: AggregateFunction[String] = new StringMinWithRetractAggFunction()
+  override def aggregator: AggregateFunction[String, MinWithRetractAccumulator[String]] =
+    new StringMinWithRetractAggFunction()
+
+  override def retractFunc = aggregator.getClass.getMethod("retract", accType, classOf[Any])
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/SumAggFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/SumAggFunctionTest.scala
@@ -26,7 +26,8 @@ import org.apache.flink.table.functions.AggregateFunction
   *
   * @tparam T the type for the aggregation result
   */
-abstract class SumAggFunctionTestBase[T: Numeric] extends AggFunctionTestBase[T] {
+abstract class SumAggFunctionTestBase[T: Numeric]
+  extends AggFunctionTestBase[T, SumAccumulator[T]] {
 
   private val numeric: Numeric[T] = implicitly[Numeric[T]]
 
@@ -63,54 +64,59 @@ abstract class SumAggFunctionTestBase[T: Numeric] extends AggFunctionTestBase[T]
     numeric.fromInt(2),
     null.asInstanceOf[T]
   )
-
-  override def supportRetraction: Boolean = false
 }
 
 class ByteSumAggFunctionTest extends SumAggFunctionTestBase[Byte] {
 
   override def maxVal = (Byte.MaxValue / 2).toByte
 
-  override def aggregator: AggregateFunction[Byte] = new ByteSumAggFunction
+  override def aggregator: AggregateFunction[Byte, SumAccumulator[Byte]] =
+    new ByteSumAggFunction
 }
 
 class ShortSumAggFunctionTest extends SumAggFunctionTestBase[Short] {
 
   override def maxVal = (Short.MaxValue / 2).toShort
 
-  override def aggregator: AggregateFunction[Short] = new ShortSumAggFunction
+  override def aggregator: AggregateFunction[Short, SumAccumulator[Short]] =
+    new ShortSumAggFunction
 }
 
 class IntSumAggFunctionTest extends SumAggFunctionTestBase[Int] {
 
   override def maxVal = Int.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Int] = new IntSumAggFunction
+  override def aggregator: AggregateFunction[Int, SumAccumulator[Int]] =
+    new IntSumAggFunction
 }
 
 class LongSumAggFunctionTest extends SumAggFunctionTestBase[Long] {
 
   override def maxVal = Long.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Long] = new LongSumAggFunction
+  override def aggregator: AggregateFunction[Long, SumAccumulator[Long]] =
+    new LongSumAggFunction
 }
 
 class FloatSumAggFunctionTest extends SumAggFunctionTestBase[Float] {
 
   override def maxVal = 12345.6789f
 
-  override def aggregator: AggregateFunction[Float] = new FloatSumAggFunction
+  override def aggregator: AggregateFunction[Float, SumAccumulator[Float]] =
+    new FloatSumAggFunction
 }
 
 class DoubleSumAggFunctionTest extends SumAggFunctionTestBase[Double] {
 
   override def maxVal = 12345.6789d
 
-  override def aggregator: AggregateFunction[Double] = new DoubleSumAggFunction
+  override def aggregator: AggregateFunction[Double, SumAccumulator[Double]] =
+    new DoubleSumAggFunction
 }
 
 
-class DecimalSumAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
+class DecimalSumAggFunctionTest
+  extends AggFunctionTestBase[BigDecimal, DecimalSumAccumulator] {
 
   override def inputValueSets: Seq[Seq[_]] = Seq(
     Seq(
@@ -143,9 +149,8 @@ class DecimalSumAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
     null
   )
 
-  override def aggregator: AggregateFunction[BigDecimal] = new DecimalSumAggFunction()
-
-  override def supportRetraction: Boolean = false
+  override def aggregator: AggregateFunction[BigDecimal, DecimalSumAccumulator] =
+    new DecimalSumAggFunction()
 }
 
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/SumWithRetractAggFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/functions/aggfunctions/SumWithRetractAggFunctionTest.scala
@@ -26,7 +26,8 @@ import org.apache.flink.table.functions.AggregateFunction
   *
   * @tparam T the type for the aggregation result
   */
-abstract class SumWithRetractAggFunctionTestBase[T: Numeric] extends AggFunctionTestBase[T] {
+abstract class SumWithRetractAggFunctionTestBase[T: Numeric]
+  extends AggFunctionTestBase[T, SumWithRetractAccumulator[T]] {
 
   private val numeric: Numeric[T] = implicitly[Numeric[T]]
 
@@ -63,52 +64,61 @@ abstract class SumWithRetractAggFunctionTestBase[T: Numeric] extends AggFunction
     numeric.fromInt(2),
     null.asInstanceOf[T]
   )
+
+  override def retractFunc = aggregator.getClass.getMethod("retract", accType, classOf[Any])
 }
 
 class ByteSumWithRetractAggFunctionTest extends SumWithRetractAggFunctionTestBase[Byte] {
 
   override def maxVal = (Byte.MaxValue / 2).toByte
 
-  override def aggregator: AggregateFunction[Byte] = new ByteSumWithRetractAggFunction
+  override def aggregator: AggregateFunction[Byte, SumWithRetractAccumulator[Byte]] =
+    new ByteSumWithRetractAggFunction
 }
 
 class ShortSumWithRetractAggFunctionTest extends SumWithRetractAggFunctionTestBase[Short] {
 
   override def maxVal = (Short.MaxValue / 2).toShort
 
-  override def aggregator: AggregateFunction[Short] = new ShortSumWithRetractAggFunction
+  override def aggregator: AggregateFunction[Short, SumWithRetractAccumulator[Short]] =
+    new ShortSumWithRetractAggFunction
 }
 
 class IntSumWithRetractAggFunctionTest extends SumWithRetractAggFunctionTestBase[Int] {
 
   override def maxVal = Int.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Int] = new IntSumWithRetractAggFunction
+  override def aggregator: AggregateFunction[Int, SumWithRetractAccumulator[Int]] =
+    new IntSumWithRetractAggFunction
 }
 
 class LongSumWithRetractAggFunctionTest extends SumWithRetractAggFunctionTestBase[Long] {
 
   override def maxVal = Long.MaxValue / 2
 
-  override def aggregator: AggregateFunction[Long] = new LongSumWithRetractAggFunction
+  override def aggregator: AggregateFunction[Long, SumWithRetractAccumulator[Long]] =
+    new LongSumWithRetractAggFunction
 }
 
 class FloatSumWithRetractAggFunctionTest extends SumWithRetractAggFunctionTestBase[Float] {
 
   override def maxVal = 12345.6789f
 
-  override def aggregator: AggregateFunction[Float] = new FloatSumWithRetractAggFunction
+  override def aggregator: AggregateFunction[Float, SumWithRetractAccumulator[Float]] =
+    new FloatSumWithRetractAggFunction
 }
 
 class DoubleSumWithRetractAggFunctionTest extends SumWithRetractAggFunctionTestBase[Double] {
 
   override def maxVal = 12345.6789d
 
-  override def aggregator: AggregateFunction[Double] = new DoubleSumWithRetractAggFunction
+  override def aggregator: AggregateFunction[Double, SumWithRetractAccumulator[Double]] =
+    new DoubleSumWithRetractAggFunction
 }
 
 
-class DecimalSumWithRetractAggFunctionTest extends AggFunctionTestBase[BigDecimal] {
+class DecimalSumWithRetractAggFunctionTest
+  extends AggFunctionTestBase[BigDecimal, DecimalSumWithRetractAccumulator] {
 
   override def inputValueSets: Seq[Seq[_]] = Seq(
     Seq(
@@ -141,7 +151,10 @@ class DecimalSumWithRetractAggFunctionTest extends AggFunctionTestBase[BigDecima
     null
   )
 
-  override def aggregator: AggregateFunction[BigDecimal] = new DecimalSumWithRetractAggFunction()
+  override def aggregator: AggregateFunction[BigDecimal, DecimalSumWithRetractAccumulator] =
+    new DecimalSumWithRetractAggFunction()
+
+  override def retractFunc = aggregator.getClass.getMethod("retract", accType, classOf[Any])
 }
 
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/aggregate/BoundedProcessingOverRangeProcessFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/aggregate/BoundedProcessingOverRangeProcessFunctionTest.scala
@@ -51,7 +51,7 @@ class BoundedProcessingOverRangeProcessFunctionTest {
 
     val aggregates =
       Array(new LongMinWithRetractAggFunction,
-            new LongMaxWithRetractAggFunction).asInstanceOf[Array[AggregateFunction[_]]]
+            new LongMaxWithRetractAggFunction).asInstanceOf[Array[AggregateFunction[_,_]]]
     val aggregationStateType: RowTypeInfo = AggregateUtil.createAccumulatorRowType(aggregates)
 
     val funcCode =
@@ -71,9 +71,9 @@ class BoundedProcessingOverRangeProcessFunctionTest {
         |    org.apache.flink.table.functions.utils.UserDefinedFunctionUtils
         |    .deserialize("rO0ABXNyAEtvcmcuYXBhY2hlLmZsaW5rLnRhYmxlLmZ1bmN0aW9ucy5hZ2dmdW5jdGlvbn" +
         |    "MuTG9uZ01pbldpdGhSZXRyYWN0QWdnRnVuY3Rpb26oIdX_DaMPxQIAAHhyAEdvcmcuYXBhY2hlLmZsaW5rL" +
-        |    "nRhYmxlLmZ1bmN0aW9ucy5hZ2dmdW5jdGlvbnMuTWluV2l0aFJldHJhY3RBZ2dGdW5jdGlvbkDcXxs1apkP" +
+        |    "nRhYmxlLmZ1bmN0aW9ucy5hZ2dmdW5jdGlvbnMuTWluV2l0aFJldHJhY3RBZ2dGdW5jdGlvbq_ZGuzxtA_S" +
         |    "AgABTAADb3JkdAAVTHNjYWxhL21hdGgvT3JkZXJpbmc7eHIAMm9yZy5hcGFjaGUuZmxpbmsudGFibGUuZnV" +
-        |    "uY3Rpb25zLkFnZ3JlZ2F0ZUZ1bmN0aW9uSa3YqbzCL3QCAAB4cgA0b3JnLmFwYWNoZS5mbGluay50YWJsZS" +
+        |    "uY3Rpb25zLkFnZ3JlZ2F0ZUZ1bmN0aW9uTcYVPtJjNfwCAAB4cgA0b3JnLmFwYWNoZS5mbGluay50YWJsZS" +
         |    "5mdW5jdGlvbnMuVXNlckRlZmluZWRGdW5jdGlvbi0B91QxuAyTAgAAeHBzcgAZc2NhbGEubWF0aC5PcmRlc" +
         |    "mluZyRMb25nJOda0iCPo2ukAgAAeHA");
         |
@@ -81,9 +81,9 @@ class BoundedProcessingOverRangeProcessFunctionTest {
         |    org.apache.flink.table.functions.utils.UserDefinedFunctionUtils
         |    .deserialize("rO0ABXNyAEtvcmcuYXBhY2hlLmZsaW5rLnRhYmxlLmZ1bmN0aW9ucy5hZ2dmdW5jdGlvbn" +
         |    "MuTG9uZ01heFdpdGhSZXRyYWN0QWdnRnVuY3Rpb25RmsI8azNGXwIAAHhyAEdvcmcuYXBhY2hlLmZsaW5rL" +
-        |    "nRhYmxlLmZ1bmN0aW9ucy5hZ2dmdW5jdGlvbnMuTWF4V2l0aFJldHJhY3RBZ2dGdW5jdGlvbu4_w_gPePlO" +
+        |    "nRhYmxlLmZ1bmN0aW9ucy5hZ2dmdW5jdGlvbnMuTWF4V2l0aFJldHJhY3RBZ2dGdW5jdGlvbvnwowlX0_Qf" +
         |    "AgABTAADb3JkdAAVTHNjYWxhL21hdGgvT3JkZXJpbmc7eHIAMm9yZy5hcGFjaGUuZmxpbmsudGFibGUuZnV" +
-        |    "uY3Rpb25zLkFnZ3JlZ2F0ZUZ1bmN0aW9uSa3YqbzCL3QCAAB4cgA0b3JnLmFwYWNoZS5mbGluay50YWJsZS" +
+        |    "uY3Rpb25zLkFnZ3JlZ2F0ZUZ1bmN0aW9uTcYVPtJjNfwCAAB4cgA0b3JnLmFwYWNoZS5mbGluay50YWJsZS" +
         |    "5mdW5jdGlvbnMuVXNlckRlZmluZWRGdW5jdGlvbi0B91QxuAyTAgAAeHBzcgAZc2NhbGEubWF0aC5PcmRlc" +
         |    "mluZyRMb25nJOda0iCPo2ukAgAAeHA");
         |  }
@@ -95,12 +95,14 @@ class BoundedProcessingOverRangeProcessFunctionTest {
         |    org.apache.flink.table.functions.AggregateFunction baseClass0 =
         |      (org.apache.flink.table.functions.AggregateFunction) fmin;
         |    output.setField(5, baseClass0.getValue(
-        |      (org.apache.flink.table.functions.Accumulator) accs.getField(0)));
+        |      (org.apache.flink.table.functions.aggfunctions.MinWithRetractAccumulator)
+        |      accs.getField(0)));
         |
         |    org.apache.flink.table.functions.AggregateFunction baseClass1 =
         |      (org.apache.flink.table.functions.AggregateFunction) fmax;
         |    output.setField(6, baseClass1.getValue(
-        |      (org.apache.flink.table.functions.Accumulator) accs.getField(1)));
+        |      (org.apache.flink.table.functions.aggfunctions.MaxWithRetractAccumulator)
+        |      accs.getField(1)));
         |  }
         |
         |  public void accumulate(
@@ -108,11 +110,13 @@ class BoundedProcessingOverRangeProcessFunctionTest {
         |    org.apache.flink.types.Row input) {
         |
         |    fmin.accumulate(
-        |      ((org.apache.flink.table.functions.Accumulator) accs.getField(0)),
+        |      ((org.apache.flink.table.functions.aggfunctions.MinWithRetractAccumulator)
+        |      accs.getField(0)),
         |      (java.lang.Long) input.getField(4));
         |
         |    fmax.accumulate(
-        |      ((org.apache.flink.table.functions.Accumulator) accs.getField(1)),
+        |      ((org.apache.flink.table.functions.aggfunctions.MaxWithRetractAccumulator)
+        |      accs.getField(1)),
         |      (java.lang.Long) input.getField(4));
         |  }
         |
@@ -121,11 +125,13 @@ class BoundedProcessingOverRangeProcessFunctionTest {
         |    org.apache.flink.types.Row input) {
         |
         |    fmin.retract(
-        |      ((org.apache.flink.table.functions.Accumulator) accs.getField(0)),
+        |      ((org.apache.flink.table.functions.aggfunctions.MinWithRetractAccumulator)
+        |      accs.getField(0)),
         |      (java.lang.Long) input.getField(4));
         |
         |    fmax.retract(
-        |      ((org.apache.flink.table.functions.Accumulator) accs.getField(1)),
+        |      ((org.apache.flink.table.functions.aggfunctions.MaxWithRetractAccumulator)
+        |      accs.getField(1)),
         |      (java.lang.Long) input.getField(4));
         |  }
         |


### PR DESCRIPTION
This PR includes the following changes:
1) remove Accumulator trait; 
2) move accumulate, retract, merge, resetAccumulator, getAccumulatorType methods out of AggregateFunction interface, and allow them to be defined as contracted methods for UDAGG; 
3) refactoring the built-in aggregates accordingly.
4) fixed a build warning in flink/table/api/Types.scala (unrelated to FLINK-6361)


Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
