### PR TITLE
[FLINK-6629] Use HAServices to find connecting address for ClusterClient's ActorSystem

### DIFF
--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -76,6 +76,14 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
 		
 		<dependency>
 			<groupId>com.data-artisans</groupId>

--- a/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
@@ -52,7 +52,7 @@ public class StandaloneClusterClient extends ClusterClient {
 
 	@Override
 	public String getWebInterfaceURL() {
-		String host = this.getJobManagerAddress().getHostString();
+		String host = getJobManagerAddress().getHostString();
 		int port = getFlinkConfiguration().getInteger(JobManagerOptions.WEB_PORT);
 		return "http://" +  host + ":" + port;
 	}
@@ -70,7 +70,7 @@ public class StandaloneClusterClient extends ClusterClient {
 				throw new RuntimeException("Received the wrong reply " + result + " from cluster.");
 			}
 		} catch (Exception e) {
-			throw new RuntimeException("Couldn't retrieve the Cluster status.", e);
+			throw new RuntimeException("Couldn't retrieve the cluster status.", e);
 		}
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientConnectionTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientConnectionTest.java
@@ -20,14 +20,14 @@ package org.apache.flink.client.program;
 
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.jobgraph.JobVertex;
-import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
 import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.*;
 
@@ -35,17 +35,16 @@ import static org.junit.Assert.*;
  * This test starts a job client without the JobManager being reachable. It
  * tests for a timely error and a meaningful error message.
  */
