### PR TITLE
[FLINK-6797][docs] Docs do not build cleanly with new version of bundler

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
     jekyll-coffeescript (1.0.1)
       coffee-script (~> 2.2)
     jekyll-gist (1.4.0)
-      octokit (~> 4.3.0)
+      octokit (~> 4.2)
     jekyll-paginate (1.1.0)
     jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
@@ -89,4 +89,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.6
+   1.15.0


### PR DESCRIPTION
Our Gemfile.lock file includes an inaccurate dependency spec for jekyll-gist 1.4.0. Bundler 1.15.0 was recently released, and it is smart enough to notice this and fails with an error. This PR updates that dependency. 