### PR TITLE
[FLINK-6763] [core] Make serialization of composite serializer configs more efficient

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -601,7 +601,10 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			}
 
 			KeyedBackendSerializationProxy<K> serializationProxy =
-					new KeyedBackendSerializationProxy<>(stateBackend.getKeySerializer(), metaInfoSnapshots);
+					new KeyedBackendSerializationProxy<>(
+							stateBackend.getKeySerializer(),
+							metaInfoSnapshots,
+							false); // TODO make this configurable
 
 			serializationProxy.write(outputView);
 		}
@@ -807,7 +810,10 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				closeableRegistry.registerClosable(outputStream);
 
 				KeyedBackendSerializationProxy<K> serializationProxy =
-					new KeyedBackendSerializationProxy<>(stateBackend.keySerializer, stateMetaInfoSnapshots);
+						new KeyedBackendSerializationProxy<>(
+								stateBackend.keySerializer,
+								stateMetaInfoSnapshots,
+								false); // TODO make this configurable
 				DataOutputView out = new DataOutputViewStreamWrapper(outputStream);
 
 				serializationProxy.write(out);
@@ -1234,7 +1240,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				stateBackend.cancelStreamRegistry.registerClosable(inputStream);
 
 				KeyedBackendSerializationProxy<T> serializationProxy =
