### PR TITLE
[FLINK-6065] Add initClient method to ElasticsearchApiCallBridge

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
@@ -21,10 +21,13 @@ package org.apache.flink.streaming.connectors.elasticsearch;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.settings.Settings;
 
 import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * An {@link ElasticsearchApiCallBridge} is used to bridge incompatible Elasticsearch Java API calls across different versions.
@@ -40,10 +43,25 @@ public interface ElasticsearchApiCallBridge extends Serializable {
 	/**
 	 * Creates an Elasticsearch {@link Client}.
 	 *
+	 * In comparison to {@link initClient}, this method creates a default {@link Client}.
+	 *
 	 * @param clientConfig The configuration to use when constructing the client.
 	 * @return The created client.
 	 */
 	Client createClient(Map<String, String> clientConfig);
+
+	/**
+	 * Initializes an Elasticsearch {@link Client}.
+	 *
+	 * A {@link Settings} object is created, which is passed to {@link mapper} in order to allow the creation of a
+	 * {@link TransportClient}. {@link createClient} creates and initializes a default client for cases where the
+	 * implementation doesn't matter.
+	 *
+	 * @param clientConfig The configuration to use when constructing the client.
+	 * @param mapper Receives a {@link Settings} object that can be used to create a {@link TransportClient}.
+	 * @return The initialized client that has been created by {@link mapper}.
+	 */
+	Client initClient(Map<String, String> clientConfig, Function<Settings, TransportClient> mapper);
 
 	/**
 	 * Extracts the cause of failure of a bulk item action.

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
@@ -32,6 +32,8 @@ import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.settings.Settings;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -44,6 +46,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.List;
+import java.util.function.Function;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -515,6 +518,11 @@ public class ElasticsearchSinkBaseTest {
 
 		@Override
 		public Client createClient(Map<String, String> clientConfig) {
+			return mock(Client.class);
+		}
+
+		@Override
+		public Client initClient(Map<String, String> clientConfig, Function<Settings, TransportClient> mapper) {
 			return mock(Client.class);
 		}
 

--- a/flink-connectors/flink-connector-elasticsearch/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/Elasticsearch1ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/Elasticsearch1ApiCallBridge.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
@@ -67,6 +68,16 @@ public class Elasticsearch1ApiCallBridge implements ElasticsearchApiCallBridge {
 
 	@Override
 	public Client createClient(Map<String, String> clientConfig) {
+		return initClient(clientConfig, new Function<Settings, TransportClient>() {
+			@Override
+			public TransportClient apply(Settings settings) {
+				return new TransportClient(settings);
+			}
+		});
+	}
+
+	@Override
+	public Client initClient(Map<String, String> clientConfig, Function<Settings, TransportClient> mapper) {
 		if (transportAddresses == null) {
 
 			// Make sure that we disable http access to our embedded node
@@ -93,7 +104,7 @@ public class Elasticsearch1ApiCallBridge implements ElasticsearchApiCallBridge {
 				.put(clientConfig)
 				.build();
 
-			TransportClient transportClient = new TransportClient(settings);
+			TransportClient transportClient = mapper.apply(settings);
 			for (TransportAddress transport: transportAddresses) {
 				transportClient.addTransportAddress(transport);
 			}

--- a/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/Elasticsearch2ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/Elasticsearch2ApiCallBridge.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Implementation of {@link ElasticsearchApiCallBridge} for Elasticsearch 2.x.
@@ -60,9 +61,19 @@ public class Elasticsearch2ApiCallBridge implements ElasticsearchApiCallBridge {
 
 	@Override
 	public Client createClient(Map<String, String> clientConfig) {
+		return initClient(clientConfig, new Function<Settings, TransportClient>() {
+			@Override
+			public TransportClient apply(Settings settings) {
+				return TransportClient.builder().settings(settings).build();
+			}
+		});
+	}
+
+	@Override
+	public Client initClient(Map<String, String> clientConfig, Function<Settings, TransportClient> mapper) {
 		Settings settings = Settings.settingsBuilder().put(clientConfig).build();
 
-		TransportClient transportClient = TransportClient.builder().settings(settings).build();
+		TransportClient transportClient = mapper.apply(settings);
 		for (TransportAddress address : ElasticsearchUtils.convertInetSocketAddresses(transportAddresses)) {
 			transportClient.addTransportAddress(address);
 		}


### PR DESCRIPTION
This adds the method `initClient` to `ElasticsearchApiCallBridge` in
order to resolve FLINK-6065. This new method takes as argument a
function that can create a `TransportClient`. This is required in order
to not hardcode the `TransportClient` in the implementation of
`createClient`. `createClient` continues to exist in order to allow
backwards compatibility.

No tests provided because I couldn't find any existing test class that
tests the implementation of `ElasticsearchApiCallBridge`.

------------------------------------------------------------------------

This is my first contribution, I haven't signed the ICLA yet (which I will do next). I didn't provide any tests yet because I had no idea how the functionality should be tested or where a test class should be added. If you would like to see tests for the changes, please tell me.

The change fixes the ticket but maybe you would like to see a different way on how to fix the issue.