### PR TITLE
[FLINK-6580] Sync default heap sizes from code with config file

### DIFF
--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -39,12 +39,12 @@ jobmanager.rpc.port: 6123
 
 # The heap size for the JobManager JVM
 
-jobmanager.heap.mb: 256
+jobmanager.heap.mb: 1024
 
 
 # The heap size for the TaskManager JVM
 
-taskmanager.heap.mb: 512
+taskmanager.heap.mb: 1024
 
 
 # The number of task slots that each TaskManager offers. Each slot runs one parallel pipeline.


### PR DESCRIPTION
Flink didn't start on YARN anymore without explicit configuration of JM and TM heap because the default heap sizes in the yaml file were set too low.
This PR increases the default heap sizes according to the `TaskManagerOptions` and `JobManagerOptions` classes.