### PR TITLE
[FLINK-6669] Scala style check errror on Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1337,6 +1337,7 @@ under the License.
 						<sourceDirectory>${basedir}/src/main/scala</sourceDirectory>
 						<testSourceDirectory>${basedir}/src/test/scala</testSourceDirectory>
 						<outputFile>${project.basedir}/target/scalastyle-output.xml</outputFile>
+						<inputEncoding>UTF-8</inputEncoding>
 						<outputEncoding>UTF-8</outputEncoding>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
When build the source code on Windows, a scala style check error happend.
It may be caused by the Windows default encoding. When set the inputEncoding to UTF-8 in scalastyle-maven-plugin, the error don't happen.

https://issues.apache.org/jira/browse/FLINK-6669