### PR TITLE
[FLINK-6616] [docs] Clarify provenance of official Docker images

### DIFF
--- a/docs/setup/docker.md
+++ b/docs/setup/docker.md
@@ -24,15 +24,15 @@ under the License.
 -->
 
 [Docker](https://www.docker.com) is a popular container runtime. There are
-official Flink Docker images available on Docker Hub which can be used directly
-or extended to better integrate into a production environment.
+official Docker images for Apache Flink available on Docker Hub which can be
+used directly or extended to better integrate into a production environment.
 
 * This will be replaced by the TOC
 {:toc}
 
-## Official Flink Docker Images
+## Official Docker Images
 
-The [official Flink Docker repository](https://hub.docker.com/_/flink/) is
+The [official Docker repository](https://hub.docker.com/_/flink/) is
 hosted on Docker Hub and serves images of Flink version 1.2.1 and later.
 
 Images for each supported combination of Hadoop and Scala are available, and
@@ -59,6 +59,8 @@ For example:
 * `flink:1.2.1-alpine`
 * `flink:1.2-scala_2.10-alpine`
 -->
+
+**Note:** The docker images are provided as a community project by individuals on a best-effort basis. They are not official releases by the Apache Flink PMC.
 
 ## Flink with Docker Compose
 


### PR DESCRIPTION
Note that the official Docker images for Flink are community supported and not an official release of the Apache Flink PMC.