### PR TITLE
[FLINK-6892][table]Add L/RPAD supported in SQL

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -1735,7 +1735,6 @@ INITCAP(string)
         <p>Returns string with the first letter of each word converter to upper case and the rest to lower case. Words are sequences of alphanumeric characters separated by non-alphanumeric characters.</p>
       </td>
     </tr>
-
     <tr>
       <td>
         {% highlight text %}
@@ -1755,6 +1754,29 @@ CONCAT_WS(separator, string1, string2,...)
       </td>
       <td>
         <p>Returns the string that results from concatenating the arguments using a separator. The separator is added between the strings to be concatenated. Returns NULL If the separator is NULL. CONCAT_WS() does not skip empty strings. However, it does skip any NULL argument. E.g. <code>CONCAT_WS("~", "AA", "BB", "", "CC")</code> returns <code>AA~BB~~CC</code></p>
+  </td>
+    </tr>
+
+        <tr>
+      <td>
+        {% highlight text %}
+LPAD(text string, len integer, pad string)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the string text, left-padded with the string pad to a length of len characters. If text is longer than len, the return value is shortened to len characters.</p>
+      </td>
+    </tr>
+
+
+        <tr>
+      <td>
+        {% highlight text %}
+RPAD(text string, len integer, pad string)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the string text, right-padded with the string pad to a length of len characters. If text is longer than len, the return value is shortened to len characters.</p>
       </td>
     </tr>
 

--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -1735,6 +1735,7 @@ INITCAP(string)
         <p>Returns string with the first letter of each word converter to upper case and the rest to lower case. Words are sequences of alphanumeric characters separated by non-alphanumeric characters.</p>
       </td>
     </tr>
+
     <tr>
       <td>
         {% highlight text %}
@@ -1764,19 +1765,17 @@ LPAD(text string, len integer, pad string)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns the string text, left-padded with the string pad to a length of len characters. If text is longer than len, the return value is shortened to len characters.</p>
+        <p>Returns the string text, left-padded with the string pad to a length of len characters. If text is longer than len, the return value is shortened to len characters. E.g. <code>LPAD('hi',4,'??')</code> returns <code>??hi</code> <code>LPAD('hi',1,'??')</code> returns <code>h</code></p>
       </td>
     </tr>
-
-
-        <tr>
+    <tr>
       <td>
         {% highlight text %}
 RPAD(text string, len integer, pad string)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns the string text, right-padded with the string pad to a length of len characters. If text is longer than len, the return value is shortened to len characters.</p>
