### PR TITLE
[FLINK-6662] [errMsg] Improve error message if recovery from RetrievableStateHandles fails

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
@@ -376,8 +377,14 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 
 		try {
 			return stateHandlePath.f0.retrieveState();
-		} catch (Exception e) {
-			throw new FlinkException("Could not retrieve checkpoint " + checkpointId + ". The state handle seems to be broken.", e);
+		} catch (ClassNotFoundException cnfe) {
+			throw new FlinkException("Could not retrieve checkpoint " + checkpointId + " from state handle under " +
+				stateHandlePath.f1 + ". This indicates that you are trying to recover from state written by an " +
+				"older Flink version which is not compatible. Try cleaning the state handle store.", cnfe);
+		} catch (IOException ioe) {
+			throw new FlinkException("Could not retrieve " + checkpointId + " worker from state handle under " +
+				stateHandlePath.f1 + ". This indicates that the retrieved state handle is broken. Try cleaning the " +
+				"state handle store.", ioe);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStateHandle.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
+import java.io.IOException;
 import java.io.Serializable;
 
 /**
@@ -28,5 +29,5 @@ public interface RetrievableStateHandle<T extends Serializable> extends StateObj
 	/**
 	 * Retrieves the object that was previously written to state.
 	 */
-	T retrieveState() throws Exception;
+	T retrieveState() throws IOException, ClassNotFoundException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
@@ -53,7 +53,7 @@ public class RetrievableStreamStateHandle<T extends Serializable> implements
 	}
 
 	@Override
-	public T retrieveState() throws Exception {
+	public T retrieveState() throws IOException, ClassNotFoundException {
 		try (FSDataInputStream in = openInputStream()) {
 			return InstantiationUtil.deserializeObject(in, Thread.currentThread().getContextClassLoader());
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -297,8 +297,9 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 			stateMap.put(key, state);
 		}
 
+		@SuppressWarnings("unchecked")
 		@Override
-		public T retrieveState() throws Exception {
+		public T retrieveState() {
 			return (T) stateMap.get(key);
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -39,6 +39,7 @@ import org.mockito.stubbing.Answer;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -93,7 +94,7 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 		expectedCheckpointIds.add(2L);
 
 		final RetrievableStateHandle<CompletedCheckpoint> failingRetrievableStateHandle = mock(RetrievableStateHandle.class);
-		when(failingRetrievableStateHandle.retrieveState()).thenThrow(new Exception("Test exception"));
+		when(failingRetrievableStateHandle.retrieveState()).thenThrow(new IOException("Test exception"));
 
 		final RetrievableStateHandle<CompletedCheckpoint> retrievableStateHandle1 = mock(RetrievableStateHandle.class);
 		when(retrievableStateHandle1.retrieveState()).thenReturn(completedCheckpoint1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
@@ -784,7 +784,7 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
 		}
 
 		@Override
-		public Long retrieveState() throws Exception {
+		public Long retrieveState() {
 			return state;
 		}
 


### PR DESCRIPTION
When recovering state from a ZooKeeperStateHandleStore it can happen that the deserialization
fails, because one tries to recover state from an old Flink version which is not compatible.
In this case we should output a better error message such that the user can easily spot the
problem.
