### PR TITLE
[FLINK-6774][build] set missing build-helper-maven-plugin version

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/pom.xml
+++ b/flink-connectors/flink-connector-kafka-base/pom.xml
@@ -216,6 +216,7 @@ under the License.
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>1.7</version>
 				<executions>
 					<execution>
 						<phase>generate-test-sources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -651,6 +651,7 @@ under the License.
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>build-helper-maven-plugin</artifactId>
+						<version>1.7</version>
 						<executions>
 							<execution>
 								<phase>generate-sources</phase>


### PR DESCRIPTION
this PR sets the version number on those sub-modules which did not set it yet