### PR TITLE
[FLINK-5742] allow docs sidebar nav to work below 1200px

### DIFF
--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -69,10 +69,10 @@ under the License.
       the _layouts directory goes here.
       {% endcomment %}
       <div class="row">
-        <div class="col-lg-3">
+        <div class="col-lg-3" id="sidenavcol">
           {% include sidenav.html %}
         </div>
-        <div class="col-lg-9 content">
+        <div class="col-lg-9 content" id="contentcol">
           {% if page.mathjax %}
           {% include latex_commands.html %}
           {% endif %}

--- a/docs/page/css/flink.css
+++ b/docs/page/css/flink.css
@@ -30,6 +30,11 @@ body {
 	background: #f8f8f8;
 }
 
+@media (min-width: 992px) and (max-width: 1200px) {
+    #contentcol { float: left; width: 70%; }
+    #sidenavcol { float: left; width: 30%; }
+}
+
 /*=============================================================================
  Per page TOC
 =============================================================================*/


### PR DESCRIPTION
The breakpoints for the docs move the content below the sidebar navigation for widths below 1200px, which is frequently annoying. Getting this down to 992px was relatively straightforward, but going much lower would require something of a redesign, in my opinion (the navigation is designed to be about 260px wide, and isn't easily shrunk).