### PR TITLE
[FLINK-6393] [gelly] Add Evenly Graph Generator to Flink Gelly

### DIFF
--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/CirculantGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/CirculantGraph.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.generator;
+
+import java.util.*;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.functions.FunctionAnnotation;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.Vertex;
+import org.apache.flink.types.LongValue;
+import org.apache.flink.types.NullValue;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.LongValueSequenceIterator;
+import org.apache.flink.util.Preconditions;
+
+/*
+ * @see <a href="http://mathworld.wolfram.com/CirculantGraph.html">Circulant Graph at Wolfram MathWorld</a>
+ */
+public class CirculantGraph
+extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
+
+	public static final int MINIMUM_VERTEX_COUNT = 1;
+
+	public static final int MINIMUM_OFFSET = 1;
+
+	// Required to create the DataSource
+	private final ExecutionEnvironment env;
+
+	// Required configuration
+	private long vertexCount;
+
+	private List<Long> signedOffsetList = new ArrayList<Long>();
+
+	/**
+	 * The {@link Graph} containing no edges.
+	 *
+	 * @param env the Flink execution environment
+	 * @param vertexCount number of vertices
+	 */
+	public CirculantGraph(ExecutionEnvironment env, long vertexCount, List<Long> offsetList) {
+		Preconditions.checkArgument(vertexCount >= MINIMUM_VERTEX_COUNT,
+			"Vertex count must be at least " + MINIMUM_VERTEX_COUNT);
+
+        if (offsetList != null && !offsetList.isEmpty()) {
+            Preconditions.checkArgument(new HashSet<>(offsetList).size() == offsetList.size(),
+                    "Offset must not be duplicated");
+
+            long maxOffset = vertexCount / 2;
+            for (long offset : offsetList) {
+                Preconditions.checkArgument(offset >= MINIMUM_OFFSET,
+                        "Offset must be at least " + MINIMUM_OFFSET);
+                Preconditions.checkArgument(offset <= maxOffset,
+                        "Offset must be at most " + maxOffset);
+
+                // add sign, ignore negative max offset when vertex count is even
+                signedOffsetList.add(offset);
+                if (!(vertexCount % 2 == 0 && offset == maxOffset)) {
+                    signedOffsetList.add(-offset);
+                }
+            }
+        }
+
+		this.env = env;
+		this.vertexCount = vertexCount;
+	}
+
+	@Override
+	public Graph<LongValue, NullValue, NullValue> generate() {
+		// Vertices
+		DataSet<Vertex<LongValue, NullValue>> vertices = GraphGeneratorUtils.vertexSequence(env, parallelism, vertexCount);
+
+        // Edges
+        LongValueSequenceIterator iterator = new LongValueSequenceIterator(0, this.vertexCount - 1);
+
+        DataSet<Edge<LongValue, NullValue>> edges = env
+                .fromParallelCollection(iterator, LongValue.class)
+                .setParallelism(parallelism)
+                .name("Edge iterators")
+                .flatMap(new LinkVertexToOffset(vertexCount, signedOffsetList))
+                .setParallelism(parallelism)
+                .name("Circulant graph edges");
+
+		// Graph
+		return Graph.fromDataSet(vertices, edges, env);
+	}
+
+    @FunctionAnnotation.ForwardedFields("*->f0")
+    public class LinkVertexToOffset
+            implements FlatMapFunction<LongValue, Edge<LongValue, NullValue>> {
+
+        private final long vertexCount;
+
+        private final List<Long> offsets;
+
+        private LongValue target = new LongValue();
+
+        private Edge<LongValue, NullValue> edge = new Edge<>(null, target, NullValue.getInstance());
+
+        public LinkVertexToOffset(long vertexCount, List<Long> offsets) {
+            this.vertexCount = vertexCount;
+            this.offsets = offsets;
+        }
+
+        @Override
+        public void flatMap(LongValue source, Collector<Edge<LongValue, NullValue>> out)
+                throws Exception {
+            // empty graph
+            if (offsets == null || offsets.isEmpty()) {
+                return;
+            }
+
+            edge.f0 = source;
+
+            // link to offset vertex
+            for (long offset : offsets) {
+                target.setValue((source.getValue() + offset + vertexCount) % vertexCount);
+                out.collect(edge);
+            }
+        }
+    }
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/CompleteGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/CompleteGraph.java
@@ -18,18 +18,13 @@
 
 package org.apache.flink.graph.generator;
 
