### PR TITLE
[FLINK-6582] [docs] Project from maven archetype is not buildable by default

### DIFF
--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@ under the License.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
+
 	<groupId>${groupId}</groupId>
 	<artifactId>${artifactId}</artifactId>
 	<version>${version}</version>
@@ -33,6 +33,8 @@ under the License.
 		<flink.version>1.4-SNAPSHOT</flink.version>
 		<slf4j.version>1.7.7</slf4j.version>
 		<log4j.version>1.2.17</log4j.version>
+		<scala.version>2.11.11</scala.version>
+		<scala.binary.version>2.11</scala.binary.version>
 	</properties>
 
 	<repositories>
@@ -48,9 +50,9 @@ under the License.
 			</snapshots>
 		</repository>
 	</repositories>
-	
+
 	<!-- 
-		
+
 		Execute "mvn clean package -Pbuild-jar"
 		to build a jar file out of this project!
 
@@ -103,7 +105,6 @@ under the License.
 			<artifactId>log4j</artifactId>
 			<version>${log4j.version}</version>
 		</dependency>
-		
 	</dependencies>
 
 	<profiles>
@@ -312,8 +313,7 @@ under the License.
 				</configuration>
 			</plugin>
 		</plugins>
-		
-			
+
 		<!-- If you want to use Java 8 Lambda Expressions uncomment the following lines -->
 		<!--
 		<pluginManagement>
@@ -333,7 +333,7 @@ under the License.
 						</dependency>
 					</dependencies>
 				</plugin>
-		
+
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
 					<artifactId>lifecycle-mapping</artifactId>
@@ -375,6 +375,5 @@ under the License.
 			</plugins>
 		</pluginManagement>
 		-->
-		
 	</build>
 </project>

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -33,7 +33,7 @@ under the License.
 		<flink.version>1.4-SNAPSHOT</flink.version>
 		<slf4j.version>1.7.7</slf4j.version>
 		<log4j.version>1.2.17</log4j.version>
-		<scala.binary.version>${scala.binary.version}</scala.binary.version>
+		<scala.binary.version>@scala.binary.version@</scala.binary.version>
 	</properties>
 
 	<repositories>
@@ -83,12 +83,12 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-java_\${scala.binary.version}</artifactId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-clients_\${scala.binary.version}</artifactId>
+			<artifactId>flink-clients_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
 
@@ -124,13 +124,13 @@ under the License.
 				</dependency>
 				<dependency>
 					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-streaming-java_\${scala.binary.version}</artifactId>
+					<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
 				</dependency>
 				<dependency>
 					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-clients_\${scala.binary.version}</artifactId>
+					<artifactId>flink-clients_${scala.binary.version}</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
 				</dependency>
@@ -201,20 +201,20 @@ under the License.
 									<exclude>org.apache.flink:flink-shaded-curator-recipes</exclude>
 									<exclude>org.apache.flink:flink-core</exclude>
 									<exclude>org.apache.flink:flink-java</exclude>
-									<exclude>org.apache.flink:flink-scala_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-runtime_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-optimizer_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-clients_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-avro_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-examples-batch_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-examples-streaming_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-streaming-java_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-streaming-scala_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-scala-shell_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-scala_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-runtime_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-optimizer_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-clients_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-avro_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-examples-batch_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-examples-streaming_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-streaming-java_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-streaming-scala_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-scala-shell_${scala.binary.version}</exclude>
 									<exclude>org.apache.flink:flink-python</exclude>
 									<exclude>org.apache.flink:flink-metrics-core</exclude>
 									<exclude>org.apache.flink:flink-metrics-jmx</exclude>
-									<exclude>org.apache.flink:flink-statebackend-rocksdb_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-statebackend-rocksdb_${scala.binary.version}</exclude>
 
 									<!-- Also exclude very big transitive dependencies of Flink
 

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -33,8 +33,7 @@ under the License.
 		<flink.version>1.4-SNAPSHOT</flink.version>
 		<slf4j.version>1.7.7</slf4j.version>
 		<log4j.version>1.2.17</log4j.version>
-		<scala.version>2.11.11</scala.version>
-		<scala.binary.version>2.11</scala.binary.version>
+		<scala.binary.version>${scala.binary.version}</scala.binary.version>
 	</properties>
 
 	<repositories>
