### PR TITLE
[Proposal] Gradually introduce checkstyle into flink-runtime

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -401,6 +401,94 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>2.17</version>
+				<dependencies>
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>6.19</version>
+					</dependency>
+				</dependencies>
+				<configuration>
+					<configLocation>/tools/maven/strict-checkstyle.xml</configLocation>
+					<suppressionsLocation>/tools/maven/suppressions.xml</suppressionsLocation>
+					<includeTestSourceDirectory>true</includeTestSourceDirectory>
+					<logViolationsToConsole>true</logViolationsToConsole>
+					<failOnViolation>true</failOnViolation>
+					<excludes>
+						**/migration/api/**,
+						**/migration/runtime/**,
+						**/migration/state/**,
+						**/migration/streaming/**,
+						**/migration/*,
+						**/runtime/accumulators/**,
+						**/runtime/akka/**,
+						**/runtime/blob/**,
+						**/runtime/broadcast/**,
+						**/runtime/checkpoint/**,
+						**/runtime/client/**,
+						**/runtime/clusterframework/**,       
+						**/runtime/concurrent/**,
+						**/runtime/deployment/**,
+						**/runtime/event/**,
+						**/runtime/execution/**,
+						**/runtime/executiongraph/**,
+						**/runtime/filecache/**,
+						**/runtime/fs/**,
+						**/runtime/heartbeat/**,
+						**/runtime/highavailability/**,
+						**/runtime/history/**,
+						**/runtime/instance/**,
+						**/runtime/io/**,
+						**/runtime/iterative/**,
+						**/runtime/jobgraph/**,
+						**/runtime/jobmanager/**,
+						**/runtime/jobmaster/**,
+						**/runtime/leaderelection/**,
+						**/runtime/leaderretrieval/**,
+						**/runtime/memory/**,
+						**/runtime/messages/**,
+						**/runtime/metrics/**,
+						**/runtime/minicluster/**,
+						**/runtime/net/**,
+						**/runtime/operators/**,
+						**/runtime/plugable/**,
+						**/runtime/process/**,
+						**/runtime/query/**,
+						**/runtime/registration/**,
+						**/runtime/resourcemanager/**,
+						**/runtime/rpc/**,
+						**/runtime/security/**,
+						**/runtime/state/**,
+						**/runtime/taskexecutor/**,
+						**/runtime/taskmanager/**,
+						**/runtime/testutils/**,
+						**/runtime/util/**,
+						**/runtime/webmonitor/**,
+						**/runtime/zookeeper/**,
+						**/runtime/*
+					</excludes>
+				</configuration>
+				<executions>
+					<!--
+					Execute checkstyle after compilation but before tests.
+
+					This ensures that any parsing or type checking errors are from
+					javac, so they look as expected. Beyond that, we want to
+					fail as early as possible.
+					-->
+					<execution>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -425,7 +425,6 @@ under the License.
 						**/migration/state/**,
 						**/migration/streaming/**,
 						**/migration/*,
-						**/runtime/accumulators/**,
 						**/runtime/akka/**,
 						**/runtime/blob/**,
 						**/runtime/broadcast/**,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/accumulators/AccumulatorRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/accumulators/AccumulatorRegistry.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.accumulators;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/accumulators/StringifiedAccumulatorResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/accumulators/StringifiedAccumulatorResult.java
@@ -50,13 +50,13 @@ public class StringifiedAccumulatorResult implements java.io.Serializable{
 	public String getValue() {
 		return value;
 	}
-	
+
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Flatten a map of accumulator names to Accumulator instances into an array of StringifiedAccumulatorResult values
+	 * Flatten a map of accumulator names to Accumulator instances into an array of StringifiedAccumulatorResult values.
      */
 	public static StringifiedAccumulatorResult[] stringifyAccumulatorResults(Map<String, Accumulator<?, ?>> accs) {
 		if (accs == null || accs.isEmpty()) {
@@ -64,7 +64,7 @@ public class StringifiedAccumulatorResult implements java.io.Serializable{
 		}
 		else {
 			StringifiedAccumulatorResult[] results = new StringifiedAccumulatorResult[accs.size()];
-			
+
 			int i = 0;
 			for (Map.Entry<String, Accumulator<?, ?>> entry : accs.entrySet()) {
 				StringifiedAccumulatorResult result;
@@ -79,7 +79,7 @@ public class StringifiedAccumulatorResult implements java.io.Serializable{
 				} else {
 					result = new StringifiedAccumulatorResult(entry.getKey(), "null", "null");
 				}
-	
+
 				results[i++] = result;
 			}
 			return results;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/accumulators/StringifiedAccumulatorResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/accumulators/StringifiedAccumulatorResultTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.IntCounter;
 import org.apache.flink.api.common.accumulators.SimpleAccumulator;
 import org.apache.flink.core.testutils.CommonTestUtils;
+
 import org.junit.Test;
 
 import java.io.IOException;
@@ -31,6 +32,9 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Tests for the {@link StringifiedAccumulatorResult}.
+ */
 public class StringifiedAccumulatorResultTest {
 
 	@Test
@@ -61,7 +65,6 @@ public class StringifiedAccumulatorResultTest {
 		acc.add(targetValue);
 		final Map<String, Accumulator<?, ?>> accumulatorMap = new HashMap<>();
 		accumulatorMap.put(name, acc);
-
 
 		final StringifiedAccumulatorResult[] results = StringifiedAccumulatorResult.stringifyAccumulatorResults(accumulatorMap);
 


### PR DESCRIPTION
This is a proposal on how to activate the strict checkstyle in flink-runtime.

We can't add the rules to all packages at once due to the generally accepted problem of massive merge-conflicts this would cause with current feature branches. However, we can also not we apply the rules one by one due to the sheer number of merge conflicts this would entail for a single rebase, as @greghogan noted in #4027.

Instead i propose to activate the full checkstyle one package at a time.

The first commit in this PR adds the maven checkstyle plugin to flink-runtime, and adds an exclusion for every single 2nd level package (e.g "runtime/accumulators") that currently exists.

We could naturally "go deeper" for certain packages.

The second commit activates the checkstyle for `runtime/accumulators`, by resolving all issues and removing the exclusion.

The list of exclusions gives us a nice overview over our current progress regarding the checkstyle introduction, provides an easy way to parallelize the work, and automatically covers any new module that is being added.