### PR TITLE
[FLINK-6477][web] Waiting the metrics retrieved from the TaskManagers

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagersHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagersHandler.java
@@ -107,7 +107,7 @@ public class TaskManagersHandler extends AbstractJsonRequestHandler  {
 					gen.writeNumberField("managedMemory", instance.getResources().getSizeOfManagedMemory());
 
 					// only send metrics when only one task manager requests them.
-					if (pathParams.containsKey(TASK_MANAGER_ID_KEY)) {
+					while (pathParams.containsKey(TASK_MANAGER_ID_KEY)) {
 						fetcher.update();
 						MetricStore.TaskManagerMetricStore metrics = fetcher.getMetricStore().getTaskManagerMetricStore(instance.getId().toString());
 						if (metrics != null) {
@@ -170,7 +170,9 @@ public class TaskManagersHandler extends AbstractJsonRequestHandler  {
 
 							gen.writeEndArray();
 							gen.writeEndObject();
+							break;
 						}
+						Thread.sleep(1000);
 					}
 
 					gen.writeEndObject();
@@ -186,7 +188,7 @@ public class TaskManagersHandler extends AbstractJsonRequestHandler  {
 				throw new Exception("No connection to the leading JobManager.");
 			}
 		}
-		catch (Exception e) {
+		catch (RuntimeException e) {
 			throw new RuntimeException("Failed to fetch list of all task managers: " + e.getMessage(), e);
 		}
 	}


### PR DESCRIPTION
problem:
Flink web page of Taskmanager metrics can not display normal, when we first login.

analysis:
The web-frontend communicates with the backend for requesting metrics, and the metrics retrieved from the TaskManagers. The first call to load metrics starts a new metrics update, and gets nothing as a result. now we wait to get the result and response to the web-frontend.
