### PR TITLE
[FLINK-6370] [webUI] Handle races for single file in FileServerHandler

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/files/StaticFileServerHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/files/StaticFileServerHandler.java
@@ -66,6 +66,7 @@ import java.io.RandomAccessFile;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -110,6 +111,8 @@ public class StaticFileServerHandler extends SimpleChannelInboundHandler<Routed>
 
 	/** Be default, we allow files to be cached for 5 minutes */
 	private static final int HTTP_CACHE_SECONDS = 300;
+
+	private static final Object COPY_LOCK = new Object();
 
 	// ------------------------------------------------------------------------
 
@@ -234,8 +237,17 @@ public class StaticFileServerHandler extends SimpleChannelInboundHandler<Routed>
 							if (!rootURI.relativize(requestedURI).equals(requestedURI)) {
 								logger.debug("Loading missing file from classloader: {}", requestPath);
 								// ensure that directory to file exists.
-								file.getParentFile().mkdirs();
-								Files.copy(resourceStream, file.toPath());
+								if (!file.getParentFile().mkdirs()) {
+									throw new IOException("Could not create directories for file " + file);
+								}
+								synchronized (COPY_LOCK) {
+									// prevent races between requests trying to write to the same file
+									try {
+										Files.copy(resourceStream, file.toPath());
+									} catch (FileAlreadyExistsException ignored) {
+										// a concurrent request may have created the file already
+									}
+								}
 
 								success = true;
 							}


### PR DESCRIPTION
This PR prevents a race between multiple requests trying to create the same file, which previously would cause one request to fail.

We can't just ignore the `FileAlreadyExistsException` since there's no guarantee that the file copying is complete. To prevent this scenario the copying is now done in a `synchronized` block, along with ignoring the `FileAlreadyExistsExceptions`.

Due to the small size of files loaded from the class-loader this should have no impact on the responsiveness of the webUI.