### PR TITLE
[FLINK-6811][table] Add TIMESTAMPADD supported in SQL

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -1906,6 +1906,18 @@ QUARTER(date)
         <p>Determines whether two anchored time intervals overlap. Time point and temporal are transformed into a range defined by two time points (start, end). The function evaluates <code>leftEnd >= rightStart && rightEnd >= leftStart</code>. E.g. <code>(TIME '2:55:00', INTERVAL '1' HOUR) OVERLAPS (TIME '3:30:00', INTERVAL '2' HOUR)</code> leads to true; <code>(TIME '9:00:00', TIME '10:00:00') OVERLAPS (TIME '10:15:00', INTERVAL '3' HOUR)</code> leads to false.</p>
       </td>
     </tr>
+
+    <tr>
+      <td>
+        {% highlight text %}
+TIMESTAMPADD(unit, interval, timestamp_expr)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Adds the integer expression interval to the timestamp expression timestamp_expr. The unit for interval is given by the unit argument, which should be one of the following values: SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR. E.g. <code>TIMESTAMPADD(WEEK, 1, '2003-01-02')</code> leads to <code>2003-01-09</code>.</p>
+      </td>
+    </tr>
+
   </tbody>
 </table>
 

--- a/flink-libraries/flink-table/src/main/java/org/apache/calcite/sql/fun/SqlTimestampAddFunction.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/calcite/sql/fun/SqlTimestampAddFunction.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+/**
+ *
+ * The <code>TIMESTAMPADD</code> function, which adds an interval to a
+ * timestamp.
+ *
+ * <p>The SQL syntax is
+ *
+ * <blockquote>
+ * <code>TIMESTAMPADD(<i>timestamp interval</i>, <i>quantity</i>,
+ * <i>timestamp</i>)</code>
+ * </blockquote>
+ *
+ * <p>The interval time unit can one of the following literals:<ul>
+ * <li>MICROSECOND (and synonyms SQL_TSI_MICROSECOND, FRAC_SECOND,
+ *     SQL_TSI_FRAC_SECOND)
+ * <li>SECOND (and synonym SQL_TSI_SECOND)
+ * <li>MINUTE (and synonym  SQL_TSI_MINUTE)
+ * <li>HOUR (and synonym  SQL_TSI_HOUR)
+ * <li>DAY (and synonym SQL_TSI_DAY)
+ * <li>WEEK (and synonym  SQL_TSI_WEEK)
+ * <li>MONTH (and synonym SQL_TSI_MONTH)
+ * <li>QUARTER (and synonym SQL_TSI_QUARTER)
+ * <li>YEAR (and synonym  SQL_TSI_YEAR)
+ * </ul>
+ *
+ * <p>Returns modified timestamp.
+ *
+ * __Note__: Due to the change of [[org.apache.calcite.rex.RexLiteral]] we should keep using this
+ * class until upgrade to calcite 1.13.
+ */
+class SqlTimestampAddFunction extends SqlFunction {
+
+    private static final SqlReturnTypeInference RETURN_TYPE_INFERENCE =
+            new SqlReturnTypeInference() {
+                public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
+                    final RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+                    final TimeUnit unit = (TimeUnit) opBinding.getOperandLiteralValue(0);
+                    switch (unit) {
+                        case HOUR:
+                        case MINUTE:
+                        case SECOND:
+                        case MILLISECOND:
+                        case MICROSECOND:
+                            return typeFactory.createTypeWithNullability(
+                                    typeFactory.createSqlType(SqlTypeName.TIMESTAMP),
+                                    opBinding.getOperandType(1).isNullable()
+                                    || opBinding.getOperandType(2).isNullable());
+                        default:
+                            return opBinding.getOperandType(2);
+                    }
+                }
+            };
+
+    /** Creates a SqlTimestampAddFunction. */
+    SqlTimestampAddFunction() {
+        super("TIMESTAMPADD", SqlKind.TIMESTAMP_ADD, RETURN_TYPE_INFERENCE, null,
+              OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER,
+                                  SqlTypeFamily.TIMESTAMP),
+              SqlFunctionCategory.TIMEDATE);
+    }
+}
+
+// End SqlTimestampAddFunction.java

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1313,7 +1313,8 @@ class CodeGenerator(
         if (decimal.isValidInt) {
           generateNonNullLiteral(resultType, decimal.intValue().toString)
         } else {
-          throw new CodeGenException("Decimal can not be converted to interval of months.")
+          throw new CodeGenException(
+            s"Decimal '${decimal}' can not be converted to interval of months.")
         }
 
       case typeName if DAY_INTERVAL_TYPES.contains(typeName) =>
@@ -1321,7 +1322,8 @@ class CodeGenerator(
         if (decimal.isValidLong) {
           generateNonNullLiteral(resultType, decimal.longValue().toString + "L")
         } else {
-          throw new CodeGenException("Decimal can not be converted to interval of milliseconds.")
+          throw new CodeGenException(
+            s"Decimal '${decimal}' can not be converted to interval of milliseconds.")
         }
 
       case t@_ =>
@@ -1387,6 +1389,13 @@ class CodeGenerator(
         val left = operands.head
         val right = operands(1)
         requireNumeric(left)
+        requireNumeric(right)
+        generateArithmeticOperator("*", nullCheck, resultType, left, right)
+
+      case MULTIPLY if isTimeInterval(resultType) =>
+        val left = operands.head
+        val right = operands(1)
+        requireTimeInterval(left)
         requireNumeric(right)
         generateArithmeticOperator("*", nullCheck, resultType, left, right)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -1101,6 +1101,10 @@ object ScalarOperators {
         && !isDecimal(operandType) && !isDecimal(resultType)) {
       (operandTerm) => s"(($resultTypeTerm) $operandTerm)"
     }
+    // result type is time interval and operand type is Integer
+    else if (isTimeInterval(resultType) && isInteger(operandType)){
+      (operandTerm) => s"(($resultTypeTerm) $operandTerm)"
+    }
     else {
       throw new CodeGenException(s"Unsupported casting from $operandType to $resultType.")
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -396,6 +396,7 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     ScalarSqlFunctions.E,
     ScalarSqlFunctions.CONCAT,
     ScalarSqlFunctions.CONCAT_WS,
+    SqlStdOperatorTable.TIMESTAMP_ADD,
 
     // EXTENSIONS
     SqlStdOperatorTable.TUMBLE,


### PR DESCRIPTION
In this PR I have add `TIMESTAMPADD` supported in SQL. (the semantics keep consistent with calcite)
* Syntax
timestampAdd (datepart SqlTypeFamily.ANY, number:SqlTypeFamily.INTEGER, date:SqlTypeFamily.TIMESTAMP )  
-datepart
Is the part of date to which an integer number is added. 
-number
Is an expression that can be resolved to an int that is added to a datepart of date
-date
Is an expression that can be resolved to a time.

* Example
SELECT timestampAdd(month, 1, '2017-05-31')  from tab; --> 2017-06-30 00:00:00.000

* Note: Due to the difference of [[org.apache.calcite.rex.Rex Literal]] between calcite 1.12 and calcite master we should temp close support the construce of TIMESTAMPADD(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER, SqlTypeFamily.DATE), until upgrade to calcite 1.13. See more https://issues.apache.org/jira/browse/FLINK-6851

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-6811][table] Add TIMESTAMPADD supported in SQL")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
