### PR TITLE
[FLINK-6659] fix (some) unit tests leaving temporary data behind

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBMergeIteratorTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBMergeIteratorTest.java
@@ -21,16 +21,16 @@ package org.apache.flink.contrib.streaming.state;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
-import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksIterator;
 
 import java.io.DataOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -43,6 +43,9 @@ public class RocksDBMergeIteratorTest {
 	private static final int NUM_KEY_VAL_STATES = 50;
 	private static final int MAX_NUM_KEYS = 20;
 
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
 	@Test
 	public void testEmptyMergeIterator() throws IOException {
 		RocksDBKeyedStateBackend.RocksDBMergeIterator emptyIterator =
@@ -51,19 +54,23 @@ public class RocksDBMergeIteratorTest {
 	}
 
 	@Test
-	public void testMergeIterator() throws Exception {
+	public void testMergeIteratorByte() throws Exception {
 		Assert.assertTrue(MAX_NUM_KEYS <= Byte.MAX_VALUE);
 
 		testMergeIterator(Byte.MAX_VALUE);
+	}
+
+	@Test
+	public void testMergeIteratorShort() throws Exception {
+		Assert.assertTrue(MAX_NUM_KEYS <= Byte.MAX_VALUE);
+
 		testMergeIterator(Short.MAX_VALUE);
 	}
 
 	public void testMergeIterator(int maxParallelism) throws Exception {
 		Random random = new Random(1234);
 
-		File tmpDir = CommonTestUtils.createTempDirectory();
-
-		RocksDB rocksDB = RocksDB.open(tmpDir.getAbsolutePath());
+		RocksDB rocksDB = RocksDB.open(tempFolder.getRoot().getAbsolutePath());
 		try {
 			List<Tuple2<RocksIterator, Integer>> rocksIteratorsWithKVStateId = new ArrayList<>();
 			List<Tuple2<ColumnFamilyHandle, Integer>> columnFamilyHandlesWithKeyCount = new ArrayList<>();

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -68,7 +68,6 @@ import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.ResponseS
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.WaitForAllVerticesToBeRunning;
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages;
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages.ResponseSubmitTaskListener;
-import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.IterativeStream;
@@ -143,7 +142,7 @@ public class SavepointITCase extends TestLogger {
 		final int numSlotsPerTaskManager = 2;
 		final int parallelism = numTaskManagers * numSlotsPerTaskManager;
 		final Deadline deadline = new FiniteDuration(5, TimeUnit.MINUTES).fromNow();
-		final File testRoot = folder.newFolder();
+		final File testRoot = folder.getRoot();
 
 		TestingCluster flink = null;
 
@@ -424,7 +423,7 @@ public class SavepointITCase extends TestLogger {
 		// Test deadline
 		final Deadline deadline = new FiniteDuration(5, TimeUnit.MINUTES).fromNow();
 
-		final File tmpDir = CommonTestUtils.createTempDirectory();
+		final File tmpDir = folder.getRoot();
 		final File savepointDir = new File(tmpDir, "savepoints");
 
 		TestingCluster flink = null;
@@ -494,7 +493,7 @@ public class SavepointITCase extends TestLogger {
 		// Test deadline
 		final Deadline deadline = new FiniteDuration(5, TimeUnit.MINUTES).fromNow();
 
-		final File tmpDir = CommonTestUtils.createTempDirectory();
+		final File tmpDir = folder.getRoot();
 		final File savepointDir = new File(tmpDir, "savepoints");
 
 		TestingCluster flink = null;


### PR DESCRIPTION
Both, `RocksDBMergeIteratorTest` as well as `SavepointITCase` were using `CommonTestUtils.createTempDirectory()` to create a temporary directory and never deleted it after the test finishes. This PR replaces this usage by a JUnit `@Rule` instead.