-import org.apache.flink.api.common.functions.FlatMapFunction;
-import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFields;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
-import org.apache.flink.util.Collector;
-import org.apache.flink.util.LongValueSequenceIterator;
 import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayList;
 
 /*
  * @see <a href="http://mathworld.wolfram.com/CompleteGraph.html">Complete Graph at Wolfram MathWorld</a>
@@ -61,54 +56,16 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 
 	@Override
 	public Graph<LongValue, NullValue, NullValue> generate() {
-		// Vertices
-		DataSet<Vertex<LongValue, NullValue>> vertices = GraphGeneratorUtils.vertexSequence(env, parallelism, vertexCount);
+		ArrayList<Long> offsetList = new ArrayList<Long>();
+		long maxOffset = vertexCount / 2;
 
-		// Edges
-		LongValueSequenceIterator iterator = new LongValueSequenceIterator(0, this.vertexCount - 1);
-
-		DataSet<Edge<LongValue, NullValue>> edges = env
-			.fromParallelCollection(iterator, LongValue.class)
-				.setParallelism(parallelism)
-				.name("Edge iterators")
-			.flatMap(new LinkVertexToAll(vertexCount))
-				.setParallelism(parallelism)
-				.name("Complete graph edges");
-
-		// Graph
-		return Graph.fromDataSet(vertices, edges, env);
-	}
-
-	@ForwardedFields("*->f0")
-	public class LinkVertexToAll
-	implements FlatMapFunction<LongValue, Edge<LongValue, NullValue>> {
-
-		private final long vertexCount;
-
-		private LongValue target = new LongValue();
-
-		private Edge<LongValue, NullValue> edge = new Edge<>(null, target, NullValue.getInstance());
-
-		public LinkVertexToAll(long vertex_count) {
-			this.vertexCount = vertex_count;
+		// add all the offset
+		for (long i = 0; i < maxOffset; i++) {
+			offsetList.add(maxOffset - i);
 		}
 
-		@Override
-		public void flatMap(LongValue source, Collector<Edge<LongValue, NullValue>> out)
-				throws Exception {
-			edge.f0 = source;
-
-			long s = source.getValue();
-			long t = (s + 1) % vertexCount;
-
-			while (s != t) {
-				target.setValue(t);
-				out.collect(edge);
-
-				if (++t == vertexCount) {
-					t = 0;
-				}
-			}
-		}
+		return new CirculantGraph(env, vertexCount, offsetList)
+				.setParallelism(parallelism)
+				.generate();
 	}
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/EvenlyGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/EvenlyGraph.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.generator;
+
+import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFields;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.Vertex;
+import org.apache.flink.types.LongValue;
+import org.apache.flink.types.NullValue;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.LongValueSequenceIterator;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Evenly graph means every {@link Vertex} in the {@link Graph} has the same degree.
+ * when vertex degree is 0, {@link EmptyGraph} will be generated.
+ * when vertex degree is vertex count - 1, {@link CompleteGraph} will be generated.
+ */
+public class EvenlyGraph
+extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
+
+	public static final int MINIMUM_VERTEX_COUNT = 1;
+
+	public static final int MINIMUM_VERTEX_DEGREE = 0;
+
+	// Required to create the DataSource
+	private final ExecutionEnvironment env;
+
+	// Required configuration
+	private long vertexCount;
+
+	private long vertexDegree;
+
+	/**
+	 * An undirected {@link Graph} whose vertices have the same degree.
+	 *
+	 * @param env the Flink execution environment
+	 * @param vertexCount number of vertices
+	 * @param vertexDegree degree of vertices
+	 */
+	public EvenlyGraph(ExecutionEnvironment env, long vertexCount,  long vertexDegree) {
+		Preconditions.checkArgument(vertexCount >= MINIMUM_VERTEX_COUNT,
+			"Vertex count must be at least " + MINIMUM_VERTEX_COUNT);
+		Preconditions.checkArgument(vertexDegree >= MINIMUM_VERTEX_DEGREE,
+				"Vertex degree must be at least " + MINIMUM_VERTEX_DEGREE);
+		Preconditions.checkArgument(vertexCount % 2 == 0 || vertexDegree % 2 == 0,
+				"Vertex degree must be even when vertex count is odd number");
+
+		this.env = env;
+		this.vertexCount = vertexCount;
+		this.vertexDegree = vertexDegree;
+	}
+
+	@Override
+	public Graph<LongValue, NullValue, NullValue> generate() {
+		// Vertices
+		DataSet<Vertex<LongValue, NullValue>> vertices = GraphGeneratorUtils.vertexSequence(env, parallelism, vertexCount);
+
+		// Edges
+		LongValueSequenceIterator iterator = new LongValueSequenceIterator(0, this.vertexCount - 1);
+
+		DataSet<Edge<LongValue, NullValue>> edges = env
+			.fromParallelCollection(iterator, LongValue.class)
+				.setParallelism(parallelism)
+				.name("Edge iterators")
+			.flatMap(new LinkVertexToOpposite(vertexCount, vertexDegree))
+				.setParallelism(parallelism)
+				.name("Evenly graph edges");
+
+		// Graph
+		return Graph.fromDataSet(vertices, edges, env);
+	}
+
+	@ForwardedFields("*->f0")
+	public class LinkVertexToOpposite
+	implements FlatMapFunction<LongValue, Edge<LongValue, NullValue>> {
+
+		private final long vertexCount;
+
+		private final long vertexDegree;
+
+		private LongValue target = new LongValue();
+
+		private Edge<LongValue, NullValue> edge = new Edge<>(null, target, NullValue.getInstance());
+
+		public LinkVertexToOpposite(long vertex_count, long vertexDegree) {
+			this.vertexCount = vertex_count;
+			this.vertexDegree = vertexDegree;
+		}
+
+		@Override
+		public void flatMap(LongValue source, Collector<Edge<LongValue, NullValue>> out)
+				throws Exception {
+			// empty graph
+			if (vertexDegree == 0) {
+				return;
+			}
+
+			edge.f0 = source;
+
+			// get opposite vertex's id
+			long opposite = (source.getValue() + vertexCount / 2) % vertexCount;
+
+			// link to opposite vertex if possible
+			if (vertexCount % 2 == 0 && vertexDegree % 2 == 1) {
+				target.setValue(opposite);
+				out.collect(edge);
+			}
+
+			// link to vertices on both sides of opposite
+			long initialOffset = (vertexCount + 1) % 2;
+			long oneSideVertexCount = (vertexDegree - vertexCount % 2) / 2;
+			for (long i = initialOffset; i <= oneSideVertexCount; i++) {
+				long previous = (opposite - i + vertexCount) % vertexCount;
+				long next = (opposite + i + vertexCount % 2) % vertexCount;
+
+				target.setValue(previous);
+				out.collect(edge);
+
+				target.setValue(next);
+				out.collect(edge);
+			}
+		}
+	}
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/EvenlyGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/EvenlyGraph.java
@@ -18,21 +18,20 @@
 
 package org.apache.flink.graph.generator;
 
