### PR TITLE
[FLINK-6382] [gelly] Support all numeric types for generated graphs in Gelly examples

### DIFF
--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/GraphMetrics.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/GraphMetrics.java
@@ -26,7 +26,6 @@ import org.apache.flink.graph.drivers.output.Hash;
 import org.apache.flink.graph.drivers.output.Print;
 import org.apache.flink.graph.drivers.parameter.ChoiceParameter;
 import org.apache.flink.graph.drivers.parameter.ParameterizedBase;
-import org.apache.flink.types.CopyableValue;
 
 /**
  * Driver for directed and undirected graph metrics analytics.
@@ -36,7 +35,7 @@ import org.apache.flink.types.CopyableValue;
  * @see org.apache.flink.graph.library.metric.undirected.EdgeMetrics
  * @see org.apache.flink.graph.library.metric.undirected.VertexMetrics
  */
-public class GraphMetrics<K extends Comparable<K> & CopyableValue<K>, VV, EV>
+public class GraphMetrics<K extends Comparable<K>, VV, EV>
 extends ParameterizedBase
 implements Driver<K, VV, EV>, Hash, Print {
 

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/JaccardIndex.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/JaccardIndex.java
@@ -25,6 +25,7 @@ import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.drivers.output.CSV;
 import org.apache.flink.graph.drivers.output.Hash;
 import org.apache.flink.graph.drivers.output.Print;
+import org.apache.flink.graph.drivers.parameter.BooleanParameter;
 import org.apache.flink.graph.drivers.parameter.LongParameter;
 import org.apache.flink.graph.library.similarity.JaccardIndex.Result;
 import org.apache.flink.types.CopyableValue;
@@ -57,6 +58,8 @@ implements CSV, Hash, Print {
 	private LongParameter littleParallelism = new LongParameter(this, "little_parallelism")
 		.setDefaultValue(PARALLELISM_DEFAULT);
 
+	private BooleanParameter mirrorResults = new BooleanParameter(this, "mirror_results");
+
 	@Override
 	public String getName() {
 		return this.getClass().getSimpleName();
@@ -88,6 +91,7 @@ implements CSV, Hash, Print {
 			.run(new org.apache.flink.graph.library.similarity.JaccardIndex<K, VV, EV>()
 				.setMinimumScore(minNumerator.getValue().intValue(), minDenominator.getValue().intValue())
 				.setMaximumScore(maxNumerator.getValue().intValue(), maxDenominator.getValue().intValue())
+				.setMirrorResults(mirrorResults.getValue())
 				.setLittleParallelism(lp));
 	}
 }

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/CompleteGraph.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/CompleteGraph.java
@@ -21,7 +21,6 @@ package org.apache.flink.graph.drivers.input;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.drivers.parameter.LongParameter;
-import org.apache.flink.graph.drivers.parameter.ParameterizedBase;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -32,8 +31,7 @@ import static org.apache.flink.graph.generator.CompleteGraph.MINIMUM_VERTEX_COUN
  * Generate a {@link org.apache.flink.graph.generator.CompleteGraph}.
  */
 public class CompleteGraph
-extends ParameterizedBase
-implements Input<LongValue, NullValue, NullValue> {
+extends GeneratedGraph<LongValue> {
 
 	private LongParameter vertexCount = new LongParameter(this, "vertex_count")
 		.setMinimumValue(MINIMUM_VERTEX_COUNT);
@@ -48,11 +46,16 @@ implements Input<LongValue, NullValue, NullValue> {
 
 	@Override
 	public String getIdentity() {
-		return getName() + " (" + vertexCount.getValue() + ")";
+		return getTypeName() + " " + getName() + " (" + vertexCount.getValue() + ")";
 	}
 
 	@Override
-	public Graph<LongValue, NullValue, NullValue> create(ExecutionEnvironment env) {
+	protected long vertexCount() {
+		return vertexCount.getValue();
+	}
+
+	@Override
+	protected Graph<LongValue, NullValue, NullValue> generate(ExecutionEnvironment env) throws Exception {
 		return new org.apache.flink.graph.generator.CompleteGraph(env, vertexCount.getValue())
 			.setParallelism(littleParallelism.getValue().intValue())
 			.generate();

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/CycleGraph.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/CycleGraph.java
@@ -21,7 +21,6 @@ package org.apache.flink.graph.drivers.input;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.drivers.parameter.LongParameter;
-import org.apache.flink.graph.drivers.parameter.ParameterizedBase;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -32,8 +31,7 @@ import static org.apache.flink.graph.generator.CycleGraph.MINIMUM_VERTEX_COUNT;
  * Generate a {@link org.apache.flink.graph.generator.CycleGraph}.
  */
 public class CycleGraph
-extends ParameterizedBase
-implements Input<LongValue, NullValue, NullValue> {
+extends GeneratedGraph<LongValue> {
 
 	private LongParameter vertexCount = new LongParameter(this, "vertex_count")
 		.setMinimumValue(MINIMUM_VERTEX_COUNT);
@@ -48,11 +46,16 @@ implements Input<LongValue, NullValue, NullValue> {
 
 	@Override
 	public String getIdentity() {
-		return getName() + " (" + vertexCount + ")";
+		return getTypeName() + " " + getName() + " (" + vertexCount + ")";
 	}
 
 	@Override
-	public Graph<LongValue, NullValue, NullValue> create(ExecutionEnvironment env) {
+	protected long vertexCount() {
+		return vertexCount.getValue();
+	}
+
+	@Override
+	public Graph<LongValue, NullValue, NullValue> generate(ExecutionEnvironment env) {
 		return new org.apache.flink.graph.generator.CycleGraph(env, vertexCount.getValue())
 			.setParallelism(littleParallelism.getValue().intValue())
 			.generate();

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/GeneratedGraph.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/GeneratedGraph.java
@@ -1,0 +1,372 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.drivers.input;
+
+import org.apache.commons.lang3.text.WordUtils;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.client.program.ProgramParametrizationException;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.asm.translate.TranslateFunction;
+import org.apache.flink.graph.asm.translate.TranslateGraphIds;
+import org.apache.flink.graph.asm.translate.translators.LongValueToStringValue;
+import org.apache.flink.graph.asm.translate.translators.LongValueToUnsignedIntValue;
+import org.apache.flink.graph.drivers.parameter.ChoiceParameter;
+import org.apache.flink.graph.drivers.parameter.ParameterizedBase;
+import org.apache.flink.types.ByteValue;
+import org.apache.flink.types.CharValue;
+import org.apache.flink.types.LongValue;
+import org.apache.flink.types.NullValue;
+import org.apache.flink.types.ShortValue;
+
+/**
+ * Base class for generated graphs.
+ *
+ * @param <K> graph ID type
+ */
+public abstract class GeneratedGraph<K>
+extends ParameterizedBase
+implements Input<K, NullValue, NullValue> {
+
+	private static final String BYTE = "byte";
+	private static final String NATIVE_BYTE = "nativeByte";
+
+	private static final String SHORT = "short";
+	private static final String NATIVE_SHORT = "nativeShort";
+
+	private static final String CHAR = "char";
+	private static final String NATIVE_CHAR = "nativeChar";
+
+	private static final String INTEGER = "integer";
+	private static final String NATIVE_INTEGER = "nativeInteger";
+
+	private static final String LONG = "long";
+	private static final String NATIVE_LONG = "nativeLong";
+
+	private static final String STRING = "string";
+	private static final String NATIVE_STRING = "nativeString";
+
+	private ChoiceParameter type = new ChoiceParameter(this, "type")
+		.setDefaultValue(INTEGER)
+		.addChoices(LONG, STRING)
+		.addHiddenChoices(BYTE, NATIVE_BYTE, SHORT, NATIVE_SHORT, CHAR, NATIVE_CHAR, NATIVE_INTEGER, NATIVE_LONG, NATIVE_STRING);
+
+	/**
+	 * The vertex count is verified to be no greater than the capacity of the
+	 * selected data type. All vertices must be counted even if skipped or
+	 * unused when generating graph edges.
+	 *
+	 * @return number of vertices configured for the graph
+	 */
+	protected abstract long vertexCount();
+
+	/**
+	 * Generate the graph as configured.
+	 *
+	 * @param env Flink execution environment
+	 * @return generated graph
+	 * @throws Exception on error
+	 */
+	protected abstract Graph<K, NullValue, NullValue> generate(ExecutionEnvironment env) throws Exception;
+
+	/**
+	 * Get the name of the type.
+	 *
+	 * @return name of the type
+	 */
+	protected String getTypeName() {
+		return WordUtils.capitalize(type.getValue());
+	}
+
+	@Override
+	public Graph<K, NullValue, NullValue> create(ExecutionEnvironment env)
+			throws Exception {
+		long maxVertexCount = Long.MAX_VALUE;
+		TranslateFunction translator = null;
+
+		switch (type.getValue()) {
+			case BYTE:
+				maxVertexCount = LongValueToUnsignedByteValue.MAX_VERTEX_COUNT;
+				translator = new LongValueToUnsignedByteValue();
+				break;
+
+			case NATIVE_BYTE:
+				maxVertexCount = LongValueToUnsignedByte.MAX_VERTEX_COUNT;
+				translator = new LongValueToUnsignedByte();
+				break;
+
+			case SHORT:
+				maxVertexCount = LongValueToUnsignedShortValue.MAX_VERTEX_COUNT;
+				translator = new LongValueToUnsignedShortValue();
+				break;
+
+			case NATIVE_SHORT:
+				maxVertexCount = LongValueToUnsignedShort.MAX_VERTEX_COUNT;
+				translator = new LongValueToUnsignedShort();
+				break;
+
+			case CHAR:
+				maxVertexCount = LongValueToCharValue.MAX_VERTEX_COUNT;
+				translator = new LongValueToCharValue();
+				break;
+
+			case NATIVE_CHAR:
+				maxVertexCount = LongValueToChar.MAX_VERTEX_COUNT;
+				translator = new LongValueToChar();
+				break;
+
+			case INTEGER:
+				maxVertexCount = LongValueToUnsignedIntValue.MAX_VERTEX_COUNT;
+				translator = new LongValueToUnsignedIntValue();
+				break;
+
+			case NATIVE_INTEGER:
+				maxVertexCount = LongValueToUnsignedInt.MAX_VERTEX_COUNT;
+				translator = new LongValueToUnsignedInt();
+				break;
+
+			case LONG:
+				break;
+
+			case NATIVE_LONG:
+				translator = new LongValueToLong();
+				break;
+
+			case STRING:
+				translator = new LongValueToStringValue();
+				break;
+
+			case NATIVE_STRING:
+				translator = new LongValueToString();
+				break;
+
+			default:
+				throw new ProgramParametrizationException("Unknown type '" + type.getValue() + "'");
+		}
+
+		long vertexCount = vertexCount();
+		if (vertexCount > maxVertexCount) {
+			throw new ProgramParametrizationException("Vertex count '" + vertexCount +
+				"' must be no greater than " + maxVertexCount +  " for type '" + type.getValue() + "'.");
+		}
+
+		Graph<K, NullValue, NullValue> graph = generate(env);
+
+		if (translator != null) {
+			graph = (Graph<K, NullValue, NullValue>) graph.run(new TranslateGraphIds(translator));
+		}
+
+		return graph;
+	}
+
+	/**
+	 * Translate {@link LongValue} to {@link ByteValue}.
+	 *
+	 * Throws {@link RuntimeException} for byte overflow.
+	 */
+	static class LongValueToUnsignedByteValue
+	implements TranslateFunction<LongValue, ByteValue> {
+		public static final long MAX_VERTEX_COUNT = 1L << 8;
+
+		@Override
+		public ByteValue translate(LongValue value, ByteValue reuse)
+				throws Exception {
+			if (reuse == null) {
+				reuse = new ByteValue();
+			}
+
+			long l = value.getValue();
+
+			if (l < 0 || l >= MAX_VERTEX_COUNT) {
+				throw new IllegalArgumentException("Cannot cast long value " + value + " to byte.");
+			} else {
+				reuse.setValue((byte) (l & (MAX_VERTEX_COUNT - 1)));
+			}
+
+			return reuse;
+		}
+	}
+
+	/**
+	 * Translate {@link LongValue} to {@link Byte}.
+	 *
+	 * Throws {@link RuntimeException} for byte overflow.
+	 */
+	static class LongValueToUnsignedByte
+	implements TranslateFunction<LongValue, Byte> {
+		public static final long MAX_VERTEX_COUNT = 1L << 8;
+
+		@Override
+		public Byte translate(LongValue value, Byte reuse)
+				throws Exception {
+			long l = value.getValue();
+
+			if (l < 0 || l >= MAX_VERTEX_COUNT) {
+				throw new IllegalArgumentException("Cannot cast long value " + value + " to byte.");
+			}
+
+			return (byte) (l & (MAX_VERTEX_COUNT - 1));
+		}
+	}
+
+	/**
+	 * Translate {@link LongValue} to {@link ShortValue}.
+	 *
+	 * Throws {@link RuntimeException} for short overflow.
+	 */
+	static class LongValueToUnsignedShortValue
+	implements TranslateFunction<LongValue, ShortValue> {
+		public static final long MAX_VERTEX_COUNT = 1L << 16;
+
+		@Override
+		public ShortValue translate(LongValue value, ShortValue reuse)
+				throws Exception {
+			if (reuse == null) {
+				reuse = new ShortValue();
+			}
+
+			long l = value.getValue();
+
+			if (l < 0 || l >= MAX_VERTEX_COUNT) {
+				throw new IllegalArgumentException("Cannot cast long value " + value + " to short.");
+			} else {
+				reuse.setValue((short) (l & (MAX_VERTEX_COUNT - 1)));
+			}
+
+			return reuse;
+		}
+	}
+
+	/**
+	 * Translate {@link LongValue} to {@link Short}.
+	 *
+	 * Throws {@link RuntimeException} for short overflow.
+	 */
+	static class LongValueToUnsignedShort
+	implements TranslateFunction<LongValue, Short> {
+		public static final long MAX_VERTEX_COUNT = 1L << 16;
+
+		@Override
+		public Short translate(LongValue value, Short reuse)
+				throws Exception {
+			long l = value.getValue();
+
+			if (l < 0 || l >= MAX_VERTEX_COUNT) {
+				throw new IllegalArgumentException("Cannot cast long value " + value + " to short.");
+			}
+
+			return (short) (l & (MAX_VERTEX_COUNT - 1));
+		}
+	}
+
+	/**
+	 * Translate {@link LongValue} to {@link CharValue}.
+	 *
+	 * Throws {@link RuntimeException} for char overflow.
+	 */
+	static class LongValueToCharValue
+	implements TranslateFunction<LongValue, CharValue> {
+		public static final long MAX_VERTEX_COUNT = 1L << 16;
+
+		@Override
+		public CharValue translate(LongValue value, CharValue reuse)
+				throws Exception {
+			if (reuse == null) {
+				reuse = new CharValue();
+			}
+
+			long l = value.getValue();
+
+			if (l < 0 || l >= MAX_VERTEX_COUNT) {
+				throw new IllegalArgumentException("Cannot cast long value " + value + " to char.");
+			} else {
+				reuse.setValue((char) (l & (MAX_VERTEX_COUNT - 1)));
+			}
+
+			return reuse;
+		}
+	}
+
+	/**
+	 * Translate {@link LongValue} to {@code Character}.
+	 *
+	 * Throws {@link RuntimeException} for char overflow.
+	 */
+	static class LongValueToChar
+	implements TranslateFunction<LongValue, Character> {
+		public static final long MAX_VERTEX_COUNT = 1L << 16;
+
+		@Override
+		public Character translate(LongValue value, Character reuse)
+				throws Exception {
+			long l = value.getValue();
+
+			if (l < 0 || l >= MAX_VERTEX_COUNT) {
+				throw new IllegalArgumentException("Cannot cast long value " + value + " to char.");
+			}
+
+			return (char) (l & (MAX_VERTEX_COUNT - 1));
+		}
+	}
+
+	/**
+	 * Translate {@link LongValue} to {@link Integer}.
+	 *
+	 * Throws {@link RuntimeException} for integer overflow.
+	 */
+	static class LongValueToUnsignedInt
+	implements TranslateFunction<LongValue, Integer> {
+		public static final long MAX_VERTEX_COUNT = 1L << 32;
+
+		@Override
+		public Integer translate(LongValue value, Integer reuse)
+				throws Exception {
+			long l = value.getValue();
+
+			if (l < 0 || l >= MAX_VERTEX_COUNT) {
+				throw new IllegalArgumentException("Cannot cast long value " + value + " to integer.");
+			}
+
+			return (int) (l & (MAX_VERTEX_COUNT - 1));
+		}
+	}
+
+	/**
+	 * Translate {@link LongValue} to {@link Long}.
+	 */
+	static class LongValueToLong
+	implements TranslateFunction<LongValue, Long> {
+		@Override
+		public Long translate(LongValue value, Long reuse)
+				throws Exception {
+			return value.getValue();
+		}
+	}
+
+	/**
+	 * Translate {@link LongValue} to {@link String}.
+	 */
+	static class LongValueToString
+	implements TranslateFunction<LongValue, String> {
+		@Override
+		public String translate(LongValue value, String reuse)
+				throws Exception {
+			return Long.toString(value.getValue());
+		}
+	}
+}

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/GridGraph.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/GridGraph.java
@@ -23,10 +23,10 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.client.program.ProgramParametrizationException;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.drivers.parameter.LongParameter;
-import org.apache.flink.graph.drivers.parameter.ParameterizedBase;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -38,8 +38,7 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
  * Generate a {@link org.apache.flink.graph.generator.GridGraph}.
  */
 public class GridGraph
-extends ParameterizedBase
-implements Input<LongValue, NullValue, NullValue> {
+extends GeneratedGraph<LongValue> {
 
 	private static final String PREFIX = "dim";
 
@@ -67,10 +66,10 @@ implements Input<LongValue, NullValue, NullValue> {
 		Map<Integer, String> dimensionMap = new TreeMap<>();
 
 		// first parse all dimensions into a sorted map
-		for (Map.Entry<String, String> entry : parameterTool.toMap().entrySet()) {
-			if (entry.getKey().startsWith(PREFIX)) {
-				int dimensionId = Integer.parseInt(entry.getKey().substring(PREFIX.length()));
-				dimensionMap.put(dimensionId, entry.getValue());
+		for (String key : parameterTool.toMap().keySet()) {
+			if (key.startsWith(PREFIX)) {
+				int dimensionId = Integer.parseInt(key.substring(PREFIX.length()));
+				dimensionMap.put(dimensionId, parameterTool.get(key));
 			}
 		}
 
@@ -82,11 +81,27 @@ implements Input<LongValue, NullValue, NullValue> {
 
 	@Override
 	public String getIdentity() {
-		return getName() + " (" + dimensions + ")";
+		return getTypeName() + " " + getName() + " (" + dimensions + ")";
 	}
 
 	@Override
-	public Graph<LongValue, NullValue, NullValue> create(ExecutionEnvironment env) {
+	protected long vertexCount() {
+		// in Java 8 use Math.multiplyExact(long, long)
+		BigInteger vertexCount = BigInteger.ONE;
+		for (Dimension dimension : dimensions) {
+			vertexCount = vertexCount.multiply(BigInteger.valueOf(dimension.size));
+		}
+
+		if (vertexCount.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0) {
+			throw new ProgramParametrizationException("Number of vertices in grid graph '" + vertexCount +
+				"' is greater than Long.MAX_VALUE.");
+		}
+
+		return vertexCount.longValue();
+	}
+
+	@Override
+	public Graph<LongValue, NullValue, NullValue> generate(ExecutionEnvironment env) {
 		org.apache.flink.graph.generator.GridGraph graph = new org.apache.flink.graph.generator.GridGraph(env);
 
 		for (Dimension dimension : dimensions) {

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/HypercubeGraph.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/HypercubeGraph.java
@@ -21,7 +21,6 @@ package org.apache.flink.graph.drivers.input;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.drivers.parameter.LongParameter;
-import org.apache.flink.graph.drivers.parameter.ParameterizedBase;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -32,11 +31,11 @@ import static org.apache.flink.graph.generator.HypercubeGraph.MINIMUM_DIMENSIONS
  * Generate a {@link org.apache.flink.graph.generator.HypercubeGraph}.
  */
 public class HypercubeGraph
-extends ParameterizedBase
-implements Input<LongValue, NullValue, NullValue> {
+extends GeneratedGraph<LongValue> {
 
 	private LongParameter dimensions = new LongParameter(this, "dimensions")
-		.setMinimumValue(MINIMUM_DIMENSIONS);
+		.setMinimumValue(MINIMUM_DIMENSIONS)
+		.setMaximumValue(63);
 
 	private LongParameter littleParallelism = new LongParameter(this, "little_parallelism")
 		.setDefaultValue(PARALLELISM_DEFAULT);
@@ -48,11 +47,16 @@ implements Input<LongValue, NullValue, NullValue> {
 
 	@Override
 	public String getIdentity() {
-		return getName() + " (" + dimensions + ")";
+		return getTypeName() + " " + getName() + " (" + dimensions + ")";
 	}
 
 	@Override
-	public Graph<LongValue, NullValue, NullValue> create(ExecutionEnvironment env) {
+	protected long vertexCount() {
+		return 1L << dimensions.getValue();
+	}
+
+	@Override
+	public Graph<LongValue, NullValue, NullValue> generate(ExecutionEnvironment env) {
 		return new org.apache.flink.graph.generator.HypercubeGraph(env, dimensions.getValue())
 			.setParallelism(littleParallelism.getValue().intValue())
 			.generate();

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/PathGraph.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/PathGraph.java
@@ -21,7 +21,6 @@ package org.apache.flink.graph.drivers.input;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.drivers.parameter.LongParameter;
-import org.apache.flink.graph.drivers.parameter.ParameterizedBase;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -32,8 +31,7 @@ import static org.apache.flink.graph.generator.PathGraph.MINIMUM_VERTEX_COUNT;
  * Generate a {@link org.apache.flink.graph.generator.PathGraph}.
  */
 public class PathGraph
-extends ParameterizedBase
-implements Input<LongValue, NullValue, NullValue> {
+extends GeneratedGraph<LongValue> {
 
 	private LongParameter vertexCount = new LongParameter(this, "vertex_count")
 		.setMinimumValue(MINIMUM_VERTEX_COUNT);
@@ -48,11 +46,16 @@ implements Input<LongValue, NullValue, NullValue> {
 
 	@Override
 	public String getIdentity() {
-		return getName() + " (" + vertexCount + ")";
+		return getTypeName() + " " + getName() + " (" + vertexCount + ")";
 	}
 
 	@Override
-	public Graph<LongValue, NullValue, NullValue> create(ExecutionEnvironment env) {
+	protected long vertexCount() {
+		return vertexCount.getValue();
+	}
+
+	@Override
+	public Graph<LongValue, NullValue, NullValue> generate(ExecutionEnvironment env) {
 		return new org.apache.flink.graph.generator.PathGraph(env, vertexCount.getValue())
 			.setParallelism(littleParallelism.getValue().intValue())
 			.generate();

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/SingletonEdgeGraph.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/SingletonEdgeGraph.java
@@ -21,7 +21,6 @@ package org.apache.flink.graph.drivers.input;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.drivers.parameter.LongParameter;
-import org.apache.flink.graph.drivers.parameter.ParameterizedBase;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -32,11 +31,11 @@ import static org.apache.flink.graph.generator.PathGraph.MINIMUM_VERTEX_COUNT;
  * Generate a {@link org.apache.flink.graph.generator.SingletonEdgeGraph}.
  */
 public class SingletonEdgeGraph
-extends ParameterizedBase
-implements Input<LongValue, NullValue, NullValue> {
+extends GeneratedGraph<LongValue> {
 
 	private LongParameter vertexPairCount = new LongParameter(this, "vertex_pair_count")
-		.setMinimumValue(MINIMUM_VERTEX_COUNT);
+		.setMinimumValue(MINIMUM_VERTEX_COUNT)
+		.setMaximumValue(1L << 62);
 
 	private LongParameter littleParallelism = new LongParameter(this, "little_parallelism")
 		.setDefaultValue(PARALLELISM_DEFAULT);
@@ -48,11 +47,16 @@ implements Input<LongValue, NullValue, NullValue> {
 
 	@Override
 	public String getIdentity() {
-		return getName() + " (" + vertexPairCount + ")";
+		return getTypeName() + " " + getName() + " (" + vertexPairCount + ")";
 	}
 
 	@Override
-	public Graph<LongValue, NullValue, NullValue> create(ExecutionEnvironment env) {
+	protected long vertexCount() {
+		return 2 * vertexPairCount.getValue();
+	}
+
+	@Override
+	public Graph<LongValue, NullValue, NullValue> generate(ExecutionEnvironment env) {
 		return new org.apache.flink.graph.generator.SingletonEdgeGraph(env, vertexPairCount.getValue())
 			.setParallelism(littleParallelism.getValue().intValue())
 			.generate();

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/StarGraph.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/input/StarGraph.java
@@ -21,7 +21,6 @@ package org.apache.flink.graph.drivers.input;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.drivers.parameter.LongParameter;
-import org.apache.flink.graph.drivers.parameter.ParameterizedBase;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -32,8 +31,7 @@ import static org.apache.flink.graph.generator.StarGraph.MINIMUM_VERTEX_COUNT;
  * Generate a {@link org.apache.flink.graph.generator.StarGraph}.
  */
 public class StarGraph
-extends ParameterizedBase
-implements Input<LongValue, NullValue, NullValue> {
+extends GeneratedGraph<LongValue> {
 
 	private LongParameter vertexCount = new LongParameter(this, "vertex_count")
 		.setMinimumValue(MINIMUM_VERTEX_COUNT);
@@ -48,11 +46,16 @@ implements Input<LongValue, NullValue, NullValue> {
 
 	@Override
 	public String getIdentity() {
-		return getName() + " (" + vertexCount + ")";
+		return getTypeName() + " " + getName() + " (" + vertexCount + ")";
 	}
 
 	@Override
-	public Graph<LongValue, NullValue, NullValue> create(ExecutionEnvironment env) {
+	protected long vertexCount() {
+		return vertexCount.getValue();
+	}
+
+	@Override
+	public Graph<LongValue, NullValue, NullValue> generate(ExecutionEnvironment env) {
 		return new org.apache.flink.graph.generator.StarGraph(env, vertexCount.getValue())
 			.setParallelism(littleParallelism.getValue().intValue())
 			.generate();

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/parameter/ChoiceParameter.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/parameter/ChoiceParameter.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.graph.drivers.parameter;
 
-import org.apache.commons.lang3.text.StrBuilder;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.StrBuilder;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.client.program.ProgramParametrizationException;
 import org.apache.flink.util.Preconditions;
@@ -36,6 +36,8 @@ public class ChoiceParameter
 extends SimpleParameter<String> {
 
 	private List<String> choices = new ArrayList<>();
+
+	private List<String> hiddenChoices = new ArrayList<>();
 
 	/**
 	 * Set the parameter name and add this parameter to the list of parameters
@@ -71,6 +73,18 @@ extends SimpleParameter<String> {
 		return this;
 	}
 
+	/**
+	 * Add additional hidden choices. This function can be called multiple
+	 * times. These choices will not be printed in the usage string.
+	 *
+	 * @param hiddenChoices additional hidden choices
+	 * @return this
+	 */
+	public ChoiceParameter addHiddenChoices(String... hiddenChoices) {
+		Collections.addAll(this.hiddenChoices, hiddenChoices);
+		return this;
+	}
+
 	@Override
 	public String getUsage() {
 		String option = new StrBuilder()
@@ -101,6 +115,13 @@ extends SimpleParameter<String> {
 		}
 
 		for (String choice : choices) {
+			if (choice.equals(selected)) {
+				this.value = selected;
+				return;
+			}
+		}
+
+		for (String choice : hiddenChoices) {
 			if (choice.equals(selected)) {
 				this.value = selected;
 				return;

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/RunnerITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/RunnerITCase.java
@@ -33,8 +33,8 @@ extends DriverBaseITCase {
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
 
-	public RunnerITCase(TestExecutionMode mode) {
-		super(mode);
+	public RunnerITCase(String idType, TestExecutionMode mode) {
+		super(idType, mode);
 	}
 
 	@Test

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/AdamicAdarITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/AdamicAdarITCase.java
@@ -18,17 +18,28 @@
 
 package org.apache.flink.graph.drivers;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.flink.client.program.ProgramParametrizationException;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
 public class AdamicAdarITCase
-extends DriverBaseITCase {
+extends CopyableValueDriverBaseITCase {
 
-	public AdamicAdarITCase(TestExecutionMode mode) {
-		super(mode);
+	public AdamicAdarITCase(String idType, TestExecutionMode mode) {
+		super(idType, mode);
+	}
+
+	private String[] parameters(int scale, String output, String... additionalParameters) {
+		String[] parameters = new String[] {
+			"--algorithm", "AdamicAdar",
+			"--input", "RMatGraph", "--scale", Integer.toString(scale), "--type", idType, "--simplify", "undirected",
+			"--output", output};
+
+		return ArrayUtils.addAll(parameters, additionalParameters);
 	}
 
 	@Test
@@ -42,11 +53,12 @@ extends DriverBaseITCase {
 	}
 
 	@Test
-	public void testPrintWithRMatIntegerGraph() throws Exception {
+	public void testPrintWithRMatGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
+
 		expectedCount(
-			new String[]{"--algorithm", "AdamicAdar",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "undirected",
-				"--output", "print"},
-			221628);
+			parameters(7, "print"),
+			5694);
 	}
 }

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/ClusteringCoefficientITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/ClusteringCoefficientITCase.java
@@ -19,16 +19,25 @@
 package org.apache.flink.graph.drivers;
 
 import org.apache.flink.client.program.ProgramParametrizationException;
+import org.apache.flink.graph.asm.dataset.ChecksumHashCode.Checksum;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
 public class ClusteringCoefficientITCase
-extends DriverBaseITCase {
+extends CopyableValueDriverBaseITCase {
 
-	public ClusteringCoefficientITCase(TestExecutionMode mode) {
-		super(mode);
+	public ClusteringCoefficientITCase(String idType, TestExecutionMode mode) {
+		super(idType, mode);
+	}
+
+	private String[] parameters(int scale, String order, String simplify, String output) {
+		return new String[] {
+			"--algorithm", "ClusteringCoefficient", "--order", order,
+			"--input", "RMatGraph", "--scale", Integer.toString(scale), "--type", idType, "--simplify", simplify,
+			"--output", output};
 	}
 
 	@Test
@@ -42,48 +51,148 @@ extends DriverBaseITCase {
 	}
 
 	@Test
-	public void testDirectedHashWithRMatIntegerGraph() throws Exception {
+	public void testHashWithSmallDirectedRMatGraph() throws Exception {
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "short":
+			case "char":
+			case "integer":
+				checksum = 0x0000003621c62ca1L;
+				break;
+
+			case "long":
+				checksum = 0x0000003b74c6719bL;
+				break;
+
+			case "string":
+				checksum = 0x0000003ab67abea8L;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
 		String expected = "\n" +
-			"ChecksumHashCode 0x000001c0409df6c0, count 902\n" +
-			"triplet count: 1003442, triangle count: 225147, global clustering coefficient: 0.22437470[0-9]+\n" +
-			"vertex count: 902, average clustering coefficient: 0.32943748[0-9]+\n";
+			new Checksum(117, checksum) + "\n" +
+			"triplet count: 29286, triangle count: 11466, global clustering coefficient: 0.39151813[0-9]+\n" +
+			"vertex count: 117, average clustering coefficient: 0.45125697[0-9]+\n";
 
-		expectedOutput(
-			new String[]{"--algorithm", "ClusteringCoefficient", "--order", "directed",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "directed",
-				"--output", "hash"},
-			expected);
+		expectedOutput(parameters(7, "directed", "directed", "hash"), expected);
 	}
 
 	@Test
-	public void testDirectedPrintWithRMatIntegerGraph() throws Exception {
-		expectedCount(
-			new String[]{"--algorithm", "ClusteringCoefficient", "--order", "directed",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "directed",
-				"--output", "print"},
-			904);
-	}
+	public void testHashWithSmallUndirectedRMatGraph() throws Exception {
+		long directed_checksum;
+		long undirected_checksum;
+		switch (idType) {
+			case "byte":
+			case "short":
+			case "char":
+			case "integer":
+				directed_checksum = 0x0000003875b38c43L;
+				undirected_checksum = 0x0000003c20344c75L;
+				break;
 
-	@Test
-	public void testUndirectedHashWithRMatIntegerGraph() throws Exception {
+			case "long":
+				directed_checksum = 0x0000003671970c59L;
+				undirected_checksum = 0x0000003939645d8cL;
+				break;
+
+			case "string":
+				directed_checksum = 0x0000003be109a770L;
+				undirected_checksum = 0x0000003b8c98d14aL;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
 		String expected = "\n" +
-			"ChecksumHashCode 0x000001ccf8c45fdb, count 902\n" +
-			"triplet count: 1003442, triangle count: 225147, global clustering coefficient: 0.22437470[0-9]+\n" +
-			"vertex count: 902, average clustering coefficient: 0.42173070[0-9]+\n";
+			"triplet count: 29286, triangle count: 11466, global clustering coefficient: 0.39151813[0-9]+\n" +
+			"vertex count: 117, average clustering coefficient: 0.57438679[0-9]+\n";
 
-		expectedOutput(
-			new String[]{"--algorithm", "ClusteringCoefficient", "--order", "undirected",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "undirected",
-				"--output", "hash"},
-			expected);
+		expectedOutput(parameters(7, "directed", "undirected", "hash"),
+			"\n" + new Checksum(117, directed_checksum) + expected);
+		expectedOutput(parameters(7, "undirected", "undirected", "hash"),
+			"\n" + new Checksum(117, undirected_checksum) + expected);
 	}
 
 	@Test
-	public void testUndirectedPrintWithRMatIntegerGraph() throws Exception {
-		expectedCount(
-			new String[]{"--algorithm", "ClusteringCoefficient", "--order", "undirected",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "undirected",
-				"--output", "print"},
-			904);
+	public void testHashWithLargeDirectedRMatGraph() throws Exception {
+		// computation is too large for collection mode
+		Assume.assumeFalse(mode == TestExecutionMode.COLLECTION);
+
+		long checksum;
+		switch (idType) {
+			case "byte":
+				return;
+
+			case "short":
+			case "char":
+			case "integer":
+				checksum = 0x0000067a9d18e7f3L;
+				break;
+
+			case "long":
+				checksum = 0x00000694a90ee6d4L;
+				break;
+
+			case "string":
+				checksum = 0x000006893e3b314fL;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		String expected = "\n" +
+			new Checksum(3349, checksum) + "\n" +
+			"triplet count: 9276207, triangle count: 1439454, global clustering coefficient: 0.15517700[0-9]+\n" +
+			"vertex count: 3349, average clustering coefficient: 0.24571815[0-9]+\n";
+
+		expectedOutput(parameters(12, "directed", "directed", "hash"), expected);
+	}
+
+	@Test
+	public void testHashWithLargeUndirectedRMatGraph() throws Exception {
+		// computation is too large for collection mode
+		Assume.assumeFalse(mode == TestExecutionMode.COLLECTION);
+
+		long directed_checksum;
+		long undirected_checksum;
+		switch (idType) {
+			case "byte":
+				return;
+
+			case "short":
+			case "char":
+			case "integer":
+				directed_checksum = 0x00000681fad1587eL;
+				undirected_checksum = 0x0000068713b3b7f1L;
+				break;
+
+			case "long":
+				directed_checksum = 0x000006928a6301b1L;
+				undirected_checksum = 0x000006a399edf0e6L;
+				break;
+
+			case "string":
+				directed_checksum = 0x000006749670a2f7L;
+				undirected_checksum = 0x0000067f19c6c4d5L;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		String expected = "\n" +
+			"triplet count: 9276207, triangle count: 1439454, global clustering coefficient: 0.15517700[0-9]+\n" +
+			"vertex count: 3349, average clustering coefficient: 0.33029442[0-9]+\n";
+
+		expectedOutput(parameters(12, "directed", "undirected", "hash"),
+			"\n" + new Checksum(3349, directed_checksum) + expected);
+		expectedOutput(parameters(12, "undirected", "undirected", "hash"),
+			"\n" + new Checksum(3349, undirected_checksum) + expected);
 	}
 }

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/ConnectedComponentsITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/ConnectedComponentsITCase.java
@@ -19,6 +19,8 @@
 package org.apache.flink.graph.drivers;
 
 import org.apache.flink.client.program.ProgramParametrizationException;
+import org.apache.flink.graph.asm.dataset.ChecksumHashCode.Checksum;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -27,8 +29,16 @@ import org.junit.runners.Parameterized;
 public class ConnectedComponentsITCase
 extends DriverBaseITCase {
 
-	public ConnectedComponentsITCase(TestExecutionMode mode) {
-		super(mode);
+	public ConnectedComponentsITCase(String idType, TestExecutionMode mode) {
+		super(idType, mode);
+	}
+
+	private String[] parameters(int scale, String output) {
+		return new String[] {
+			"--algorithm", "ConnectedComponents",
+			"--input", "RMatGraph", "--scale", Integer.toString(scale), "--type", idType, "--simplify", "undirected",
+				"--edge_factor", "1", "--a", "0.25", "--b", "0.25", "--c", "0.25", "--noise_enabled", "--noise", "1.0",
+			"--output", output};
 	}
 
 	@Test
@@ -42,24 +52,101 @@ extends DriverBaseITCase {
 	}
 
 	@Test
-	public void testHashWithRMatIntegerGraph() throws Exception {
-		String expected = "\\nChecksumHashCode 0x0000000000cdc7e7, count 838\\n";
+	public void testHashWithSmallRMatGraph() throws Exception {
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "nativeByte":
+			case "short":
+			case "nativeShort":
+			case "char":
+			case "nativeChar":
+			case "integer":
+			case "nativeInteger":
+			case "nativeLong":
+				checksum = 0x0000000000033e88L;
+				break;
 
-		expectedOutput(
-			new String[]{"--algorithm", "ConnectedComponents",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "undirected", "--edge_factor", "1",
-					"--a", "0.25", "--b", "0.25", "--c", "0.25", "--noise_enabled", "--noise", "1.0",
-				"--output", "hash"},
-			expected);
+			case "long":
+				checksum = 0x0000000000057848L;
+				break;
+
+			case "string":
+			case "nativeString":
+				checksum = 0x000000000254a4c3L;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		expectedChecksum(parameters(7, "hash"), 106, checksum);
 	}
 
 	@Test
-	public void testPrintWithRMatIntegerGraph() throws Exception {
-		expectedCount(
-			new String[]{"--algorithm", "ConnectedComponents",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "undirected", "--edge_factor", "1",
-					"--a", "0.25", "--b", "0.25", "--c", "0.25", "--noise_enabled", "--noise", "1.0",
-				"--output", "print"},
-			838);
+	public void testHashWithLargeRMatGraph() throws Exception {
+		// computation is too large for collection mode
+		Assume.assumeFalse(mode == TestExecutionMode.COLLECTION);
+
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "nativeByte":
+				return;
+
+			case "short":
+			case "nativeShort":
+			case "char":
+			case "nativeChar":
+			case "integer":
+			case "nativeInteger":
+			case "nativeLong":
+				checksum = 0x00000003094ffba2L;
+				break;
+
+			case "long":
+				checksum = 0x000000030b68e522L;
+				break;
+
+			case "string":
+			case "nativeString":
+				checksum = 0x00001839ad14edb1L;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		expectedChecksum(parameters(15, "hash"), 25572, checksum);
+	}
+
+	@Test
+	public void testPrintWithSmallRMatGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
+
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "nativeByte":
+			case "short":
+			case "nativeShort":
+			case "integer":
+			case "nativeInteger":
+			case "long":
+			case "nativeLong":
+				checksum = 0x00000024edd0568dL;
+				break;
+
+			case "string":
+			case "nativeString":
+				checksum = 0x000000232d8bf58dL;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		expectedOutputChecksum(parameters(7, "print"), new Checksum(106, checksum));
 	}
 }

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/CopyableValueDriverBaseITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/CopyableValueDriverBaseITCase.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.drivers;
+
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Base class for drivers requiring the key ID to implement
+ * {@code CopyableValue}. This class overrides {@link DriverBaseITCase}
+ * to restrict the tested ID types.
+ */
+public abstract class CopyableValueDriverBaseITCase
+extends DriverBaseITCase {
+
+	protected CopyableValueDriverBaseITCase(String idType, TestExecutionMode mode) {
+		super(idType, mode);
+	}
+
+	// limit tests to types supporting CopyableValue
+	@Parameterized.Parameters(name = "ID type = {0}, Execution mode = {1}")
+	public static Collection<Object[]> executionModes() {
+		List<Object[]> executionModes = new ArrayList<>();
+
+		for (String idType : new String[] {"byte", "short", "char", "integer", "long", "string"}) {
+			for (TestExecutionMode executionMode : TestExecutionMode.values()) {
+				executionModes.add(new Object[] {idType, executionMode});
+			}
+		}
+
+		return executionModes;
+	}
+}

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/EdgeListITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/EdgeListITCase.java
@@ -18,7 +18,10 @@
 
 package org.apache.flink.graph.drivers;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.flink.client.program.ProgramParametrizationException;
+import org.apache.flink.graph.asm.dataset.ChecksumHashCode.Checksum;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -27,8 +30,17 @@ import org.junit.runners.Parameterized;
 public class EdgeListITCase
 extends DriverBaseITCase {
 
-	public EdgeListITCase(TestExecutionMode mode) {
-		super(mode);
+	public EdgeListITCase(String idType, TestExecutionMode mode) {
+		super(idType, mode);
+	}
+
+	private String[] parameters(String input, String output, String... additionalParameters) {
+		String[] parameters = new String[] {
+			"--algorithm", "EdgeList",
+			"--input", input, "--type", idType,
+			"--output", output};
+
+		return ArrayUtils.addAll(parameters, additionalParameters);
 	}
 
 	@Test
@@ -43,198 +55,448 @@ extends DriverBaseITCase {
 
 	@Test
 	public void testHashWithCompleteGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x0000000006788c22, count 1722\n";
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "nativeByte":
+			case "short":
+			case "nativeShort":
+			case "char":
+			case "nativeChar":
+			case "integer":
+			case "nativeInteger":
+			case "nativeLong":
+				checksum = 0x000000000217bbe2L;
+				break;
 
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "CompleteGraph", "--vertex_count", "42",
-				"--output", "hash"},
-			expected);
+			case "long":
+				checksum = 0x0000000006788c22L;
+				break;
+
+			case "string":
+			case "nativeString":
+				checksum = 0x000000007ddfd962L;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		expectedChecksum(
+			parameters("CompleteGraph", "hash", "--vertex_count", "42"),
+			1722, checksum);
+	}
+
+	@Test
+	public void testPrintWithCompleteGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
+
+		expectedOutputChecksum(
+			parameters("CompleteGraph", "print", "--vertex_count", "42"),
+			new Checksum(1722, 0x0000031109a0c398L));
 	}
 
 	@Test
 	public void testHashWithCycleGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x000000000050cea4, count 84\n";
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "nativeByte":
+			case "short":
+			case "nativeShort":
+			case "char":
+			case "nativeChar":
+			case "integer":
+			case "nativeInteger":
+			case "nativeLong":
+				checksum = 0x00000000001a2224L;
+				break;
 
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "CycleGraph", "--vertex_count", "42",
-				"--output", "hash"},
-			expected);
+			case "long":
+				checksum = 0x000000000050cea4L;
+				break;
+
+			case "string":
+			case "nativeString":
+				checksum = 0x000000000623e524L;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		expectedChecksum(
+			parameters("CycleGraph", "hash", "--vertex_count", "42"),
+			84, checksum);
+	}
+
+	@Test
+	public void testPrintWithCycleGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
+
+		expectedOutputChecksum(
+			parameters("CycleGraph", "print", "--vertex_count", "42"),
+			new Checksum(84, 0x000000272a136fcaL));
 	}
 
 	@Test
 	public void testHashWithEmptyGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x0000000000000000, count 0\n";
-
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "EmptyGraph", "--vertex_count", "42",
-				"--output", "hash"},
-			expected);
+		expectedChecksum(
+			parameters("EmptyGraph", "hash", "--vertex_count", "42"),
+			0, 0x0000000000000000);
 	}
 
 	@Test
 	public void testHashWithGridGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x00000000357d33a6, count 2990\n";
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "nativeByte":
+			case "short":
+			case "nativeShort":
+			case "char":
+			case "nativeChar":
+			case "integer":
+			case "nativeInteger":
+			case "nativeLong":
+				checksum = 0x00000000001ca34aL;
+				break;
 
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "GridGraph", "--dim0", "5:true", "--dim1", "8:false", "--dim2", "13:true",
-				"--output", "hash"},
-			expected);
+			case "long":
+				checksum = 0x000000000071408aL;
+				break;
+
+			case "string":
+			case "nativeString":
+				checksum = 0x00000000081ee80aL;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		expectedChecksum(
+			parameters("GridGraph", "hash", "--dim0", "2:true", "--dim1", "3:false", "--dim2", "5:true"),
+			130, checksum);
+	}
+
+	@Test
+	public void testPrintWithGridGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
+
+		expectedOutputChecksum(
+			parameters("GridGraph", "print", "--dim0", "2:true", "--dim1", "3:false", "--dim2", "5:true"),
+			new Checksum(130, 0x00000033237d24eeL));
 	}
 
 	@Test
 	public void testHashWithHypercubeGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x0000000014a72800, count 2048\n";
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "nativeByte":
+			case "short":
+			case "nativeShort":
+			case "char":
+			case "nativeChar":
+			case "integer":
+			case "nativeInteger":
+			case "nativeLong":
+				checksum = 0x00000000035df180L;
+				break;
 
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "HypercubeGraph", "--dimensions", "8",
-				"--output", "hash"},
-			expected);
+			case "long":
+				checksum = 0x0000000005a52180L;
+				break;
+
+			case "string":
+			case "nativeString":
+				checksum = 0x0000000273474480L;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		expectedChecksum(
+			parameters("HypercubeGraph", "hash", "--dimensions", "7"),
+			896, checksum);
+	}
+
+	@Test
+	public void testPrintWithHypercubeGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
+
+		expectedOutputChecksum(
+			parameters("HypercubeGraph", "print", "--dimensions", "7"),
+			new Checksum(896, 0x000001f243ee33b2L));
 	}
 
 	@Test
 	public void testHashWithPathGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x00000000004ee21a, count 82\n";
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "nativeByte":
+			case "short":
+			case "nativeShort":
+			case "char":
+			case "nativeChar":
+			case "integer":
+			case "nativeInteger":
+			case "nativeLong":
+				checksum = 0x00000000001982daL;
+				break;
 
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "PathGraph", "--vertex_count", "42",
-				"--output", "hash"},
-			expected);
+			case "long":
+				checksum = 0x00000000004ee21aL;
+				break;
+
+			case "string":
+			case "nativeString":
+				checksum = 0x00000000060a065aL;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		expectedChecksum(
+			parameters("PathGraph", "hash", "--vertex_count", "42"),
+			82, checksum);
 	}
 
 	@Test
-	public void testHashWithRMatIntegerGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x00000000ed469103, count 16384\n";
+	public void testPrintWithPathGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
 
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "RMatGraph", "--type", "integer",
-				"--output", "hash"},
-			expected);
+		expectedOutputChecksum(
+			parameters("PathGraph", "print", "--vertex_count", "42"),
+			new Checksum(82, 0x000000269be2d4c2L));
 	}
 
 	@Test
-	public void testHashWithRMatIntegerDirectedGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x00000000c53bfc9b, count 12009\n";
+	public void testHashWithRMatGraph() throws Exception {
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "nativeByte":
+			case "short":
+			case "nativeShort":
+			case "char":
+			case "nativeChar":
+			case "integer":
+			case "nativeInteger":
+			case "nativeLong":
+				checksum = 0x0000000003bf67f7L;
+				break;
 
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "directed",
-				"--output", "hash"},
-			expected);
+			case "long":
+				checksum = 0x0000000008f467f7L;
+				break;
+
+			case "string":
+			case "nativeString":
+				checksum = 0x00000001660861bdL;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		expectedChecksum(
+			parameters("RMatGraph", "hash", "--scale", "7"),
+			2048, checksum);
 	}
 
 	@Test
-	public void testHashWithRMatIntegerUndirectedGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x00000001664eb9e4, count 20884\n";
+	public void testPrintWithRMatGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
 
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "undirected",
-				"--output", "hash"},
-			expected);
+		expectedOutputChecksum(
+			parameters("RMatGraph", "print", "--scale", "7"),
+			new Checksum(2048, 0x000002f737939f05L));
 	}
 
 	@Test
-	public void testHashWithRMatLongGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x0000000116ee9103, count 16384\n";
+	public void testHashWithDirectedRMatGraph() throws Exception {
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "nativeByte":
+			case "short":
+			case "nativeShort":
+			case "char":
+			case "nativeChar":
+			case "integer":
+			case "nativeInteger":
+			case "nativeLong":
+				checksum = 0x00000000029aafb3L;
+				break;
 
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "RMatGraph", "--type", "long",
-				"--output", "hash"},
-			expected);
+			case "long":
+				checksum = 0x000000000592e9b3L;
+				break;
+
+			case "string":
+			case "nativeString":
+				checksum = 0x000000011b079691L;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		expectedChecksum(
+			parameters("RMatGraph", "hash", "--scale", "7", "--simplify", "directed"),
+			1168, checksum);
 	}
 
 	@Test
-	public void testPrintWithRMatLongGraph() throws Exception {
+	public void testPrintWithDirectedRMatGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
 
-		expectedCount(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "RMatGraph", "--type", "long",
-				"--output", "print"},
-			16384);
+		expectedOutputChecksum(
+			parameters("RMatGraph", "print", "--scale", "7", "--simplify", "directed"),
+			new Checksum(1168, 0x0000020e35b0f35dL));
 	}
 
 	@Test
-	public void testHashWithRMatLongDirectedGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x00000000e3c4643b, count 12009\n";
+	public void testHashWithUndirectedRMatGraph() throws Exception {
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "nativeByte":
+			case "short":
+			case "nativeShort":
+			case "char":
+			case "nativeChar":
+			case "integer":
+			case "nativeInteger":
+			case "nativeLong":
+				checksum = 0x0000000004627ab6L;
+				break;
 
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "RMatGraph", "--type", "long", "--simplify", "directed",
-				"--output", "hash"},
-			expected);
+			case "long":
+				checksum = 0x0000000009193576L;
+				break;
+
+			case "string":
+			case "nativeString":
+				checksum = 0x00000001e9adcf56L;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		expectedChecksum(
+			parameters("RMatGraph", "hash", "--scale", "7", "--simplify", "undirected"),
+			1854, checksum);
 	}
 
 	@Test
-	public void testHashWithRMatLongUndirectedGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x000000019b67ae64, count 20884\n";
+	public void testPrintWithUndirectedRMatGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
 
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "RMatGraph", "--type", "long", "--simplify", "undirected",
-				"--output", "hash"},
-			expected);
-	}
-
-	@Test
-	public void testHashWithRMatStringGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x00000071dc80a623, count 16384\n";
-
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "RMatGraph", "--type", "string",
-				"--output", "hash"},
-			expected);
-	}
-
-	@Test
-	public void testHashWithRMatStringDirectedGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x0000005d58b3fa7d, count 12009\n";
-
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "RMatGraph", "--type", "string", "--simplify", "directed",
-				"--output", "hash"},
-			expected);
-	}
-
-	@Test
-	public void testHashWithRMatStringUndirectedGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x000000aa54987304, count 20884\n";
-
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "RMatGraph", "--type", "string", "--simplify", "undirected",
-				"--output", "hash"},
-			expected);
+		expectedOutputChecksum(
+			parameters("RMatGraph", "print", "--scale", "7", "--simplify", "undirected"),
+			new Checksum(1854, 0x0000036fe5802162L));
 	}
 
 	@Test
 	public void testHashWithSingletonEdgeGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x0000000001af8ee8, count 200\n";
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "nativeByte":
+			case "short":
+			case "nativeShort":
+			case "char":
+			case "nativeChar":
+			case "integer":
+			case "nativeInteger":
+			case "nativeLong":
+				checksum = 0x000000000034d5a4L;
+				break;
 
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "SingletonEdgeGraph", "--vertex_pair_count", "100",
-				"--output", "hash"},
-			expected);
+			case "long":
+				checksum = 0x00000000006b8224L;
+				break;
+
+			case "string":
+			case "nativeString":
+				checksum = 0x000000000757c6a4L;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		expectedChecksum(
+			parameters("SingletonEdgeGraph", "hash", "--vertex_pair_count", "42"),
+			84, checksum);
+	}
+
+	@Test
+	public void testPrintWithSingletonEdgeGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
+
+		expectedOutputChecksum(
+			parameters("SingletonEdgeGraph", "print", "--vertex_pair_count", "42"),
+			new Checksum(84, 0x0000002e59e10d9aL));
 	}
 
 	@Test
 	public void testHashWithStarGraph() throws Exception {
-		String expected = "\nChecksumHashCode 0x000000000042789a, count 82\n";
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "nativeByte":
+			case "short":
+			case "nativeShort":
+			case "char":
+			case "nativeChar":
+			case "integer":
+			case "nativeInteger":
+			case "nativeLong":
+				checksum = 0x00000000000d195aL;
+				break;
 
-		expectedOutput(
-			new String[]{"--algorithm", "EdgeList",
-				"--input", "StarGraph", "--vertex_count", "42",
-				"--output", "hash"},
-			expected);
+			case "long":
+				checksum = 0x000000000042789aL;
+				break;
+
+			case "string":
+			case "nativeString":
+				checksum = 0x00000000032f0adaL;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		expectedChecksum(
+			parameters("StarGraph", "hash", "--vertex_count", "42"),
+			82, checksum);
+	}
+
+	@Test
+	public void testPrintWithStarGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
+
+		expectedOutputChecksum(
+			parameters("StarGraph", "print", "--vertex_count", "42"),
+			new Checksum(82, 0x00000011ec3faee8L));
 	}
 }

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/GraphMetricsITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/GraphMetricsITCase.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.graph.drivers;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.flink.client.program.ProgramParametrizationException;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -28,8 +28,15 @@ import org.junit.runners.Parameterized;
 public class GraphMetricsITCase
 extends DriverBaseITCase {
 
-	public GraphMetricsITCase(TestExecutionMode mode) {
-		super(mode);
+	public GraphMetricsITCase(String idType, TestExecutionMode mode) {
+		super(idType, mode);
+	}
+
+	private String[] parameters(int scale, String order, String output) {
+		return new String[] {
+			"--algorithm", "GraphMetrics", "--order", order,
+			"--input", "RMatGraph", "--scale", Integer.toString(scale), "--type", idType, "--simplify", order,
+			"--output", output};
 	}
 
 	@Test
@@ -43,58 +50,110 @@ extends DriverBaseITCase {
 	}
 
 	@Test
-	public void testWithDirectedRMatIntegerGraph() throws Exception {
+	public void testWithSmallDirectedRMatIntegerGraph() throws Exception {
 		String expected = "\n" +
 			"Vertex metrics:\n" +
-			"  vertex count: 902\n" +
-			"  edge count: 12,009\n" +
-			"  unidirectional edge count: 8,875\n" +
-			"  bidirectional edge count: 1,567\n" +
-			"  average degree: 13.314\n" +
-			"  density: 0.01477663\n" +
-			"  triplet count: 1,003,442\n" +
-			"  maximum degree: 463\n" +
-			"  maximum out degree: 334\n" +
-			"  maximum in degree: 342\n" +
-			"  maximum triplets: 106,953\n" +
+			"  vertex count: 117\n" +
+			"  edge count: 1,168\n" +
+			"  unidirectional edge count: 686\n" +
+			"  bidirectional edge count: 241\n" +
+			"  average degree: 9.983\n" +
+			"  density: 0.08605953\n" +
+			"  triplet count: 29,286\n" +
+			"  maximum degree: 91\n" +
+			"  maximum out degree: 77\n" +
+			"  maximum in degree: 68\n" +
+			"  maximum triplets: 4,095\n" +
 			"\n" +
 			"Edge metrics:\n" +
-			"  triangle triplet count: 107,817\n" +
-			"  rectangle triplet count: 315,537\n" +
-			"  maximum triangle triplets: 820\n" +
-			"  maximum rectangle triplets: 3,822\n";
+			"  triangle triplet count: 4,575\n" +
+			"  rectangle triplet count: 11,756\n" +
+			"  maximum triangle triplets: 153\n" +
+			"  maximum rectangle triplets: 391\n";
 
-		String[] arguments = new String[]{"--algorithm", "GraphMetrics", "--order", "directed",
-			"--input", "RMatGraph", "--type", "integer", "--simplify", "directed",
-			"--output"};
-
-		expectedOutput(ArrayUtils.addAll(arguments, "hash"), expected);
-		expectedOutput(ArrayUtils.addAll(arguments, "print"), expected);
+		expectedOutput(parameters(7, "directed", "hash"), expected);
+		expectedOutput(parameters(7, "directed", "print"), expected);
 	}
 
 	@Test
-	public void testWithUndirectedRMatIntegerGraph() throws Exception {
+	public void testWithLargeDirectedRMatIntegerGraph() throws Exception {
+		// skip 'byte' which cannot store vertex IDs for scale > 8
+		Assume.assumeFalse(idType.equals("byte") || idType.equals("nativeByte"));
+
+		// skip 'string' which does not compare numerically and generates a different triangle count
+		Assume.assumeFalse(idType.equals("string") || idType.equals("nativeString"));
+
 		String expected = "\n" +
 			"Vertex metrics:\n" +
-			"  vertex count: 902\n" +
-			"  edge count: 10,442\n" +
-			"  average degree: 23.153\n" +
-			"  density: 0.025697\n" +
-			"  triplet count: 1,003,442\n" +
-			"  maximum degree: 463\n" +
-			"  maximum triplets: 106,953\n" +
+			"  vertex count: 3,349\n" +
+			"  edge count: 53,368\n" +
+			"  unidirectional edge count: 43,602\n" +
+			"  bidirectional edge count: 4,883\n" +
+			"  average degree: 15.936\n" +
+			"  density: 0.00475971\n" +
+			"  triplet count: 9,276,207\n" +
+			"  maximum degree: 1,356\n" +
+			"  maximum out degree: 921\n" +
+			"  maximum in degree: 966\n" +
+			"  maximum triplets: 918,690\n" +
 			"\n" +
 			"Edge metrics:\n" +
-			"  triangle triplet count: 107,817\n" +
-			"  rectangle triplet count: 315,537\n" +
-			"  maximum triangle triplets: 820\n" +
-			"  maximum rectangle triplets: 3,822\n";
+			"  triangle triplet count: 779,202\n" +
+			"  rectangle triplet count: 2,506,371\n" +
+			"  maximum triangle triplets: 3,160\n" +
+			"  maximum rectangle triplets: 16,835\n";
 
-		String[] arguments = new String[]{"--algorithm", "GraphMetrics", "--order", "undirected",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "undirected",
-				"--output"};
+		expectedOutput(parameters(12, "directed", "hash"), expected);
+		expectedOutput(parameters(12, "directed", "print"), expected);
+	}
 
-		expectedOutput(ArrayUtils.addAll(arguments, "hash"), expected);
-		expectedOutput(ArrayUtils.addAll(arguments, "print"), expected);
+	@Test
+	public void testWithSmallUndirectedRMatIntegerGraph() throws Exception {
+		String expected = "\n" +
+			"Vertex metrics:\n" +
+			"  vertex count: 117\n" +
+			"  edge count: 927\n" +
+			"  average degree: 15.846\n" +
+			"  density: 0.13660477\n" +
+			"  triplet count: 29,286\n" +
+			"  maximum degree: 91\n" +
+			"  maximum triplets: 4,095\n" +
+			"\n" +
+			"Edge metrics:\n" +
+			"  triangle triplet count: 4,575\n" +
+			"  rectangle triplet count: 11,756\n" +
+			"  maximum triangle triplets: 153\n" +
+			"  maximum rectangle triplets: 391\n";
+
+		expectedOutput(parameters(7, "undirected", "hash"), expected);
+		expectedOutput(parameters(7, "undirected", "print"), expected);
+	}
+
+	@Test
+	public void testWithLargelUndirectedRMatIntegerGraph() throws Exception {
+		// skip 'byte' which cannot store vertex IDs for scale > 8
+		Assume.assumeFalse(idType.equals("byte") || idType.equals("nativeByte"));
+
+		// skip 'string' which does not compare numerically and generates a different triangle count
+		Assume.assumeFalse(idType.equals("string") || idType.equals("nativeString"));
+
+		String expected = "\n" +
+			"Vertex metrics:\n" +
+			"  vertex count: 3,349\n" +
+			"  edge count: 48,485\n" +
+			"  average degree: 28.955\n" +
+			"  density: 0.00864842\n" +
+			"  triplet count: 9,276,207\n" +
+			"  maximum degree: 1,356\n" +
+			"  maximum triplets: 918,690\n" +
+			"\n" +
+			"Edge metrics:\n" +
+			"  triangle triplet count: 779,202\n" +
+			"  rectangle triplet count: 2,506,371\n" +
+			"  maximum triangle triplets: 3,160\n" +
+			"  maximum rectangle triplets: 16,835\n";
+
+		expectedOutput(parameters(12, "undirected", "hash"), expected);
+		expectedOutput(parameters(12, "undirected", "print"), expected);
 	}
 }

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/HITSITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/HITSITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.graph.drivers;
 
 import org.apache.flink.client.program.ProgramParametrizationException;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -27,8 +28,15 @@ import org.junit.runners.Parameterized;
 public class HITSITCase
 extends DriverBaseITCase {
 
-	public HITSITCase(TestExecutionMode mode) {
-		super(mode);
+	public HITSITCase(String idType, TestExecutionMode mode) {
+		super(idType, mode);
+	}
+
+	private String[] parameters(int scale, String output) {
+		return new String[] {
+			"--algorithm", "HITS",
+			"--input", "RMatGraph", "--scale", Integer.toString(scale), "--type", idType, "--simplify", "directed",
+			"--output", output};
 	}
 
 	@Test
@@ -42,11 +50,21 @@ extends DriverBaseITCase {
 	}
 
 	@Test
-	public void testPrintWithRMatIntegerGraph() throws Exception {
-		expectedCount(
-			new String[]{"--algorithm", "HITS",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "directed",
-				"--output", "print"},
-			902);
+	public void testPrintWithSmallRMatGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
+
+		expectedCount(parameters(8, "print"), 233);
+	}
+
+	@Test
+	public void testPrintWithLargeRMatGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
+
+		// skip 'byte' which cannot store vertex IDs for scale > 8
+		Assume.assumeFalse(idType.equals("byte") || idType.equals("nativeByte"));
+
+		expectedCount(parameters(12, "print"), 3349);
 	}
 }

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/PageRankITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/PageRankITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.graph.drivers;
 
 import org.apache.flink.client.program.ProgramParametrizationException;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -27,8 +28,15 @@ import org.junit.runners.Parameterized;
 public class PageRankITCase
 extends DriverBaseITCase {
 
-	public PageRankITCase(TestExecutionMode mode) {
-		super(mode);
+	public PageRankITCase(String idType, TestExecutionMode mode) {
+		super(idType, mode);
+	}
+
+	private String[] parameters(int scale, String output) {
+		return new String[] {
+			"--algorithm", "PageRank",
+			"--input", "RMatGraph", "--scale", Integer.toString(scale), "--type", idType, "--simplify", "directed",
+			"--output", output};
 	}
 
 	@Test
@@ -42,11 +50,21 @@ extends DriverBaseITCase {
 	}
 
 	@Test
-	public void testPrintWithRMatIntegerGraph() throws Exception {
-		expectedCount(
-			new String[]{"--algorithm", "PageRank",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "directed",
-				"--output", "print"},
-			902);
+	public void testPrintWithSmallRMatGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
+
+		expectedCount(parameters(8, "print"), 233);
+	}
+
+	@Test
+	public void testPrintWithLargeRMatGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
+
+		// skip 'byte' which cannot store vertex IDs for scale > 8
+		Assume.assumeFalse(idType.equals("byte") || idType.equals("nativeByte"));
+
+		expectedCount(parameters(12, "print"), 3349);
 	}
 }

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/TriangleListingITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/TriangleListingITCase.java
@@ -18,17 +18,33 @@
 
 package org.apache.flink.graph.drivers;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.flink.client.program.ProgramParametrizationException;
+import org.apache.flink.graph.asm.dataset.ChecksumHashCode.Checksum;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
 public class TriangleListingITCase
-extends DriverBaseITCase {
+extends CopyableValueDriverBaseITCase {
 
-	public TriangleListingITCase(TestExecutionMode mode) {
-		super(mode);
+	public TriangleListingITCase(String idType, TestExecutionMode mode) {
+		super(idType, mode);
+	}
+
+	private String[] parameters(int scale, String order, String output) {
+		String[] parameters =  new String[] {
+			"--algorithm", "TriangleListing", "--order", order,
+			"--input", "RMatGraph", "--scale", Integer.toString(scale), "--type", idType, "--simplify", order,
+			"--output", output};
+
+		if (output.equals("hash")) {
+			return ArrayUtils.addAll(parameters, "--sort_triangle_vertices", "--triadic_census");
+		} else {
+			return parameters;
+		}
 	}
 
 	@Test
@@ -42,66 +58,224 @@ extends DriverBaseITCase {
 	}
 
 	@Test
-	public void testDirectedHashWithRMatIntegerGraph() throws Exception {
+	public void testHashWithSmallDirectedRMatGraph() throws Exception {
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "short":
+			case "char":
+			case "integer":
+				checksum = 0x000000003d2f0a9aL;
+				break;
+
+			case "long":
+				checksum = 0x000000016aba3720L;
+				break;
+
+			case "string":
+				checksum = 0x0000005bfef84facL;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
 		String expected = "\n" +
-			"ChecksumHashCode 0x0000001beffe6edd, count 75049\n" +
+			new Checksum(3822, checksum) + "\n" +
 			"Triadic census:\n" +
-			"  003: 113,435,893\n" +
-			"  012: 6,632,528\n" +
-			"  102: 983,535\n" +
-			"  021d: 118,574\n" +
-			"  021u: 118,566\n" +
-			"  021c: 237,767\n" +
-			"  111d: 129,773\n" +
-			"  111u: 130,041\n" +
-			"  030t: 16,981\n" +
-			"  030c: 5,535\n" +
-			"  201: 43,574\n" +
-			"  120d: 7,449\n" +
-			"  120u: 7,587\n" +
-			"  120c: 15,178\n" +
-			"  210: 17,368\n" +
-			"  300: 4,951\n";
+			"  003: 178,989\n" +
+			"  012: 47,736\n" +
+			"  102: 11,763\n" +
+			"  021d: 2,258\n" +
+			"  021u: 2,064\n" +
+			"  021c: 4,426\n" +
+			"  111d: 3,359\n" +
+			"  111u: 3,747\n" +
+			"  030t: 624\n" +
+			"  030c: 220\n" +
+			"  201: 1,966\n" +
+			"  120d: 352\n" +
+			"  120u: 394\n" +
+			"  120c: 704\n" +
+			"  210: 1,120\n" +
+			"  300: 408\n";
 
-		expectedOutput(
-			new String[]{"--algorithm", "TriangleListing", "--order", "directed", "--sort_triangle_vertices", "--triadic_census",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "directed",
-				"--output", "hash"},
-			expected);
+		expectedOutput(parameters(7, "directed", "hash"), expected);
 	}
 
 	@Test
-	public void testDirectedPrintWithRMatIntegerGraph() throws Exception {
-		expectedCount(
-			new String[]{"--algorithm", "TriangleListing", "--order", "directed",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "directed",
-				"--output", "print"},
-			75049);
-	}
+	public void testHashWithSmallUndirectedRMatGraph() throws Exception {
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "short":
+			case "char":
+			case "integer":
+				checksum = 0x0000000001f92b0cL;
+				break;
 
-	@Test
-	public void testUndirectedHashWithRMatIntegerGraph() throws Exception {
+			case "long":
+				checksum = 0x000000000bb355c6L;
+				break;
+
+			case "string":
+				checksum = 0x00000002f7b5576aL;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
 		String expected = "\n" +
-			"ChecksumHashCode 0x00000000e6b3f32c, count 75049\n" +
+			new Checksum(3822, checksum) + "\n" +
 			"Triadic census:\n" +
-			"  03: 113,435,893\n" +
-			"  12: 7,616,063\n" +
-			"  21: 778,295\n" +
-			"  30: 75,049\n";
+			"  03: 178,989\n" +
+			"  12: 59,499\n" +
+			"  21: 17,820\n" +
+			"  30: 3,822\n";
 
-		expectedOutput(
-			new String[]{"--algorithm", "TriangleListing", "--order", "undirected", "--sort_triangle_vertices", "--triadic_census",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "undirected",
-				"--output", "hash"},
-			expected);
+		expectedOutput(parameters(7, "undirected", "hash"), expected);
 	}
 
 	@Test
-	public void testUndirectedPrintWithRMatIntegerGraph() throws Exception {
-		expectedCount(
-			new String[]{"--algorithm", "TriangleListing", "--order", "undirected",
-				"--input", "RMatGraph", "--type", "integer", "--simplify", "undirected",
-				"--output", "print"},
-			75049);
+	public void testHashWithLargeDirectedRMatGraph() throws Exception {
+		// computation is too large for collection mode
+		Assume.assumeFalse(mode == TestExecutionMode.COLLECTION);
+
+		long checksum;
+		switch (idType) {
+			case "byte":
+				return;
+
+			case "short":
+			case "char":
+			case "integer":
+				checksum = 0x00000248fef26209L;
+				break;
+
+			case "long":
+				checksum = 0x000002dcdf0fbb1bL;
+				break;
+
+			case "string":
+				checksum = 0x00035b760ab9da74L;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		String expected = "\n" +
+			new Checksum(479818, checksum) + "\n" +
+			"Triadic census:\n" +
+			"  003: 6,101,196,568\n" +
+			"  012: 132,051,207\n" +
+			"  102: 13,115,128\n" +
+			"  021d: 1,330,423\n" +
+			"  021u: 1,336,897\n" +
+			"  021c: 2,669,285\n" +
+			"  111d: 1,112,144\n" +
+			"  111u: 1,097,452\n" +
+			"  030t: 132,048\n" +
+			"  030c: 44,127\n" +
+			"  201: 290,552\n" +
+			"  120d: 47,734\n" +
+			"  120u: 47,780\n" +
+			"  120c: 95,855\n" +
+			"  210: 90,618\n" +
+			"  300: 21,656\n";
+
+		expectedOutput(parameters(12, "directed", "hash"), expected);
+	}
+
+	@Test
+	public void testHashWithLargeUndirectedRMatGraph() throws Exception {
+		// computation is too large for collection mode
+		Assume.assumeFalse(mode == TestExecutionMode.COLLECTION);
+
+		long checksum;
+		switch (idType) {
+			case "byte":
+				return;
+
+			case "short":
+			case "char":
+			case "integer":
+				checksum = 0x00000012dee4bf2cL;
+				break;
+
+			case "long":
+				checksum = 0x00000017a40efbdaL;
+				break;
+
+			case "string":
+				checksum = 0x000159e8be3e370bL;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		String expected = "\n" +
+			new Checksum(479818, checksum) + "\n" +
+			"Triadic census:\n" +
+			"  03: 6,101,196,568\n" +
+			"  12: 145,166,335\n" +
+			"  21: 7,836,753\n" +
+			"  30: 479,818\n";
+
+		expectedOutput(parameters(12, "undirected", "hash"), expected);
+	}
+
+
+	@Test
+	public void testPrintWithSmallDirectedRMatGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
+
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "short":
+			case "integer":
+			case "long":
+				checksum = 0x00000764227995aaL;
+				break;
+
+			case "string":
+				checksum = 0x000007643d93c30aL;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		expectedOutputChecksum(parameters(7, "directed", "print"), new Checksum(3822, checksum));
+	}
+
+
+	@Test
+	public void testPrintWithSmallUndirectedRMatGraph() throws Exception {
+		// skip 'char' since it is not printed as a number
+		Assume.assumeFalse(idType.equals("char") || idType.equals("nativeChar"));
+
+		long checksum;
+		switch (idType) {
+			case "byte":
+			case "short":
+			case "integer":
+			case "long":
+				checksum = 0x0000077d1582e206L;
+				break;
+
+			case "string":
+				checksum = 0x0000077a49cb5268L;
+				break;
+
+			default:
+				throw new IllegalArgumentException("Unknown type: " + idType);
+		}
+
+		expectedOutputChecksum(parameters(7, "undirected", "print"), new Checksum(3822, checksum));
 	}
 }

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/input/GeneratedGraphTest.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/drivers/input/GeneratedGraphTest.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.drivers.input;
+
+import org.apache.flink.graph.asm.translate.TranslateFunction;
+import org.apache.flink.graph.drivers.input.GeneratedGraph.LongValueToChar;
+import org.apache.flink.graph.drivers.input.GeneratedGraph.LongValueToCharValue;
+import org.apache.flink.graph.drivers.input.GeneratedGraph.LongValueToString;
+import org.apache.flink.graph.drivers.input.GeneratedGraph.LongValueToUnsignedByte;
+import org.apache.flink.graph.drivers.input.GeneratedGraph.LongValueToUnsignedByteValue;
+import org.apache.flink.graph.drivers.input.GeneratedGraph.LongValueToUnsignedInt;
+import org.apache.flink.graph.drivers.input.GeneratedGraph.LongValueToLong;
+import org.apache.flink.graph.drivers.input.GeneratedGraph.LongValueToUnsignedShort;
+import org.apache.flink.graph.drivers.input.GeneratedGraph.LongValueToUnsignedShortValue;
+import org.apache.flink.types.ByteValue;
+import org.apache.flink.types.CharValue;
+import org.apache.flink.types.LongValue;
+import org.apache.flink.types.ShortValue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GeneratedGraphTest {
+
+	private TranslateFunction<LongValue, ByteValue> byteValueTranslator = new LongValueToUnsignedByteValue();
+	private TranslateFunction<LongValue, Byte> byteTranslator = new LongValueToUnsignedByte();
+	private TranslateFunction<LongValue, ShortValue> shortValueTranslator = new LongValueToUnsignedShortValue();
+	private TranslateFunction<LongValue, Short> shortTranslator = new LongValueToUnsignedShort();
+	private TranslateFunction<LongValue, CharValue> charValueTranslator = new LongValueToCharValue();
+	private TranslateFunction<LongValue, Character> charTranslator = new LongValueToChar();
+	private TranslateFunction<LongValue, Integer> intTranslator = new LongValueToUnsignedInt();
+	private TranslateFunction<LongValue, Long> longTranslator = new LongValueToLong();
+	private TranslateFunction<LongValue, String> stringTranslator = new LongValueToString();
+
+	private ByteValue byteValue = new ByteValue();
+	private ShortValue shortValue = new ShortValue();
+	private CharValue charValue = new CharValue();
+
+	// ByteValue
+
+	@Test
+	public void testByteValueTranslation() throws Exception {
+		assertEquals(new ByteValue((byte) 0), byteValueTranslator.translate(new LongValue(0L), byteValue));
+		assertEquals(new ByteValue(Byte.MIN_VALUE), byteValueTranslator.translate(new LongValue((long) Byte.MAX_VALUE + 1), byteValue));
+		assertEquals(new ByteValue((byte) -1), byteValueTranslator.translate(new LongValue((1L << 8) - 1), byteValue));
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testByteValueTranslationUpperOutOfRange() throws Exception {
+		byteValueTranslator.translate(new LongValue(1L << 8), byteValue);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testByteValueTranslationLowerOutOfRange() throws Exception {
+		byteValueTranslator.translate(new LongValue(-1), byteValue);
+	}
+
+	// Byte
+
+	@Test
+	public void testByteTranslation() throws Exception {
+		assertEquals(Byte.valueOf((byte) 0), byteTranslator.translate(new LongValue(0L), null));
+		assertEquals(Byte.valueOf(Byte.MIN_VALUE), byteTranslator.translate(new LongValue((long) Byte.MAX_VALUE + 1), null));
+		assertEquals(Byte.valueOf((byte) -1), byteTranslator.translate(new LongValue((1L << 8) - 1), null));
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testByteTranslationUpperOutOfRange() throws Exception {
+		byteTranslator.translate(new LongValue(1L << 8), null);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testByteTranslationLowerOutOfRange() throws Exception {
+		byteTranslator.translate(new LongValue(-1), null);
+	}
+
+	// ShortValue
+
+	@Test
+	public void testShortValueTranslation() throws Exception {
+		assertEquals(new ShortValue((short) 0), shortValueTranslator.translate(new LongValue(0L), shortValue));
+		assertEquals(new ShortValue(Short.MIN_VALUE), shortValueTranslator.translate(new LongValue((long) Short.MAX_VALUE + 1), shortValue));
+		assertEquals(new ShortValue((short) -1), shortValueTranslator.translate(new LongValue((1L << 16) - 1), shortValue));
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testShortValueTranslationUpperOutOfRange() throws Exception {
+		shortValueTranslator.translate(new LongValue(1L << 16), shortValue);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testShortValueTranslationLowerOutOfRange() throws Exception {
+		shortValueTranslator.translate(new LongValue(-1), shortValue);
+	}
+
+	// Short
+
+	@Test
+	public void testShortTranslation() throws Exception {
+		assertEquals(Short.valueOf((short) 0), shortTranslator.translate(new LongValue(0L), null));
+		assertEquals(Short.valueOf(Short.MIN_VALUE), shortTranslator.translate(new LongValue((long) Short.MAX_VALUE + 1), null));
+		assertEquals(Short.valueOf((short) -1), shortTranslator.translate(new LongValue((1L << 16) - 1), null));
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testShortTranslationUpperOutOfRange() throws Exception {
+		shortTranslator.translate(new LongValue(1L << 16), null);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testShortTranslationLowerOutOfRange() throws Exception {
+		shortTranslator.translate(new LongValue(-1), null);
+	}
+
+	// CharValue
+
+	@Test
+	public void testCharValueTranslation() throws Exception {
+		assertEquals(new CharValue((char) 0), charValueTranslator.translate(new LongValue(0L), charValue));
+		assertEquals(new CharValue(Character.MAX_VALUE), charValueTranslator.translate(new LongValue((long) Character.MAX_VALUE), charValue));
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testCharValueTranslationUpperOutOfRange() throws Exception {
+		charValueTranslator.translate(new LongValue(1L << 16), charValue);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testCharValueTranslationLowerOutOfRange() throws Exception {
+		charValueTranslator.translate(new LongValue(-1), charValue);
+	}
+
+	// Character
+
+	@Test
+	public void testCharacterTranslation() throws Exception {
+		assertEquals(Character.valueOf((char) 0), charTranslator.translate(new LongValue(0L), null));
+		assertEquals(Character.valueOf(Character.MAX_VALUE), charTranslator.translate(new LongValue((long) Character.MAX_VALUE), null));
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testCharacterTranslationUpperOutOfRange() throws Exception {
+		charTranslator.translate(new LongValue(1L << 16), null);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testCharacterTranslationLowerOutOfRange() throws Exception {
+		charTranslator.translate(new LongValue(-1), null);
+	}
+
+	// Integer
+
+	@Test
+	public void testIntegerTranslation() throws Exception {
+		assertEquals(Integer.valueOf(0), intTranslator.translate(new LongValue(0L), null));
+		assertEquals(Integer.valueOf(Integer.MIN_VALUE), intTranslator.translate(new LongValue((long) Integer.MAX_VALUE + 1), null));
+		assertEquals(Integer.valueOf(-1), intTranslator.translate(new LongValue((1L << 32) - 1), null));
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testIntegerTranslationUpperOutOfRange() throws Exception {
+		intTranslator.translate(new LongValue(1L << 32), null);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testIntegerTranslationLowerOutOfRange() throws Exception {
+		intTranslator.translate(new LongValue(-1), null);
+	}
+
+	// Long
+
+	@Test
+	public void testLongTranslation() throws Exception {
+		assertEquals(Long.valueOf(0L), longTranslator.translate(new LongValue(0L), null));
+		assertEquals(Long.valueOf(Long.MIN_VALUE), longTranslator.translate(new LongValue(Long.MIN_VALUE), null));
+		assertEquals(Long.valueOf(Long.MAX_VALUE), longTranslator.translate(new LongValue(Long.MAX_VALUE), null));
+	}
+
+	// String
+
+	@Test
+	public void testStringTranslation() throws Exception {
+		assertEquals("0", stringTranslator.translate(new LongValue(0L), null));
+		assertEquals("-9223372036854775808", stringTranslator.translate(new LongValue(Long.MIN_VALUE), null));
+		assertEquals("9223372036854775807", stringTranslator.translate(new LongValue(Long.MAX_VALUE), null));
+	}
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongValueToSignedIntValue.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongValueToSignedIntValue.java
@@ -31,6 +31,8 @@ import org.apache.flink.util.MathUtils;
 public class LongValueToSignedIntValue
 implements TranslateFunction<LongValue, IntValue> {
 
+	public static final long MAX_VERTEX_COUNT = 1L << 32;
+
 	@Override
 	public IntValue translate(LongValue value, IntValue reuse)
 			throws Exception {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongValueToUnsignedIntValue.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/translators/LongValueToUnsignedIntValue.java
@@ -30,6 +30,8 @@ import org.apache.flink.types.LongValue;
 public class LongValueToUnsignedIntValue
 implements TranslateFunction<LongValue, IntValue> {
 
+	public static final long MAX_VERTEX_COUNT = 1L << 32;
+
 	@Override
 	public IntValue translate(LongValue value, IntValue reuse)
 			throws Exception {
@@ -39,10 +41,10 @@ implements TranslateFunction<LongValue, IntValue> {
 
 		long l = value.getValue();
 
-		if (l < 0 || l >= (1L << 32)) {
+		if (l < 0 || l >= MAX_VERTEX_COUNT) {
 			throw new IllegalArgumentException("Cannot cast long value " + value + " to integer.");
 		} else {
-			reuse.setValue((int)(l & 0xffffffffL));
+			reuse.setValue((int) (l & (MAX_VERTEX_COUNT - 1)));
 		}
 
 		return reuse;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/CompleteGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/CompleteGraph.java
@@ -80,17 +80,16 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 	}
 
 	@ForwardedFields("*->f0")
-	public class LinkVertexToAll
+	private static class LinkVertexToAll
 	implements FlatMapFunction<LongValue, Edge<LongValue, NullValue>> {
-
 		private final long vertexCount;
 
 		private LongValue target = new LongValue();
 
 		private Edge<LongValue, NullValue> edge = new Edge<>(null, target, NullValue.getInstance());
 
-		public LinkVertexToAll(long vertex_count) {
-			this.vertexCount = vertex_count;
+		public LinkVertexToAll(long vertexCount) {
+			this.vertexCount = vertexCount;
 		}
 
 		@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/GridGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/GridGraph.java
@@ -107,7 +107,7 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 	}
 
 	@ForwardedFields("*->f0")
-	public class LinkVertexToNeighbors
+	private static class LinkVertexToNeighbors
 	implements FlatMapFunction<LongValue, Edge<LongValue, NullValue>> {
 
 		private long vertexCount;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/RMatGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/RMatGraph.java
@@ -166,7 +166,7 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 		return Graph.fromDataSet(vertices, edges, env);
 	}
 
-	private static final class GenerateEdges<T extends RandomGenerator>
+	private static class GenerateEdges<T extends RandomGenerator>
 	implements FlatMapFunction<BlockInfo<T>, Edge<LongValue, NullValue>> {
 
 		// Configuration

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/StarGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/StarGraph.java
@@ -80,7 +80,7 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 	}
 
 	@ForwardedFields("*->f0")
-	public class LinkVertexToCenter
+	private static class LinkVertexToCenter
 	implements FlatMapFunction<LongValue, Edge<LongValue, NullValue>> {
 
 		private LongValue center = new LongValue(0);

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/link_analysis/HITS.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/link_analysis/HITS.java
@@ -60,8 +60,6 @@ import static org.apache.flink.api.common.ExecutionConfig.PARALLELISM_DEFAULT;
  * <p>
  * http://www.cs.cornell.edu/home/kleinber/auth.pdf
  *
- * http://www.cs.cornell.edu/home/kleinber/auth.pdf
- *
  * @param <K> graph ID type
  * @param <VV> vertex value type
  * @param <EV> edge value type

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/AsmTestBase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/AsmTestBase.java
@@ -60,7 +60,7 @@ public class AsmTestBase {
 		env = ExecutionEnvironment.createCollectionsEnvironment();
 		env.getConfig().enableObjectReuse();
 
-		// the "fish" graph
+		// a "fish" graph
 		Object[][] edges = new Object[][]{
 			new Object[]{0, 1},
 			new Object[]{0, 2},

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/translate/translators/LongValueToSignedIntValueTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/translate/translators/LongValueToSignedIntValueTest.java
@@ -40,11 +40,11 @@ public class LongValueToSignedIntValueTest {
 
 	@Test(expected=IllegalArgumentException.class)
 	public void testUpperOutOfRange() throws Exception {
-		assertEquals(new IntValue(), translator.translate(new LongValue((long)Integer.MAX_VALUE + 1), reuse));
+		translator.translate(new LongValue((long)Integer.MAX_VALUE + 1), reuse);
 	}
 
 	@Test(expected=IllegalArgumentException.class)
 	public void testLowerOutOfRange() throws Exception {
-		assertEquals(new IntValue(), translator.translate(new LongValue((long)Integer.MIN_VALUE - 1), reuse));
+		translator.translate(new LongValue((long)Integer.MIN_VALUE - 1), reuse);
 	}
 }

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/translate/translators/LongValueToUnsignedIntValueTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/translate/translators/LongValueToUnsignedIntValueTest.java
@@ -34,17 +34,17 @@ public class LongValueToUnsignedIntValueTest {
 	@Test
 	public void testTranslation() throws Exception {
 		assertEquals(new IntValue(0), translator.translate(new LongValue(0L), reuse));
-		assertEquals(new IntValue(Integer.MIN_VALUE), translator.translate(new LongValue((long)Integer.MAX_VALUE + 1), reuse));
+		assertEquals(new IntValue(Integer.MIN_VALUE), translator.translate(new LongValue((long) Integer.MAX_VALUE + 1), reuse));
 		assertEquals(new IntValue(-1), translator.translate(new LongValue((1L << 32) - 1), reuse));
 	}
 
 	@Test(expected=IllegalArgumentException.class)
 	public void testUpperOutOfRange() throws Exception {
-		assertEquals(new IntValue(), translator.translate(new LongValue(1L << 32), reuse));
+		translator.translate(new LongValue(1L << 32), reuse);
 	}
 
 	@Test(expected=IllegalArgumentException.class)
 	public void testLowerOutOfRange() throws Exception {
-		assertEquals(new IntValue(), translator.translate(new LongValue(-1), reuse));
+		translator.translate(new LongValue(-1), reuse);
 	}
 }


### PR DESCRIPTION
The Gelly examples current support IntValue, LongValue, and StringValue for RMatGraph. Allow transformations and tests for all generated graphs for ByteValue, Byte, ShortValue, Short, CharValue, Character, Integer, Long, and String.