### PR TITLE
[FLINK-6541] Improve tmp dir setup in TM/WebMonitor

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -174,7 +174,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 			// create storage for uploads
 			this.uploadDir = getUploadDir(config);
 			// the upload directory should either 1. exist and writable or 2. can be created and writable
-			if (!(uploadDir.exists() && uploadDir.canWrite()) && !(uploadDir.mkdir() && uploadDir.canWrite())) {
+			if (!(uploadDir.exists() && uploadDir.canWrite()) && !(uploadDir.mkdirs() && uploadDir.canWrite())) {
 				throw new IOException(
 					String.format("Jar upload directory %s cannot be created or is not writable.",
 						uploadDir.getAbsolutePath()));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -603,11 +603,11 @@ public class TaskManagerServices {
 	}
 
 	/**
-	 * Validates that all the directories denoted by the strings do actually exist, are proper
+	 * Validates that all the directories denoted by the strings do actually exist or can be created, are proper
 	 * directories (not files), and are writable.
 	 *
 	 * @param tmpDirs The array of directory paths to check.
-	 * @throws IOException Thrown if any of the directories does not exist or is not writable
+	 * @throws IOException Thrown if any of the directories does not exist and cannot be created or is not writable
 	 *                     or is a file, rather than a directory.
 	 */
 	private static void checkTempDirs(String[] tmpDirs) throws IOException {
@@ -615,7 +615,9 @@ public class TaskManagerServices {
 			if (dir != null && !dir.equals("")) {
 				File file = new File(dir);
 				if (!file.exists()) {
-					throw new IOException("Temporary file directory " + file.getAbsolutePath() + " does not exist.");
+					if (!file.mkdirs()) {
+						throw new IOException("Temporary file directory " + file.getAbsolutePath() + " does not exist and could not be created.");
+					}
 				}
 				if (!file.isDirectory()) {
 					throw new IOException("Temporary file directory " + file.getAbsolutePath() + " is not a directory.");


### PR DESCRIPTION
This PR contains 2 changes related to temporary directories.

1. The `WebRuntimeMonitor` now uses `mkdirs` instead of `mkdir`
2. The `TaskManagerServices` now create the temporary directory if it doesn't already exist.