### PR TITLE
[FLINK-6775] [state] Duplicate StateDescriptor's serializer

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ListStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ListStateDescriptor.java
@@ -95,7 +95,7 @@ public class ListStateDescriptor<T> extends StateDescriptor<ListState<T>, List<T
 			throw new IllegalStateException();
 		}
 
-		return ((ListSerializer<T>)serializer).getElementSerializer();
+		return ((ListSerializer<T>) rawSerializer).getElementSerializer();
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateDescriptor.java
@@ -174,7 +174,7 @@ public abstract class StateDescriptor<S extends State, T> implements Serializabl
 	 */
 	public TypeSerializer<T> getSerializer() {
 		if (serializer != null) {
-			return serializer;
+			return serializer.duplicate();
 		} else {
 			throw new IllegalStateException("Serializer not yet initialized.");
 		}

--- a/flink-core/src/test/java/org/apache/flink/api/common/state/AggregatingStateDescriptorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/state/AggregatingStateDescriptorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.state;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.junit.Assert.assertNotSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AggregatingStateDescriptorTest extends TestLogger {
+
+	/**
+	 * FLINK-6775
+	 *
+	 * Tests that the returned serializer is duplicated. This allows to
+	 * share the state descriptor.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testSerializerDuplication() {
+		TypeSerializer<Long> serializer = mock(TypeSerializer.class);
+		when(serializer.duplicate()).thenAnswer(new Answer<TypeSerializer<Long>>() {
+			@Override
+			public TypeSerializer<Long> answer(InvocationOnMock invocation) throws Throwable {
+				return mock(TypeSerializer.class);
+			}
+		});
+
+		AggregateFunction<Long, Long, Long> aggregatingFunction = mock(AggregateFunction.class);
+
+		AggregatingStateDescriptor<Long, Long, Long> descr = new AggregatingStateDescriptor<>(
+			"foobar",
+			aggregatingFunction,
+			serializer);
+
+		TypeSerializer<Long> serializerA = descr.getSerializer();
+		TypeSerializer<Long> serializerB = descr.getSerializer();
+
+		// check that the retrieved serializers are not the same
+		assertNotSame(serializerA, serializerB);
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/state/ValueStateDescriptorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/state/ValueStateDescriptorTest.java
@@ -27,16 +27,22 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.CommonTestUtils;
 
+import org.apache.flink.util.TestLogger;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.io.File;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-public class ValueStateDescriptorTest {
+public class ValueStateDescriptorTest extends TestLogger {
 	
 	@Test
 	public void testValueStateDescriptorEagerSerializer() throws Exception {
@@ -129,5 +135,31 @@ public class ValueStateDescriptorTest {
 		assertEquals(defaultValue, copy.getDefaultValue());
 		assertNotNull(copy.getSerializer());
 		assertEquals(serializer, copy.getSerializer());
+	}
+
+	/**
+	 * FLINK-6775
+	 *
+	 * Tests that the returned serializer is duplicated. This allows to
+	 * share the state descriptor.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testSerializerDuplication() {
+		TypeSerializer<String> statefulSerializer = mock(TypeSerializer.class);
+		when(statefulSerializer.duplicate()).thenAnswer(new Answer<TypeSerializer<String>>() {
+			@Override
+			public TypeSerializer<String> answer(InvocationOnMock invocation) throws Throwable {
+				return mock(TypeSerializer.class);
+			}
+		});
+
+		ValueStateDescriptor<String> descr = new ValueStateDescriptor<>("foobar", statefulSerializer);
+
+		TypeSerializer<String> serializerA = descr.getSerializer();
+		TypeSerializer<String> serializerB = descr.getSerializer();
+
+		// check that the retrieved serializers are not the same
+		assertNotSame(serializerA, serializerB);
 	}
 }


### PR DESCRIPTION
Duplicate the TypeSerializer before returning it from the StateDescriptor. That way
we ensure that StateDescriptors can be shared by multiple threads.