### PR TITLE
[FLINK-6367] support custom header settings of allow origin

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -371,6 +371,8 @@ These parameters allow for advanced tuning. The default values are sufficient wh
 
 - `jobmanager.web.ssl.enabled`: Enable https access to the web frontend. This is applicable only when the global ssl flag security.ssl.enabled is set to true (DEFAULT: `true`).
 
+- `jobmanager.web.access-control-allow-origin`: Enable custom access control parameter for allow origin header, default is `*`.
+
 ### File Systems
 
 The parameters define the behavior of tasks that create result files.

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -1333,10 +1333,11 @@ public final class ConfigConstants {
 		key("jobmanager.web.address")
 			.noDefaultValue();
 
-	/** Web response header of Access-Control-Allow-Origin's key and default value. */
+	/** The config parameter defining the Access-Control-Allow-Origin header for all
+	 * responses from the web-frontend. */
 	public static final ConfigOption<String> JOB_MANAGER_WEB_ACCESS_CONTROL_ALLOW_ORIGIN =
-		key("jobmanager.web.access-control-allow-origin").defaultValue("*");
-
+		key("jobmanager.web.access-control-allow-origin")
+			.defaultValue("*");
 
 	/** The config key for the port of the JobManager web frontend.
 	 * Setting this value to {@code -1} disables the web frontend. */

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -701,9 +701,6 @@ public final class ConfigConstants {
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_BACK_PRESSURE_DELAY = "jobmanager.web.backpressure.delay-between-samples";
 
-	/** Web response header of Access-Control-Allow-Origin */
-	public static final String JOB_MANAGER_WEB_ACCESS_CONTROL_ALLOW_ORIGIN = "jobmanager.web.access-control-allow-origin";
-
 	// ------------------------------ AKKA ------------------------------------
 
 	/**
@@ -1336,6 +1333,11 @@ public final class ConfigConstants {
 		key("jobmanager.web.address")
 			.noDefaultValue();
 
+	/** Web response header of Access-Control-Allow-Origin's key and default value. */
+	public static final ConfigOption<String> JOB_MANAGER_WEB_ACCESS_CONTROL_ALLOW_ORIGIN =
+		key("jobmanager.web.access-control-allow-origin").defaultValue("*");
+
+
 	/** The config key for the port of the JobManager web frontend.
 	 * Setting this value to {@code -1} disables the web frontend. */
 	public static final int DEFAULT_JOB_MANAGER_WEB_FRONTEND_PORT = 8081;
@@ -1367,9 +1369,6 @@ public final class ConfigConstants {
 
 	/** Delay between samples to determine back pressure. */
 	public static final int DEFAULT_JOB_MANAGER_WEB_BACK_PRESSURE_DELAY = 50;
-
-	/** Default access control allow any origin site. */
-	public static final String DEFAULT_JOB_MANAGER_WEB_ACCESS_CONTROL_ALLOW_ORIGIN = "*";
 
 	// ------------------------------ Akka Values ------------------------------
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -701,6 +701,9 @@ public final class ConfigConstants {
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_BACK_PRESSURE_DELAY = "jobmanager.web.backpressure.delay-between-samples";
 
+	/** Web response header of Access-Control-Allow-Origin */
+	public static final String JOB_MANAGER_WEB_ACCESS_CONTROL_ALLOW_ORIGIN = "jobmanager.web.access-control-allow-origin";
+
 	// ------------------------------ AKKA ------------------------------------
 
 	/**
@@ -1364,6 +1367,9 @@ public final class ConfigConstants {
 
 	/** Delay between samples to determine back pressure. */
 	public static final int DEFAULT_JOB_MANAGER_WEB_BACK_PRESSURE_DELAY = 50;
+
+	/** Default access control allow any origin site. */
+	public static final String DEFAULT_JOB_MANAGER_WEB_ACCESS_CONTROL_ALLOW_ORIGIN = "*";
 
 	// ------------------------------ Akka Values ------------------------------
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/RuntimeMonitorHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/RuntimeMonitorHandler.java
@@ -66,14 +66,19 @@ public class RuntimeMonitorHandler extends RuntimeMonitorHandlerBase {
 
 	private final RequestHandler handler;
 
+	private final String allowOrigin;
+
 	public RuntimeMonitorHandler(
+			WebMonitorConfig cfg,
 			RequestHandler handler,
 			JobManagerRetriever retriever,
 			Future<String> localJobManagerAddressFuture,
 			FiniteDuration timeout,
 			boolean httpsEnabled) {
+
 		super(retriever, localJobManagerAddressFuture, timeout, httpsEnabled);
 		this.handler = checkNotNull(handler);
+		this.allowOrigin = cfg.getAllowOrigin();
 	}
 
 	@Override
@@ -122,7 +127,7 @@ public class RuntimeMonitorHandler extends RuntimeMonitorHandlerBase {
 			LOG.debug("Error while handling request", e);
 		}
 
-		response.headers().set(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
+		response.headers().set(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN, allowOrigin);
 		// Content-Encoding:utf-8
 		response.headers().set(HttpHeaders.Names.CONTENT_ENCODING, ENCODING.name());
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorConfig.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorConfig.java
@@ -81,7 +81,7 @@ public class WebMonitorConfig {
 
 	public String getAllowOrigin() {
 		return config.getString(
-			ConfigConstants.JOB_MANAGER_WEB_ACCESS_CONTROL_ALLOW_ORIGIN,
-			ConfigConstants.DEFAULT_JOB_MANAGER_WEB_ACCESS_CONTROL_ALLOW_ORIGIN);
+			ConfigConstants.JOB_MANAGER_WEB_ACCESS_CONTROL_ALLOW_ORIGIN.key(),
+			ConfigConstants.JOB_MANAGER_WEB_ACCESS_CONTROL_ALLOW_ORIGIN.defaultValue());
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorConfig.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorConfig.java
@@ -80,8 +80,6 @@ public class WebMonitorConfig {
 	}
 
 	public String getAllowOrigin() {
-		return config.getString(
-			ConfigConstants.JOB_MANAGER_WEB_ACCESS_CONTROL_ALLOW_ORIGIN.key(),
-			ConfigConstants.JOB_MANAGER_WEB_ACCESS_CONTROL_ALLOW_ORIGIN.defaultValue());
+		return config.getString(ConfigConstants.JOB_MANAGER_WEB_ACCESS_CONTROL_ALLOW_ORIGIN);
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorConfig.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorConfig.java
@@ -78,4 +78,10 @@ public class WebMonitorConfig {
 			ConfigConstants.JOB_MANAGER_WEB_SUBMIT_ENABLED_KEY,
 			ConfigConstants.DEFAULT_JOB_MANAGER_WEB_SUBMIT_ENABLED);
 	}
+
+	public String getAllowOrigin() {
+		return config.getString(
+			ConfigConstants.JOB_MANAGER_WEB_ACCESS_CONTROL_ALLOW_ORIGIN,
+			ConfigConstants.DEFAULT_JOB_MANAGER_WEB_ACCESS_CONTROL_ALLOW_ORIGIN);
+	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -136,6 +136,8 @@ public class WebRuntimeMonitor implements WebMonitor {
 
 	private final BackPressureStatsTracker backPressureStatsTracker;
 
+	private final WebMonitorConfig cfg;
+
 	private AtomicBoolean cleanedUp = new AtomicBoolean();
 
 	private ExecutorService executorService;
@@ -150,8 +152,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 		this.leaderRetrievalService = checkNotNull(leaderRetrievalService);
 		this.timeout = AkkaUtils.getTimeout(config);
 		this.retriever = new JobManagerRetriever(this, actorSystem, AkkaUtils.getTimeout(config), timeout);
-		
-		final WebMonitorConfig cfg = new WebMonitorConfig(config);
+		this.cfg = new WebMonitorConfig(config);
 
 		final String configuredAddress = cfg.getWebFrontendAddress();
 
@@ -515,7 +516,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 	// ------------------------------------------------------------------------
 
 	private RuntimeMonitorHandler handler(RequestHandler handler) {
-		return new RuntimeMonitorHandler(handler, retriever, jobManagerAddressPromise.future(), timeout,
+		return new RuntimeMonitorHandler(cfg, handler, retriever, jobManagerAddressPromise.future(), timeout,
 			serverSSLContext !=  null);
 	}
 


### PR DESCRIPTION
`jobmanager.web.access-control-allow-origin`: Enable custom access control parameter for allow origin header, default is `*`.

- [X] General
  - The pull request references the related JIRA issue ("[FLINK-6367] support custom header settings of allow origin")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [X] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [X] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
