### PR TITLE
[FLINK-6900] [metrics] Limit size of metric name components

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -632,6 +632,7 @@ Parameters:
 - `host` - the Graphite server host
 - `port` - the Graphite server port
 - `protocol` - protocol to use (TCP/UDP)
+- `maxComponentLength` - limits the length of each scope component
 
 Example configuration:
 
@@ -641,6 +642,7 @@ metrics.reporter.grph.class: org.apache.flink.metrics.graphite.GraphiteReporter
 metrics.reporter.grph.host: localhost
 metrics.reporter.grph.port: 2003
 metrics.reporter.grph.protocol: TCP
+metrics.reporter.grph.maxComponentLength: 80
 
 {% endhighlight %}
 
@@ -708,6 +710,7 @@ Parameters:
 
 - `host` - the StatsD server host
 - `port` - the StatsD server port
+- `maxComponentLength` - limits the length of each scope component
 
 Example configuration:
 
@@ -716,6 +719,7 @@ Example configuration:
 metrics.reporter.stsd.class: org.apache.flink.metrics.statsd.StatsDReporter
 metrics.reporter.stsd.host: localhost
 metrics.reporter.stsd.port: 8125
+metrics.reporter.stsd.maxComponentLength: 80
 
 {% endhighlight %}
 

--- a/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/main/java/org/apache/flink/dropwizard/ScheduledDropwizardReporter.java
@@ -61,6 +61,7 @@ public abstract class ScheduledDropwizardReporter implements MetricReporter, Sch
 	public static final String ARG_PREFIX = "prefix";
 	public static final String ARG_CONVERSION_RATE = "rateConversion";
 	public static final String ARG_CONVERSION_DURATION = "durationConversion";
+	public static final String ARG_MAX_COMPONENT_LENGTH = "maxComponentLength";
 
 	// ------------------------------------------------------------------------
 
@@ -72,6 +73,8 @@ public abstract class ScheduledDropwizardReporter implements MetricReporter, Sch
 	private final Map<Counter, String> counters = new HashMap<>();
 	private final Map<Histogram, String> histograms = new HashMap<>();
 	private final Map<Meter, String> meters = new HashMap<>();
+
+	private int maxComponentLength = 80;
 
 	// ------------------------------------------------------------------------
 
@@ -109,6 +112,7 @@ public abstract class ScheduledDropwizardReporter implements MetricReporter, Sch
 
 	@Override
 	public void open(MetricConfig config) {
+		this.maxComponentLength = config.getInteger(ARG_MAX_COMPONENT_LENGTH, 80);
 		this.reporter = getReporter(config);
 	}
 
