### PR TITLE
[FLINK-6642] Return -1 in EnvInfo#getOpenFileHandlesLimit on Windows

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/EnvironmentInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/EnvironmentInformation.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Properties;
 
+import org.apache.flink.util.OperatingSystem;
 import org.apache.hadoop.util.VersionInfo;
 
 import org.slf4j.Logger;
@@ -232,6 +233,9 @@ public class EnvironmentInformation {
 	 * @return The limit of open file handles, or {@code -1}, if the limit could not be determined.
 	 */
 	public static long getOpenFileHandlesLimit() {
+		if (OperatingSystem.isWindows()) { // getMaxFileDescriptorCount method is not available on Windows
+			return -1L;
+		}
 		Class<?> sunBeanClass;
 		try {
 			sunBeanClass = Class.forName("com.sun.management.UnixOperatingSystemMXBean");


### PR DESCRIPTION
Returns -1 for Windows, as the accessed UnixOSMXBean is obviously not available on Windows.

This reduces logging noise on Windows.