### PR TITLE
[FLINK-6357] [java] ParameterTool get unrequested parameters

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/ParameterTool.java
@@ -565,7 +565,7 @@ public class ParameterTool extends ExecutionConfig.GlobalJobParameters implement
 	public ParameterTool mergeWith(ParameterTool other) {
 		ParameterTool ret = new ParameterTool(this.data);
 		ret.data.putAll(other.data);
-		ret.unrequestedParameters.addAll(other.data.keySet());
+		ret.unrequestedParameters.addAll(other.unrequestedParameters);
 		return ret;
 	}
 

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
@@ -20,7 +20,9 @@ package org.apache.flink.api.java.utils;
 
 import com.google.common.collect.Sets;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -30,7 +32,13 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
+/**
+ * Tests for {@link ParameterTool}.
+ */
 public class ParameterToolTest extends AbstractParameterToolTest {
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
 
 	// ----- Parser tests -----------------
 
@@ -150,6 +158,8 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		validate(parameter);
 	}
 
+	// Boolean
+
 	@Test
 	public void testUnrequestedBoolean() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean", "true"});
@@ -161,7 +171,33 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 
 		// test repeated access
 		Assert.assertTrue(parameter.getBoolean("boolean"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
+
+	@Test
+	public void testUnrequestedBooleanWithDefaultValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean", "true"});
+		Assert.assertEquals(Sets.newHashSet("boolean"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertTrue(parameter.getBoolean("boolean", false));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertTrue(parameter.getBoolean("boolean", false));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	@Test
+	public void testUnrequestedBooleanWithMissingValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean"});
+		Assert.assertEquals(Sets.newHashSet("byte"), parameter.getUnrequestedParameters());
+
+		parameter.getBoolean("boolean");
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	// Byte
 
 	@Test
 	public void testUnrequestedByte() {
@@ -174,7 +210,36 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 
 		// test repeated access
 		Assert.assertEquals(1, parameter.getByte("byte"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
+
+	@Test
+	public void testUnrequestedByteWithDefaultValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-byte", "1"});
+		Assert.assertEquals(Sets.newHashSet("byte"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertEquals(1, parameter.getByte("byte", (byte) 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertEquals(1, parameter.getByte("byte", (byte) 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	@Test
+	public void testUnrequestedByteWithMissingValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-byte"});
+		Assert.assertEquals(Sets.newHashSet("byte"), parameter.getUnrequestedParameters());
+
+		exception.expect(RuntimeException.class);
+		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
+
+		parameter.getByte("byte");
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	// Short
 
 	@Test
 	public void testUnrequestedShort() {
@@ -187,7 +252,36 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 
 		// test repeated access
 		Assert.assertEquals(2, parameter.getShort("short"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
+
+	@Test
+	public void testUnrequestedShortWithDefaultValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-short", "2"});
+		Assert.assertEquals(Sets.newHashSet("short"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertEquals(2, parameter.getShort("short", (short) 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertEquals(2, parameter.getShort("short", (short) 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	@Test
+	public void testUnrequestedShortWithMissingValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-short"});
+		Assert.assertEquals(Sets.newHashSet("short"), parameter.getUnrequestedParameters());
+
+		exception.expect(RuntimeException.class);
+		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
+
+		parameter.getShort("short");
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	// Int
 
 	@Test
 	public void testUnrequestedInt() {
@@ -195,12 +289,41 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		Assert.assertEquals(Sets.newHashSet("int"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals(4, parameter.getByte("int"));
+		Assert.assertEquals(4, parameter.getInt("int"));
 		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals(4, parameter.getByte("int"));
+		Assert.assertEquals(4, parameter.getInt("int"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
+
+	@Test
+	public void testUnrequestedIntWithDefaultValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-int", "4"});
+		Assert.assertEquals(Sets.newHashSet("int"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertEquals(4, parameter.getInt("int", 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertEquals(4, parameter.getInt("int", 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	@Test
+	public void testUnrequestedIntWithMissingValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-int"});
+		Assert.assertEquals(Sets.newHashSet("int"), parameter.getUnrequestedParameters());
+
+		exception.expect(RuntimeException.class);
+		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
+
+		parameter.getInt("int");
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	// Long
 
 	@Test
 	public void testUnrequestedLong() {
@@ -208,12 +331,41 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		Assert.assertEquals(Sets.newHashSet("long"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals(8, parameter.getByte("long"));
+		Assert.assertEquals(8, parameter.getLong("long"));
 		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals(8, parameter.getByte("long"));
+		Assert.assertEquals(8, parameter.getLong("long"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
+
+	@Test
+	public void testUnrequestedLongWithDefaultValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-long", "8"});
+		Assert.assertEquals(Sets.newHashSet("long"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertEquals(8, parameter.getLong("long", 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertEquals(8, parameter.getLong("long", 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	@Test
+	public void testUnrequestedLongWithMissingValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-long"});
+		Assert.assertEquals(Sets.newHashSet("long"), parameter.getUnrequestedParameters());
+
+		exception.expect(RuntimeException.class);
+		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
+
+		parameter.getLong("long");
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	// Float
 
 	@Test
 	public void testUnrequestedFloat() {
@@ -226,7 +378,36 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 
 		// test repeated access
 		Assert.assertEquals(4.0, parameter.getFloat("float"), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
+
+	@Test
+	public void testUnrequestedFloatWithDefaultValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-float", "4"});
+		Assert.assertEquals(Sets.newHashSet("float"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertEquals(4.0, parameter.getFloat("float", 0.0f), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertEquals(4.0, parameter.getFloat("float", 0.0f), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	@Test
+	public void testUnrequestedFloatWithMissingValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-float"});
+		Assert.assertEquals(Sets.newHashSet("float"), parameter.getUnrequestedParameters());
+
+		exception.expect(RuntimeException.class);
+		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
+
+		parameter.getFloat("float");
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	// Double
 
 	@Test
 	public void testUnrequestedDouble() {
@@ -239,7 +420,36 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 
 		// test repeated access
 		Assert.assertEquals(8.0, parameter.getDouble("double"), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
+
+	@Test
+	public void testUnrequestedDoubleWithDefaultValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-double", "8"});
+		Assert.assertEquals(Sets.newHashSet("double"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertEquals(8.0, parameter.getDouble("double", 0.0), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertEquals(8.0, parameter.getDouble("double", 0.0), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	@Test
+	public void testUnrequestedDoubleWithMissingValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-double"});
+		Assert.assertEquals(Sets.newHashSet("double"), parameter.getUnrequestedParameters());
+
+		exception.expect(RuntimeException.class);
+		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
+
+		parameter.getDouble("double");
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	// String
 
 	@Test
 	public void testUnrequestedString() {
@@ -252,7 +462,36 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 
 		// test repeated access
 		Assert.assertEquals("∞", parameter.get("string"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
+
+	@Test
+	public void testUnrequestedStringWithDefaultValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-string", "∞"});
+		Assert.assertEquals(Sets.newHashSet("string"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertEquals("∞", parameter.get("string", "0.0"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertEquals("∞", parameter.get("string", "0.0"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	@Test
+	public void testUnrequestedStringWithMissingValue() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-string"});
+		Assert.assertEquals(Sets.newHashSet("string"), parameter.getUnrequestedParameters());
+
+		exception.expect(RuntimeException.class);
+		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
+
+		parameter.get("string");
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	// Additional methods
 
 	@Test
 	public void testUnrequestedHas() {
@@ -265,6 +504,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 
 		// test repeated access
 		Assert.assertTrue(parameter.has("boolean"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
@@ -278,6 +518,26 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 
 		// test repeated access
 		Assert.assertEquals("∞", parameter.getRequired("required"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	@Test
+	public void testUnrequestedMultiple() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean", "true", "-byte", "1",
+			"-short", "2", "-int", "4", "-long", "8", "-float", "4.0", "-double", "8.0", "-string", "∞"});
+		Assert.assertEquals(Sets.newHashSet("boolean", "byte", "short", "int", "long", "float", "double", "string"),
+			parameter.getUnrequestedParameters());
+
+		Assert.assertTrue(parameter.getBoolean("boolean"));
+		Assert.assertEquals(1, parameter.getByte("byte"));
+		Assert.assertEquals(2, parameter.getShort("short"));
+		Assert.assertEquals(4, parameter.getInt("int"));
+		Assert.assertEquals(8, parameter.getLong("long"));
+		Assert.assertEquals(4.0, parameter.getFloat("float"), 0.00001);
+		Assert.assertEquals(8.0, parameter.getDouble("double"), 0.00001);
+		Assert.assertEquals("∞", parameter.get("string"));
+
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
@@ -293,5 +553,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		Assert.assertEquals(0, parameter.getFloat("float", 0), 0.00001);
 		Assert.assertEquals(0, parameter.getDouble("double", 0), 0.00001);
 		Assert.assertEquals("0", parameter.get("string", "0"));
+
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 }

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
@@ -236,7 +236,6 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
 
 		parameter.getByte("byte");
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	// Short
@@ -278,7 +277,6 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
 
 		parameter.getShort("short");
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	// Int
@@ -320,7 +318,6 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
 
 		parameter.getInt("int");
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	// Long
@@ -362,7 +359,6 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
 
 		parameter.getLong("long");
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	// Float
@@ -404,7 +400,6 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
 
 		parameter.getFloat("float");
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	// Double
@@ -446,7 +441,6 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
 
 		parameter.getDouble("double");
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	// String

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
@@ -191,7 +191,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedBooleanWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean"});
-		Assert.assertEquals(Sets.newHashSet("byte"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(Sets.newHashSet("boolean"), parameter.getUnrequestedParameters());
 
 		parameter.getBoolean("boolean");
 		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
@@ -484,9 +484,6 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-string"});
 		Assert.assertEquals(Sets.newHashSet("string"), parameter.getUnrequestedParameters());
 
-		exception.expect(RuntimeException.class);
-		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
-
 		parameter.get("string");
 		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
@@ -529,14 +526,34 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 			parameter.getUnrequestedParameters());
 
 		Assert.assertTrue(parameter.getBoolean("boolean"));
-		Assert.assertEquals(1, parameter.getByte("byte"));
-		Assert.assertEquals(2, parameter.getShort("short"));
-		Assert.assertEquals(4, parameter.getInt("int"));
-		Assert.assertEquals(8, parameter.getLong("long"));
-		Assert.assertEquals(4.0, parameter.getFloat("float"), 0.00001);
-		Assert.assertEquals(8.0, parameter.getDouble("double"), 0.00001);
-		Assert.assertEquals("∞", parameter.get("string"));
+		Assert.assertEquals(Sets.newHashSet("byte", "short", "int", "long", "float", "double", "string"),
+			parameter.getUnrequestedParameters());
 
+		Assert.assertEquals(1, parameter.getByte("byte"));
+		Assert.assertEquals(Sets.newHashSet("short", "int", "long", "float", "double", "string"),
+			parameter.getUnrequestedParameters());
+
+		Assert.assertEquals(2, parameter.getShort("short"));
+		Assert.assertEquals(Sets.newHashSet("int", "long", "float", "double", "string"),
+			parameter.getUnrequestedParameters());
+
+		Assert.assertEquals(4, parameter.getInt("int"));
+		Assert.assertEquals(Sets.newHashSet("long", "float", "double", "string"),
+			parameter.getUnrequestedParameters());
+
+		Assert.assertEquals(8, parameter.getLong("long"));
+		Assert.assertEquals(Sets.newHashSet("float", "double", "string"),
+			parameter.getUnrequestedParameters());
+
+		Assert.assertEquals(4.0, parameter.getFloat("float"), 0.00001);
+		Assert.assertEquals(Sets.newHashSet("double", "string"),
+			parameter.getUnrequestedParameters());
+
+		Assert.assertEquals(8.0, parameter.getDouble("double"), 0.00001);
+		Assert.assertEquals(Sets.newHashSet("string"),
+			parameter.getUnrequestedParameters());
+
+		Assert.assertEquals("∞", parameter.get("string"));
 		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.utils;
 
+import com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -25,6 +26,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
@@ -34,8 +36,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 
 	@Test(expected = RuntimeException.class)
 	public void testIllegalArgs() {
-		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"berlin"});
-		Assert.assertEquals(0, parameter.getNumberOfParameters());
+		ParameterTool.fromArgs(new String[]{"berlin"});
 	}
 
 	@Test
@@ -78,18 +79,12 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testEmptyVal() {
-		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"--a", "-b", "--"});
-		Assert.assertEquals(2, parameter.getNumberOfParameters());
-		Assert.assertTrue(parameter.has("a"));
-		Assert.assertTrue(parameter.has("b"));
+		ParameterTool.fromArgs(new String[]{"--a", "-b", "--"});
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testEmptyValShort() {
-		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"--a", "-b", "-"});
-		Assert.assertEquals(2, parameter.getNumberOfParameters());
-		Assert.assertTrue(parameter.has("a"));
-		Assert.assertTrue(parameter.has("b"));
+		ParameterTool.fromArgs(new String[]{"--a", "-b", "-"});
 	}
 
 	@Test
@@ -153,5 +148,150 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	public void testFromGenericOptionsParser() throws IOException {
 		ParameterTool parameter = ParameterTool.fromGenericOptionsParser(new String[]{"-D", "input=myInput", "-DexpectedCount=15"});
 		validate(parameter);
+	}
+
+	@Test
+	public void testUnrequestedBoolean() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean", "true"});
+		Assert.assertEquals(Sets.newHashSet("boolean"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertTrue(parameter.getBoolean("boolean"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertTrue(parameter.getBoolean("boolean"));
+	}
+
+	@Test
+	public void testUnrequestedByte() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-byte", "1"});
+		Assert.assertEquals(Sets.newHashSet("byte"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertEquals(1, parameter.getByte("byte"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertEquals(1, parameter.getByte("byte"));
+	}
+
+	@Test
+	public void testUnrequestedShort() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-short", "2"});
+		Assert.assertEquals(Sets.newHashSet("short"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertEquals(2, parameter.getShort("short"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertEquals(2, parameter.getShort("short"));
+	}
+
+	@Test
+	public void testUnrequestedInt() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-int", "4"});
+		Assert.assertEquals(Sets.newHashSet("int"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertEquals(4, parameter.getByte("int"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertEquals(4, parameter.getByte("int"));
+	}
+
+	@Test
+	public void testUnrequestedLong() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-long", "8"});
+		Assert.assertEquals(Sets.newHashSet("long"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertEquals(8, parameter.getByte("long"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertEquals(8, parameter.getByte("long"));
+	}
+
+	@Test
+	public void testUnrequestedFloat() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-float", "4"});
+		Assert.assertEquals(Sets.newHashSet("float"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertEquals(4.0, parameter.getFloat("float"), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertEquals(4.0, parameter.getFloat("float"), 0.00001);
+	}
+
+	@Test
+	public void testUnrequestedDouble() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-double", "8"});
+		Assert.assertEquals(Sets.newHashSet("double"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertEquals(8.0, parameter.getDouble("double"), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertEquals(8.0, parameter.getDouble("double"), 0.00001);
+	}
+
+	@Test
+	public void testUnrequestedString() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-string", "∞"});
+		Assert.assertEquals(Sets.newHashSet("string"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertEquals("∞", parameter.get("string"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertEquals("∞", parameter.get("string"));
+	}
+
+	@Test
+	public void testUnrequestedHas() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean"});
+		Assert.assertEquals(Sets.newHashSet("boolean"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertTrue(parameter.has("boolean"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertTrue(parameter.has("boolean"));
+	}
+
+	@Test
+	public void testUnrequestedRequired() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-required", "∞"});
+		Assert.assertEquals(Sets.newHashSet("required"), parameter.getUnrequestedParameters());
+
+		// test parameter access
+		Assert.assertEquals("∞", parameter.getRequired("required"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		// test repeated access
+		Assert.assertEquals("∞", parameter.getRequired("required"));
+	}
+
+	@Test
+	public void testUnrequestedUnknown() {
+		ParameterTool parameter = ParameterTool.fromArgs(new String[]{});
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+
+		Assert.assertTrue(parameter.getBoolean("boolean", true));
+		Assert.assertEquals(0, parameter.getByte("byte", (byte) 0));
+		Assert.assertEquals(0, parameter.getShort("short", (short) 0));
+		Assert.assertEquals(0, parameter.getInt("int", 0));
+		Assert.assertEquals(0, parameter.getLong("long", 0));
+		Assert.assertEquals(0, parameter.getFloat("float", 0), 0.00001);
+		Assert.assertEquals(0, parameter.getDouble("double", 0), 0.00001);
+		Assert.assertEquals("0", parameter.get("string", "0"));
 	}
 }


### PR DESCRIPTION
Adds ParameterTool#getUnrequestedParameters returning a Set<String> of parameter arguments names not yet requested by ParameterTool#has or any of the ParameterTool#get methods.