@@ -184,7 +188,11 @@ public abstract class ScheduledDropwizardReporter implements MetricReporter, Sch
 	@Override
 	public String filterCharacters(String metricName) {
 		char[] chars = null;
-		final int strLen = metricName.length();
+		int strLen = metricName.length();
+		if (strLen > maxComponentLength) {
+			log.warn("The metric name component {} exceeded the {} characters length limit and was truncated.", metricName, maxComponentLength);
+			strLen = maxComponentLength;
+		}
 		int pos = 0;
 
 		for (int i = 0; i < strLen; i++) {

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
@@ -44,7 +44,6 @@ import org.apache.flink.util.AbstractID;
 import com.codahale.metrics.ScheduledReporter;
 import org.junit.Test;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Map;
 
@@ -58,23 +57,27 @@ public class ScheduledDropwizardReporterTest {
 
 	@Test
 	public void testNameTruncating() {
-		ScheduledDropwizardReporter reporter = new ScheduledDropwizardReporter() {
+		final MetricConfig config = new MetricConfig();
+		config.setProperty(ScheduledDropwizardReporter.ARG_MAX_COMPONENT_LENGTH, "10");
+
+		final ScheduledDropwizardReporter reporter = new ScheduledDropwizardReporter() {
 			@Override
 			public ScheduledReporter getReporter(MetricConfig config) {
 				return null;
 			}
 		};
 
-		MetricConfig config = new MetricConfig();
-		config.setProperty(ScheduledDropwizardReporter.ARG_MAX_COMPONENT_LENGTH, "10");
+		try {
+			reporter.open(config);
 
-		reporter.open(config);
-
-		assertEquals("0123456789", reporter.filterCharacters("0123456789DEADBEEF"));
+			assertEquals("0123456789", reporter.filterCharacters("0123456789DEADBEEF"));
+		} finally {
+			reporter.close();
+		}
 	}
 
 	@Test
-	public void testInvalidCharacterReplacement() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+	public void testInvalidCharacterReplacement() {
 		ScheduledDropwizardReporter reporter = new ScheduledDropwizardReporter() {
 			@Override
 			public ScheduledReporter getReporter(MetricConfig config) {

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
@@ -57,6 +57,23 @@ import static org.junit.Assert.assertTrue;
 public class ScheduledDropwizardReporterTest {
 
 	@Test
+	public void testNameTruncating() {
+		ScheduledDropwizardReporter reporter = new ScheduledDropwizardReporter() {
+			@Override
+			public ScheduledReporter getReporter(MetricConfig config) {
+				return null;
+			}
+		};
+
+		MetricConfig config = new MetricConfig();
+		config.setProperty(ScheduledDropwizardReporter.ARG_MAX_COMPONENT_LENGTH, "10");
+
+		reporter.open(config);
+
+		assertEquals("0123456789", reporter.filterCharacters("0123456789DEADBEEF"));
+	}
+
+	@Test
 	public void testInvalidCharacterReplacement() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 		ScheduledDropwizardReporter reporter = new ScheduledDropwizardReporter() {
 			@Override

--- a/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
+++ b/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
@@ -62,20 +62,23 @@ public class StatsDReporterTest extends TestLogger {
 
 	@Test
 	public void testNameTruncating() {
-		StatsDReporter reporter = new StatsDReporter();
-
-		MetricConfig config = new MetricConfig();
+		final MetricConfig config = new MetricConfig();
 		config.setProperty(StatsDReporter.ARG_HOST, "localhost");
 		config.setProperty(StatsDReporter.ARG_PORT, "12345");
 		config.setProperty(StatsDReporter.ARG_MAX_COMPONENT_LENGTH, "10");
-		
-		reporter.open(config);
-		
-		assertEquals("0123456789", reporter.filterCharacters("0123456789DEADBEEF"));
+
+		final StatsDReporter reporter = new StatsDReporter();
+		try {
+			reporter.open(config);
+
+			assertEquals("0123456789", reporter.filterCharacters("0123456789DEADBEEF"));
+		} finally {
+			reporter.close();
+		}
 	}
 
 	@Test
-	public void testReplaceInvalidChars() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+	public void testReplaceInvalidChars() {
 		StatsDReporter reporter = new StatsDReporter();
 
 		assertEquals("", reporter.filterCharacters(""));

--- a/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
+++ b/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
@@ -61,6 +61,20 @@ import static org.junit.Assert.assertTrue;
 public class StatsDReporterTest extends TestLogger {
 
 	@Test
+	public void testNameTruncating() {
+		StatsDReporter reporter = new StatsDReporter();
+
+		MetricConfig config = new MetricConfig();
+		config.setProperty(StatsDReporter.ARG_HOST, "localhost");
+		config.setProperty(StatsDReporter.ARG_PORT, "12345");
+		config.setProperty(StatsDReporter.ARG_MAX_COMPONENT_LENGTH, "10");
+		
+		reporter.open(config);
+		
+		assertEquals("0123456789", reporter.filterCharacters("0123456789DEADBEEF"));
+	}
+
+	@Test
 	public void testReplaceInvalidChars() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 		StatsDReporter reporter = new StatsDReporter();
 


### PR DESCRIPTION
This PR modifies the `ScheduledDropwizardReporter` to limit the size of every metric name component to 80 characters, with the same reasoning as #4109.