### PR TITLE
[FLINK-6589] [core] Deserialize ArrayList with capacity of size+1 to prevent growth.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializer.java
@@ -82,7 +82,7 @@ public final class ListSerializer<T> extends TypeSerializer<List<T>> {
 	@Override
 	public TypeSerializer<List<T>> duplicate() {
 		TypeSerializer<T> duplicateElement = elementSerializer.duplicate();
-		return duplicateElement == elementSerializer ? this : new ListSerializer<T>(duplicateElement);
+		return duplicateElement == elementSerializer ? this : new ListSerializer<>(duplicateElement);
 	}
 
 	@Override
@@ -129,7 +129,8 @@ public final class ListSerializer<T> extends TypeSerializer<List<T>> {
 	@Override
 	public List<T> deserialize(DataInputView source) throws IOException {
 		final int size = source.readInt();
-		final List<T> list = new ArrayList<>(size);
+		// create new list with (size + 1) capacity to prevent expensive growth when a single element is added
+		final List<T> list = new ArrayList<>(size + 1);
 		for (int i = 0; i < size; i++) {
 			list.add(elementSerializer.deserialize(source));
 		}


### PR DESCRIPTION
Several Table API / SQL operators hold records in a `MapState[Long, List[X]]` keyed on a timestamp.
When a new record arrives, the corresponding list is fetched and the record is added to the list. 

Currently, the `ListSerializer` deserializes lists as `ArrayList` with capacity exactly equal to the number of serialized elements. Hence, the `ArrayList` will grow when a new element is added which is an expensive operation.

This PR changes the capacity of the deserialized `ArrayList` to #elements + 1 to avoid the growing the list when a single element is added.