@@ -84,12 +83,12 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<artifactId>flink-streaming-java_\${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-clients_${scala.binary.version}</artifactId>
+			<artifactId>flink-clients_\${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
 
@@ -125,13 +124,13 @@ under the License.
 				</dependency>
 				<dependency>
 					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+					<artifactId>flink-streaming-java_\${scala.binary.version}</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
 				</dependency>
 				<dependency>
 					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-clients_${scala.binary.version}</artifactId>
+					<artifactId>flink-clients_\${scala.binary.version}</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
 				</dependency>
@@ -202,20 +201,20 @@ under the License.
 									<exclude>org.apache.flink:flink-shaded-curator-recipes</exclude>
 									<exclude>org.apache.flink:flink-core</exclude>
 									<exclude>org.apache.flink:flink-java</exclude>
-									<exclude>org.apache.flink:flink-scala_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-runtime_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-optimizer_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-clients_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-avro_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-examples-batch_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-examples-streaming_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-streaming-java_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-streaming-scala_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-scala-shell_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-scala_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-runtime_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-optimizer_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-clients_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-avro_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-examples-batch_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-examples-streaming_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-streaming-java_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-streaming-scala_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-scala-shell_\${scala.binary.version}</exclude>
 									<exclude>org.apache.flink:flink-python</exclude>
 									<exclude>org.apache.flink:flink-metrics-core</exclude>
 									<exclude>org.apache.flink:flink-metrics-jmx</exclude>
-									<exclude>org.apache.flink:flink-statebackend-rocksdb_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-statebackend-rocksdb_\${scala.binary.version}</exclude>
 
 									<!-- Also exclude very big transitive dependencies of Flink
 

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -48,10 +48,12 @@ under the License.
 		<flink.version>1.4-SNAPSHOT</flink.version>
 		<slf4j.version>1.7.7</slf4j.version>
 		<log4j.version>1.2.17</log4j.version>
+		<scala.version>2.11.11</scala.version>
+		<scala.binary.version>2.11</scala.binary.version>
 	</properties>
 
 	<!-- 
-		
+
 		Execute "mvn clean package -Pbuild-jar"
 		to build a jar file out of this project!
 
@@ -91,7 +93,7 @@ under the License.
 			<artifactId>flink-clients_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
-		
+
 		<!-- explicitly add a standard loggin framework, as Flink does not have
 			a hard dependency on one specific framework by default -->
 		<dependency>

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -48,8 +48,7 @@ under the License.
 		<flink.version>1.4-SNAPSHOT</flink.version>
 		<slf4j.version>1.7.7</slf4j.version>
 		<log4j.version>1.2.17</log4j.version>
-		<scala.version>2.11.11</scala.version>
-		<scala.binary.version>2.11</scala.binary.version>
+		<scala.binary.version>${scala.binary.version}</scala.binary.version>
 	</properties>
 
 	<!-- 
@@ -80,17 +79,17 @@ under the License.
 		<!-- Apache Flink dependencies -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-scala_${scala.binary.version}</artifactId>
+			<artifactId>flink-scala_\${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
+			<artifactId>flink-streaming-scala_\${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-clients_${scala.binary.version}</artifactId>
+			<artifactId>flink-clients_\${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
 
@@ -118,19 +117,19 @@ under the License.
 			<dependencies>
 				<dependency>
 					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-scala_${scala.binary.version}</artifactId>
+					<artifactId>flink-scala_\${scala.binary.version}</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
 				</dependency>
 				<dependency>
 					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
+					<artifactId>flink-streaming-scala_\${scala.binary.version}</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
 				</dependency>
 				<dependency>
 					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-clients_${scala.binary.version}</artifactId>
+					<artifactId>flink-clients_\${scala.binary.version}</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
 				</dependency>
@@ -204,20 +203,20 @@ under the License.
 									<exclude>org.apache.flink:flink-shaded-curator-recipes</exclude>
 									<exclude>org.apache.flink:flink-core</exclude>
 									<exclude>org.apache.flink:flink-java</exclude>
-									<exclude>org.apache.flink:flink-scala_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-runtime_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-optimizer_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-clients_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-avro_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-examples-batch_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-examples-streaming_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-streaming-java_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-streaming-scala_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-scala-shell_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-scala_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-runtime_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-optimizer_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-clients_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-avro_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-examples-batch_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-examples-streaming_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-streaming-java_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-streaming-scala_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-scala-shell_\${scala.binary.version}</exclude>
 									<exclude>org.apache.flink:flink-python</exclude>
 									<exclude>org.apache.flink:flink-metrics-core</exclude>
 									<exclude>org.apache.flink:flink-metrics-jmx</exclude>
-									<exclude>org.apache.flink:flink-statebackend-rocksdb_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-statebackend-rocksdb_\${scala.binary.version}</exclude>
 
 									<!-- Also exclude very big transitive dependencies of Flink
 

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -48,7 +48,7 @@ under the License.
 		<flink.version>1.4-SNAPSHOT</flink.version>
 		<slf4j.version>1.7.7</slf4j.version>
 		<log4j.version>1.2.17</log4j.version>
-		<scala.binary.version>${scala.binary.version}</scala.binary.version>
+		<scala.binary.version>@scala.binary.version@</scala.binary.version>
 	</properties>
 
 	<!-- 
@@ -79,17 +79,17 @@ under the License.
 		<!-- Apache Flink dependencies -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-scala_\${scala.binary.version}</artifactId>
+			<artifactId>flink-scala_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-scala_\${scala.binary.version}</artifactId>
+			<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-clients_\${scala.binary.version}</artifactId>
+			<artifactId>flink-clients_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
 
@@ -117,19 +117,19 @@ under the License.
 			<dependencies>
 				<dependency>
 					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-scala_\${scala.binary.version}</artifactId>
+					<artifactId>flink-scala_${scala.binary.version}</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
 				</dependency>
 				<dependency>
 					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-streaming-scala_\${scala.binary.version}</artifactId>
+					<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
 				</dependency>
 				<dependency>
 					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-clients_\${scala.binary.version}</artifactId>
+					<artifactId>flink-clients_${scala.binary.version}</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
 				</dependency>
@@ -203,20 +203,20 @@ under the License.
 									<exclude>org.apache.flink:flink-shaded-curator-recipes</exclude>
 									<exclude>org.apache.flink:flink-core</exclude>
 									<exclude>org.apache.flink:flink-java</exclude>
-									<exclude>org.apache.flink:flink-scala_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-runtime_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-optimizer_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-clients_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-avro_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-examples-batch_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-examples-streaming_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-streaming-java_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-streaming-scala_\${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-scala-shell_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-scala_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-runtime_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-optimizer_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-clients_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-avro_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-examples-batch_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-examples-streaming_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-streaming-java_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-streaming-scala_${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-scala-shell_${scala.binary.version}</exclude>
 									<exclude>org.apache.flink:flink-python</exclude>
 									<exclude>org.apache.flink:flink-metrics-core</exclude>
 									<exclude>org.apache.flink:flink-metrics-jmx</exclude>
-									<exclude>org.apache.flink:flink-statebackend-rocksdb_\${scala.binary.version}</exclude>
+									<exclude>org.apache.flink:flink-statebackend-rocksdb_${scala.binary.version}</exclude>
 
 									<!-- Also exclude very big transitive dependencies of Flink
 

--- a/flink-quickstart/pom.xml
+++ b/flink-quickstart/pom.xml
@@ -92,7 +92,7 @@ under the License.
 		</plugins>
 		<resources>
 			<resource>
-				<directory>src/main/resources/archetype-resources</directory>
+				<directory>src/main/resources</directory>
 				<filtering>true</filtering>
 			</resource>
 		</resources>

--- a/flink-quickstart/pom.xml
+++ b/flink-quickstart/pom.xml
@@ -80,6 +80,21 @@ under the License.
 					<skip>true</skip>
 				</configuration>
 			</plugin>
+
+			<!-- enable the escape string for filtering resources -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<configuration>
+					<escapeString>\</escapeString>
+				</configuration>
+			</plugin>
 		</plugins>
+		<resources>
+			<resource>
+				<directory>src/main/resources/archetype-resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 	</build>
 </project>

--- a/flink-quickstart/pom.xml
+++ b/flink-quickstart/pom.xml
@@ -81,12 +81,15 @@ under the License.
 				</configuration>
 			</plugin>
 
-			<!-- enable the escape string for filtering resources -->
+			<!-- use alternative delimiter for filtering resources -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
 				<configuration>
-					<escapeString>\</escapeString>
+					<useDefaultDelimiters>false</useDefaultDelimiters>
+					<delimiters>
+						<delimiter>@</delimiter>
+					</delimiters>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
The pom.xml for flink-quickstart-java and flink-quickstart-scala must specify scala.version and scala.binary.version.