### PR TITLE
[FLINK-6938][FLINK-6939] [cep] Not store IterativeCondition with NFA state and support RichFunction interface

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/ConditionRegistry.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/ConditionRegistry.java
@@ -101,9 +101,7 @@ public class ConditionRegistry implements Serializable {
 		}
 
 		TransitionInfo(StateTransition<?> transition) {
-			this.action = transition.getAction();
-			this.sourceStateName = transition.getSourceState().getName();
-			this.targetStateName = transition.getTargetState().getName();
+			update(transition);
 		}
 
 		void update(StateTransition<?> transition) {

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/ConditionRegistry.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/ConditionRegistry.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep.nfa;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.functions.util.FunctionUtils;
+import org.apache.flink.cep.pattern.conditions.IterativeCondition;
+import org.apache.flink.configuration.Configuration;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The {@link ConditionRegistry} is a registry to manage the mapping from a {@link StateTransition}
+ * to the {@link IterativeCondition}. A {@link StateTransition} is unique in a {@link NFA}, that's
+ * why we use {@link StateTransition} as the key.
+ */
+public class ConditionRegistry implements Serializable {
+	private static final long serialVersionUID = -4130291010425184830L;
+
+	private final Map<TransitionInfo, IterativeCondition<?>> registeredConditions;
+
+	private final TransitionInfo reuse = new TransitionInfo();
+
+	/**
+	 * Creates a new condition registry.
+	 */
+	public ConditionRegistry() {
+		this.registeredConditions = new HashMap<>();
+	}
+
+	/**
+	 * Registers an {@link IterativeCondition} for the {@link StateTransition}.
+	 * @param transition the state transition
+	 * @param condition the condition to register, maybe null
+	 */
+	public <T> void registerCondition(StateTransition<T> transition, IterativeCondition<T> condition) {
+		registeredConditions.put(new TransitionInfo(transition), condition);
+	}
+
+	/**
+	 * Gets the corresponding {@link IterativeCondition} with the given {@link StateTransition}.
+	 * @param transition the state transition
+	 * @return the corresponding {@link IterativeCondition}, maybe null.
+	 */
+	public <T> IterativeCondition<T> getCondition(StateTransition<T> transition) {
+		reuse.update(transition);
+		//noinspection unchecked
+		return (IterativeCondition<T>) registeredConditions.get(reuse);
+	}
+
+	/**
+	 * Opens every non-null conditions.
+	 */
+	public void open() throws Exception {
+		for (IterativeCondition<?> condition : registeredConditions.values()) {
+			if (condition != null) {
+				FunctionUtils.openFunction(condition, new Configuration());
+			}
+		}
+	}
+
+	/**
+	 * Sets the RuntimeContext for every non-null conditions.
+	 * @param context the runtime context
+	 */
+	public void setRuntimeContext(RuntimeContext context) {
+		for (IterativeCondition<?> condition : registeredConditions.values()) {
+			if (condition != null) {
+				FunctionUtils.setFunctionRuntimeContext(condition, context);
+			}
+		}
+	}
+
+	private static class TransitionInfo implements Serializable {
+		private static final long serialVersionUID = -6446693486080356589L;
+
+		private StateTransitionAction action;
+		private String sourceStateName;
+		private String targetStateName;
+
+		TransitionInfo(){
+		}
+
+		TransitionInfo(StateTransition<?> transition) {
+			this.action = transition.getAction();
+			this.sourceStateName = transition.getSourceState().getName();
+			this.targetStateName = transition.getTargetState().getName();
+		}
+
+		void update(StateTransition<?> transition) {
+			this.action = transition.getAction();
+			this.sourceStateName = transition.getSourceState().getName();
+			this.targetStateName = transition.getTargetState().getName();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj instanceof TransitionInfo) {
+				@SuppressWarnings("unchecked")
+				TransitionInfo other = (TransitionInfo) obj;
+
+				return action == other.action &&
+						sourceStateName.equals(other.sourceStateName) &&
+						targetStateName.equals(other.targetStateName);
+			} else {
+				return false;
+			}
+		}
+
+		@Override
+		public int hashCode() {
+			// we have to take the name of targetState because the transition might be reflexive
+			return Objects.hash(action, targetStateName, sourceStateName);
+		}
+	}
+}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/State.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/State.java
@@ -76,30 +76,57 @@ public class State<T> implements Serializable {
 	}
 
 	public void addStateTransition(
-			final StateTransitionAction action,
-			final State<T> targetState,
-			final IterativeCondition<T> condition) {
-		stateTransitions.add(new StateTransition<T>(this, action, targetState, condition));
+		final StateTransitionAction action,
+		final State<T> targetState,
+		final IterativeCondition<T> condition,
+		final ConditionRegistry conditionRegistry) {
+		StateTransition<T> transition = new StateTransition<>(this, action, targetState);
+		conditionRegistry.registerCondition(transition, condition);
+		stateTransitions.add(transition);
 	}
 
