### PR TITLE
[FLINK-6581] [cli] Correct dynamic property parsing for YARN cli

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -68,7 +68,8 @@ public class FlinkYarnSessionCliTest {
 		CommandLineParser parser = new DefaultParser();
 		CommandLine cmd = null;
 		try {
-			cmd = parser.parse(options, new String[]{"run", "-j", "fake.jar", "-n", "15", "-D", "akka.ask.timeout=5 min"});
+			cmd = parser.parse(options, new String[]{"run", "-j", "fake.jar", "-n", "15",
+				"-D", "akka.ask.timeout=5 min", "-D", "env.java.opts=-DappName=foobar"});
 		} catch(Exception e) {
 			e.printStackTrace();
 			Assert.fail("Parsing failed with " + e.getMessage());
@@ -80,8 +81,9 @@ public class FlinkYarnSessionCliTest {
 
 		Map<String, String> dynProperties =
 			FlinkYarnSessionCli.getDynamicProperties(flinkYarnDescriptor.getDynamicPropertiesEncoded());
-		Assert.assertEquals(1, dynProperties.size());
+		Assert.assertEquals(2, dynProperties.size());
 		Assert.assertEquals("5 min", dynProperties.get("akka.ask.timeout"));
+		Assert.assertEquals("-DappName=foobar", dynProperties.get("env.java.opts"));
 	}
 
 	@Test

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -708,7 +708,7 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 					String key = propLine.substring(0, firstEquals).trim();
 					String value = propLine.substring(firstEquals + 1, propLine.length()).trim();
 
-					if (!key.isEmpty() && !value.isEmpty()) {
+					if (!key.isEmpty()) {
 						properties.put(key, value);
 					}
 				}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -702,9 +702,15 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 					continue;
 				}
 
-				String[] kv = propLine.split("=");
-				if (kv.length >= 2 && kv[0] != null && kv[1] != null && kv[0].length() > 0) {
-					properties.put(kv[0], kv[1]);
+				int firstEquals = propLine.indexOf("=");
+
+				if (firstEquals >= 0) {
+					String key = propLine.substring(0, firstEquals).trim();
+					String value = propLine.substring(firstEquals + 1, propLine.length()).trim();
+
+					if (!key.isEmpty() && !value.isEmpty()) {
+						properties.put(key, value);
+					}
 				}
 			}
 			return properties;


### PR DESCRIPTION
The YARN cli will now split the dynamic propertie at the first occurrence of
the = sign instead of splitting it at every = sign. That way we support dynamic
properties of the form -yDenv.java.opts="-DappName=foobar".
