### PR TITLE
[hotfix] [docs] Fix typos (Souce -> Source)

### DIFF
--- a/docs/dev/table/sourceSinks.md
+++ b/docs/dev/table/sourceSinks.md
@@ -40,7 +40,7 @@ Currently, Flink provides the `CsvTableSource` to read CSV files and a few table
 A custom `TableSource` can be defined by implementing the `BatchTableSource` or `StreamTableSource` interface. See section on [defining a custom TableSource](#define-a-tablesource) for details.
 
 | **Class name** | **Maven dependency** | **Batch?** | **Streaming?** | **Description**
-| `CsvTableSouce` | `flink-table` | Y | Y | A simple source for CSV files.
+| `CsvTableSource` | `flink-table` | Y | Y | A simple source for CSV files.
 | `Kafka08JsonTableSource` | `flink-connector-kafka-0.8` | N | Y | A Kafka 0.8 source for JSON data.
 | `Kafka08AvroTableSource` | `flink-connector-kafka-0.8` | N | Y | A Kafka 0.8 source for Avro data.
 | `Kafka09JsonTableSource` | `flink-connector-kafka-0.9` | N | Y | A Kafka 0.9 source for JSON data.

--- a/docs/fig/state_partitioning.svg
+++ b/docs/fig/state_partitioning.svg
@@ -111,7 +111,7 @@ under the License.
          y="271.23022"
          id="text3013"
          xml:space="preserve"
-         style="font-size:12.45310211px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Souce</text>
+         style="font-size:12.45310211px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Source</text>
       <text
          x="56.959515"
          y="286.23395"


### PR DESCRIPTION
This changes occurrences of *Souce* in the documentation to *Source*.