### PR TITLE
[FLINK-6416] Fix divide-by-zero in InputGateMetrics

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateMetrics.java
@@ -130,7 +130,7 @@ public class InputGateMetrics {
 			}
 		}
 
-		return total / (float) count;
+		return count == 0 ? 0 : total / (float) count;
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
Should be merged for 1.3 and 1.4.