### PR TITLE
{FLINK-6965] Include snappy-java in flink-dist

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -79,13 +79,12 @@ under the License.
 		<dependency>
 			<groupId>org.apache.avro</groupId>
 			<artifactId>avro</artifactId>
-			<!-- managed version -->
-			<exclusions>
-				<exclusion>
-					<groupId>org.xerial.snappy</groupId>
-					<artifactId>snappy-java</artifactId>
-				</exclusion>
-			</exclusions>
+		</dependency>
+
+		<!-- We explicitly depend on snappy since connectors that require it load it through the system class loader -->
+		<dependency>
+			<groupId>org.xerial.snappy</groupId>
+			<artifactId>snappy-java</artifactId>
 		</dependency>
 
 		<!-- ASM is needed for type extraction -->

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,12 @@ under the License.
 				<version>1.7.7</version>
 			</dependency>
 
+			<dependency>
+				<groupId>org.xerial.snappy</groupId>
+				<artifactId>snappy-java</artifactId>
+				<version>1.0.5</version>
+			</dependency>
+
 			<!-- Make sure we use a consistent commons-cli version throughout the project -->
 			<dependency>
 				<groupId>commons-cli</groupId>

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -163,7 +163,7 @@ watchdog () {
 	done
 }
 
-# Check the final fat jar for illegal artifacts
+# Check the final fat jar for illegal or missing artifacts
 check_shaded_artifacts() {
 	jar tf build-target/lib/flink-dist*.jar > allClasses
 	ASM=`cat allClasses | grep '^org/objectweb/asm/' | wc -l`
@@ -182,6 +182,13 @@ check_shaded_artifacts() {
 		exit 1
 	fi
 
+	SNAPPY=`cat allClasses | grep '^org/xerial/snappy' | wc -l`
+	if [ AVRO == "0" ]; then
+		echo "=============================================================================="
+		echo "Missing snappy dependencies in fat jar"
+		echo "=============================================================================="
+		exit 1
+	fi
 }
 
 # =============================================================================

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -183,7 +183,7 @@ check_shaded_artifacts() {
 	fi
 
 	SNAPPY=`cat allClasses | grep '^org/xerial/snappy' | wc -l`
-	if [ SNAPPY == "0" ]; then
+	if [ $SNAPPY == "0" ]; then
 		echo "=============================================================================="
 		echo "Missing snappy dependencies in fat jar"
 		echo "=============================================================================="

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -183,7 +183,7 @@ check_shaded_artifacts() {
 	fi
 
 	SNAPPY=`cat allClasses | grep '^org/xerial/snappy' | wc -l`
-	if [ AVRO == "0" ]; then
+	if [ SNAPPY == "0" ]; then
 		echo "=============================================================================="
 		echo "Missing snappy dependencies in fat jar"
 		echo "=============================================================================="


### PR DESCRIPTION
This PR adds removes the snappy dependency exclusion from flink-core.

Without this dependency Flink components that work with avro, and thus potentially snappy, fail when loading snappy. This also happens if snappy is provided in the user-jar since the flink component doesn't use the user class loader.

To prevent this dependency from being removed again in the future by accident i modified `checkShadedArtifacts()` function in the travis scripts to check for the presence of the dependency.