### PR TITLE
[FLINK-6773] [checkpoint] Introduce compression (snappy) for keyed st…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -18,12 +18,13 @@
 
 package org.apache.flink.api.common;
 
-import com.esotericsoftware.kryo.Serializer;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.TaskManagerOptions;
+
+import com.esotericsoftware.kryo.Serializer;
 
 import java.io.Serializable;
 import java.util.Collections;
@@ -145,6 +146,9 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	 * TaskManager error, usually killing the JVM.
 	 */
 	private long taskCancellationTimeoutMillis = -1;
+
+	/** This flag defines if we use compression for the state snapshot data or not. Default: false */
+	private boolean useSnapshotCompression = false;
 
 	// ------------------------------- User code values --------------------------------------------
 
@@ -840,6 +844,14 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 		this.autoTypeRegistrationEnabled = false;
 	}
 
+	public boolean isUseSnapshotCompression() {
+		return useSnapshotCompression;
+	}
+
+	public void setUseSnapshotCompression(boolean useSnapshotCompression) {
+		this.useSnapshotCompression = useSnapshotCompression;
+	}
+
 	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof ExecutionConfig) {
@@ -864,7 +876,8 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 				defaultKryoSerializerClasses.equals(other.defaultKryoSerializerClasses) &&
 				registeredKryoTypes.equals(other.registeredKryoTypes) &&
 				registeredPojoTypes.equals(other.registeredPojoTypes) &&
-				taskCancellationIntervalMillis == other.taskCancellationIntervalMillis;
+				taskCancellationIntervalMillis == other.taskCancellationIntervalMillis &&
+				useSnapshotCompression == other.useSnapshotCompression;
 
 		} else {
 			return false;
@@ -891,7 +904,8 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 			defaultKryoSerializerClasses,
 			registeredKryoTypes,
 			registeredPojoTypes,
-			taskCancellationIntervalMillis);
+			taskCancellationIntervalMillis,
+			useSnapshotCompression);
 	}
 
 	public boolean canEqual(Object obj) {

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -144,6 +144,12 @@ under the License.
 			<artifactId>zookeeper</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.xerial.snappy</groupId>
+			<artifactId>snappy-java</artifactId>
+			<version>1.1.4</version>
+		</dependency>
+
 		<!--
 		The KryoSerializer dynamically loads Kryo instances via Chill and requires that Chill
 		is in the classpath. Because we do not want to have transitive Scala dependencies

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedBackendStateMetaInfoSnapshotReaderWriters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedBackendStateMetaInfoSnapshotReaderWriters.java
@@ -51,6 +51,7 @@ public class KeyedBackendStateMetaInfoSnapshotReaderWriters {
 			case 2:
 				return new KeyedBackendStateMetaInfoWriterV1V2<>(stateMetaInfo);
 
+			case 3:
 			// current version
 			case KeyedBackendSerializationProxy.VERSION:
 				return new KeyedBackendStateMetaInfoWriterV3<>(stateMetaInfo);
@@ -130,6 +131,7 @@ public class KeyedBackendStateMetaInfoSnapshotReaderWriters {
 				return new KeyedBackendStateMetaInfoReaderV1V2<>(userCodeClassLoader);
 
 			// current version
+			case 3:
 			case KeyedBackendSerializationProxy.VERSION:
 				return new KeyedBackendStateMetaInfoReaderV3<>(userCodeClassLoader);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnappyStreamCompressionDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnappyStreamCompressionDecorator.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.util.NonClosingInputStreamDecorator;
+import org.apache.flink.runtime.util.NonClosingOutpusStreamDecorator;
+
+import org.xerial.snappy.SnappyFramedInputStream;
+import org.xerial.snappy.SnappyFramedOutputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * This implementation decorates the stream with snappy compression.
+ */
+@Internal
+public class SnappyStreamCompressionDecorator extends StreamCompressionDecorator {
+
+	public static final StreamCompressionDecorator INSTANCE = new SnappyStreamCompressionDecorator();
+
+	private static final long serialVersionUID = 1L;
+
+	private static final int COMPRESSION_BLOCK_SIZE = 64 * 1024;
+	private static final double MIN_COMPRESSION_RATIO = 0.85d;
+
+	@Override
+	protected OutputStream decorateWithCompression(NonClosingOutpusStreamDecorator stream) throws IOException {
+		return new SnappyFramedOutputStream(stream, COMPRESSION_BLOCK_SIZE, MIN_COMPRESSION_RATIO);
+	}
+
+	@Override
+	protected InputStream decorateWithCompression(NonClosingInputStreamDecorator stream) throws IOException {
+		return new SnappyFramedInputStream(stream, false);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StatePartitionStreamProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StatePartitionStreamProvider.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.runtime.util.NonClosingStreamDecorator;
+import org.apache.flink.runtime.util.NonClosingInputStreamDecorator;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
@@ -45,7 +45,7 @@ public class StatePartitionStreamProvider {
 	}
 
 	public StatePartitionStreamProvider(InputStream stream) {
-		this.stream = new NonClosingStreamDecorator(Preconditions.checkNotNull(stream));
+		this.stream = new NonClosingInputStreamDecorator(Preconditions.checkNotNull(stream));
 		this.creationException = null;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StreamCompressionDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StreamCompressionDecorator.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.util.NonClosingInputStreamDecorator;
+import org.apache.flink.runtime.util.NonClosingOutpusStreamDecorator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+
+/**
+ * Implementations of this interface decorate streams with a compression scheme. Subclasses should be stateless.
+ */
+@Internal
+public abstract class StreamCompressionDecorator implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Decorates the stream by wrapping it into a stream that applies a compression.
+	 *
+	 * IMPORTANT: For streams returned by this method, {@link OutputStream#close()} is not propagated to the inner
+	 * stream. The inner stream must be closed separately.
+	 *
+	 * @param stream the stream to decorate.
+	 * @return an output stream that is decorated by the compression scheme.
+	 */
+	public final OutputStream decorateWithCompression(OutputStream stream) throws IOException {
+		return decorateWithCompression(new NonClosingOutpusStreamDecorator(stream));
+	}
+
+	/**
+	 * IMPORTANT: For streams returned by this method, {@link InputStream#close()} is not propagated to the inner
+	 * stream. The inner stream must be closed separately.
+	 *
+	 * @param stream the stream to decorate.
+	 * @return an input stream that is decorated by the compression scheme.
+	 */
+	public final InputStream decorateWithCompression(InputStream stream) throws IOException {
+		return decorateWithCompression(new NonClosingInputStreamDecorator(stream));
+	}
+
+	/**
+	 * @param stream the stream to decorate
+	 * @return an output stream that is decorated by the compression scheme.
+	 */
+	protected abstract OutputStream decorateWithCompression(NonClosingOutpusStreamDecorator stream) throws IOException;
+
+	/**
+	 * @param stream the stream to decorate.
+	 * @return an input stream that is decorated by the compression scheme.
+	 */
+	protected abstract InputStream decorateWithCompression(NonClosingInputStreamDecorator stream) throws IOException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/UncompressedStreamCompressionDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/UncompressedStreamCompressionDecorator.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.util.NonClosingInputStreamDecorator;
+import org.apache.flink.runtime.util.NonClosingOutpusStreamDecorator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * This implementation does not decorate the stream with any compression.
+ */
+@Internal
+public class UncompressedStreamCompressionDecorator extends StreamCompressionDecorator {
+
+	public static final StreamCompressionDecorator INSTANCE = new UncompressedStreamCompressionDecorator();
+
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	protected OutputStream decorateWithCompression(NonClosingOutpusStreamDecorator stream) throws IOException {
+		return stream;
+	}
+
+	@Override
+	protected InputStream decorateWithCompression(NonClosingInputStreamDecorator stream) throws IOException {
+		return stream;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTableByKeyGroupReaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTableByKeyGroupReaders.java
@@ -48,6 +48,7 @@ class StateTableByKeyGroupReaders {
 				return new StateTableByKeyGroupReaderV1<>(table);
 			case 2:
 			case 3:
+			case 4:
 				return new StateTableByKeyGroupReaderV2V3<>(table);
 			default:
 				throw new IllegalArgumentException("Unknown version: " + version);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ForwardingInputStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ForwardingInputStream.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Input stream, that wraps another input stream and forwards all method calls to the wrapped stream.
+ */
+@Internal
+public class ForwardingInputStream extends InputStream {
+
+	private final InputStream delegate;
+
+	public ForwardingInputStream(InputStream delegate) {
+		this.delegate = Preconditions.checkNotNull(delegate);
+	}
+
+	@Override
+	public int read() throws IOException {
+		return delegate.read();
+	}
+
+	@Override
+	public int read(byte[] b) throws IOException {
+		return delegate.read(b);
+	}
+
+	@Override
+	public int read(byte[] b, int off, int len) throws IOException {
+		return delegate.read(b, off, len);
+	}
+
+	@Override
+	public long skip(long n) throws IOException {
+		return delegate.skip(n);
+	}
+
+	@Override
+	public int available() throws IOException {
+		return delegate.available();
+	}
+
+	@Override
+	public void close() throws IOException {
+		delegate.close();
+	}
+
+	@Override
+	public void mark(int readlimit) {
+		delegate.mark(readlimit);
+	}
+
+	@Override
+	public void reset() throws IOException {
+		delegate.reset();
+	}
+
+	@Override
+	public boolean markSupported() {
+		return delegate.markSupported();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ForwardingOutputStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ForwardingOutputStream.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Output stream, that wraps another input stream and forwards all method calls to the wrapped stream.
+ */
+@Internal
+public class ForwardingOutputStream extends OutputStream {
+
+	private final OutputStream delegate;
+
+	public ForwardingOutputStream(OutputStream delegate) {
+		this.delegate = Preconditions.checkNotNull(delegate);
+	}
+
+	@Override
+	public void write(int b) throws IOException {
+		delegate.write(b);
+	}
+
+	@Override
+	public void write(byte[] b) throws IOException {
+		delegate.write(b);
+	}
+
+	@Override
+	public void write(byte[] b, int off, int len) throws IOException {
+		delegate.write(b, off, len);
+	}
+
+	@Override
+	public void flush() throws IOException {
+		delegate.flush();
+	}
+
+	@Override
+	public void close() throws IOException {
+		delegate.close();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/NonClosingInputStreamDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/NonClosingInputStreamDecorator.java
@@ -18,62 +18,23 @@
 
 package org.apache.flink.runtime.util;
 
+import org.apache.flink.annotation.Internal;
+
 import java.io.IOException;
 import java.io.InputStream;
 
 /**
  * Decorator for input streams that ignores calls to {@link InputStream#close()}.
  */
-public class NonClosingStreamDecorator extends InputStream {
+@Internal
+public class NonClosingInputStreamDecorator extends ForwardingInputStream {
 
-	private final InputStream delegate;
-
-	public NonClosingStreamDecorator(InputStream delegate) {
-		this.delegate = delegate;
-	}
-
-	@Override
-	public int read() throws IOException {
-		return delegate.read();
-	}
-
-	@Override
-	public int read(byte[] b) throws IOException {
-		return delegate.read(b);
-	}
-
-	@Override
-	public int read(byte[] b, int off, int len) throws IOException {
-		return delegate.read(b, off, len);
-	}
-
-	@Override
-	public long skip(long n) throws IOException {
-		return delegate.skip(n);
-	}
-
-	@Override
-	public int available() throws IOException {
-		return super.available();
+	public NonClosingInputStreamDecorator(InputStream delegate) {
+		super(delegate);
 	}
 
 	@Override
 	public void close() throws IOException {
 		// ignore
-	}
-
-	@Override
-	public void mark(int readlimit) {
-		super.mark(readlimit);
-	}
-
-	@Override
-	public void reset() throws IOException {
-		super.reset();
-	}
-
-	@Override
-	public boolean markSupported() {
-		return super.markSupported();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/NonClosingOutpusStreamDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/NonClosingOutpusStreamDecorator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Decorator for input streams that ignores calls to {@link OutputStream#close()}.
+ */
+@Internal
+public class NonClosingOutpusStreamDecorator extends ForwardingOutputStream {
+
+
+	public NonClosingOutpusStreamDecorator(OutputStream delegate) {
+		super(delegate);
+	}
+
+	@Override
+	public void close() throws IOException {
+		// ignore
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SerializationProxiesTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,7 +65,7 @@ public class SerializationProxiesTest {
 			StateDescriptor.Type.VALUE, "c", namespaceSerializer, stateSerializer).snapshot());
 
 		KeyedBackendSerializationProxy<?> serializationProxy =
-				new KeyedBackendSerializationProxy<>(keySerializer, stateMetaInfoList);
+				new KeyedBackendSerializationProxy<>(keySerializer, stateMetaInfoList, true);
 
 		byte[] serialized;
 		try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
@@ -79,6 +80,7 @@ public class SerializationProxiesTest {
 			serializationProxy.read(new DataInputViewStreamWrapper(in));
 		}
 
+		Assert.assertEquals(true, serializationProxy.isUsingKeyGroupCompression());
 		Assert.assertEquals(keySerializer, serializationProxy.getKeySerializer());
 		Assert.assertEquals(keySerializer.snapshotConfiguration(), serializationProxy.getKeySerializerConfigSnapshot());
 		Assert.assertEquals(stateMetaInfoList, serializationProxy.getStateMetaInfoSnapshots());
@@ -101,7 +103,7 @@ public class SerializationProxiesTest {
 			StateDescriptor.Type.VALUE, "c", namespaceSerializer, stateSerializer).snapshot());
 
 		KeyedBackendSerializationProxy<?> serializationProxy =
-			new KeyedBackendSerializationProxy<>(keySerializer, stateMetaInfoList);
+			new KeyedBackendSerializationProxy<>(keySerializer, stateMetaInfoList, true);
 
 		byte[] serialized;
 		try (ByteArrayOutputStreamWithPos out = new ByteArrayOutputStreamWithPos()) {
@@ -122,6 +124,7 @@ public class SerializationProxiesTest {
 			serializationProxy.read(new DataInputViewStreamWrapper(in));
 		}
 
+		Assert.assertEquals(true, serializationProxy.isUsingKeyGroupCompression());
 		Assert.assertEquals(null, serializationProxy.getKeySerializer());
 		Assert.assertEquals(keySerializer.snapshotConfiguration(), serializationProxy.getKeySerializerConfigSnapshot());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
+import org.apache.flink.runtime.state.heap.HeapReducingStateTest;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.RunnableFuture;
+
+import static org.mockito.Mockito.mock;
+
+public class StateSnapshotCompressionTest {
+
+	@Test
+	public void testCompressionConfiguration() throws Exception {
+
+		ExecutionConfig executionConfig = new ExecutionConfig();
+		executionConfig.setUseSnapshotCompression(true);
+
+		AbstractKeyedStateBackend<String> stateBackend = new HeapKeyedStateBackend<>(
+			mock(TaskKvStateRegistry.class),
+			StringSerializer.INSTANCE,
+			HeapReducingStateTest.class.getClassLoader(),
+			16,
+			new KeyGroupRange(0, 15),
+			true,
+			executionConfig);
+
+		try {
+			Assert.assertTrue(SnappyStreamCompressionDecorator.INSTANCE.equals(stateBackend.getKeyGroupCompressionDecorator()));
+
+		} finally {
+			IOUtils.closeQuietly(stateBackend);
+			stateBackend.dispose();
+		}
+
+		executionConfig = new ExecutionConfig();
+		executionConfig.setUseSnapshotCompression(false);
+
+		stateBackend = new HeapKeyedStateBackend<>(
+			mock(TaskKvStateRegistry.class),
+			StringSerializer.INSTANCE,
+			HeapReducingStateTest.class.getClassLoader(),
+			16,
+			new KeyGroupRange(0, 15),
+			true,
+			executionConfig);
+
+		try {
+			Assert.assertTrue(UncompressedStreamCompressionDecorator.INSTANCE.equals(stateBackend.getKeyGroupCompressionDecorator()));
+
+		} finally {
+			IOUtils.closeQuietly(stateBackend);
+			stateBackend.dispose();
+		}
+	}
+
+	@Test
+	public void snapshotRestoreRoundtripWithCompression() throws Exception {
+		snapshotRestoreRoundtrip(true);
+	}
+
+	@Test
+	public void snapshotRestoreRoundtripUncompressed() throws Exception {
+		snapshotRestoreRoundtrip(false);
+	}
+
+	private void snapshotRestoreRoundtrip(boolean useCompression) throws Exception {
+
+		ExecutionConfig executionConfig = new ExecutionConfig();
+		executionConfig.setUseSnapshotCompression(useCompression);
+
+		KeyedStateHandle stateHandle = null;
+
+		ValueStateDescriptor<String> stateDescriptor = new ValueStateDescriptor<>("test", String.class);
+		stateDescriptor.initializeSerializerUnlessSet(executionConfig);
+
+		AbstractKeyedStateBackend<String> stateBackend = new HeapKeyedStateBackend<>(
+			mock(TaskKvStateRegistry.class),
+			StringSerializer.INSTANCE,
+			HeapReducingStateTest.class.getClassLoader(),
+			16,
+			new KeyGroupRange(0, 15),
+			true,
+			executionConfig);
+
+		try {
+
+			InternalValueState<VoidNamespace, String> state =
+				stateBackend.createValueState(
+					new VoidNamespaceSerializer(),
+					stateDescriptor);
+
+			stateBackend.setCurrentKey("A");
+			state.setCurrentNamespace(VoidNamespace.INSTANCE);
+			state.update("42");
+			stateBackend.setCurrentKey("B");
+			state.setCurrentNamespace(VoidNamespace.INSTANCE);
+			state.update("43");
+			stateBackend.setCurrentKey("C");
+			state.setCurrentNamespace(VoidNamespace.INSTANCE);
+			state.update("44");
+			stateBackend.setCurrentKey("D");
+			state.setCurrentNamespace(VoidNamespace.INSTANCE);
+			state.update("45");
+			CheckpointStreamFactory streamFactory = new MemCheckpointStreamFactory(4 * 1024 * 1024);
+			RunnableFuture<KeyedStateHandle> snapshot = stateBackend.snapshot(0L, 0L, streamFactory, CheckpointOptions.forFullCheckpoint());
+			snapshot.run();
+			stateHandle = snapshot.get();
+
+		} finally {
+			IOUtils.closeQuietly(stateBackend);
+			stateBackend.dispose();
+		}
+
+		executionConfig = new ExecutionConfig();
+
+		stateBackend = new HeapKeyedStateBackend<>(
+			mock(TaskKvStateRegistry.class),
+			StringSerializer.INSTANCE,
+			HeapReducingStateTest.class.getClassLoader(),
+			16,
+			new KeyGroupRange(0, 15),
+			true,
+			executionConfig);
+		try {
+
+			stateBackend.restore(Collections.singletonList(stateHandle));
+
+			InternalValueState<VoidNamespace, String> state = stateBackend.createValueState(
+				new VoidNamespaceSerializer(),
+				stateDescriptor);
+
+			stateBackend.setCurrentKey("A");
+			state.setCurrentNamespace(VoidNamespace.INSTANCE);
+			Assert.assertEquals("42", state.value());
+			stateBackend.setCurrentKey("B");
+			state.setCurrentNamespace(VoidNamespace.INSTANCE);
+			Assert.assertEquals("43", state.value());
+			stateBackend.setCurrentKey("C");
+			state.setCurrentNamespace(VoidNamespace.INSTANCE);
+			Assert.assertEquals("44", state.value());
+			stateBackend.setCurrentKey("D");
+			state.setCurrentNamespace(VoidNamespace.INSTANCE);
+			Assert.assertEquals("45", state.value());
+
+		} finally {
+			IOUtils.closeQuietly(stateBackend);
+			stateBackend.dispose();
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
@@ -111,6 +111,7 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 		cluster.start();
 
 		env = new TestStreamEnvironment(cluster, PARALLELISM);
+		env.getConfig().setUseSnapshotCompression(true);
 	}
 
 	@AfterClass
@@ -318,6 +319,7 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 			env.setStateBackend(this.stateBackend);
+			env.getConfig().setUseSnapshotCompression(true);
 
 			env
 					.addSource(new FailingSource(NUM_KEYS, NUM_ELEMENTS_PER_KEY, NUM_ELEMENTS_PER_KEY / 3))

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.test.checkpointing;
 
-import io.netty.util.internal.ConcurrentSet;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
@@ -55,6 +54,8 @@ import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunctio
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
+
+import io.netty.util.internal.ConcurrentSet;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -62,11 +63,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import scala.Option;
-import scala.concurrent.Await;
-import scala.concurrent.Future;
-import scala.concurrent.duration.Deadline;
-import scala.concurrent.duration.FiniteDuration;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -77,6 +73,12 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import scala.Option;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Deadline;
+import scala.concurrent.duration.FiniteDuration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -679,6 +681,7 @@ public class RescalingITCase extends TestLogger {
 		}
 		env.enableCheckpointing(checkpointingInterval);
 		env.setRestartStrategy(RestartStrategies.noRestart());
+		env.getConfig().setUseSnapshotCompression(true);
 
 		DataStream<Integer> input = env.addSource(new SubtaskIndexSource(
 				numberKeys,


### PR DESCRIPTION
This PR introduce optional snappy compression for the keyed state in full checkpoints and savepoints. This feature can be activated through a flag in `ExecutionConfig`.

For the future, we can also support user-defined compression schemes, which will also require a upgrade and compatibility feature, as described in FLINK-6931.