-public class ClientConnectionTest {
+public class ClientConnectionTest extends TestLogger {
 
-	private static final long CONNECT_TIMEOUT = 2 * 1000; // 2 seconds
-	private static final long ASK_STARTUP_TIMEOUT = 100 * 1000; // 100 seconds
-	private static final long MAX_DELAY = 50 * 1000; // less than the startup timeout
+	private static final long CONNECT_TIMEOUT = 100L; // 100 ms
+	private static final long ASK_STARTUP_TIMEOUT = 20000L; // 10 seconds
 
 	/**
 	 * Tests the behavior against a LOCAL address where no job manager is running.
 	 */
 	@Test
-	public void testExceptionWhenLocalJobManagerUnreachablelocal() {
+	public void testExceptionWhenLocalJobManagerUnreachablelocal() throws Exception {
 
 		final InetSocketAddress unreachableEndpoint;
 		try {
@@ -64,7 +63,7 @@ public class ClientConnectionTest {
 	 * Tests the behavior against a REMOTE address where no job manager is running.
 	 */
 	@Test
-	public void testExceptionWhenRemoteJobManagerUnreachable() {
+	public void testExceptionWhenRemoteJobManagerUnreachable() throws Exception {
 
 		final InetSocketAddress unreachableEndpoint;
 		try {
@@ -79,78 +78,24 @@ public class ClientConnectionTest {
 		testFailureBehavior(unreachableEndpoint);
 	}
 
-	private void testFailureBehavior(final InetSocketAddress unreachableEndpoint) {
+	private static void testFailureBehavior(final InetSocketAddress unreachableEndpoint) throws Exception {
 
 		final Configuration config = new Configuration();
-		config.setString(ConfigConstants.AKKA_ASK_TIMEOUT, (ASK_STARTUP_TIMEOUT/1000) + " s");
-		config.setString(ConfigConstants.AKKA_LOOKUP_TIMEOUT, (CONNECT_TIMEOUT/1000) + " s");
+		config.setString(ConfigConstants.AKKA_ASK_TIMEOUT, (ASK_STARTUP_TIMEOUT) + " ms");
+		config.setString(ConfigConstants.AKKA_LOOKUP_TIMEOUT, (CONNECT_TIMEOUT) + " ms");
 		config.setString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, unreachableEndpoint.getHostName());
 		config.setInteger(ConfigConstants.JOB_MANAGER_IPC_PORT_KEY, unreachableEndpoint.getPort());
 
+		ClusterClient client = new StandaloneClusterClient(config);
 
 		try {
-			JobVertex vertex = new JobVertex("Test Vertex");
-			vertex.setInvokableClass(TestInvokable.class);
-
-			final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
-
-			Thread invoker = new Thread("test invoker") {
-				@Override
-				public void run() {
-					try {
-						new StandaloneClusterClient(config);
-						fail("This should fail with an exception since the JobManager is unreachable.");
-					}
-					catch (Throwable t) {
-						synchronized (error) {
-							error.set(t);
-							error.notifyAll();
-						}
-					}
-				}
-			};
-
-			invoker.setDaemon(true);
-			invoker.start();
-
-			try {
-				// wait until the caller is successful, for at most the given time
-				long now = System.nanoTime();
-				long deadline = now + MAX_DELAY * 1_000_000;
-
-				synchronized (error) {
-					while (invoker.isAlive() && error.get() == null && now < deadline) {
-						error.wait(1000);
-						now = System.nanoTime();
-					}
-				}
-
-				Throwable t = error.get();
-				if (t == null) {
-					fail("Job invocation did not fail in expected time interval.");
-				}
-				else {
-					assertNotNull(t.getMessage());
-					assertTrue(t.getMessage(), t.getMessage().contains("JobManager"));
-				}
-			}
-			finally {
-				if (invoker.isAlive()) {
-					invoker.interrupt();
-				}
-			}
+			// we have to query the cluster status to start the connection attempts
+			client.getClusterStatus();
+			fail("This should fail with an exception since the endpoint is unreachable.");
+		} catch (Exception e) {
+			// check that we have failed with a LeaderRetrievalException which says that we could
+			// not connect to the leading JobManager
+			assertTrue(CommonTestUtils.containsCause(e, LeaderRetrievalException.class));
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-	}
-
-	// --------------------------------------------------------------------------------------------
-
-	public static class TestInvokable extends AbstractInvokable {
-
-		@Override
-		public void invoke() {}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
@@ -137,8 +137,8 @@ public class LeaderRetrievalUtils {
 	}
 
 	public static InetAddress findConnectingAddress(
-		LeaderRetrievalService leaderRetrievalService,
-		Time timeout) throws LeaderRetrievalException {
+			LeaderRetrievalService leaderRetrievalService,
+			Time timeout) throws LeaderRetrievalException {
 		return findConnectingAddress(leaderRetrievalService, new FiniteDuration(timeout.getSize(), timeout.getUnit()));
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
@@ -76,7 +76,7 @@ public class LeaderRetrievalUtils {
 
 			return Await.result(actorGatewayFuture, timeout);
 		} catch (Exception e) {
-			throw new LeaderRetrievalException("Could not retrieve the leader gateway", e);
+			throw new LeaderRetrievalException("Could not retrieve the leader gateway.", e);
 		} finally {
 			try {
 				leaderRetrievalService.stop();

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
@@ -302,4 +302,26 @@ public class CommonTestUtils {
 			throw new RuntimeException("Unclassified error while trying to access the sun.misc.Unsafe handle.", t);
 		}
 	}
+
+	/**
+	 * Checks whether the given throwable contains the given cause as a cause. The cause is not checked
+	 * on equality but on type equality.
+	 *
+	 * @param throwable Throwable to check for the cause
+	 * @param cause Cause to look for
+	 * @return True if the given Throwable contains the given cause (type equality); otherwise false
+	 */
+	public static boolean containsCause(Throwable throwable, Class<? extends Throwable> cause) {
+		Throwable current = throwable;
+
+		while (current != null) {
+			if (cause.isAssignableFrom(current.getClass())) {
+				return true;
+			}
+
+			current = current.getCause();
+		}
+
+		return false;
+	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/RemoteEnvironmentITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/javaApiOperators/RemoteEnvironmentITCase.java
@@ -23,11 +23,13 @@ import org.apache.flink.api.common.operators.util.TestNonRichInputFormat;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
+import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.GenericInputSplit;
 import org.apache.flink.runtime.minicluster.StandaloneMiniCluster;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -73,7 +75,7 @@ public class RemoteEnvironmentITCase extends TestLogger {
 	/**
 	 * Ensure that that Akka configuration parameters can be set.
 	 */
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected=FlinkException.class)
 	public void testInvalidAkkaConfiguration() throws Throwable {
 		Configuration config = new Configuration();
 		config.setString(ConfigConstants.AKKA_STARTUP_TIMEOUT, INVALID_STARTUP_TIMEOUT);
@@ -86,11 +88,11 @@ public class RemoteEnvironmentITCase extends TestLogger {
 		env.getConfig().disableSysoutLogging();
 
 		DataSet<String> result = env.createInput(new TestNonRichInputFormat());
-		result.output(new LocalCollectionOutputFormat<String>(new ArrayList<String>()));
+		result.output(new LocalCollectionOutputFormat<>(new ArrayList<String>()));
 		try {
 			env.execute();
 			Assert.fail("Program should not run successfully, cause of invalid akka settings.");
-		} catch (IOException ex) {
+		} catch (ProgramInvocationException ex) {
 			throw ex.getCause();
 		}
 	}


### PR DESCRIPTION
The ClusterClient starts its ActorSystem lazily. In order to find out the address
to which to bind, the ClusterClient tries to connect to the JobManager. In order
to find out the JobManager's address it is important to use the
HighAvailabilityServices instead of retrieving the address information from the
configuration, because otherwise it conflicts with HA mode.

cc @rmetzger.