### PR TITLE
[FLINK-6387] [webfrontend]Flink UI support access log

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -645,6 +645,10 @@ public final class ConfigConstants {
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_LOG_PATH_KEY = "jobmanager.web.log.path";
 
+	/** Config parameter indicating whether jobs can be uploaded and run from the web-frontend. */
+	public static final ConfigOption<Boolean> JOB_MANAGER_WEB_ACCESSLOG_ENABLE =
+			key("jobmanager.web.accesslog.enable").defaultValue(false);
+
 	/**
 	 * Config parameter indicating whether jobs can be uploaded and run from the web-frontend.
 	 *

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -645,10 +645,6 @@ public final class ConfigConstants {
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_LOG_PATH_KEY = "jobmanager.web.log.path";
 
-	/** Config parameter indicating whether jobs can be uploaded and run from the web-frontend. */
-	public static final ConfigOption<Boolean> JOB_MANAGER_WEB_ACCESSLOG_ENABLE =
-			key("jobmanager.web.accesslog.enable").defaultValue(false);
-
 	/**
 	 * Config parameter indicating whether jobs can be uploaded and run from the web-frontend.
 	 *

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -168,6 +168,10 @@ public class JobManagerOptions {
 		key("jobmanager.archive.fs.dir")
 			.noDefaultValue();
 
+	/** Config parameter indicating whether enable the web access log. */
+	public static final ConfigOption<Boolean> JOB_MANAGER_WEB_ACCESSLOG_ENABLE =
+		key("jobmanager.web.accesslog.enable")
+			.defaultValue(false);
 	// ---------------------------------------------------------------------------------------------
 
 	private JobManagerOptions() {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/HttpRequestHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/HttpRequestHandler.java
@@ -108,7 +108,7 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<HttpObject> 
 				}
 
 				if (enableAccesslog) {
-					accesslog(ctx, currentRequest);
+					logAccess(ctx, currentRequest);
 				}
 
 				if (currentRequest.getMethod() == HttpMethod.GET || currentRequest.getMethod() == HttpMethod.DELETE) {
@@ -197,17 +197,16 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<HttpObject> 
 
   /**
    * Record the access log if enable configure of
-   * {@link org.apache.flink.configuration.ConfigConstants#JOB_MANAGER_WEB_ACCESSLOG_ENABLE}.
+   * {@link org.apache.flink.configuration.JobManagerOptions#JOB_MANAGER_WEB_ACCESSLOG_ENABLE}.
    * record format:
    * remote_addr - [time_local] "request_method URI protocolVersion" "http_referer" "http_user_agent"
    */
-	private void accesslog(ChannelHandlerContext ctx, HttpRequest req) {
+	private void logAccess(ChannelHandlerContext ctx, HttpRequest req) {
 		HttpHeaders headers = req.headers();
 		if (headers != null) {
-			String line = ctx.channel().remoteAddress() + " - [" + new Date() + "] \""
+			LOG.info(ctx.channel().remoteAddress() + " - [" + new Date() + "] \""
 					+ req.getMethod().name() + " " + req.getUri() + " " + req.getProtocolVersion().text() + "\" "
-					+ getHeader(Names.REFERER, headers) + "\" \"" + getHeader(Names.USER_AGENT, headers) + "\" ";
-			LOG.info(line);
+					+ getHeader(Names.REFERER, headers) + "\" \"" + getHeader(Names.USER_AGENT, headers) + "\" ");
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/HttpRequestHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/HttpRequestHandler.java
@@ -204,9 +204,10 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<HttpObject> 
 	private void logAccess(ChannelHandlerContext ctx, HttpRequest req) {
 		HttpHeaders headers = req.headers();
 		if (headers != null) {
-			LOG.info(ctx.channel().remoteAddress() + " - [" + new Date() + "] \""
-					+ req.getMethod().name() + " " + req.getUri() + " " + req.getProtocolVersion().text() + "\" "
-					+ getHeader(Names.REFERER, headers) + "\" \"" + getHeader(Names.USER_AGENT, headers) + "\" ");
+			LOG.info("%s - [%s] \"%s %s %s\" \"%s\" \"%s\"",
+				ctx.channel().remoteAddress(), new Date().toString(), req.getMethod().name(),
+				req.getUri(), req.getProtocolVersion().text(), getHeader(Names.REFERER, headers),
+				getHeader(Names.USER_AGENT, headers));
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
@@ -29,6 +29,7 @@ import io.netty.handler.codec.http.router.Handler;
 import io.netty.handler.codec.http.router.Router;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.runtime.webmonitor.HttpRequestHandler;
@@ -65,6 +66,8 @@ public class WebFrontendBootstrap {
 		this.uploadDir = Preconditions.checkNotNull(directory);
 		this.serverSSLContext = sslContext;
 
+		final boolean enableAccesslog = config.getBoolean(ConfigConstants.JOB_MANAGER_WEB_ACCESSLOG_ENABLE);
+
 		ChannelInitializer<SocketChannel> initializer = new ChannelInitializer<SocketChannel>() {
 
 			@Override
@@ -82,7 +85,7 @@ public class WebFrontendBootstrap {
 				ch.pipeline()
 					.addLast(new HttpServerCodec())
 					.addLast(new ChunkedWriteHandler())
-					.addLast(new HttpRequestHandler(uploadDir))
+					.addLast(new HttpRequestHandler(uploadDir, enableAccesslog))
 					.addLast(handler.name(), handler)
 					.addLast(new PipelineErrorHandler(WebFrontendBootstrap.this.log));
 			}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
@@ -29,8 +29,8 @@ import io.netty.handler.codec.http.router.Handler;
 import io.netty.handler.codec.http.router.Router;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.runtime.webmonitor.HttpRequestHandler;
 import org.apache.flink.runtime.webmonitor.PipelineErrorHandler;
@@ -66,7 +66,7 @@ public class WebFrontendBootstrap {
 		this.uploadDir = Preconditions.checkNotNull(directory);
 		this.serverSSLContext = sslContext;
 
-		final boolean enableAccesslog = config.getBoolean(ConfigConstants.JOB_MANAGER_WEB_ACCESSLOG_ENABLE);
+		final boolean enableAccesslog = config.getBoolean(JobManagerOptions.JOB_MANAGER_WEB_ACCESSLOG_ENABLE);
 
 		ChannelInitializer<SocketChannel> initializer = new ChannelInitializer<SocketChannel>() {
 


### PR DESCRIPTION
Record the use request to the access log. Append use access to the log file.

- [X] General
  - The pull request references the related JIRA issue ("[FLINK-6387] [webfrontend]Flink UI support access log")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [X] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [X] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