-import org.apache.flink.api.common.functions.FlatMapFunction;
-import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFields;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
-import org.apache.flink.util.Collector;
-import org.apache.flink.util.LongValueSequenceIterator;
 import org.apache.flink.util.Preconditions;
 
+import java.util.ArrayList;
+
 /**
- * Evenly graph means every {@link Vertex} in the {@link Graph} has the same degree.
+ * Every {@link Vertex} in the {@link EvenlyGraph} has the same degree.
+ * there may exist multiple cases satisfy the condition above, so further vertices
+ * are chose to be linked.
+ * {@link EvenlyGraph} is a specific case of {@link CirculantGraph}.
  * when vertex degree is 0, {@link EmptyGraph} will be generated.
  * when vertex degree is vertex count - 1, {@link CompleteGraph} will be generated.
  */
@@ -63,6 +62,8 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 			"Vertex count must be at least " + MINIMUM_VERTEX_COUNT);
 		Preconditions.checkArgument(vertexDegree >= MINIMUM_VERTEX_DEGREE,
 				"Vertex degree must be at least " + MINIMUM_VERTEX_DEGREE);
+		Preconditions.checkArgument(vertexDegree <= vertexCount - 1,
+				"Vertex degree must be at most " + (vertexCount - 1));
 		Preconditions.checkArgument(vertexCount % 2 == 0 || vertexDegree % 2 == 0,
 				"Vertex degree must be even when vertex count is odd number");
 
