### PR TITLE
[FLINK-6987] Fix erroneous when path containing spaces

### DIFF
--- a/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
@@ -108,7 +108,7 @@ public class TextInputFormatTest {
 			}
 			File parentDir = new File("tmp");
 
-			TextInputFormat inputFormat = new TextInputFormat(new Path(parentDir.toURI().toString()));
+			TextInputFormat inputFormat = new TextInputFormat(new Path(parentDir.toURI()));
 			inputFormat.setNestedFileEnumeration(true);
 			inputFormat.setNumLineSamples(10);
 


### PR DESCRIPTION
We will get an error ```Reason: "Test erroneous"``` when use a folder was called "flink-1.3.1 2" to build flink and in which contains spaces then that error was triggered. The reason is that the spaces will encode into ```flink-1.3.1%202``` and then the system can not find the path.