### PR TITLE
[FLINK-6764] Deduplicate stateless serializers in checkpoints

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -601,7 +601,10 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			}
 
 			KeyedBackendSerializationProxy<K> serializationProxy =
-					new KeyedBackendSerializationProxy<>(stateBackend.getKeySerializer(), metaInfoSnapshots);
+					new KeyedBackendSerializationProxy<>(
+							stateBackend.getKeySerializer(),
+							metaInfoSnapshots,
+							false); // TODO make this configurable
 
 			serializationProxy.write(outputView);
 		}
@@ -807,7 +810,10 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				closeableRegistry.registerClosable(outputStream);
 
 				KeyedBackendSerializationProxy<K> serializationProxy =
-					new KeyedBackendSerializationProxy<>(stateBackend.keySerializer, stateMetaInfoSnapshots);
+						new KeyedBackendSerializationProxy<>(
+								stateBackend.keySerializer,
+								stateMetaInfoSnapshots,
+								false); // TODO make this configurable
 				DataOutputView out = new DataOutputViewStreamWrapper(outputStream);
 
 				serializationProxy.write(out);
@@ -1234,7 +1240,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				stateBackend.cancelStreamRegistry.registerClosable(inputStream);
 
 				KeyedBackendSerializationProxy<T> serializationProxy =
