### PR TITLE
[FLINK-6600] Add key serializer config snapshot to keyed backend checkpoints

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
@@ -44,7 +44,10 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({KeyedBackendStateMetaInfoSnapshotReaderWriters.class, OperatorBackendStateMetaInfoSnapshotReaderWriters.class})
+@PrepareForTest({
+	KeyedBackendSerializationProxy.class,
+	KeyedBackendStateMetaInfoSnapshotReaderWriters.class,
+	OperatorBackendStateMetaInfoSnapshotReaderWriters.class})
 public class SerializationProxiesTest {
 
 	@Test
@@ -80,7 +83,56 @@ public class SerializationProxiesTest {
 		}
 
 		Assert.assertEquals(keySerializer, serializationProxy.getKeySerializer());
+		Assert.assertEquals(keySerializer.snapshotConfiguration(), serializationProxy.getKeySerializerConfigSnapshot());
 		Assert.assertEquals(stateMetaInfoList, serializationProxy.getStateMetaInfoSnapshots());
+	}
+
+	@Test
+	public void testKeyedBackendSerializationProxyRoundtripWithSerializerSerializationFailures() throws Exception {
+
+		TypeSerializer<?> keySerializer = IntSerializer.INSTANCE;
+		TypeSerializer<?> namespaceSerializer = LongSerializer.INSTANCE;
+		TypeSerializer<?> stateSerializer = DoubleSerializer.INSTANCE;
+
+		List<RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?>> stateMetaInfoList = new ArrayList<>();
+
+		stateMetaInfoList.add(new RegisteredKeyedBackendStateMetaInfo<>(
+			StateDescriptor.Type.VALUE, "a", namespaceSerializer, stateSerializer).snapshot());
+		stateMetaInfoList.add(new RegisteredKeyedBackendStateMetaInfo<>(
+			StateDescriptor.Type.VALUE, "b", namespaceSerializer, stateSerializer).snapshot());
+		stateMetaInfoList.add(new RegisteredKeyedBackendStateMetaInfo<>(
+			StateDescriptor.Type.VALUE, "c", namespaceSerializer, stateSerializer).snapshot());
+
+		KeyedBackendSerializationProxy serializationProxy =
+			new KeyedBackendSerializationProxy(keySerializer, stateMetaInfoList);
+
+		byte[] serialized;
+		try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
+			serializationProxy.write(new DataOutputViewStreamWrapper(out));
+			serialized = out.toByteArray();
+		}
+
+		serializationProxy =
+			new KeyedBackendSerializationProxy(Thread.currentThread().getContextClassLoader());
+
+		// mock failure when deserializing serializers
+		TypeSerializerSerializationProxy<?> mockProxy = mock(TypeSerializerSerializationProxy.class);
+		doThrow(new IOException()).when(mockProxy).read(any(DataInputViewStreamWrapper.class));
+		PowerMockito.whenNew(TypeSerializerSerializationProxy.class).withAnyArguments().thenReturn(mockProxy);
+
+		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
+			serializationProxy.read(new DataInputViewStreamWrapper(in));
+		}
+
+		Assert.assertEquals(null, serializationProxy.getKeySerializer());
+		Assert.assertEquals(keySerializer.snapshotConfiguration(), serializationProxy.getKeySerializerConfigSnapshot());
+
+		for (RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?> meta : serializationProxy.getStateMetaInfoSnapshots()) {
+			Assert.assertEquals(null, meta.getNamespaceSerializer());
+			Assert.assertEquals(null, meta.getStateSerializer());
+			Assert.assertEquals(namespaceSerializer.snapshotConfiguration(), meta.getNamespaceSerializerConfigSnapshot());
+			Assert.assertEquals(stateSerializer.snapshotConfiguration(), meta.getStateSerializerConfigSnapshot());
+		}
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -38,6 +38,7 @@ import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.DoubleSerializer;
 import org.apache.flink.api.common.typeutils.base.FloatSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
@@ -1802,6 +1803,47 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 		firstHalfBackend.dispose();
 		secondHalfBackend.dispose();
+	}
+
+	@Test
+	public void testRestoreWithWrongKeySerializer() {
+		try {
+			CheckpointStreamFactory streamFactory = createStreamFactory();
+
+			// use an IntSerializer at first
+			AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+
+			ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class);
+
+			ValueState<String> state = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
+
+			// write some state
+			backend.setCurrentKey(1);
+			state.update("1");
+			backend.setCurrentKey(2);
+			state.update("2");
+
+			// draw a snapshot
+			KeyedStateHandle snapshot1 = FutureUtil.runIfNotDoneAndGet(backend.snapshot(682375462378L, 2, streamFactory, CheckpointOptions.forFullCheckpoint()));
+
+			backend.dispose();
+
+			// restore with the wrong key serializer
+			try {
+				restoreKeyedBackend(DoubleSerializer.INSTANCE, snapshot1);
+
+				fail("should recognize wrong key serializer");
+			} catch (RuntimeException e) {
+				if (!e.getMessage().contains("The new key serializer is not compatible")) {
+					fail("wrong exception " + e);
+				}
+				// expected
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 	@Test


### PR DESCRIPTION
This PR adds the config snapshot of the key serializer of keyed backends to its checkpoints. This allows the opportunity to upgrade key serializers, as well as state migration in the future in the case of incompatible old and new key serializers.

This PR also adds a test to verify serialization failure resilience of the key serializer, as well as a base test for all keyed state backends that restore fails if using incompatible key serializer on restore.