### PR TITLE
[FLINK-6836] [tests] Fix YARNSessionCapacitySchedulerITCase to work with Hadoop 2.6.5, 2.7.3 and 2.8.0

### DIFF
--- a/flink-shaded-hadoop/flink-shaded-hadoop2/pom.xml
+++ b/flink-shaded-hadoop/flink-shaded-hadoop2/pom.xml
@@ -676,22 +676,6 @@ under the License.
 		</dependency>
 	</dependencies>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.apache.httpcomponents</groupId>
-				<artifactId>httpcore</artifactId>
-				<version>4.4.4</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.httpcomponents</groupId>
-				<artifactId>httpclient</artifactId>
-				<version>4.5.2</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<profiles>
 		<profile>
 			<!-- MapR build profile -->

--- a/pom.xml
+++ b/pom.xml
@@ -452,13 +452,13 @@ under the License.
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpcore</artifactId>
-				<version>4.2.5</version>
+				<version>4.4.6</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
-				<version>4.2.6</version>
+				<version>4.5.3</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -445,6 +445,22 @@ under the License.
 				<version>4.0.27.Final</version>
 			</dependency>
 
+			<!-- We have to define the versions for httpcore and httpclient here such that a consistent
+			 version is used by the shaded hadoop jars and the flink-yarn-test project because of MNG-5899.
+
+			 See FLINK-6836 for more details -->
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpcore</artifactId>
+				<version>4.2.5</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient</artifactId>
+				<version>4.2.6</version>
+			</dependency>
+
 			<dependency>
 				<groupId>tv.cntt</groupId>
 				<artifactId>netty-router</artifactId>


### PR DESCRIPTION
Due to MNG-5899, maven cannot resolve dependency reduced poms in a multi project build. Therefore, flink-yarn-tests pulls in a wrong version of org.apache.httpcomponents.httpclient which does not work with Hadoop's ServletUtils together. As a solution we have to move the dependency management for the httpclient and httpcore version into the parent pom.xml.

Another problem is the version of these libraries which has been recently bumped. In 4.4, httpclient changed its behaviour such that URLEncodedUtils#parse(String, Charset) now throws a NPE if the first parameter is null. In 4.2.6, an empty list was returned instead. Due to this incompatibility, we reverted the change and set the version to its previous value.
