### PR TITLE
[FLINK-6704][yarn] Fix user-jars not being possible to exclude from system class path

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -676,7 +676,13 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 		// upload and register ship files	
 		List<String> systemClassPaths = uploadAndRegisterFiles(systemShipFiles, fs, appId.toString(), paths, localResources, envShipFileList);
-		List<String> userClassPaths = uploadAndRegisterFiles(userJarFiles, fs, appId.toString(), paths, localResources, envShipFileList);
+
+		List<String> userClassPaths;
+		if (userJarInclusion != YarnConfigOptions.UserJarInclusion.DISABLED) {
+			userClassPaths = uploadAndRegisterFiles(userJarFiles, fs, appId.toString(), paths, localResources, envShipFileList);
+		} else {
+			userClassPaths = Collections.emptyList();
+		}
 
 		if (userJarInclusion == YarnConfigOptions.UserJarInclusion.ORDER) {
 			systemClassPaths.addAll(userClassPaths);


### PR DESCRIPTION
This PR fixes the `DISABLED` setting; the user-jars were included in the system CP even if the flag was set.

There was one place in the cluster descriptor where we were touching the user jars even though it was set.