### PR TITLE
[FLINK-6384] [py] Remove python binary check via additional process

### DIFF
--- a/flink-libraries/flink-python/src/test/java/org/apache/flink/python/api/PythonPlanBinderTest.java
+++ b/flink-libraries/flink-python/src/test/java/org/apache/flink/python/api/PythonPlanBinderTest.java
@@ -16,6 +16,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.python.api.streaming.data.PythonStreamer;
 import org.apache.flink.test.util.JavaProgramTestBase;
 
 import java.io.IOException;
@@ -50,21 +51,33 @@ public class PythonPlanBinderTest extends JavaProgramTestBase {
 		return files;
 	}
 
-	private static boolean isPython2Supported() {
+	private static boolean isPython2Supported() throws IOException {
+		Process process = null;
+
 		try {
-			Runtime.getRuntime().exec("python");
+			process = Runtime.getRuntime().exec("python");
 			return true;
 		} catch (IOException ex) {
 			return false;
+		} finally {
+			if (process != null) {
+				PythonStreamer.destroyProcess(process);
+			}
 		}
 	}
 
-	private static boolean isPython3Supported() {
+	private static boolean isPython3Supported() throws IOException {
+		Process process = null;
+
 		try {
-			Runtime.getRuntime().exec("python3");
+			process = Runtime.getRuntime().exec("python3");
 			return true;
 		} catch (IOException ex) {
 			return false;
+		} finally {
+			if (process != null) {
+				PythonStreamer.destroyProcess(process);
+			}
 		}
 	}
 


### PR DESCRIPTION
The PythonStreamer used to check for the existence of the python binary by
starting a python process. This process was not closed afterwards. This caused
the PythonPlanBinderTest to fail locally.

I think the check whether a python binary exists is not necessary since the
subsequent python command would fail anyway if there is no binary available on
the system. The system failure message is that there is no such file or directory.
This error message should be descriptive enough in order to debug such a problem.

cc @zentol