-					new KeyedBackendSerializationProxy<>(stateBackend.userCodeClassLoader);
+						new KeyedBackendSerializationProxy<>(stateBackend.userCodeClassLoader);
 				DataInputView in = new DataInputViewStreamWrapper(inputStream);
 				serializationProxy.read(in);
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/IdentitySerializerIndex.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/IdentitySerializerIndex.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.io.IOReadableWritable;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+/**
+ * An {@code IdentitySerializerIndex} is a bidirectional map that serves as an index for multiple serializers.
+ * It allows lookup for the index of a serializer, and the serializer given a specific index.
+ * Same serializer instances are maintained as a single entry in the index.
+ *
+ * <p>NOTE: Serializing and then deserializing the serializer index essentially results in new serializer
+ * instances created for each entry in the index. Therefore, adding the same serializers to the same index
+ * after it was serialized would result in new entries.
+ */
+@Internal
+public class IdentitySerializerIndex implements IOReadableWritable {
+
+	/**
+	 * Serializer to index directional map. An {@link IdentityHashMap} is
+	 * used so that the same serializer instance will only ever be indexed
+	 * once and maintained as a single entry.
+	 */
+	private IdentityHashMap<TypeSerializer<?>, Integer> serializerToIndex;
+
+	/**
+	 * Index to serializer directional map.
+	 */
+	private HashMap<Integer, TypeSerializer<?>> indexToSerializer;
+
+	private int nextAvailableIndex = 0;
+
+	private ClassLoader userCodeClassLoader;
+
+	public IdentitySerializerIndex(ClassLoader userCodeClassLoader) {
+		this.userCodeClassLoader = Preconditions.checkNotNull(userCodeClassLoader);
+	}
+
+	public IdentitySerializerIndex() {
+		serializerToIndex = new IdentityHashMap<>();
+		indexToSerializer = new HashMap<>();
+	}
+
+	public void index(TypeSerializer<?> serializer) {
+		if (!serializerToIndex.containsKey(serializer)) {
+			serializerToIndex.put(serializer, nextAvailableIndex);
+			indexToSerializer.put(nextAvailableIndex, serializer);
+
+			nextAvailableIndex++;
+		}
+	}
+
+	public int getIndexOf(TypeSerializer<?> serializer) {
+		if (serializerToIndex.containsKey(serializer)) {
+			return serializerToIndex.get(serializer);
+		} else {
+			return -1;
+		}
+	}
+
+	public TypeSerializer<?> getSerializer(int index) {
+		return indexToSerializer.get(index);
+	}
+
+	public boolean containsSerializer(TypeSerializer<?> serializer) {
+		return getIndexOf(serializer) != -1;
+	}
+
+	public int getSize() {
+		return nextAvailableIndex;
+	}
+
+	@Override
+	public void write(DataOutputView out) throws IOException {
+		// number of index entries
+		out.writeInt(nextAvailableIndex);
+
+		// just need to write one side of the bidirectional map
+		for (Map.Entry<TypeSerializer<?>, Integer> entry : serializerToIndex.entrySet()) {
+			TypeSerializerSerializationUtil.writeSerializerWithResilience(out, entry.getKey());
+			out.writeInt(entry.getValue());
+		}
+	}
+
+	@Override
+	public void read(DataInputView in) throws IOException {
+		nextAvailableIndex = in.readInt();
+
+		serializerToIndex = new IdentityHashMap<>(nextAvailableIndex);
+		indexToSerializer = new HashMap<>(nextAvailableIndex);
+		for (int i = 0; i < nextAvailableIndex; i++) {
+			TypeSerializer<?> serializer = TypeSerializerSerializationUtil.tryReadSerializerWithResilience(in, userCodeClassLoader);
+			int index = in.readInt();
+
+			serializerToIndex.put(serializer, index);
+			indexToSerializer.put(index, serializer);
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
@@ -32,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.util.ArrayList;
@@ -115,13 +114,13 @@ public class TypeSerializerSerializationUtil {
 	 */
 	public static <T> void writeSerializerWithResilience(DataOutputView out, TypeSerializer<T> serializer) throws IOException {
 		try (
-			ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+			ByteArrayOutputStreamWithPos buffer = new ByteArrayOutputStreamWithPos();
 			DataOutputViewStreamWrapper bufferWrapper = new DataOutputViewStreamWrapper(buffer)) {
 
 			writeSerializer(bufferWrapper, serializer);
 
-			out.writeInt(buffer.size());
-			out.write(buffer.toByteArray(), 0, buffer.size());
+			out.writeInt(buffer.getPosition());
+			out.write(buffer.getBuf(), 0, buffer.getPosition());
 		}
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
@@ -21,7 +21,6 @@ package org.apache.flink.api.common.typeutils;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.io.VersionedIOReadableWritable;
-import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
@@ -32,6 +31,8 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.util.ArrayList;
@@ -49,6 +50,36 @@ public class TypeSerializerSerializationUtil {
 	 * Writes a {@link TypeSerializer} to the provided data output view.
 	 *
 	 * <p>It is written with a format that can be later read again using
+	 * {@link #tryReadSerializerWithResilience(DataInputView, ClassLoader, boolean)}, which
+	 * allows skipping the serializer in the byte stream if any error occurs while reading it.
+	 *
+	 * <p>Format:
+	 *   1. length of serialized serializer
+	 *   2. serialized serializer
+	 *
+	 * @param out the data output view.
+	 * @param serializer the serializer to write.
+	 *
+	 * @param <T> Data type of the serializer.
+	 *
+	 * @throws IOException
+	 */
+	public static <T> void writeSerializerWithResilience(DataOutputView out, TypeSerializer<T> serializer) throws IOException {
+		try (
+			ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+			DataOutputViewStreamWrapper bufferWrapper = new DataOutputViewStreamWrapper(buffer)) {
+
+			writeSerializer(bufferWrapper, serializer);
+
+			out.writeInt(buffer.size());
+			out.write(buffer.toByteArray(), 0, buffer.size());
+		}
+	}
+
+	/**
+	 * Writes a {@link TypeSerializer} to the provided data output view.
+	 *
+	 * <p>It is written with a format that can be later read again using
 	 * {@link #tryReadSerializer(DataInputView, ClassLoader, boolean)}.
 	 *
 	 * @param out the data output view.
@@ -60,6 +91,70 @@ public class TypeSerializerSerializationUtil {
 	 */
 	public static <T> void writeSerializer(DataOutputView out, TypeSerializer<T> serializer) throws IOException {
 		new TypeSerializerSerializationUtil.TypeSerializerSerializationProxy<>(serializer).write(out);
+	}
+
+	/**
+	 * Reads from a data input view a {@link TypeSerializer} that was previously
+	 * written using {@link #writeSerializerWithResilience(DataOutputView, TypeSerializer)}.
+	 *
+	 * <p>If deserialization fails for any reason (corrupted serializer bytes, serializer class
+	 * no longer in classpath, serializer class no longer valid, etc.), {@code null} will
+	 * be returned instead.
+	 *
+	 * <p>Also, if deserialization fails, it is guaranteed that the remaining bytes for
+	 * the serializer will be skipped so that the position of the byte stream will be right
+	 * after the serializer bytes.
+	 *
+	 * @param in the data input view.
+	 * @param userCodeClassLoader the user code class loader to use.
+	 *
+	 * @param <T> Data type of the serializer.
+	 *
+	 * @return the deserialized serializer.
+	 */
+	public static <T> TypeSerializer<T> tryReadSerializerWithResilience(DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
+		return tryReadSerializerWithResilience(in, userCodeClassLoader, false);
+	}
+
+	/**
+	 * Reads from a data input view a {@link TypeSerializer} that was previously
+	 * written using {@link #writeSerializerWithResilience(DataOutputView, TypeSerializer)}.
+	 *
+	 * <p>If deserialization fails due to {@link ClassNotFoundException} or {@link InvalidClassException},
+	 * users can opt to use a dummy {@link UnloadableDummyTypeSerializer} to hold the serializer bytes,
+	 * otherwise {@code null} is returned. If the failure is due to a {@link java.io.StreamCorruptedException},
+	 * then {@code null} is returned.
+	 *
+	 * <p>Also, if deserialization fails, it is guaranteed that the remaining bytes for
+	 * the serializer will be skipped so that the position of the byte stream will be right
+	 * after the serializer bytes.
+	 *
+	 * @param in the data input view.
+	 * @param userCodeClassLoader the user code class loader to use.
+	 * @param useDummyPlaceholder whether or not to use a dummy {@link UnloadableDummyTypeSerializer} to hold the
+	 *                            serializer bytes in the case of a {@link ClassNotFoundException} or
+	 *                            {@link InvalidClassException}.
+	 *
+	 * @param <T> Data type of the serializer.
+	 *
+	 * @return the deserialized serializer.
+	 */
+	public static <T> TypeSerializer<T> tryReadSerializerWithResilience(
+			DataInputView in,
+			ClassLoader userCodeClassLoader,
+			boolean useDummyPlaceholder) throws IOException {
+
+		int numSerializerBytes = in.readInt();
+
+		byte[] serializerBytes = new byte[numSerializerBytes];
+		in.readFully(serializerBytes);
+
+		try (
+			ByteArrayInputStream buffer = new ByteArrayInputStream(serializerBytes);
+			DataInputViewStreamWrapper bufferWrapper = new DataInputViewStreamWrapper(buffer)) {
+
+			return tryReadSerializer(bufferWrapper, userCodeClassLoader, useDummyPlaceholder);
+		}
 	}
 
 	/**
@@ -100,7 +195,11 @@ public class TypeSerializerSerializationUtil {
 	 *
 	 * @return the deserialized serializer.
 	 */
-	public static <T> TypeSerializer<T> tryReadSerializer(DataInputView in, ClassLoader userCodeClassLoader, boolean useDummyPlaceholder) {
+	public static <T> TypeSerializer<T> tryReadSerializer(
+			DataInputView in,
+			ClassLoader userCodeClassLoader,
+			boolean useDummyPlaceholder) {
+
 		final TypeSerializerSerializationUtil.TypeSerializerSerializationProxy<T> proxy =
 			new TypeSerializerSerializationUtil.TypeSerializerSerializationProxy<>(userCodeClassLoader, useDummyPlaceholder);
 
@@ -124,9 +223,8 @@ public class TypeSerializerSerializationUtil {
 	 * offset positions within the serialized bytes. The serialization format is as follows:
 	 * <ul>
 	 *     <li>1. number of serializer and configuration snapshot pairs.</li>
-	 *     <li>2. offsets of each serializer and configuration snapshot, in order.</li>
-	 *     <li>3. total number of bytes for the serialized serializers and the config snapshots.</li>
-	 *     <li>4. serialized serializers and the config snapshots.</li>
+	 *     <li>2. Each serializer and configuration snapshot pair, which contains of the
+	 *            serializer length, followed by the serializer bytes, and finally the config snapshot bytes.</li>
 	 * </ul>
 	 *
 	 * @param out the data output view.
@@ -138,21 +236,10 @@ public class TypeSerializerSerializationUtil {
 			DataOutputView out,
 			List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> serializersAndConfigs) throws IOException {
 
-		try (
-			ByteArrayOutputStreamWithPos bufferWithPos = new ByteArrayOutputStreamWithPos();
-			DataOutputViewStreamWrapper bufferWrapper = new DataOutputViewStreamWrapper(bufferWithPos)) {
-
-			out.writeInt(serializersAndConfigs.size());
-			for (Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> serAndConfSnapshot : serializersAndConfigs) {
-				out.writeInt(bufferWithPos.getPosition());
-				writeSerializer(bufferWrapper, serAndConfSnapshot.f0);
-
-				out.writeInt(bufferWithPos.getPosition());
-				writeSerializerConfigSnapshot(bufferWrapper, serAndConfSnapshot.f1);
-			}
-
-			out.writeInt(bufferWithPos.getPosition());
-			out.write(bufferWithPos.getBuf(), 0, bufferWithPos.getPosition());
+		out.writeInt(serializersAndConfigs.size());
+		for (Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> serAndConfSnapshot : serializersAndConfigs) {
+			writeSerializerWithResilience(out, serAndConfSnapshot.f0);
+			writeSerializerConfigSnapshot(out, serAndConfSnapshot.f1);
 		}
 	}
 
@@ -175,37 +262,14 @@ public class TypeSerializerSerializationUtil {
 
 		int numSerializersAndConfigSnapshots = in.readInt();
 
-		int[] offsets = new int[numSerializersAndConfigSnapshots * 2];
-
-		for (int i = 0; i < numSerializersAndConfigSnapshots; i++) {
-			offsets[i * 2] = in.readInt();
-			offsets[i * 2 + 1] = in.readInt();
-		}
-
-		int totalBytes = in.readInt();
-		byte[] buffer = new byte[totalBytes];
-		in.readFully(buffer);
-
 		List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> serializersAndConfigSnapshots =
 			new ArrayList<>(numSerializersAndConfigSnapshots);
 
-		TypeSerializer<?> serializer;
-		TypeSerializerConfigSnapshot configSnapshot;
-		try (
-			ByteArrayInputStreamWithPos bufferWithPos = new ByteArrayInputStreamWithPos(buffer);
-			DataInputViewStreamWrapper bufferWrapper = new DataInputViewStreamWrapper(bufferWithPos)) {
-
-			for (int i = 0; i < numSerializersAndConfigSnapshots; i++) {
-
-				bufferWithPos.setPosition(offsets[i * 2]);
-				serializer = tryReadSerializer(bufferWrapper, userCodeClassLoader);
-
-				bufferWithPos.setPosition(offsets[i * 2 + 1]);
-				configSnapshot = readSerializerConfigSnapshot(bufferWrapper, userCodeClassLoader);
-
-				serializersAndConfigSnapshots.add(
-					new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(serializer, configSnapshot));
-			}
+		for (int i = 0; i < numSerializersAndConfigSnapshots; i++) {
+			serializersAndConfigSnapshots.add(new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(
+				tryReadSerializerWithResilience(in, userCodeClassLoader),
+				readSerializerConfigSnapshot(in, userCodeClassLoader))
+			);
 		}
 
 		return serializersAndConfigSnapshots;

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
@@ -42,12 +42,8 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil;
 import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
-import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
-import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputView;
-import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.util.Preconditions;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -806,63 +802,49 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 		public void write(DataOutputView out) throws IOException {
 			super.write(out);
 
-			try (
-				ByteArrayOutputStreamWithPos outWithPos = new ByteArrayOutputStreamWithPos();
-				DataOutputViewStreamWrapper outViewWrapper = new DataOutputViewStreamWrapper(outWithPos)) {
+			// --- write fields and their serializers, in order
 
-				// --- write fields and their serializers, in order
+			out.writeInt(fieldToSerializerConfigSnapshot.size());
+			for (Map.Entry<Field, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> entry
+				: fieldToSerializerConfigSnapshot.entrySet()) {
 
-				out.writeInt(fieldToSerializerConfigSnapshot.size());
-				for (Map.Entry<Field, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> entry
-						: fieldToSerializerConfigSnapshot.entrySet()) {
+				out.writeUTF(entry.getKey().getName());
 
-					outViewWrapper.writeUTF(entry.getKey().getName());
-
-					out.writeInt(outWithPos.getPosition());
-					if (!ignoreTypeSerializerSerialization) {
-						TypeSerializerSerializationUtil.writeSerializer(outViewWrapper, entry.getValue().f0);
-					}
-
-					out.writeInt(outWithPos.getPosition());
-					TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(outViewWrapper, entry.getValue().f1);
+				if (!ignoreTypeSerializerSerialization) {
+					TypeSerializerSerializationUtil.writeSerializerWithResilience(out, entry.getValue().f0);
 				}
 
-				// --- write registered subclasses and their serializers, in registration order
+				TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(out, entry.getValue().f1);
+			}
 
-				out.writeInt(registeredSubclassesToSerializerConfigSnapshots.size());
-				for (Map.Entry<Class<?>, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> entry
-						: registeredSubclassesToSerializerConfigSnapshots.entrySet()) {
+			// --- write registered subclasses and their serializers, in registration order
 
-					outViewWrapper.writeUTF(entry.getKey().getName());
+			out.writeInt(registeredSubclassesToSerializerConfigSnapshots.size());
+			for (Map.Entry<Class<?>, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> entry
+				: registeredSubclassesToSerializerConfigSnapshots.entrySet()) {
 
-					out.writeInt(outWithPos.getPosition());
-					if (!ignoreTypeSerializerSerialization) {
-						TypeSerializerSerializationUtil.writeSerializer(outViewWrapper, entry.getValue().f0);
-					}
+				out.writeUTF(entry.getKey().getName());
 
-					out.writeInt(outWithPos.getPosition());
-					TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(outViewWrapper, entry.getValue().f1);
+				if (!ignoreTypeSerializerSerialization) {
+					TypeSerializerSerializationUtil.writeSerializerWithResilience(out, entry.getValue().f0);
 				}
 
-				// --- write snapshot of non-registered subclass serializer cache
+				TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(out, entry.getValue().f1);
+			}
 
-				out.writeInt(nonRegisteredSubclassesToSerializerConfigSnapshots.size());
-				for (Map.Entry<Class<?>, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> entry
-						: nonRegisteredSubclassesToSerializerConfigSnapshots.entrySet()) {
+			// --- write snapshot of non-registered subclass serializer cache
 
-					outViewWrapper.writeUTF(entry.getKey().getName());
+			out.writeInt(nonRegisteredSubclassesToSerializerConfigSnapshots.size());
+			for (Map.Entry<Class<?>, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> entry
+				: nonRegisteredSubclassesToSerializerConfigSnapshots.entrySet()) {
 
-					out.writeInt(outWithPos.getPosition());
-					if (!ignoreTypeSerializerSerialization) {
-						TypeSerializerSerializationUtil.writeSerializer(outViewWrapper, entry.getValue().f0);
-					}
+				out.writeUTF(entry.getKey().getName());
 
-					out.writeInt(outWithPos.getPosition());
-					TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(outViewWrapper, entry.getValue().f1);
+				if (!ignoreTypeSerializerSerialization) {
+					TypeSerializerSerializationUtil.writeSerializerWithResilience(out, entry.getValue().f0);
 				}
 
-				out.writeInt(outWithPos.getPosition());
-				out.write(outWithPos.getBuf(), 0 , outWithPos.getPosition());
+				TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(out, entry.getValue().f1);
 			}
 		}
 
@@ -870,126 +852,83 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 		public void read(DataInputView in) throws IOException {
 			super.read(in);
 
+			// --- read fields and their serializers, in order
+
 			int numFields = in.readInt();
-			int[] fieldSerializerOffsets = new int[numFields * 2];
+
+			this.fieldToSerializerConfigSnapshot = new LinkedHashMap<>(numFields);
+			String fieldName;
+			Field field;
 			for (int i = 0; i < numFields; i++) {
-				fieldSerializerOffsets[i * 2] = in.readInt();
-				fieldSerializerOffsets[i * 2 + 1] = in.readInt();
+				fieldName = in.readUTF();
+
+				// search all superclasses for the field
+				Class<?> clazz = getTypeClass();
+				field = null;
+				while (clazz != null) {
+					try {
+						field = clazz.getDeclaredField(fieldName);
+						field.setAccessible(true);
+						break;
+					} catch (NoSuchFieldException e) {
+						clazz = clazz.getSuperclass();
+					}
+				}
+
+				if (field == null) {
+					// the field no longer exists in the POJO
+					throw new IOException("Can't find field " + fieldName + " in POJO class " + getTypeClass().getName());
+				} else {
+					fieldToSerializerConfigSnapshot.put(
+						field,
+						new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(
+							TypeSerializerSerializationUtil.tryReadSerializerWithResilience(in, getUserCodeClassLoader()),
+							TypeSerializerSerializationUtil.readSerializerConfigSnapshot(in, getUserCodeClassLoader())));
+				}
 			}
 
+			// --- read registered subclasses and their serializers, in registration order
 
 			int numRegisteredSubclasses = in.readInt();
-			int[] registeredSerializerOffsets = new int[numRegisteredSubclasses * 2];
+
+			this.registeredSubclassesToSerializerConfigSnapshots = new LinkedHashMap<>(numRegisteredSubclasses);
+			String registeredSubclassname;
+			Class<?> registeredSubclass;
 			for (int i = 0; i < numRegisteredSubclasses; i++) {
-				registeredSerializerOffsets[i * 2] = in.readInt();
-				registeredSerializerOffsets[i * 2 + 1] = in.readInt();
+				registeredSubclassname = in.readUTF();
+				try {
+					registeredSubclass = Class.forName(registeredSubclassname, true, getUserCodeClassLoader());
+				} catch (ClassNotFoundException e) {
+					throw new IOException("Cannot find requested class " + registeredSubclassname + " in classpath.", e);
+				}
+
+				this.registeredSubclassesToSerializerConfigSnapshots.put(
+					registeredSubclass,
+					new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(
+						TypeSerializerSerializationUtil.tryReadSerializerWithResilience(in, getUserCodeClassLoader()),
+						TypeSerializerSerializationUtil.readSerializerConfigSnapshot(in, getUserCodeClassLoader())));
 			}
+
+			// --- read snapshot of non-registered subclass serializer cache
 
 			int numCachedSubclassSerializers = in.readInt();
-			int[] cachedSerializerOffsets = new int[numCachedSubclassSerializers * 2];
+
+			this.nonRegisteredSubclassesToSerializerConfigSnapshots = new HashMap<>(numCachedSubclassSerializers);
+			String cachedSubclassname;
+			Class<?> cachedSubclass;
 			for (int i = 0; i < numCachedSubclassSerializers; i++) {
-				cachedSerializerOffsets[i * 2] = in.readInt();
-				cachedSerializerOffsets[i * 2 + 1] = in.readInt();
-			}
-
-			int totalBytes = in.readInt();
-			byte[] buffer = new byte[totalBytes];
-			in.readFully(buffer);
-
-			try (
-				ByteArrayInputStreamWithPos inWithPos = new ByteArrayInputStreamWithPos(buffer);
-				DataInputViewStreamWrapper inViewWrapper = new DataInputViewStreamWrapper(inWithPos)) {
-
-				// --- read fields and their serializers, in order
-
-				this.fieldToSerializerConfigSnapshot = new LinkedHashMap<>(numFields);
-				String fieldName;
-				Field field;
-				TypeSerializer<?> fieldSerializer;
-				TypeSerializerConfigSnapshot fieldSerializerConfigSnapshot;
-				for (int i = 0; i < numFields; i++) {
-					fieldName = inViewWrapper.readUTF();
-
-					// search all superclasses for the field
-					Class<?> clazz = getTypeClass();
-					field = null;
-					while (clazz != null) {
-						try {
-							field = clazz.getDeclaredField(fieldName);
-							field.setAccessible(true);
-							break;
-						} catch (NoSuchFieldException e) {
-							clazz = clazz.getSuperclass();
-						}
-					}
-
-					if (field == null) {
-						// the field no longer exists in the POJO
-						throw new IOException("Can't find field " + fieldName + " in POJO class " + getTypeClass().getName());
-					} else {
-						inWithPos.setPosition(fieldSerializerOffsets[i * 2]);
-						fieldSerializer = TypeSerializerSerializationUtil.tryReadSerializer(inViewWrapper, getUserCodeClassLoader());
-
-						inWithPos.setPosition(fieldSerializerOffsets[i * 2 + 1]);
-						fieldSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(inViewWrapper, getUserCodeClassLoader());
-
-						fieldToSerializerConfigSnapshot.put(
-							field,
-							new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(fieldSerializer, fieldSerializerConfigSnapshot));
-					}
+				cachedSubclassname = in.readUTF();
+				try {
+					cachedSubclass = Class.forName(cachedSubclassname, true, getUserCodeClassLoader());
+				} catch (ClassNotFoundException e) {
+					throw new IOException("Cannot find requested class " + cachedSubclassname + " in classpath.", e);
 				}
 
-				// --- read registered subclasses and their serializers, in registration order
-
-				this.registeredSubclassesToSerializerConfigSnapshots = new LinkedHashMap<>(numRegisteredSubclasses);
-				String registeredSubclassname;
-				Class<?> registeredSubclass;
-				TypeSerializer<?> registeredSubclassSerializer;
-				TypeSerializerConfigSnapshot registeredSubclassSerializerConfigSnapshot;
-				for (int i = 0; i < numRegisteredSubclasses; i++) {
-					registeredSubclassname = inViewWrapper.readUTF();
-					try {
-						registeredSubclass = Class.forName(registeredSubclassname, true, getUserCodeClassLoader());
-					} catch (ClassNotFoundException e) {
-						throw new IOException("Cannot find requested class " + registeredSubclassname + " in classpath.", e);
-					}
-
-					inWithPos.setPosition(registeredSerializerOffsets[i * 2]);
-					registeredSubclassSerializer = TypeSerializerSerializationUtil.tryReadSerializer(inViewWrapper, getUserCodeClassLoader());
-
-					inWithPos.setPosition(registeredSerializerOffsets[i * 2 + 1]);
-					registeredSubclassSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(inViewWrapper, getUserCodeClassLoader());
-
-					this.registeredSubclassesToSerializerConfigSnapshots.put(
-						registeredSubclass,
-						new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(registeredSubclassSerializer, registeredSubclassSerializerConfigSnapshot));
-				}
-
-				// --- read snapshot of non-registered subclass serializer cache
-
-				this.nonRegisteredSubclassesToSerializerConfigSnapshots = new HashMap<>(numCachedSubclassSerializers);
-				String cachedSubclassname;
-				Class<?> cachedSubclass;
-				TypeSerializer<?> cachedSubclassSerializer;
-				TypeSerializerConfigSnapshot cachedSubclassSerializerConfigSnapshot;
-				for (int i = 0; i < numCachedSubclassSerializers; i++) {
-					cachedSubclassname = inViewWrapper.readUTF();
-					try {
-						cachedSubclass = Class.forName(cachedSubclassname, true, getUserCodeClassLoader());
-					} catch (ClassNotFoundException e) {
-						throw new IOException("Cannot find requested class " + cachedSubclassname + " in classpath.", e);
-					}
-
-					inWithPos.setPosition(cachedSerializerOffsets[i * 2]);
-					cachedSubclassSerializer = TypeSerializerSerializationUtil.tryReadSerializer(inViewWrapper, getUserCodeClassLoader());
-
-					inWithPos.setPosition(cachedSerializerOffsets[i * 2 + 1]);
-					cachedSubclassSerializerConfigSnapshot = TypeSerializerSerializationUtil.readSerializerConfigSnapshot(inViewWrapper, getUserCodeClassLoader());
-
-					this.nonRegisteredSubclassesToSerializerConfigSnapshots.put(
-						cachedSubclass,
-						new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(cachedSubclassSerializer, cachedSubclassSerializerConfigSnapshot));
-				}
+				this.nonRegisteredSubclassesToSerializerConfigSnapshots.put(
+					cachedSubclass,
+					new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(
+						TypeSerializerSerializationUtil.tryReadSerializerWithResilience(in, getUserCodeClassLoader()),
+						TypeSerializerSerializationUtil.readSerializerConfigSnapshot(in, getUserCodeClassLoader())));
 			}
 		}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/IdentitySerializerIndexTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/IdentitySerializerIndexTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+/**
+ * Unit tests for the {@link IdentitySerializerIndex}.
+ */
+public class IdentitySerializerIndexTest {
+
+	@Test
+	public void testNonDuplicatedSerializerIndexing() {
+		final IdentitySerializerIndex serializerIndex = new IdentitySerializerIndex();
+
+		// -- test that the same serializer instances should be maintained as a single entry
+
+		// using stateless serializers; duplicate should return the same serializer
+		serializerIndex.index(IntSerializer.INSTANCE);
+		serializerIndex.index(IntSerializer.INSTANCE.duplicate());
+
+		Assert.assertEquals(1, serializerIndex.getSize());
+		Assert.assertTrue(serializerIndex.containsSerializer(IntSerializer.INSTANCE));
+
+		// -- test that the different serializer instances should be maintained as separate entries
+
+		// use a stateful serializer and duplicate it to create a separate serializer
+		TypeSerializer<Object> serializer = TypeExtractor.getForClass(Object.class).createSerializer(new ExecutionConfig());
+		TypeSerializer<Object> otherSerializer = serializer.duplicate();
+
+		// make sure our assumption is correct
+		Assert.assertTrue(serializer != otherSerializer);
+
+		serializerIndex.index(serializer);
+		serializerIndex.index(otherSerializer);
+
+		Assert.assertEquals(3, serializerIndex.getSize());
+		Assert.assertTrue(serializerIndex.containsSerializer(serializer));
+		Assert.assertTrue(serializerIndex.containsSerializer(otherSerializer));
+	}
+
+	@Test
+	public void testSerializerIndexSerializationRoundtrip() throws IOException {
+		IdentitySerializerIndex serializerIndex = new IdentitySerializerIndex();
+
+		TypeSerializer<?> serializer1 = IntSerializer.INSTANCE;
+		TypeSerializer<?> serializer2 = TypeExtractor.getForClass(Object.class).createSerializer(new ExecutionConfig());
+		TypeSerializer<?> serializer3 = serializer2.duplicate();
+
+		serializerIndex.index(serializer1);
+		serializerIndex.index(serializer2);
+		serializerIndex.index(serializer3);
+
+		int index1 = serializerIndex.getIndexOf(serializer1);
+		int index2 = serializerIndex.getIndexOf(serializer2);
+		int index3 = serializerIndex.getIndexOf(serializer3);
+
+		// serializer to bytes
+		byte[] bytes;
+		try (
+			ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+			DataOutputViewStreamWrapper bufferWrapper = new DataOutputViewStreamWrapper(buffer)) {
+
+			serializerIndex.write(bufferWrapper);
+			bytes = buffer.toByteArray();
+		}
+
+		// ... and then deserialize again
+		try (
+			ByteArrayInputStream buffer = new ByteArrayInputStream(bytes);
+			DataInputViewStreamWrapper bufferWrapper = new DataInputViewStreamWrapper(buffer)) {
+
+			serializerIndex = new IdentitySerializerIndex(Thread.currentThread().getContextClassLoader());
+			serializerIndex.read(bufferWrapper);
+		}
+
+		Assert.assertEquals(3, serializerIndex.getSize());
+		Assert.assertEquals(serializer1, serializerIndex.getSerializer(index1));
+		Assert.assertEquals(serializer2, serializerIndex.getSerializer(index2));
+		Assert.assertEquals(serializer3, serializerIndex.getSerializer(index3));
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
@@ -213,7 +213,7 @@ public class TypeSerializerSerializationUtilTest {
 		byte[] serializedSerializersAndConfigs;
 		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
 			TypeSerializerSerializationUtil.writeSerializersAndConfigsWithResilience(
-					new DataOutputViewStreamWrapper(out), serializersAndConfigs);
+					new DataOutputViewStreamWrapper(out), serializersAndConfigs, false);
 			serializedSerializersAndConfigs = out.toByteArray();
 		}
 
@@ -226,7 +226,7 @@ public class TypeSerializerSerializationUtilTest {
 		List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> restored;
 		try (ByteArrayInputStream in = new ByteArrayInputStream(serializedSerializersAndConfigs)) {
 			restored = TypeSerializerSerializationUtil.readSerializersAndConfigsWithResilience(
-				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
+				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader(), false);
 		}
 
 		Assert.assertEquals(2, restored.size());

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
@@ -213,7 +213,7 @@ public class TypeSerializerSerializationUtilTest {
 		byte[] serializedSerializersAndConfigs;
 		try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
 			TypeSerializerSerializationUtil.writeSerializersAndConfigsWithResilience(
-					new DataOutputViewStreamWrapper(out), serializersAndConfigs, false);
+					new DataOutputViewStreamWrapper(out), serializersAndConfigs, null);
 			serializedSerializersAndConfigs = out.toByteArray();
 		}
 
@@ -226,7 +226,7 @@ public class TypeSerializerSerializationUtilTest {
 		List<Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> restored;
 		try (ByteArrayInputStream in = new ByteArrayInputStream(serializedSerializersAndConfigs)) {
 			restored = TypeSerializerSerializationUtil.readSerializersAndConfigsWithResilience(
-				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader(), false);
+				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader(), null);
 		}
 
 		Assert.assertEquals(2, restored.size());

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtilTest.java
@@ -67,13 +67,13 @@ public class TypeSerializerSerializationUtilTest {
 
 		byte[] serialized;
 		try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
-			TypeSerializerSerializationUtil.writeSerializer(new DataOutputViewStreamWrapper(out), serializer);
+			TypeSerializerSerializationUtil.writeSerializerWithResilience(new DataOutputViewStreamWrapper(out), serializer);
 			serialized = out.toByteArray();
 		}
 
 		TypeSerializer<?> deserializedSerializer;
 		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
-			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializer(
+			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializerWithResilience(
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 
@@ -91,20 +91,20 @@ public class TypeSerializerSerializationUtilTest {
 
 		byte[] serialized;
 		try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
-			TypeSerializerSerializationUtil.writeSerializer(new DataOutputViewStreamWrapper(out), serializer);
+			TypeSerializerSerializationUtil.writeSerializerWithResilience(new DataOutputViewStreamWrapper(out), serializer);
 			serialized = out.toByteArray();
 		}
 
 		TypeSerializer<?> deserializedSerializer;
 
 		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
-			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializer(
+			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializerWithResilience(
 				new DataInputViewStreamWrapper(in), new URLClassLoader(new URL[0], null));
 		}
 		Assert.assertEquals(null, deserializedSerializer);
 
 		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
-			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializer(
+			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializerWithResilience(
 				new DataInputViewStreamWrapper(in), new URLClassLoader(new URL[0], null), true);
 		}
 		Assert.assertTrue(deserializedSerializer instanceof UnloadableDummyTypeSerializer);
@@ -125,7 +125,7 @@ public class TypeSerializerSerializationUtilTest {
 
 		byte[] serialized;
 		try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
-			TypeSerializerSerializationUtil.writeSerializer(new DataOutputViewStreamWrapper(out), serializer);
+			TypeSerializerSerializationUtil.writeSerializerWithResilience(new DataOutputViewStreamWrapper(out), serializer);
 			serialized = out.toByteArray();
 		}
 
@@ -138,7 +138,7 @@ public class TypeSerializerSerializationUtilTest {
 		PowerMockito.whenNew(TypeSerializerSerializationUtil.TypeSerializerSerializationProxy.class).withAnyArguments().thenReturn(mockProxy);
 
 		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
-			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializer(
+			deserializedSerializer = TypeSerializerSerializationUtil.tryReadSerializerWithResilience(
 				new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
 		}
 		Assert.assertEquals(null, deserializedSerializer);

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
@@ -709,9 +709,9 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 			PojoSerializer.PojoSerializerConfigSnapshot<?> deserializedConfig) {
 
 		LinkedHashMap<Field, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> originalFieldSerializersAndConfs =
-				original.getFieldToSerializerConfigSnapshot();
+				original.getFieldsToSerializersAndConfigSnapshots();
 		for (Map.Entry<Field, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> entry
-				: deserializedConfig.getFieldToSerializerConfigSnapshot().entrySet()) {
+				: deserializedConfig.getFieldsToSerializersAndConfigSnapshots().entrySet()) {
 
 			Assert.assertEquals(null, entry.getValue().f0);
 
@@ -725,10 +725,10 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 		}
 
 		LinkedHashMap<Class<?>, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> originalRegistrations =
-				original.getRegisteredSubclassesToSerializerConfigSnapshots();
+				original.getRegisteredSubclassesToSerializersAndConfigSnapshots();
 
 		for (Map.Entry<Class<?>, Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>> entry
-				: deserializedConfig.getRegisteredSubclassesToSerializerConfigSnapshots().entrySet()) {
+				: deserializedConfig.getRegisteredSubclassesToSerializersAndConfigSnapshots().entrySet()) {
 
 			Assert.assertEquals(null, entry.getValue().f0);
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
@@ -42,6 +42,8 @@ import org.apache.flink.api.common.operators.Keys.ExpressionKeys;
 import org.apache.flink.api.common.operators.Keys.IncompatibleKeysException;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil;
+import org.apache.flink.api.common.typeutils.base.DoubleSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
@@ -230,6 +232,63 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 		public float subDumm2;
 
 		public SubTestUserClassB() {}
+	}
+
+	public static class TestUserClassWithSameFieldTypes {
+		public int dumm1;
+		public int dumm2;
+		public double dumm3;
+		public double dumm4;
+
+		public NestedTestUserClass dumm5;
+		public NestedTestUserClass dumm6;
+
+		public TestUserClassWithSameFieldTypes() {
+		}
+
+		public TestUserClassWithSameFieldTypes(int dumm1, int dumm2, double dumm3, double dumm4, NestedTestUserClass dumm5, NestedTestUserClass dumm6) {
+			this.dumm1 = dumm1;
+			this.dumm2 = dumm2;
+			this.dumm3 = dumm3;
+			this.dumm4 = dumm4;
+			this.dumm5 = dumm5;
+			this.dumm6 = dumm6;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(dumm1, dumm2, dumm3, dumm4, dumm5, dumm6);
+		}
+
+		@Override
+		public boolean equals(Object other) {
+			if (!(other instanceof TestUserClassWithSameFieldTypes)) {
+				return false;
+			}
+
+			TestUserClassWithSameFieldTypes otherTUC = (TestUserClassWithSameFieldTypes) other;
+			if (dumm1 != otherTUC.dumm1) {
+				return false;
+			}
+			if (dumm2 != otherTUC.dumm2) {
+				return false;
+			}
+			if (dumm3 != otherTUC.dumm3) {
+				return false;
+			}
+			if (dumm4 != otherTUC.dumm4) {
+				return false;
+			}
+			if ((dumm5 == null && otherTUC.dumm5 != null)
+				|| (dumm5 != null && !dumm5.equals(otherTUC.dumm5))) {
+				return false;
+			}
+			if ((dumm6 == null && otherTUC.dumm6 != null)
+				|| (dumm6 != null && !dumm6.equals(otherTUC.dumm6))) {
+				return false;
+			}
+			return true;
+		}
 	}
 	
 	/**
@@ -604,6 +663,45 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 
 		Assert.assertFalse(pojoSerializer.ensureCompatibility(deserializedConfig).isRequiresMigration());
 		verifyPojoSerializerConfigSnapshotWithEmptyNestedSerializers(config, deserializedConfig);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testNonDuplicatedStatelessSerializersInConfigSnapshot() throws IOException {
+		PojoSerializer<TestUserClassWithSameFieldTypes> pojoSerializer = (PojoSerializer<TestUserClassWithSameFieldTypes>)
+			TypeExtractor.getForClass(TestUserClassWithSameFieldTypes.class).createSerializer(new ExecutionConfig());
+
+		// snapshot configuration and serialize to bytes
+		PojoSerializer.PojoSerializerConfigSnapshot<TestUserClassWithSameFieldTypes> config = pojoSerializer.snapshotConfiguration();
+		byte[] serializedConfig;
+		try (
+			ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+			TypeSerializerSerializationUtil.writeSerializerConfigSnapshot(new DataOutputViewStreamWrapper(out), config);
+			serializedConfig = out.toByteArray();
+		}
+
+		// read configuration from bytes
+		PojoSerializer.PojoSerializerConfigSnapshot<TestUserClass> deserializedConfig;
+		try(ByteArrayInputStream in = new ByteArrayInputStream(serializedConfig)) {
+			deserializedConfig = (PojoSerializer.PojoSerializerConfigSnapshot<TestUserClass>)
+				TypeSerializerSerializationUtil.readSerializerConfigSnapshot(
+					new DataInputViewStreamWrapper(in), Thread.currentThread().getContextClassLoader());
+		}
+
+		Assert.assertFalse(pojoSerializer.ensureCompatibility(deserializedConfig).isRequiresMigration());
+
+		// the int fields
+		Assert.assertEquals(IntSerializer.INSTANCE, pojoSerializer.getFieldSerializers()[0]);
+		Assert.assertTrue(pojoSerializer.getFieldSerializers()[0] == pojoSerializer.getFieldSerializers()[1]);
+
+		// the double fields
+		Assert.assertEquals(DoubleSerializer.INSTANCE, pojoSerializer.getFieldSerializers()[2]);
+		Assert.assertTrue(pojoSerializer.getFieldSerializers()[2] == pojoSerializer.getFieldSerializers()[3]);
+
+		// the nested POJOs fields, should be separate PojoSerializers
+		Assert.assertTrue(pojoSerializer.getFieldSerializers()[4] instanceof PojoSerializer);
+		Assert.assertFalse(pojoSerializer.getFieldSerializers()[4] == pojoSerializer.getFieldSerializers()[5]);
+		Assert.assertTrue(pojoSerializer.getFieldSerializers()[4].equals(pojoSerializer.getFieldSerializers()[5]));
 	}
 
 	private static void verifyPojoSerializerConfigSnapshotWithEmptyNestedSerializers(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -225,7 +225,9 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 					DataOutputView dov = new DataOutputViewStreamWrapper(out);
 
 					OperatorBackendSerializationProxy backendSerializationProxy =
-						new OperatorBackendSerializationProxy(metaInfoSnapshots);
+						new OperatorBackendSerializationProxy(
+							metaInfoSnapshots,
+							false); // TODO make this configurable
 
 					backendSerializationProxy.write(dov);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedBackendStateMetaInfoSnapshotReaderWriters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedBackendStateMetaInfoSnapshotReaderWriters.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.IdentitySerializerIndex;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil;
@@ -30,7 +31,6 @@ import org.apache.flink.util.Preconditions;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Readers and writers for different versions of the {@link RegisteredKeyedBackendStateMetaInfo.Snapshot}.
@@ -64,7 +64,7 @@ public class KeyedBackendStateMetaInfoSnapshotReaderWriters {
 	}
 
 	public interface KeyedBackendStateMetaInfoWriter {
-		void writeStateMetaInfo(DataOutputView out, Map<TypeSerializer<?>, Integer> serializerIndices) throws IOException;
+		void writeStateMetaInfo(DataOutputView out, IdentitySerializerIndex serializerIndex) throws IOException;
 	}
 
 	static abstract class AbstractKeyedBackendStateMetaInfoWriter<N, S> implements KeyedBackendStateMetaInfoWriter {
@@ -84,11 +84,11 @@ public class KeyedBackendStateMetaInfoSnapshotReaderWriters {
 		}
 
 		@Override
-		public void writeStateMetaInfo(DataOutputView out, Map<TypeSerializer<?>, Integer> serializerIndices) throws IOException {
+		public void writeStateMetaInfo(DataOutputView out, IdentitySerializerIndex serializerIndex) throws IOException {
 			out.writeInt(stateMetaInfo.getStateType().ordinal());
 			out.writeUTF(stateMetaInfo.getName());
 
-			// V1 / V2 does not respect the serializer indices
+			// V1 / V2 does not respect the serializer index
 			TypeSerializerSerializationUtil.writeSerializer(out, stateMetaInfo.getNamespaceSerializer());
 			TypeSerializerSerializationUtil.writeSerializer(out, stateMetaInfo.getStateSerializer());
 		}
@@ -101,7 +101,7 @@ public class KeyedBackendStateMetaInfoSnapshotReaderWriters {
 		}
 
 		@Override
-		public void writeStateMetaInfo(DataOutputView out, Map<TypeSerializer<?>, Integer> serializerIndices) throws IOException {
+		public void writeStateMetaInfo(DataOutputView out, IdentitySerializerIndex serializerIndex) throws IOException {
 			out.writeInt(stateMetaInfo.getStateType().ordinal());
 			out.writeUTF(stateMetaInfo.getName());
 
@@ -113,7 +113,7 @@ public class KeyedBackendStateMetaInfoSnapshotReaderWriters {
 						stateMetaInfo.getNamespaceSerializer(), stateMetaInfo.getNamespaceSerializerConfigSnapshot()),
 					new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(
 						stateMetaInfo.getStateSerializer(), stateMetaInfo.getStateSerializerConfigSnapshot())),
-				serializerIndices);
+				serializerIndex);
 		}
 	}
 
@@ -145,7 +145,7 @@ public class KeyedBackendStateMetaInfoSnapshotReaderWriters {
 
 	public interface KeyedBackendStateMetaInfoReader<N, S> {
 		RegisteredKeyedBackendStateMetaInfo.Snapshot<N, S> readStateMetaInfo(
-				DataInputView in, Map<Integer, TypeSerializer<?>> serializerIndex) throws IOException;
+				DataInputView in, IdentitySerializerIndex serializerIndex) throws IOException;
 	}
 
 	static abstract class AbstractKeyedBackendStateMetaInfoReader<N, S> implements KeyedBackendStateMetaInfoReader<N, S> {
@@ -166,7 +166,7 @@ public class KeyedBackendStateMetaInfoSnapshotReaderWriters {
 
 		@Override
 		public RegisteredKeyedBackendStateMetaInfo.Snapshot<N, S> readStateMetaInfo(
-				DataInputView in, Map<Integer, TypeSerializer<?>> serializerIndex) throws IOException {
+				DataInputView in, IdentitySerializerIndex serializerIndex) throws IOException {
 			RegisteredKeyedBackendStateMetaInfo.Snapshot<N, S> metaInfo =
 				new RegisteredKeyedBackendStateMetaInfo.Snapshot<>();
 
@@ -194,7 +194,7 @@ public class KeyedBackendStateMetaInfoSnapshotReaderWriters {
 
 		@Override
 		public RegisteredKeyedBackendStateMetaInfo.Snapshot<N, S> readStateMetaInfo(
-				DataInputView in, Map<Integer, TypeSerializer<?>> serializerIndex) throws IOException {
+				DataInputView in, IdentitySerializerIndex serializerIndex) throws IOException {
 			RegisteredKeyedBackendStateMetaInfo.Snapshot<N, S> metaInfo =
 				new RegisteredKeyedBackendStateMetaInfo.Snapshot<>();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorBackendStateMetaInfoSnapshotReaderWriters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorBackendStateMetaInfoSnapshotReaderWriters.java
@@ -27,8 +27,6 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -38,8 +36,6 @@ import java.util.Collections;
  * Outdated formats are also kept here for documentation of history backlog.
  */
 public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
-
-	private static final Logger LOG = LoggerFactory.getLogger(OperatorBackendStateMetaInfoSnapshotReaderWriters.class);
 
 	// -------------------------------------------------------------------------------
 	//  Writers

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorBackendStateMetaInfoSnapshotReaderWriters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorBackendStateMetaInfoSnapshotReaderWriters.java
@@ -62,7 +62,7 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 	}
 
 	public interface OperatorBackendStateMetaInfoWriter {
-		void writeStateMetaInfo(DataOutputView out) throws IOException;
+		void writeStateMetaInfo(DataOutputView out, boolean excludeSerializers) throws IOException;
 	}
 
 	public static abstract class AbstractOperatorBackendStateMetaInfoWriter<S>
@@ -82,9 +82,11 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 		}
 
 		@Override
-		public void writeStateMetaInfo(DataOutputView out) throws IOException {
+		public void writeStateMetaInfo(DataOutputView out, boolean excludeSerializers) throws IOException {
 			out.writeUTF(stateMetaInfo.getName());
 			out.writeByte(stateMetaInfo.getAssignmentMode().ordinal());
+
+			// V1 does not respect the exclude serializer flag
 			TypeSerializerSerializationUtil.writeSerializer(out, stateMetaInfo.getPartitionStateSerializer());
 		}
 	}
@@ -96,7 +98,7 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 		}
 
 		@Override
-		public void writeStateMetaInfo(DataOutputView out) throws IOException {
+		public void writeStateMetaInfo(DataOutputView out, boolean excludeSerializers) throws IOException {
 			out.writeUTF(stateMetaInfo.getName());
 			out.writeByte(stateMetaInfo.getAssignmentMode().ordinal());
 
@@ -105,7 +107,8 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 				out,
 				Collections.singletonList(new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(
 					stateMetaInfo.getPartitionStateSerializer(),
-					stateMetaInfo.getPartitionStateSerializerConfigSnapshot())));
+					stateMetaInfo.getPartitionStateSerializerConfigSnapshot())),
+				excludeSerializers);
 		}
 	}
 
@@ -134,7 +137,8 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 	}
 
 	public interface OperatorBackendStateMetaInfoReader<S> {
-		RegisteredOperatorBackendStateMetaInfo.Snapshot<S> readStateMetaInfo(DataInputView in) throws IOException;
+		RegisteredOperatorBackendStateMetaInfo.Snapshot<S> readStateMetaInfo(
+			DataInputView in, boolean excludeSerializers) throws IOException;
 	}
 
 	public static abstract class AbstractOperatorBackendStateMetaInfoReader<S>
@@ -154,12 +158,16 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 		}
 
 		@Override
-		public RegisteredOperatorBackendStateMetaInfo.Snapshot<S> readStateMetaInfo(DataInputView in) throws IOException {
+		public RegisteredOperatorBackendStateMetaInfo.Snapshot<S> readStateMetaInfo(
+				DataInputView in, boolean excludeSerializers) throws IOException {
+
 			RegisteredOperatorBackendStateMetaInfo.Snapshot<S> stateMetaInfo =
 				new RegisteredOperatorBackendStateMetaInfo.Snapshot<>();
 
 			stateMetaInfo.setName(in.readUTF());
 			stateMetaInfo.setAssignmentMode(OperatorStateHandle.Mode.values()[in.readByte()]);
+
+			// V1 does not respect the exclude serializer flag
 			DataInputViewStream dis = new DataInputViewStream(in);
 			try {
 				TypeSerializer<S> stateSerializer = InstantiationUtil.deserializeObject(dis, userCodeClassLoader);
@@ -183,7 +191,9 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 		}
 
 		@Override
-		public RegisteredOperatorBackendStateMetaInfo.Snapshot<S> readStateMetaInfo(DataInputView in) throws IOException {
+		public RegisteredOperatorBackendStateMetaInfo.Snapshot<S> readStateMetaInfo(
+				DataInputView in, boolean excludeSerializers) throws IOException {
+
 			RegisteredOperatorBackendStateMetaInfo.Snapshot<S> stateMetaInfo =
 				new RegisteredOperatorBackendStateMetaInfo.Snapshot<>();
 
@@ -191,7 +201,8 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 			stateMetaInfo.setAssignmentMode(OperatorStateHandle.Mode.values()[in.readByte()]);
 
 			Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot> stateSerializerAndConfig =
-				TypeSerializerSerializationUtil.readSerializersAndConfigsWithResilience(in, userCodeClassLoader).get(0);
+				TypeSerializerSerializationUtil.readSerializersAndConfigsWithResilience(
+					in, userCodeClassLoader, excludeSerializers).get(0);
 
 			stateMetaInfo.setPartitionStateSerializer((TypeSerializer<S>) stateSerializerAndConfig.f0);
 			stateMetaInfo.setPartitionStateSerializerConfigSnapshot(stateSerializerAndConfig.f1);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorBackendStateMetaInfoSnapshotReaderWriters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorBackendStateMetaInfoSnapshotReaderWriters.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.api.common.typeutils.IdentitySerializerIndex;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil;
@@ -30,7 +31,6 @@ import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Map;
 
 /**
  * Readers and writers for different versions of the {@link RegisteredOperatorBackendStateMetaInfo.Snapshot}.
@@ -63,7 +63,7 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 	}
 
 	public interface OperatorBackendStateMetaInfoWriter {
-		void writeStateMetaInfo(DataOutputView out, Map<TypeSerializer<?>, Integer> serializerIndices) throws IOException;
+		void writeStateMetaInfo(DataOutputView out, IdentitySerializerIndex serializerIndex) throws IOException;
 	}
 
 	public static abstract class AbstractOperatorBackendStateMetaInfoWriter<S>
@@ -83,11 +83,11 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 		}
 
 		@Override
-		public void writeStateMetaInfo(DataOutputView out, Map<TypeSerializer<?>, Integer> serializerIndices) throws IOException {
+		public void writeStateMetaInfo(DataOutputView out, IdentitySerializerIndex serializerIndex) throws IOException {
 			out.writeUTF(stateMetaInfo.getName());
 			out.writeByte(stateMetaInfo.getAssignmentMode().ordinal());
 
-			// V1 does not respect the serializer indices
+			// V1 does not respect the serializer index
 			TypeSerializerSerializationUtil.writeSerializer(out, stateMetaInfo.getPartitionStateSerializer());
 		}
 	}
@@ -99,7 +99,7 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 		}
 
 		@Override
-		public void writeStateMetaInfo(DataOutputView out, Map<TypeSerializer<?>, Integer> serializerIndices) throws IOException {
+		public void writeStateMetaInfo(DataOutputView out, IdentitySerializerIndex serializerIndex) throws IOException {
 			out.writeUTF(stateMetaInfo.getName());
 			out.writeByte(stateMetaInfo.getAssignmentMode().ordinal());
 
@@ -109,7 +109,7 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 				Collections.singletonList(new Tuple2<TypeSerializer<?>, TypeSerializerConfigSnapshot>(
 					stateMetaInfo.getPartitionStateSerializer(),
 					stateMetaInfo.getPartitionStateSerializerConfigSnapshot())),
-				serializerIndices);
+				serializerIndex);
 		}
 	}
 
@@ -139,7 +139,7 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 
 	public interface OperatorBackendStateMetaInfoReader<S> {
 		RegisteredOperatorBackendStateMetaInfo.Snapshot<S> readStateMetaInfo(
-			DataInputView in, Map<Integer, TypeSerializer<?>> serializerIndex) throws IOException;
+			DataInputView in, IdentitySerializerIndex serializerIndex) throws IOException;
 	}
 
 	public static abstract class AbstractOperatorBackendStateMetaInfoReader<S>
@@ -160,7 +160,7 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 
 		@Override
 		public RegisteredOperatorBackendStateMetaInfo.Snapshot<S> readStateMetaInfo(
-				DataInputView in, Map<Integer, TypeSerializer<?>> serializerIndex) throws IOException {
+				DataInputView in, IdentitySerializerIndex serializerIndex) throws IOException {
 
 			RegisteredOperatorBackendStateMetaInfo.Snapshot<S> stateMetaInfo =
 				new RegisteredOperatorBackendStateMetaInfo.Snapshot<>();
@@ -193,7 +193,7 @@ public class OperatorBackendStateMetaInfoSnapshotReaderWriters {
 
 		@Override
 		public RegisteredOperatorBackendStateMetaInfo.Snapshot<S> readStateMetaInfo(
-				DataInputView in, Map<Integer, TypeSerializer<?>> serializerIndex) throws IOException {
+				DataInputView in, IdentitySerializerIndex serializerIndex) throws IOException {
 
 			RegisteredOperatorBackendStateMetaInfo.Snapshot<S> stateMetaInfo =
 				new RegisteredOperatorBackendStateMetaInfo.Snapshot<>();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -273,7 +273,10 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		}
 
 		final KeyedBackendSerializationProxy<K> serializationProxy =
-				new KeyedBackendSerializationProxy<>(keySerializer, metaInfoSnapshots);
+				new KeyedBackendSerializationProxy<>(
+						keySerializer,
+						metaInfoSnapshots,
+						false); // TODO make this configurable
 
 		//--------------------------------------------------- this becomes the end of sync part
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSerializationUtil;
 import org.apache.flink.api.common.typeutils.base.DoubleSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
@@ -179,20 +180,75 @@ public class SerializationProxiesTest {
 	}
 
 	@Test
+	public void testNonDuplicatedStatelessSerializersWithKeyedBackendSerializationProxyRoundtrip() throws IOException {
+		TypeSerializer<?> keySerializer = IntSerializer.INSTANCE;
+		TypeSerializer<?> namespaceSerializer = IntSerializer.INSTANCE;
+
+		TypeSerializer<?> stateSerializer1 = DoubleSerializer.INSTANCE;
+		TypeSerializer<?> stateSerializer2 = DoubleSerializer.INSTANCE;
+		TypeSerializer<?> stateSerializer3 = StringSerializer.INSTANCE;
+		TypeSerializer<?> stateSerializer4 = StringSerializer.INSTANCE;
+
+		List<RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?>> stateMetaInfoList = new ArrayList<>();
+
+		stateMetaInfoList.add(new RegisteredKeyedBackendStateMetaInfo<>(
+			StateDescriptor.Type.VALUE, "a", namespaceSerializer, stateSerializer1).snapshot());
+		stateMetaInfoList.add(new RegisteredKeyedBackendStateMetaInfo<>(
+			StateDescriptor.Type.VALUE, "b", namespaceSerializer, stateSerializer2).snapshot());
+		stateMetaInfoList.add(new RegisteredKeyedBackendStateMetaInfo<>(
+			StateDescriptor.Type.VALUE, "c", namespaceSerializer, stateSerializer3).snapshot());
+		stateMetaInfoList.add(new RegisteredKeyedBackendStateMetaInfo<>(
+			StateDescriptor.Type.VALUE, "d", namespaceSerializer, stateSerializer4).snapshot());
+
+		KeyedBackendSerializationProxy<?> serializationProxy =
+			new KeyedBackendSerializationProxy<>(keySerializer, stateMetaInfoList, false);
+
+		byte[] serialized;
+		try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
+			serializationProxy.write(new DataOutputViewStreamWrapper(out));
+			serialized = out.toByteArray();
+		}
+
+		serializationProxy =
+			new KeyedBackendSerializationProxy<>(Thread.currentThread().getContextClassLoader());
+
+		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
+			serializationProxy.read(new DataInputViewStreamWrapper(in));
+		}
+
+		Assert.assertEquals(IntSerializer.INSTANCE, serializationProxy.getKeySerializer());
+
+		// the namespace serializers should share the same IntSerializer
+		for (RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?> stateMetaInfoSnapshot : serializationProxy.getStateMetaInfoSnapshots()) {
+			Assert.assertTrue(serializationProxy.getKeySerializer() == stateMetaInfoSnapshot.getNamespaceSerializer());
+		}
+
+		// first and second state should share the same DoubleSerializer
+		Assert.assertEquals(DoubleSerializer.INSTANCE, serializationProxy.getStateMetaInfoSnapshots().get(0).getStateSerializer());
+		Assert.assertTrue(serializationProxy.getStateMetaInfoSnapshots().get(0).getStateSerializer() ==
+			serializationProxy.getStateMetaInfoSnapshots().get(1).getStateSerializer());
+
+		// third and fourth state should share the same StringSerializer
+		Assert.assertEquals(StringSerializer.INSTANCE, serializationProxy.getStateMetaInfoSnapshots().get(2).getStateSerializer());
+		Assert.assertTrue(serializationProxy.getStateMetaInfoSnapshots().get(2).getStateSerializer() ==
+			serializationProxy.getStateMetaInfoSnapshots().get(3).getStateSerializer());
+	}
+
+	@Test
 	public void testKeyedStateMetaInfoSerialization() throws Exception {
 
 		String name = "test";
-		TypeSerializer<?> namespaceSerializer = LongSerializer.INSTANCE;
-		TypeSerializer<?> stateSerializer = DoubleSerializer.INSTANCE;
+		TypeSerializer<Long> namespaceSerializer = LongSerializer.INSTANCE;
+		TypeSerializer<Double> stateSerializer = DoubleSerializer.INSTANCE;
 
-		RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?> metaInfo = new RegisteredKeyedBackendStateMetaInfo<>(
+		RegisteredKeyedBackendStateMetaInfo.Snapshot<Long, Double> metaInfo = new RegisteredKeyedBackendStateMetaInfo<>(
 			StateDescriptor.Type.VALUE, name, namespaceSerializer, stateSerializer).snapshot();
 
 		byte[] serialized;
 		try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
 			KeyedBackendStateMetaInfoSnapshotReaderWriters
 				.getWriterForVersion(KeyedBackendSerializationProxy.VERSION, metaInfo)
-				.writeStateMetaInfo(new DataOutputViewStreamWrapper(out), false);
+				.writeStateMetaInfo(new DataOutputViewStreamWrapper(out), null);
 
 			serialized = out.toByteArray();
 		}
@@ -200,7 +256,7 @@ public class SerializationProxiesTest {
 		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
 			metaInfo = KeyedBackendStateMetaInfoSnapshotReaderWriters
 				.getReaderForVersion(KeyedBackendSerializationProxy.VERSION, Thread.currentThread().getContextClassLoader())
-				.readStateMetaInfo(new DataInputViewStreamWrapper(in), false);
+				.readStateMetaInfo(new DataInputViewStreamWrapper(in), null);
 		}
 
 		Assert.assertEquals(name, metaInfo.getName());
@@ -219,7 +275,7 @@ public class SerializationProxiesTest {
 		try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
 			KeyedBackendStateMetaInfoSnapshotReaderWriters
 				.getWriterForVersion(KeyedBackendSerializationProxy.VERSION, metaInfo)
-				.writeStateMetaInfo(new DataOutputViewStreamWrapper(out), false);
+				.writeStateMetaInfo(new DataOutputViewStreamWrapper(out), null);
 
 			serialized = out.toByteArray();
 		}
@@ -233,7 +289,7 @@ public class SerializationProxiesTest {
 		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
 			metaInfo = KeyedBackendStateMetaInfoSnapshotReaderWriters
 				.getReaderForVersion(KeyedBackendSerializationProxy.VERSION, Thread.currentThread().getContextClassLoader())
-				.readStateMetaInfo(new DataInputViewStreamWrapper(in), false);
+				.readStateMetaInfo(new DataInputViewStreamWrapper(in), null);
 		}
 
 		Assert.assertEquals(name, metaInfo.getName());
@@ -326,7 +382,7 @@ public class SerializationProxiesTest {
 		try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
 			OperatorBackendStateMetaInfoSnapshotReaderWriters
 				.getWriterForVersion(OperatorBackendSerializationProxy.VERSION, metaInfo)
-				.writeStateMetaInfo(new DataOutputViewStreamWrapper(out), false);
+				.writeStateMetaInfo(new DataOutputViewStreamWrapper(out), null);
 
 			serialized = out.toByteArray();
 		}
@@ -334,7 +390,7 @@ public class SerializationProxiesTest {
 		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
 			metaInfo = OperatorBackendStateMetaInfoSnapshotReaderWriters
 				.getReaderForVersion(OperatorBackendSerializationProxy.VERSION, Thread.currentThread().getContextClassLoader())
-				.readStateMetaInfo(new DataInputViewStreamWrapper(in), false);
+				.readStateMetaInfo(new DataInputViewStreamWrapper(in), null);
 		}
 
 		Assert.assertEquals(name, metaInfo.getName());
@@ -353,7 +409,7 @@ public class SerializationProxiesTest {
 		try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
 			OperatorBackendStateMetaInfoSnapshotReaderWriters
 				.getWriterForVersion(OperatorBackendSerializationProxy.VERSION, metaInfo)
-				.writeStateMetaInfo(new DataOutputViewStreamWrapper(out), false);
+				.writeStateMetaInfo(new DataOutputViewStreamWrapper(out), null);
 
 			serialized = out.toByteArray();
 		}
@@ -367,12 +423,57 @@ public class SerializationProxiesTest {
 		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
 			metaInfo = OperatorBackendStateMetaInfoSnapshotReaderWriters
 				.getReaderForVersion(OperatorBackendSerializationProxy.VERSION, Thread.currentThread().getContextClassLoader())
-				.readStateMetaInfo(new DataInputViewStreamWrapper(in), false);
+				.readStateMetaInfo(new DataInputViewStreamWrapper(in), null);
 		}
 
 		Assert.assertEquals(name, metaInfo.getName());
 		Assert.assertEquals(null, metaInfo.getPartitionStateSerializer());
 		Assert.assertEquals(stateSerializer.snapshotConfiguration(), metaInfo.getPartitionStateSerializerConfigSnapshot());
+	}
+
+	@Test
+	public void testNonDuplicatedStatelessSerializersWithOperatorBackendSerializationProxyRoundtrip() throws IOException {
+		TypeSerializer<?> stateSerializer1 = IntSerializer.INSTANCE;
+		TypeSerializer<?> stateSerializer2 = IntSerializer.INSTANCE;
+		TypeSerializer<?> stateSerializer3 = DoubleSerializer.INSTANCE;
+		TypeSerializer<?> stateSerializer4 = DoubleSerializer.INSTANCE;
+
+		List<RegisteredOperatorBackendStateMetaInfo.Snapshot<?>> stateMetaInfoSnapshots = new ArrayList<>();
+
+		stateMetaInfoSnapshots.add(new RegisteredOperatorBackendStateMetaInfo<>(
+			"a", stateSerializer1, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE).snapshot());
+		stateMetaInfoSnapshots.add(new RegisteredOperatorBackendStateMetaInfo<>(
+			"b", stateSerializer2, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE).snapshot());
+		stateMetaInfoSnapshots.add(new RegisteredOperatorBackendStateMetaInfo<>(
+			"c", stateSerializer3, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE).snapshot());
+		stateMetaInfoSnapshots.add(new RegisteredOperatorBackendStateMetaInfo<>(
+			"d", stateSerializer4, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE).snapshot());
+
+		OperatorBackendSerializationProxy serializationProxy =
+			new OperatorBackendSerializationProxy(stateMetaInfoSnapshots, false);
+
+		byte[] serialized;
+		try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
+			serializationProxy.write(new DataOutputViewStreamWrapper(out));
+			serialized = out.toByteArray();
+		}
+
+		serializationProxy =
+			new OperatorBackendSerializationProxy(Thread.currentThread().getContextClassLoader());
+
+		try (ByteArrayInputStreamWithPos in = new ByteArrayInputStreamWithPos(serialized)) {
+			serializationProxy.read(new DataInputViewStreamWrapper(in));
+		}
+
+		// first and second state should share the same IntSerializer
+		Assert.assertEquals(IntSerializer.INSTANCE, serializationProxy.getStateMetaInfoSnapshots().get(0).getPartitionStateSerializer());
+		Assert.assertTrue(serializationProxy.getStateMetaInfoSnapshots().get(0).getPartitionStateSerializer() ==
+			serializationProxy.getStateMetaInfoSnapshots().get(1).getPartitionStateSerializer());
+
+		// third and fourth state should share the same DoubleSerializer
+		Assert.assertEquals(DoubleSerializer.INSTANCE, serializationProxy.getStateMetaInfoSnapshots().get(2).getPartitionStateSerializer());
+		Assert.assertTrue(serializationProxy.getStateMetaInfoSnapshots().get(2).getPartitionStateSerializer() ==
+			serializationProxy.getStateMetaInfoSnapshots().get(3).getPartitionStateSerializer());
 	}
 
 	/**


### PR DESCRIPTION
This PR is based on #4014, so only the last commit 39ffe7e is relevant.

Prior to this PR, we would write multiple instances of the same serializer even if it was stateless. This commit changes that by first writing a serializer index at the head of the stream, and only write the index of a serializer when one needs to be written. The index map is built using `IdentitiyHashMap`s, so that stateful serializers are considered as separate entries in the index.

## Test

New tests are added to `PojoSerializerTest` and `SerializationProxiesTest` to test that stateless serializers are not duplicated on restore.