-	public void addIgnore(final IterativeCondition<T> condition) {
-		addStateTransition(StateTransitionAction.IGNORE, this, condition);
+	public void addStateTransition(
+		final StateTransitionAction action,
+		final State<T> targetState) {
+		StateTransition<T> transition = new StateTransition<>(this, action, targetState);
+		stateTransitions.add(transition);
 	}
 
-	public void addIgnore(final State<T> targetState, final IterativeCondition<T> condition) {
-		addStateTransition(StateTransitionAction.IGNORE, targetState, condition);
+	public void addIgnore(
+		final IterativeCondition<T> condition,
+		ConditionRegistry conditionRegistry) {
+		addStateTransition(StateTransitionAction.IGNORE, this, condition, conditionRegistry);
 	}
 
-	public void addTake(final State<T> targetState, final IterativeCondition<T> condition) {
-		addStateTransition(StateTransitionAction.TAKE, targetState, condition);
+	public void addIgnore(
+		final State<T> targetState,
+		final IterativeCondition<T> condition,
+		ConditionRegistry conditionRegistry) {
+		addStateTransition(StateTransitionAction.IGNORE, targetState, condition, conditionRegistry);
 	}
 
-	public void addProceed(final State<T> targetState, final IterativeCondition<T> condition) {
-		addStateTransition(StateTransitionAction.PROCEED, targetState, condition);
+	public void addTake(
+		final State<T> targetState,
+		final IterativeCondition<T> condition,
+		ConditionRegistry conditionRegistry) {
+		addStateTransition(StateTransitionAction.TAKE, targetState, condition, conditionRegistry);
 	}
 
-	public void addTake(final IterativeCondition<T> condition) {
-		addStateTransition(StateTransitionAction.TAKE, this, condition);
+	public void addProceed(
+		final State<T> targetState,
+		final IterativeCondition<T> condition,
+		ConditionRegistry conditionRegistry) {
+		addStateTransition(
+			StateTransitionAction.PROCEED,
+			targetState,
+			condition,
+			conditionRegistry);
+	}
+
+	public void addTake(
+		final IterativeCondition<T> condition,
+		ConditionRegistry conditionRegistry) {
+		addStateTransition(StateTransitionAction.TAKE, this, condition, conditionRegistry);
 	}
 
 	@Override
@@ -109,8 +136,8 @@ public class State<T> implements Serializable {
 			State<T> other = (State<T>) obj;
 
 			return name.equals(other.name) &&
-				stateType == other.stateType &&
-				stateTransitions.equals(other.stateTransitions);
+					stateType == other.stateType &&
+					stateTransitions.equals(other.stateTransitions);
 		} else {
 			return false;
 		}
@@ -121,7 +148,7 @@ public class State<T> implements Serializable {
 		StringBuilder builder = new StringBuilder();
 
 		builder.append(stateType).append(" State ").append(name).append(" [\n");
-		for (StateTransition<T> stateTransition: stateTransitions) {
+		for (StateTransition<T> stateTransition : stateTransitions) {
 			builder.append("\t").append(stateTransition).append(",\n");
 		}
 		builder.append("])");
@@ -160,7 +187,7 @@ public class State<T> implements Serializable {
 
 			this.stateTransitions.clear();
 			for (StateTransition<T> transition : tmp) {
-				addStateTransition(transition.getAction(), transition.getTargetState(), transition.getCondition());
+				addStateTransition(transition.getAction(), transition.getTargetState());
 			}
 		}
 	}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/StateTransition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/StateTransition.java
@@ -36,6 +36,12 @@ public class StateTransition<T> implements Serializable {
 	private final StateTransitionAction action;
 	private final State<T> sourceState;
 	private final State<T> targetState;
+
+	/**
+	 * @deprecated 	This field remains for backwards compatibility.
+	 * Now the condition is stored in {@link ConditionRegistry}.
+	 */
+	@Deprecated
 	private IterativeCondition<T> newCondition;
 
 	/**
@@ -48,12 +54,10 @@ public class StateTransition<T> implements Serializable {
 	public StateTransition(
 			final State<T> sourceState,
 			final StateTransitionAction action,
-			final State<T> targetState,
-			final IterativeCondition<T> condition) {
+			final State<T> targetState) {
 		this.action = action;
 		this.targetState = targetState;
 		this.sourceState = sourceState;
-		this.newCondition = condition;
 	}
 
 	public StateTransitionAction getAction() {
@@ -68,6 +72,15 @@ public class StateTransition<T> implements Serializable {
 		return sourceState;
 	}
 
+	public IterativeCondition<T> getCondition(ConditionRegistry conditionRegistry) {
+		return conditionRegistry.getCondition(this);
+	}
+
+	/**
+	 * @deprecated 	This field remains for backwards compatibility.
+	 * Now the condition getter should use {@link #getCondition(ConditionRegistry)}.
+	 */
+	@Deprecated
 	public IterativeCondition<T> getCondition() {
 		if (condition != null) {
 			this.newCondition = new FilterWrapper<>(condition);
@@ -98,13 +111,10 @@ public class StateTransition<T> implements Serializable {
 
 	@Override
 	public String toString() {
-		return new StringBuilder()
-				.append("StateTransition(")
-				.append(action).append(", ")
-				.append("from ").append(sourceState.getName())
-				.append("to ").append(targetState.getName())
-				.append(newCondition != null ? ", with condition)" : ")")
-				.toString();
+		return "StateTransition(" +
+				action + ", " +
+				"from " + sourceState.getName() +
+				" to " + targetState.getName();
 	}
 
 	/**

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/StateTransition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/StateTransition.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.cep.nfa;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.cep.pattern.conditions.IterativeCondition;
-import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -36,20 +34,6 @@ public class StateTransition<T> implements Serializable {
 	private final StateTransitionAction action;
 	private final State<T> sourceState;
 	private final State<T> targetState;
-
-	/**
-	 * @deprecated 	This field remains for backwards compatibility.
-	 * Now the condition is stored in {@link ConditionRegistry}.
-	 */
-	@Deprecated
-	private IterativeCondition<T> newCondition;
-
-	/**
-	 * @deprecated 	This field remains for backwards compatibility.
-	 * Now the conditions extend the {@link IterativeCondition}.
-	 */
-	@Deprecated
-	private FilterFunction<T> condition;
 
 	public StateTransition(
 			final State<T> sourceState,
@@ -74,19 +58,6 @@ public class StateTransition<T> implements Serializable {
 
 	public IterativeCondition<T> getCondition(ConditionRegistry conditionRegistry) {
 		return conditionRegistry.getCondition(this);
-	}
-
-	/**
-	 * @deprecated 	This field remains for backwards compatibility.
-	 * Now the condition getter should use {@link #getCondition(ConditionRegistry)}.
-	 */
-	@Deprecated
-	public IterativeCondition<T> getCondition() {
-		if (condition != null) {
-			this.newCondition = new FilterWrapper<>(condition);
-			this.condition = null;
-		}
-		return newCondition;
 	}
 
 	@Override
@@ -115,25 +86,5 @@ public class StateTransition<T> implements Serializable {
 				action + ", " +
 				"from " + sourceState.getName() +
 				" to " + targetState.getName();
-	}
-
-	/**
-	 * A wrapper to transform a {@link FilterFunction} into a {@link SimpleCondition}.
-	 * This is used only when migrating from an older Flink version.
-	 */
-	private static class FilterWrapper<T> extends SimpleCondition<T> {
-
-		private static final long serialVersionUID = -4973016745698940430L;
-
-		private final FilterFunction<T> filterFunction;
-
-		FilterWrapper(FilterFunction<T> filterFunction) {
-			this.filterFunction = filterFunction;
-		}
-
-		@Override
-		public boolean filter(T value) throws Exception {
-			return filterFunction.filter(value);
-		}
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
@@ -643,10 +643,10 @@ public class NFACompiler {
 
 			newSecond = new State<T>(oldSecondToThirdTake.getTargetState().getName(), State.StateType.Normal);
 			convertedStates.put(newSecond.getName(), newSecond);
-			newFirst.addTake(newSecond, oldFirstToSecondTake.getCondition(), conditionRegistry);
+			newFirst.addTake(newSecond, null, conditionRegistry);
 
 			if (oldFirstIgnore != null) {
-				newFirst.addIgnore(oldFirstIgnore.getCondition(), conditionRegistry);
+				newFirst.addIgnore(null, conditionRegistry);
 			}
 
 			oldFirst = oldSecond;
@@ -688,10 +688,10 @@ public class NFACompiler {
 
 		final State<T> endingState = new State<>(ENDING_STATE_NAME, State.StateType.Final);
 
-		newFirst.addTake(endingState, oldFirstToSecondTake.getCondition(), conditionRegistry);
+		newFirst.addTake(endingState, null, conditionRegistry);
 
 		if (oldFirstIgnore != null) {
-			newFirst.addIgnore(oldFirstIgnore.getCondition(), conditionRegistry);
+			newFirst.addIgnore(null, conditionRegistry);
 		}
 
 		convertedStates.put(endingState.getName(), endingState);
@@ -706,6 +706,7 @@ public class NFACompiler {
 	 */
 	public interface NFAFactory<T> extends Serializable {
 		NFA<T> createNFA();
+		ConditionRegistry getConditionRegistry();
 	}
 
 	/**
@@ -747,6 +748,11 @@ public class NFACompiler {
 			result.addStates(states);
 
 			return result;
+		}
+
+		@Override
+		public ConditionRegistry getConditionRegistry() {
+			return conditionRegistry;
 		}
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
@@ -129,7 +129,7 @@ public abstract class AbstractKeyedCEPPatternOperator<IN, KEY, OUT>
 		this.isProcessingTime = Preconditions.checkNotNull(isProcessingTime);
 		this.keySerializer = Preconditions.checkNotNull(keySerializer);
 		this.nfaFactory = Preconditions.checkNotNull(nfaFactory);
-		this.conditionRegistry = nfaFactory.createNFA().getConditionRegistry();
+		this.conditionRegistry = nfaFactory.getConditionRegistry();
 
 		this.migratingFromOldKeyedOperator = migratingFromOldKeyedOperator;
 	}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/AndCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/AndCondition.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.functions.util.FunctionUtils;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -26,7 +29,7 @@ import org.apache.flink.util.Preconditions;
  *
  * @param <T> Type of the element to filter
  */
-public class AndCondition<T> extends IterativeCondition<T> {
+public class AndCondition<T> extends RichIterativeCondition<T> {
 
 	private static final long serialVersionUID = -2471892317390197319L;
 
@@ -36,6 +39,27 @@ public class AndCondition<T> extends IterativeCondition<T> {
 	public AndCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
 		this.left = Preconditions.checkNotNull(left, "The condition cannot be null.");
 		this.right = Preconditions.checkNotNull(right, "The condition cannot be null.");
+	}
+
+	@Override
+	public void setRuntimeContext(RuntimeContext t) {
+		super.setRuntimeContext(t);
+		FunctionUtils.setFunctionRuntimeContext(left, t);
+		FunctionUtils.setFunctionRuntimeContext(right, t);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+		FunctionUtils.openFunction(left, parameters);
+		FunctionUtils.openFunction(right, parameters);
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		FunctionUtils.closeFunction(left);
+		FunctionUtils.closeFunction(right);
 	}
 
 	@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/NotCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/NotCondition.java
@@ -18,19 +18,47 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.functions.util.FunctionUtils;
+import org.apache.flink.configuration.Configuration;
+
 /**
  * A {@link IterativeCondition condition} which negates the condition it wraps
  * and returns {@code true} if the original condition returns {@code false}.
  *
  * @param <T> Type of the element to filter
  */
-public class NotCondition<T> extends IterativeCondition<T> {
+public class NotCondition<T> extends RichIterativeCondition<T> {
 	private static final long serialVersionUID = -2109562093871155005L;
 
 	private final IterativeCondition<T> original;
 
 	public NotCondition(final IterativeCondition<T> original) {
 		this.original = original;
+	}
+
+	@Override
+	public void setRuntimeContext(RuntimeContext t) {
+		super.setRuntimeContext(t);
+		if (original != null) {
+			FunctionUtils.setFunctionRuntimeContext(original, t);
+		}
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+		if (original != null) {
+			FunctionUtils.openFunction(original, parameters);
+		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		if (original != null) {
+			FunctionUtils.closeFunction(original);
+		}
 	}
 
 	@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/OrCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/OrCondition.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.cep.pattern.conditions;
 
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.functions.util.FunctionUtils;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -26,7 +29,7 @@ import org.apache.flink.util.Preconditions;
  *
  * @param <T> Type of the element to filter
  */
-public class OrCondition<T> extends IterativeCondition<T> {
+public class OrCondition<T> extends RichIterativeCondition<T> {
 
 	private static final long serialVersionUID = 2554610954278485106L;
 
@@ -36,6 +39,27 @@ public class OrCondition<T> extends IterativeCondition<T> {
 	public OrCondition(final IterativeCondition<T> left, final IterativeCondition<T> right) {
 		this.left = Preconditions.checkNotNull(left, "The condition cannot be null.");
 		this.right = Preconditions.checkNotNull(right, "The condition cannot be null.");
+	}
+
+	@Override
+	public void setRuntimeContext(RuntimeContext t) {
+		super.setRuntimeContext(t);
+		FunctionUtils.setFunctionRuntimeContext(left, t);
+		FunctionUtils.setFunctionRuntimeContext(right, t);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+		FunctionUtils.openFunction(left, parameters);
+		FunctionUtils.openFunction(right, parameters);
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		FunctionUtils.closeFunction(left);
+		FunctionUtils.closeFunction(right);
 	}
 
 	@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichIterativeCondition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/pattern/conditions/RichIterativeCondition.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cep.pattern.conditions;
+
+import org.apache.flink.api.common.functions.IterationRuntimeContext;
+import org.apache.flink.api.common.functions.RichFunction;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Rich variant of the {@link IterativeCondition}. As a {@link RichFunction}, it gives access to the
+ * {@link org.apache.flink.api.common.functions.RuntimeContext} and provides setup and teardown methods:
+ * {@link RichFunction#open(org.apache.flink.configuration.Configuration)} and
+ * {@link RichFunction#close()}.
+ */
+public abstract class RichIterativeCondition<T>
+	extends IterativeCondition<T>
+	implements RichFunction {
+
+	private static final long serialVersionUID = -8877558011192469582L;
+
+
+	// --------------------------------------------------------------------------------------------
+	//  Runtime context access
+	// --------------------------------------------------------------------------------------------
+
+	private transient RuntimeContext runtimeContext;
+
+	@Override
+	public void setRuntimeContext(RuntimeContext t) {
+		this.runtimeContext = t;
+	}
+
+	@Override
+	public RuntimeContext getRuntimeContext() {
+		if (this.runtimeContext != null) {
+			return this.runtimeContext;
+		} else {
+			throw new IllegalStateException("The runtime context has not been initialized.");
+		}
+	}
+
+	@Override
+	public IterationRuntimeContext getIterationRuntimeContext() {
+		throw new UnsupportedOperationException("Not support to get the IterationRuntimeContext in IterativeCondition.");
+	}
+
+	// --------------------------------------------------------------------------------------------
+	//  Default life cycle methods
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public void open(Configuration parameters) throws Exception {}
+
+	@Override
+	public void close() throws Exception {}
+
+}

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
@@ -23,7 +23,9 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.pattern.Pattern;
+import org.apache.flink.cep.pattern.conditions.RichIterativeCondition;
 import org.apache.flink.cep.pattern.conditions.SimpleCondition;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -42,6 +44,8 @@ import org.junit.rules.TemporaryFolder;
 
 import java.util.List;
 import java.util.Map;
+
+import static org.junit.Assert.fail;
 
 /**
  * End to end tests of both CEP operators and {@link NFA}.
@@ -94,13 +98,7 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 			new Event(8, "end", 1.0)
 		);
 
-		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new SimpleCondition<Event>() {
-
-			@Override
-			public boolean filter(Event value) throws Exception {
-				return value.getName().equals("start");
-			}
-		})
+		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new NameCondition("start"))
 		.followedByAny("middle").subtype(SubEvent.class).where(
 				new SimpleCondition<SubEvent>() {
 
@@ -110,13 +108,7 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 					}
 				}
 			)
-		.followedByAny("end").where(new SimpleCondition<Event>() {
-
-			@Override
-			public boolean filter(Event value) throws Exception {
-				return value.getName().equals("end");
-			}
-		});
+		.followedByAny("end").where(new NameCondition("end"));
 
 		DataStream<String> result = CEP.pattern(input, pattern).select(new PatternSelectFunction<Event, String>() {
 
@@ -138,6 +130,29 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 		expected = "2,6,8";
 
 		env.execute();
+	}
+
+	private static class NameCondition extends RichIterativeCondition<Event> {
+
+		private final String matchName;
+		private boolean isOpen = false;
+
+		private NameCondition(String matchName) {
+			this.matchName = matchName;
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			isOpen = true;
+		}
+
+		@Override
+		public boolean filter(Event value, Context<Event> ctx) throws Exception {
+			if (!isOpen) {
+				fail("open() method is not called.");
+			}
+			return value.getName().equals(matchName);
+		}
 	}
 
 	@Test

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFATest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFATest.java
@@ -72,7 +72,8 @@ public class NFATest extends TestLogger {
 				public boolean filter(Event value) throws Exception {
 					return value.getName().equals("start");
 				}
-			});
+			},
+			nfa.getConditionRegistry());
 		endState.addTake(
 			endingState,
 			new SimpleCondition<Event>() {
@@ -82,8 +83,9 @@ public class NFATest extends TestLogger {
 				public boolean filter(Event value) throws Exception {
 					return value.getName().equals("end");
 				}
-			});
-		endState.addIgnore(BooleanConditions.<Event>trueFunction());
+			},
+			nfa.getConditionRegistry());
+		endState.addIgnore(BooleanConditions.<Event>trueFunction(), nfa.getConditionRegistry());
 
 		nfa.addState(startState);
 		nfa.addState(endState);
@@ -340,7 +342,8 @@ public class NFATest extends TestLogger {
 				public boolean filter(Event value) throws Exception {
 					return value.getName().equals("start");
 				}
-			});
+			},
+			nfa.getConditionRegistry());
 		endState.addTake(
 			endingState,
 			new SimpleCondition<Event>() {
@@ -350,8 +353,9 @@ public class NFATest extends TestLogger {
 				public boolean filter(Event value) throws Exception {
 					return value.getName().equals("end");
 				}
-			});
-		endState.addIgnore(BooleanConditions.<Event>trueFunction());
+			},
+			nfa.getConditionRegistry());
+		endState.addIgnore(BooleanConditions.<Event>trueFunction(), nfa.getConditionRegistry());
 
 		nfa.addState(startState);
 		nfa.addState(endState);

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigration11to13Test.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigration11to13Test.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.functions.NullByteKeySelector;
 import org.apache.flink.cep.Event;
 import org.apache.flink.cep.SubEvent;
+import org.apache.flink.cep.nfa.ConditionRegistry;
 import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.cep.pattern.Pattern;
@@ -349,6 +350,11 @@ public class CEPMigration11to13Test {
 					.within(Time.milliseconds(10L));
 
 			return NFACompiler.compile(pattern, Event.createTypeSerializer(), handleTimeout);
+		}
+
+		@Override
+		public ConditionRegistry getConditionRegistry() {
+			return createNFA().getConditionRegistry();
 		}
 	}
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigrationTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigrationTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.cep.Event;
 import org.apache.flink.cep.SubEvent;
+import org.apache.flink.cep.nfa.ConditionRegistry;
 import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.cep.pattern.Pattern;
@@ -573,6 +574,11 @@ public class CEPMigrationTest {
 
 			return NFACompiler.compile(pattern, Event.createTypeSerializer(), handleTimeout);
 		}
+
+		@Override
+		public ConditionRegistry getConditionRegistry() {
+			return createNFA().getConditionRegistry();
+		}
 	}
 
 	private static class NFAFactory implements NFACompiler.NFAFactory<Event> {
@@ -603,6 +609,11 @@ public class CEPMigrationTest {
 					.within(Time.milliseconds(10L));
 
 			return NFACompiler.compile(pattern, Event.createTypeSerializer(), handleTimeout);
+		}
+
+		@Override
+		public ConditionRegistry getConditionRegistry() {
+			return createNFA().getConditionRegistry();
 		}
 	}
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.cep.Event;
 import org.apache.flink.cep.SubEvent;
+import org.apache.flink.cep.nfa.ConditionRegistry;
 import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.cep.pattern.Pattern;
@@ -635,6 +636,11 @@ public class CEPOperatorTest extends TestLogger {
 					public NFA<Event> createNFA() {
 						return NFACompiler.compile(pattern, Event.createTypeSerializer(), false);
 					}
+
+					@Override
+					public ConditionRegistry getConditionRegistry() {
+						return createNFA().getConditionRegistry();
+					}
 				},
 				true);
 
@@ -848,6 +854,11 @@ public class CEPOperatorTest extends TestLogger {
 
 			return NFACompiler.compile(pattern, Event.createTypeSerializer(), handleTimeout);
 		}
+
+		@Override
+		public ConditionRegistry getConditionRegistry() {
+			return createNFA().getConditionRegistry();
+		}
 	}
 
 	private static class ComplexNFAFactory implements NFACompiler.NFAFactory<Event> {
@@ -898,6 +909,11 @@ public class CEPOperatorTest extends TestLogger {
 			}).within(Time.milliseconds(10L));
 
 			return NFACompiler.compile(pattern, Event.createTypeSerializer(), handleTimeout);
+		}
+
+		@Override
+		public ConditionRegistry getConditionRegistry() {
+			return createNFA().getConditionRegistry();
 		}
 	}
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPRescalingTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPRescalingTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.cep.Event;
 import org.apache.flink.cep.SubEvent;
+import org.apache.flink.cep.nfa.ConditionRegistry;
 import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.cep.pattern.Pattern;
@@ -431,6 +432,11 @@ public class CEPRescalingTest {
 				.within(Time.milliseconds(10L));
 
 			return NFACompiler.compile(pattern, Event.createTypeSerializer(), handleTimeout);
+		}
+
+		@Override
+		public ConditionRegistry getConditionRegistry() {
+			return createNFA().getConditionRegistry();
 		}
 	}
 


### PR DESCRIPTION
The core idea is that the `StateTransition` is unique in a NFA graph. So we store the conditions with a map which mapping from `StateTransition` to `IterativeCondition`, so the conditions can not serialized with NFA state. If I missed something, please point out.

This PR also includes FLINK-6938: IterativeCondition supports RichFunction interface. 


Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
