### PR TITLE
[FLINK-6649][table]Improve Non-window group aggregate with update int…

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/queryConfig.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/queryConfig.scala
@@ -37,6 +37,13 @@ class BatchQueryConfig private[table] extends QueryConfig
 class StreamQueryConfig private[table] extends QueryConfig {
 
   /**
+    * The non-windowed groupby aggregate update the calculation result according a configuration of
+    * time interval. By default non-windowed groupby aggregate will update calculation result each
+    * row.
+    */
+  private var unboundedAggregateUpdateInterval: Time = Time.milliseconds(0)
+
+  /**
     * The minimum time until state which was not updated will be retained.
     * State might be cleared and removed if it was not updated for the defined period of time.
     */
@@ -47,6 +54,20 @@ class StreamQueryConfig private[table] extends QueryConfig {
     * State will be cleared and removed if it was not updated for the defined period of time.
     */
   private var maxIdleStateRetentionTime: Long = Long.MinValue
+
+  /**
+    * Specifies the time interval for updating the calculation results.
+    *
+    * __Note__: The first record of each key will be emit, and the data after the first is update
+    * the calculation result by the value of updateInterval.
+    *
+    * @param updateInterval The time interval for updating the calculation result.
+    *                       Update calculation result each row if set to less than 1 milliseconds.
+    */
+  def withUnboundedAggregateUpdateInterval(updateInterval: Time): StreamQueryConfig = {
+    unboundedAggregateUpdateInterval = updateInterval
+    this
+  }
 
   /**
     * Specifies the time interval for how long idle state, i.e., state which was not updated, will
@@ -90,6 +111,10 @@ class StreamQueryConfig private[table] extends QueryConfig {
     minIdleStateRetentionTime = minTime.toMilliseconds
     maxIdleStateRetentionTime = maxTime.toMilliseconds
     this
+  }
+
+  def getUnboundedAggregateUpdateInterval: Long = {
+    unboundedAggregateUpdateInterval.toMilliseconds
   }
 
   def getMinIdleStateRetentionTime: Long = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupAggregate.scala
@@ -144,6 +144,7 @@ class DataStreamGroupAggregate(
       physicalNamedAggregates,
       inputSchema.logicalType,
       inputSchema.physicalFieldTypeInfo,
+      outRowType.rowType,
       groupings,
       queryConfig,
       DataStreamRetractionRules.isAccRetract(this),

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
@@ -162,6 +162,7 @@ object AggregateUtil {
       namedAggregates: Seq[CalcitePair[AggregateCall, String]],
       inputRowType: RelDataType,
       inputFieldTypes: Seq[TypeInformation[_]],
+      outputRowType: RowTypeInfo,
       groupings: Array[Int],
       queryConfig: StreamQueryConfig,
       generateRetraction: Boolean,
@@ -196,11 +197,20 @@ object AggregateUtil {
       needReset = false
     )
 
-    new GroupAggProcessFunction(
-      genFunction,
-      aggregationStateType,
-      generateRetraction,
-      queryConfig)
+    if (queryConfig.getUnboundedAggregateUpdateInterval >= 1) {
+      new GroupAggProcessFunctionWithUpdateInterval(
+        genFunction,
+        aggregationStateType,
+        outputRowType,
+        generateRetraction,
+        queryConfig)
+    } else {
+      new GroupAggProcessFunction(
+        genFunction,
+        aggregationStateType,
+        generateRetraction,
+        queryConfig)
+    }
 
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/GroupAggProcessFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/GroupAggProcessFunction.scala
@@ -57,8 +57,8 @@ class GroupAggProcessFunction(
   private var cntState: ValueState[JLong] = _
 
   override def open(config: Configuration) {
-    LOG.debug(s"Compiling AggregateHelper: $genAggregations.name \n\n " +
-      s"Code:\n$genAggregations.code")
+    LOG.debug(s"Compiling AggregateHelper: ${genAggregations.name} \n\n" +
+      s"Code:\n${genAggregations.code}")
     val clazz = compile(
       getRuntimeContext.getUserCodeClassLoader,
       genAggregations.name,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/GroupAggProcessFunctionWithUpdateInterval.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/GroupAggProcessFunctionWithUpdateInterval.scala
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.runtime.aggregate
+
+import java.lang.{Long => JLong}
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.state.{ValueState, ValueStateDescriptor}
+import org.apache.flink.api.common.typeutils.TypeSerializer
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.table.api.{StreamQueryConfig, Types}
+import org.apache.flink.table.codegen.{Compiler, GeneratedAggregationsFunction}
+import org.apache.flink.table.runtime.types.CRow
+import org.apache.flink.types.Row
+import org.apache.flink.util.Collector
+import org.slf4j.{Logger, LoggerFactory}
+
+/**
+  * Aggregate Function used for the groupby (without window) aggregate
+  * with update interval config.
+  *
+  * @param genAggregations      Generated aggregate helper function
+  * @param aggregationStateType The row type info of aggregation
+  * @param outputRowType The row type info of output.
+  */
+class GroupAggProcessFunctionWithUpdateInterval(
+    private val genAggregations: GeneratedAggregationsFunction,
+    private val aggregationStateType: RowTypeInfo,
+    private val outputRowType: RowTypeInfo,
+    private val generateRetraction: Boolean,
+    private val queryConfig: StreamQueryConfig)
+  extends ProcessFunctionWithCleanupState[CRow, CRow](queryConfig)
+with Compiler[GeneratedAggregations] {
+
+  protected val LOG: Logger = LoggerFactory.getLogger(this.getClass)
+  protected var function: GeneratedAggregations = _
+
+  private var emitRow: Row = _
+  protected var newRow: CRow = _
+  protected var prevRow: CRow = _
+
+  private var typeSerializer: TypeSerializer[Row] = _
+
+  // stores the accumulators
+  protected var state: ValueState[Row] = _
+
+  // counts the number of added and retracted input records
+  protected var cntState: ValueState[JLong] = _
+
+  // stores the last emit row
+  private var preEmitState: ValueState[Row] = _
+
+  // stores the current emit row
+  private var emitState: ValueState[Row] = _
+
+  // stores the emit time
+  private var emitTimerState: ValueState[JLong] = _
+
+
+  override def open(config: Configuration) {
+    LOG.debug(s"Compiling AggregateHelper: ${genAggregations.name}\n\n" +
+                s"Code:\n${genAggregations.code}")
+    val clazz = compile(
+      getRuntimeContext.getUserCodeClassLoader,
+      genAggregations.name,
+      genAggregations.code)
+    LOG.debug("Instantiating AggregateHelper.")
+    function = clazz.newInstance()
+
+    emitRow = function.createOutputRow
+    newRow = new CRow(function.createOutputRow, true)
+    prevRow = new CRow(function.createOutputRow, false)
+    typeSerializer = outputRowType.createSerializer(new ExecutionConfig())
+
+    state = getRuntimeContext.getState(
+      new ValueStateDescriptor[Row]("GroupAggregateState", aggregationStateType))
+    cntState = getRuntimeContext.getState(
+      new ValueStateDescriptor[JLong]("GroupAggregateInputCounter", Types.LONG))
+    preEmitState = getRuntimeContext.getState(
+      new ValueStateDescriptor[Row]("GroupAggregatePreEmitState", outputRowType))
+    emitState = getRuntimeContext.getState(
+      new ValueStateDescriptor[Row]("GroupAggregateEmitState", outputRowType))
+    emitTimerState = getRuntimeContext.getState(
+      new ValueStateDescriptor[JLong]("emitTimeState", Types.LONG))
+
+    initCleanupTimeState("GroupAggregateWithUpdateIntervalCleanupTime")
+  }
+
+  override def processElement(
+      inputC: CRow,
+      ctx: ProcessFunction[CRow, CRow]#Context,
+      out: Collector[CRow]): Unit = {
+
+    val currentTime = ctx.timerService().currentProcessingTime()
+    // register state-cleanup timer
+    registerProcessingCleanupTimer(ctx, currentTime)
+
+    val input = inputC.row
+
+    // get accumulators and input counter
+    var accumulators = state.value
+    var inputCnt = cntState.value
+
+    if (null == accumulators) {
+      accumulators = function.createAccumulators()
+      inputCnt = 0L
+    }
+
+    // update aggregate result and set to the newRow
+    if (inputC.change) {
+      inputCnt += 1
+      // accumulate input
+      function.accumulate(accumulators, input)
+    } else {
+      inputCnt -= 1
+      // retract input
+      function.retract(accumulators, input)
+    }
+
+    state.update(accumulators)
+    cntState.update(inputCnt)
+
+    var triggerTimer = emitTimerState.value
+
+    if (null == triggerTimer) {
+      triggerTimer = 0L
+    }
+
+    if (0 == triggerTimer || currentTime >= triggerTimer) {
+
+      // set group keys value to the final output
+      function.setForwardedFields(input, emitRow)
+      // set previous aggregate result to the prevRow
+      function.setAggregationResults(accumulators, emitRow)
+      // store emit row
+      emitState.update(typeSerializer.copy(emitRow))
+
+      // emit the first row for each key
+      if (0 == triggerTimer) {
+        ctx.timerService().registerProcessingTimeTimer(currentTime)
+      }
+
+      val newTimer = if (currentTime > triggerTimer) {
+        currentTime + queryConfig.getUnboundedAggregateUpdateInterval
+      } else {
+        triggerTimer + queryConfig.getUnboundedAggregateUpdateInterval
+      }
+
+      emitTimerState.update(newTimer)
+
+      ctx.timerService().registerProcessingTimeTimer(newTimer)
+    }
+
+  }
+
+  override def onTimer(
+      timestamp: Long,
+      ctx: ProcessFunction[CRow, CRow]#OnTimerContext,
+      out: Collector[CRow]): Unit = {
+
+    if (needToCleanupState(timestamp)) {
+      cleanupState(state, cntState, preEmitState, emitTimerState, emitState)
+    } else {
+      newRow.row = emitState.value
+      val preEmit = preEmitState.value
+
+      if (null != preEmit) {
+        prevRow.row = preEmit
+      }
+
+      val inputCnt = cntState.value
+      if (!prevRow.row.equals(newRow.row)) {
+        // emit the data
+        if (inputCnt != 0) {
+          // we aggregated at least one record for this key
+          // if this was not the first row and we have to emit retractions
+          if (generateRetraction && null != preEmit) {
+            // retract previous result
+            out.collect(prevRow)
+          }
+          // emit the new result
+          out.collect(newRow)
+          // update preState
+          preEmitState.update(typeSerializer.copy(newRow.row))
+        } else {
+          if (null != preEmit) {
+            // we retracted the last record for this key
+            // sent out a delete message
+            out.collect(prevRow)
+          }
+
+          // and clear all state
+          cleanupState(state, cntState, preEmitState, emitTimerState, emitState)
+        }
+      }
+    }
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/HarnessTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/HarnessTestBase.scala
@@ -308,6 +308,22 @@ class HarnessTestBase {
   def verify(
     expected: JQueue[Object],
     actual: JQueue[Object],
+    checkWaterMark: Boolean = false): Unit = {
+    if (!checkWaterMark) {
+      val it = actual.iterator()
+      while (it.hasNext) {
+        val data = it.next()
+        if (data.isInstanceOf[Watermark]) {
+          actual.remove(data)
+        }
+      }
+    }
+    TestHarnessUtil.assertOutputEquals("Verify Error...", expected, actual)
+  }
+
+  def verifySorted(
+    expected: JQueue[Object],
+    actual: JQueue[Object],
     comparator: Comparator[Object],
     checkWaterMark: Boolean = false): Unit = {
     if (!checkWaterMark) {
@@ -328,7 +344,7 @@ object HarnessTestBase {
   /**
     * Return 0 for equal Rows and non zero for different rows
     */
-  class RowResultSortComparator(indexCounter: Int) extends Comparator[Object] with Serializable {
+  class RowResultSortComparator extends Comparator[Object] with Serializable {
 
     override def compare(o1: Object, o2: Object): Int = {
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/HarnessTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/HarnessTestBase.scala
@@ -29,8 +29,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.streaming.util.{KeyedOneInputStreamOperatorTestHarness, TestHarnessUtil}
 import org.apache.flink.table.codegen.GeneratedAggregationsFunction
 import org.apache.flink.table.functions.AggregateFunction
+import org.apache.flink.table.functions.aggfunctions.{IntSumWithRetractAggFunction, LongMaxWithRetractAggFunction, LongMinWithRetractAggFunction}
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils
-import org.apache.flink.table.functions.aggfunctions.{LongMaxWithRetractAggFunction, LongMinWithRetractAggFunction, IntSumWithRetractAggFunction}
 import org.apache.flink.table.runtime.aggregate.AggregateUtil
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
 
@@ -45,7 +45,7 @@ class HarnessTestBase {
   val intSumWithRetractAggFunction =
     UserDefinedFunctionUtils.serialize(new IntSumWithRetractAggFunction)
 
-  protected val MinMaxRowType = new RowTypeInfo(Array[TypeInformation[_]](
+  protected val minMaxRowType = new RowTypeInfo(Array[TypeInformation[_]](
     INT_TYPE_INFO,
     LONG_TYPE_INFO,
     INT_TYPE_INFO,
@@ -53,14 +53,14 @@ class HarnessTestBase {
     LONG_TYPE_INFO),
     Array("a", "b", "c", "d", "e"))
 
-  protected val SumRowType = new RowTypeInfo(Array[TypeInformation[_]](
+  protected val sumRowType = new RowTypeInfo(Array[TypeInformation[_]](
     LONG_TYPE_INFO,
     INT_TYPE_INFO,
     STRING_TYPE_INFO),
     Array("a", "b", "c"))
 
-  protected val minMaxCRowType = new CRowTypeInfo(MinMaxRowType)
-  protected val sumCRowType = new CRowTypeInfo(SumRowType)
+  protected val minMaxCRowType = new CRowTypeInfo(minMaxRowType)
+  protected val sumCRowType = new CRowTypeInfo(sumRowType)
 
   protected val minMaxAggregates =
     Array(new LongMinWithRetractAggFunction,
@@ -74,6 +74,9 @@ class HarnessTestBase {
 
   protected val sumAggregationStateType: RowTypeInfo =
     AggregateUtil.createAccumulatorRowType(sumAggregates)
+
+  protected val sumAggregationRowType: RowTypeInfo =
+    new RowTypeInfo(LONG_TYPE_INFO, STRING_TYPE_INFO, INT_TYPE_INFO)
 
   val minMaxCode: String =
     s"""
@@ -219,7 +222,7 @@ class HarnessTestBase {
       |      sum;
       |
       |    output.setField(
-      |      1,
+      |      2,
       |      baseClass0.getValue((org.apache.flink.table.functions.aggfunctions
       |      .SumWithRetractAccumulator) accs.getField(0)));
       |  }
@@ -259,9 +262,8 @@ class HarnessTestBase {
       |    org.apache.flink.types.Row output)
       |     {
       |
-      |    output.setField(
-      |      0,
-      |      input.getField(0));
+      |    output.setField(0, input.getField(0));
+      |    output.setField(1, input.getField(2));
       |  }
       |
       |  public final void setConstantFlags(org.apache.flink.types.Row output)
@@ -270,7 +272,7 @@ class HarnessTestBase {
       |  }
       |
       |  public final org.apache.flink.types.Row createOutputRow() {
-      |    return new org.apache.flink.types.Row(2);
+      |    return new org.apache.flink.types.Row(3);
       |  }
       |
       |

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/NonWindowHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/NonWindowHarnessTest.scala
@@ -91,7 +91,7 @@ class NonWindowHarnessTest extends HarnessTestBase {
     expectedOutput.add(new StreamRecord(CRow(Row.of(9L: JLong, "aaa", 18: JInt), true), 1))
     expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, "bbb", 3: JInt), true), 1))
 
-    verify(expectedOutput, result, new RowResultSortComparator(0))
+    verifySorted(expectedOutput, result, new RowResultSortComparator)
 
     testHarness.close()
   }
@@ -144,15 +144,15 @@ class NonWindowHarnessTest extends HarnessTestBase {
 
     val expectedOutput = new ConcurrentLinkedQueue[Object]()
 
-    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, "aaa", 1: JInt), true), 1))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(2L: JLong, "bbb", 1: JInt), true), 1))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(5L: JLong, "aaa", 10: JInt), true), 2002))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(6L: JLong, "bbb", 3: JInt), true), 2002))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(7L: JLong, "aaa", 15: JInt), true), 5001))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(9L: JLong, "aaa", 7: JInt), true), 10003))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, "bbb", 3: JInt), true), 10003))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, "aaa", 6: JInt), true), 1001))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(2L: JLong, "bbb", 1: JInt), true), 1001))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, "aaa", 10: JInt), true), 2002))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(2L: JLong, "bbb", 3: JInt), true), 2002))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, "aaa", 21: JInt), true), 5001))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(9L: JLong, "aaa", 7: JInt), true), 11003))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, "bbb", 3: JInt), true), 11003))
 
-    verify(expectedOutput, result, new RowResultSortComparator(0))
+    verify(expectedOutput, result)
 
     testHarness.close()
   }
@@ -211,7 +211,7 @@ class NonWindowHarnessTest extends HarnessTestBase {
     expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, "bbb", 2: JInt), false), 10))
     expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, "bbb", 5: JInt), true), 10))
 
-    verify(expectedOutput, result, new RowResultSortComparator(0))
+    verifySorted(expectedOutput, result, new RowResultSortComparator)
 
     testHarness.close()
   }
@@ -261,18 +261,18 @@ class NonWindowHarnessTest extends HarnessTestBase {
 
     val expectedOutput = new ConcurrentLinkedQueue[Object]()
 
-    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, "aaa", 1: JInt), true), 1))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(2L: JLong, "bbb", 1: JInt), true), 1))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(4L: JLong, "ccc", 3: JInt), true), 1))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, "aaa", 1: JInt), false), 4002))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(5L: JLong, "aaa", 7: JInt), true), 4002))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, "aaa", 3: JInt), true), 1001))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(2L: JLong, "bbb", 1: JInt), true), 1001))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(4L: JLong, "ccc", 3: JInt), true), 1001))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, "aaa", 3: JInt), false), 4002))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, "aaa", 12: JInt), true), 4002))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(8L: JLong, "eee", 6: JInt), true), 4002))
     expectedOutput.add(new StreamRecord(CRow(Row.of(2L: JLong, "bbb", 1: JInt), false), 4002))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(6L: JLong, "bbb", 3: JInt), true), 4002))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(8L: JLong, "eee", 6: JInt), true), 3002))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(9L: JLong, "aaa", 7: JInt), true), 8003))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, "bbb", 3: JInt), true), 8003))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(2L: JLong, "bbb", 3: JInt), true), 4002))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(9L: JLong, "aaa", 7: JInt), true), 9003))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, "bbb", 3: JInt), true), 9003))
 
-    verify(expectedOutput, result, new RowResultSortComparator(0))
+    verify(expectedOutput, result)
 
     testHarness.close()
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/NonWindowHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/NonWindowHarnessTest.scala
@@ -80,18 +80,79 @@ class NonWindowHarnessTest extends HarnessTestBase {
 
     val expectedOutput = new ConcurrentLinkedQueue[Object]()
 
-    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, 1: JInt), true), 1))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(2L: JLong, 1: JInt), true), 1))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(3L: JLong, 3: JInt), true), 1))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(4L: JLong, 6: JInt), true), 1))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(5L: JLong, 10: JInt), true), 1))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(6L: JLong, 3: JInt), true), 1))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(7L: JLong, 5: JInt), true), 1))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(8L: JLong, 11: JInt), true), 1))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(9L: JLong, 18: JInt), true), 1))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, 3: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, "aaa", 1: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(2L: JLong, "bbb", 1: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(3L: JLong, "aaa", 3: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(4L: JLong, "aaa", 6: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(5L: JLong, "aaa", 10: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(6L: JLong, "bbb", 3: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(7L: JLong, "aaa", 5: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(8L: JLong, "aaa", 11: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(9L: JLong, "aaa", 18: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, "bbb", 3: JInt), true), 1))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verify(expectedOutput, result, new RowResultSortComparator(0))
+
+    testHarness.close()
+  }
+
+  @Test
+  def testProcTimeNonWindowWithUpdateInterval(): Unit = {
+
+    val processFunction = new KeyedProcessOperator[String, CRow, CRow](
+      new GroupAggProcessFunctionWithUpdateInterval(
+        genSumAggFunction,
+        sumAggregationStateType,
+        sumAggregationRowType,
+        false,
+        queryConfig
+        .withIdleStateRetentionTime(Time.seconds(4), Time.seconds(5))
+        .withUnboundedAggregateUpdateInterval(Time.seconds(1))))
+
+    val testHarness =
+      createHarnessTester(
+        processFunction,
+        new TupleRowKeySelector[String](2),
+        BasicTypeInfo.STRING_TYPE_INFO)
+
+    testHarness.open()
+
+    testHarness.setProcessingTime(1)
+
+    testHarness.processElement(new StreamRecord(CRow(Row.of(1L: JLong, 1: JInt, "aaa"), true), 1))
+    testHarness.processElement(new StreamRecord(CRow(Row.of(2L: JLong, 1: JInt, "bbb"), true), 1))
+    testHarness.setProcessingTime(1000)
+    testHarness.processElement(new StreamRecord(CRow(Row.of(3L: JLong, 2: JInt, "aaa"), true), 1))
+    testHarness.processElement(new StreamRecord(CRow(Row.of(4L: JLong, 3: JInt, "aaa"), true), 1))
+
+    testHarness.setProcessingTime(1002)
+    testHarness.processElement(new StreamRecord(CRow(Row.of(5L: JLong, 4: JInt, "aaa"), true), 1))
+    testHarness.processElement(new StreamRecord(CRow(Row.of(6L: JLong, 2: JInt, "bbb"), true), 1))
+
+    testHarness.setProcessingTime(4003)
+    testHarness.processElement(new StreamRecord(CRow(Row.of(7L: JLong, 5: JInt, "aaa"), true), 1))
+    testHarness.processElement(new StreamRecord(CRow(Row.of(8L: JLong, 6: JInt, "aaa"), true), 1))
+
+    // clear all states
+    testHarness.setProcessingTime(10003)
+    testHarness.processElement(new StreamRecord(CRow(Row.of(9L: JLong, 7: JInt, "aaa"), true), 1))
+    testHarness.processElement(new StreamRecord(CRow(Row.of(10L: JLong, 3: JInt, "bbb"), true), 1))
+
+    testHarness.setProcessingTime(12003)
+
+    val result = testHarness.getOutput
+
+    val expectedOutput = new ConcurrentLinkedQueue[Object]()
+
+    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, "aaa", 1: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(2L: JLong, "bbb", 1: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(5L: JLong, "aaa", 10: JInt), true), 2002))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(6L: JLong, "bbb", 3: JInt), true), 2002))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(7L: JLong, "aaa", 15: JInt), true), 5001))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(9L: JLong, "aaa", 7: JInt), true), 10003))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, "bbb", 3: JInt), true), 10003))
+
+    verify(expectedOutput, result, new RowResultSortComparator(0))
 
     testHarness.close()
   }
@@ -135,20 +196,81 @@ class NonWindowHarnessTest extends HarnessTestBase {
 
     val expectedOutput = new ConcurrentLinkedQueue[Object]()
 
-    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, 1: JInt), true), 1))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(2L: JLong, 1: JInt), true), 2))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(3L: JLong, 1: JInt), false), 3))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(3L: JLong, 3: JInt), true), 3))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(4L: JLong, 3: JInt), true), 4))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(5L: JLong, 4: JInt), true), 5))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(6L: JLong, 2: JInt), true), 6))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(7L: JLong, 4: JInt), false), 7))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(7L: JLong, 9: JInt), true), 7))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(8L: JLong, 6: JInt), true), 8))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(9L: JLong, 9: JInt), false), 9))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(9L: JLong, 16: JInt), true), 9))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, 2: JInt), false), 10))
-    expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, 5: JInt), true), 10))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, "aaa", 1: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(2L: JLong, "bbb", 1: JInt), true), 2))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(3L: JLong, "aaa", 1: JInt), false), 3))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(3L: JLong, "aaa", 3: JInt), true), 3))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(4L: JLong, "ccc", 3: JInt), true), 4))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(5L: JLong, "aaa", 4: JInt), true), 5))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(6L: JLong, "bbb", 2: JInt), true), 6))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(7L: JLong, "aaa", 4: JInt), false), 7))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(7L: JLong, "aaa", 9: JInt), true), 7))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(8L: JLong, "eee", 6: JInt), true), 8))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(9L: JLong, "aaa", 9: JInt), false), 9))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(9L: JLong, "aaa", 16: JInt), true), 9))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, "bbb", 2: JInt), false), 10))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, "bbb", 5: JInt), true), 10))
+
+    verify(expectedOutput, result, new RowResultSortComparator(0))
+
+    testHarness.close()
+  }
+
+  @Test
+  def testProcTimeNonWindowWithRetractAndUpdateInterval(): Unit = {
+
+    val processFunction = new KeyedProcessOperator[String, CRow, CRow](
+      new GroupAggProcessFunctionWithUpdateInterval(
+        genSumAggFunction,
+        sumAggregationStateType,
+        sumAggregationRowType,
+        true,
+        queryConfig
+        .withIdleStateRetentionTime(Time.seconds(4), Time.seconds(5))
+        .withUnboundedAggregateUpdateInterval(Time.seconds(1))))
+
+    val testHarness =
+      createHarnessTester(
+        processFunction,
+        new TupleRowKeySelector[String](2),
+        BasicTypeInfo.STRING_TYPE_INFO)
+
+    testHarness.open()
+
+    testHarness.setProcessingTime(1)
+
+    testHarness.processElement(new StreamRecord(CRow(Row.of(1L: JLong, 1: JInt, "aaa"), true), 1))
+    testHarness.processElement(new StreamRecord(CRow(Row.of(2L: JLong, 1: JInt, "bbb"), true), 2))
+    testHarness.processElement(new StreamRecord(CRow(Row.of(3L: JLong, 2: JInt, "aaa"), true), 3))
+    testHarness.processElement(new StreamRecord(CRow(Row.of(4L: JLong, 3: JInt, "ccc"), true), 4))
+
+    testHarness.setProcessingTime(3002)
+    testHarness.processElement(new StreamRecord(CRow(Row.of(5L: JLong, 4: JInt, "aaa"), true), 5))
+    testHarness.processElement(new StreamRecord(CRow(Row.of(6L: JLong, 2: JInt, "bbb"), true), 6))
+    testHarness.processElement(new StreamRecord(CRow(Row.of(7L: JLong, 5: JInt, "aaa"), true), 7))
+    testHarness.processElement(new StreamRecord(CRow(Row.of(8L: JLong, 6: JInt, "eee"), true), 8))
+
+    // clear all states
+    testHarness.setProcessingTime(8003)
+    testHarness.processElement(new StreamRecord(CRow(Row.of(9L: JLong, 7: JInt, "aaa"), true), 9))
+    testHarness.processElement(new StreamRecord(CRow(Row.of(10L: JLong, 3: JInt, "bbb"), true), 10))
+
+    testHarness.setProcessingTime(10002)
+
+    val result = testHarness.getOutput
+
+    val expectedOutput = new ConcurrentLinkedQueue[Object]()
+
+    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, "aaa", 1: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(2L: JLong, "bbb", 1: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(4L: JLong, "ccc", 3: JInt), true), 1))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(1L: JLong, "aaa", 1: JInt), false), 4002))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(5L: JLong, "aaa", 7: JInt), true), 4002))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(2L: JLong, "bbb", 1: JInt), false), 4002))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(6L: JLong, "bbb", 3: JInt), true), 4002))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(8L: JLong, "eee", 6: JInt), true), 3002))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(9L: JLong, "aaa", 7: JInt), true), 8003))
+    expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, "bbb", 3: JInt), true), 8003))
 
     verify(expectedOutput, result, new RowResultSortComparator(0))
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
@@ -141,7 +141,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
       CRow(
         Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong, 40L: JLong, 40L: JLong), true), 2))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verifySorted(expectedOutput, result, new RowResultSortComparator)
 
     testHarness.close()
   }
@@ -267,7 +267,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
       CRow(
       Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong, 40L: JLong, 40L: JLong), true), 11005))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verifySorted(expectedOutput, result, new RowResultSortComparator)
 
     testHarness.close()
   }
@@ -371,7 +371,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
       CRow(
       Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong, 40L: JLong, 40L: JLong), true), 5003))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verifySorted(expectedOutput, result, new RowResultSortComparator)
     testHarness.close()
   }
 
@@ -539,7 +539,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
       CRow(
         Row.of(3: JInt, 0L: JLong, 0: JInt, "ccc", 3L: JLong, 3L: JLong, 3L: JLong), true), 20011))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verifySorted(expectedOutput, result, new RowResultSortComparator)
     testHarness.close()
   }
 
@@ -700,7 +700,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
       CRow(
         Row.of(3: JInt, 0L: JLong, 0: JInt, "ccc", 3L: JLong, 3L: JLong, 3L: JLong), true), 20011))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verifySorted(expectedOutput, result, new RowResultSortComparator)
     testHarness.close()
   }
 
@@ -851,7 +851,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
       CRow(
         Row.of(2: JInt, 0L: JLong, 0: JInt, "ccc", 2L: JLong, 1L: JLong, 2L: JLong), true), 20002))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verifySorted(expectedOutput, result, new RowResultSortComparator)
     testHarness.close()
   }
 
@@ -998,7 +998,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
       CRow(
         Row.of(2: JInt, 0L: JLong, 0: JInt, "ccc", 2L: JLong, 1L: JLong, 2L: JLong), true), 20002))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verifySorted(expectedOutput, result, new RowResultSortComparator)
     testHarness.close()
   }
 }


### PR DESCRIPTION
In this PR. I have add supports updating the calculated data according to the specified time interval on non-window group AGG. If we config the time interval is N seconds, then the next update time relative to the latest update time T, is T+N seconds. For example, the time interval is 2 seconds, the previous update time is T seconds, and the next update time T1> = T + 2 seconds. If no data arrives during T to T + 2, no updates are made.

Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
In addition to going through the list, please provide a meaningful description of your changes.

- [x] General
  - The pull request references the related JIRA issue ("[Flink 6649][table]Improve Non-window group aggregate with update interval.")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
