### PR TITLE
[FLINK-6628] Fix start scripts on Windows

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -391,7 +391,7 @@ rotateLogFilesWithPrefix() {
     dir=$1
     prefix=$2
     while read -r log ; do
-        rotateLogFile $log
+        rotateLogFile "$log"
     # find distinct set of log file names, ignoring the rotation number (trailing dot and digit)
     done < <(find "$dir" ! -type d -path "${prefix}*" | sed -E s/\.[0-9]+$// | sort | uniq)
 }

--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -97,7 +97,7 @@ case $STARTSTOP in
 
     (start)
         # Rotate log files
-        rotateLogFilesWithPrefix $FLINK_LOG_DIR $FLINK_LOG_PREFIX
+        rotateLogFilesWithPrefix "$FLINK_LOG_DIR" "$FLINK_LOG_PREFIX"
 
         # Print a warning if daemons are already running on host
         if [ -f $pid ]; then

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -75,11 +75,9 @@ fi
 if [[ $STARTSTOP == "start-foreground" ]]; then
     exec "${FLINK_BIN_DIR}"/flink-console.sh taskmanager "${args[@]}"
 else
-    TM_COMMAND="${FLINK_BIN_DIR}/flink-daemon.sh $STARTSTOP taskmanager ${args[@]}"
-    
     if [[ $FLINK_TM_COMPUTE_NUMA == "false" ]]; then
         # Start a single TaskManager
-        $TM_COMMAND
+        "${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP taskmanager "${args[@]}"
     else
         # Example output from `numactl --show` on an AWS c4.8xlarge:
         # policy: default
@@ -91,7 +89,7 @@ else
         read -ra NODE_LIST <<< $(numactl --show | grep "^nodebind: ")
         for NODE_ID in "${NODE_LIST[@]:1}"; do
             # Start a TaskManager for each NUMA node
-            numactl --membind=$NODE_ID --cpunodebind=$NODE_ID -- $TM_COMMAND
+            numactl --membind=$NODE_ID --cpunodebind=$NODE_ID -- "${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP taskmanager "${args[@]}"
         done
     fi
 fi


### PR DESCRIPTION
This PR fixes the `flink-daemon.sh` and `taskmanager.sh` script for cygwin for directories containing spaces.
They were broken in 11c868f91db773af626ac6ac4dcba9820c13fa8a.

The change in the daemon script is straight-forward; to prevent the path containing the space to be interpreted as to arguments we wrap it in `"` which causes the entire path, including the space, to be passed  as a single argument.

The change in the taskmanager script is as subtle as it gets. When storing the call like this `TM_COMMAND="${FLINK_BIN_DIR}/flink-daemon.sh $STARTSTOP taskmanager ${args[@]}"` and executing it later spaces are once again used to separate arguments, breaking the execution. We can't use the trick used above, since then the entire expressions is used as a single argument (i.e. path to an executable) which obviously fails.