### PR TITLE
[FLINK-6639] fix code tabs in CEP docs

### DIFF
--- a/docs/dev/libs/cep.md
+++ b/docs/dev/libs/cep.md
@@ -282,6 +282,7 @@ Pattern<Event, ?> nonStrictNext = start.followedBy("middle");
 val nonStrictNext : Pattern[Event, _] = start.followedBy("middle")
 {% endhighlight %}
 </div>
+</div>
 
 For non-strict contiguity one can specify if only the first succeeding matching event will be matched, or
 all. In the latter case multiple matches will be emitted for the same beginning.


### PR DESCRIPTION
- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

Added a missing `</div>`, which fixes the code tabs for the CEP docs.