### PR TITLE
[FLINK-6560] [build] Restore maven parallelism in flink-tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,9 @@ under the License.
 			 forkCount is not exposed as a property. With this we can set
 			 it on the "mvn" commandline in travis. -->
 		<flink.forkCount>1C</flink.forkCount>
+		<!-- Allow overriding the fork behaviour for the expensive tests in flink-tests
+			 to avoid process kills due to container limits on TravisCI -->
+		<flink.forkCountTestPackage>${flink.forkCount}</flink.forkCountTestPackage>
 		<flink.reuseForks>true</flink.reuseForks>
 		<log4j.configuration>log4j-test.properties</log4j.configuration>
 		<guava.version>18.0</guava.version>


### PR DESCRIPTION
Configure a default value for Maven variable 'flink.forkCountTestPackage'.