### PR TITLE
[FLINK-6952] [FLINK-6985] [docs] Add Javadocs links and remove bugfix version (1.2)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,8 +26,11 @@
 # to reference a specific Flink version, because this is the only place where
 # we change the version for the complete docs when forking of a release branch
 # etc.
-version: "1.2.0"
-version_short: "1.2" # Used for the top navbar w/o snapshot suffix
+# The full version string as referenced in Maven (e.g. 1.2.1)
+version: "1.2.1"
+# For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
+# release this should be the same as the regular version
+version_short: "1.2"
 is_snapshot_version: false
 
 # This suffix is appended to the Scala-dependent Maven artifact names

--- a/docs/_includes/sidenav.html
+++ b/docs/_includes/sidenav.html
@@ -72,7 +72,7 @@ level is determined by 'nav-pos'.
 {% assign pos = 0 %}
 
 <div class="sidenav-logo">
-  <p><a href="{{ site.baseurl }}"><img class="bottom" alt="Apache Flink" src="{{ site.baseurl }}/page/img/navbar-brand-logo.jpg"></a> v{{ site.version }}</p>
+  <p><a href="{{ site.baseurl }}"><img class="bottom" alt="Apache Flink" src="{{ site.baseurl }}/page/img/navbar-brand-logo.jpg"></a> v{{ site.version_short }}</p>
 </div>
 <ul id="sidenav">
 {% for i in (1..10000) %}

--- a/docs/_includes/sidenav.html
+++ b/docs/_includes/sidenav.html
@@ -126,6 +126,7 @@ level is determined by 'nav-pos'.
   {% endif %}
 {% endfor %}
   <li class="divider"></li>
+  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-{{site.version_short}}/api/java"><i class="fa fa-external-link title" aria-hidden="true"></i> Javadocs</a></li>
   <li><a href="http://flink.apache.org"><i class="fa fa-external-link title" aria-hidden="true"></i> Project Page</a></li>
 </ul>
 

--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -23,7 +23,7 @@ under the License.
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <title>Apache Flink {{ site.version}} Documentation: {{ page.title }}</title>
+    <title>Apache Flink {{ site.version_short }} Documentation: {{ page.title }}</title>
     <link rel="shortcut icon" href="{{ site.baseurl }}/page/favicon.ico" type="image/x-icon">
     <link rel="icon" href="{{ site.baseurl }}/page/favicon.ico" type="image/x-icon">
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ under the License.
 
 
 
-This documentation is for Apache Flink version {{ site.version }}. These pages have been built at: {% build_time %}.
+This documentation is for Apache Flink version {{ site.version_short }}. These pages have been built at: {% build_time %}.
 
 Apache Flink is an open source platform for distributed stream and batch data processing. Flink’s core is a streaming dataflow engine that provides data distribution, communication, and fault tolerance for distributed computations over data streams. Flink also builds batch processing on top of the streaming engine, overlaying native iteration support, managed memory, and program optimization.
 


### PR DESCRIPTION
Backport of #4162 for the `release-1.2` branch.