### PR TITLE
[FLINK-6888] [table] Can not determine TypeInformation of ACC type of AggregateFunction when ACC is a Scala class

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/java/BatchTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/java/BatchTableEnvironment.scala
@@ -196,6 +196,10 @@ class BatchTableEnvironment(
       .createTypeInfo(f, classOf[AggregateFunction[T, ACC]], f.getClass, 0)
       .asInstanceOf[TypeInformation[T]]
 
+    implicit val accTypeInfo: TypeInformation[ACC] = TypeExtractor
+      .createTypeInfo(f, classOf[AggregateFunction[T, ACC]], f.getClass, 1)
+      .asInstanceOf[TypeInformation[ACC]]
+
     registerAggregateFunctionInternal[T, ACC](name, f)
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/java/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/java/StreamTableEnvironment.scala
@@ -482,6 +482,10 @@ class StreamTableEnvironment(
       .createTypeInfo(f, classOf[AggregateFunction[T, ACC]], f.getClass, 0)
       .asInstanceOf[TypeInformation[T]]
 
+    implicit val accTypeInfo: TypeInformation[ACC] = TypeExtractor
+      .createTypeInfo(f, classOf[AggregateFunction[T, ACC]], f.getClass, 1)
+      .asInstanceOf[TypeInformation[ACC]]
+
     registerAggregateFunctionInternal[T, ACC](name, f)
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/BatchTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/BatchTableEnvironment.scala
@@ -161,7 +161,7 @@ class BatchTableEnvironment(
     * @tparam T The type of the output value.
     * @tparam ACC The type of aggregate accumulator.
     */
-  def registerFunction[T: TypeInformation, ACC](
+  def registerFunction[T: TypeInformation, ACC: TypeInformation](
       name: String,
       f: AggregateFunction[T, ACC])
   : Unit = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/StreamTableEnvironment.scala
@@ -274,7 +274,7 @@ class StreamTableEnvironment(
     * @tparam T The type of the output value.
     * @tparam ACC The type of aggregate accumulator.
     */
-  def registerFunction[T: TypeInformation, ACC](
+  def registerFunction[T: TypeInformation, ACC: TypeInformation](
       name: String,
       f: AggregateFunction[T, ACC])
   : Unit = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -792,7 +792,7 @@ trait ImplicitExpressionConversions {
   implicit def sqlTimestamp2Literal(sqlTimestamp: Timestamp): Expression =
     Literal(sqlTimestamp)
   implicit def array2ArrayConstructor(array: Array[_]): Expression = convertArray(array)
-  implicit def userDefinedAggFunctionConstructor[T: TypeInformation, ACC]
+  implicit def userDefinedAggFunctionConstructor[T: TypeInformation, ACC: TypeInformation]
       (udagg: AggregateFunction[T, ACC]): UDAGGExpression[T, ACC] = UDAGGExpression(udagg)
 }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/aggregations.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/aggregations.scala
@@ -228,12 +228,14 @@ case class VarSamp(child: Expression) extends Aggregation {
 
 case class AggFunctionCall(
     aggregateFunction: AggregateFunction[_, _],
+    resultTypeInfo: TypeInformation[_],
+    accTypeInfo: TypeInformation[_],
     args: Seq[Expression])
   extends Aggregation {
 
   override private[flink] def children: Seq[Expression] = args
 
-  override def resultType: TypeInformation[_] = getResultTypeOfAggregateFunction(aggregateFunction)
+  override def resultType: TypeInformation[_] = resultTypeInfo
 
   override def validateInput(): ValidationResult = {
     val signature = children.map(_.resultType)
@@ -258,12 +260,13 @@ case class AggFunctionCall(
 
   override private[flink] def getSqlAggFunction()(implicit relBuilder: RelBuilder) = {
     val typeFactory = relBuilder.getTypeFactory.asInstanceOf[FlinkTypeFactory]
-    val sqlAgg = AggSqlFunction(aggregateFunction.getClass.getSimpleName,
-                   aggregateFunction,
-                   resultType,
-                   typeFactory,
-                   aggregateFunction.requiresOver)
-    sqlAgg
+    AggSqlFunction(
+      aggregateFunction.getClass.getSimpleName,
+      aggregateFunction,
+      resultType,
+      accTypeInfo,
+      typeFactory,
+      aggregateFunction.requiresOver)
   }
 
   override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/AggSqlFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/AggSqlFunction.scala
@@ -37,12 +37,14 @@ import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils._
   * @param name function name (used by SQL parser)
   * @param aggregateFunction aggregate function to be called
   * @param returnType the type information of returned value
+  * @param accType the type information of the accumulator
   * @param typeFactory type factory for converting Flink's between Calcite's types
   */
 class AggSqlFunction(
     name: String,
     aggregateFunction: AggregateFunction[_, _],
-    returnType: TypeInformation[_],
+    val returnType: TypeInformation[_],
+    val accType: TypeInformation[_],
     typeFactory: FlinkTypeFactory,
     requiresOver: Boolean)
   extends SqlUserDefinedAggFunction(
@@ -67,10 +69,11 @@ object AggSqlFunction {
       name: String,
       aggregateFunction: AggregateFunction[_, _],
       returnType: TypeInformation[_],
+      accType: TypeInformation[_],
       typeFactory: FlinkTypeFactory,
       requiresOver: Boolean): AggSqlFunction = {
 
-    new AggSqlFunction(name, aggregateFunction, returnType, typeFactory, requiresOver)
+    new AggSqlFunction(name, aggregateFunction, returnType, accType, typeFactory, requiresOver)
   }
 
   private[flink] def createOperandTypeInference(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/ProjectionTranslator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/ProjectionTranslator.scala
@@ -316,28 +316,28 @@ object ProjectionTranslator {
       identifyFieldReferences(b.right, l)
 
     // Functions calls
-    case c @ Call(name, args) =>
+    case Call(_, args: Seq[Expression]) =>
       args.foldLeft(fieldReferences) {
         (fieldReferences, expr) => identifyFieldReferences(expr, fieldReferences)
       }
-    case sfc @ ScalarFunctionCall(clazz, args) =>
+    case ScalarFunctionCall(_, args: Seq[Expression]) =>
       args.foldLeft(fieldReferences) {
         (fieldReferences, expr) => identifyFieldReferences(expr, fieldReferences)
       }
 
-    case aggfc @ AggFunctionCall(clazz, args) =>
+    case AggFunctionCall(_, _, _, args) =>
       args.foldLeft(fieldReferences) {
         (fieldReferences, expr) => identifyFieldReferences(expr, fieldReferences)
       }
 
     // array constructor
-    case c @ ArrayConstructor(args) =>
+    case ArrayConstructor(args) =>
       args.foldLeft(fieldReferences) {
         (fieldReferences, expr) => identifyFieldReferences(expr, fieldReferences)
       }
 
     // ignore fields from window property
-    case w : WindowProperty =>
+    case _: WindowProperty =>
       fieldReferences
 
     // keep this case after all unwanted unary expressions

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -105,7 +105,9 @@ class FunctionCatalog {
           .getOrElse(throw ValidationException(s"Undefined table function: $name"))
           .asInstanceOf[AggSqlFunction]
         val function = aggregateFunction.getFunction
-        AggFunctionCall(function, children)
+        val returnType = aggregateFunction.returnType
+        val accType = aggregateFunction.accType
+        AggFunctionCall(function, returnType, accType, children)
 
       // general expression call
       case expression if classOf[Expression].isAssignableFrom(expression) =>

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/utils/UserDefinedAggFunctions.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/utils/UserDefinedAggFunctions.java
@@ -59,7 +59,7 @@ public class UserDefinedAggFunctions {
 	/**
 	 * Accumulator for WeightedAvg.
 	 */
-	public static class WeightedAvgAccum extends Tuple2<Long, Integer> {
+	public static class WeightedAvgAccum {
 		public long sum = 0;
 		public int count = 0;
 	}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/HarnessTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/HarnessTestBase.scala
@@ -30,8 +30,8 @@ import org.apache.flink.streaming.util.{KeyedOneInputStreamOperatorTestHarness, 
 import org.apache.flink.table.codegen.GeneratedAggregationsFunction
 import org.apache.flink.table.functions.AggregateFunction
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils
-import org.apache.flink.table.functions.aggfunctions.{LongMaxWithRetractAggFunction, LongMinWithRetractAggFunction, IntSumWithRetractAggFunction}
-import org.apache.flink.table.runtime.aggregate.AggregateUtil
+import org.apache.flink.table.functions.aggfunctions.{IntSumWithRetractAggFunction, LongMaxWithRetractAggFunction, LongMinWithRetractAggFunction}
+import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils.getAccumulatorTypeOfAggregateFunction
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
 
 class HarnessTestBase {
@@ -70,10 +70,10 @@ class HarnessTestBase {
     Array(new IntSumWithRetractAggFunction).asInstanceOf[Array[AggregateFunction[_, _]]]
 
   protected val minMaxAggregationStateType: RowTypeInfo =
-    AggregateUtil.createAccumulatorRowType(minMaxAggregates)
+    new RowTypeInfo(minMaxAggregates.map(getAccumulatorTypeOfAggregateFunction(_)): _*)
 
   protected val sumAggregationStateType: RowTypeInfo =
-    AggregateUtil.createAccumulatorRowType(sumAggregates)
+    new RowTypeInfo(sumAggregates.map(getAccumulatorTypeOfAggregateFunction(_)): _*)
 
   val minMaxCode: String =
     s"""


### PR DESCRIPTION
Currently the `ACC TypeInformation of `org.apache.flink.table.functions.AggregateFunction[T, ACC]` is extracted using `TypeInformation.of(Class)`. When `ACC` is a Scala case class or tuple class, the TypeInformation will fall back to `GenericType` which result in bad performance when state de/serialization. 

This PR fix this issue by extracting ACC TypeInformation when calling `TableEnvironment.registerFunction()`.