@@ -73,73 +74,21 @@ extends AbstractGraphGenerator<LongValue, NullValue, NullValue> {
 
 	@Override
 	public Graph<LongValue, NullValue, NullValue> generate() {
-		// Vertices
-		DataSet<Vertex<LongValue, NullValue>> vertices = GraphGeneratorUtils.vertexSequence(env, parallelism, vertexCount);
+		ArrayList<Long> offsetList = new ArrayList<Long>();
+		long maxOffset = vertexCount / 2;
 
-		// Edges
-		LongValueSequenceIterator iterator = new LongValueSequenceIterator(0, this.vertexCount - 1);
-
-		DataSet<Edge<LongValue, NullValue>> edges = env
-			.fromParallelCollection(iterator, LongValue.class)
-				.setParallelism(parallelism)
-				.name("Edge iterators")
-			.flatMap(new LinkVertexToOpposite(vertexCount, vertexDegree))
-				.setParallelism(parallelism)
-				.name("Evenly graph edges");
-
-		// Graph
-		return Graph.fromDataSet(vertices, edges, env);
-	}
-
-	@ForwardedFields("*->f0")
-	public class LinkVertexToOpposite
-	implements FlatMapFunction<LongValue, Edge<LongValue, NullValue>> {
-
-		private final long vertexCount;
-
-		private final long vertexDegree;
-
-		private LongValue target = new LongValue();
-
-		private Edge<LongValue, NullValue> edge = new Edge<>(null, target, NullValue.getInstance());
-
-		public LinkVertexToOpposite(long vertex_count, long vertexDegree) {
-			this.vertexCount = vertex_count;
-			this.vertexDegree = vertexDegree;
+		// add max offset when vertex degree is even and vertex count is odd
+		if (vertexDegree % 2 == 1 && vertexCount % 2 == 0) {
+			offsetList.add(maxOffset);
 		}
 
-		@Override
-		public void flatMap(LongValue source, Collector<Edge<LongValue, NullValue>> out)
-				throws Exception {
-			// empty graph
-			if (vertexDegree == 0) {
-				return;
-			}
-
-			edge.f0 = source;
-
-			// get opposite vertex's id
-			long opposite = (source.getValue() + vertexCount / 2) % vertexCount;
-
-			// link to opposite vertex if possible
-			if (vertexCount % 2 == 0 && vertexDegree % 2 == 1) {
-				target.setValue(opposite);
-				out.collect(edge);
-			}
-
-			// link to vertices on both sides of opposite
-			long initialOffset = (vertexCount + 1) % 2;
-			long oneSideVertexCount = (vertexDegree - vertexCount % 2) / 2;
-			for (long i = initialOffset; i <= oneSideVertexCount; i++) {
-				long previous = (opposite - i + vertexCount) % vertexCount;
-				long next = (opposite + i + vertexCount % 2) % vertexCount;
-
-				target.setValue(previous);
-				out.collect(edge);
-
-				target.setValue(next);
-				out.collect(edge);
-			}
+		// add other offset nearby max offset
+		for (long i = 0; i < vertexDegree / 2; i++) {
+			offsetList.add(maxOffset - i - (vertexCount + 1) % 2);
 		}
+
+		return new CirculantGraph(env, vertexCount, offsetList)
+				.setParallelism(parallelism)
+				.generate();
 	}
 }

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CirculantGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CirculantGraphTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.generator;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.Vertex;
+import org.apache.flink.types.LongValue;
+import org.apache.flink.types.NullValue;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class CirculantGraphTest
+extends AbstractGraphTest {
+
+	@Test
+	public void testGraph()
+			throws Exception {
+		Graph<LongValue, NullValue, NullValue> graph = new CirculantGraph(env, 10, Arrays.asList(4L, 5L))
+			.generate();
+
+		String vertices = "0; 1; 2; 3; 4; 5; 6; 7; 8; 9";
+		String edges = "0,4; 0,5; 0,6; 1,5; 1,6; 1,7; 2,6;" +
+				"2,7; 2,8; 3,7; 3,8; 3,9; 4,0; 4,8; 4,9;" +
+				"5,0; 5,1; 5,9; 6,0; 6,1; 6,2; 7,1; 7,2; 7,3;" +
+				"8,2; 8,3; 8,4; 9,3; 9,4; 9,5";
+
+		TestUtils.compareGraph(graph, vertices, edges);
+	}
+
+	@Test
+	public void testGraphMetrics()
+			throws Exception {
+		int vertexCount = 10;
+
+		Graph<LongValue, NullValue, NullValue> graph = new CirculantGraph(env, vertexCount, Arrays.asList(4L, 5L))
+			.generate();
+
+		assertEquals(vertexCount, graph.numberOfVertices());
+		assertEquals(vertexCount * 3, graph.numberOfEdges());
+
+		long maxInDegree = graph.inDegrees().max(1).collect().get(0).f1.getValue();
+		long maxOutDegree = graph.outDegrees().max(1).collect().get(0).f1.getValue();
+
+		assertEquals(3, maxInDegree);
+		assertEquals(3, maxOutDegree);
+	}
+
+	@Test
+	public void testParallelism()
+			throws Exception {
+		int parallelism = 2;
+
+		Graph<LongValue, NullValue, NullValue> graph = new CirculantGraph(env, 10, Arrays.asList(4L, 5L))
+			.setParallelism(parallelism)
+			.generate();
+
+		graph.getVertices().output(new DiscardingOutputFormat<Vertex<LongValue, NullValue>>());
+		graph.getEdges().output(new DiscardingOutputFormat<Edge<LongValue, NullValue>>());
+
+		TestUtils.verifyParallelism(env, parallelism);
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/EvenlyGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/EvenlyGraphTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.graph.generator;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.Vertex;
+import org.apache.flink.types.LongValue;
+import org.apache.flink.types.NullValue;
+import org.junit.Test;
+
+public class EvenlyGraphTest
+extends AbstractGraphTest {
+
+	@Test
+	public void testGraph()
+			throws Exception {
+		Graph<LongValue, NullValue, NullValue> graph = new EvenlyGraph(env, 10, 3)
+			.generate();
+
+		String vertices = "0; 1; 2; 3; 4; 5; 6; 7; 8; 9";
+		String edges = "0,4; 0,5; 0,6; 1,5; 1,6; 1,7; 2,6;" +
+				"2,7; 2,8; 3,7; 3,8; 3,9; 4,0; 4,8; 4,9;" +
+				"5,0; 5,1; 5,9; 6,0; 6,1; 6,2; 7,1; 7,2; 7,3;" +
+				"8,2; 8,3; 8,4; 9,3; 9,4; 9,5";
+
+		TestUtils.compareGraph(graph, vertices, edges);
+	}
+
+	@Test
+	public void testGraphMetrics()
+			throws Exception {
+		int vertexCount = 10;
+		int vertexDegree = 3;
+
+		Graph<LongValue, NullValue, NullValue> graph = new EvenlyGraph(env, vertexCount, vertexDegree)
+			.generate();
+
+		assertEquals(vertexCount, graph.numberOfVertices());
+		assertEquals(vertexCount * vertexDegree, graph.numberOfEdges());
+
+		long maxInDegree = graph.inDegrees().max(1).collect().get(0).f1.getValue();
+		long maxOutDegree = graph.outDegrees().max(1).collect().get(0).f1.getValue();
+
+		assertEquals(vertexDegree, maxInDegree);
+		assertEquals(vertexDegree, maxOutDegree);
+	}
+
+	@Test
+	public void testParallelism()
+			throws Exception {
+		int parallelism = 2;
+
+		Graph<LongValue, NullValue, NullValue> graph = new EvenlyGraph(env, 10, 3)
+			.setParallelism(parallelism)
+			.generate();
+
+		graph.getVertices().output(new DiscardingOutputFormat<Vertex<LongValue, NullValue>>());
+		graph.getEdges().output(new DiscardingOutputFormat<Edge<LongValue, NullValue>>());
+
+		TestUtils.verifyParallelism(env, parallelism);
+	}
+}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -216,7 +216,7 @@ class JobManager(
       case Some(group) =>
         instantiateMetrics(group)
       case None =>
-        log.warn("Could not instantiate JobManager metrics.")
+        log.warn("Could not instantiate JobManager metric group.")
     }
   }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/FoldApplyProcessWindowFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/FoldApplyProcessWindowFunction.java
@@ -100,16 +100,14 @@ public class FoldApplyProcessWindowFunction<K, W extends Window, T, ACC, R>
 		}
 
 		this.ctx.window = context.window();
-		this.ctx.windowState = context.windowState();
-		this.ctx.globalState = context.globalState();
+		this.ctx.context = context;
 		windowFunction.process(key, ctx, Collections.singletonList(result), out);
 	}
 
 	@Override
 	public void clear(final Context context) throws Exception{
 		this.ctx.window = context.window();
-		this.ctx.windowState = context.windowState();
-		this.ctx.globalState = context.globalState();
+		this.ctx.context = context;
 		windowFunction.clear(ctx);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/InternalProcessApplyWindowContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/InternalProcessApplyWindowContext.java
@@ -34,8 +34,7 @@ public class InternalProcessApplyWindowContext<IN, OUT, KEY, W extends Window>
 	extends ProcessWindowFunction<IN, OUT, KEY, W>.Context {
 
 	W window;
-	KeyedStateStore windowState;
-	KeyedStateStore globalState;
+	ProcessWindowFunction.Context context;
 
 	InternalProcessApplyWindowContext(ProcessWindowFunction<IN, OUT, KEY, W> function) {
 		function.super();
@@ -47,12 +46,21 @@ public class InternalProcessApplyWindowContext<IN, OUT, KEY, W extends Window>
 	}
 
 	@Override
+	public long currentProcessingTime() {
+		return context.currentProcessingTime();
+	}
+
+	@Override
+	public long currentWatermark() {
+		return context.currentWatermark();
+	}
+
 	public KeyedStateStore windowState() {
-		return windowState;
+		return context.windowState();
 	}
 
 	@Override
 	public KeyedStateStore globalState() {
-		return globalState;
+		return context.globalState();
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/ProcessWindowFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/ProcessWindowFunction.java
@@ -63,9 +63,15 @@ public abstract class ProcessWindowFunction<IN, OUT, KEY, W extends Window> impl
 	 */
 	public abstract class Context implements java.io.Serializable {
 		/**
-		 * @return The window that is being evaluated.
+		 * Returns the window that is being evaluated.
 		 */
 		public abstract W window();
+
+		/** Returns the current processing time. */
+		public abstract long currentProcessingTime();
+
+		/** Returns the current event-time watermark. */
+		public abstract long currentWatermark();
 
 		/**
 		 * State accessor for per-key and per-window state.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/ReduceApplyProcessWindowFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/windowing/ReduceApplyProcessWindowFunction.java
@@ -59,16 +59,14 @@ public class ReduceApplyProcessWindowFunction<K, W extends Window, T, R>
 		}
 
 		this.ctx.window = context.window();
-		this.ctx.windowState = context.windowState();
-		this.ctx.globalState = context.globalState();
+		this.ctx.context = context;
 		windowFunction.process(k, ctx, Collections.singletonList(curr), out);
 	}
 
 	@Override
 	public void clear(final Context context) throws Exception {
 		this.ctx.window = context.window();
-		this.ctx.windowState = context.windowState();
-		this.ctx.globalState = context.globalState();
+		this.ctx.context = context;
 		windowFunction.clear(ctx);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AccumulatingKeyedTimePanes.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/AccumulatingKeyedTimePanes.java
@@ -194,6 +194,16 @@ public class AccumulatingKeyedTimePanes<Type, Key, Result> extends AbstractKeyed
 		}
 
 		@Override
+		public long currentProcessingTime() {
+			throw new UnsupportedOperationException("current processing time is not supported in this context");
+		}
+
+		@Override
+		public long currentWatermark() {
+			throw new UnsupportedOperationException("current watermark is not supported in this context");
+		}
+
+		@Override
 		public KeyedStateStore windowState() {
 			return throwingStore;
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -817,6 +817,16 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		}
 
 		@Override
+		public long currentProcessingTime() {
+			return internalTimerService.currentProcessingTime();
+		}
+
+		@Override
+		public long currentWatermark() {
+			return internalTimerService.currentWatermark();
+		}
+
+		@Override
 		public KeyedStateStore windowState() {
 			this.windowState.window = this.window;
 			return this.windowState;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/functions/InternalProcessWindowContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/functions/InternalProcessWindowContext.java
@@ -47,6 +47,16 @@ public class InternalProcessWindowContext<IN, OUT, KEY, W extends Window>
 	}
 
 	@Override
+	public long currentProcessingTime() {
+		return internalContext.currentProcessingTime();
+	}
+
+	@Override
+	public long currentWatermark() {
+		return internalContext.currentWatermark();
+	}
+
+	@Override
 	public KeyedStateStore windowState() {
 		return internalContext.windowState();
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/functions/InternalWindowFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/functions/InternalWindowFunction.java
@@ -55,6 +55,10 @@ public interface InternalWindowFunction<IN, OUT, KEY, W extends Window> extends 
 	 * for internal use.
 	 */
 	interface InternalWindowContext extends java.io.Serializable {
+		long currentProcessingTime();
+
+		long currentWatermark();
+
 		KeyedStateStore windowState();
 
 		KeyedStateStore globalState();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/FoldApplyProcessWindowFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/FoldApplyProcessWindowFunctionTest.java
@@ -154,6 +154,16 @@ public class FoldApplyProcessWindowFunctionTest {
 			}
 
 			@Override
+			public long currentProcessingTime() {
+				return 0;
+			}
+
+			@Override
+			public long currentWatermark() {
+				return 0;
+			}
+
+			@Override
 			public KeyedStateStore windowState() {
 				return new DummyKeyedStateStore();
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorMigrationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorMigrationTest.java
@@ -826,7 +826,7 @@ public class WindowOperatorMigrationTest {
 					if (comparison != 0) {
 						return comparison;
 					}
-					return (int) (sr0.getValue().f1 - sr1.getValue().f1);
+					return (int) (sr0.getValue().f2 - sr1.getValue().f2);
 				}
 			}
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
@@ -2560,7 +2560,7 @@ public class WindowOperatorTest extends TestLogger {
 					if (comparison != 0) {
 						return comparison;
 					}
-					return (int) (sr0.getValue().f1 - sr1.getValue().f1);
+					return (int) (sr0.getValue().f2 - sr1.getValue().f2);
 				}
 			}
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
@@ -38,6 +38,8 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 
 	private final OneInputStreamOperator<IN, OUT> oneInputOperator;
 
+	private long currentWatermark;
+
 	public OneInputStreamOperatorTestHarness(
 			OneInputStreamOperator<IN, OUT> operator,
 			TypeSerializer<IN> typeSerializerIn) throws Exception {
@@ -98,10 +100,15 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 	}
 
 	public void processWatermark(long watermark) throws Exception {
-		oneInputOperator.processWatermark(new Watermark(watermark));
+		processWatermark(new Watermark(watermark));
 	}
 
 	public void processWatermark(Watermark mark) throws Exception {
+		currentWatermark = mark.getTimestamp();
 		oneInputOperator.processWatermark(mark);
+	}
+
+	public long getCurrentWatermark() {
+		return currentWatermark;
 	}
 }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/ProcessWindowFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/ProcessWindowFunction.scala
@@ -63,9 +63,19 @@ abstract class ProcessWindowFunction[IN, OUT, KEY, W <: Window] extends Function
     */
   abstract class Context {
     /**
-      * @return The window that is being evaluated.
+      * Returns the window that is being evaluated.
       */
     def window: W
+
+    /**
+      * Returns the current processing time.
+      */
+    def currentProcessingTime: Long
+
+    /**
+      * Returns the current event-time watermark.
+      */
+    def currentWatermark: Long
 
     /**
       * State accessor for per-key and per-window state.

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/util/ScalaProcessWindowFunctionWrapper.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/function/util/ScalaProcessWindowFunctionWrapper.scala
@@ -53,6 +53,10 @@ final class ScalaProcessWindowFunctionWrapper[IN, OUT, KEY, W <: Window](
     val ctx = new func.Context {
       override def window = context.window
 
+      override def currentProcessingTime = context.currentProcessingTime
+
+      override def currentWatermark = context.currentWatermark
+
       override def windowState = context.windowState()
 
       override def globalState = context.globalState()
@@ -63,6 +67,10 @@ final class ScalaProcessWindowFunctionWrapper[IN, OUT, KEY, W <: Window](
   override def clear(context: JProcessWindowFunction[IN, OUT, KEY, W]#Context): Unit = {
     val ctx = new func.Context {
       override def window = context.window
+
+      override def currentProcessingTime = context.currentProcessingTime
+
+      override def currentWatermark = context.currentWatermark
 
       override def windowState = context.windowState()
 


### PR DESCRIPTION
Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed

Evenly graph means every vertex in the graph has the same degree, so the graph can be treated as evenly due to all the edges in the graph are distributed evenly. when vertex degree is 0, an empty graph will be generated. when vertex degree is vertex count - 1, complete graph will be generated.

The core idea is based on the concept of central symmetry. From the view of any vertex in the graph, the other vertices and edges are the same. So in the intermediate cases, edges are created from one vertex to the opposite vertex(if exists) and vertices on both sides of it.