### PR TITLE
[FLINK-6632][table]Improved the method BoolLiteral of ExpressionParse…

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
@@ -167,9 +167,8 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
     str => Literal(str.substring(1, str.length - 1))
   }
 
-  lazy val boolLiteral: PackratParser[Expression] = ("true" | "false") ^^ {
-    str => Literal(str.toBoolean)
-  }
+  lazy val boolLiteral: PackratParser[Expression] =
+    ("(t|T)(r|R)(u|U)(e|E)".r | "(f|F)(a|A)(l|L)(s|S)(e|E)".r) ^^ { str => Literal(str.toBoolean)}
 
   lazy val nullLiteral: PackratParser[Expression] = NULL ~ "(" ~> dataType <~ ")" ^^ {
     dt => Null(dt)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/stringexpr/CalcStringExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/table/stringexpr/CalcStringExpressionTest.scala
@@ -112,7 +112,7 @@ class CalcStringExpressionTest {
     val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
 
     val t1 = ds.filter( Literal(false) )
-    val t2 = ds.filter("false")
+    val t2 = ds.filter("faLsE")
 
     val lPlan1 = t1.logicalPlan
     val lPlan2 = t2.logicalPlan
@@ -128,7 +128,7 @@ class CalcStringExpressionTest {
     val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
 
     val t1 = ds.filter( Literal(true) )
-    val t2 = ds.filter("true")
+    val t2 = ds.filter("trUe")
 
     val lPlan1 = t1.logicalPlan
     val lPlan2 = t2.logicalPlan

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ExpressionParserTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ExpressionParserTest.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.expressions
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.expressions.utils.ExpressionTestBase
+import org.apache.flink.types.Row
+import org.junit.Test
+
+/**
+  * Functionality test for [[ExpressionParser]]
+  */
+class ExpressionParserTest extends ExpressionTestBase{
+
+  @Test
+  def testBoolLiteral(): Unit = {
+    testAllApis(
+      Literal(true),
+      "true",
+      "true",
+      "true")
+
+    testAllApis(
+      Literal(true),
+      "True",
+      "tRue",
+      "true")
+
+    testAllApis(
+      Literal(true),
+      "TrUe",
+      "tRuE",
+      "true")
+  }
+
+  override def testData: Any = new Row(0)
+
+  override def typeInfo: TypeInformation[Any] =
+    new RowTypeInfo().asInstanceOf[TypeInformation[Any]]
+}


### PR DESCRIPTION
This PR. only improved the method `BoolLiteral` of `ExpressionParser` for case insensitive.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-6632][table]Improved the method BoolLiteral of ExpressionParser for case insensitive.")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
