### PR TITLE
[FLINK-6411] [flip-6] Remove job removal from RunningJobsRegistry in YarnFlinkApplicationMasterRunner.shutdown

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkApplicationMasterRunner.java
@@ -103,9 +103,6 @@ public class YarnFlinkApplicationMasterRunner extends AbstractYarnFlinkApplicati
 	@GuardedBy("lock")
 	private JobManagerRunner jobManagerRunner;
 
-	@GuardedBy("lock")
-	private JobGraph jobGraph;
-
 	// ------------------------------------------------------------------------
 	//  Program entry point
 	// ------------------------------------------------------------------------
@@ -217,7 +214,7 @@ public class YarnFlinkApplicationMasterRunner extends AbstractYarnFlinkApplicati
 	private JobManagerRunner createJobManagerRunner(Configuration config) throws Exception{
 		// first get JobGraph from local resources
 		//TODO: generate the job graph from user's jar
-		jobGraph = loadJobGraph(config);
+		JobGraph jobGraph = loadJobGraph(config);
 
 		// now the JobManagerRunner
 		return new JobManagerRunner(
@@ -232,13 +229,6 @@ public class YarnFlinkApplicationMasterRunner extends AbstractYarnFlinkApplicati
 	}
 
 	protected void shutdown(ApplicationStatus status, String msg) {
-		// Need to clear the job state in the HA services before shutdown
-		try {
-			haServices.getRunningJobsRegistry().clearJob(jobGraph.getJobID());
-		}
-		catch (Throwable t) {
-			LOG.warn("Could not clear the job at the high-availability services", t);
-		}
 
 		synchronized (lock) {
 			if (jobManagerRunner != null) {


### PR DESCRIPTION
The YarnFlinkApplicationMasterRunner should not be concerned with removing jobs from
the RunningJobsRegistry. This is the responsibility of the JobManagerRunner.

This PR removes the job removal from the RunningJobRegistry from the
YarnFlinkApplicationMasterRunner.shutdown method.