### PR TITLE
[FLINK-6587] [table] Simplification and bug fixing of the ExpressionParser

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/Compiler.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/Compiler.scala
@@ -32,9 +32,9 @@ trait Compiler[T] {
     try {
       compiler.cook(code)
     } catch {
-      case e: CompileException =>
+      case t: Throwable =>
         throw new InvalidProgramException("Table program cannot be compiled. " +
-          "This is a bug. Please file an issue.", e)
+          "This is a bug. Please file an issue.", t)
     }
     compiler.getClassLoader.loadClass(name).asInstanceOf[Class[T]]
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/ProjectionTranslator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/ProjectionTranslator.scala
@@ -338,7 +338,7 @@ object ProjectionTranslator {
       // Functions calls
       case c @ Call(name, args) =>
         val function = tableEnv.getFunctionCatalog.lookupFunction(name, args)
-        if (function.isInstanceOf[AggFunctionCall]) {
+        if (function.isInstanceOf[AggFunctionCall] || function.isInstanceOf[Aggregation]) {
           function
         } else {
           val newArgs =

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -21,14 +21,14 @@ package org.apache.flink.table.validate
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.sql.util.{ChainedSqlOperatorTable, ListSqlOperatorTable, ReflectiveSqlOperatorTable}
 import org.apache.calcite.sql.{SqlFunction, SqlOperator, SqlOperatorTable}
-import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.api._
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.utils.{AggSqlFunction, ScalarSqlFunction, TableSqlFunction}
 import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableFunction}
 
-import scala.collection.JavaConversions._
-import scala.collection.mutable
-import scala.util.{Failure, Success, Try}
+import _root_.scala.collection.JavaConversions._
+import _root_.scala.collection.mutable
+import _root_.scala.util.{Failure, Success, Try}
 
 /**
   * A catalog for looking up (user-defined) functions, used during validation phases
@@ -150,10 +150,6 @@ object FunctionCatalog {
 
   val builtInFunctions: Map[String, Class[_]] = Map(
 
-//    SqlStdOperatorTable.AS,
-//    SqlStdOperatorTable.DIVIDE_INTEGER,
-//    SqlStdOperatorTable.DOT,
-
     // logic
     "and" -> classOf[And],
     "or" -> classOf[Or],
@@ -194,7 +190,6 @@ object FunctionCatalog {
     "similar" -> classOf[Similar],
     "substring" -> classOf[Substring],
     "trim" -> classOf[Trim],
-    // duplicate functions for calcite
     "upper" -> classOf[Upper],
     "upperCase" -> classOf[Upper],
     "position" -> classOf[Position],
@@ -240,13 +235,18 @@ object FunctionCatalog {
     "dateTimePlus" -> classOf[Plus],
 
     // array
+    "array" -> classOf[ArrayConstructor],
     "cardinality" -> classOf[ArrayCardinality],
     "at" -> classOf[ArrayElementAt],
-    "element" -> classOf[ArrayElement]
+    "element" -> classOf[ArrayElement],
 
-    // TODO implement function overloading here
-    // "floor" -> classOf[TemporalFloor]
-    // "ceil" -> classOf[TemporalCeil]
+    // window properties
+    "start" -> classOf[WindowStart],
+    "end" -> classOf[WindowEnd],
+
+    // ordering
+    "asc" -> classOf[Asc],
+    "desc" -> classOf[Desc]
   )
 
   /**

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/stringexpr/CastingStringExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/stringexpr/CastingStringExpressionTest.scala
@@ -86,13 +86,13 @@ class CastingStringExpressionTest {
       // * -> String
       "_1.cast(STRING), _2.cast(STRING), _3.cast(STRING), _4.cast(STRING)," +
         // NUMERIC TYPE -> Boolean
-        "_1.cast(BOOL), _2.cast(BOOL), _3.cast(BOOL)," +
+        "_1.cast(BOOLEAN), _2.cast(BOOLEAN), _3.cast(BOOLEAN)," +
         // NUMERIC TYPE -> NUMERIC TYPE
         "_1.cast(DOUBLE), _2.cast(INT), _3.cast(SHORT)," +
         // Boolean -> NUMERIC TYPE
         "_4.cast(DOUBLE)," +
         // identity casting
-        "_1.cast(INT), _2.cast(DOUBLE), _3.cast(LONG), _4.cast(BOOL)")
+        "_1.cast(INT), _2.cast(DOUBLE), _3.cast(LONG), _4.cast(BOOLEAN)")
 
     val lPlan1 = t1.logicalPlan
     val lPlan2 = t2.logicalPlan
@@ -110,7 +110,7 @@ class CastingStringExpressionTest {
         '_3.cast(DOUBLE), '_3.cast(FLOAT), '_2.cast(BOOLEAN))
     val t2 = table.select(
       "_1.cast(BYTE), _1.cast(SHORT), _1.cast(INT), _1.cast(LONG), " +
-        "_3.cast(DOUBLE), _3.cast(FLOAT), _2.cast(BOOL)")
+        "_3.cast(DOUBLE), _3.cast(FLOAT), _2.cast(BOOLEAN)")
 
     val lPlan1 = t1.logicalPlan
     val lPlan2 = t2.logicalPlan

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/DecimalTypeTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/DecimalTypeTest.scala
@@ -154,12 +154,12 @@ class DecimalTypeTest extends ExpressionTestBase {
     // to boolean (not SQL compliant)
     testTableApi(
       'f1.cast(Types.BOOLEAN),
-      "f1.cast(BOOL)",
+      "f1.cast(BOOLEAN)",
       "true")
 
     testTableApi(
       'f5.cast(Types.BOOLEAN),
-      "f5.cast(BOOL)",
+      "f5.cast(BOOLEAN)",
       "false")
 
     testTableApi(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -1409,7 +1409,7 @@ class ScalarFunctionsTest extends ExpressionTestBase {
 
     testAllApis(
       temporalOverlaps("9:00:00".toTime, "9:30:00".toTime, "9:29:00".toTime, "9:31:00".toTime),
-      "temporalOverlaps('9:00:00'.toTime, '9:30:00'.toTime, '9:29:00'.toTime, '9:31:00'.toTime)",
+      "temporalOverlaps(toTime('9:00:00'), '9:30:00'.toTime, '9:29:00'.toTime, '9:31:00'.toTime)",
       "(TIME '9:00:00', TIME '9:30:00') OVERLAPS (TIME '9:29:00', TIME '9:31:00')",
       "true")
 
@@ -1421,14 +1421,14 @@ class ScalarFunctionsTest extends ExpressionTestBase {
 
     testAllApis(
       temporalOverlaps("2011-03-10".toDate, 10.days, "2011-03-19".toDate, 10.days),
-      "temporalOverlaps('2011-03-10'.toDate, 10.days, '2011-03-19'.toDate, 10.days)",
+      "temporalOverlaps(toDate('2011-03-10'), 10.days, '2011-03-19'.toDate, 10.days)",
       "(DATE '2011-03-10', INTERVAL '10' DAY) OVERLAPS (DATE '2011-03-19', INTERVAL '10' DAY)",
       "true")
 
     testAllApis(
       temporalOverlaps("2011-03-10 05:02:02".toTimestamp, 0.milli,
         "2011-03-10 05:02:02".toTimestamp, "2011-03-10 05:02:01".toTimestamp),
-      "temporalOverlaps('2011-03-10 05:02:02'.toTimestamp, 0.milli, " +
+      "temporalOverlaps(toTimestamp('2011-03-10 05:02:02'), 0.milli, " +
         "'2011-03-10 05:02:02'.toTimestamp, '2011-03-10 05:02:01'.toTimestamp)",
       "(TIMESTAMP '2011-03-10 05:02:02', INTERVAL '0' SECOND) OVERLAPS " +
         "(TIMESTAMP '2011-03-10 05:02:02', TIMESTAMP '2011-03-10 05:02:01')",

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/TemporalTypesTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/TemporalTypesTest.scala
@@ -45,7 +45,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
     testAllApis(
       "1500-04-30".cast(Types.SQL_DATE),
-      "'1500-04-30'.cast(DATE)",
+      "'1500-04-30'.cast(SQL_DATE)",
       "CAST('1500-04-30' AS DATE)",
       "1500-04-30")
 
@@ -62,7 +62,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
     testAllApis(
       "1:30:00".cast(Types.SQL_TIME),
-      "'1:30:00'.cast(TIME)",
+      "'1:30:00'.cast(SQL_TIME)",
       "CAST('1:30:00' AS TIME)",
       "01:30:00")
 
@@ -79,7 +79,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
     testAllApis(
       "1500-04-30 12:00:00".cast(Types.SQL_TIMESTAMP),
-      "'1500-04-30 12:00:00'.cast(TIMESTAMP)",
+      "'1500-04-30 12:00:00'.cast(SQL_TIMESTAMP)",
       "CAST('1500-04-30 12:00:00' AS TIMESTAMP)",
       "1500-04-30 12:00:00.0")
   }
@@ -169,62 +169,62 @@ class TemporalTypesTest extends ExpressionTestBase {
   def testTimePointCasting(): Unit = {
     testAllApis(
       'f0.cast(Types.SQL_TIMESTAMP),
-      "f0.cast(TIMESTAMP)",
+      "f0.cast(SQL_TIMESTAMP)",
       "CAST(f0 AS TIMESTAMP)",
       "1990-10-14 00:00:00.0")
 
     testAllApis(
       'f1.cast(Types.SQL_TIMESTAMP),
-      "f1.cast(TIMESTAMP)",
+      "f1.cast(SQL_TIMESTAMP)",
       "CAST(f1 AS TIMESTAMP)",
       "1970-01-01 10:20:45.0")
 
     testAllApis(
       'f2.cast(Types.SQL_DATE),
-      "f2.cast(DATE)",
+      "f2.cast(SQL_DATE)",
       "CAST(f2 AS DATE)",
       "1990-10-14")
 
     testAllApis(
       'f2.cast(Types.SQL_TIME),
-      "f2.cast(TIME)",
+      "f2.cast(SQL_TIME)",
       "CAST(f2 AS TIME)",
       "10:20:45")
 
     testAllApis(
       'f2.cast(Types.SQL_TIME),
-      "f2.cast(TIME)",
+      "f2.cast(SQL_TIME)",
       "CAST(f2 AS TIME)",
       "10:20:45")
 
     testTableApi(
       'f7.cast(Types.SQL_DATE),
-      "f7.cast(DATE)",
+      "f7.cast(SQL_DATE)",
       "2002-11-09")
 
     testTableApi(
       'f7.cast(Types.SQL_DATE).cast(Types.INT),
-      "f7.cast(DATE).cast(INT)",
+      "f7.cast(SQL_DATE).cast(INT)",
       "12000")
 
     testTableApi(
       'f7.cast(Types.SQL_TIME),
-      "f7.cast(TIME)",
+      "f7.cast(SQL_TIME)",
       "00:00:12")
 
     testTableApi(
       'f7.cast(Types.SQL_TIME).cast(Types.INT),
-      "f7.cast(TIME).cast(INT)",
+      "f7.cast(SQL_TIME).cast(INT)",
       "12000")
 
     testTableApi(
       'f8.cast(Types.SQL_TIMESTAMP),
-      "f8.cast(TIMESTAMP)",
+      "f8.cast(SQL_TIMESTAMP)",
       "2016-06-27 07:23:33.0")
 
     testTableApi(
       'f8.cast(Types.SQL_TIMESTAMP).cast(Types.LONG),
-      "f8.cast(TIMESTAMP).cast(LONG)",
+      "f8.cast(SQL_TIMESTAMP).cast(LONG)",
       "1467012213000")
   }
 
@@ -263,13 +263,13 @@ class TemporalTypesTest extends ExpressionTestBase {
 
     testAllApis(
       'f0.cast(Types.SQL_TIMESTAMP) !== 'f2,
-      "f0.cast(TIMESTAMP) !== f2",
+      "f0.cast(SQL_TIMESTAMP) !== f2",
       "CAST(f0 AS TIMESTAMP) <> f2",
       "true")
 
     testAllApis(
       'f0.cast(Types.SQL_TIMESTAMP) === 'f6,
-      "f0.cast(TIMESTAMP) === f6",
+      "f0.cast(SQL_TIMESTAMP) === f6",
       "CAST(f0 AS TIMESTAMP) = f6",
       "true")
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
@@ -64,6 +64,31 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       "Func6(f4, f5, f6)",
       "Func6(f4, f5, f6)",
       "(1990-10-14,12:10:10,1990-10-14 12:10:10.0)")
+
+    // function names containing keywords
+    testAllApis(
+      Func0('f0),
+      "getFunc0(f0)",
+      "getFunc0(f0)",
+      "42")
+
+    testAllApis(
+      Func0('f0),
+      "asAlways(f0)",
+      "asAlways(f0)",
+      "42")
+
+    testAllApis(
+      Func0('f0),
+      "toWhatever(f0)",
+      "toWhatever(f0)",
+      "42")
+
+    testAllApis(
+      Func0('f0),
+      "Nullable(f0)",
+      "Nullable(f0)",
+      "42")
   }
 
   @Test
@@ -286,7 +311,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
 
     testAllApis(
       JavaFunc1(Null(Types.SQL_TIME), 15, Null(Types.SQL_TIMESTAMP)),
-      "JavaFunc1(Null(TIME), 15, Null(TIMESTAMP))",
+      "JavaFunc1(Null(SQL_TIME), 15, Null(SQL_TIMESTAMP))",
       "JavaFunc1(NULL, 15, NULL)",
       "null and 15 and null")
 
@@ -358,6 +383,10 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
 
   override def functions: Map[String, ScalarFunction] = Map(
     "Func0" -> Func0,
+    "getFunc0" -> Func0,
+    "asAlways" -> Func0,
+    "toWhatever" -> Func0,
+    "Nullable" -> Func0,
     "Func1" -> Func1,
     "Func2" -> Func2,
     "Func3" -> Func3,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/util/RexProgramExtractorTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/util/RexProgramExtractorTest.scala
@@ -24,7 +24,7 @@ import org.apache.calcite.rex.{RexBuilder, RexProgram, RexProgramBuilder}
 import org.apache.calcite.sql.SqlPostfixOperator
 import org.apache.calcite.sql.`type`.SqlTypeName.{BIGINT, INTEGER, VARCHAR}
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
-import org.apache.flink.table.expressions.{Expression, ExpressionParser}
+import org.apache.flink.table.expressions._
 import org.apache.flink.table.utils.InputTypeBuilder.inputOf
 import org.apache.flink.table.validate.FunctionCatalog
 import org.hamcrest.CoreMatchers.is
@@ -253,8 +253,8 @@ class RexProgramExtractorTest extends RexProgramTestBase {
         functionCatalog)
 
     val expected: Array[Expression] = Array(
-      ExpressionParser.parseExpression("sum(amount) > 100"),
-      ExpressionParser.parseExpression("min(id) == 100")
+      GreaterThan(Sum(UnresolvedFieldReference("amount")), Literal(100)),
+      EqualTo(Min(UnresolvedFieldReference("id")), Literal(100))
     )
     assertExpressionArrayEquals(expected, convertedExpressions)
     assertEquals(0, unconvertedRexNodes.length)


### PR DESCRIPTION
This PR fixes several issues related to the ExpressionParser and the resolution of expression produced by it. Only special cases are handled by the parser, other expressions will resolved by the function catalog. I also updated the data types such that they are in sync with `org.apache.flink.table.api.Types`.