### PR TITLE
[FLINK-6886][table]Fix Timestamp field can not be selected in event time case when toDataStream[T], `T` not a `Row` Type.

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
@@ -715,15 +715,8 @@ abstract class TableEnvironment(val config: TableConfig) {
       functionName: String):
     GeneratedFunction[MapFunction[Row, OUT], OUT] = {
 
-    // validate that at least the field types of physical and logical type match
-    // we do that here to make sure that plan translation was correct
-    if (schema.physicalTypeInfo != inputTypeInfo) {
-      throw TableException("The field types of physical and logical row types do not match." +
-        "This is a bug and should not happen. Please file an issue.")
-    }
-
-    val fieldTypes = schema.physicalFieldTypeInfo
-    val fieldNames = schema.physicalFieldNames
+    val fieldTypes = schema.logicalFieldTypeInfo
+    val fieldNames = schema.logicalFieldNames
 
     // validate requested type
     if (requestedTypeInfo.getArity != fieldTypes.length) {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/RowSchema.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/RowSchema.scala
@@ -45,10 +45,19 @@ class RowSchema(private val logicalRowType: RelDataType) {
     FlinkTypeFactory.toTypeInfo(f.getType)
   }
 
+  private lazy val logicalRowFieldTypes: Seq[TypeInformation[_]] = logicalRowType.getFieldList map {
+    f => FlinkTypeFactory.toTypeInfo(f.getType)
+  }
+
   private lazy val physicalRowFieldNames: Seq[String] = physicalRowFields.map(_.getName)
+
+  private lazy val logicalRowFieldNames: Seq[String] = logicalRowType.getFieldList.map(_.getName)
 
   private lazy val physicalRowTypeInfo: TypeInformation[Row] = new RowTypeInfo(
     physicalRowFieldTypes.toArray, physicalRowFieldNames.toArray)
+
+  private lazy val logicalRowTypeInfo: TypeInformation[Row] = new RowTypeInfo(
+    logicalRowFieldTypes.toArray, logicalRowFieldNames.toArray)
 
   private lazy val indexMapping: Array[Int] = generateIndexMapping
 
@@ -113,9 +122,19 @@ class RowSchema(private val logicalRowType: RelDataType) {
   def physicalTypeInfo: TypeInformation[Row] = physicalRowTypeInfo
 
   /**
+    * Returns a logical [[TypeInformation]] of row with all logical fields.
+    */
+  def logicalTypeInfo: TypeInformation[Row] = logicalRowTypeInfo
+
+  /**
     * Returns [[TypeInformation]] of the row's fields with no logical fields (i.e. time indicators).
     */
   def physicalFieldTypeInfo: Seq[TypeInformation[_]] = physicalRowFieldTypes
+
+  /**
+    * Returns [[TypeInformation]] of the row's fields with all logical fields.
+    */
+  def logicalFieldTypeInfo: Seq[TypeInformation[_]] = logicalRowFieldTypes
 
   /**
     * Returns the logical fields names including logical fields (i.e. time indicators).

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/stream/sql/SqlITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/stream/sql/SqlITCase.java
@@ -71,7 +71,7 @@ public class SqlITCase extends StreamingMultipleProgramsTestBase {
 		Table result = tableEnv.sql(sqlQuery);
 
 		DataStream<Row> resultSet = tableEnv.toAppendStream(result, Row.class);
-		resultSet.addSink(new StreamITCase.StringSink());
+		resultSet.addSink(new StreamITCase.StringSink<Row>());
 		env.execute();
 
 		List<String> expected = new ArrayList<>();
@@ -96,7 +96,7 @@ public class SqlITCase extends StreamingMultipleProgramsTestBase {
 		Table result = tableEnv.sql(sqlQuery);
 
 		DataStream<Row> resultSet = tableEnv.toAppendStream(result, Row.class);
-		resultSet.addSink(new StreamITCase.StringSink());
+		resultSet.addSink(new StreamITCase.StringSink<Row>());
 		env.execute();
 
 		List<String> expected = new ArrayList<>();
@@ -151,7 +151,7 @@ public class SqlITCase extends StreamingMultipleProgramsTestBase {
 		Table result = tableEnv.sql(sqlQuery);
 
 		DataStream<Row> resultSet = tableEnv.toAppendStream(result, Row.class);
-		resultSet.addSink(new StreamITCase.StringSink());
+		resultSet.addSink(new StreamITCase.StringSink<Row>());
 		env.execute();
 
 		List<String> expected = new ArrayList<>();

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/utils/Pojos.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/utils/Pojos.java
@@ -1,0 +1,268 @@
+package org.apache.flink.table.api.java.utils;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+
+/**
+ * All pojos for table api testing.
+ */
+public class Pojos {
+
+	/**
+	 * Pojo0 for test.
+	 */
+	public static class Pojo0 implements Serializable {
+		private Timestamp winStart;
+		private Timestamp winEnd;
+		private String name;
+		private Long cnt;
+
+		public Timestamp getWinStart() {
+			return winStart;
+		}
+
+		public void setWinStart(Timestamp winStart) {
+			this.winStart = winStart;
+		}
+
+		public Timestamp getWinEnd() {
+			return winEnd;
+		}
+
+		public void setWinEnd(Timestamp winEnd) {
+			this.winEnd = winEnd;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Long getCnt() {
+			return cnt;
+		}
+
+		public void setCnt(Long cnt) {
+			this.cnt = cnt;
+		}
+
+		@Override
+		public String toString() {
+			return "Pojo0{" +
+				"winStart=" + winStart +
+				", winEnd=" + winEnd +
+				", name='" + name + '\'' +
+				", cnt=" + cnt +
+				'}';
+		}
+	}
+
+	/**
+	 * Pojo1 for test.
+	 */
+	public static class Pojo1 implements Serializable {
+		private Timestamp id;
+		private String name;
+		private Long myCnt;
+		private Long mySum;
+
+		public Timestamp getId() {
+			return id;
+		}
+
+		public void setId(Timestamp id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Long getMyCnt() {
+			return myCnt;
+		}
+
+		public void setMyCnt(Long myCnt) {
+			this.myCnt = myCnt;
+		}
+
+		public Long getMySum() {
+			return mySum;
+		}
+
+		public void setMySum(Long mySum) {
+			this.mySum = mySum;
+		}
+
+		@Override
+		public String toString() {
+			return "Pojo1{" +
+				"id=" + id +
+				", name='" + name + '\'' +
+				", myCnt=" + myCnt +
+				", mySum=" + mySum +
+				'}';
+		}
+	}
+
+	/**
+	 * Pojo2 for test.
+	 */
+	public static class Pojo2 implements Serializable {
+		private String string;
+		private Long myCnt;
+		private Integer myAvg;
+		private Long myWeightAvg;
+		private Integer myMin;
+		private Integer myMax;
+		private Integer mySum;
+		private Timestamp winStart;
+		private Timestamp winEnd;
+
+		public String getString() {
+			return string;
+		}
+
+		public void setString(String string) {
+			this.string = string;
+		}
+
+		public Long getMyCnt() {
+			return myCnt;
+		}
+
+		public void setMyCnt(Long myCnt) {
+			this.myCnt = myCnt;
+		}
+
+		public Integer getMyAvg() {
+			return myAvg;
+		}
+
+		public void setMyAvg(Integer myAvg) {
+			this.myAvg = myAvg;
+		}
+
+		public Long getMyWeightAvg() {
+			return myWeightAvg;
+		}
+
+		public void setMyWeightAvg(Long myWeightAvg) {
+			this.myWeightAvg = myWeightAvg;
+		}
+
+		public Integer getMyMin() {
+			return myMin;
+		}
+
+		public void setMyMin(Integer myMin) {
+			this.myMin = myMin;
+		}
+
+		public Integer getMyMax() {
+			return myMax;
+		}
+
+		public void setMyMax(Integer myMax) {
+			this.myMax = myMax;
+		}
+
+		public Integer getMySum() {
+			return mySum;
+		}
+
+		public void setMySum(Integer mySum) {
+			this.mySum = mySum;
+		}
+
+		public Timestamp getWinStart() {
+			return winStart;
+		}
+
+		public void setWinStart(Timestamp winStart) {
+			this.winStart = winStart;
+		}
+
+		public Timestamp getWinEnd() {
+			return winEnd;
+		}
+
+		public void setWinEnd(Timestamp winEnd) {
+			this.winEnd = winEnd;
+		}
+
+		@Override
+		public String toString() {
+			return "Pojo2{" +
+				"string='" + string + '\'' +
+				", myCnt=" + myCnt +
+				", myAvg=" + myAvg +
+				", myWeightAvg=" + myWeightAvg +
+				", myMin=" + myMin +
+				", myMax=" + myMax +
+				", mySum=" + mySum +
+				", winStart=" + winStart +
+				", winEnd=" + winEnd +
+				'}';
+		}
+	}
+
+	/**
+	 * Pojo3 for test.
+	 */
+	public static class Pojo3 implements Serializable {
+		private String myMsg;
+		private Timestamp myTs;
+		private Long myCnt;
+		private Long mySum;
+
+		public String getMyMsg() {
+			return myMsg;
+		}
+
+		public void setMyMsg(String myMsg) {
+			this.myMsg = myMsg;
+		}
+
+		public Timestamp getMyTs() {
+			return myTs;
+		}
+
+		public void setMyTs(Timestamp myTs) {
+			this.myTs = myTs;
+		}
+
+		public Long getMyCnt() {
+			return myCnt;
+		}
+
+		public void setMyCnt(Long myCnt) {
+			this.myCnt = myCnt;
+		}
+
+		public Long getMySum() {
+			return mySum;
+		}
+
+		public void setMySum(Long mySum) {
+			this.mySum = mySum;
+		}
+
+		@Override
+		public String toString() {
+			return "Pojo3{" +
+				"myMsg='" + myMsg + '\'' +
+				", myTs=" + myTs +
+				", myCnt=" + myCnt +
+				", mySum=" + mySum +
+				'}';
+		}
+	}
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/TableSourceITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/TableSourceITCase.scala
@@ -18,12 +18,20 @@
 
 package org.apache.flink.table.api.scala.stream
 
+import java.lang.{Integer => JInt, Long => JLong}
+
+import java.sql.Timestamp
+import org.apache.flink.table.api.java.utils.Pojos._
+import org.apache.flink.table.api.scala.stream.TableSources._
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.scala.stream.utils.StreamITCase
 import org.apache.flink.table.api.scala._
 import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase
-import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.{TableEnvironment, Types}
 import org.apache.flink.table.utils.{CommonTestData, TestFilterableTableSource}
 import org.apache.flink.types.Row
 import org.junit.Assert._
@@ -47,7 +55,7 @@ class TableSourceITCase extends StreamingMultipleProgramsTestBase {
     tEnv.sql(
       "SELECT id, `first`, `last`, score FROM persons WHERE id < 4 ")
       .toAppendStream[Row]
-      .addSink(new StreamITCase.StringSink)
+      .addSink(new StreamITCase.StringSink[Row])
 
     env.execute()
 
@@ -72,7 +80,7 @@ class TableSourceITCase extends StreamingMultipleProgramsTestBase {
       .where('id > 4)
       .select('last, 'score * 2)
       .toAppendStream[Row]
-      .addSink(new StreamITCase.StringSink)
+      .addSink(new StreamITCase.StringSink[Row])
 
     env.execute()
 
@@ -94,12 +102,265 @@ class TableSourceITCase extends StreamingMultipleProgramsTestBase {
     tEnv.scan(tableName)
       .where("amount > 4 && price < 9")
       .select("id, name")
-      .addSink(new StreamITCase.StringSink)
+      .addSink(new StreamITCase.StringSink[Row])
 
     env.execute()
 
     val expected = mutable.MutableList(
       "5,Record_5", "6,Record_6", "7,Record_7", "8,Record_8")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testRowTypeGroupWindowWithTimestampColumn(): Unit = {
+    val datas: List[Row] = List(
+      Row.of(JLong.valueOf(1L), JInt.valueOf(1), "Hi"),
+      Row.of(JLong.valueOf(2L), JInt.valueOf(2), "Hello"),
+      Row.of(JLong.valueOf(4L), JInt.valueOf(2), "Hello"),
+      Row.of(JLong.valueOf(8L), JInt.valueOf(3), "Hello world"),
+      Row.of(JLong.valueOf(16L), JInt.valueOf(3), "Hello world"))
+
+   val typeInfo = new RowTypeInfo(
+      Array(Types.LONG, Types.INT, Types.STRING)
+      .asInstanceOf[Array[TypeInformation[_]]],
+      Array("ts", "id", "name"))
+
+    StreamITCase.testResults = mutable.MutableList()
+    val tableName = "MyTable"
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    tEnv.registerTableSource(tableName, new StreamTableSource0(datas, typeInfo,"ts", 0L))
+    val querySql =
+      "SELECT " +
+        "TUMBLE_START(rowtime, INTERVAL '3' SECOND) as winStart," +
+        "TUMBLE_END(rowtime, INTERVAL '3' SECOND) as winEnd," +
+        "COUNT(1) as cnt, name " +
+        "FROM MyTable GROUP BY name, " +
+        "TUMBLE(rowtime, INTERVAL '3' SECOND)"
+
+    val table = tEnv.sql(querySql)
+
+    table.toAppendStream[Row].addSink(new StreamITCase.StringSink[Row])
+
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "1970-01-01 00:00:00.0,1970-01-01 00:00:03.0,1,Hi",
+      "1970-01-01 00:00:00.0,1970-01-01 00:00:03.0,2,Hello",
+      "1970-01-01 00:00:00.0,1970-01-01 00:00:03.0,2,Hello world")
+
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testPojoTypeGroupWindowWithTimestampColumnSQL(): Unit = {
+    val datas: List[Row] = List(
+      Row.of(JLong.valueOf(1L), JInt.valueOf(1), "Hi"),
+      Row.of(JLong.valueOf(2L), JInt.valueOf(2), "Hello"),
+      Row.of(JLong.valueOf(4L), JInt.valueOf(2), "Hello"),
+      Row.of(JLong.valueOf(8L), JInt.valueOf(3), "Hello world"),
+      Row.of(JLong.valueOf(16L), JInt.valueOf(3), "Hello world"))
+
+   val typeInfo = new RowTypeInfo(
+      Array(Types.LONG, Types.INT, Types.STRING)
+      .asInstanceOf[Array[TypeInformation[_]]],
+      Array("ts", "id", "name"))
+
+    StreamITCase.testResults = mutable.MutableList()
+    val tableName = "MyTable"
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    tEnv.registerTableSource(tableName, new StreamTableSource0(datas, typeInfo,"ts", 0L))
+    val querySql =
+      "SELECT " +
+        "TUMBLE_START(rowtime, INTERVAL '3' SECOND) as winStart," +
+        "TUMBLE_END(rowtime, INTERVAL '3' SECOND) as winEnd," +
+        "COUNT(1) as cnt, name " +
+        "FROM MyTable GROUP BY name, " +
+        "TUMBLE(rowtime, INTERVAL '3' SECOND)"
+
+    val table = tEnv.sql(querySql)
+
+    table.toAppendStream[Pojo0].addSink(new StreamITCase.StringSink[Pojo0])
+
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "Pojo0{winStart=1970-01-01 00:00:00.0, winEnd=1970-01-01 00:00:03.0, name='Hello world', " +
+      "cnt=2}",
+      "Pojo0{winStart=1970-01-01 00:00:00.0, winEnd=1970-01-01 00:00:03.0, name='Hello', cnt=2}",
+      "Pojo0{winStart=1970-01-01 00:00:00.0, winEnd=1970-01-01 00:00:03.0, name='Hi', cnt=1}")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testPojoTypeGroupWindowWithTimestampColumn(): Unit = {
+    val datas: List[Row] = List(
+      Row.of(JLong.valueOf(1L), JInt.valueOf(1), "Hi"),
+      Row.of(JLong.valueOf(2L), JInt.valueOf(2), "Hello"),
+      Row.of(JLong.valueOf(4L), JInt.valueOf(2), "Hello"),
+      Row.of(JLong.valueOf(8L), JInt.valueOf(3), "Hello world"),
+      Row.of(JLong.valueOf(16L), JInt.valueOf(3), "Hello world"))
+
+   val typeInfo = new RowTypeInfo(
+      Array(Types.LONG, Types.INT, Types.STRING)
+      .asInstanceOf[Array[TypeInformation[_]]],
+      Array("ts", "id", "name"))
+
+    StreamITCase.testResults = mutable.MutableList()
+    val tableName = "MyTable"
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    tEnv.registerTableSource(tableName, new StreamTableSource0(datas, typeInfo,"ts", 0L))
+
+    val table = tEnv.scan(tableName)
+      .window(Tumble over 3.seconds on 'rowtime as 'w)
+      .groupBy('w, 'name)
+      .select('w.start as 'winStart, 'w.end as 'winEnd, 'ts.count as 'cnt, 'name)
+
+    table.toAppendStream[Pojo0].addSink(new StreamITCase.StringSink[Pojo0])
+
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "Pojo0{winStart=1970-01-01 00:00:00.0, winEnd=1970-01-01 00:00:03.0, name='Hello world', " +
+      "cnt=2}",
+      "Pojo0{winStart=1970-01-01 00:00:00.0, winEnd=1970-01-01 00:00:03.0, name='Hello', cnt=2}",
+      "Pojo0{winStart=1970-01-01 00:00:00.0, winEnd=1970-01-01 00:00:03.0, name='Hi', cnt=1}")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testRowTypeOverWindowWithTimestampColumn(): Unit = {
+    val datas: List[Row] = List(
+      Row.of(JLong.valueOf(1L), Timestamp.valueOf("2017-06-11 12:12:12.999"), "Hi"),
+      Row.of(JLong.valueOf(2L), Timestamp.valueOf("2017-06-11 12:12:12.999"), "Hello"),
+      Row.of(JLong.valueOf(4L), Timestamp.valueOf("2017-06-11 12:12:12.999"), "Hello"),
+      Row.of(JLong.valueOf(8L), Timestamp.valueOf("2017-06-11 12:12:12.999"), "Hello world"),
+      Row.of(JLong.valueOf(16L), Timestamp.valueOf("2017-06-11 12:12:12.999"), "Hello world"))
+
+   val typeInfo = new RowTypeInfo(
+      Array(Types.LONG, Types.SQL_TIMESTAMP, Types.STRING)
+      .asInstanceOf[Array[TypeInformation[_]]],
+      Array("ts", "id", "name"))
+
+    StreamITCase.testResults = mutable.MutableList()
+    val tableName = "MyTable"
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    tEnv.registerTableSource(tableName, new StreamTableSource0(datas, typeInfo,"ts", 0L))
+    val sqlQuery = "SELECT " +
+      "id, " +
+      "name, " +
+      "count(ts) OVER (PARTITION BY name ORDER BY rowtime RANGE UNBOUNDED preceding) as myCnt, " +
+      "sum(ts) OVER (PARTITION BY name ORDER BY rowtime RANGE UNBOUNDED preceding) as mySum " +
+      "from MyTable"
+
+    val table = tEnv.sql(sqlQuery)
+
+    table.toAppendStream[Row].addSink(new StreamITCase.StringSink[Row])
+
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "2017-06-11 12:12:12.999,Hello world,1,8",
+      "2017-06-11 12:12:12.999,Hello world,2,24",
+      "2017-06-11 12:12:12.999,Hello,1,2",
+      "2017-06-11 12:12:12.999,Hello,2,6",
+      "2017-06-11 12:12:12.999,Hi,1,1")
+
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testPojoTypeOverWindowWithTimestampColumnSQL(): Unit = {
+    val datas: List[Row] = List(
+      Row.of(JLong.valueOf(1L), Timestamp.valueOf("2017-06-11 12:12:12.999"), "Hi"),
+      Row.of(JLong.valueOf(2L), Timestamp.valueOf("2017-06-11 12:12:12.999"), "Hello"),
+      Row.of(JLong.valueOf(4L), Timestamp.valueOf("2017-06-11 12:12:12.999"), "Hello"),
+      Row.of(JLong.valueOf(8L), Timestamp.valueOf("2017-06-11 12:12:12.999"), "Hello world"),
+      Row.of(JLong.valueOf(16L), Timestamp.valueOf("2017-06-11 12:12:12.999"), "Hello world"))
+
+   val typeInfo = new RowTypeInfo(
+      Array(Types.LONG, Types.SQL_TIMESTAMP, Types.STRING)
+      .asInstanceOf[Array[TypeInformation[_]]],
+      Array("ts", "id", "name"))
+
+    StreamITCase.testResults = mutable.MutableList()
+    val tableName = "MyTable"
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    tEnv.registerTableSource(tableName, new StreamTableSource0(datas, typeInfo,"ts", 0L))
+    val sqlQuery = "SELECT " +
+      "id, " +
+      "name, " +
+      "count(ts) OVER (PARTITION BY name ORDER BY rowtime RANGE UNBOUNDED preceding) as myCnt, " +
+      "sum(ts) OVER (PARTITION BY name ORDER BY rowtime RANGE UNBOUNDED preceding) as mySum " +
+      "from MyTable"
+
+    val table = tEnv.sql(sqlQuery)
+
+    table.toAppendStream[Pojo1].addSink(new StreamITCase.StringSink[Pojo1])
+
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "Pojo1{id=2017-06-11 12:12:12.999, name='Hello world', myCnt=1, mySum=8}",
+      "Pojo1{id=2017-06-11 12:12:12.999, name='Hello world', myCnt=2, mySum=24}",
+      "Pojo1{id=2017-06-11 12:12:12.999, name='Hello', myCnt=1, mySum=2}",
+      "Pojo1{id=2017-06-11 12:12:12.999, name='Hello', myCnt=2, mySum=6}",
+      "Pojo1{id=2017-06-11 12:12:12.999, name='Hi', myCnt=1, mySum=1}")
+
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testPojoTypeOverWindowWithTimestampColumn(): Unit = {
+    val datas: List[Row] = List(
+      Row.of(JLong.valueOf(1L), Timestamp.valueOf("2017-06-11 12:12:12.999"), "Hi"),
+      Row.of(JLong.valueOf(2L), Timestamp.valueOf("2017-06-11 12:12:12.999"), "Hello"),
+      Row.of(JLong.valueOf(4L), Timestamp.valueOf("2017-06-11 12:12:12.999"), "Hello"),
+      Row.of(JLong.valueOf(8L), Timestamp.valueOf("2017-06-11 12:12:12.999"), "Hello world"),
+      Row.of(JLong.valueOf(16L), Timestamp.valueOf("2017-06-11 12:12:12.999"), "Hello world"))
+
+   val typeInfo = new RowTypeInfo(
+      Array(Types.LONG, Types.SQL_TIMESTAMP, Types.STRING)
+      .asInstanceOf[Array[TypeInformation[_]]],
+      Array("ts", "id", "name"))
+
+    StreamITCase.testResults = mutable.MutableList()
+    val tableName = "MyTable"
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    tEnv.registerTableSource(tableName, new StreamTableSource0(datas, typeInfo,"ts", 0L))
+
+    val windowedTable = tEnv.scan(tableName)
+      .window(Over partitionBy 'name orderBy 'rowtime preceding UNBOUNDED_RANGE as 'w)
+      .select('id, 'name, 'ts.count over 'w as 'myCnt, 'ts.sum over 'w as 'mySum)
+
+    windowedTable.toAppendStream[Pojo1].addSink(new StreamITCase.StringSink[Pojo1])
+
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "Pojo1{id=2017-06-11 12:12:12.999, name='Hello world', myCnt=1, mySum=8}",
+      "Pojo1{id=2017-06-11 12:12:12.999, name='Hello world', myCnt=2, mySum=24}",
+      "Pojo1{id=2017-06-11 12:12:12.999, name='Hello', myCnt=1, mySum=2}",
+      "Pojo1{id=2017-06-11 12:12:12.999, name='Hello', myCnt=2, mySum=6}",
+      "Pojo1{id=2017-06-11 12:12:12.999, name='Hi', myCnt=1, mySum=1}")
+
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/TableSources.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/TableSources.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.api.scala.stream
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.functions.source.SourceFunction
+import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
+import org.apache.flink.streaming.api.watermark.Watermark
+import org.apache.flink.table.sources.{DefinedRowtimeAttribute, StreamTableSource}
+import org.apache.flink.types.Row
+
+object TableSources {
+
+  class StreamTableSource0(
+      datas: List[Row],
+      returnTypeInfo: TypeInformation[Row],
+      timeField: String,
+      watermarkWithOffset: Long) extends StreamTableSource[Row] with DefinedRowtimeAttribute {
+
+    override def getDataStream(execEnv: StreamExecutionEnvironment): DataStream[Row] = {
+
+      val timeFileIndex = getReturnType.asInstanceOf[RowTypeInfo].getFieldIndex(timeField)
+
+      var dataWithTsAndWatermark: Seq[Either[(Long, Row), Long]] = Seq[Either[(Long, Row), Long]]()
+      datas.foreach {
+        data =>
+          val left = Left(data.getField(timeFileIndex).asInstanceOf[Long], data)
+          val right = Right(data.getField(timeFileIndex).asInstanceOf[Long] - watermarkWithOffset)
+          dataWithTsAndWatermark = dataWithTsAndWatermark ++ Seq(left) ++ Seq(right)
+      }
+
+      execEnv
+      .addSource(new EventTimeSourceFunction(dataWithTsAndWatermark))
+      .returns(getReturnType)
+    }
+
+    override def getRowtimeAttribute: String = "rowtime"
+
+    override def getReturnType: TypeInformation[Row] = returnTypeInfo
+  }
+
+  class EventTimeSourceFunction(
+      dataWithTimestampList: Seq[Either[(Long, Row), Long]]) extends SourceFunction[Row] {
+    override def run(ctx: SourceContext[Row]): Unit = {
+      dataWithTimestampList.foreach {
+        case Left(t) => ctx.collectWithTimestamp(t._2, t._1)
+        case Right(w) => ctx.emitWatermark(new Watermark(w))
+      }
+    }
+
+    override def cancel(): Unit = ???
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/sql/GroupWindowAggregationsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/sql/GroupWindowAggregationsITCase.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.api.scala.stream.sql
+
+import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.TimeCharacteristic
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.java.utils.Pojos.Pojo2
+import org.apache.flink.table.api.java.utils.UserDefinedAggFunctions.WeightedAvg
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.scala.stream.table.GroupWindowAggregationsITCase.TimestampAndWatermarkWithOffset
+import org.apache.flink.table.api.scala.stream.utils.{StreamITCase, StreamingWithStateTestBase}
+import org.apache.flink.table.functions.aggfunctions.CountAggFunction
+import org.junit.Assert._
+import org.junit._
+
+import scala.collection.mutable
+
+class GroupWindowAggregationsITCase extends StreamingWithStateTestBase {
+
+  val data = List(
+    (1000L, 1, "Hi"),
+    (2000L, 2, "Hello"),
+    (4000L, 2, "Hello"),
+    (8000L, 3, "Hello world"),
+    (16000L, 3, "Hello world"))
+
+  @Test
+  def testEventTimeTumblingWindowWithPojoType(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.testResults = mutable.MutableList()
+
+    val stream = env
+      .fromCollection(data)
+      .assignTimestampsAndWatermarks(new TimestampAndWatermarkWithOffset(0L))
+
+    val table = stream.toTable(tEnv, 'rowtime.rowtime, 'num, 'name)
+    tEnv.registerTable("T1", table)
+
+    val countFun = new CountAggFunction
+    val weightAvgFun = new WeightedAvg
+
+    tEnv.registerFunction("countFun", countFun)
+    tEnv.registerFunction("weightAvgFun", weightAvgFun)
+
+    val querySql =
+      "SELECT " +
+        "name as string," +
+        "countFun(name) as myCnt," +
+        "avg(num) as myAvg," +
+        "weightAvgFun(num, num) as myWeightAvg," +
+        "min(num) as myMin," +
+        "max(num) as myMax," +
+        "sum(num) as mySum," +
+        "TUMBLE_START(rowtime, INTERVAL '5' SECOND) as winStart," +
+        "TUMBLE_END(rowtime, INTERVAL '5' SECOND) as winEnd " +
+        "FROM T1 GROUP BY name, " +
+        "TUMBLE(rowtime, INTERVAL '5' SECOND)"
+
+    println(querySql)
+
+    val results = tEnv.sql(querySql).toAppendStream[Pojo2]
+    results.addSink(new StreamITCase.StringSink[Pojo2])
+    env.execute()
+
+    val expected = Seq(
+      "Pojo2{string='Hello world', myCnt=1, myAvg=3, myWeightAvg=3, myMin=3, myMax=3, mySum=3, " +
+        "winStart=1970-01-01 00:00:05.0, winEnd=1970-01-01 00:00:10.0}",
+      "Pojo2{string='Hello world', myCnt=1, myAvg=3, myWeightAvg=3, myMin=3, myMax=3, mySum=3, " +
+        "winStart=1970-01-01 00:00:15.0, winEnd=1970-01-01 00:00:20.0}",
+      "Pojo2{string='Hello', myCnt=2, myAvg=2, myWeightAvg=2, myMin=2, myMax=2, mySum=4, " +
+        "winStart=1970-01-01 00:00:00.0, winEnd=1970-01-01 00:00:05.0}",
+      "Pojo2{string='Hi', myCnt=1, myAvg=1, myWeightAvg=1, myMin=1, myMax=1, mySum=1, " +
+        "winStart=1970-01-01 00:00:00.0, winEnd=1970-01-01 00:00:05.0}"
+      )
+
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+}
+

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/sql/OverWindowITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/sql/OverWindowITCase.scala
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.api.scala.stream.sql
 
+import java.sql.Timestamp
+
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala.stream.sql.OverWindowITCase.EventTimeSourceFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction
@@ -31,6 +33,7 @@ import org.junit.Assert._
 import org.junit._
 import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
+import org.apache.flink.table.api.java.utils.Pojos.Pojo3
 
 import scala.collection.mutable
 
@@ -68,7 +71,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
       "from T1"
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
   }
 
@@ -93,7 +96,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
       "FROM MyTable"
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -135,7 +138,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
       "    ORDER BY proctime ROWS BETWEEN 10 PRECEDING AND CURRENT ROW) " +
       "FROM MyTable"
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -178,7 +181,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
       "from T1"
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -206,7 +209,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
       "as cnt1 from T1)"
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -236,7 +239,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
       "from T1"
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -261,7 +264,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
       "from T1"
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List("1", "2", "3", "4", "5", "6", "7", "8", "9")
@@ -323,7 +326,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
       " FROM T1"
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -384,7 +387,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
       "FROM T1"
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -452,7 +455,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
       " FROM T1"
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -513,7 +516,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
       "FROM T1"
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -574,7 +577,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     tEnv.registerTable("T1", t1)
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -640,7 +643,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     tEnv.registerTable("T1", t1)
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList(
@@ -702,7 +705,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     tEnv.registerTable("T1", t1)
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -763,7 +766,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     tEnv.registerTable("T1", t1)
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList(
@@ -835,7 +838,7 @@ class OverWindowITCase extends StreamingWithStateTestBase {
     tEnv.registerTable("T1", t1)
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -854,6 +857,90 @@ class OverWindowITCase extends StreamingWithStateTestBase {
       "2,5,Hello world,8,3,2,5,1",
       "3,5,Hello world,8,3,2,5,1"
     )
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testRowTimeBoundedPartitionedRangeOverWithPojoType(): Unit = {
+    val data = Seq(
+      Left((1500L, (1L, Timestamp.valueOf("2017-06-11 11:12:15"), "Hello"))),
+      Left((1600L, (1L, Timestamp.valueOf("2017-06-11 11:17:15"), "Hello"))),
+      Left((1000L, (1L, Timestamp.valueOf("2017-06-12 11:12:15"), "Hello"))),
+      Left((2000L, (2L, Timestamp.valueOf("2017-06-12 11:12:15"), "Hello"))),
+      Right(1000L),
+      Left((2000L, (2L, Timestamp.valueOf("2017-06-11 11:12:15"), "Hello"))),
+      Left((2000L, (2L, Timestamp.valueOf("2017-06-11 11:12:15"), "Hello"))),
+      Left((3000L, (3L, Timestamp.valueOf("2017-07-11 11:12:15"), "Hello"))),
+      Right(2000L),
+      Left((4000L, (4L, Timestamp.valueOf("2017-07-11 11:12:15"), "Hello"))),
+      Right(3000L),
+      Left((5000L, (5L, Timestamp.valueOf("2018-06-11 11:12:15"), "Hello"))),
+      Right(5000L),
+      Left((6000L, (6L, Timestamp.valueOf("2017-06-11 11:12:15"), "Hello"))),
+      Left((6500L, (6L, Timestamp.valueOf("2017-06-11 11:12:12"), "Hello"))),
+      Right(7000L),
+      Left((9000L, (6L, Timestamp.valueOf("2017-06-11 11:01:15"), "Hello"))),
+      Left((9500L, (6L, Timestamp.valueOf("2017-06-19 11:12:15"), "Hello"))),
+      Left((9000L, (6L, Timestamp.valueOf("2015-06-11 11:12:15"), "Hello"))),
+      Right(10000L),
+      Left((10000L, (7L, Timestamp.valueOf("2017-07-11 11:12:15"), "Hello World"))),
+      Left((11000L, (7L, Timestamp.valueOf("2017-01-11 11:12:15"), "Hello World"))),
+      Left((11000L, (7L, Timestamp.valueOf("2018-06-11 11:12:15"), "Hello World"))),
+      Right(12000L),
+      Left((14000L, (7L, Timestamp.valueOf("2017-09-11 11:12:15"), "Hello World"))),
+      Right(14000L),
+      Left((15000L, (8L, Timestamp.valueOf("2020-06-11 11:12:15"), "Hello World"))),
+      Right(17000L),
+      Left((20000L, (20L, Timestamp.valueOf("2017-06-11 11:12:15"), "Hello World"))),
+      Right(19000L))
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    env.setStateBackend(getStateBackend)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
+    val table = env
+      .addSource[(Long, Timestamp, String)](
+        new EventTimeSourceFunction[(Long, Timestamp, String)](data))
+      .toTable(tEnv, 'a, 'b, 'c, 'rowtime.rowtime)
+
+    tEnv.registerTable("T1", table)
+
+    val sqlQuery = "SELECT " +
+      "c as myMsg," +
+      "b as myTs, " +
+      "count(a) over (partition by c order by rowtime range between interval '1' second preceding" +
+      " and current row) as myCnt, " +
+      "sum(a) over (partition by c order by rowtime range between interval '1' second preceding" +
+      " and current row) as mySum " +
+      "from T1"
+
+    val result = tEnv.sql(sqlQuery).toAppendStream[Pojo3]
+    result.addSink(new StreamITCase.StringSink[Pojo3])
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "Pojo3{myMsg='Hello World', myTs=2017-01-11 11:12:15.0, myCnt=3, mySum=21}",
+      "Pojo3{myMsg='Hello World', myTs=2017-06-11 11:12:15.0, myCnt=1, mySum=20}",
+      "Pojo3{myMsg='Hello World', myTs=2017-07-11 11:12:15.0, myCnt=1, mySum=7}",
+      "Pojo3{myMsg='Hello World', myTs=2017-09-11 11:12:15.0, myCnt=1, mySum=7}",
+      "Pojo3{myMsg='Hello World', myTs=2018-06-11 11:12:15.0, myCnt=3, mySum=21}",
+      "Pojo3{myMsg='Hello World', myTs=2020-06-11 11:12:15.0, myCnt=2, mySum=15}",
+      "Pojo3{myMsg='Hello', myTs=2015-06-11 11:12:15.0, myCnt=2, mySum=12}",
+      "Pojo3{myMsg='Hello', myTs=2017-06-11 11:01:15.0, myCnt=2, mySum=12}",
+      "Pojo3{myMsg='Hello', myTs=2017-06-11 11:12:12.0, myCnt=2, mySum=12}",
+      "Pojo3{myMsg='Hello', myTs=2017-06-11 11:12:15.0, myCnt=2, mySum=11}",
+      "Pojo3{myMsg='Hello', myTs=2017-06-11 11:12:15.0, myCnt=2, mySum=2}",
+      "Pojo3{myMsg='Hello', myTs=2017-06-11 11:12:15.0, myCnt=6, mySum=9}",
+      "Pojo3{myMsg='Hello', myTs=2017-06-11 11:12:15.0, myCnt=6, mySum=9}",
+      "Pojo3{myMsg='Hello', myTs=2017-06-11 11:17:15.0, myCnt=3, mySum=3}",
+      "Pojo3{myMsg='Hello', myTs=2017-06-12 11:12:15.0, myCnt=1, mySum=1}",
+      "Pojo3{myMsg='Hello', myTs=2017-06-12 11:12:15.0, myCnt=6, mySum=9}",
+      "Pojo3{myMsg='Hello', myTs=2017-06-19 11:12:15.0, myCnt=3, mySum=18}",
+      "Pojo3{myMsg='Hello', myTs=2017-07-11 11:12:15.0, myCnt=2, mySum=7}",
+      "Pojo3{myMsg='Hello', myTs=2017-07-11 11:12:15.0, myCnt=4, mySum=9}",
+      "Pojo3{myMsg='Hello', myTs=2018-06-11 11:12:15.0, myCnt=2, mySum=9}")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/sql/SqlITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/sql/SqlITCase.scala
@@ -58,7 +58,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     tEnv.registerTable("MyTableRow", t)
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List("Hello,Worlds,1","Hello again,Worlds,2")
@@ -100,7 +100,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List("2,0", "4,1", "6,1")
@@ -121,7 +121,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List("3,2,Hello world")
@@ -142,7 +142,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     tEnv.registerDataStream("MyTable", t)
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List("3,2,Hello world")
@@ -166,7 +166,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     tEnv.registerTable("T2", t2)
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -193,7 +193,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     tEnv.registerTable("T2", t2)
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -219,7 +219,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     tEnv.registerDataStream("T2", t2, 'a, 'b, 'c)
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List("Hello", "Hello world")
@@ -244,7 +244,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     val sqlQuery = "SELECT a, b, s FROM T, UNNEST(T.b) AS A (s)"
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -276,7 +276,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     val sqlQuery = "SELECT a, s FROM T, UNNEST(T.c) AS A (s)"
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(
@@ -306,7 +306,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     val sqlQuery = "SELECT a, b, s, t FROM T, UNNEST(T.b) AS A (s, t) WHERE s > 13"
 
     val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = List(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/table/CalcITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/table/CalcITCase.scala
@@ -42,7 +42,7 @@ class CalcITCase extends StreamingMultipleProgramsTestBase {
     val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).select('_1, '_2, '_3)
 
     val results = ds.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList(
@@ -61,7 +61,7 @@ class CalcITCase extends StreamingMultipleProgramsTestBase {
     val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).select('_1)
 
     val results = ds.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList("1", "2", "3")
@@ -80,7 +80,7 @@ class CalcITCase extends StreamingMultipleProgramsTestBase {
       .select('a, 'b)
 
     val results = ds.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList(
@@ -100,7 +100,7 @@ class CalcITCase extends StreamingMultipleProgramsTestBase {
       .select('a, 'b, 'c)
 
     val results = ds.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList(
@@ -119,7 +119,7 @@ class CalcITCase extends StreamingMultipleProgramsTestBase {
     val ds = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c, 'd)
 
     val results = ds.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList("no")
@@ -135,7 +135,7 @@ class CalcITCase extends StreamingMultipleProgramsTestBase {
     val ds = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'b)
 
     val results = ds.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList("no")
@@ -152,7 +152,7 @@ class CalcITCase extends StreamingMultipleProgramsTestBase {
     val ds = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b as 'c, 'd)
 
     val results = ds.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList("no")
@@ -172,7 +172,7 @@ class CalcITCase extends StreamingMultipleProgramsTestBase {
 
     val filterDs = ds.filter('a === 3)
     val results = filterDs.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList("3,2,Hello world")
@@ -192,7 +192,7 @@ class CalcITCase extends StreamingMultipleProgramsTestBase {
 
     val filterDs = ds.filter( Literal(false) )
     val results = filterDs.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     assertEquals(true, StreamITCase.testResults.isEmpty)
@@ -211,7 +211,7 @@ class CalcITCase extends StreamingMultipleProgramsTestBase {
 
     val filterDs = ds.filter( Literal(true) )
     val results = filterDs.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList(
@@ -234,7 +234,7 @@ class CalcITCase extends StreamingMultipleProgramsTestBase {
 
     val filterDs = ds.filter( 'a % 2 === 0 )
     val results = filterDs.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList(
@@ -258,7 +258,7 @@ class CalcITCase extends StreamingMultipleProgramsTestBase {
 
     val filterDs = ds.filter( 'a % 2 !== 0)
     val results = filterDs.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
     val expected = mutable.MutableList(
       "1,1,Hi", "3,2,Hello world",

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/table/UnionITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/table/UnionITCase.scala
@@ -44,7 +44,7 @@ class UnionITCase extends StreamingMultipleProgramsTestBase {
     val unionDs = ds1.unionAll(ds2).select('c)
 
     val results = unionDs.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList(
@@ -64,7 +64,7 @@ class UnionITCase extends StreamingMultipleProgramsTestBase {
     val unionDs = ds1.unionAll(ds2.select('a, 'b, 'c)).filter('b < 2).select('c)
 
     val results = unionDs.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList("Hi", "Hallo")
@@ -83,7 +83,7 @@ class UnionITCase extends StreamingMultipleProgramsTestBase {
     val unionDs = ds1.unionAll(ds2)
 
     val results = unionDs.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     assertEquals(true, StreamITCase.testResults.isEmpty)
@@ -102,7 +102,7 @@ class UnionITCase extends StreamingMultipleProgramsTestBase {
     val unionDs = ds1.unionAll(ds2)
 
     val results = unionDs.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     assertEquals(true, StreamITCase.testResults.isEmpty)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/utils/StreamITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/utils/StreamITCase.scala
@@ -44,8 +44,8 @@ object StreamITCase {
     assertEquals(expected.asScala, StreamITCase.testResults.sorted)
   }
 
-  final class StringSink extends RichSinkFunction[Row]() {
-    def invoke(value: Row) {
+  final class StringSink[T] extends RichSinkFunction[T]() {
+    def invoke(value: T) {
       testResults.synchronized {
         testResults += value.toString
       }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/datastream/DataStreamAggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/datastream/DataStreamAggregateITCase.scala
@@ -70,7 +70,7 @@ class DataStreamAggregateITCase extends StreamingMultipleProgramsTestBase {
       .select('int.count, 'w.start, 'w.end)
 
     val results = windowedTable.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
@@ -105,7 +105,7 @@ class DataStreamAggregateITCase extends StreamingMultipleProgramsTestBase {
       .select('string, 'int.count, 'w.start, 'w.end)
 
     val results = windowedTable.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
@@ -142,7 +142,7 @@ class DataStreamAggregateITCase extends StreamingMultipleProgramsTestBase {
       .select('string, 'int.count, 'w.start, 'w.end)
 
     val results = windowedTable.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
@@ -176,7 +176,7 @@ class DataStreamAggregateITCase extends StreamingMultipleProgramsTestBase {
       .select('string, 'int.count, 'w.start, 'w.end)
 
     val results = windowedTable.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
@@ -205,7 +205,7 @@ class DataStreamAggregateITCase extends StreamingMultipleProgramsTestBase {
       .select('string, 'int.count, 'w.start, 'w.end)
 
     val results = windowedTable.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
@@ -233,7 +233,7 @@ class DataStreamAggregateITCase extends StreamingMultipleProgramsTestBase {
       .select('string, 'int.count, 'w.start, 'w.end)
 
     val results = windowedTable.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
     val expected = Seq(
       "Hallo,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003",

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/datastream/DataStreamCalcITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/datastream/DataStreamCalcITCase.scala
@@ -49,7 +49,7 @@ class DataStreamCalcITCase extends StreamingMultipleProgramsTestBase {
       .select('c)
 
     val results = result.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList("Hello")
@@ -72,7 +72,7 @@ class DataStreamCalcITCase extends StreamingMultipleProgramsTestBase {
       .select('c)
 
     val results = result.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList("Hello", "Hello world")

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/datastream/DataStreamUserDefinedFunctionITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/datastream/DataStreamUserDefinedFunctionITCase.scala
@@ -55,7 +55,7 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
       .select('c, 'name, 'age)
       .toAppendStream[Row]
 
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList("Jack#22,Jack,22", "Anna#44,Anna,44")
@@ -72,7 +72,7 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
       .select('c, 'd, 'e)
       .toAppendStream[Row]
 
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList(
@@ -92,7 +92,7 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
       .select('c, 'd, 'e)
       .toAppendStream[Row]
 
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList("Jack#22,Jack,22", "John#19,John,19")
@@ -112,7 +112,7 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
       .select('a, 's)
 
     val results = result.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList("3,Hello", "3,world")
@@ -136,7 +136,7 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
       .select('a, 's)
 
     val results = result.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList(
@@ -166,7 +166,7 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
       .select('c, 'd, 'f, 'h, 'e, 'g, 'i)
       .toAppendStream[Row]
 
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList(
@@ -189,7 +189,7 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
 
     val result = t.select(func0('c), func1('c),func2('c))
 
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList(
@@ -211,7 +211,7 @@ class DataStreamUserDefinedFunctionITCase extends StreamingMultipleProgramsTestB
       .select('c)
       .join(varArgsFunc0("1", "2", 'c))
 
-    result.addSink(new StreamITCase.StringSink)
+    result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = mutable.MutableList(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/datastream/TimeAttributesITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/datastream/TimeAttributesITCase.scala
@@ -104,7 +104,7 @@ class TimeAttributesITCase extends StreamingMultipleProgramsTestBase {
     val t = table.select('rowtime.cast(Types.STRING))
 
     val results = t.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
@@ -135,7 +135,7 @@ class TimeAttributesITCase extends StreamingMultipleProgramsTestBase {
       .select('rowtime, 'rowtime.floor(TimeIntervalUnit.DAY), 'rowtime.ceil(TimeIntervalUnit.DAY))
 
     val results = t.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
@@ -162,7 +162,7 @@ class TimeAttributesITCase extends StreamingMultipleProgramsTestBase {
     val t = table.join(func('rowtime, 'proctime, 'string) as 's).select('rowtime, 's)
 
     val results = t.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
@@ -197,7 +197,7 @@ class TimeAttributesITCase extends StreamingMultipleProgramsTestBase {
       .select('w.rowtime, 's.count)
 
     val results = t.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
@@ -223,7 +223,7 @@ class TimeAttributesITCase extends StreamingMultipleProgramsTestBase {
     val t = table.unionAll(table).select('rowtime)
 
     val results = t.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
@@ -261,7 +261,7 @@ class TimeAttributesITCase extends StreamingMultipleProgramsTestBase {
       "GROUP BY TUMBLE(rowtime, INTERVAL '0.003' SECOND)")
 
     val results = t.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
@@ -294,7 +294,7 @@ class TimeAttributesITCase extends StreamingMultipleProgramsTestBase {
       .select('w2.rowtime, 'w2.end, 'int.count)
 
     val results = t.toAppendStream[Row]
-    results.addSink(new StreamITCase.StringSink)
+    results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(


### PR DESCRIPTION
In this JIRA. will fix the exception when we run the folllows SQL:
`SELECT name, max(num) as myMax, TUMBLE_START(rowtime, INTERVAL '5' SECOND) as winStart,TUMBLE_END(rowtime, INTERVAL '5' SECOND) as winEnd FROM T1 GROUP BY name, TUMBLE(rowtime, INTERVAL '5' SECOND)`
Exception Info:
```
org.apache.flink.table.api.TableException: The field types of physical and logical row types do not match.This is a bug and should not happen. Please file an issue.

	at org.apache.flink.table.api.TableException$.apply(exceptions.scala:53)
	at org.apache.flink.table.api.TableEnvironment.generateRowConverterFunction(TableEnvironment.scala:721)
	at org.apache.flink.table.api.StreamTableEnvironment.getConversionMapper(StreamTableEnvironment.scala:247)
	at org.apache.flink.table.api.StreamTableEnvironment.translate(StreamTableEnvironment.scala:647)
```

- [x] General
  - The pull request references the related JIRA issue ("Fix Timestamp field can not be selected in event time case when toDataStream[T], `T` not a `Row` Type.")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
