### PR TITLE
[FLINK-6868][build] Using `scala.binary.version` for `flink-streaming-scala` in `Cassandra Connector`

### DIFF
--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -100,7 +100,7 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-scala_2.10</artifactId>
+			<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>


### PR DESCRIPTION
Using `scala.binary.version` for `flink-streaming-scala` in `Cassandra Connector`