### PR TITLE
[FLINK-7005] [table] Optimization steps are missing for nested registered tables

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
@@ -276,8 +276,12 @@ abstract class BatchTableEnvironment(
     */
   private[flink] def optimize(relNode: RelNode): RelNode = {
 
+    // 0. convert registered tables
+    val fullRelNode = runHepPlanner(
+      HepMatchOrder.BOTTOM_UP, FlinkRuleSets.TABLE_CONV_RULES, relNode, relNode.getTraitSet)
+
     // 1. decorrelate
-    val decorPlan = RelDecorrelator.decorrelateQuery(relNode)
+    val decorPlan = RelDecorrelator.decorrelateQuery(fullRelNode)
 
     // 2. normalize the logical plan
     val normRuleSet = getNormRuleSet

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
@@ -559,8 +559,12 @@ abstract class StreamTableEnvironment(
     */
   private[flink] def optimize(relNode: RelNode, updatesAsRetraction: Boolean): RelNode = {
 
+    // 0. convert registered tables
+    val fullRelNode = runHepPlanner(
+      HepMatchOrder.BOTTOM_UP, FlinkRuleSets.TABLE_CONV_RULES, relNode, relNode.getTraitSet)
+
     // 1. decorrelate
-    val decorPlan = RelDecorrelator.decorrelateQuery(relNode)
+    val decorPlan = RelDecorrelator.decorrelateQuery(fullRelNode)
 
     // 2. convert time indicators
     val convPlan = RelTimeIndicatorConverter.convert(decorPlan, getRelBuilder.getRexBuilder)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -28,11 +28,14 @@ import org.apache.flink.table.plan.nodes.logical._
 
 object FlinkRuleSets {
 
-  val LOGICAL_OPT_RULES: RuleSet = RuleSets.ofList(
-
-    // convert a logical table scan to a relational expression
+  /**
+    * Convert a logical table scan to a relational expression.
+    */
+  val TABLE_CONV_RULES: RuleSet = RuleSets.ofList(
     TableScanRule.INSTANCE,
-    EnumerableToLogicalTableScan.INSTANCE,
+    EnumerableToLogicalTableScan.INSTANCE)
+
+  val LOGICAL_OPT_RULES: RuleSet = RuleSets.ofList(
 
     // push a filter into a join
     FilterJoinRule.FILTER_ON_JOIN,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/ExpressionReductionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/ExpressionReductionTest.scala
@@ -422,4 +422,22 @@ class ExpressionReductionTest extends TableTestBase {
     util.verifyTable(result, expected)
   }
 
+  @Test
+  def testNestedTablesReduction(): Unit = {
+    val util = streamTestUtil()
+
+    util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
+
+    val newTable = util.tEnv.sql("SELECT 1 + 1 + a AS a FROM MyTable")
+
+    util.tEnv.registerTable("NewTable", newTable)
+
+    val sqlQuery = "SELECT a FROM NewTable"
+
+    // 1+1 should be normalized to 2
+    val expected = unaryNode("DataStreamCalc", streamTableNode(0), term("select", "+(2, a) AS a"))
+
+    util.verifySql(sqlQuery, expected)
+  }
+
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/rules/NormalizationRulesTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/rules/NormalizationRulesTest.scala
@@ -51,7 +51,7 @@ class NormalizationRulesTest extends TableTestBase {
       unaryNode("LogicalAggregate",
         unaryNode("LogicalAggregate",
           unaryNode("LogicalProject",
-            values("LogicalTableScan", term("table", "[MyTable]")),
+            values("LogicalTableScan", term("table", "[_DataSetTable_0]")),
             term("b", "$1"), term("a", "$0")),
           term("group", "{0, 1}")),
         term("group", "{0}"), term("EXPR$0", "COUNT($1)")
@@ -86,7 +86,7 @@ class NormalizationRulesTest extends TableTestBase {
       unaryNode("LogicalAggregate",
         unaryNode("LogicalAggregate",
           unaryNode("LogicalProject",
-            values("LogicalTableScan", term("table", "[MyTable]")),
+            values("LogicalTableScan", term("table", "[_DataStreamTable_0]")),
             term("b", "$1"), term("a", "$0")),
           term("group", "{0, 1}")),
         term("group", "{0}"), term("EXPR$0", "COUNT($1)")


### PR DESCRIPTION
This PR solves the bug described in FLINK-7005. This PR adds another stage to the optimization phase that converts table scans to full plans. However, it makes 2 rules non-optional. Do we want to make those two rules also configurable through the Calcite config?

This should definitely be part of Flink 1.3.2.