### PR TITLE
[FLINK-6654][build] let 'flink-dist' properly depend on 'flink-shaded…

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -45,6 +45,18 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-hadoop2-uber</artifactId>
+			<version>${project.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-shaded-hadoop2</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-java</artifactId>
 			<version>${project.version}</version>
 			<exclusions>

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -47,12 +47,10 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2-uber</artifactId>
 			<version>${project.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-shaded-hadoop2</artifactId>
-				</exclusion>
-			</exclusions>
+			<!--
+				Exclusion of flink-shaded-hadoop2 not necessary, dependencies
+				are shaded away properly by flink-shaded-hadoop2-uber.
+			-->
 		</dependency>
 
 		<dependency>

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -51,6 +51,7 @@ under the License.
 				Exclusion of flink-shaded-hadoop2 not necessary, dependencies
 				are shaded away properly by flink-shaded-hadoop2-uber.
 			-->
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Since applying FLINK-6514, flink-dist includes `flink-shaded-hadoop2-uber-*.jar` but without giving this dependency in its `pom.xml`. This may lead to concurrency issues during builds but also fails building the flink-dist module only (with dependencies) as in

`mvn clean install -pl flink-dist -am`

This PR adds the missing dependency.
