### PR TITLE
[FLINK-6381] [connector] Unnecessary synchronizing object in Bucketin…

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
@@ -724,9 +724,7 @@ public class BucketingSink<T>
 
 			handlePendingFilesForPreviousCheckpoints(bucketState.pendingFilesPerCheckpoint);
 
-			synchronized (bucketState.pendingFilesPerCheckpoint) {
-				bucketState.pendingFilesPerCheckpoint.clear();
-			}
+			bucketState.pendingFilesPerCheckpoint.clear();
 		}
 	}
 
@@ -741,9 +739,7 @@ public class BucketingSink<T>
 
 		handlePendingFilesForPreviousCheckpoints(restoredState.pendingFilesPerCheckpoint);
 
-		synchronized (restoredState.pendingFilesPerCheckpoint) {
-			restoredState.pendingFilesPerCheckpoint.clear();
-		}
+		restoredState.pendingFilesPerCheckpoint.clear();
 	}
 
 	private void handlePendingInProgressFile(String file, long validLength) {


### PR DESCRIPTION
Currently there are two places should not employ the synchronized to describe ```pendingFilesPerCheckpoint```, as it is only restored state object for checkpoint and no sharing of the data-structure between different threads