### PR TITLE
[FLINK-6293] [tests] Harden JobManagerITCase

### DIFF
--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
@@ -765,6 +765,11 @@ class JobManagerITCase(_system: ActorSystem)
           val jobManager = flinkCluster
             .getLeaderGateway(deadline.timeLeft)
 
+          // we have to make sure that the job manager knows also that he is the leader
+          // in case of standalone leader retrieval this can happen after the getLeaderGateway call
+          val leaderFuture = jobManager.ask(NotifyWhenLeader, timeout.duration)
+          Await.ready(leaderFuture, timeout.duration)
+
           val jobId = new JobID()
 
           // Trigger savepoint for non-existing job


### PR DESCRIPTION
One of the unit tests in JobManagerITCase starts a MiniCluster and sends a
LeaderSessionMessage to the JobManager without waiting until the JobManager
has gained leadership. This can lead to a dropped TriggerSavepoint message
which will cause the test to deadlock.

This PR fixes the problem by explicitly waiting for the JobManager to become
the leader.