### PR TITLE
[FLINK-6509] [tests] Perform TestingListener#waitForNewLeader under lock

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingListener.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingListener.java
@@ -51,11 +51,11 @@ public class TestingListener implements LeaderRetrievalListener {
 		long start = System.currentTimeMillis();
 		long curTimeout;
 
-		while (
+		synchronized (lock) {
+			while (
 				exception == null &&
-				(address == null || address.equals(oldAddress)) &&
-				(curTimeout = timeout - System.currentTimeMillis() + start) > 0) {
-			synchronized (lock) {
+					(address == null || address.equals(oldAddress)) &&
+					(curTimeout = timeout - System.currentTimeMillis() + start) > 0) {
 				try {
 					lock.wait(curTimeout);
 				} catch (InterruptedException e) {


### PR DESCRIPTION
Performin TestingListener#waitForNewLeader under the lock which is also hold when
updating the leader information makes sure that leader changes won't go unnoticed.
This led before to failing test cases due to timeouts.

cc @StefanRRichter.