### PR TITLE
[backport 1.3] [FLINK-6612] Allow ZooKeeperStateHandleStore to lock created ZNodes

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -304,6 +305,14 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
 		public void awaitDiscard() throws InterruptedException {
 			if (discardLatch != null) {
 				discardLatch.await();
+			}
+		}
+
+		public boolean awaitDiscard(long timeout) throws InterruptedException {
+			if (discardLatch != null) {
+				return discardLatch.await(timeout, TimeUnit.MILLISECONDS);
+			} else {
+				return false;
 			}
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -24,50 +24,52 @@ import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.zookeeper.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.zookeeper.ZooKeeperTestEnvironment;
+import org.apache.zookeeper.data.Stat;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for basic {@link CompletedCheckpointStore} contract and ZooKeeper state handling.
  */
 public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpointStoreTest {
 
-	private final static ZooKeeperTestEnvironment ZooKeeper = new ZooKeeperTestEnvironment(1);
+	private static final ZooKeeperTestEnvironment ZOOKEEPER = new ZooKeeperTestEnvironment(1);
 
-	private final static String CheckpointsPath = "/checkpoints";
+	private static final String CHECKPOINT_PATH = "/checkpoints";
 
 	@AfterClass
 	public static void tearDown() throws Exception {
-		if (ZooKeeper != null) {
-			ZooKeeper.shutdown();
+		if (ZOOKEEPER != null) {
+			ZOOKEEPER.shutdown();
 		}
 	}
 
 	@Before
 	public void cleanUp() throws Exception {
-		ZooKeeper.deleteAll();
+		ZOOKEEPER.deleteAll();
 	}
 
 	@Override
-	protected AbstractCompletedCheckpointStore createCompletedCheckpoints(
-			int maxNumberOfCheckpointsToRetain) throws Exception {
-
+	protected ZooKeeperCompletedCheckpointStore createCompletedCheckpoints(int maxNumberOfCheckpointsToRetain) throws Exception {
 		return new ZooKeeperCompletedCheckpointStore(maxNumberOfCheckpointsToRetain,
-			ZooKeeper.createClient(), CheckpointsPath, new RetrievableStateStorageHelper<CompletedCheckpoint>() {
-			@Override
-			public RetrievableStateHandle<CompletedCheckpoint> store(CompletedCheckpoint state) throws Exception {
-				return new HeapRetrievableStateHandle<>(state);
-			}
-		}, Executors.directExecutor());
+			ZOOKEEPER.getClient(),
+			CHECKPOINT_PATH,
+			new HeapStateStorageHelper(),
+			Executors.directExecutor());
 	}
 
 	// ---------------------------------------------------------------------------------------------
@@ -95,7 +97,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 		verifyCheckpointRegistered(expected[2].getOperatorStates().values(), checkpoints.sharedStateRegistry);
 
 		// All three should be in ZK
-		assertEquals(3, ZooKeeper.getClient().getChildren().forPath(CheckpointsPath).size());
+		assertEquals(3, ZOOKEEPER.getClient().getChildren().forPath(CHECKPOINT_PATH).size());
 		assertEquals(3, checkpoints.getNumberOfRetainedCheckpoints());
 
 		resetCheckpoint(expected[0].getOperatorStates().values());
@@ -105,7 +107,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 		// Recover TODO!!! clear registry!
 		checkpoints.recover();
 
-		assertEquals(3, ZooKeeper.getClient().getChildren().forPath(CheckpointsPath).size());
+		assertEquals(3, ZOOKEEPER.getClient().getChildren().forPath(CHECKPOINT_PATH).size());
 		assertEquals(3, checkpoints.getNumberOfRetainedCheckpoints());
 		assertEquals(expected[2], checkpoints.getLatestCheckpoint());
 
@@ -130,18 +132,18 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 	 */
 	@Test
 	public void testShutdownDiscardsCheckpoints() throws Exception {
-		CuratorFramework client = ZooKeeper.getClient();
+		CuratorFramework client = ZOOKEEPER.getClient();
 
 		CompletedCheckpointStore store = createCompletedCheckpoints(1);
 		TestCompletedCheckpoint checkpoint = createCheckpoint(0);
 
 		store.addCheckpoint(checkpoint);
 		assertEquals(1, store.getNumberOfRetainedCheckpoints());
-		assertNotNull(client.checkExists().forPath(CheckpointsPath + ZooKeeperCompletedCheckpointStore.checkpointIdToPath(checkpoint.getCheckpointID())));
+		assertNotNull(client.checkExists().forPath(CHECKPOINT_PATH + ZooKeeperCompletedCheckpointStore.checkpointIdToPath(checkpoint.getCheckpointID())));
 
 		store.shutdown(JobStatus.FINISHED);
 		assertEquals(0, store.getNumberOfRetainedCheckpoints());
-		assertNull(client.checkExists().forPath(CheckpointsPath + ZooKeeperCompletedCheckpointStore.checkpointIdToPath(checkpoint.getCheckpointID())));
+		assertNull(client.checkExists().forPath(CHECKPOINT_PATH + ZooKeeperCompletedCheckpointStore.checkpointIdToPath(checkpoint.getCheckpointID())));
 
 		store.recover();
 
@@ -149,24 +151,30 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 	}
 
 	/**
-	 * Tests that suspends keeps all checkpoints (as they can be recovered
-	 * later by the ZooKeeper store).
+	 * Tests that suspends keeps all checkpoints (so that they can be recovered
+	 * later by the ZooKeeper store). Furthermore, suspending a job should release
+	 * all locks.
 	 */
 	@Test
 	public void testSuspendKeepsCheckpoints() throws Exception {
-		CuratorFramework client = ZooKeeper.getClient();
+		CuratorFramework client = ZOOKEEPER.getClient();
 
 		CompletedCheckpointStore store = createCompletedCheckpoints(1);
 		TestCompletedCheckpoint checkpoint = createCheckpoint(0);
 
 		store.addCheckpoint(checkpoint);
 		assertEquals(1, store.getNumberOfRetainedCheckpoints());
-		assertNotNull(client.checkExists().forPath(CheckpointsPath + ZooKeeperCompletedCheckpointStore.checkpointIdToPath(checkpoint.getCheckpointID())));
+		assertNotNull(client.checkExists().forPath(CHECKPOINT_PATH + ZooKeeperCompletedCheckpointStore.checkpointIdToPath(checkpoint.getCheckpointID())));
 
 		store.shutdown(JobStatus.SUSPENDED);
 
 		assertEquals(0, store.getNumberOfRetainedCheckpoints());
-		assertNotNull(client.checkExists().forPath(CheckpointsPath + ZooKeeperCompletedCheckpointStore.checkpointIdToPath(checkpoint.getCheckpointID())));
+
+		final String checkpointPath = CHECKPOINT_PATH + ZooKeeperCompletedCheckpointStore.checkpointIdToPath(checkpoint.getCheckpointID());
+		Stat stat = client.checkExists().forPath(checkpointPath);
+
+		assertNotNull("The checkpoint node should exist.", stat);
+		assertEquals("The checkpoint node should not be locked.", 0, stat.getNumChildren());
 
 		// Recover again
 		store.recover();
@@ -201,24 +209,91 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 		assertEquals(checkpoints.get(checkpoints.size() -1), latestCheckpoint);
 	}
 
+	/**
+	 * FLINK-6612
+	 *
+	 * Checks that a concurrent checkpoint completion won't discard a checkpoint which has been
+	 * recovered by a different completed checkpoint store.
+	 */
+	@Test
+	public void testConcurrentCheckpointOperations() throws Exception {
+		final int numberOfCheckpoints = 1;
+		final long waitingTimeout = 50L;
+
+		ZooKeeperCompletedCheckpointStore zkCheckpointStore1 = createCompletedCheckpoints(numberOfCheckpoints);
+		ZooKeeperCompletedCheckpointStore zkCheckpointStore2 = createCompletedCheckpoints(numberOfCheckpoints);
+
+		TestCompletedCheckpoint completedCheckpoint = createCheckpoint(1);
+
+		// complete the first checkpoint
+		zkCheckpointStore1.addCheckpoint(completedCheckpoint);
+
+		// recover the checkpoint by a different checkpoint store
+		zkCheckpointStore2.recover();
+
+		CompletedCheckpoint recoveredCheckpoint = zkCheckpointStore2.getLatestCheckpoint();
+		assertTrue(recoveredCheckpoint instanceof TestCompletedCheckpoint);
+		TestCompletedCheckpoint recoveredTestCheckpoint = (TestCompletedCheckpoint) recoveredCheckpoint;
+
+		// Check that the recovered checkpoint is not yet discarded
+		assertFalse(recoveredTestCheckpoint.isDiscarded());
+
+		// complete another checkpoint --> this should remove the first checkpoint from the store
+		// because the number of retained checkpoints == 1
+		TestCompletedCheckpoint completedCheckpoint2 = createCheckpoint(2);
+		zkCheckpointStore1.addCheckpoint(completedCheckpoint2);
+
+		List<CompletedCheckpoint> allCheckpoints = zkCheckpointStore1.getAllCheckpoints();
+
+		// check that we have removed the first checkpoint from zkCompletedStore1
+		assertEquals(Collections.singletonList(completedCheckpoint2), allCheckpoints);
+
+		// lets wait a little bit to see that no discard operation will be executed
+		assertFalse("The checkpoint should not have been discarded.", recoveredTestCheckpoint.awaitDiscard(waitingTimeout));
+
+		// check that we have not discarded the first completed checkpoint
+		assertFalse(recoveredTestCheckpoint.isDiscarded());
+
+		TestCompletedCheckpoint completedCheckpoint3 = createCheckpoint(3);
+
+		// this should release the last lock on completedCheckoint and thus discard it
+		zkCheckpointStore2.addCheckpoint(completedCheckpoint3);
+
+		// the checkpoint should be discarded eventually because there is no lock on it anymore
+		recoveredTestCheckpoint.awaitDiscard();
+	}
+
+
+	static class HeapStateStorageHelper implements RetrievableStateStorageHelper<CompletedCheckpoint> {
+		@Override
+		public RetrievableStateHandle<CompletedCheckpoint> store(CompletedCheckpoint state) throws Exception {
+			return new HeapRetrievableStateHandle<>(state);
+		}
+	}
+
 	static class HeapRetrievableStateHandle<T extends Serializable> implements RetrievableStateHandle<T> {
 
 		private static final long serialVersionUID = -268548467968932L;
 
-		public HeapRetrievableStateHandle(T state) {
-			this.state = state;
-		}
+		private static AtomicInteger nextKey = new AtomicInteger(0);
 
-		private T state;
+		private static HashMap<Integer, Object> stateMap = new HashMap<>();
+
+		private final int key;
+
+		public HeapRetrievableStateHandle(T state) {
+			key = nextKey.getAndIncrement();
+			stateMap.put(key, state);
+		}
 
 		@Override
 		public T retrieveState() throws Exception {
-			return state;
+			return (T) stateMap.get(key);
 		}
 
 		@Override
 		public void discardState() throws Exception {
-			state = null;
+			stateMap.remove(key);
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -110,7 +110,7 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 
 		ZooKeeperStateHandleStore<CompletedCheckpoint> zooKeeperStateHandleStoreMock = spy(new ZooKeeperStateHandleStore<>(client, storageHelperMock, Executors.directExecutor()));
 		whenNew(ZooKeeperStateHandleStore.class).withAnyArguments().thenReturn(zooKeeperStateHandleStoreMock);
-		doReturn(checkpointsInZooKeeper).when(zooKeeperStateHandleStoreMock).getAllSortedByName();
+		doReturn(checkpointsInZooKeeper).when(zooKeeperStateHandleStoreMock).getAllSortedByNameAndLock();
 
 		final int numCheckpointsToRetain = 1;
 
@@ -126,7 +126,6 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 		when(
 			client
 				.delete()
-				.deletingChildrenIfNeeded()
 				.inBackground(any(BackgroundCallback.class), any(Executor.class))
 		).thenAnswer(new Answer<ErrorListenerPathable<Void>>() {
 			@Override
@@ -150,13 +149,13 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 		});
 
 		final String checkpointsPath = "foobar";
-		final RetrievableStateStorageHelper<CompletedCheckpoint> stateSotrage = mock(RetrievableStateStorageHelper.class);
+		final RetrievableStateStorageHelper<CompletedCheckpoint> stateStorage = mock(RetrievableStateStorageHelper.class);
 
 		ZooKeeperCompletedCheckpointStore zooKeeperCompletedCheckpointStore = new ZooKeeperCompletedCheckpointStore(
 			numCheckpointsToRetain,
 			client,
 			checkpointsPath,
-			stateSotrage,
+			stateStorage,
 			Executors.directExecutor());
 
 		zooKeeperCompletedCheckpointStore.recover();
@@ -209,9 +208,9 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 				
 				return retrievableStateHandle;
 			}
-		}).when(zookeeperStateHandleStoreMock).add(anyString(), any(CompletedCheckpoint.class));
+		}).when(zookeeperStateHandleStoreMock).addAndLock(anyString(), any(CompletedCheckpoint.class));
 		
