### PR TITLE
[FLINK-6618][table] Fix GroupWindowStringExpressionTest test case bug

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/ProjectionTranslator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/ProjectionTranslator.scala
@@ -334,11 +334,11 @@ object ProjectionTranslator {
         val l = replaceAggFunctionCall(b.left, tableEnv)
         val r = replaceAggFunctionCall(b.right, tableEnv)
         b.makeCopy(Array(l, r))
-
       // Functions calls
       case c @ Call(name, args) =>
         val function = tableEnv.getFunctionCatalog.lookupFunction(name, args)
-        if (function.isInstanceOf[AggFunctionCall] || function.isInstanceOf[Aggregation]) {
+        if (function.isInstanceOf[AbstractWindowProperty] ||
+          function.isInstanceOf[AggFunctionCall] || function.isInstanceOf[Aggregation]) {
           function
         } else {
           val newArgs =

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/table/stringexpr/GroupWindowStringExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/table/stringexpr/GroupWindowStringExpressionTest.scala
@@ -23,7 +23,7 @@ import org.apache.flink.table.api.java.{Slide => JSlide}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.functions.aggfunctions.CountAggFunction
 import org.apache.flink.table.utils.TableTestBase
-import org.junit.{Assert, Test}
+import org.junit.Test
 
 
 class GroupWindowStringExpressionTest extends TableTestBase {
@@ -47,7 +47,9 @@ class GroupWindowStringExpressionTest extends TableTestBase {
         myCountFun('string),
         'int.sum,
         weightAvgFun('long, 'int),
-        weightAvgFun('int, 'int) * 2)
+        weightAvgFun('int, 'int) * 2,
+        'w.start,
+        'w.end)
 
     // String / Java API
     val resJava = t
@@ -55,11 +57,13 @@ class GroupWindowStringExpressionTest extends TableTestBase {
       .groupBy("w, string")
       .select(
         "string, " +
-          "myCountFun(string), " +
-          "int.sum, " +
-          "weightAvgFun(long, int), " +
-          "weightAvgFun(int, int) * 2")
+        "myCountFun(string), " +
+        "int.sum, " +
+        "weightAvgFun(long, int), " +
+        "weightAvgFun(int, int) * 2, " +
+        "start(w)," +
+        "end(w)")
 
-    Assert.assertEquals("Logical Plans do not match", resJava.logicalPlan, resJava.logicalPlan)
+    verifyTableEquals(resJava, resScala)
   }
 }


### PR DESCRIPTION
This PR. have fixed 2 bugs;
 1. fix the `GroupWindowStringExpressionTest` test case bug.
 2. fix window properties(w.start, w.end) can not select in JAVA API.
- [x] General
  - The pull request references the related JIRA issue ("[FLINK-6618][table] Fix GroupWindowStringExpressionTest testcase bug")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
