### PR TITLE
[FLINK-6561] Disable glob test on Windows

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/io/GlobFilePathFilterTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/GlobFilePathFilterTest.java
@@ -19,6 +19,8 @@ package org.apache.flink.api.common.io;
 
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.util.OperatingSystem;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -110,6 +112,8 @@ public class GlobFilePathFilterTest {
 
 	@Test
 	public void testExcludeFilenameWithStart() {
+		Assume.assumeTrue("Windows does not allow asterisks in file names.", !OperatingSystem.isWindows());
+
 		GlobFilePathFilter matcher = new GlobFilePathFilter(
 			Collections.singletonList("**"),
 			Collections.singletonList("\\*"));


### PR DESCRIPTION
This PR disables a test case in the `GlobFilePathFilterTest`. The test verified that a file name containing asterisks `(*)` was properly filtered out; this however can't succeed on Windows since asterisks aren't allowed in file names in the first place. The creation of a nio path for such a file name throws an exception.