### PR TITLE
[FLINK-6389] [connector] Upgrade hbase dependency to 1.3.1

### DIFF
--- a/flink-connectors/flink-hbase/pom.xml
+++ b/flink-connectors/flink-hbase/pom.xml
@@ -34,7 +34,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<hbase.version>1.3.0</hbase.version>
+		<hbase.version>1.3.1</hbase.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
Upgrade to the last maintenance releases of hbase 1.3.1