### PR TITLE
[FLINK-6531] Deserialize checkpoint hooks with user classloader

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.java
@@ -134,7 +134,9 @@ public interface MasterTriggerRestoreHook<T> {
 
 		/**
 		 * Instantiates the {@code MasterTriggerRestoreHook}.
+		 *
+		 * @param userClassLoader User-code class loader associated with the job
 		 */
-		<V> MasterTriggerRestoreHook<V> create();
+		<V> MasterTriggerRestoreHook<V> create(ClassLoader userClassLoader);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -244,14 +244,18 @@ public class ExecutionGraphBuilder {
 			final MasterTriggerRestoreHook.Factory[] hookFactories = snapshotSettings.getMasterHooks();
 			final List<MasterTriggerRestoreHook<?>> hooks;
 
-			if (hookFactories == null || hookFactories.length == 0) {
-				hooks = Collections.emptyList();
-			}
-			else {
-				hooks = new ArrayList<>(hookFactories.length);
-				for (MasterTriggerRestoreHook.Factory factory : hookFactories) {
-					hooks.add(factory.create());
+			try {
+				if (hookFactories == null || hookFactories.length == 0) {
+					hooks = Collections.emptyList();
+				} else {
+					hooks = new ArrayList<>(hookFactories.length);
+					for (MasterTriggerRestoreHook.Factory factory : hookFactories) {
+						hooks.add(factory.create(classLoader));
+					}
 				}
+			}
+			catch(Exception e) {
+				throw new JobExecutionException(jobId, "Could not instantiate user-defined checkpoint hooks", e);
 			}
 
 			executionGraph.enableCheckpointing(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/WithMasterCheckpointHookConfigTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/WithMasterCheckpointHookConfigTest.java
@@ -84,7 +84,7 @@ public class WithMasterCheckpointHookConfigTest {
 
 		// check that all hooks are contained and exist exactly once
 		for (Factory f : jg.getCheckpointingSettings().getMasterHooks()) {
-			MasterTriggerRestoreHook<?> hook = f.create();
+			MasterTriggerRestoreHook<?> hook = f.create(Thread.currentThread().getContextClassLoader());
 			assertTrue(hooks.remove(hook));
 		}
 		assertTrue(hooks.isEmpty());


### PR DESCRIPTION
- enhance MasterTriggerRestoreHook.Factory::create to take user-code classloader
- deserialize WithMasterCheckpointHook instance with supplied classloader
- throw JobExecutionException when hook cannot be instantiated
