### PR TITLE
[FLINK-7004] Switch to Travis Trusty image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 # s3 deployment based on http://about.travis-ci.org/blog/2012-12-18-travis-artifacts/
 
-# send to container based infrastructure: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
+# send to fully-virtualized infrastructure: https://docs.travis-ci.com/user/trusty-ci-environment/
+sudo: required
+dist: trusty
 
 #cache:
 #  directories:
@@ -36,11 +37,11 @@ matrix:
     - jdk: "openjdk7"
       env: PROFILE="-Dhadoop.version=2.6.5 -Dscala-2.11 -Pflink-fast-tests-c,include-kinesis -Dmaven.javadoc.skip=true"
 
-    - jdk: "oraclejdk7"
+    - jdk: "openjdk7"
       env: PROFILE="-Dhadoop.version=2.4.1 -Pflink-fast-tests-a,include-kinesis -Dmaven.javadoc.skip=true"
-    - jdk: "oraclejdk7"
+    - jdk: "openjdk7"
       env: PROFILE="-Dhadoop.version=2.4.1 -Pflink-fast-tests-b,include-kinesis -Dmaven.javadoc.skip=true"
-    - jdk: "oraclejdk7"
+    - jdk: "openjdk7"
       env: PROFILE="-Dhadoop.version=2.4.1 -Pflink-fast-tests-c,include-kinesis -Dmaven.javadoc.skip=true"
 
 
@@ -59,6 +60,14 @@ env:
 
 before_script:
    - "gem install --no-document --version 0.8.9 faraday "
+
+# Install maven 3.2.5 since trusty uses 3.3.9 for which shading is broken
+before_install:
+   - "wget https://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip"
+   - "unzip -qq apache-maven-3.2.5-bin.zip"
+   - "rm apache-maven-3.2.5-bin.zip"
+   - "export M2_HOME=$PWD/apache-maven-3.2.5"
+   - "export PATH=$M2_HOME/bin:$PATH"
 
 # We run mvn and monitor its output. If there is no output for the specified number of seconds, we
 # print the stack traces of all running Java processes.

--- a/pom.xml
+++ b/pom.xml
@@ -1021,6 +1021,8 @@ under the License.
 						<!-- Tools: watchdog -->
 						<exclude>tools/artifacts/**</exclude>
 						<exclude>tools/flink*/**</exclude>
+						<!-- manually installed version on travis -->
+						<exclude>apache-maven-3.2.5/**</exclude>
 						<!-- PyCharm -->
 						<exclude>**/.idea/**</exclude>
 					</excludes>
@@ -1073,7 +1075,7 @@ under the License.
 						<forkNumber>0${surefire.forkNumber}</forkNumber>
 						<log4j.configuration>${log4j.configuration}</log4j.configuration>
 					</systemPropertyVariables>
-					<argLine>-Xms256m -Xmx1536m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseSerialGC</argLine>
+					<argLine>-Xms256m -Xmx2048m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseSerialGC</argLine>
 				</configuration>
 				<executions>
 					<!--execute all the unit tests-->


### PR DESCRIPTION
Cleaned up version of #4167. With this PR we switch to the trusty image on Travis as it appears to have more stable build times.

Other changes include:
* run in a sudo-enabled environment for more memory
* increase java heap size
* replace oraclejdk7 profile since it is no longer supported (see https://github.com/travis-ci/travis-ci/issues/7884)
* manually install maven 3.2.5 since trusty works with 3.3.9

This should be merged for 1.2, 1.3 and 1.4.