### PR TITLE
[FLINK-6792] [mvn] Move maven-checkstyle-plugin before maven-shade-plugin definition in pom.xml

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -403,6 +403,46 @@ under the License.
 				</configuration>
 			</plugin>
 
+			<!-- IMPORTANT: Moving the plugin definition after the shade and assembly plugin definition somehow
+			 changes the order in which the assembly and shade plugins are executed in the package phase.
+			 Therefore, we have to define the checkstyle-plugin before the shade-plugin. See FLINK-6792 for more
+			 details. -->
+			<!-- Java Code Style -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>2.17</version>
+				<dependencies>
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>6.19</version>
+					</dependency>
+				</dependencies>
+				<configuration>
+					<configLocation>/tools/maven/strict-checkstyle.xml</configLocation>
+					<suppressionsLocation>/tools/maven/suppressions.xml</suppressionsLocation>
+					<includeTestSourceDirectory>true</includeTestSourceDirectory>
+					<logViolationsToConsole>true</logViolationsToConsole>
+					<failOnViolation>true</failOnViolation>
+				</configuration>
+				<executions>
+					<!--
+					Execute checkstyle after compilation but before tests.
+
+					This ensures that any parsing or type checking errors are from
+					javac, so they look as expected. Beyond that, we want to
+					fail as early as possible.
+					-->
+					<execution>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
 			<!--Build uber jar-->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -529,43 +569,6 @@ under the License.
 					</gitDescribe>
 				</configuration>
 			</plugin>
-
-			<!-- Java Code Style -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>2.17</version>
-				<dependencies>
-					<dependency>
-						<groupId>com.puppycrawl.tools</groupId>
-						<artifactId>checkstyle</artifactId>
-						<version>6.19</version>
-					</dependency>
-				</dependencies>
-				<configuration>
-					<configLocation>/tools/maven/strict-checkstyle.xml</configLocation>
-					<suppressionsLocation>/tools/maven/suppressions.xml</suppressionsLocation>
-					<includeTestSourceDirectory>true</includeTestSourceDirectory>
-					<logViolationsToConsole>true</logViolationsToConsole>
-					<failOnViolation>true</failOnViolation>
-				</configuration>
-				<executions>
-					<!--
-					Execute checkstyle after compilation but before tests.
-
-					This ensures that any parsing or type checking errors are from
-					javac, so they look as expected. Beyond that, we want to
-					fail as early as possible.
-					-->
-					<execution>
-						<phase>test-compile</phase>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Somehow appending the maven-checkstyle-plugin at the end of the pom.xml changed the order
of the maven-assembly-plugin and the maven-shade-plugin in the package phase. This breaks
things since the shade plugin has to run before the assembly plugin to build the fat-jar.
Specifying the checkstyle-plugin before the maven-shade-plugin resolves the issue.
