### PR TITLE
FLINK-6284 Incorrect sorting of completed checkpoints in ZooKeeperCompletedCheckpointStore

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -182,7 +182,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-test</artifactId>
-			<version>${curator.version}</version>
+			<version>${curator-test.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -346,11 +346,7 @@ public class ZooKeeperStateHandleStore<T extends Serializable> {
 			} else {
 				// Initial cVersion (number of changes to the children of this node)
 				int initialCVersion = stat.getCversion();
-
-				List<String> children = ZKPaths.getSortedChildren(
-						client.getZookeeperClient().getZooKeeper(),
-						ZKPaths.fixForNamespace(client.getNamespace(), "/"));
-
+				List<String> children = client.getZookeeperClient().getZooKeeper().getChildren(ZKPaths.fixForNamespace(client.getNamespace(), "/"), false);
 				for (String path : children) {
 					path = "/" + path;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -352,7 +352,9 @@ public class ZooKeeperStateHandleStore<T extends Serializable> {
 				for(String child : children) {
 					String childPath = "/" + child;
 					Stat childStat = client.checkExists().forPath(childPath);
-					czxIds.put(childStat.getCzxid(), childPath);
+					if(childStat != null) {
+						czxIds.put(childStat.getCzxid(), childPath);
+					}
 				}
 				for(Map.Entry<Long, String> entry : czxIds.entrySet()) {
 					String pathStr = entry.getValue();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -353,6 +353,7 @@ public class ZooKeeperStateHandleStore<T extends Serializable> {
 				for(String childNode : childrenInStr) {
 					children.add(new Long(childNode));
 				}
+				Collections.sort(children);
 				for (Long path : children) {
 					String pathStr = path.toString();
 					pathStr = "/" + pathStr;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -346,13 +346,20 @@ public class ZooKeeperStateHandleStore<T extends Serializable> {
 			} else {
 				// Initial cVersion (number of changes to the children of this node)
 				int initialCVersion = stat.getCversion();
-				List<String> children = client.getZookeeperClient().getZooKeeper().getChildren(ZKPaths.fixForNamespace(client.getNamespace(), "/"), false);
-				for (String path : children) {
-					path = "/" + path;
+				List<String> childrenInStr =
+					client.getZookeeperClient().getZooKeeper().
+						getChildren(ZKPaths.fixForNamespace(client.getNamespace(), "/"), false);
+				List<Long> children = new ArrayList<Long>(childrenInStr.size());
+				for(String childNode : childrenInStr) {
+					children.add(new Long(childNode));
+				}
+				for (Long path : children) {
+					String pathStr = path.toString();
+					pathStr = "/" + pathStr;
 
 					try {
-						final RetrievableStateHandle<T> stateHandle = get(path);
-						stateHandles.add(new Tuple2<>(stateHandle, path));
+						final RetrievableStateHandle<T> stateHandle = get(pathStr);
+						stateHandles.add(new Tuple2<>(stateHandle, pathStr));
 					} catch (KeeperException.NoNodeException ignored) {
 						// Concurrent deletion, retry
 						continue retry;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -82,7 +82,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 		AbstractCompletedCheckpointStore checkpoints = createCompletedCheckpoints(3);
 
 		TestCompletedCheckpoint[] expected = new TestCompletedCheckpoint[] {
-				createCheckpoint(99), createCheckpoint(100), createCheckpoint(101)
+				createCheckpoint(101), createCheckpoint(99), createCheckpoint(100)
 		};
 
 		// Add multiple checkpoints

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -82,7 +82,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 		AbstractCompletedCheckpointStore checkpoints = createCompletedCheckpoints(3);
 
 		TestCompletedCheckpoint[] expected = new TestCompletedCheckpoint[] {
-				createCheckpoint(0), createCheckpoint(1), createCheckpoint(2)
+				createCheckpoint(99), createCheckpoint(100), createCheckpoint(101)
 		};
 
 		// Add multiple checkpoints

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,8 @@ under the License.
 		<chill.version>0.7.4</chill.version>
 		<asm.version>5.0.4</asm.version>
 		<zookeeper.version>3.4.6</zookeeper.version>
-		<curator.version>2.12.0</curator.version>
+		<curator.version>2.11.0</curator.version>
+				<curator-test.version>2.12.0</curator-test.version>
 		<jackson.version>2.7.4</jackson.version>
 		<metrics.version>3.1.0</metrics.version>
 		<junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,7 @@ under the License.
 		<chill.version>0.7.4</chill.version>
 		<asm.version>5.0.4</asm.version>
 		<zookeeper.version>3.4.6</zookeeper.version>
-		<curator.version>2.11.0</curator.version>
-				<curator-test.version>2.12.0</curator-test.version>
+		<curator.version>2.12.0</curator.version>
 		<jackson.version>2.7.4</jackson.version>
 		<metrics.version>3.1.0</metrics.version>
 		<junit.version>4.12</junit.version>


### PR DESCRIPTION
ZooKeeperCompletedCheckpointStore

Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [ ] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed


Making use of the Zookeeper's getChildren() API directly so that it just creates a list in the sequence order. If we go with the ZKPaths API then we need to do some sorting by converting the List<STring> to List<Long>.