-		doThrow(new Exception()).when(zookeeperStateHandleStoreMock).remove(anyString(), any(BackgroundCallback.class));
+		doThrow(new Exception()).when(zookeeperStateHandleStoreMock).releaseAndTryRemove(anyString(), any(ZooKeeperStateHandleStore.RemoveCallback.class));
 		
 		final int numCheckpointsToRetain = 1;
 		final String checkpointsPath = "foobar";

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
@@ -19,14 +19,14 @@
 package org.apache.flink.runtime.zookeeper;
 
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.api.BackgroundCallback;
-import org.apache.curator.framework.api.CuratorEvent;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.TestLogger;
-import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.Stat;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -34,7 +34,9 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -42,11 +44,12 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -63,116 +66,66 @@ import static org.mockito.Mockito.when;
  * <li>Correct ordering of ZooKeeper and state handle operations</li>
  * </ul>
  */
-public class ZooKeeperStateHandleStoreITCase extends TestLogger {
+public class ZooKeeperStateHandleStoreTest extends TestLogger {
 
-	private final static ZooKeeperTestEnvironment ZooKeeper = new ZooKeeperTestEnvironment(1);
+	private static final ZooKeeperTestEnvironment ZOOKEEPER = new ZooKeeperTestEnvironment(1);
 
 	@AfterClass
 	public static void tearDown() throws Exception {
-		if (ZooKeeper != null) {
-			ZooKeeper.shutdown();
+		if (ZOOKEEPER != null) {
+			ZOOKEEPER.shutdown();
 		}
 	}
 
 	@Before
 	public void cleanUp() throws Exception {
-		ZooKeeper.deleteAll();
+		ZOOKEEPER.deleteAll();
 	}
 
 	/**
-	 * Tests add operation with default {@link CreateMode}.
+	 * Tests add operation with lock.
 	 */
 	@Test
-	public void testAdd() throws Exception {
+	public void testAddAndLock() throws Exception {
 		LongStateStorage longStateStorage = new LongStateStorage();
 		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<Long>(
-				ZooKeeper.getClient(), longStateStorage, Executors.directExecutor());
+				ZOOKEEPER.getClient(), longStateStorage, Executors.directExecutor());
 
 		// Config
 		final String pathInZooKeeper = "/testAdd";
 		final Long state = 1239712317L;
 
 		// Test
-		store.add(pathInZooKeeper, state);
+		store.addAndLock(pathInZooKeeper, state);
 
 		// Verify
 		// State handle created
-		assertEquals(1, store.getAll().size());
-		assertEquals(state, store.get(pathInZooKeeper).retrieveState());
+		assertEquals(1, store.getAllAndLock().size());
+		assertEquals(state, store.getAndLock(pathInZooKeeper).retrieveState());
 
 		// Path created and is persistent
-		Stat stat = ZooKeeper.getClient().checkExists().forPath(pathInZooKeeper);
+		Stat stat = ZOOKEEPER.getClient().checkExists().forPath(pathInZooKeeper);
 		assertNotNull(stat);
 		assertEquals(0, stat.getEphemeralOwner());
+
+		List<String> children = ZOOKEEPER.getClient().getChildren().forPath(pathInZooKeeper);
+
+		// there should be one child which is the lock
+		assertEquals(1, children.size());
+
+		stat = ZOOKEEPER.getClient().checkExists().forPath(pathInZooKeeper + '/' + children.get(0));
+		assertNotNull(stat);
+
+		// check that the child is an ephemeral node
+		assertNotEquals(0, stat.getEphemeralOwner());
 
 		// Data is equal
 		@SuppressWarnings("unchecked")
 		Long actual = ((RetrievableStateHandle<Long>) InstantiationUtil.deserializeObject(
-				ZooKeeper.getClient().getData().forPath(pathInZooKeeper),
+				ZOOKEEPER.getClient().getData().forPath(pathInZooKeeper),
 				ClassLoader.getSystemClassLoader())).retrieveState();
 
 		assertEquals(state, actual);
-	}
-
-	/**
-	 * Tests that {@link CreateMode} is respected.
-	 */
-	@Test
-	public void testAddWithCreateMode() throws Exception {
-		LongStateStorage longStateStorage = new LongStateStorage();
-		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<Long>(
-				ZooKeeper.getClient(), longStateStorage, Executors.directExecutor());
-
-		// Config
-		Long state = 3457347234L;
-
-		CreateMode[] modes = CreateMode.values();
-		for (int i = 0; i < modes.length; i++) {
-			CreateMode mode = modes[i];
-			state += i;
-
-			String pathInZooKeeper = "/testAddWithCreateMode" + mode.name();
-
-			// Test
-			store.add(pathInZooKeeper, state, mode);
-
-			if (mode.isSequential()) {
-				// Figure out the sequential ID
-				List<String> paths = ZooKeeper.getClient().getChildren().forPath("/");
-				for (String p : paths) {
-					if (p.startsWith("testAddWithCreateMode" + mode.name())) {
-						pathInZooKeeper = "/" + p;
-						break;
-					}
-				}
-			}
-
-			// Verify
-			// State handle created
-			assertEquals(i + 1, store.getAll().size());
-			assertEquals(state, longStateStorage.getStateHandles().get(i).retrieveState());
-
-			// Path created
-			Stat stat = ZooKeeper.getClient().checkExists().forPath(pathInZooKeeper);
-
-			assertNotNull(stat);
-
-			// Is ephemeral or persistent
-			if (mode.isEphemeral()) {
-				assertTrue(stat.getEphemeralOwner() != 0);
-			}
-			else {
-				assertEquals(0, stat.getEphemeralOwner());
-			}
-
-			// Data is equal
-			@SuppressWarnings("unchecked")
-			Long actual = ((RetrievableStateHandle<Long>) InstantiationUtil.deserializeObject(
-					ZooKeeper.getClient().getData().forPath(pathInZooKeeper),
-					ClassLoader.getSystemClassLoader())).retrieveState();
-
-			assertEquals(state, actual);
-		}
 	}
 
 	/**
@@ -183,11 +136,17 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		LongStateStorage stateHandleProvider = new LongStateStorage();
 
 		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<>(
-				ZooKeeper.getClient(), stateHandleProvider, Executors.directExecutor());
+				ZOOKEEPER.getClient(), stateHandleProvider, Executors.directExecutor());
 
-		ZooKeeper.getClient().create().forPath("/testAddAlreadyExistingPath");
+		ZOOKEEPER.getClient().create().forPath("/testAddAlreadyExistingPath");
 
-		store.add("/testAddAlreadyExistingPath", 1L);
+		store.addAndLock("/testAddAlreadyExistingPath", 1L);
+
+		// writing to the state storage should have succeeded
+		assertEquals(1, stateHandleProvider.getStateHandles());
+
+		// the created state handle should have been cleaned up if the add operation failed
+		assertEquals(1, stateHandleProvider.getStateHandles().get(0).getNumberOfDiscardCalls());
 	}
 
 	/**
@@ -198,8 +157,8 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		// Setup
 		LongStateStorage stateHandleProvider = new LongStateStorage();
 
-		CuratorFramework client = spy(ZooKeeper.getClient());
-		when(client.create()).thenThrow(new RuntimeException("Expected test Exception."));
+		CuratorFramework client = spy(ZOOKEEPER.getClient());
+		when(client.inTransaction().create()).thenThrow(new RuntimeException("Expected test Exception."));
 
 		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<>(
 				client, stateHandleProvider, Executors.directExecutor());
@@ -210,7 +169,7 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 
 		try {
 			// Test
-			store.add(pathInZooKeeper, state);
+			store.addAndLock(pathInZooKeeper, state);
 			fail("Did not throw expected exception");
 		}
 		catch (Exception ignored) {
@@ -232,7 +191,7 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		LongStateStorage stateHandleProvider = new LongStateStorage();
 
 		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<>(
-				ZooKeeper.getClient(), stateHandleProvider, Executors.directExecutor());
+				ZOOKEEPER.getClient(), stateHandleProvider, Executors.directExecutor());
 
 		// Config
 		final String pathInZooKeeper = "/testReplace";
@@ -240,7 +199,7 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		final Long replaceState = 88383776661L;
 
 		// Test
-		store.add(pathInZooKeeper, initialState);
+		store.addAndLock(pathInZooKeeper, initialState);
 		store.replace(pathInZooKeeper, 0, replaceState);
 
 		// Verify
@@ -250,14 +209,14 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		assertEquals(replaceState, stateHandleProvider.getStateHandles().get(1).retrieveState());
 
 		// Path created and is persistent
-		Stat stat = ZooKeeper.getClient().checkExists().forPath(pathInZooKeeper);
+		Stat stat = ZOOKEEPER.getClient().checkExists().forPath(pathInZooKeeper);
 		assertNotNull(stat);
 		assertEquals(0, stat.getEphemeralOwner());
 
 		// Data is equal
 		@SuppressWarnings("unchecked")
 		Long actual = ((RetrievableStateHandle<Long>) InstantiationUtil.deserializeObject(
-				ZooKeeper.getClient().getData().forPath(pathInZooKeeper),
+				ZOOKEEPER.getClient().getData().forPath(pathInZooKeeper),
 				ClassLoader.getSystemClassLoader())).retrieveState();
 
 		assertEquals(replaceState, actual);
@@ -271,7 +230,7 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		RetrievableStateStorageHelper<Long> stateStorage = new LongStateStorage();
 
 		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<>(
-				ZooKeeper.getClient(), stateStorage, Executors.directExecutor());
+				ZOOKEEPER.getClient(), stateStorage, Executors.directExecutor());
 
 		store.replace("/testReplaceNonExistingPath", 0, 1L);
 	}
@@ -284,7 +243,7 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		// Setup
 		LongStateStorage stateHandleProvider = new LongStateStorage();
 
-		CuratorFramework client = spy(ZooKeeper.getClient());
+		CuratorFramework client = spy(ZOOKEEPER.getClient());
 		when(client.setData()).thenThrow(new RuntimeException("Expected test Exception."));
 
 		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<>(
@@ -296,7 +255,7 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		final Long replaceState = 88383776661L;
 
 		// Test
-		store.add(pathInZooKeeper, initialState);
+		store.addAndLock(pathInZooKeeper, initialState);
 
 		try {
 			store.replace(pathInZooKeeper, 0, replaceState);
@@ -315,7 +274,7 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		// Initial value
 		@SuppressWarnings("unchecked")
 		Long actual = ((RetrievableStateHandle<Long>) InstantiationUtil.deserializeObject(
-				ZooKeeper.getClient().getData().forPath(pathInZooKeeper),
+				ZOOKEEPER.getClient().getData().forPath(pathInZooKeeper),
 				ClassLoader.getSystemClassLoader())).retrieveState();
 
 		assertEquals(initialState, actual);
@@ -330,7 +289,7 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		LongStateStorage stateHandleProvider = new LongStateStorage();
 
 		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<>(
-				ZooKeeper.getClient(), stateHandleProvider, Executors.directExecutor());
+				ZOOKEEPER.getClient(), stateHandleProvider, Executors.directExecutor());
 
 		// Config
 		final String pathInZooKeeper = "/testGetAndExists";
@@ -339,8 +298,8 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		// Test
 		assertEquals(-1, store.exists(pathInZooKeeper));
 
-		store.add(pathInZooKeeper, state);
-		RetrievableStateHandle<Long> actual = store.get(pathInZooKeeper);
+		store.addAndLock(pathInZooKeeper, state);
+		RetrievableStateHandle<Long> actual = store.getAndLock(pathInZooKeeper);
 
 		// Verify
 		assertEquals(state, actual.retrieveState());
@@ -355,9 +314,9 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		LongStateStorage stateHandleProvider = new LongStateStorage();
 
 		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<>(
-				ZooKeeper.getClient(), stateHandleProvider, Executors.directExecutor());
+				ZOOKEEPER.getClient(), stateHandleProvider, Executors.directExecutor());
 
-		store.get("/testGetNonExistingPath");
+		store.getAndLock("/testGetNonExistingPath");
 	}
 
 	/**
@@ -369,7 +328,7 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		LongStateStorage stateHandleProvider = new LongStateStorage();
 
 		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<>(
-				ZooKeeper.getClient(), stateHandleProvider, Executors.directExecutor());
+				ZOOKEEPER.getClient(), stateHandleProvider, Executors.directExecutor());
 
 		// Config
 		final String pathInZooKeeper = "/testGetAll";
@@ -382,10 +341,10 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 
 		// Test
 		for (long val : expected) {
-			store.add(pathInZooKeeper, val, CreateMode.PERSISTENT_SEQUENTIAL);
+			store.addAndLock(pathInZooKeeper + val, val);
 		}
 
-		for (Tuple2<RetrievableStateHandle<Long>, String> val : store.getAll()) {
+		for (Tuple2<RetrievableStateHandle<Long>, String> val : store.getAllAndLock()) {
 			assertTrue(expected.remove(val.f0.retrieveState()));
 		}
 		assertEquals(0, expected.size());
@@ -400,21 +359,25 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		LongStateStorage stateHandleProvider = new LongStateStorage();
 
 		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<>(
-				ZooKeeper.getClient(), stateHandleProvider, Executors.directExecutor());
+				ZOOKEEPER.getClient(), stateHandleProvider, Executors.directExecutor());
 
 		// Config
-		final String pathInZooKeeper = "/testGetAllSortedByName";
+		final String basePath = "/testGetAllSortedByName";
 
 		final Long[] expected = new Long[] {
 				311222268470898L, 132812888L, 27255442L, 11122233124L };
 
 		// Test
 		for (long val : expected) {
-			store.add(pathInZooKeeper, val, CreateMode.PERSISTENT_SEQUENTIAL);
+			final String pathInZooKeeper = String.format("%s%016d", basePath, val);
+			store.addAndLock(pathInZooKeeper, val);
 		}
 
-		List<Tuple2<RetrievableStateHandle<Long>, String>> actual = store.getAllSortedByName();
+		List<Tuple2<RetrievableStateHandle<Long>, String>> actual = store.getAllSortedByNameAndLock();
 		assertEquals(expected.length, actual.size());
+
+		// bring the elements in sort order
+		Arrays.sort(expected);
 
 		for (int i = 0; i < expected.length; i++) {
 			assertEquals(expected[i], actual.get(i).f0.retrieveState());
@@ -430,19 +393,19 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		LongStateStorage stateHandleProvider = new LongStateStorage();
 
 		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<>(
-				ZooKeeper.getClient(), stateHandleProvider, Executors.directExecutor());
+				ZOOKEEPER.getClient(), stateHandleProvider, Executors.directExecutor());
 
 		// Config
 		final String pathInZooKeeper = "/testRemove";
 		final Long state = 27255442L;
 
-		store.add(pathInZooKeeper, state);
+		store.addAndLock(pathInZooKeeper, state);
 
 		// Test
-		store.remove(pathInZooKeeper);
+		store.releaseAndTryRemove(pathInZooKeeper);
 
 		// Verify discarded
-		assertEquals(0, ZooKeeper.getClient().getChildren().forPath("/").size());
+		assertEquals(0, ZOOKEEPER.getClient().getChildren().forPath("/").size());
 	}
 
 	/**
@@ -454,68 +417,44 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		LongStateStorage stateHandleProvider = new LongStateStorage();
 
 		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<>(
-				ZooKeeper.getClient(), stateHandleProvider, Executors.directExecutor());
+				ZOOKEEPER.getClient(), stateHandleProvider, Executors.directExecutor());
 
 		// Config
 		final String pathInZooKeeper = "/testRemoveWithCallback";
 		final Long state = 27255442L;
 
-		store.add(pathInZooKeeper, state);
+		store.addAndLock(pathInZooKeeper, state);
 
 		final CountDownLatch sync = new CountDownLatch(1);
-		BackgroundCallback callback = mock(BackgroundCallback.class);
+		ZooKeeperStateHandleStore.RemoveCallback<Long> callback = mock(ZooKeeperStateHandleStore.RemoveCallback.class);
 		doAnswer(new Answer<Void>() {
 			@Override
 			public Void answer(InvocationOnMock invocation) throws Throwable {
 				sync.countDown();
 				return null;
 			}
-		}).when(callback).processResult(eq(ZooKeeper.getClient()), any(CuratorEvent.class));
+		}).when(callback).apply(any(RetrievableStateHandle.class));
 
 		// Test
-		store.remove(pathInZooKeeper, callback);
+		store.releaseAndTryRemove(pathInZooKeeper, callback);
 
 		// Verify discarded and callback called
-		assertEquals(0, ZooKeeper.getClient().getChildren().forPath("/").size());
+		assertEquals(0, ZOOKEEPER.getClient().getChildren().forPath("/").size());
 
 		sync.await();
 
 		verify(callback, times(1))
-				.processResult(eq(ZooKeeper.getClient()), any(CuratorEvent.class));
-	}
-
-	/**
-	 * Tests that state handles are correctly discarded.
-	 */
-	@Test
-	public void testRemoveAndDiscardState() throws Exception {
-		// Setup
-		LongStateStorage stateHandleProvider = new LongStateStorage();
-
-		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<>(
-				ZooKeeper.getClient(), stateHandleProvider, Executors.directExecutor());
-
-		// Config
-		final String pathInZooKeeper = "/testDiscard";
-		final Long state = 27255442L;
-
-		store.add(pathInZooKeeper, state);
-
-		// Test
-		store.removeAndDiscardState(pathInZooKeeper);
-
-		// Verify discarded
-		assertEquals(0, ZooKeeper.getClient().getChildren().forPath("/").size());
+				.apply(any(RetrievableStateHandle.class));
 	}
 
 	/** Tests that all state handles are correctly discarded. */
 	@Test
-	public void testRemoveAndDiscardAllState() throws Exception {
+	public void testReleaseAndTryRemoveAll() throws Exception {
 		// Setup
 		LongStateStorage stateHandleProvider = new LongStateStorage();
 
 		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<>(
-				ZooKeeper.getClient(), stateHandleProvider, Executors.directExecutor());
+				ZOOKEEPER.getClient(), stateHandleProvider, Executors.directExecutor());
 
 		// Config
 		final String pathInZooKeeper = "/testDiscardAll";
@@ -528,25 +467,25 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 
 		// Test
 		for (long val : expected) {
-			store.add(pathInZooKeeper, val, CreateMode.PERSISTENT_SEQUENTIAL);
+			store.addAndLock(pathInZooKeeper + val, val);
 		}
 
-		store.removeAndDiscardAllState();
+		store.releaseAndTryRemoveAll();
 
 		// Verify all discarded
-		assertEquals(0, ZooKeeper.getClient().getChildren().forPath("/").size());
+		assertEquals(0, ZOOKEEPER.getClient().getChildren().forPath("/").size());
 	}
 
 	/**
-	 * Tests that the ZooKeeperStateHandleStore can handle corrupted data by ignoring the respective
-	 * ZooKeeper ZNodes.
+	 * Tests that the ZooKeeperStateHandleStore can handle corrupted data by releasing and trying to remove the
+	 * respective ZooKeeper ZNodes.
 	 */
 	@Test
 	public void testCorruptedData() throws Exception {
 		LongStateStorage stateStorage = new LongStateStorage();
 
 		ZooKeeperStateHandleStore<Long> store = new ZooKeeperStateHandleStore<>(
-			ZooKeeper.getClient(),
+			ZOOKEEPER.getClient(),
 			stateStorage,
 			Executors.directExecutor());
 
@@ -556,13 +495,13 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		input.add(3L);
 
 		for (Long aLong : input) {
-			store.add("/" + aLong, aLong);
+			store.addAndLock("/" + aLong, aLong);
 		}
 
 		// corrupt one of the entries
-		ZooKeeper.getClient().setData().forPath("/" + 2, new byte[2]);
+		ZOOKEEPER.getClient().setData().forPath("/" + 2, new byte[2]);
 
-		List<Tuple2<RetrievableStateHandle<Long>, String>> allEntries = store.getAll();
+		List<Tuple2<RetrievableStateHandle<Long>, String>> allEntries = store.getAllAndLock();
 
 		Collection<Long> expected = new HashSet<>(input);
 		expected.remove(2L);
@@ -576,7 +515,7 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		assertEquals(expected, actual);
 
 		// check the same for the all sorted by name call
-		allEntries = store.getAllSortedByName();
+		allEntries = store.getAllSortedByNameAndLock();
 
 		actual.clear();
 
@@ -585,6 +524,230 @@ public class ZooKeeperStateHandleStoreITCase extends TestLogger {
 		}
 
 		assertEquals(expected, actual);
+
+		Stat stat = ZOOKEEPER.getClient().checkExists().forPath("/" + 2);
+
+		// check that the corrupted node no longer exists
+		assertNull("The corrupted node should no longer exist.", stat);
+	}
+
+	/**
+	 * FLINK-6612
+	 *
+	 * Tests that a concurrent delete operation cannot succeed if another instance holds a lock on the specified
+	 * node.
+	 */
+	@Test
+	public void testConcurrentDeleteOperation() throws Exception {
+		LongStateStorage longStateStorage = new LongStateStorage();
+
+		ZooKeeperStateHandleStore<Long> zkStore1 = new ZooKeeperStateHandleStore<>(
+			ZOOKEEPER.getClient(),
+			longStateStorage,
+			Executors.directExecutor());
+
+		ZooKeeperStateHandleStore<Long> zkStore2 = new ZooKeeperStateHandleStore<>(
+			ZOOKEEPER.getClient(),
+			longStateStorage,
+			Executors.directExecutor());
+
+		final String statePath = "/state";
+
+		zkStore1.addAndLock(statePath, 42L);
+		RetrievableStateHandle<Long> stateHandle = zkStore2.getAndLock(statePath);
+
+		// this should not remove the referenced node because we are still holding a state handle
+		// reference via zkStore2
+		zkStore1.releaseAndTryRemove(statePath);
+
+		// sanity check
+		assertEquals(42L, (long) stateHandle.retrieveState());
+
+		Stat nodeStat = ZOOKEEPER.getClient().checkExists().forPath(statePath);
+
+		assertNotNull("NodeStat should not be null, otherwise the referenced node does not exist.", nodeStat);
+
+		zkStore2.releaseAndTryRemove(statePath);
+
+		nodeStat = ZOOKEEPER.getClient().checkExists().forPath(statePath);
+
+		assertNull("NodeState should be null, because the referenced node should no longer exist.", nodeStat);
+	}
+
+	/**
+	 * FLINK-6612
+	 *
+	 * Tests that getAndLock removes a created lock if the RetrievableStateHandle cannot be retrieved
+	 * (e.g. deserialization problem).
+	 */
+	@Test
+	public void testLockCleanupWhenGetAndLockFails() throws Exception {
+		LongStateStorage longStateStorage = new LongStateStorage();
+
+		ZooKeeperStateHandleStore<Long> zkStore1 = new ZooKeeperStateHandleStore<>(
+			ZOOKEEPER.getClient(),
+			longStateStorage,
+			Executors.directExecutor());
+
+		ZooKeeperStateHandleStore<Long> zkStore2 = new ZooKeeperStateHandleStore<>(
+			ZOOKEEPER.getClient(),
+			longStateStorage,
+			Executors.directExecutor());
+
+		final String path = "/state";
+
+		zkStore1.addAndLock(path, 42L);
+
+		final byte[] corruptedData = {1, 2};
+
+		// corrupt the data
+		ZOOKEEPER.getClient().setData().forPath(path, corruptedData);
+
+		try {
+			zkStore2.getAndLock(path);
+			fail("Should fail because we cannot deserialize the node's data");
+		} catch (IOException ignored) {
+			// expected to fail
+		}
+
+		// check that there is no lock node left
+		String lockNodePath = zkStore2.getLockPath(path);
+
+		Stat stat = ZOOKEEPER.getClient().checkExists().forPath(lockNodePath);
+
+		// zkStore2 should not have created a lock node
+		assertNull("zkStore2 should not have created a lock node.", stat);
+
+		Collection<String> children = ZOOKEEPER.getClient().getChildren().forPath(path);
+
+		// there should be exactly one lock node from zkStore1
+		assertEquals(1, children.size());
+
+		zkStore1.releaseAndTryRemove(path);
+
+		stat = ZOOKEEPER.getClient().checkExists().forPath(path);
+
+		assertNull("The state node should have been removed.", stat);
+	}
+
+	/**
+	 * FLINK-6612
+	 *
+	 * Tests that lock nodes will be released if the client dies.
+	 */
+	@Test
+	public void testLockCleanupWhenClientTimesOut() throws Exception {
+		LongStateStorage longStateStorage = new LongStateStorage();
+
+		Configuration configuration = new Configuration();
+		configuration.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, ZOOKEEPER.getConnectString());
+		configuration.setInteger(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT, 100);
+		configuration.setString(HighAvailabilityOptions.HA_ZOOKEEPER_ROOT, "timeout");
+
+		try (CuratorFramework client = ZooKeeperUtils.startCuratorFramework(configuration);
+			CuratorFramework client2 = ZooKeeperUtils.startCuratorFramework(configuration)) {
+
+			ZooKeeperStateHandleStore<Long> zkStore = new ZooKeeperStateHandleStore<>(
+				client,
+				longStateStorage,
+				Executors.directExecutor());
+
+			final String path = "/state";
+
+			zkStore.addAndLock(path, 42L);
+
+			// this should delete all ephemeral nodes
+			client.close();
+
+			Stat stat = client2.checkExists().forPath(path);
+
+			// check that our state node still exists
+			assertNotNull(stat);
+
+			Collection<String> children = client2.getChildren().forPath(path);
+
+			// check that the lock node has been released
+			assertEquals(0, children.size());
+		}
+	}
+
+	/**
+	 * FLINK-6612
+	 *
+	 * Tests that we can release a locked state handles in the ZooKeeperStateHandleStore.
+	 */
+	@Test
+	public void testRelease() throws Exception {
+		LongStateStorage longStateStorage = new LongStateStorage();
+
+		ZooKeeperStateHandleStore<Long> zkStore = new ZooKeeperStateHandleStore<>(
+			ZOOKEEPER.getClient(),
+			longStateStorage,
+			Executors.directExecutor());
+
+		final String path = "/state";
+
+		zkStore.addAndLock(path, 42L);
+
+		final String lockPath = zkStore.getLockPath(path);
+
+		Stat stat = ZOOKEEPER.getClient().checkExists().forPath(lockPath);
+
+		assertNotNull("Expected an existing lock", stat);
+
+		zkStore.release(path);
+
+		stat = ZOOKEEPER.getClient().checkExists().forPath(path);
+
+		// release should have removed the lock child
+		assertEquals("Expected no lock nodes as children", 0, stat.getNumChildren());
+
+		zkStore.releaseAndTryRemove(path);
+
+		stat = ZOOKEEPER.getClient().checkExists().forPath(path);
+
+		assertNull("State node should have been removed.",stat);
+	}
+
+	/**
+	 * FLINK-6612
+	 *
+	 * Tests that we can release all locked state handles in the ZooKeeperStateHandleStore
+	 */
+	@Test
+	public void testReleaseAll() throws Exception {
+		LongStateStorage longStateStorage = new LongStateStorage();
+
+		ZooKeeperStateHandleStore<Long> zkStore = new ZooKeeperStateHandleStore<>(
+			ZOOKEEPER.getClient(),
+			longStateStorage,
+			Executors.directExecutor());
+
+		final Collection<String> paths = Arrays.asList("/state1", "/state2", "/state3");
+
+		for (String path : paths) {
+			zkStore.addAndLock(path, 42L);
+		}
+
+		for (String path : paths) {
+			Stat stat = ZOOKEEPER.getClient().checkExists().forPath(zkStore.getLockPath(path));
+
+			assertNotNull("Expecte and existing lock.", stat);
+		}
+
+		zkStore.releaseAll();
+
+		for (String path : paths) {
+			Stat stat = ZOOKEEPER.getClient().checkExists().forPath(path);
+
+			assertEquals(0, stat.getNumChildren());
+		}
+
+		zkStore.releaseAndTryRemoveAll();
+
+		Stat stat = ZOOKEEPER.getClient().checkExists().forPath("/");
+
+		assertEquals(0, stat.getNumChildren());
 	}
 
 	// ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
Backport of #3939 onto the `release-1.3` branch.

In order to guard against deletions of ZooKeeper nodes which are still being used
by a different ZooKeeperStateHandleStore, we have to introduce a locking mechanism.
Only after all ZooKeeperStateHandleStores have released their lock, the ZNode is
allowed to be deleted.

THe locking mechanism is implemented via ephemeral child nodes of the respective
ZooKeeper node. Whenever a ZooKeeperStateHandleStore wants to lock a ZNode, thus,
protecting it from being deleted, it creates an ephemeral child node. The node's
name is unique to the ZooKeeperStateHandleStore instance. The delete operations
will then only delete the node if it does not have any children associated.

In order to guard against oprhaned lock nodes, they are created as ephemeral nodes.
This means that they will be deleted by ZooKeeper once the connection of the
ZooKeeper client which created the node timed out.
