### PR TITLE
[FLINK-6776] [runtime] Use skip instead of seek for small forward rep…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopDataInputStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopDataInputStream.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.fs.hdfs;
 import org.apache.flink.core.fs.FSDataInputStream;
 
 import javax.annotation.Nonnull;
+
 import java.io.IOException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -31,11 +32,27 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public final class HadoopDataInputStream extends FSDataInputStream {
 
+	/**
+	 * Minimum amount of bytes to skip forward before we issue a seek instead of discarding read.
+	 * <p>
+	 * The current value is just a magic number. In the long run, this value could become configurable, but for now it
+	 * is a conservative, relatively small value that should bring safe improvements for small skips (e.g. in reading
+	 * meta data), that would hurt the most with frequent seeks.
+	 * <p>
+	 * The optimal value depends on the DFS implementation and configuration plus the underlying filesystem.
+	 * For now, this number is chosen "big enough" to provide improvements for smaller seeks, and "small enough" to
+	 * avoid disadvantages over real seeks. While the minimum should be the page size, a true optimum per system would
+	 * be the amounts of bytes the can be consumed sequentially within the seektime. Unfortunately, seektime is not
+	 * constant and devices, OS, and DFS potentially also use read buffers and read-ahead.
+	 */
+	private static final int MIN_SKIP_BYTES = 1024 * 1024;
+
+	/** The internal stream */
 	private final org.apache.hadoop.fs.FSDataInputStream fsDataInputStream;
 
 	/**
 	 * Creates a new data input stream from the given Hadoop input stream
-	 * 
+	 *
 	 * @param fsDataInputStream The Hadoop input stream
 	 */
 	public HadoopDataInputStream(org.apache.hadoop.fs.FSDataInputStream fsDataInputStream) {
@@ -44,12 +61,18 @@ public final class HadoopDataInputStream extends FSDataInputStream {
 
 
 	@Override
-	public void seek(long desired) throws IOException {
-		// This optimization prevents some implementations of distributed FS to perform expensive seeks when they are
-		// actually not needed
-		if (desired != getPos()) {
-			fsDataInputStream.seek(desired);
-		}
+	public void seek(long seekPos) throws IOException {
+		// We do some optimizations to avoid that some implementations of distributed FS perform
+		// expensive seeks when they are actually not needed.
+		long delta = seekPos - getPos();
+
+		if (delta > 0L && delta <= MIN_SKIP_BYTES) {
+			// Instead of a small forward seek, we skip over the gap
+			skipFully(delta);
+		} else if (delta != 0L) {
+			// For larger gaps and backward seeks, we do a real seek
+			forceSeek(delta);
+		} // Do nothing if delta is zero.
 	}
 
 	@Override
@@ -71,7 +94,7 @@ public final class HadoopDataInputStream extends FSDataInputStream {
 	public int read(@Nonnull byte[] buffer, int offset, int length) throws IOException {
 		return fsDataInputStream.read(buffer, offset, length);
 	}
-	
+
 	@Override
 	public int available() throws IOException {
 		return fsDataInputStream.available();
@@ -88,5 +111,30 @@ public final class HadoopDataInputStream extends FSDataInputStream {
 	 */
 	public org.apache.hadoop.fs.FSDataInputStream getHadoopInputStream() {
 		return fsDataInputStream;
+	}
+
+	/**
+	 * Positions the stream to the given location. In contrast to {@link #seek(long)}, this method will
+	 * always issue a "seek" command to the dfs and may not replace it by {@link #skip(long)} for small seeks.
+	 * <p>
+	 * Notice that the underlying DFS implementation can still decide to do skip instead of seek.
+	 *
+	 * @param seekPos the position to seek to.
+	 * @throws IOException
+	 */
+	public void forceSeek(long seekPos) throws IOException {
+		fsDataInputStream.seek(seekPos);
+	}
+
+	/**
+	 * Skips over a given amount of bytes in the stream.
+	 *
+	 * @param bytes the number of bytes to skip.
+	 * @throws IOException
+	 */
+	public void skipFully(long bytes) throws IOException {
+		while (bytes > 0) {
+			bytes -= fsDataInputStream.skip(bytes);
+		}
 	}
 }


### PR DESCRIPTION
…ositioning in DFS streams

Reading checkpoint meta data and finding key-groups in restores sometimes require to seek in input streams. Currently, we always use a seek, even for small position changes. As small true seeks are far more expensive than small reads/skips, we should just skip over small gaps instead of performing the seek.
