### PR TITLE
[FLINK-6999] [build] Print TravisCI CPU, memory, and filesystem info

### DIFF
--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -195,6 +195,25 @@ WD_PID=$!
 
 echo "STARTED watchdog (${WD_PID})."
 
+
+# Print and fold CPU, memory, and filesystem info
+FOLD_ESCAPE="\x0d\x1b"
+COLOR_ON="\x5b\x30\x4b\x1b\x5b\x33\x33\x3b\x31\x6d"
+COLOR_OFF="\x1b\x5b\x30\x6d"
+
+echo -e "travis_fold:start:cpu_info${FOLD_ESCAPE}${COLOR_ON}CPU information${COLOR_OFF}"
+lscpu
+echo -en "travis_fold:end:cpu_info${FOLD_ESCAPE}"
+
+echo -e "travis_fold:start:mem_info${FOLD_ESCAPE}${COLOR_ON}Memory information${COLOR_OFF}"
+cat /proc/meminfo
+echo -en "travis_fold:end:mem_info${FOLD_ESCAPE}"
+
+echo -e "travis_fold:start:disk_info${FOLD_ESCAPE}${COLOR_ON}Disk information${COLOR_OFF}"
+df -hH
+echo -en "travis_fold:end:disk_info${FOLD_ESCAPE}"
+
+
 # Make sure to be in project root
 cd $HERE/../
 


### PR DESCRIPTION
Search for or scroll down to "CPU information" near the start of the logs.

Note: had to replace `Filesystem` with `Disk` since TravisCI has an issue parsing `Filesys`.