### PR TITLE
[FLINK-6557] Fix RocksDBKeyedStateBackend on Windows

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -831,7 +831,9 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			}
 
 			// save state data
-			backupPath = new Path(stateBackend.instanceBasePath.getAbsolutePath(), "chk-" + checkpointId);
+			File backupFile = new File(stateBackend.instanceBasePath, "chk-" + checkpointId);
+			String absoluteBackupPath = backupFile.getAbsolutePath();
+			backupPath = new Path(absoluteBackupPath);
 			backupFileSystem = backupPath.getFileSystem();
 			if (backupFileSystem.exists(backupPath)) {
 				throw new IllegalStateException("Unexpected existence of the backup directory.");
@@ -839,7 +841,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 			// create hard links of living files in the checkpoint path
 			Checkpoint checkpoint = Checkpoint.create(stateBackend.db);
-			checkpoint.createCheckpoint(backupPath.getPath());
+			checkpoint.createCheckpoint(absoluteBackupPath);
 		}
 
 		KeyedStateHandle materializeSnapshot() throws Exception {
@@ -1255,9 +1257,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				boolean hasExtraKeys) throws Exception {
 
 			// read state data
-			Path restoreInstancePath = new Path(
-				stateBackend.instanceBasePath.getAbsolutePath(),
-				UUID.randomUUID().toString());
+			String restoreInstancePathString =  new File(stateBackend.instanceBasePath, UUID.randomUUID().toString()).getAbsolutePath();
+			Path restoreInstancePath = new Path(restoreInstancePathString);
 
 			try {
 				Map<String, StreamStateHandle> newSstFiles = restoreStateHandle.getNewSstFiles();
@@ -1307,7 +1308,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 					List<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>();
 
 					try (RocksDB restoreDb = stateBackend.openDB(
-							restoreInstancePath.getPath(),
+							restoreInstancePathString,
 							columnFamilyDescriptors,
 							columnFamilyHandles)) {
 


### PR DESCRIPTION
This PR fixes the `RocksDBKeyedStateBackend` on Windows. The backend was passing file paths generated from a Flink `Path` directly to RocksDB, and by extension to the native file system.

Besides the actual problem being caused this was questionable anyway since the starting point for all this is actually a `File` (`stateBackend.instanceBasePath`). It is first converted to a String, then to a Path, then to a String again before passing it to RocksDB. We were just roller coasting through the abstraction layers.