### PR TITLE
[FLINK-6608] [security, config] Relax Kerberos login contexts parsing

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
@@ -37,7 +37,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -235,17 +234,11 @@ public class SecurityUtils {
 				return Collections.emptyList();
 			}
 
-			List<String> parsed = new LinkedList<>();
-
-			String[] splitArr = value.split(",");
-			for (int i = 0; i < splitArr.length; i++) {
-				String trimmed = splitArr[i].trim();
-				if (!trimmed.isEmpty()) {
-					parsed.add(trimmed);
-				}
-			}
-
-			return parsed;
+			return Arrays.asList(value
+				.replaceAll("\\s*,\\s*", ",") // remove whitespaces surrounding commas
+				.replaceAll(",,", ",") // remove empty entries
+				.trim() // remove leading and trailing whitespaces of whole list
+				.split(","));
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
@@ -37,6 +37,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -230,10 +231,21 @@ public class SecurityUtils {
 		}
 
 		private static List<String> parseList(String value) {
-			if(value == null) {
+			if(value == null || value.isEmpty()) {
 				return Collections.emptyList();
 			}
-			return Arrays.asList(value.split(","));
+
+			List<String> parsed = new LinkedList<>();
+
+			String[] splitArr = value.split(",");
+			for (int i = 0; i < splitArr.length; i++) {
+				String trimmed = splitArr[i].trim();
+				if (!trimmed.isEmpty()) {
+					parsed.add(trimmed);
+				}
+			}
+
+			return parsed;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
@@ -235,9 +235,8 @@ public class SecurityUtils {
 			}
 
 			return Arrays.asList(value
-				.replaceAll("\\s*,\\s*", ",") // remove whitespaces surrounding commas
-				.replaceAll(",,", ",") // remove empty entries
-				.trim() // remove leading and trailing whitespaces of whole list
+				.trim()
+				.replaceAll("(\\s*,+\\s*)+", ",")
 				.split(","));
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityUtilsTest.java
@@ -129,10 +129,10 @@ public class SecurityUtilsTest {
 			Collections.singletonList(TestSecurityModule.class));
 		assertEquals(expectedLoginContexts, testSecurityConf.getLoginContextNames());
 
-		// ------- empty String entries with whitespaces
+		// ------- empty trailing String entries with whitespaces
 
 		testFlinkConf = new Configuration();
-		testFlinkConf.setString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar, , Client");
+		testFlinkConf.setString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar, , Client,");
 		testSecurityConf = new SecurityUtils.SecurityConfiguration(
 			testFlinkConf, new org.apache.hadoop.conf.Configuration(),
 			Collections.singletonList(TestSecurityModule.class));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityUtilsTest.java
@@ -132,7 +132,7 @@ public class SecurityUtilsTest {
 		// ------- empty trailing String entries with whitespaces
 
 		testFlinkConf = new Configuration();
-		testFlinkConf.setString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar, , Client,");
+		testFlinkConf.setString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar, ,, Client,");
 		testSecurityConf = new SecurityUtils.SecurityConfiguration(
 			testFlinkConf, new org.apache.hadoop.conf.Configuration(),
 			Collections.singletonList(TestSecurityModule.class));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityUtilsTest.java
@@ -18,13 +18,19 @@
 package org.apache.flink.runtime.security;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.security.modules.SecurityModule;
 import org.junit.AfterClass;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the {@link SecurityUtils}.
@@ -77,5 +83,59 @@ public class SecurityUtilsTest {
 
 		SecurityUtils.uninstall();
 		assertEquals(NoOpSecurityContext.class, SecurityUtils.getInstalledContext().getClass());
+	}
+
+	@Test
+	public void testKerberosLoginContextParsing() {
+
+		List<String> expectedLoginContexts = Arrays.asList("Foo bar", "Client");
+
+		Configuration testFlinkConf;
+		SecurityUtils.SecurityConfiguration testSecurityConf;
+
+		// ------- no whitespaces
+
+		testFlinkConf = new Configuration();
+		testFlinkConf.setString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar,Client");
+		testSecurityConf = new SecurityUtils.SecurityConfiguration(
+			testFlinkConf, new org.apache.hadoop.conf.Configuration(),
+			Collections.singletonList(TestSecurityModule.class));
+		assertEquals(expectedLoginContexts, testSecurityConf.getLoginContextNames());
+
+		// ------- with whitespaces surrounding comma
+
+		testFlinkConf = new Configuration();
+		testFlinkConf.setString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar , Client");
+		testSecurityConf = new SecurityUtils.SecurityConfiguration(
+			testFlinkConf, new org.apache.hadoop.conf.Configuration(),
+			Collections.singletonList(TestSecurityModule.class));
+		assertEquals(expectedLoginContexts, testSecurityConf.getLoginContextNames());
+
+		// ------- leading / trailing whitespaces at start and end of list
+
+		testFlinkConf = new Configuration();
+		testFlinkConf.setString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, " Foo bar , Client ");
+		testSecurityConf = new SecurityUtils.SecurityConfiguration(
+			testFlinkConf, new org.apache.hadoop.conf.Configuration(),
+			Collections.singletonList(TestSecurityModule.class));
+		assertEquals(expectedLoginContexts, testSecurityConf.getLoginContextNames());
+
+		// ------- empty entries
+
+		testFlinkConf = new Configuration();
+		testFlinkConf.setString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar,,Client");
+		testSecurityConf = new SecurityUtils.SecurityConfiguration(
+			testFlinkConf, new org.apache.hadoop.conf.Configuration(),
+			Collections.singletonList(TestSecurityModule.class));
+		assertEquals(expectedLoginContexts, testSecurityConf.getLoginContextNames());
+
+		// ------- empty String entries with whitespaces
+
+		testFlinkConf = new Configuration();
+		testFlinkConf.setString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar, , Client");
+		testSecurityConf = new SecurityUtils.SecurityConfiguration(
+			testFlinkConf, new org.apache.hadoop.conf.Configuration(),
+			Collections.singletonList(TestSecurityModule.class));
+		assertEquals(expectedLoginContexts, testSecurityConf.getLoginContextNames());
 	}
 }


### PR DESCRIPTION
This PR allows whitespaces in the list of configured Kerberos login contexts.
It generally covers some over scenarios as well (covered in the additional parsing test in `SecurityUtilsTest`).