-					new KeyedBackendSerializationProxy<>(stateBackend.userCodeClassLoader);
+						new KeyedBackendSerializationProxy<>(stateBackend.userCodeClassLoader);
 				DataInputView in = new DataInputViewStreamWrapper(inputStream);
 				serializationProxy.read(in);
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
@@ -21,7 +21,6 @@ package org.apache.flink.api.common.typeutils;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.io.VersionedIOReadableWritable;
-import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
@@ -32,6 +31,8 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.util.ArrayList;
@@ -49,6 +50,36 @@ public class TypeSerializerSerializationUtil {
 	 * Writes a {@link TypeSerializer} to the provided data output view.
 	 *
 	 * <p>It is written with a format that can be later read again using
+	 * {@link #tryReadSerializerWithResilience(DataInputView, ClassLoader, boolean)}, which
+	 * allows skipping the serializer in the byte stream if any error occurs while reading it.
+	 *
+	 * <p>Format:
+	 *   1. length of serialized serializer
+	 *   2. serialized serializer
+	 *
+	 * @param out the data output view.
+	 * @param serializer the serializer to write.
+	 *
+	 * @param <T> Data type of the serializer.
+	 *
+	 * @throws IOException
+	 */
+	public static <T> void writeSerializerWithResilience(DataOutputView out, TypeSerializer<T> serializer) throws IOException {
+		try (
+			ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+			DataOutputViewStreamWrapper bufferWrapper = new DataOutputViewStreamWrapper(buffer)) {
+
+			writeSerializer(bufferWrapper, serializer);
+
+			out.writeInt(buffer.size());
+			out.write(buffer.toByteArray(), 0, buffer.size());
+		}
+	}
+
+	/**
+	 * Writes a {@link TypeSerializer} to the provided data output view.
+	 *
+	 * <p>It is written with a format that can be later read again using
 	 * {@link #tryReadSerializer(DataInputView, ClassLoader, boolean)}.
 	 *
 	 * @param out the data output view.
@@ -60,6 +91,70 @@ public class TypeSerializerSerializationUtil {
 	 */
 	public static <T> void writeSerializer(DataOutputView out, TypeSerializer<T> serializer) throws IOException {
 		new TypeSerializerSerializationUtil.TypeSerializerSerializationProxy<>(serializer).write(out);
+	}
+
+	/**
+	 * Reads from a data input view a {@link TypeSerializer} that was previously
+	 * written using {@link #writeSerializerWithResilience(DataOutputView, TypeSerializer)}.
+	 *
+	 * <p>If deserialization fails for any reason (corrupted serializer bytes, serializer class
+	 * no longer in classpath, serializer class no longer valid, etc.), {@code null} will
+	 * be returned instead.
+	 *
+	 * <p>Also, if deserialization fails, it is guaranteed that the remaining bytes for
+	 * the serializer will be skipped so that the position of the byte stream will be right
+	 * after the serializer bytes.
+	 *
+	 * @param in the data input view.
+	 * @param userCodeClassLoader the user code class loader to use.
+	 *
+	 * @param <T> Data type of the serializer.
+	 *
+	 * @return the deserialized serializer.
+	 */
+	public static <T> TypeSerializer<T> tryReadSerializerWithResilience(DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
+		return tryReadSerializerWithResilience(in, userCodeClassLoader, false);
+	}
+
+	/**
+	 * Reads from a data input view a {@link TypeSerializer} that was previously
+	 * written using {@link #writeSerializerWithResilience(DataOutputView, TypeSerializer)}.
+	 *
+	 * <p>If deserialization fails due to {@link ClassNotFoundException} or {@link InvalidClassException},
+	 * users can opt to use a dummy {@link UnloadableDummyTypeSerializer} to hold the serializer bytes,
+	 * otherwise {@code null} is returned. If the failure is due to a {@link java.io.StreamCorruptedException},
+	 * then {@code null} is returned.
+	 *
+	 * <p>Also, if deserialization fails, it is guaranteed that the remaining bytes for
+	 * the serializer will be skipped so that the position of the byte stream will be right
+	 * after the serializer bytes.
+	 *
+	 * @param in the data input view.
+	 * @param userCodeClassLoader the user code class loader to use.
+	 * @param useDummyPlaceholder whether or not to use a dummy {@link UnloadableDummyTypeSerializer} to hold the
+	 *                            serializer bytes in the case of a {@link ClassNotFoundException} or
+	 *                            {@link InvalidClassException}.
+	 *
+	 * @param <T> Data type of the serializer.
+	 *
+	 * @return the deserialized serializer.
+	 */
+	public static <T> TypeSerializer<T> tryReadSerializerWithResilience(
+			DataInputView in,
+			ClassLoader userCodeClassLoader,
+			boolean useDummyPlaceholder) throws IOException {
+
+		int numSerializerBytes = in.readInt();
+
+		byte[] serializerBytes = new byte[numSerializerBytes];
+		in.readFully(serializerBytes);
+
+		try (
+			ByteArrayInputStream buffer = new ByteArrayInputStream(serializerBytes);
+			DataInputViewStreamWrapper bufferWrapper = new DataInputViewStreamWrapper(buffer)) {
+
+			return tryReadSerializer(bufferWrapper, userCodeClassLoader, useDummyPlaceholder);
+		}
 	}
 
 	/**
@@ -100,7 +195,11 @@ public class TypeSerializerSerializationUtil {
 	 *
 	 * @return the deserialized serializer.
 	 */
-	public static <T> TypeSerializer<T> tryReadSerializer(DataInputView in, ClassLoader userCodeClassLoader, boolean useDummyPlaceholder) {
+	public static <T> TypeSerializer<T> tryReadSerializer(
+			DataInputView in,
+			ClassLoader userCodeClassLoader,
+			boolean useDummyPlaceholder) {
+
 		final TypeSerializerSerializationUtil.TypeSerializerSerializationProxy<T> proxy =
 			new TypeSerializerSerializationUtil.TypeSerializerSerializationProxy<>(userCodeClassLoader, useDummyPlaceholder);
 
@@ -124,9 +223,8 @@ public class TypeSerializerSerializationUtil {
 	 * offset positions within the serialized bytes. The serialization format is as follows:
 	 * <ul>
 	 *     <li>1. number of serializer and configuration snapshot pairs.</li>
-	 *     <li>2. offsets of each serializer and configuration snapshot, in order.</li>
-	 *     <li>3. total number of bytes for the serialized serializers and the config snapshots.</li>
-	 *     <li>4. serialized serializers and the config snapshots.</li>
+	 *     <li>2. Each serializer and configuration snapshot pair, which contains of the
+	 *            serializer length, followed by the serializer bytes, and finally the config snapshot bytes.</li>
 	 * </ul>
 	 *
 	 * @param out the data output view.
@@ -138,21 +236,10 @@ public class TypeSerializerSerializationUtil {
 			DataOutputView out,
 			List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> serializersAndConfigs) throws IOException {
 
-		try (
-			ByteArrayOutputStreamWithPos bufferWithPos = new ByteArrayOutputStreamWithPos();
-			DataOutputViewStreamWrapper bufferWrapper = new DataOutputViewStreamWrapper(bufferWithPos)) {
-
-			out.writeInt(serializersAndConfigs.size());
-			for (Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> serAndConfSnapshot : serializersAndConfigs) {
-				out.writeInt(bufferWithPos.getPosition());
-				writeSerializer(bufferWrapper, serAndConfSnapshot.f0);
-
-				out.writeInt(bufferWithPos.getPosition());
-				writeSerializerConfigSnapshot(bufferWrapper, serAndConfSnapshot.f1);
-			}
-
-			out.writeInt(bufferWithPos.getPosition());
-			out.write(bufferWithPos.getBuf(), 0, bufferWithPos.getPosition());
+		out.writeInt(serializersAndConfigs.size());
+		for (Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> serAndConfSnapshot : serializersAndConfigs) {
+			writeSerializerWithResilience(out, serAndConfSnapshot.f0);
+			writeSerializerConfigSnapshot(out, serAndConfSnapshot.f1);
 		}
 	}
 
@@ -175,37 +262,14 @@ public class TypeSerializerSerializationUtil {
 
 		int numSerializersAndConfigSnapshots = in.readInt();
 
-		int[] offsets = new int[numSerializersAndConfigSnapshots * 2];
-
-		for (int i = 0; i < numSerializersAndConfigSnapshots; i++) {
-			offsets[i * 2] = in.readInt();
-			offsets[i * 2 + 1] = in.readInt();
-		}
-
-		int totalBytes = in.readInt();
-		byte[] buffer = new byte[totalBytes];
-		in.readFully(buffer);
-
 		List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> serializersAndConfigSnapshots =
 			new ArrayList<>(numSerializersAndConfigSnapshots);
 
-		TypeSerializer<?> serializer;
-		TypeSerializerConfigSnapshot configSnapshot;
-		try (
-			ByteArrayInputStreamWithPos bufferWithPos = new ByteArrayInputStreamWithPos(buffer);
-			DataInputViewStreamWrapper bufferWrapper = new DataInputViewStreamWrapper(bufferWithPos)) {
-
-			for (int i = 0; i < numSerializersAndConfigSnapshots; i++) {
-
-				bufferWithPos.setPosition(offsets[i * 2]);
-				serializer = tryReadSerializer(bufferWrapper, userCodeClassLoader);
-
-				bufferWithPos.setPosition(offsets[i * 2 + 1]);
-				configSnapshot = readSerializerConfigSnapshot(bufferWrapper, userCodeClassLoader);
-
-				serializersAndConfigSnapshots.add(
-					new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(serializer, configSnapshot));
-			}
+		for (int i = 0; i < numSerializersAndConfigSnapshots; i++) {
+			serializersAndConfigSnapshots.add(new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(
+				tryReadSerializerWithResilience(in, userCodeClassLoader),
+				readSerializerConfigSnapshot(in, userCodeClassLoader))
+			);
 		}
 
 		return serializersAndConfigSnapshots;

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
@@ -42,12 +42,8 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil;
 import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
-import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
-import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputView;
-import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.util.Preconditions;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -806,63 +802,49 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 		public void write(DataOutputView out) throws IOException {
 			super.write(out);
 
-			try (
-				ByteArrayOutputStreamWithPos outWithPos = new ByteArrayOutputStreamWithPos();
-				DataOutputViewStreamWrapper outViewWrapper = new DataOutputViewStreamWrapper(outWithPos)) {
+			// --- write fields and their serializers, in order
 
-				// --- write fields and their serializers, in order
+			out.writeInt(fieldToSerializerConfigSnapshot.size());
+			for (Map.Entry<Field, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> entry
+				: fieldToSerializerConfigSnapshot.entrySet()) {
 
-				out.writeInt(fieldToSerializerConfigSnapshot.size());
-				for (Map.Entry<Field, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> entry
-						: fieldToSerializerConfigSnapshot.entrySet()) {
+				out.writeUTF(entry.getKey().getName());
 
-					outViewWrapper.writeUTF(entry.getKey().getName());
-
-					out.writeInt(outWithPos.getPosition());
-					if (!ignoreTypeSerializerSerialization) {
-						TypeSerializerSerializationUtil.writeSerializer(outViewWrapper, entry.getValue().f0);
-					}
-
-					out.writeInt(outWithPos.getPosition());
-					TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(outViewWrapper, entry.getValue().f1);
+				if (!ignoreTypeSerializerSerialization) {
+					TypeSerializerSerializationUtil.writeSerializerWithResilience(out, entry.getValue().f0);
 				}
 
-				// --- write registered subclasses and their serializers, in registration order
+				TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(out, entry.getValue().f1);
+			}
 
-				out.writeInt(registeredSubclassesToSerializerConfigSnapshots.size());
-				for (Map.Entry<Class<?>, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> entry
-						: registeredSubclassesToSerializerConfigSnapshots.entrySet()) {
+			// --- write registered subclasses and their serializers, in registration order
 
-					outViewWrapper.writeUTF(entry.getKey().getName());
+			out.writeInt(registeredSubclassesToSerializerConfigSnapshots.size());
+			for (Map.Entry<Class<?>, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> entry
+				: registeredSubclassesToSerializerConfigSnapshots.entrySet()) {
 
-					out.writeInt(outWithPos.getPosition());
-					if (!ignoreTypeSerializerSerialization) {
-						TypeSerializerSerializationUtil.writeSerializer(outViewWrapper, entry.getValue().f0);
-					}
+				out.writeUTF(entry.getKey().getName());
 
-					out.writeInt(outWithPos.getPosition());
-					TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(outViewWrapper, entry.getValue().f1);
+				if (!ignoreTypeSerializerSerialization) {
+					TypeSerializerSerializationUtil.writeSerializerWithResilience(out, entry.getValue().f0);
 				}
 
-				// --- write snapshot of non-registered subclass serializer cache
+				TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(out, entry.getValue().f1);
+			}
 
-				out.writeInt(nonRegisteredSubclassesToSerializerConfigSnapshots.size());
-				for (Map.Entry<Class<?>, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> entry
-						: nonRegisteredSubclassesToSerializerConfigSnapshots.entrySet()) {
+			// --- write snapshot of non-registered subclass serializer cache
 
-					outViewWrapper.writeUTF(entry.getKey().getName());
+			out.writeInt(nonRegisteredSubclassesToSerializerConfigSnapshots.size());
+			for (Map.Entry<Class<?>, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> entry
+				: nonRegisteredSubclassesToSerializerConfigSnapshots.entrySet()) {
 
-					out.writeInt(outWithPos.getPosition());
-					if (!ignoreTypeSerializerSerialization) {
-						TypeSerializerSerializationUtil.writeSerializer(outViewWrapper, entry.getValue().f0);
-					}
+				out.writeUTF(entry.getKey().getName());
 
-					out.writeInt(outWithPos.getPosition());
-					TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(outViewWrapper, entry.getValue().f1);
+				if (!ignoreTypeSerializerSerialization) {
+					TypeSerializerSerializationUtil.writeSerializerWithResilience(out, entry.getValue().f0);
 				}
 
-				out.writeInt(outWithPos.getPosition());
-				out.write(outWithPos.getBuf(), 0 , outWithPos.getPosition());
+				TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(out, entry.getValue().f1);
 			}
 		}
 
@@ -870,126 +852,83 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 		public void read(DataInputView in) throws IOException {
 			super.read(in);
 
+			// --- read fields and their serializers, in order
+
 			int numFields = in.readInt();
-			int[] fieldSerializerOffsets = new int[numFields * 2];
+
+			this.fieldToSerializerConfigSnapshot = new LinkedHashMap<>(numFields);
+			String fieldName;
+			Field field;
 			for (int i = 0; i < numFields; i++) {
-				fieldSerializerOffsets[i * 2] = in.readInt();
-				fieldSerializerOffsets[i * 2 + 1] = in.readInt();
+				fieldName = in.readUTF();
+
+				// search all superclasses for the field
+				Class<?> clazz = getTypeClass();
+				field = null;
+				while (clazz != null) {
+					try {
+						field = clazz.getDeclaredField(fieldName);
+						field.setAccessible(true);
+						break;
+					} catch (NoSuchFieldException e) {
+						clazz = clazz.getSuperclass();
+					}
+				}
+
+				if (field == null) {
+					// the field no longer exists in the POJO
+					throw new IOException("Can't find field " + fieldName + " in POJO class " + getTypeClass().getName());
+				} else {
+					fieldToSerializerConfigSnapshot.put(
+						field,
+						new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(
+							TypeSerializerSerializationUtil.tryReadSerializerWithResilience(in, getUserCodeClassLoader()),
+							TypeSerializerSerializationUtil.readSerializerConfigSnapshot(in, getUserCodeClassLoader())));
+				}
 			}
 
+			// --- read registered subclasses and their serializers, in registration order
 
 			int numRegisteredSubclasses = in.readInt();
-			int[] registeredSerializerOffsets = new int[numRegisteredSubclasses * 2];
+
+			this.registeredSubclassesToSerializerConfigSnapshots = new LinkedHashMap<>(numRegisteredSubclasses);
+			String registeredSubclassname;
+			Class<?> registeredSubclass;
 			for (int i = 0; i < numRegisteredSubclasses; i++) {
-				registeredSerializerOffsets[i * 2] = in.readInt();
-				registeredSerializerOffsets[i * 2 + 1] = in.readInt();
+				registeredSubclassname = in.readUTF();
+				try {
+					registeredSubclass = Class.forName(registeredSubclassname, true, getUserCodeClassLoader());
+				} catch (ClassNotFoundException e) {
+					throw new IOException("Cannot find requested class " + registeredSubclassname + " in classpath.", e);
+				}
+
+				this.registeredSubclassesToSerializerConfigSnapshots.put(
+					registeredSubclass,
+					new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(
+						TypeSerializerSerializationUtil.tryReadSerializerWithResilience(in, getUserCodeClassLoader()),
+						TypeSerializerSerializationUtil.readSerializerConfigSnapshot(in, getUserCodeClassLoader())));
 			}
+
+			// --- read snapshot of non-registered subclass serializer cache
 
 			int numCachedSubclassSerializers = in.readInt();
-			int[] cachedSerializerOffsets = new int[numCachedSubclassSerializers * 2];
+
+			this.nonRegisteredSubclassesToSerializerConfigSnapshots = new HashMap<>(numCachedSubclassSerializers);
+			String cachedSubclassname;
+			Class<?> cachedSubclass;
 			for (int i = 0; i < numCachedSubclassSerializers; i++) {
-				cachedSerializerOffsets[i * 2] = in.readInt();
-				cachedSerializerOffsets[i * 2 + 1] = in.readInt();
-			}
-
-			int totalBytes = in.readInt();
-			byte[] buffer = new byte[totalBytes];
-			in.readFully(buffer);
-
-			try (
-				ByteArrayInputStreamWithPos inWithPos = new ByteArrayInputStreamWithPos(buffer);
-				DataInputViewStreamWrapper inViewWrapper = new DataInputViewStreamWrapper(inWithPos)) {
-
-				// --- read fields and their serializers, in order
-
-				this.fieldToSerializerConfigSnapshot = new LinkedHashMap<>(numFields);
-				String fieldName;
-				Field field;
-				TypeSerializer<?> fieldSerializer;
-				TypeSerializerConfigSnapshot fieldSerializerConfigSnapshot;
-				for (int i = 0; i < numFields; i++) {
-					fieldName = inViewWrapper.readUTF();
-
-					// search all superclasses for the field
-					Class<?> clazz = getTypeClass();
-					field = null;
-					while (clazz != null) {
-						try {
-							field = clazz.getDeclaredField(fieldName);
-							field.setAccessible(true);
-							break;
-						} catch (NoSuchFieldException e) {
-							clazz = clazz.getSuperclass();
-						}
-					}
-
-					if (field == null) {
-						// the field no longer exists in the POJO
-						throw new IOException("Can't find field " + fieldName + " in POJO class " + getTypeClass().getName());
-					} else {
-						inWithPos.setPosition(fieldSerializerOffsets[i * 2]);
-						fieldSerializer = TypeSerializerSerializationUtil.tryReadSerializer(inViewWrapper, getUserCodeClassLoader());
-
-						inWithPos.setPosition(fieldSerializerOffsets[i * 2 + 1]);
-						fieldSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(inViewWrapper, getUserCodeClassLoader());
-
-						fieldToSerializerConfigSnapshot.put(
-							field,
-							new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(fieldSerializer, fieldSerializerConfigSnapshot));
-					}
+				cachedSubclassname = in.readUTF();
+				try {
+					cachedSubclass = Class.forName(cachedSubclassname, true, getUserCodeClassLoader());
+				} catch (ClassNotFoundException e) {
+					throw new IOException("Cannot find requested class " + cachedSubclassname + " in classpath.", e);
 				}
 
-				// --- read registered subclasses and their serializers, in registration order
-
-				this.registeredSubclassesToSerializerConfigSnapshots = new LinkedHashMap<>(numRegisteredSubclasses);
-				String registeredSubclassname;
-				Class<?> registeredSubclass;
-				TypeSerializer<?> registeredSubclassSerializer;
-				TypeSerializerConfigSnapshot registeredSubclassSerializerConfigSnapshot;
-				for (int i = 0; i < numRegisteredSubclasses; i++) {
-					registeredSubclassname = inViewWrapper.readUTF();
-					try {
-						registeredSubclass = Class.forName(registeredSubclassname, true, getUserCodeClassLoader());
-					} catch (ClassNotFoundException e) {
-						throw new IOException("Cannot find requested class " + registeredSubclassname + " in classpath.", e);
-					}
-
-					inWithPos.setPosition(registeredSerializerOffsets[i * 2]);
-					registeredSubclassSerializer = TypeSerializerSerializationUtil.tryReadSerializer(inViewWrapper, getUserCodeClassLoader());
-
-					inWithPos.setPosition(registeredSerializerOffsets[i * 2 + 1]);
-					registeredSubclassSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(inViewWrapper, getUserCodeClassLoader());
-
-					this.registeredSubclassesToSerializerConfigSnapshots.put(
-						registeredSubclass,
-						new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(registeredSubclassSerializer, registeredSubclassSerializerConfigSnapshot));
-				}
-
-				// --- read snapshot of non-registered subclass serializer cache
-
-				this.nonRegisteredSubclassesToSerializerConfigSnapshots = new HashMap<>(numCachedSubclassSerializers);
-				String cachedSubclassname;
-				Class<?> cachedSubclass;
-				TypeSerializer<?> cachedSubclassSerializer;
-				TypeSerializerConfigSnapshot cachedSubclassSerializerConfigSnapshot;
-				for (int i = 0; i < numCachedSubclassSerializers; i++) {
-					cachedSubclassname = inViewWrapper.readUTF();
-					try {
-						cachedSubclass = Class.forName(cachedSubclassname, true, getUserCodeClassLoader());
-					} catch (ClassNotFoundException e) {
-						throw new IOException("Cannot find requested class " + cachedSubclassname + " in classpath.", e);
-					}
-
-					inWithPos.setPosition(cachedSerializerOffsets[i * 2]);
-					cachedSubclassSerializer = TypeSerializerSerializationUtil.tryReadSerializer(inViewWrapper, getUserCodeClassLoader());
-
-					inWithPos.setPosition(cachedSerializerOffsets[i * 2 + 1]);
-					cachedSubclassSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(inViewWrapper, getUserCodeClassLoader());
-
-					this.nonRegisteredSubclassesToSerializerConfigSnapshots.put(
-						cachedSubclass,
-						new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(cachedSubclassSerializer, cachedSubclassSerializerConfigSnapshot));
-				}
+				this.nonRegisteredSubclassesToSerializerConfigSnapshots.put(
+					cachedSubclass,
+					new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(
+						TypeSerializerSerializationUtil.tryReadSerializerWithResilience(in, getUserCodeClassLoader()),
+						TypeSerializerSerializationUtil.readSerializerConfigSnapshot(in, getUserCodeClassLoader())));
 			}
 		}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
@@ -213,7 +213,7 @@ public class TypeSerializerSerializationUtilTest {
 		byte[] serializedSerializersAndConfigs;
 		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
 			TypeSerializerSerializationUtil.writeSerializersAndConfigsWithResilience(
-					new DataOutputViewStreamWrapper(out), serializersAndConfigs);
+					new DataOutputViewStreamWrapper(out), serializersAndConfigs, false);
 			serializedSerializersAndConfigs = out.toByteArray();
 		}
 
@@ -226,7 +226,7 @@ public class TypeSerializerSerializationUtilTest {
 		List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> restored;
 		try (ByteArrayInputStream in = new ByteArrayInputStream(serializedSerializersAndConfigs)) {
 			restored = TypeSerializerSerializationUtil.readSerializersAndConfigsWithResilience(
-				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
+				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader(), false);
 		}
 
 		Assert.assertEquals(2, restored.size());

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
@@ -67,13 +67,13 @@ public class TypeSerializerSerializationUtilTest {
 
 		byte[] serialized;
 		try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
-			TypeSerializerSerializationUtil.writeSerializer(new DataOutputViewStreamWrapper(out), serializer);
+			TypeSerializerSerializationUtil.writeSerializerWithResilience(new DataOutputViewStreamWrapper(out), serializer);
 			serialized = out.toByteArray();
 		}
 
 		TypeSerializer<?> deserializedSerializer;
 		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
-			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializer(
+			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializerWithResilience(
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 
@@ -91,20 +91,20 @@ public class TypeSerializerSerializationUtilTest {
 
 		byte[] serialized;
 		try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
-			TypeSerializerSerializationUtil.writeSerializer(new DataOutputViewStreamWrapper(out), serializer);
+			TypeSerializerSerializationUtil.writeSerializerWithResilience(new DataOutputViewStreamWrapper(out), serializer);
 			serialized = out.toByteArray();
 		}
 
 		TypeSerializer<?> deserializedSerializer;
 
 		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
-			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializer(
+			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializerWithResilience(
 				new DataInputViewStreamWrapper(in), new URLClassLoader(new URL[0], null));
 		}
 		Assert.assertEquals(null, deserializedSerializer);
 
 		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
-			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializer(
+			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializerWithResilience(
 				new DataInputViewStreamWrapper(in), new URLClassLoader(new URL[0], null), true);
 		}
 		Assert.assertTrue(deserializedSerializer instanceof UnloadableDummyTypeSerializer);
@@ -125,7 +125,7 @@ public class TypeSerializerSerializationUtilTest {
 
 		byte[] serialized;
 		try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
-			TypeSerializerSerializationUtil.writeSerializer(new DataOutputViewStreamWrapper(out), serializer);
+			TypeSerializerSerializationUtil.writeSerializerWithResilience(new DataOutputViewStreamWrapper(out), serializer);
 			serialized = out.toByteArray();
 		}
 
@@ -138,7 +138,7 @@ public class TypeSerializerSerializationUtilTest {
 		PowerMockito.whenNew(TypeSerializerSerializationUtil.TypeSerializerSerializationProxy.class).withAnyArguments().thenReturn(mockProxy);
 
 		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
-			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializer(
+			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializerWithResilience(
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 		Assert.assertEquals(null, deserializedSerializer);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -225,7 +225,9 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 					DataOutputView dov = new DataOutputViewStreamWrapper(out);
 
 					OperatorBackendSerializationProxy backendSerializationProxy =
-						new OperatorBackendSerializationProxy(metaInfoSnapshots);
+						new OperatorBackendSerializationProxy(
+							metaInfoSnapshots,
+							false); // TODO make this configurable
 
 					backendSerializationProxy.write(dov);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorBackendStateMetaInfoSnapshotReaderWriters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorBackendStateMetaInfoSnapshotReaderWriters.java
@@ -27,8 +27,6 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -38,8 +36,6 @@ import java.util.Collections;
  * Outdated formats are also kept here for documentation of history backlog.
  */
 public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
-
-	private static final Logger LOG = LoggerFactory.getLogger(OperatorBackendStateMetaInfoSnapshotReaderWriters.class);
 
 	// -------------------------------------------------------------------------------
 	//  Writers

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorBackendStateMetaInfoSnapshotReaderWriters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorBackendStateMetaInfoSnapshotReaderWriters.java
@@ -62,7 +62,7 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 	}
 
 	public interface OperatorBackendStateMetaInfoWriter {
-		void writeStateMetaInfo(DataOutputView out) throws IOException;
+		void writeStateMetaInfo(DataOutputView out, boolean excludeSerializers) throws IOException;
 	}
 
 	public static abstract class AbstractOperatorBackendStateMetaInfoWriter<S>
@@ -82,9 +82,11 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 		}
 
 		@Override
-		public void writeStateMetaInfo(DataOutputView out) throws IOException {
+		public void writeStateMetaInfo(DataOutputView out, boolean excludeSerializers) throws IOException {
 			out.writeUTF(stateMetaInfo.getName());
 			out.writeByte(stateMetaInfo.getAssignmentMode().ordinal());
+
+			// V1 does not respect the exclude serializer flag
 			TypeSerializerSerializationUtil.writeSerializer(out, stateMetaInfo.getPartitionStateSerializer());
 		}
 	}
@@ -96,7 +98,7 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 		}
 
 		@Override
-		public void writeStateMetaInfo(DataOutputView out) throws IOException {
+		public void writeStateMetaInfo(DataOutputView out, boolean excludeSerializers) throws IOException {
 			out.writeUTF(stateMetaInfo.getName());
 			out.writeByte(stateMetaInfo.getAssignmentMode().ordinal());
 
@@ -105,7 +107,8 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 				out,
 				Collections.singletonList(new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(
 					stateMetaInfo.getPartitionStateSerializer(),
-					stateMetaInfo.getPartitionStateSerializerConfigSnapshot())));
+					stateMetaInfo.getPartitionStateSerializerConfigSnapshot())),
+				excludeSerializers);
 		}
 	}
 
@@ -134,7 +137,8 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 	}
 
 	public interface OperatorBackendStateMetaInfoReader<S> {
-		RegisteredOperatorBackendStateMetaInfo.Snapshot<S> readStateMetaInfo(DataInputView in) throws IOException;
+		RegisteredOperatorBackendStateMetaInfo.Snapshot<S> readStateMetaInfo(
+			DataInputView in, boolean excludeSerializers) throws IOException;
 	}
 
 	public static abstract class AbstractOperatorBackendStateMetaInfoReader<S>
@@ -154,12 +158,16 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 		}
 
 		@Override
-		public RegisteredOperatorBackendStateMetaInfo.Snapshot<S> readStateMetaInfo(DataInputView in) throws IOException {
+		public RegisteredOperatorBackendStateMetaInfo.Snapshot<S> readStateMetaInfo(
+				DataInputView in, boolean excludeSerializers) throws IOException {
+
 			RegisteredOperatorBackendStateMetaInfo.Snapshot<S> stateMetaInfo =
 				new RegisteredOperatorBackendStateMetaInfo.Snapshot<>();
 
 			stateMetaInfo.setName(in.readUTF());
 			stateMetaInfo.setAssignmentMode(OperatorStateHandle.Mode.values()[in.readByte()]);
+
+			// V1 does not respect the exclude serializer flag
 			DataInputViewStream dis = new DataInputViewStream(in);
 			try {
 				TypeSerializer<S> stateSerializer = InstantiationUtil.deserializeObject(dis, userCodeClassLoader);
@@ -183,7 +191,9 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 		}
 
 		@Override
-		public RegisteredOperatorBackendStateMetaInfo.Snapshot<S> readStateMetaInfo(DataInputView in) throws IOException {
+		public RegisteredOperatorBackendStateMetaInfo.Snapshot<S> readStateMetaInfo(
+				DataInputView in, boolean excludeSerializers) throws IOException {
+
 			RegisteredOperatorBackendStateMetaInfo.Snapshot<S> stateMetaInfo =
 				new RegisteredOperatorBackendStateMetaInfo.Snapshot<>();
 
@@ -191,7 +201,8 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 			stateMetaInfo.setAssignmentMode(OperatorStateHandle.Mode.values()[in.readByte()]);
 
 			Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> stateSerializerAndConfig =
-				TypeSerializerSerializationUtil.readSerializersAndConfigsWithResilience(in, userCodeClassLoader).get(0);
+				TypeSerializerSerializationUtil.readSerializersAndConfigsWithResilience(
+					in, userCodeClassLoader, excludeSerializers).get(0);
 
 			stateMetaInfo.setPartitionStateSerializer((TypeSerializer<S>) stateSerializerAndConfig.f0);
 			stateMetaInfo.setPartitionStateSerializerConfigSnapshot(stateSerializerAndConfig.f1);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -273,7 +273,10 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		}
 
 		final KeyedBackendSerializationProxy<K> serializationProxy =
-				new KeyedBackendSerializationProxy<>(keySerializer, metaInfoSnapshots);
+				new KeyedBackendSerializationProxy<>(
+						keySerializer,
+						metaInfoSnapshots,
+						false); // TODO make this configurable
 
 		//--------------------------------------------------- this becomes the end of sync part
 


### PR DESCRIPTION
This PR affects the serialization formats of configuration snapshots of composite serializers, most notably the `PojoSerializer`, as well as others such as `MapSerializer`, `GenericArraySerializer`, `TupleSerializer`, etc. It also affects the serialization formats of the `OperatorBackendSerializationProxy` and `KeyedBackendSerializationProxy`.

Prior to this PR, whenever we write a serializer and its config snapshot into a checkpoint, we always write the start offset and end offset of the serializer bytes, effectively indexing every serializer and its config. This required buffering the whole list of serializer and config snapshot pairs when writing the checkpoint.

This PR changes this to be more efficient by just writing the length of the serializer bytes prior to writing the serializer. This also allows lesser buffering for the writes.

## Implementation

Now, `TypeSerializerSerializationUtil` has the following methods for writing / reading serializers:

- `writeSerializer`
- `tryReadSerializer`
- `writeSerializerWithResilience`
- `tryReadSerializerWithResilience`

The first two non-resilient variants remains as they were (not containing write serializer length logic), and needs to remain untouched for backwards compatibility (previous checkpoints do not contain the serializer length before the serializer bytes). They are only used in code paths for backwards compatibility.

All composite type serializers now use the latter two `*WithResilience` variants.

## Affect on backwards compatibility

Backwards compatibility is still maintained for prior versions.
However, depending on whether or not this PR makes it into the 1.3.0 release, it may need to be changed more. The current state of the PR assumes that it will be merged for 1.3.0.
If it misses it, the PR needs additional changes to have separate code paths for the config snapshot reads of composite serializers, one for VERSION 1 which still uses offsets, and one for an upticked VERSION 2 which use the new `*WithResilience` variants.

## Tests

Since the tests in `TypeSerializerSerializationUtilTest`, `SerializationProxiesTest`, and `PojoSerializerTest` already cover tests for resilience of serializer read failures, and this PR only changes the way we store information to achieve the same functionality, no new tests are added for that.

New tests are added to `PojoSerializerTest` and `SerializationProxiesTest` to verify that serialize / deserialize roundtrip of `PojoSerializerConfigSnapshot` and the operator / keyed state backends works correctly when serializers are excluded.

## Other remarks

With this PR, the `excludeSerializers` behaviour isn't yet configurable. The code currently just uses a placeholder flag (`false`), so that we can at least nail down the serialization formats. I prefer to think a bit more on how the behaviour configuration should be exposed and do that as a separate PR in the future.
