### PR TITLE
[FLINK-6598][table]Remove useless param rowRelDataType of DataStreamGroupAggregate

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupAggregate.scala
@@ -43,7 +43,6 @@ import org.slf4j.LoggerFactory
   * @param traitSet        Trait set of the RelNode
   * @param inputNode       The input RelNode of aggregation
   * @param namedAggregates List of calls to aggregate functions and their output field names
-  * @param rowRelDataType  The type of the rows of the RelNode
   * @param inputSchema     The type of the rows consumed by this RelNode
   * @param schema          The type of the rows emitted by this RelNode
   * @param groupings       The position (in the input Row) of the grouping keys
@@ -53,7 +52,6 @@ class DataStreamGroupAggregate(
     traitSet: RelTraitSet,
     inputNode: RelNode,
     namedAggregates: Seq[CalcitePair[AggregateCall, String]],
-    rowRelDataType: RelDataType,
     schema: RowSchema,
     inputSchema: RowSchema,
     groupings: Array[Int])
@@ -79,7 +77,6 @@ class DataStreamGroupAggregate(
       traitSet,
       inputs.get(0),
       namedAggregates,
-      getRowType,
       schema,
       inputSchema,
       groupings)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamGroupAggregateRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamGroupAggregateRule.scala
@@ -68,7 +68,6 @@ class DataStreamGroupAggregateRule
       traitSet,
       convInput,
       agg.getNamedAggCalls,
-      rel.getRowType,
       new RowSchema(rel.getRowType),
       new RowSchema(agg.getInput.getRowType),
       agg.getGroupSet.toArray)


### PR DESCRIPTION
This PR only remove useless param `rowRelDataType` of `DataStreamGroupAggregate`.
- [x] General
  - The pull request references the related JIRA issue ("[FLINK-6598][table] Fix `DataStreamGroupAggregateRule` and `DataStreamGroupWindowAggregateRule` matches error.")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
