### PR TITLE
[FLINK-5998] Fix shaded Hadoop Jar

### DIFF
--- a/flink-shaded-hadoop/pom.xml
+++ b/flink-shaded-hadoop/pom.xml
@@ -113,19 +113,7 @@ under the License.
 							</transformers>
 							<artifactSet>
 								<includes>
-									<include>com.google.guava:*</include>
-									<include>com.google.protobuf:*</include>
-									<include>com.google.code.findbugs:*</include>
-									<include>asm:asm</include>
-									<include>io.netty:netty:*</include>
-									<include>org.apache.curator:*</include>
-									<include>org.apache.hadoop:*</include>
-									<include>org.htrace:htrace-core</include>
-
-									<!-- This dependency needs to be included to properly get rid of the HTTP Components dependency -->
-									<include>net.java.dev.jets3t:jets3t</include>
-									<include>org.apache.httpcomponents:*</include>
-									<include>commons-httpclient:commons-httpclient</include>
+									<include>*:*</include>
 								</includes>
 							</artifactSet>
 							<relocations>


### PR DESCRIPTION
Now that flink-dist has the shaded hadoop jar as a provided dependency
we need to ensure that the shaded hadoop jar includes all the
dependencies that it needs because flink-dist does not include them
anymore in its shading.

The manifestation of this was that we couldn't start a cluster anymore
because of missing class files.

The upside of this PR is that we can run a cluster again. The downside is that we now have some dependencies both in the `flink-dist` jar and in the shaded Hadoop jar, i.e. total size increases.