### PR TITLE
[FLINK-6428][table] Add support DISTINCT in dataStream SQL

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamDistinct.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamDistinct.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.nodes.datastream
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.table.api.StreamTableEnvironment
+import org.apache.flink.table.runtime.aggregate.DataStreamDistinctReduce
+import org.apache.flink.types.Row
+
+import scala.collection.JavaConverters._
+
+class DataStreamDistinct(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    input: RelNode,
+    rowRelDataType: RelDataType,
+    ruleDescription: String)
+  extends SingleRel(cluster, traitSet, input) with DataStreamRel {
+
+  override def deriveRowType() = rowRelDataType
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    new DataStreamDistinct(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      rowRelDataType,
+      ruleDescription
+    )
+  }
+
+  override def toString: String = {
+    s"Distinct(distinct: (${rowTypeToString(rowRelDataType)}))"
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    super.explainTerms(pw).item("distinct", rowTypeToString(rowRelDataType))
+  }
+
+  def rowTypeToString(rowType: RelDataType): String = {
+    rowType.getFieldList.asScala.map(_.getName).mkString(", ")
+  }
+
+  override def translateToPlan(tableEnv: StreamTableEnvironment): DataStream[Row] = {
+
+    val inputDS = getInput.asInstanceOf[DataStreamRel].translateToPlan(tableEnv)
+    val groupKeys = (0 until rowRelDataType.getFieldCount).toArray
+    // group on all fields
+    inputDS
+      .keyBy(groupKeys: _*)
+      .flatMap(new DataStreamDistinctReduce(inputDS.getType))
+      .name("distinct")
+      .returns(inputDS.getType)
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -175,6 +175,7 @@ object FlinkRuleSets {
     // translate to DataStream nodes
     DataStreamOverAggregateRule.INSTANCE,
     DataStreamAggregateRule.INSTANCE,
+    DataStreamDistinctRule.INSTANCE,
     DataStreamCalcRule.INSTANCE,
     DataStreamScanRule.INSTANCE,
     DataStreamUnionRule.INSTANCE,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamDistinctRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamDistinctRule.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.rules.datastream
+
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalAggregate
+import org.apache.flink.table.plan.nodes.datastream.DataStreamDistinct
+
+class DataStreamDistinctRule extends ConverterRule(
+    classOf[FlinkLogicalAggregate],
+    FlinkConventions.LOGICAL,
+    FlinkConventions.DATASTREAM,
+    "DataStreamDistinctRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val agg: FlinkLogicalAggregate = call.rel(0).asInstanceOf[FlinkLogicalAggregate]
+
+    // only accept distinct
+    agg.getAggCallList.isEmpty &&
+      agg.getGroupCount == agg.getRowType.getFieldCount &&
+      agg.getRowType.equals(agg.getInput.getRowType) &&
+      agg.getGroupSets.size() == 1
+  }
+
+  def convert(rel: RelNode): RelNode = {
+    val agg: FlinkLogicalAggregate = rel.asInstanceOf[FlinkLogicalAggregate]
+    val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.DATASTREAM)
+    val convInput: RelNode = RelOptRule.convert(agg.getInput, FlinkConventions.DATASTREAM)
+
+    new DataStreamDistinct(
+      rel.getCluster,
+      traitSet,
+      convInput,
+      agg.getRowType,
+      description)
+  }
+}
+
+object DataStreamDistinctRule {
+  val INSTANCE: RelOptRule = new DataStreamDistinctRule
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataStreamDistinctReduce.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataStreamDistinctReduce.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.runtime.aggregate
+
+import java.io.ByteArrayOutputStream
+import java.util
+
+import org.apache.flink.api.common.functions.RichFlatMapFunction
+import org.apache.flink.api.common.state.{MapState, MapStateDescriptor}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeutils.TypeSerializer
+import org.apache.flink.api.java.typeutils.runtime.RowSerializer
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper
+import org.apache.flink.types.Row
+import org.apache.flink.util.Collector
+
+/**
+  * Wrap input to rawBytes
+  */
+class HashWrapper(raw: Row, serializer: TypeSerializer[Row]) extends Serializable {
+  val rawBytes = raw match {
+    case row: Row =>
+      val baos: ByteArrayOutputStream = new ByteArrayOutputStream
+      val out: DataOutputViewStreamWrapper = new DataOutputViewStreamWrapper(baos)
+      serializer.asInstanceOf[RowSerializer].serialize(row, out)
+      baos.toByteArray
+    case _ =>
+      val baos: ByteArrayOutputStream = new ByteArrayOutputStream
+      val out: DataOutputViewStreamWrapper = new DataOutputViewStreamWrapper(baos)
+      serializer.serialize(raw, out)
+      baos.toByteArray
+  }
+
+  override def hashCode(): Int = util.Arrays.hashCode(rawBytes)
+
+  def canEqual(other: Any) = other.isInstanceOf[HashWrapper]
+
+  override def equals(other: Any) = other match {
+    case that: HashWrapper =>
+      that.canEqual(this) && util.Arrays.equals(this.rawBytes, that.rawBytes)
+    case _ => false
+  }
+}
+
+class DataStreamDistinctReduce(rowType: TypeInformation[Row])
+  extends RichFlatMapFunction[Row, Row] {
+  @transient var state: MapState[HashWrapper, Boolean] = null
+  @transient var serializer: TypeSerializer[Row] = null;
+  @transient var descriptor: MapStateDescriptor[HashWrapper, Boolean] = null
+
+
+  override def open(parameters: Configuration): Unit = {
+    serializer = rowType.createSerializer(getRuntimeContext.getExecutionConfig)
+    descriptor = new MapStateDescriptor("left", classOf[HashWrapper], classOf[Boolean])
+    state = getRuntimeContext.getMapState(descriptor)
+  }
+
+  override def flatMap(value: Row, out: Collector[Row]): Unit = {
+    val serializedValue = new HashWrapper(value, serializer)
+    if (!state.contains(serializedValue)) {
+      state.put(serializedValue, true)
+      out.collect(value)
+    }
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/sql/SelectDistinctTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/sql/SelectDistinctTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.api.scala.stream.sql
+
+import org.apache.flink.table.utils.TableTestUtil.{streamTableNode, term, unaryNode}
+import org.apache.flink.table.utils.TableTestBase
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.junit.Test
+
+class SelectDistinctTest extends TableTestBase {
+  @Test
+  def testLeftOuterJoin(): Unit = {
+    val util = streamTestUtil()
+    util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
+    val sqlQuery = "SELECT distinct a, b FROM MyTable"
+
+    val expected = unaryNode(
+      "DataStreamDistinct",
+      unaryNode(
+        "DataStreamCalc",
+        streamTableNode(0),
+        term("select", "a, b")
+      ),
+      term("distinct", "a, b")
+    )
+    util.verifySql(sqlQuery, expected)
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/datastream/SelectDistinctITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/datastream/SelectDistinctITCase.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.runtime.datastream
+
+import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.{TableEnvironment}
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.scala.stream.utils.{StreamITCase, StreamingWithStateTestBase}
+import org.apache.flink.types.Row
+import org.junit.Assert._
+import org.junit._
+
+import scala.collection.mutable
+
+class SelectDistinctITCase extends StreamingWithStateTestBase {
+  val data = List(
+    (1L, 1, "Hello"),
+    (2L, 2, "Hello"),
+    (3L, 3, "Hi"),
+    (4L, 2, "Hello"),
+    (5L, 3, "Hi"),
+    (6L, 1, "Hello"),
+    (7L, 7, "Hello World"),
+    (8L, 7, "Hello World"),
+    (20L, 7, "Hello World"))
+
+  @Test
+  def testSelectDistinctWithSingleField(): Unit = {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStateBackend(getStateBackend)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.testResults = mutable.MutableList()
+
+    val t1 = env.fromCollection(data).toTable(tEnv).as('a, 'b, 'c)
+
+    tEnv.registerTable("MyTable", t1)
+
+    val sqlQuery = "SELECT distinct c FROM MyTable"
+
+    val result = tEnv.sql(sqlQuery).toDataStream[Row]
+    result.addSink(new StreamITCase.StringSink)
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "Hello",
+      "Hello World",
+      "Hi")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testSelectDistinctWithMultiField(): Unit = {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStateBackend(getStateBackend)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.testResults = mutable.MutableList()
+
+    val t1 = env.fromCollection(data).toTable(tEnv).as('a, 'b, 'c)
+
+    tEnv.registerTable("MyTable", t1)
+
+    val sqlQuery = "SELECT distinct b, c FROM MyTable"
+
+    val result = tEnv.sql(sqlQuery).toDataStream[Row]
+    result.addSink(new StreamITCase.StringSink)
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "1,Hello",
+      "2,Hello",
+      "7,Hello World",
+      "3,Hi")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+}


### PR DESCRIPTION
With the changes of this PR. `DISTINCT` keyword can be supported `SELECT Clause`  of dataStream SQL.

In standard database there are two situations can using `DISTINCT` keyword.
* in `SELECT Clause`, e.g.: `SELECT DISTINCT name FROM table`
* in `AGG Clause`, e.g.: `COUNT([ALL|DISTINCT] expression)`,`SUM([ALL|DISTINCT] expression)`, etc.

In this JIRA. we talk about `SELECT Clause`. With the growing elements, the limitations tend to be back-end storage(flink state). In theory, external storage is infinitely large (user can control and expect), this point of view, the infinite STREAM of the DISTINCT can be supported.In addition, external storage, for example: RocksDB, the user can set the TTL according to the actual amount of business data to ensure that external storage is working properly.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-6428][table] Add support DISTINCT in dataStream SQL")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
