### PR TITLE
[FLINK-6569] flink-table KafkaJsonTableSource example doesn't work.

### DIFF
--- a/docs/dev/table_api.md
+++ b/docs/dev/table_api.md
@@ -231,9 +231,9 @@ You can then create the source as follows (example for Kafka 0.8):
 <div data-lang="java" markdown="1">
 {% highlight java %}
 // specify JSON field names and types
-TypeInformation<Row> typeInfo = Types.ROW(
+TypeInformation<Row> typeInfo = Types.ROW_NAMED(
   new String[] { "id", "name", "score" },
-  new TypeInformation<?>[] { Types.INT(), Types.STRING(), Types.DOUBLE() }
+  Types.INT, Types.STRING, Types.DOUBLE
 );
 
 KafkaJsonTableSource kafkaTableSource = new Kafka08JsonTableSource(

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/JsonRowDeserializationSchemaTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/JsonRowDeserializationSchemaTest.java
@@ -20,10 +20,10 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.table.api.Types;
-import org.apache.flink.types.Row;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
 import org.apache.flink.streaming.util.serialization.JsonRowDeserializationSchema;
+import org.apache.flink.types.Row;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -58,10 +58,9 @@ public class JsonRowDeserializationSchemaTest {
 		byte[] serializedJson = objectMapper.writeValueAsBytes(root);
 
 		JsonRowDeserializationSchema deserializationSchema = new JsonRowDeserializationSchema(
-			Types.ROW(
+			Types.ROW_NAMED(
 				new String[] { "id", "name", "bytes" },
-				new TypeInformation<?>[] { Types.LONG(), Types.STRING(), Types.PRIMITIVE_ARRAY(Types.BYTE()) }
-			)
+				Types.LONG, Types.STRING, ObjectArrayTypeInfo.getInfoFor(Types.BYTE))
 		);
 
 		Row deserialized = deserializationSchema.deserialize(serializedJson);
@@ -85,9 +84,9 @@ public class JsonRowDeserializationSchemaTest {
 		byte[] serializedJson = objectMapper.writeValueAsBytes(root);
 
 		JsonRowDeserializationSchema deserializationSchema = new JsonRowDeserializationSchema(
-			Types.ROW(
+			Types.ROW_NAMED(
 				new String[] { "name" },
-				new TypeInformation<?>[] { Types.STRING() }
+				Types.STRING
 			)
 		);
 
@@ -113,9 +112,9 @@ public class JsonRowDeserializationSchemaTest {
 	public void testNumberOfFieldNamesAndTypesMismatch() throws Exception {
 		try {
 			new JsonRowDeserializationSchema(
-				Types.ROW(
+				Types.ROW_NAMED(
 					new String[] { "one", "two", "three" },
-					new TypeInformation<?>[] { Types.LONG() }
+					Types.LONG
 				)
 			);
 			fail("Did not throw expected Exception");


### PR DESCRIPTION
This PR makes the proposed changes on the document and changes the Java unit tests to reflect the suggested usages of the API.