### PR TITLE
[FLINK-6397] MultipleProgramsTestBase does not reset ContextEnvironment

### DIFF
--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/util/FlinkTestBase.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/util/FlinkTestBase.scala
@@ -70,6 +70,8 @@ trait FlinkTestBase extends BeforeAndAfter {
 
   after {
     cluster.foreach(c => TestBaseUtils.stopCluster(c, TestBaseUtils.DEFAULT_TIMEOUT))
+
+    TestEnvironment.unsetAsContext()
   }
 
 }

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/CollectionTestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/CollectionTestEnvironment.java
@@ -49,7 +49,7 @@ public class CollectionTestEnvironment extends CollectionEnvironment {
 		return result;
 	}
 
-	protected void setAsContext() {
+	public void setAsContext() {
 		ExecutionEnvironmentFactory factory = new ExecutionEnvironmentFactory() {
 			@Override
 			public ExecutionEnvironment createExecutionEnvironment() {
@@ -59,5 +59,9 @@ public class CollectionTestEnvironment extends CollectionEnvironment {
 		};
 
 		initializeContextEnvironment(factory);
+	}
+
+	public static void unsetAsContext() {
+		resetContextEnvironment();
 	}
 }

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/CollectionTestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/CollectionTestEnvironment.java
@@ -49,7 +49,7 @@ public class CollectionTestEnvironment extends CollectionEnvironment {
 		return result;
 	}
 
-	public void setAsContext() {
+	protected void setAsContext() {
 		ExecutionEnvironmentFactory factory = new ExecutionEnvironmentFactory() {
 			@Override
 			public ExecutionEnvironment createExecutionEnvironment() {
@@ -61,7 +61,7 @@ public class CollectionTestEnvironment extends CollectionEnvironment {
 		initializeContextEnvironment(factory);
 	}
 
-	public static void unsetAsContext() {
+	protected static void unsetAsContext() {
 		resetContextEnvironment();
 	}
 }

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/JavaProgramTestBase.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/JavaProgramTestBase.java
@@ -97,8 +97,9 @@ public abstract class JavaProgramTestBase extends AbstractTestBase {
 	@Test
 	public void testJobWithObjectReuse() throws Exception {
 		isCollectionExecution = false;
-		
+
 		startCluster();
+
 		try {
 			// pre-submit
 			try {
@@ -109,7 +110,7 @@ public abstract class JavaProgramTestBase extends AbstractTestBase {
 				e.printStackTrace();
 				Assert.fail("Pre-submit work caused an error: " + e.getMessage());
 			}
-			
+
 			// prepare the test environment
 			TestEnvironment env = new TestEnvironment(this.executor, this.parallelism, false);
 			env.getConfig().enableObjectReuse();
@@ -143,6 +144,7 @@ public abstract class JavaProgramTestBase extends AbstractTestBase {
 			}
 		} finally {
 			stopCluster();
+			TestEnvironment.unsetAsContext();
 		}
 	}
 
@@ -195,6 +197,7 @@ public abstract class JavaProgramTestBase extends AbstractTestBase {
 			}
 		} finally {
 			stopCluster();
+			TestEnvironment.unsetAsContext();
 		}
 	}
 	
@@ -231,6 +234,8 @@ public abstract class JavaProgramTestBase extends AbstractTestBase {
 			System.err.println(e.getMessage());
 			e.printStackTrace();
 			Assert.fail("Error while calling the test program: " + e.getMessage());
+		} finally {
+			env.unsetContext();
 		}
 		
 		Assert.assertNotNull("The test program never triggered an execution.", this.latestExecutionResult);

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/JavaProgramTestBase.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/JavaProgramTestBase.java
@@ -235,7 +235,7 @@ public abstract class JavaProgramTestBase extends AbstractTestBase {
 			e.printStackTrace();
 			Assert.fail("Error while calling the test program: " + e.getMessage());
 		} finally {
-			env.unsetContext();
+			CollectionTestEnvironment.unsetAsContext();
 		}
 		
 		Assert.assertNotNull("The test program never triggered an execution.", this.latestExecutionResult);

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MultipleProgramsTestBase.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MultipleProgramsTestBase.java
@@ -107,8 +107,15 @@ public class MultipleProgramsTestBase extends TestBaseUtils {
 
 	@After
 	public void teardownEnvironment() {
-		TestEnvironment.unsetAsContext();
-		CollectionTestEnvironment.unsetAsContext();
+		switch(mode) {
+			case CLUSTER:
+			case CLUSTER_OBJECT_REUSE:
+				TestEnvironment.unsetAsContext();
+				break;
+			case COLLECTION:
+				CollectionTestEnvironment.unsetAsContext();
+				break;
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MultipleProgramsTestBase.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MultipleProgramsTestBase.java
@@ -19,7 +19,9 @@
 package org.apache.flink.test.util;
 
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.runners.Parameterized;
 
@@ -82,7 +84,14 @@ public class MultipleProgramsTestBase extends TestBaseUtils {
 
 	public MultipleProgramsTestBase(TestExecutionMode mode) {
 		this.mode = mode;
+	}
 
+	// ------------------------------------------------------------------------
+	//  Environment setup & teardown
+	// ------------------------------------------------------------------------
+
+	@Before
+	public void setupEnvironment() {
 		switch(mode){
 			case CLUSTER:
 				new TestEnvironment(cluster, 4, false).setAsContext();
@@ -94,7 +103,12 @@ public class MultipleProgramsTestBase extends TestBaseUtils {
 				new CollectionTestEnvironment().setAsContext();
 				break;
 		}
+	}
 
+	@After
+	public void teardownEnvironment() {
+		TestEnvironment.unsetAsContext();
+		CollectionTestEnvironment.unsetAsContext();
 	}
 
 	// ------------------------------------------------------------------------
@@ -114,9 +128,6 @@ public class MultipleProgramsTestBase extends TestBaseUtils {
 	@AfterClass
 	public static void teardown() throws Exception {
 		stopCluster(cluster, TestBaseUtils.DEFAULT_TIMEOUT);
-
-		TestEnvironment.unsetAsContext();
-		CollectionTestEnvironment.unsetAsContext();
 	}
 	
 	// ------------------------------------------------------------------------

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MultipleProgramsTestBase.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MultipleProgramsTestBase.java
@@ -102,7 +102,7 @@ public class MultipleProgramsTestBase extends TestBaseUtils {
 	// ------------------------------------------------------------------------
 
 	@BeforeClass
-	public void setup() throws Exception {
+	public static void setup() throws Exception {
 		cluster = TestBaseUtils.startCluster(
 			1,
 			DEFAULT_PARALLELISM,
@@ -112,7 +112,7 @@ public class MultipleProgramsTestBase extends TestBaseUtils {
 	}
 
 	@AfterClass
-	public void teardown() throws Exception {
+	public static void teardown() throws Exception {
 		stopCluster(cluster, TestBaseUtils.DEFAULT_TIMEOUT);
 
 		TestEnvironment.unsetAsContext();

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MultipleProgramsTestBase.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MultipleProgramsTestBase.java
@@ -80,10 +80,9 @@ public class MultipleProgramsTestBase extends TestBaseUtils {
 	
 	protected final TestExecutionMode mode;
 
-	
 	public MultipleProgramsTestBase(TestExecutionMode mode) {
 		this.mode = mode;
-		
+
 		switch(mode){
 			case CLUSTER:
 				new TestEnvironment(cluster, 4, false).setAsContext();
@@ -95,6 +94,7 @@ public class MultipleProgramsTestBase extends TestBaseUtils {
 				new CollectionTestEnvironment().setAsContext();
 				break;
 		}
+
 	}
 
 	// ------------------------------------------------------------------------
@@ -102,7 +102,7 @@ public class MultipleProgramsTestBase extends TestBaseUtils {
 	// ------------------------------------------------------------------------
 
 	@BeforeClass
-	public static void setup() throws Exception {
+	public void setup() throws Exception {
 		cluster = TestBaseUtils.startCluster(
 			1,
 			DEFAULT_PARALLELISM,
@@ -112,8 +112,11 @@ public class MultipleProgramsTestBase extends TestBaseUtils {
 	}
 
 	@AfterClass
-	public static void teardown() throws Exception {
+	public void teardown() throws Exception {
 		stopCluster(cluster, TestBaseUtils.DEFAULT_TIMEOUT);
+
+		TestEnvironment.unsetAsContext();
+		CollectionTestEnvironment.unsetAsContext();
 	}
 	
 	// ------------------------------------------------------------------------

--- a/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/CustomDistributionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/CustomDistributionITCase.java
@@ -36,6 +36,7 @@ import org.apache.flink.test.util.TestEnvironment;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -68,6 +69,11 @@ public class CustomDistributionITCase extends TestLogger {
 	public void prepare() {
 		TestEnvironment clusterEnv = new TestEnvironment(cluster, 1, false);
 		clusterEnv.setAsContext();
+	}
+
+	@After
+	public void cleanup() {
+		TestEnvironment.unsetAsContext();
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
Reset ContextEnvironment when finished testing in MultipleProgramsTestBase.java and some other ITCases.
Remove some useless importing.
Add unsetContext method in TestEnvironment.java.