### PR TITLE
[FLINK-6923] [Kafka Connector] Expose in-processing/in-flight record …

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
@@ -108,7 +108,7 @@ public abstract class AbstractFetcher<T, KPH> {
 
 	/** Expose current processing/in-flight record offset. */
 	private volatile long inFlightRecordOffset = -1;
-	
+
 	// ------------------------------------------------------------------------
 
 	protected AbstractFetcher(


### PR DESCRIPTION
This PR exposes current in-processing record partition and offset information per Kafka consumer instance. This allows custom offset management and/or periodical metric reporting etc.