+        <p>Returns the string text, right-padded with the string pad to a length of len characters. If text is longer than len, the return value is shortened to len characters. E.g. <code>RPAD('hi',4,'??')</code> returns <code>hi??</code> <code>RPAD('hi',1,'??')</code> returns <code>h</code></p>
       </td>
     </tr>
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
@@ -90,11 +90,22 @@ object BuiltInMethods {
   val ROUND_LONG = Types.lookupMethod(classOf[SqlFunctions], "sround", classOf[Long], classOf[Int])
   val ROUND_DEC = Types.lookupMethod(classOf[SqlFunctions], "sround", classOf[JBigDecimal],
     classOf[Int])
-
   val CONCAT = Types.lookupMethod(classOf[ScalarFunctions], "concat", classOf[Array[String]])
   val CONCAT_WS =
     Types.lookupMethod(
       classOf[ScalarFunctions], "concat_ws", classOf[String], classOf[Array[String]])
+  val LPAD = Types.lookupMethod(
+    classOf[ScalarFunctions],
+    "lpad",
+    classOf[String],
+    classOf[Integer],
+    classOf[String])
+  val RPAD = Types.lookupMethod(
+    classOf[ScalarFunctions],
+    "rpad",
+    classOf[String],
+    classOf[Integer],
+    classOf[String])
 
   val BIN = Types.lookupMethod(classOf[JLong], "toBinaryString", classOf[Long])
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
@@ -90,10 +90,12 @@ object BuiltInMethods {
   val ROUND_LONG = Types.lookupMethod(classOf[SqlFunctions], "sround", classOf[Long], classOf[Int])
   val ROUND_DEC = Types.lookupMethod(classOf[SqlFunctions], "sround", classOf[JBigDecimal],
     classOf[Int])
+
   val CONCAT = Types.lookupMethod(classOf[ScalarFunctions], "concat", classOf[Array[String]])
   val CONCAT_WS =
     Types.lookupMethod(
       classOf[ScalarFunctions], "concat_ws", classOf[String], classOf[Array[String]])
+
   val LPAD = Types.lookupMethod(
     classOf[ScalarFunctions],
     "lpad",

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -512,6 +512,17 @@ object FunctionGenerator {
     Seq(SqlTimeTypeInfo.TIMESTAMP, STRING_TYPE_INFO),
     new DateFormatCallGen
   )
+  addSqlFunctionMethod(
+    ScalarSqlFunctions.LPAD,
+    Seq(STRING_TYPE_INFO, INT_TYPE_INFO, STRING_TYPE_INFO),
+    STRING_TYPE_INFO,
+    BuiltInMethods.LPAD)
+
+  addSqlFunctionMethod(
+    ScalarSqlFunctions.RPAD,
+    Seq(STRING_TYPE_INFO, INT_TYPE_INFO, STRING_TYPE_INFO),
+    STRING_TYPE_INFO,
+    BuiltInMethods.RPAD)
 
   // ----------------------------------------------------------------------------------------------
   // Cryptographic Hash functions

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
@@ -67,6 +67,24 @@ object ScalarSqlFunctions {
       OperandTypes.family(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC)),
     SqlFunctionCategory.NUMERIC)
 
+  val LPAD = new SqlFunction(
+    "LPAD",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.cascade(
+      ReturnTypes.explicit(SqlTypeName.VARCHAR), SqlTypeTransforms.FORCE_NULLABLE),
+    null,
+    OperandTypes.family(SqlTypeFamily.CHARACTER, SqlTypeFamily.INTEGER, SqlTypeFamily.CHARACTER),
+    SqlFunctionCategory.STRING)
+
+  val RPAD = new SqlFunction(
+    "RPAD",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.cascade(
+      ReturnTypes.explicit(SqlTypeName.VARCHAR), SqlTypeTransforms.FORCE_NULLABLE),
+    null,
+    OperandTypes.family(SqlTypeFamily.CHARACTER, SqlTypeFamily.INTEGER, SqlTypeFamily.CHARACTER),
+    SqlFunctionCategory.STRING)
+
   val MD5 = new SqlFunction(
     "MD5",
     SqlKind.OTHER_FUNCTION,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
@@ -113,7 +113,7 @@ object ScalarFunctions {
     * If str is longer than len, the return value is shortened to len characters.
     */
   def lpad(base: String, len: Integer, pad: String): String = {
-    if (base == null || len == null || pad == null || len < 0) {
+    if (len < 0) {
       return null
     }
     var data = "".toCharArray
@@ -153,7 +153,7 @@ object ScalarFunctions {
     * If str is longer than len, the return value is shortened to len characters.
     */
   def rpad(base: String, len: Integer, pad: String): String = {
-    if (base == null || len == null || pad == null || len < 0) {
+    if (len < 0) {
       return null
     }
     var data = "".toCharArray

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
@@ -89,8 +89,7 @@ object ScalarFunctions {
   def log(x: Double): Double = {
     if (x <= 0.0) {
       throw new IllegalArgumentException(s"x of 'log(x)' must be > 0, but x = $x")
-    }
-    else {
+    } else {
       Math.log(x)
     }
   }
@@ -104,9 +103,84 @@ object ScalarFunctions {
     }
     if (base <= 1.0) {
       throw new IllegalArgumentException(s"base of 'log(base, x)' must be > 1, but base = $base")
-    }
-    else {
+    } else {
       Math.log(x) / Math.log(base)
     }
+  }
+
+  /**
+    * Returns the string str, left-padded with the string pad to a length of len characters.
+    * If str is longer than len, the return value is shortened to len characters.
+    */
+  def lpad(base: String, len: Integer, pad: String): String = {
+    if (base == null || len == null || pad == null || len < 0) {
+      return null
+    }
+    var data = "".toCharArray
+    if (data.length < len) {
+      data = new Array[Char](len)
+    }
+    val baseChars = base.toCharArray
+    val padChars = pad.toCharArray
+
+    // The length of the padding needed
+    val pos = Math.max(len - base.length, 0)
+
+    // Copy the padding
+    var i = 0
+    while (i < pos) {
+      {
+        var j = 0
+        while (j < pad.length && j < pos - i) {
+          data(i + j) = padChars(j)
+          j += 1
+        }
+      }
+      i += pad.length
+    }
+
+    // Copy the base
+    i = 0
+    while (pos + i < len && i < base.length) {
+      data(pos + i) = baseChars(i)
+      i += 1
+    }
+    new String(data)
+  }
+
+  /**
+    * Returns the string str, right-padded with the string pad to a length of len characters.
+    * If str is longer than len, the return value is shortened to len characters.
+    */
+  def rpad(base: String, len: Integer, pad: String): String = {
+    if (base == null || len == null || pad == null || len < 0) {
+      return null
+    }
+    var data = "".toCharArray
+    if (data.length < len) {
+      data = new Array[Char](len)
+    }
+    val baseChars = base.toCharArray
+    val padChars = pad.toCharArray
+
+    var pos = 0
+
+    // Copy the base
+    while (pos < base.length && pos < len) {
+      data(pos) = baseChars(pos)
+      pos += 1
+    }
+
+    // Copy the padding
+    while (pos < len) {
+      var i = 0
+      while (i < pad.length && i < len - pos) {
+        data(pos + i) = padChars(i)
+        i += 1
+      }
+      pos += pad.length
+    }
+
+    new String(data)
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -27,6 +27,7 @@ import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.sql.ScalarSqlFunctions
 import org.apache.flink.table.functions.utils.{AggSqlFunction, ScalarSqlFunction, TableSqlFunction}
 import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableFunction}
+
 import _root_.scala.collection.JavaConversions._
 import _root_.scala.collection.mutable
 import _root_.scala.util.{Failure, Success, Try}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -27,7 +27,6 @@ import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.sql.ScalarSqlFunctions
 import org.apache.flink.table.functions.utils.{AggSqlFunction, ScalarSqlFunction, TableSqlFunction}
 import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableFunction}
-
 import _root_.scala.collection.JavaConversions._
 import _root_.scala.collection.mutable
 import _root_.scala.util.{Failure, Success, Try}
@@ -420,9 +419,12 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     ScalarSqlFunctions.BIN,
     SqlStdOperatorTable.TIMESTAMP_ADD,
     ScalarSqlFunctions.LOG,
+    ScalarSqlFunctions.LPAD,
+    ScalarSqlFunctions.RPAD,
     ScalarSqlFunctions.MD5,
     ScalarSqlFunctions.SHA1,
     ScalarSqlFunctions.SHA256,
+
     // EXTENSIONS
     BasicOperatorTable.TUMBLE,
     BasicOperatorTable.HOP,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -353,6 +353,31 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   }
 
   @Test
+  def testLPad(): Unit = {
+    testSqlApi("LPAD('hi',4,'??')", "??hi")
+    testSqlApi("LPAD('hi',1,'??')", "h")
+    testSqlApi("LPAD('',1,'??')", "?")
+    testSqlApi("LPAD('',30,'??')", "??????????????????????????????")
+    testSqlApi("LPAD('111',-2,'??')", "null")
+    testSqlApi("LPAD(f33,1,'??')", "null")
+    testSqlApi("LPAD('\u0061\u0062',1,'??')", "a") // the unicode of ab is \u0061\u0062
+    testSqlApi("LPAD('⎨⎨',1,'??')", "⎨")
+
+  }
+
+  @Test
+  def testRPad(): Unit = {
+    testSqlApi("RPAD('hi',4,'??')", "hi??")
+    testSqlApi("RPAD('hi',1,'??')", "h")
+    testSqlApi("RPAD('',1,'??')", "?")
+    testSqlApi("RPAD('1',30,'??')", "1?????????????????????????????")
+    testSqlApi("RPAD('111',-2,'??')", "null")
+    testSqlApi("RPAD(f33,1,'??')", "null")
+    testSqlApi("RPAD('\u0061\u0062',1,'??')", "a") // the unicode of ab is \u0061\u0062
+    testSqlApi("RPAD('üö',1,'??')", "ü")
+  }
+
+  @Test
   def testBin(): Unit = {
 
     testAllApis(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
@@ -97,6 +97,17 @@ class ScalarFunctionsValidationTest extends ScalarTypesTestBase {
     testSqlApi("TIMESTAMPADD(YEAR, 1.0, timestamp '2016-02-24 12:42:25')", "2016-06-16")
   }
 
+  @Test(expected = classOf[ValidationException])
+  def testLpadWithNull(): Unit = {
+    // Must fail. Parameter of base string must not be null.
+    testSqlApi("LPAD(null,1,'??')", "")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testRpadWithNull(): Unit = {
+    // Must fail. Parameter of base string must not be null.
+    testSqlApi("RPAD(null,1,'??')", "")
+  }
   // ----------------------------------------------------------------------------------------------
   // Sub-query functions
   // ----------------------------------------------------------------------------------------------
@@ -128,3 +139,4 @@ class ScalarFunctionsValidationTest extends ScalarTypesTestBase {
     )
   }
 }
+

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarFunctionsValidationTest.scala
@@ -97,17 +97,6 @@ class ScalarFunctionsValidationTest extends ScalarTypesTestBase {
     testSqlApi("TIMESTAMPADD(YEAR, 1.0, timestamp '2016-02-24 12:42:25')", "2016-06-16")
   }
 
-  @Test(expected = classOf[ValidationException])
-  def testLpadWithNull(): Unit = {
-    // Must fail. Parameter of base string must not be null.
-    testSqlApi("LPAD(null,1,'??')", "")
-  }
-
-  @Test(expected = classOf[ValidationException])
-  def testRpadWithNull(): Unit = {
-    // Must fail. Parameter of base string must not be null.
-    testSqlApi("RPAD(null,1,'??')", "")
-  }
   // ----------------------------------------------------------------------------------------------
   // Sub-query functions
   // ----------------------------------------------------------------------------------------------
@@ -139,4 +128,3 @@ class ScalarFunctionsValidationTest extends ScalarTypesTestBase {
     )
   }
 }
-


### PR DESCRIPTION
In this PR. have Add L/RPAD supported in SQL,For Example:
```
LPAD('hi',4,'??') -> '??hi'
LPAD('hi',1,'??') -> 'h'
RPAD('hi',4,'') -> 'hi'
RPAD('hi',1,'??') -> 'h'
```
- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
