### PR TITLE
[FLINK-7023] [gelly] Remaining types for Gelly ValueArrays

### DIFF
--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ByteValueArrayComparator.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ByteValueArrayComparator.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.types.NormalizableKey;
+
+import java.io.IOException;
+
+/**
+ * Specialized comparator for ByteValueArray based on CopyableValueComparator.
+ *
+ * <p>This can be used for grouping keys but not for sorting keys.
+ */
+@Internal
+public class ByteValueArrayComparator extends TypeComparator<ByteValueArray> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final boolean ascendingComparison;
+
+	private final ByteValueArray reference = new ByteValueArray();
+
+	private final TypeComparator<?>[] comparators = new TypeComparator[] {this};
+
+	public ByteValueArrayComparator(boolean ascending) {
+		this.ascendingComparison = ascending;
+	}
+
+	@Override
+	public int hash(ByteValueArray record) {
+		return record.hashCode();
+	}
+
+	@Override
+	public void setReference(ByteValueArray toCompare) {
+		toCompare.copyTo(reference);
+	}
+
+	@Override
+	public boolean equalToReference(ByteValueArray candidate) {
+		return candidate.equals(this.reference);
+	}
+
+	@Override
+	public int compareToReference(TypeComparator<ByteValueArray> referencedComparator) {
+		int comp = ((ByteValueArrayComparator) referencedComparator).reference.compareTo(reference);
+		return ascendingComparison ? comp : -comp;
+	}
+
+	@Override
+	public int compare(ByteValueArray first, ByteValueArray second) {
+		int comp = first.compareTo(second);
+		return ascendingComparison ? comp : -comp;
+	}
+
+	@Override
+	public int compareSerialized(DataInputView firstSource, DataInputView secondSource) throws IOException {
+		int firstCount = firstSource.readInt();
+		int secondCount = secondSource.readInt();
+
+		int minCount = Math.min(firstCount, secondCount);
+		while (minCount-- > 0) {
+			byte firstValue = firstSource.readByte();
+			byte secondValue = secondSource.readByte();
+
+			int cmp = Byte.compare(firstValue, secondValue);
+			if (cmp != 0) {
+				return ascendingComparison ? cmp : -cmp;
+			}
+		}
+
+		int cmp = Integer.compare(firstCount, secondCount);
+		return ascendingComparison ? cmp : -cmp;
+	}
+
+	@Override
+	public boolean supportsNormalizedKey() {
+		return NormalizableKey.class.isAssignableFrom(ByteValueArray.class);
+	}
+
+	@Override
+	public int getNormalizeKeyLen() {
+		return reference.getMaxNormalizedKeyLen();
+	}
+
+	@Override
+	public boolean isNormalizedKeyPrefixOnly(int keyBytes) {
+		return keyBytes < getNormalizeKeyLen();
+	}
+
+	@Override
+	public void putNormalizedKey(ByteValueArray record, MemorySegment target, int offset, int numBytes) {
+		record.copyNormalizedKey(target, offset, numBytes);
+	}
+
+	@Override
+	public boolean invertNormalizedKey() {
+		return !ascendingComparison;
+	}
+
+	@Override
+	public TypeComparator<ByteValueArray> duplicate() {
+		return new ByteValueArrayComparator(ascendingComparison);
+	}
+
+	@Override
+	public int extractKeys(Object record, Object[] target, int index) {
+		target[index] = record;
+		return 1;
+	}
+
+	@Override
+	public TypeComparator<?>[] getFlatComparators() {
+		return comparators;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// unsupported normalization
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public boolean supportsSerializationWithKeyNormalization() {
+		return false;
+	}
+
+	@Override
+	public void writeWithKeyNormalization(ByteValueArray record, DataOutputView target) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ByteValueArray readWithKeyDenormalization(ByteValueArray reuse, DataInputView source) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ByteValueArraySerializer.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ByteValueArraySerializer.java
@@ -7,13 +7,14 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.flink.graph.types.valuearray;
@@ -26,9 +27,9 @@ import org.apache.flink.core.memory.DataOutputView;
 import java.io.IOException;
 
 /**
- * Specialized serializer for {@code LongValueArray}.
+ * Specialized serializer for {@code ByteValueArray}.
  */
-public final class LongValueArraySerializer extends TypeSerializerSingleton<LongValueArray> {
+public final class ByteValueArraySerializer extends TypeSerializerSingleton<ByteValueArray> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -38,17 +39,17 @@ public final class LongValueArraySerializer extends TypeSerializerSingleton<Long
 	}
 
 	@Override
-	public LongValueArray createInstance() {
-		return new LongValueArray();
+	public ByteValueArray createInstance() {
+		return new ByteValueArray();
 	}
 
 	@Override
-	public LongValueArray copy(LongValueArray from) {
-		return copy(from, new LongValueArray());
+	public ByteValueArray copy(ByteValueArray from) {
+		return copy(from, new ByteValueArray());
 	}
 
 	@Override
-	public LongValueArray copy(LongValueArray from, LongValueArray reuse) {
+	public ByteValueArray copy(ByteValueArray from, ByteValueArray reuse) {
 		reuse.setValue(from);
 		return reuse;
 	}
@@ -59,29 +60,29 @@ public final class LongValueArraySerializer extends TypeSerializerSingleton<Long
 	}
 
 	@Override
-	public void serialize(LongValueArray record, DataOutputView target) throws IOException {
+	public void serialize(ByteValueArray record, DataOutputView target) throws IOException {
 		record.write(target);
 	}
 
 	@Override
-	public LongValueArray deserialize(DataInputView source) throws IOException {
-		return deserialize(new LongValueArray(), source);
+	public ByteValueArray deserialize(DataInputView source) throws IOException {
+		return deserialize(new ByteValueArray(), source);
 	}
 
 	@Override
-	public LongValueArray deserialize(LongValueArray reuse, DataInputView source) throws IOException {
+	public ByteValueArray deserialize(ByteValueArray reuse, DataInputView source) throws IOException {
 		reuse.read(source);
 		return reuse;
 	}
 
 	@Override
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
-		LongValueArray.copyInternal(source, target);
+		ByteValueArray.copyInternal(source, target);
 	}
 
 	@Override
 	public boolean canEqual(Object obj) {
-		return obj instanceof LongValueArraySerializer;
+		return obj instanceof ByteValueArraySerializer;
 	}
 
 	@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/CharValueArray.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/CharValueArray.java
@@ -7,13 +7,14 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.flink.graph.types.valuearray;
@@ -22,59 +23,39 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.graph.utils.MurmurHash;
+import org.apache.flink.types.CharValue;
 import org.apache.flink.types.IntValue;
-import org.apache.flink.types.StringValue;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
-import java.nio.CharBuffer;
 import java.util.Arrays;
 import java.util.Iterator;
 
 /**
- * An array of {@link StringValue}.
- *
- * <p>Strings are serialized to a byte array. Concatenating arrays is as simple
- * and fast as extending and copying byte arrays. Strings are serialized when
- * individually added to {@code StringValueArray}.
- *
- * <p>For each string added to the array the length is first serialized using a
- * variable length integer. Then the string characters are serialized using a
- * variable length encoding where the lower 128 ASCII/UFT-8 characters are
- * encoded in a single byte. This ensures that common characters are serialized
- * in only two bytes.
+ * An array of {@link CharValue}.
  */
-public class StringValueArray
-implements ValueArray<StringValue> {
+public class CharValueArray
+implements ValueArray<CharValue> {
 
-	protected static final int DEFAULT_CAPACITY_IN_BYTES = 4096;
+	protected static final int ELEMENT_LENGTH_IN_BYTES = 2;
+
+	protected static final int DEFAULT_CAPACITY_IN_BYTES = 1024;
 
 	// see note in ArrayList, HashTable, ...
 	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
 
-	protected static final int HIGH_BIT = 0x1 << 7;
-
 	private boolean isBounded;
 
-	// the initial length of a bounded array, which is allowed to expand to
-	// store one additional element beyond this initial length
-	private int boundedLength;
+	private char[] data;
 
-	private byte[] data;
-
-	// number of StringValue elements currently stored
-	private int length;
-
-	// the number of bytes currently stored
+	// the number of elements currently stored
 	private int position;
 
-	// state for the bookmark used by mark() and reset()
-	private transient int markLength;
-
-	private transient int markPosition;
+	// location of the bookmark used by mark() and reset()
+	private transient int mark;
 
 	// hasher used to generate the normalized key
-	private MurmurHash hash = new MurmurHash(0x19264330);
+	private MurmurHash hash = new MurmurHash(0x43ba83a0);
 
 	// hash result stored as normalized key
 	private IntValue hashValue = new IntValue();
@@ -82,19 +63,18 @@ implements ValueArray<StringValue> {
 	/**
 	 * Initializes an expandable array with default capacity.
 	 */
-	public StringValueArray() {
+	public CharValueArray() {
 		isBounded = false;
 		initialize(DEFAULT_CAPACITY_IN_BYTES);
 	}
 
 	/**
-	 * Initializes a fixed-size array with the provided number of bytes.
+	 * Initializes a fixed-size array with the provided number of chars.
 	 *
 	 * @param bytes number of bytes of the encapsulated array
 	 */
-	public StringValueArray(int bytes) {
+	public CharValueArray(int bytes) {
 		isBounded = true;
-		boundedLength = bytes;
 		initialize(bytes);
 	}
 
@@ -104,10 +84,12 @@ implements ValueArray<StringValue> {
 	 * @param bytes initial size of the encapsulated array in bytes
 	 */
 	private void initialize(int bytes) {
-		Preconditions.checkArgument(bytes > 0, "Requested array with zero capacity");
-		Preconditions.checkArgument(bytes <= MAX_ARRAY_SIZE, "Requested capacity exceeds limit of " + MAX_ARRAY_SIZE);
+		int capacity = bytes / ELEMENT_LENGTH_IN_BYTES;
 
-		data = new byte[bytes];
+		Preconditions.checkArgument(capacity > 0, "Requested array with zero capacity");
+		Preconditions.checkArgument(capacity <= MAX_ARRAY_SIZE, "Requested capacity exceeds limit of " + MAX_ARRAY_SIZE);
+
+		data = new char[capacity];
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -140,15 +122,12 @@ implements ValueArray<StringValue> {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder("[");
-		String separator = "";
-
-		for (StringValue sv : this) {
-			sb
-				.append(sv.getValue())
-				.append(separator);
-			separator = ",";
+		for (int idx = 0; idx < this.position; idx++) {
+			sb.append(data[idx]);
+			if (idx < position - 1) {
+				sb.append(",");
+			}
 		}
-
 		sb.append("]");
 
 		return sb.toString();
@@ -161,18 +140,14 @@ implements ValueArray<StringValue> {
 	private final ReadIterator iterator = new ReadIterator();
 
 	@Override
-	public Iterator<StringValue> iterator() {
+	public Iterator<CharValue> iterator() {
 		iterator.reset();
 		return iterator;
 	}
 
 	private class ReadIterator
-	implements Iterator<StringValue> {
-		private static final int DEFAULT_SIZE = 64;
-
-		private StringValue value = new StringValue(CharBuffer.allocate(DEFAULT_SIZE));
-
-		private int size = DEFAULT_SIZE;
+	implements Iterator<CharValue> {
+		private CharValue value = new CharValue();
 
 		private int pos;
 
@@ -182,50 +157,9 @@ implements ValueArray<StringValue> {
 		}
 
 		@Override
-		public StringValue next() {
-			// read length
-			int len = data[pos++] & 0xFF;
-
-			if (len >= HIGH_BIT) {
-				int shift = 7;
-				int curr;
-				len = len & 0x7F;
-				while ((curr = data[pos++] & 0xFF) >= HIGH_BIT) {
-					len |= (curr & 0x7F) << shift;
-					shift += 7;
-				}
-				len |= curr << shift;
-			}
-
-			// ensure capacity
-			if (len > size) {
-				while (size < len) {
-					size *= 2;
-				}
-
-				value = new StringValue(CharBuffer.allocate(size));
-			}
-
-			// read string characters
-			final char[] valueData = value.getCharArray();
-
-			for (int i = 0; i < len; i++) {
-				int c = data[pos++] & 0xFF;
-				if (c >= HIGH_BIT) {
-					int shift = 7;
-					int curr;
-					c = c & 0x7F;
-					while ((curr = data[pos++] & 0xFF) >= HIGH_BIT) {
-						c |= (curr & 0x7F) << shift;
-						shift += 7;
-					}
-					c |= curr << shift;
-				}
-				valueData[i] = (char) c;
-			}
-
-			// cannot prevent allocation of new StringValue!
-			return value.substring(0, len);
+		public CharValue next() {
+			value.setValue(data[pos++]);
+			return value;
 		}
 
 		@Override
@@ -244,23 +178,23 @@ implements ValueArray<StringValue> {
 
 	@Override
 	public void write(DataOutputView out) throws IOException {
-		out.writeInt(length);
 		out.writeInt(position);
 
-		out.write(data, 0, position);
+		for (int i = 0; i < position; i++) {
+			out.writeChar(data[i]);
+		}
 	}
 
 	@Override
 	public void read(DataInputView in) throws IOException {
-		length = in.readInt();
 		position = in.readInt();
-
-		markLength = 0;
-		markPosition = 0;
+		mark = 0;
 
 		ensureCapacity(position);
 
-		in.read(data, 0, position);
+		for (int i = 0; i < position; i++) {
+			data[i] = in.readChar();
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -290,26 +224,19 @@ implements ValueArray<StringValue> {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public int compareTo(ValueArray<StringValue> o) {
-		StringValueArray other = (StringValueArray) o;
+	public int compareTo(ValueArray<CharValue> o) {
+		CharValueArray other = (CharValueArray) o;
 
-		// sorts first on number of data in the array, then comparison between
-		// the first non-equal element in the arrays
-		int cmp = Integer.compare(position, other.position);
-
-		if (cmp != 0) {
-			return cmp;
-		}
-
-		for (int i = 0; i < position; i++) {
-			cmp = Byte.compare(data[i], other.data[i]);
+		int min = Math.min(position, other.position);
+		for (int i = 0; i < min; i++) {
+			int cmp = Character.compare(data[i], other.data[i]);
 
 			if (cmp != 0) {
 				return cmp;
 			}
 		}
 
-		return 0;
+		return Integer.compare(position, other.position);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -329,12 +256,8 @@ implements ValueArray<StringValue> {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof StringValueArray) {
-			StringValueArray other = (StringValueArray) obj;
-
-			if (length != other.length) {
-				return false;
-			}
+		if (obj instanceof CharValueArray) {
+			CharValueArray other = (CharValueArray) obj;
 
 			if (position != other.position) {
 				return false;
@@ -357,7 +280,7 @@ implements ValueArray<StringValue> {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public void setValue(ValueArray<StringValue> value) {
+	public void setValue(ValueArray<CharValue> value) {
 		value.copyTo(this);
 	}
 
@@ -371,21 +294,19 @@ implements ValueArray<StringValue> {
 	}
 
 	@Override
-	public void copyTo(ValueArray<StringValue> target) {
-		StringValueArray other = (StringValueArray) target;
+	public void copyTo(ValueArray<CharValue> target) {
+		CharValueArray other = (CharValueArray) target;
 
-		other.length = length;
 		other.position = position;
-		other.markLength = markLength;
-		other.markPosition = markPosition;
+		other.mark = mark;
 
 		other.ensureCapacity(position);
 		System.arraycopy(data, 0, other.data, 0, position);
 	}
 
 	@Override
-	public ValueArray<StringValue> copy() {
-		ValueArray<StringValue> copy = new StringValueArray();
+	public ValueArray<CharValue> copy() {
+		ValueArray<CharValue> copy = new CharValueArray();
 
 		this.copyTo(copy);
 
@@ -398,13 +319,11 @@ implements ValueArray<StringValue> {
 	}
 
 	protected static void copyInternal(DataInputView source, DataOutputView target) throws IOException {
-		int length = source.readInt();
-		target.writeInt(length);
+		int count = source.readInt();
+		target.writeInt(count);
 
-		int position = source.readInt();
-		target.writeInt(position);
-
-		target.write(source, position);
+		int bytes = ELEMENT_LENGTH_IN_BYTES * count;
+		target.write(source, bytes);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -413,73 +332,39 @@ implements ValueArray<StringValue> {
 
 	@Override
 	public int size() {
-		return length;
+		return position;
 	}
 
 	@Override
 	public boolean isFull() {
 		if (isBounded) {
-			return position >= boundedLength;
+			return position == data.length;
 		} else {
 			return position == MAX_ARRAY_SIZE;
 		}
 	}
 
 	@Override
-	public boolean add(StringValue value) {
-		if (isBounded && position >= boundedLength) {
-			return false;
-		}
+	public boolean add(CharValue value) {
+		int newPosition = position + 1;
 
-		// up to five bytes storing length
-		if (position + 5 > data.length) {
-			ensureCapacity(position + 5);
-		}
-
-		// update local variable until serialization succeeds
-		int newPosition = position;
-
-		// write the length, variable-length encoded
-		int len = value.length();
-
-		while (len >= HIGH_BIT) {
-			data[newPosition++] = (byte) (len | HIGH_BIT);
-			len >>>= 7;
-		}
-		data[newPosition++] = (byte) len;
-
-		// write the char data, variable-length encoded
-		final char[] valueData = value.getCharArray();
-		int remainingCapacity = data.length - newPosition;
-
-		len = value.length();
-		for (int i = 0; i < len; i++) {
-			// up to three bytes storing length
-			if (remainingCapacity < 3) {
-				ensureCapacity(remainingCapacity + 3);
-				remainingCapacity = data.length - newPosition;
+		if (newPosition > data.length) {
+			if (isBounded) {
+				return false;
+			} else {
+				ensureCapacity(newPosition);
 			}
-
-			int c = valueData[i];
-
-			while (c >= HIGH_BIT) {
-				data[newPosition++] = (byte) (c | HIGH_BIT);
-				remainingCapacity--;
-				c >>>= 7;
-			}
-			data[newPosition++] = (byte) c;
-			remainingCapacity--;
 		}
 
-		length++;
+		data[position] = value.getValue();
 		position = newPosition;
 
 		return true;
 	}
 
 	@Override
-	public boolean addAll(ValueArray<StringValue> other) {
-		StringValueArray source = (StringValueArray) other;
+	public boolean addAll(ValueArray<CharValue> other) {
+		CharValueArray source = (CharValueArray) other;
 
 		int sourceSize = source.position;
 		int newPosition = position + sourceSize;
@@ -493,27 +378,23 @@ implements ValueArray<StringValue> {
 		}
 
 		System.arraycopy(source.data, 0, data, position, sourceSize);
-		length += source.length;
-  	    position = newPosition;
+		position = newPosition;
 
 		return true;
 	}
 
 	@Override
 	public void clear() {
-		length = 0;
 		position = 0;
 	}
 
 	@Override
 	public void mark() {
-		markLength = length;
-		markPosition = position;
+		mark = position;
 	}
 
 	@Override
 	public void reset() {
-		length = markLength;
-		position = markPosition;
+		position = mark;
 	}
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/CharValueArrayComparator.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/CharValueArrayComparator.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.types.NormalizableKey;
+
+import java.io.IOException;
+
+/**
+ * Specialized comparator for CharValueArray based on CopyableValueComparator.
+ *
+ * <p>This can be used for grouping keys but not for sorting keys.
+ */
+@Internal
+public class CharValueArrayComparator extends TypeComparator<CharValueArray> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final boolean ascendingComparison;
+
+	private final CharValueArray reference = new CharValueArray();
+
+	private final TypeComparator<?>[] comparators = new TypeComparator[] {this};
+
+	public CharValueArrayComparator(boolean ascending) {
+		this.ascendingComparison = ascending;
+	}
+
+	@Override
+	public int hash(CharValueArray record) {
+		return record.hashCode();
+	}
+
+	@Override
+	public void setReference(CharValueArray toCompare) {
+		toCompare.copyTo(reference);
+	}
+
+	@Override
+	public boolean equalToReference(CharValueArray candidate) {
+		return candidate.equals(this.reference);
+	}
+
+	@Override
+	public int compareToReference(TypeComparator<CharValueArray> referencedComparator) {
+		int comp = ((CharValueArrayComparator) referencedComparator).reference.compareTo(reference);
+		return ascendingComparison ? comp : -comp;
+	}
+
+	@Override
+	public int compare(CharValueArray first, CharValueArray second) {
+		int comp = first.compareTo(second);
+		return ascendingComparison ? comp : -comp;
+	}
+
+	@Override
+	public int compareSerialized(DataInputView firstSource, DataInputView secondSource) throws IOException {
+		int firstCount = firstSource.readInt();
+		int secondCount = secondSource.readInt();
+
+		int minCount = Math.min(firstCount, secondCount);
+		while (minCount-- > 0) {
+			char firstValue = firstSource.readChar();
+			char secondValue = secondSource.readChar();
+
+			int cmp = Character.compare(firstValue, secondValue);
+			if (cmp != 0) {
+				return ascendingComparison ? cmp : -cmp;
+			}
+		}
+
+		int cmp = Integer.compare(firstCount, secondCount);
+		return ascendingComparison ? cmp : -cmp;
+	}
+
+	@Override
+	public boolean supportsNormalizedKey() {
+		return NormalizableKey.class.isAssignableFrom(CharValueArray.class);
+	}
+
+	@Override
+	public int getNormalizeKeyLen() {
+		return reference.getMaxNormalizedKeyLen();
+	}
+
+	@Override
+	public boolean isNormalizedKeyPrefixOnly(int keyChars) {
+		return keyChars < getNormalizeKeyLen();
+	}
+
+	@Override
+	public void putNormalizedKey(CharValueArray record, MemorySegment target, int offset, int numChars) {
+		record.copyNormalizedKey(target, offset, numChars);
+	}
+
+	@Override
+	public boolean invertNormalizedKey() {
+		return !ascendingComparison;
+	}
+
+	@Override
+	public TypeComparator<CharValueArray> duplicate() {
+		return new CharValueArrayComparator(ascendingComparison);
+	}
+
+	@Override
+	public int extractKeys(Object record, Object[] target, int index) {
+		target[index] = record;
+		return 1;
+	}
+
+	@Override
+	public TypeComparator<?>[] getFlatComparators() {
+		return comparators;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// unsupported normalization
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public boolean supportsSerializationWithKeyNormalization() {
+		return false;
+	}
+
+	@Override
+	public void writeWithKeyNormalization(CharValueArray record, DataOutputView target) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CharValueArray readWithKeyDenormalization(CharValueArray reuse, DataInputView source) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/CharValueArraySerializer.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/CharValueArraySerializer.java
@@ -7,13 +7,14 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.flink.graph.types.valuearray;
@@ -26,9 +27,9 @@ import org.apache.flink.core.memory.DataOutputView;
 import java.io.IOException;
 
 /**
- * Specialized serializer for {@code LongValueArray}.
+ * Specialized serializer for {@code CharValueArray}.
  */
-public final class LongValueArraySerializer extends TypeSerializerSingleton<LongValueArray> {
+public final class CharValueArraySerializer extends TypeSerializerSingleton<CharValueArray> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -38,17 +39,17 @@ public final class LongValueArraySerializer extends TypeSerializerSingleton<Long
 	}
 
 	@Override
-	public LongValueArray createInstance() {
-		return new LongValueArray();
+	public CharValueArray createInstance() {
+		return new CharValueArray();
 	}
 
 	@Override
-	public LongValueArray copy(LongValueArray from) {
-		return copy(from, new LongValueArray());
+	public CharValueArray copy(CharValueArray from) {
+		return copy(from, new CharValueArray());
 	}
 
 	@Override
-	public LongValueArray copy(LongValueArray from, LongValueArray reuse) {
+	public CharValueArray copy(CharValueArray from, CharValueArray reuse) {
 		reuse.setValue(from);
 		return reuse;
 	}
@@ -59,29 +60,29 @@ public final class LongValueArraySerializer extends TypeSerializerSingleton<Long
 	}
 
 	@Override
-	public void serialize(LongValueArray record, DataOutputView target) throws IOException {
+	public void serialize(CharValueArray record, DataOutputView target) throws IOException {
 		record.write(target);
 	}
 
 	@Override
-	public LongValueArray deserialize(DataInputView source) throws IOException {
-		return deserialize(new LongValueArray(), source);
+	public CharValueArray deserialize(DataInputView source) throws IOException {
+		return deserialize(new CharValueArray(), source);
 	}
 
 	@Override
-	public LongValueArray deserialize(LongValueArray reuse, DataInputView source) throws IOException {
+	public CharValueArray deserialize(CharValueArray reuse, DataInputView source) throws IOException {
 		reuse.read(source);
 		return reuse;
 	}
 
 	@Override
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
-		LongValueArray.copyInternal(source, target);
+		CharValueArray.copyInternal(source, target);
 	}
 
 	@Override
 	public boolean canEqual(Object obj) {
-		return obj instanceof LongValueArraySerializer;
+		return obj instanceof CharValueArraySerializer;
 	}
 
 	@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/DoubleValueArray.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/DoubleValueArray.java
@@ -7,13 +7,14 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.flink.graph.types.valuearray;
@@ -22,59 +23,39 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.graph.utils.MurmurHash;
+import org.apache.flink.types.DoubleValue;
 import org.apache.flink.types.IntValue;
-import org.apache.flink.types.StringValue;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
-import java.nio.CharBuffer;
 import java.util.Arrays;
 import java.util.Iterator;
 
 /**
- * An array of {@link StringValue}.
- *
- * <p>Strings are serialized to a byte array. Concatenating arrays is as simple
- * and fast as extending and copying byte arrays. Strings are serialized when
- * individually added to {@code StringValueArray}.
- *
- * <p>For each string added to the array the length is first serialized using a
- * variable length integer. Then the string characters are serialized using a
- * variable length encoding where the lower 128 ASCII/UFT-8 characters are
- * encoded in a single byte. This ensures that common characters are serialized
- * in only two bytes.
+ * An array of {@link DoubleValue}.
  */
-public class StringValueArray
-implements ValueArray<StringValue> {
+public class DoubleValueArray
+implements ValueArray<DoubleValue> {
 
-	protected static final int DEFAULT_CAPACITY_IN_BYTES = 4096;
+	protected static final int ELEMENT_LENGTH_IN_BYTES = 8;
+
+	protected static final int DEFAULT_CAPACITY_IN_BYTES = 1024;
 
 	// see note in ArrayList, HashTable, ...
 	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
 
-	protected static final int HIGH_BIT = 0x1 << 7;
-
 	private boolean isBounded;
 
-	// the initial length of a bounded array, which is allowed to expand to
-	// store one additional element beyond this initial length
-	private int boundedLength;
+	private double[] data;
 
-	private byte[] data;
-
-	// number of StringValue elements currently stored
-	private int length;
-
-	// the number of bytes currently stored
+	// the number of elements currently stored
 	private int position;
 
-	// state for the bookmark used by mark() and reset()
-	private transient int markLength;
-
-	private transient int markPosition;
+	// location of the bookmark used by mark() and reset()
+	private transient int mark;
 
 	// hasher used to generate the normalized key
-	private MurmurHash hash = new MurmurHash(0x19264330);
+	private MurmurHash hash = new MurmurHash(0xae2f2cb7);
 
 	// hash result stored as normalized key
 	private IntValue hashValue = new IntValue();
@@ -82,19 +63,18 @@ implements ValueArray<StringValue> {
 	/**
 	 * Initializes an expandable array with default capacity.
 	 */
-	public StringValueArray() {
+	public DoubleValueArray() {
 		isBounded = false;
 		initialize(DEFAULT_CAPACITY_IN_BYTES);
 	}
 
 	/**
-	 * Initializes a fixed-size array with the provided number of bytes.
+	 * Initializes a fixed-size array with the provided number of doubles.
 	 *
 	 * @param bytes number of bytes of the encapsulated array
 	 */
-	public StringValueArray(int bytes) {
+	public DoubleValueArray(int bytes) {
 		isBounded = true;
-		boundedLength = bytes;
 		initialize(bytes);
 	}
 
@@ -104,10 +84,12 @@ implements ValueArray<StringValue> {
 	 * @param bytes initial size of the encapsulated array in bytes
 	 */
 	private void initialize(int bytes) {
-		Preconditions.checkArgument(bytes > 0, "Requested array with zero capacity");
-		Preconditions.checkArgument(bytes <= MAX_ARRAY_SIZE, "Requested capacity exceeds limit of " + MAX_ARRAY_SIZE);
+		int capacity = bytes / ELEMENT_LENGTH_IN_BYTES;
 
-		data = new byte[bytes];
+		Preconditions.checkArgument(capacity > 0, "Requested array with zero capacity");
+		Preconditions.checkArgument(capacity <= MAX_ARRAY_SIZE, "Requested capacity exceeds limit of " + MAX_ARRAY_SIZE);
+
+		data = new double[capacity];
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -140,15 +122,12 @@ implements ValueArray<StringValue> {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder("[");
-		String separator = "";
-
-		for (StringValue sv : this) {
-			sb
-				.append(sv.getValue())
-				.append(separator);
-			separator = ",";
+		for (int idx = 0; idx < this.position; idx++) {
+			sb.append(data[idx]);
+			if (idx < position - 1) {
+				sb.append(",");
+			}
 		}
-
 		sb.append("]");
 
 		return sb.toString();
@@ -161,18 +140,14 @@ implements ValueArray<StringValue> {
 	private final ReadIterator iterator = new ReadIterator();
 
 	@Override
-	public Iterator<StringValue> iterator() {
+	public Iterator<DoubleValue> iterator() {
 		iterator.reset();
 		return iterator;
 	}
 
 	private class ReadIterator
-	implements Iterator<StringValue> {
-		private static final int DEFAULT_SIZE = 64;
-
-		private StringValue value = new StringValue(CharBuffer.allocate(DEFAULT_SIZE));
-
-		private int size = DEFAULT_SIZE;
+	implements Iterator<DoubleValue> {
+		private DoubleValue value = new DoubleValue();
 
 		private int pos;
 
@@ -182,50 +157,9 @@ implements ValueArray<StringValue> {
 		}
 
 		@Override
-		public StringValue next() {
-			// read length
-			int len = data[pos++] & 0xFF;
-
-			if (len >= HIGH_BIT) {
-				int shift = 7;
-				int curr;
-				len = len & 0x7F;
-				while ((curr = data[pos++] & 0xFF) >= HIGH_BIT) {
-					len |= (curr & 0x7F) << shift;
-					shift += 7;
-				}
-				len |= curr << shift;
-			}
-
-			// ensure capacity
-			if (len > size) {
-				while (size < len) {
-					size *= 2;
-				}
-
-				value = new StringValue(CharBuffer.allocate(size));
-			}
-
-			// read string characters
-			final char[] valueData = value.getCharArray();
-
-			for (int i = 0; i < len; i++) {
-				int c = data[pos++] & 0xFF;
-				if (c >= HIGH_BIT) {
-					int shift = 7;
-					int curr;
-					c = c & 0x7F;
-					while ((curr = data[pos++] & 0xFF) >= HIGH_BIT) {
-						c |= (curr & 0x7F) << shift;
-						shift += 7;
-					}
-					c |= curr << shift;
-				}
-				valueData[i] = (char) c;
-			}
-
-			// cannot prevent allocation of new StringValue!
-			return value.substring(0, len);
+		public DoubleValue next() {
+			value.setValue(data[pos++]);
+			return value;
 		}
 
 		@Override
@@ -244,23 +178,23 @@ implements ValueArray<StringValue> {
 
 	@Override
 	public void write(DataOutputView out) throws IOException {
-		out.writeInt(length);
 		out.writeInt(position);
 
-		out.write(data, 0, position);
+		for (int i = 0; i < position; i++) {
+			out.writeDouble(data[i]);
+		}
 	}
 
 	@Override
 	public void read(DataInputView in) throws IOException {
-		length = in.readInt();
 		position = in.readInt();
-
-		markLength = 0;
-		markPosition = 0;
+		mark = 0;
 
 		ensureCapacity(position);
 
-		in.read(data, 0, position);
+		for (int i = 0; i < position; i++) {
+			data[i] = in.readDouble();
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -290,26 +224,19 @@ implements ValueArray<StringValue> {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public int compareTo(ValueArray<StringValue> o) {
-		StringValueArray other = (StringValueArray) o;
+	public int compareTo(ValueArray<DoubleValue> o) {
+		DoubleValueArray other = (DoubleValueArray) o;
 
-		// sorts first on number of data in the array, then comparison between
-		// the first non-equal element in the arrays
-		int cmp = Integer.compare(position, other.position);
-
-		if (cmp != 0) {
-			return cmp;
-		}
-
-		for (int i = 0; i < position; i++) {
-			cmp = Byte.compare(data[i], other.data[i]);
+		int min = Math.min(position, other.position);
+		for (int i = 0; i < min; i++) {
+			int cmp = Double.compare(data[i], other.data[i]);
 
 			if (cmp != 0) {
 				return cmp;
 			}
 		}
 
-		return 0;
+		return Integer.compare(position, other.position);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -321,7 +248,8 @@ implements ValueArray<StringValue> {
 		int hash = 0;
 
 		for (int i = 0; i < position; i++) {
-			hash = 31 * hash + data[i];
+			long bits = Double.doubleToLongBits(data[i]);
+			hash = 31 * hash + (int) (bits + bits >>> 32);
 		}
 
 		return hash;
@@ -329,12 +257,8 @@ implements ValueArray<StringValue> {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof StringValueArray) {
-			StringValueArray other = (StringValueArray) obj;
-
-			if (length != other.length) {
-				return false;
-			}
+		if (obj instanceof DoubleValueArray) {
+			DoubleValueArray other = (DoubleValueArray) obj;
 
 			if (position != other.position) {
 				return false;
@@ -357,7 +281,7 @@ implements ValueArray<StringValue> {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public void setValue(ValueArray<StringValue> value) {
+	public void setValue(ValueArray<DoubleValue> value) {
 		value.copyTo(this);
 	}
 
@@ -371,21 +295,19 @@ implements ValueArray<StringValue> {
 	}
 
 	@Override
-	public void copyTo(ValueArray<StringValue> target) {
-		StringValueArray other = (StringValueArray) target;
+	public void copyTo(ValueArray<DoubleValue> target) {
+		DoubleValueArray other = (DoubleValueArray) target;
 
-		other.length = length;
 		other.position = position;
-		other.markLength = markLength;
-		other.markPosition = markPosition;
+		other.mark = mark;
 
 		other.ensureCapacity(position);
 		System.arraycopy(data, 0, other.data, 0, position);
 	}
 
 	@Override
-	public ValueArray<StringValue> copy() {
-		ValueArray<StringValue> copy = new StringValueArray();
+	public ValueArray<DoubleValue> copy() {
+		ValueArray<DoubleValue> copy = new DoubleValueArray();
 
 		this.copyTo(copy);
 
@@ -398,13 +320,11 @@ implements ValueArray<StringValue> {
 	}
 
 	protected static void copyInternal(DataInputView source, DataOutputView target) throws IOException {
-		int length = source.readInt();
-		target.writeInt(length);
+		int count = source.readInt();
+		target.writeInt(count);
 
-		int position = source.readInt();
-		target.writeInt(position);
-
-		target.write(source, position);
+		int bytes = ELEMENT_LENGTH_IN_BYTES * count;
+		target.write(source, bytes);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -413,73 +333,39 @@ implements ValueArray<StringValue> {
 
 	@Override
 	public int size() {
-		return length;
+		return position;
 	}
 
 	@Override
 	public boolean isFull() {
 		if (isBounded) {
-			return position >= boundedLength;
+			return position == data.length;
 		} else {
 			return position == MAX_ARRAY_SIZE;
 		}
 	}
 
 	@Override
-	public boolean add(StringValue value) {
-		if (isBounded && position >= boundedLength) {
-			return false;
-		}
+	public boolean add(DoubleValue value) {
+		int newPosition = position + 1;
 
-		// up to five bytes storing length
-		if (position + 5 > data.length) {
-			ensureCapacity(position + 5);
-		}
-
-		// update local variable until serialization succeeds
-		int newPosition = position;
-
-		// write the length, variable-length encoded
-		int len = value.length();
-
-		while (len >= HIGH_BIT) {
-			data[newPosition++] = (byte) (len | HIGH_BIT);
-			len >>>= 7;
-		}
-		data[newPosition++] = (byte) len;
-
-		// write the char data, variable-length encoded
-		final char[] valueData = value.getCharArray();
-		int remainingCapacity = data.length - newPosition;
-
-		len = value.length();
-		for (int i = 0; i < len; i++) {
-			// up to three bytes storing length
-			if (remainingCapacity < 3) {
-				ensureCapacity(remainingCapacity + 3);
-				remainingCapacity = data.length - newPosition;
+		if (newPosition > data.length) {
+			if (isBounded) {
+				return false;
+			} else {
+				ensureCapacity(newPosition);
 			}
-
-			int c = valueData[i];
-
-			while (c >= HIGH_BIT) {
-				data[newPosition++] = (byte) (c | HIGH_BIT);
-				remainingCapacity--;
-				c >>>= 7;
-			}
-			data[newPosition++] = (byte) c;
-			remainingCapacity--;
 		}
 
-		length++;
+		data[position] = value.getValue();
 		position = newPosition;
 
 		return true;
 	}
 
 	@Override
-	public boolean addAll(ValueArray<StringValue> other) {
-		StringValueArray source = (StringValueArray) other;
+	public boolean addAll(ValueArray<DoubleValue> other) {
+		DoubleValueArray source = (DoubleValueArray) other;
 
 		int sourceSize = source.position;
 		int newPosition = position + sourceSize;
@@ -493,27 +379,23 @@ implements ValueArray<StringValue> {
 		}
 
 		System.arraycopy(source.data, 0, data, position, sourceSize);
-		length += source.length;
-  	    position = newPosition;
+		position = newPosition;
 
 		return true;
 	}
 
 	@Override
 	public void clear() {
-		length = 0;
 		position = 0;
 	}
 
 	@Override
 	public void mark() {
-		markLength = length;
-		markPosition = position;
+		mark = position;
 	}
 
 	@Override
 	public void reset() {
-		length = markLength;
-		position = markPosition;
+		position = mark;
 	}
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/DoubleValueArrayComparator.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/DoubleValueArrayComparator.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.types.NormalizableKey;
+
+import java.io.IOException;
+
+/**
+ * Specialized comparator for DoubleValueArray based on CopyableValueComparator.
+ *
+ * <p>This can be used for grouping keys but not for sorting keys.
+ */
+@Internal
+public class DoubleValueArrayComparator extends TypeComparator<DoubleValueArray> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final boolean ascendingComparison;
+
+	private final DoubleValueArray reference = new DoubleValueArray();
+
+	private final TypeComparator<?>[] comparators = new TypeComparator[] {this};
+
+	public DoubleValueArrayComparator(boolean ascending) {
+		this.ascendingComparison = ascending;
+	}
+
+	@Override
+	public int hash(DoubleValueArray record) {
+		return record.hashCode();
+	}
+
+	@Override
+	public void setReference(DoubleValueArray toCompare) {
+		toCompare.copyTo(reference);
+	}
+
+	@Override
+	public boolean equalToReference(DoubleValueArray candidate) {
+		return candidate.equals(this.reference);
+	}
+
+	@Override
+	public int compareToReference(TypeComparator<DoubleValueArray> referencedComparator) {
+		int comp = ((DoubleValueArrayComparator) referencedComparator).reference.compareTo(reference);
+		return ascendingComparison ? comp : -comp;
+	}
+
+	@Override
+	public int compare(DoubleValueArray first, DoubleValueArray second) {
+		int comp = first.compareTo(second);
+		return ascendingComparison ? comp : -comp;
+	}
+
+	@Override
+	public int compareSerialized(DataInputView firstSource, DataInputView secondSource) throws IOException {
+		int firstCount = firstSource.readInt();
+		int secondCount = secondSource.readInt();
+
+		int minCount = Math.min(firstCount, secondCount);
+		while (minCount-- > 0) {
+			double firstValue = firstSource.readDouble();
+			double secondValue = secondSource.readDouble();
+
+			int cmp = Double.compare(firstValue, secondValue);
+			if (cmp != 0) {
+				return ascendingComparison ? cmp : -cmp;
+			}
+		}
+
+		int cmp = Integer.compare(firstCount, secondCount);
+		return ascendingComparison ? cmp : -cmp;
+	}
+
+	@Override
+	public boolean supportsNormalizedKey() {
+		return NormalizableKey.class.isAssignableFrom(DoubleValueArray.class);
+	}
+
+	@Override
+	public int getNormalizeKeyLen() {
+		return reference.getMaxNormalizedKeyLen();
+	}
+
+	@Override
+	public boolean isNormalizedKeyPrefixOnly(int keyDoubles) {
+		return keyDoubles < getNormalizeKeyLen();
+	}
+
+	@Override
+	public void putNormalizedKey(DoubleValueArray record, MemorySegment target, int offset, int numDoubles) {
+		record.copyNormalizedKey(target, offset, numDoubles);
+	}
+
+	@Override
+	public boolean invertNormalizedKey() {
+		return !ascendingComparison;
+	}
+
+	@Override
+	public TypeComparator<DoubleValueArray> duplicate() {
+		return new DoubleValueArrayComparator(ascendingComparison);
+	}
+
+	@Override
+	public int extractKeys(Object record, Object[] target, int index) {
+		target[index] = record;
+		return 1;
+	}
+
+	@Override
+	public TypeComparator<?>[] getFlatComparators() {
+		return comparators;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// unsupported normalization
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public boolean supportsSerializationWithKeyNormalization() {
+		return false;
+	}
+
+	@Override
+	public void writeWithKeyNormalization(DoubleValueArray record, DataOutputView target) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public DoubleValueArray readWithKeyDenormalization(DoubleValueArray reuse, DataInputView source) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/DoubleValueArraySerializer.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/DoubleValueArraySerializer.java
@@ -7,13 +7,14 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.flink.graph.types.valuearray;
@@ -26,9 +27,9 @@ import org.apache.flink.core.memory.DataOutputView;
 import java.io.IOException;
 
 /**
- * Specialized serializer for {@code LongValueArray}.
+ * Specialized serializer for {@code DoubleValueArray}.
  */
-public final class LongValueArraySerializer extends TypeSerializerSingleton<LongValueArray> {
+public final class DoubleValueArraySerializer extends TypeSerializerSingleton<DoubleValueArray> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -38,17 +39,17 @@ public final class LongValueArraySerializer extends TypeSerializerSingleton<Long
 	}
 
 	@Override
-	public LongValueArray createInstance() {
-		return new LongValueArray();
+	public DoubleValueArray createInstance() {
+		return new DoubleValueArray();
 	}
 
 	@Override
-	public LongValueArray copy(LongValueArray from) {
-		return copy(from, new LongValueArray());
+	public DoubleValueArray copy(DoubleValueArray from) {
+		return copy(from, new DoubleValueArray());
 	}
 
 	@Override
-	public LongValueArray copy(LongValueArray from, LongValueArray reuse) {
+	public DoubleValueArray copy(DoubleValueArray from, DoubleValueArray reuse) {
 		reuse.setValue(from);
 		return reuse;
 	}
@@ -59,29 +60,29 @@ public final class LongValueArraySerializer extends TypeSerializerSingleton<Long
 	}
 
 	@Override
-	public void serialize(LongValueArray record, DataOutputView target) throws IOException {
+	public void serialize(DoubleValueArray record, DataOutputView target) throws IOException {
 		record.write(target);
 	}
 
 	@Override
-	public LongValueArray deserialize(DataInputView source) throws IOException {
-		return deserialize(new LongValueArray(), source);
+	public DoubleValueArray deserialize(DataInputView source) throws IOException {
+		return deserialize(new DoubleValueArray(), source);
 	}
 
 	@Override
-	public LongValueArray deserialize(LongValueArray reuse, DataInputView source) throws IOException {
+	public DoubleValueArray deserialize(DoubleValueArray reuse, DataInputView source) throws IOException {
 		reuse.read(source);
 		return reuse;
 	}
 
 	@Override
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
-		LongValueArray.copyInternal(source, target);
+		DoubleValueArray.copyInternal(source, target);
 	}
 
 	@Override
 	public boolean canEqual(Object obj) {
-		return obj instanceof LongValueArraySerializer;
+		return obj instanceof DoubleValueArraySerializer;
 	}
 
 	@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/FloatValueArray.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/FloatValueArray.java
@@ -7,13 +7,14 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.flink.graph.types.valuearray;
@@ -22,59 +23,39 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.graph.utils.MurmurHash;
+import org.apache.flink.types.FloatValue;
 import org.apache.flink.types.IntValue;
-import org.apache.flink.types.StringValue;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
-import java.nio.CharBuffer;
 import java.util.Arrays;
 import java.util.Iterator;
 
 /**
- * An array of {@link StringValue}.
- *
- * <p>Strings are serialized to a byte array. Concatenating arrays is as simple
- * and fast as extending and copying byte arrays. Strings are serialized when
- * individually added to {@code StringValueArray}.
- *
- * <p>For each string added to the array the length is first serialized using a
- * variable length integer. Then the string characters are serialized using a
- * variable length encoding where the lower 128 ASCII/UFT-8 characters are
- * encoded in a single byte. This ensures that common characters are serialized
- * in only two bytes.
+ * An array of {@link FloatValue}.
  */
-public class StringValueArray
-implements ValueArray<StringValue> {
+public class FloatValueArray
+implements ValueArray<FloatValue> {
 
-	protected static final int DEFAULT_CAPACITY_IN_BYTES = 4096;
+	protected static final int ELEMENT_LENGTH_IN_BYTES = 4;
+
+	protected static final int DEFAULT_CAPACITY_IN_BYTES = 1024;
 
 	// see note in ArrayList, HashTable, ...
 	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
 
-	protected static final int HIGH_BIT = 0x1 << 7;
-
 	private boolean isBounded;
 
-	// the initial length of a bounded array, which is allowed to expand to
-	// store one additional element beyond this initial length
-	private int boundedLength;
+	private float[] data;
 
-	private byte[] data;
-
-	// number of StringValue elements currently stored
-	private int length;
-
-	// the number of bytes currently stored
+	// the number of elements currently stored
 	private int position;
 
-	// state for the bookmark used by mark() and reset()
-	private transient int markLength;
-
-	private transient int markPosition;
+	// location of the bookmark used by mark() and reset()
+	private transient int mark;
 
 	// hasher used to generate the normalized key
-	private MurmurHash hash = new MurmurHash(0x19264330);
+	private MurmurHash hash = new MurmurHash(0xae2f2cb7);
 
 	// hash result stored as normalized key
 	private IntValue hashValue = new IntValue();
@@ -82,19 +63,18 @@ implements ValueArray<StringValue> {
 	/**
 	 * Initializes an expandable array with default capacity.
 	 */
-	public StringValueArray() {
+	public FloatValueArray() {
 		isBounded = false;
 		initialize(DEFAULT_CAPACITY_IN_BYTES);
 	}
 
 	/**
-	 * Initializes a fixed-size array with the provided number of bytes.
+	 * Initializes a fixed-size array with the provided number of floats.
 	 *
 	 * @param bytes number of bytes of the encapsulated array
 	 */
-	public StringValueArray(int bytes) {
+	public FloatValueArray(int bytes) {
 		isBounded = true;
-		boundedLength = bytes;
 		initialize(bytes);
 	}
 
@@ -104,10 +84,12 @@ implements ValueArray<StringValue> {
 	 * @param bytes initial size of the encapsulated array in bytes
 	 */
 	private void initialize(int bytes) {
-		Preconditions.checkArgument(bytes > 0, "Requested array with zero capacity");
-		Preconditions.checkArgument(bytes <= MAX_ARRAY_SIZE, "Requested capacity exceeds limit of " + MAX_ARRAY_SIZE);
+		int capacity = bytes / ELEMENT_LENGTH_IN_BYTES;
 
-		data = new byte[bytes];
+		Preconditions.checkArgument(capacity > 0, "Requested array with zero capacity");
+		Preconditions.checkArgument(capacity <= MAX_ARRAY_SIZE, "Requested capacity exceeds limit of " + MAX_ARRAY_SIZE);
+
+		data = new float[capacity];
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -140,15 +122,12 @@ implements ValueArray<StringValue> {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder("[");
-		String separator = "";
-
-		for (StringValue sv : this) {
-			sb
-				.append(sv.getValue())
-				.append(separator);
-			separator = ",";
+		for (int idx = 0; idx < this.position; idx++) {
+			sb.append(data[idx]);
+			if (idx < position - 1) {
+				sb.append(",");
+			}
 		}
-
 		sb.append("]");
 
 		return sb.toString();
@@ -161,18 +140,14 @@ implements ValueArray<StringValue> {
 	private final ReadIterator iterator = new ReadIterator();
 
 	@Override
-	public Iterator<StringValue> iterator() {
+	public Iterator<FloatValue> iterator() {
 		iterator.reset();
 		return iterator;
 	}
 
 	private class ReadIterator
-	implements Iterator<StringValue> {
-		private static final int DEFAULT_SIZE = 64;
-
-		private StringValue value = new StringValue(CharBuffer.allocate(DEFAULT_SIZE));
-
-		private int size = DEFAULT_SIZE;
+	implements Iterator<FloatValue> {
+		private FloatValue value = new FloatValue();
 
 		private int pos;
 
@@ -182,50 +157,9 @@ implements ValueArray<StringValue> {
 		}
 
 		@Override
-		public StringValue next() {
-			// read length
-			int len = data[pos++] & 0xFF;
-
-			if (len >= HIGH_BIT) {
-				int shift = 7;
-				int curr;
-				len = len & 0x7F;
-				while ((curr = data[pos++] & 0xFF) >= HIGH_BIT) {
-					len |= (curr & 0x7F) << shift;
-					shift += 7;
-				}
-				len |= curr << shift;
-			}
-
-			// ensure capacity
-			if (len > size) {
-				while (size < len) {
-					size *= 2;
-				}
-
-				value = new StringValue(CharBuffer.allocate(size));
-			}
-
-			// read string characters
-			final char[] valueData = value.getCharArray();
-
-			for (int i = 0; i < len; i++) {
-				int c = data[pos++] & 0xFF;
-				if (c >= HIGH_BIT) {
-					int shift = 7;
-					int curr;
-					c = c & 0x7F;
-					while ((curr = data[pos++] & 0xFF) >= HIGH_BIT) {
-						c |= (curr & 0x7F) << shift;
-						shift += 7;
-					}
-					c |= curr << shift;
-				}
-				valueData[i] = (char) c;
-			}
-
-			// cannot prevent allocation of new StringValue!
-			return value.substring(0, len);
+		public FloatValue next() {
+			value.setValue(data[pos++]);
+			return value;
 		}
 
 		@Override
@@ -244,23 +178,23 @@ implements ValueArray<StringValue> {
 
 	@Override
 	public void write(DataOutputView out) throws IOException {
-		out.writeInt(length);
 		out.writeInt(position);
 
-		out.write(data, 0, position);
+		for (int i = 0; i < position; i++) {
+			out.writeFloat(data[i]);
+		}
 	}
 
 	@Override
 	public void read(DataInputView in) throws IOException {
-		length = in.readInt();
 		position = in.readInt();
-
-		markLength = 0;
-		markPosition = 0;
+		mark = 0;
 
 		ensureCapacity(position);
 
-		in.read(data, 0, position);
+		for (int i = 0; i < position; i++) {
+			data[i] = in.readFloat();
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -290,26 +224,19 @@ implements ValueArray<StringValue> {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public int compareTo(ValueArray<StringValue> o) {
-		StringValueArray other = (StringValueArray) o;
+	public int compareTo(ValueArray<FloatValue> o) {
+		FloatValueArray other = (FloatValueArray) o;
 
-		// sorts first on number of data in the array, then comparison between
-		// the first non-equal element in the arrays
-		int cmp = Integer.compare(position, other.position);
-
-		if (cmp != 0) {
-			return cmp;
-		}
-
-		for (int i = 0; i < position; i++) {
-			cmp = Byte.compare(data[i], other.data[i]);
+		int min = Math.min(position, other.position);
+		for (int i = 0; i < min; i++) {
+			int cmp = Float.compare(data[i], other.data[i]);
 
 			if (cmp != 0) {
 				return cmp;
 			}
 		}
 
-		return 0;
+		return Integer.compare(position, other.position);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -321,7 +248,7 @@ implements ValueArray<StringValue> {
 		int hash = 0;
 
 		for (int i = 0; i < position; i++) {
-			hash = 31 * hash + data[i];
+			hash = 31 * hash + Float.floatToIntBits(data[i]);
 		}
 
 		return hash;
@@ -329,12 +256,8 @@ implements ValueArray<StringValue> {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof StringValueArray) {
-			StringValueArray other = (StringValueArray) obj;
-
-			if (length != other.length) {
-				return false;
-			}
+		if (obj instanceof FloatValueArray) {
+			FloatValueArray other = (FloatValueArray) obj;
 
 			if (position != other.position) {
 				return false;
@@ -357,7 +280,7 @@ implements ValueArray<StringValue> {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public void setValue(ValueArray<StringValue> value) {
+	public void setValue(ValueArray<FloatValue> value) {
 		value.copyTo(this);
 	}
 
@@ -371,21 +294,19 @@ implements ValueArray<StringValue> {
 	}
 
 	@Override
-	public void copyTo(ValueArray<StringValue> target) {
-		StringValueArray other = (StringValueArray) target;
+	public void copyTo(ValueArray<FloatValue> target) {
+		FloatValueArray other = (FloatValueArray) target;
 
-		other.length = length;
 		other.position = position;
-		other.markLength = markLength;
-		other.markPosition = markPosition;
+		other.mark = mark;
 
 		other.ensureCapacity(position);
 		System.arraycopy(data, 0, other.data, 0, position);
 	}
 
 	@Override
-	public ValueArray<StringValue> copy() {
-		ValueArray<StringValue> copy = new StringValueArray();
+	public ValueArray<FloatValue> copy() {
+		ValueArray<FloatValue> copy = new FloatValueArray();
 
 		this.copyTo(copy);
 
@@ -398,13 +319,11 @@ implements ValueArray<StringValue> {
 	}
 
 	protected static void copyInternal(DataInputView source, DataOutputView target) throws IOException {
-		int length = source.readInt();
-		target.writeInt(length);
+		int count = source.readInt();
+		target.writeInt(count);
 
-		int position = source.readInt();
-		target.writeInt(position);
-
-		target.write(source, position);
+		int bytes = ELEMENT_LENGTH_IN_BYTES * count;
+		target.write(source, bytes);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -413,73 +332,39 @@ implements ValueArray<StringValue> {
 
 	@Override
 	public int size() {
-		return length;
+		return position;
 	}
 
 	@Override
 	public boolean isFull() {
 		if (isBounded) {
-			return position >= boundedLength;
+			return position == data.length;
 		} else {
 			return position == MAX_ARRAY_SIZE;
 		}
 	}
 
 	@Override
-	public boolean add(StringValue value) {
-		if (isBounded && position >= boundedLength) {
-			return false;
-		}
+	public boolean add(FloatValue value) {
+		int newPosition = position + 1;
 
-		// up to five bytes storing length
-		if (position + 5 > data.length) {
-			ensureCapacity(position + 5);
-		}
-
-		// update local variable until serialization succeeds
-		int newPosition = position;
-
-		// write the length, variable-length encoded
-		int len = value.length();
-
-		while (len >= HIGH_BIT) {
-			data[newPosition++] = (byte) (len | HIGH_BIT);
-			len >>>= 7;
-		}
-		data[newPosition++] = (byte) len;
-
-		// write the char data, variable-length encoded
-		final char[] valueData = value.getCharArray();
-		int remainingCapacity = data.length - newPosition;
-
-		len = value.length();
-		for (int i = 0; i < len; i++) {
-			// up to three bytes storing length
-			if (remainingCapacity < 3) {
-				ensureCapacity(remainingCapacity + 3);
-				remainingCapacity = data.length - newPosition;
+		if (newPosition > data.length) {
+			if (isBounded) {
+				return false;
+			} else {
+				ensureCapacity(newPosition);
 			}
-
-			int c = valueData[i];
-
-			while (c >= HIGH_BIT) {
-				data[newPosition++] = (byte) (c | HIGH_BIT);
-				remainingCapacity--;
-				c >>>= 7;
-			}
-			data[newPosition++] = (byte) c;
-			remainingCapacity--;
 		}
 
-		length++;
+		data[position] = value.getValue();
 		position = newPosition;
 
 		return true;
 	}
 
 	@Override
-	public boolean addAll(ValueArray<StringValue> other) {
-		StringValueArray source = (StringValueArray) other;
+	public boolean addAll(ValueArray<FloatValue> other) {
+		FloatValueArray source = (FloatValueArray) other;
 
 		int sourceSize = source.position;
 		int newPosition = position + sourceSize;
@@ -493,27 +378,23 @@ implements ValueArray<StringValue> {
 		}
 
 		System.arraycopy(source.data, 0, data, position, sourceSize);
-		length += source.length;
-  	    position = newPosition;
+		position = newPosition;
 
 		return true;
 	}
 
 	@Override
 	public void clear() {
-		length = 0;
 		position = 0;
 	}
 
 	@Override
 	public void mark() {
-		markLength = length;
-		markPosition = position;
+		mark = position;
 	}
 
 	@Override
 	public void reset() {
-		length = markLength;
-		position = markPosition;
+		position = mark;
 	}
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/FloatValueArrayComparator.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/FloatValueArrayComparator.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.types.NormalizableKey;
+
+import java.io.IOException;
+
+/**
+ * Specialized comparator for FloatValueArray based on CopyableValueComparator.
+ *
+ * <p>This can be used for grouping keys but not for sorting keys.
+ */
+@Internal
+public class FloatValueArrayComparator extends TypeComparator<FloatValueArray> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final boolean ascendingComparison;
+
+	private final FloatValueArray reference = new FloatValueArray();
+
+	private final TypeComparator<?>[] comparators = new TypeComparator[] {this};
+
+	public FloatValueArrayComparator(boolean ascending) {
+		this.ascendingComparison = ascending;
+	}
+
+	@Override
+	public int hash(FloatValueArray record) {
+		return record.hashCode();
+	}
+
+	@Override
+	public void setReference(FloatValueArray toCompare) {
+		toCompare.copyTo(reference);
+	}
+
+	@Override
+	public boolean equalToReference(FloatValueArray candidate) {
+		return candidate.equals(this.reference);
+	}
+
+	@Override
+	public int compareToReference(TypeComparator<FloatValueArray> referencedComparator) {
+		int comp = ((FloatValueArrayComparator) referencedComparator).reference.compareTo(reference);
+		return ascendingComparison ? comp : -comp;
+	}
+
+	@Override
+	public int compare(FloatValueArray first, FloatValueArray second) {
+		int comp = first.compareTo(second);
+		return ascendingComparison ? comp : -comp;
+	}
+
+	@Override
+	public int compareSerialized(DataInputView firstSource, DataInputView secondSource) throws IOException {
+		int firstCount = firstSource.readInt();
+		int secondCount = secondSource.readInt();
+
+		int minCount = Math.min(firstCount, secondCount);
+		while (minCount-- > 0) {
+			float firstValue = firstSource.readFloat();
+			float secondValue = secondSource.readFloat();
+
+			int cmp = Float.compare(firstValue, secondValue);
+			if (cmp != 0) {
+				return ascendingComparison ? cmp : -cmp;
+			}
+		}
+
+		int cmp = Integer.compare(firstCount, secondCount);
+		return ascendingComparison ? cmp : -cmp;
+	}
+
+	@Override
+	public boolean supportsNormalizedKey() {
+		return NormalizableKey.class.isAssignableFrom(FloatValueArray.class);
+	}
+
+	@Override
+	public int getNormalizeKeyLen() {
+		return reference.getMaxNormalizedKeyLen();
+	}
+
+	@Override
+	public boolean isNormalizedKeyPrefixOnly(int keyFloats) {
+		return keyFloats < getNormalizeKeyLen();
+	}
+
+	@Override
+	public void putNormalizedKey(FloatValueArray record, MemorySegment target, int offset, int numFloats) {
+		record.copyNormalizedKey(target, offset, numFloats);
+	}
+
+	@Override
+	public boolean invertNormalizedKey() {
+		return !ascendingComparison;
+	}
+
+	@Override
+	public TypeComparator<FloatValueArray> duplicate() {
+		return new FloatValueArrayComparator(ascendingComparison);
+	}
+
+	@Override
+	public int extractKeys(Object record, Object[] target, int index) {
+		target[index] = record;
+		return 1;
+	}
+
+	@Override
+	public TypeComparator<?>[] getFlatComparators() {
+		return comparators;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// unsupported normalization
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public boolean supportsSerializationWithKeyNormalization() {
+		return false;
+	}
+
+	@Override
+	public void writeWithKeyNormalization(FloatValueArray record, DataOutputView target) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public FloatValueArray readWithKeyDenormalization(FloatValueArray reuse, DataInputView source) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/FloatValueArraySerializer.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/FloatValueArraySerializer.java
@@ -7,13 +7,14 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.flink.graph.types.valuearray;
@@ -26,9 +27,9 @@ import org.apache.flink.core.memory.DataOutputView;
 import java.io.IOException;
 
 /**
- * Specialized serializer for {@code LongValueArray}.
+ * Specialized serializer for {@code FloatValueArray}.
  */
-public final class LongValueArraySerializer extends TypeSerializerSingleton<LongValueArray> {
+public final class FloatValueArraySerializer extends TypeSerializerSingleton<FloatValueArray> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -38,17 +39,17 @@ public final class LongValueArraySerializer extends TypeSerializerSingleton<Long
 	}
 
 	@Override
-	public LongValueArray createInstance() {
-		return new LongValueArray();
+	public FloatValueArray createInstance() {
+		return new FloatValueArray();
 	}
 
 	@Override
-	public LongValueArray copy(LongValueArray from) {
-		return copy(from, new LongValueArray());
+	public FloatValueArray copy(FloatValueArray from) {
+		return copy(from, new FloatValueArray());
 	}
 
 	@Override
-	public LongValueArray copy(LongValueArray from, LongValueArray reuse) {
+	public FloatValueArray copy(FloatValueArray from, FloatValueArray reuse) {
 		reuse.setValue(from);
 		return reuse;
 	}
@@ -59,29 +60,29 @@ public final class LongValueArraySerializer extends TypeSerializerSingleton<Long
 	}
 
 	@Override
-	public void serialize(LongValueArray record, DataOutputView target) throws IOException {
+	public void serialize(FloatValueArray record, DataOutputView target) throws IOException {
 		record.write(target);
 	}
 
 	@Override
-	public LongValueArray deserialize(DataInputView source) throws IOException {
-		return deserialize(new LongValueArray(), source);
+	public FloatValueArray deserialize(DataInputView source) throws IOException {
+		return deserialize(new FloatValueArray(), source);
 	}
 
 	@Override
-	public LongValueArray deserialize(LongValueArray reuse, DataInputView source) throws IOException {
+	public FloatValueArray deserialize(FloatValueArray reuse, DataInputView source) throws IOException {
 		reuse.read(source);
 		return reuse;
 	}
 
 	@Override
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
-		LongValueArray.copyInternal(source, target);
+		FloatValueArray.copyInternal(source, target);
 	}
 
 	@Override
 	public boolean canEqual(Object obj) {
-		return obj instanceof LongValueArraySerializer;
+		return obj instanceof FloatValueArraySerializer;
 	}
 
 	@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/IntValueArray.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/IntValueArray.java
@@ -243,7 +243,7 @@ implements ValueArray<IntValue> {
 
 	@Override
 	public int hashCode() {
-		int hash = 1;
+		int hash = 0;
 
 		for (int i = 0; i < position; i++) {
 			hash = 31 * hash + data[i];

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/LongValueArray.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/LongValueArray.java
@@ -54,7 +54,7 @@ implements ValueArray<LongValue> {
 	private transient int mark;
 
 	// hasher used to generate the normalized key
-	private MurmurHash hash = new MurmurHash(0xdf099ea8);
+	private MurmurHash hash = new MurmurHash(0x2d37e1b6);
 
 	// hash result stored as normalized key
 	private IntValue hashValue = new IntValue();
@@ -244,7 +244,7 @@ implements ValueArray<LongValue> {
 
 	@Override
 	public int hashCode() {
-		int hash = 1;
+		int hash = 0;
 
 		for (int i = 0; i < position; i++) {
 			hash = 31 * hash + (int) (data[i] ^ data[i] >>> 32);

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ShortValueArray.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ShortValueArray.java
@@ -7,13 +7,14 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.flink.graph.types.valuearray;
@@ -23,58 +24,38 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.graph.utils.MurmurHash;
 import org.apache.flink.types.IntValue;
-import org.apache.flink.types.StringValue;
+import org.apache.flink.types.ShortValue;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
-import java.nio.CharBuffer;
 import java.util.Arrays;
 import java.util.Iterator;
 
 /**
- * An array of {@link StringValue}.
- *
- * <p>Strings are serialized to a byte array. Concatenating arrays is as simple
- * and fast as extending and copying byte arrays. Strings are serialized when
- * individually added to {@code StringValueArray}.
- *
- * <p>For each string added to the array the length is first serialized using a
- * variable length integer. Then the string characters are serialized using a
- * variable length encoding where the lower 128 ASCII/UFT-8 characters are
- * encoded in a single byte. This ensures that common characters are serialized
- * in only two bytes.
+ * An array of {@link ShortValue}.
  */
-public class StringValueArray
-implements ValueArray<StringValue> {
+public class ShortValueArray
+implements ValueArray<ShortValue> {
 
-	protected static final int DEFAULT_CAPACITY_IN_BYTES = 4096;
+	protected static final int ELEMENT_LENGTH_IN_BYTES = 2;
+
+	protected static final int DEFAULT_CAPACITY_IN_BYTES = 1024;
 
 	// see note in ArrayList, HashTable, ...
 	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
 
-	protected static final int HIGH_BIT = 0x1 << 7;
-
 	private boolean isBounded;
 
-	// the initial length of a bounded array, which is allowed to expand to
-	// store one additional element beyond this initial length
-	private int boundedLength;
+	private short[] data;
 
-	private byte[] data;
-
-	// number of StringValue elements currently stored
-	private int length;
-
-	// the number of bytes currently stored
+	// the number of elements currently stored
 	private int position;
 
-	// state for the bookmark used by mark() and reset()
-	private transient int markLength;
-
-	private transient int markPosition;
+	// location of the bookmark used by mark() and reset()
+	private transient int mark;
 
 	// hasher used to generate the normalized key
-	private MurmurHash hash = new MurmurHash(0x19264330);
+	private MurmurHash hash = new MurmurHash(0xb3148e81);
 
 	// hash result stored as normalized key
 	private IntValue hashValue = new IntValue();
@@ -82,19 +63,18 @@ implements ValueArray<StringValue> {
 	/**
 	 * Initializes an expandable array with default capacity.
 	 */
-	public StringValueArray() {
+	public ShortValueArray() {
 		isBounded = false;
 		initialize(DEFAULT_CAPACITY_IN_BYTES);
 	}
 
 	/**
-	 * Initializes a fixed-size array with the provided number of bytes.
+	 * Initializes a fixed-size array with the provided number of shorts.
 	 *
 	 * @param bytes number of bytes of the encapsulated array
 	 */
-	public StringValueArray(int bytes) {
+	public ShortValueArray(int bytes) {
 		isBounded = true;
-		boundedLength = bytes;
 		initialize(bytes);
 	}
 
@@ -104,10 +84,12 @@ implements ValueArray<StringValue> {
 	 * @param bytes initial size of the encapsulated array in bytes
 	 */
 	private void initialize(int bytes) {
-		Preconditions.checkArgument(bytes > 0, "Requested array with zero capacity");
-		Preconditions.checkArgument(bytes <= MAX_ARRAY_SIZE, "Requested capacity exceeds limit of " + MAX_ARRAY_SIZE);
+		int capacity = bytes / ELEMENT_LENGTH_IN_BYTES;
 
-		data = new byte[bytes];
+		Preconditions.checkArgument(capacity > 0, "Requested array with zero capacity");
+		Preconditions.checkArgument(capacity <= MAX_ARRAY_SIZE, "Requested capacity exceeds limit of " + MAX_ARRAY_SIZE);
+
+		data = new short[capacity];
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -140,15 +122,12 @@ implements ValueArray<StringValue> {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder("[");
-		String separator = "";
-
-		for (StringValue sv : this) {
-			sb
-				.append(sv.getValue())
-				.append(separator);
-			separator = ",";
+		for (int idx = 0; idx < this.position; idx++) {
+			sb.append(data[idx]);
+			if (idx < position - 1) {
+				sb.append(",");
+			}
 		}
-
 		sb.append("]");
 
 		return sb.toString();
@@ -161,18 +140,14 @@ implements ValueArray<StringValue> {
 	private final ReadIterator iterator = new ReadIterator();
 
 	@Override
-	public Iterator<StringValue> iterator() {
+	public Iterator<ShortValue> iterator() {
 		iterator.reset();
 		return iterator;
 	}
 
 	private class ReadIterator
-	implements Iterator<StringValue> {
-		private static final int DEFAULT_SIZE = 64;
-
-		private StringValue value = new StringValue(CharBuffer.allocate(DEFAULT_SIZE));
-
-		private int size = DEFAULT_SIZE;
+	implements Iterator<ShortValue> {
+		private ShortValue value = new ShortValue();
 
 		private int pos;
 
@@ -182,50 +157,9 @@ implements ValueArray<StringValue> {
 		}
 
 		@Override
-		public StringValue next() {
-			// read length
-			int len = data[pos++] & 0xFF;
-
-			if (len >= HIGH_BIT) {
-				int shift = 7;
-				int curr;
-				len = len & 0x7F;
-				while ((curr = data[pos++] & 0xFF) >= HIGH_BIT) {
-					len |= (curr & 0x7F) << shift;
-					shift += 7;
-				}
-				len |= curr << shift;
-			}
-
-			// ensure capacity
-			if (len > size) {
-				while (size < len) {
-					size *= 2;
-				}
-
-				value = new StringValue(CharBuffer.allocate(size));
-			}
-
-			// read string characters
-			final char[] valueData = value.getCharArray();
-
-			for (int i = 0; i < len; i++) {
-				int c = data[pos++] & 0xFF;
-				if (c >= HIGH_BIT) {
-					int shift = 7;
-					int curr;
-					c = c & 0x7F;
-					while ((curr = data[pos++] & 0xFF) >= HIGH_BIT) {
-						c |= (curr & 0x7F) << shift;
-						shift += 7;
-					}
-					c |= curr << shift;
-				}
-				valueData[i] = (char) c;
-			}
-
-			// cannot prevent allocation of new StringValue!
-			return value.substring(0, len);
+		public ShortValue next() {
+			value.setValue(data[pos++]);
+			return value;
 		}
 
 		@Override
@@ -244,23 +178,23 @@ implements ValueArray<StringValue> {
 
 	@Override
 	public void write(DataOutputView out) throws IOException {
-		out.writeInt(length);
 		out.writeInt(position);
 
-		out.write(data, 0, position);
+		for (int i = 0; i < position; i++) {
+			out.writeShort(data[i]);
+		}
 	}
 
 	@Override
 	public void read(DataInputView in) throws IOException {
-		length = in.readInt();
 		position = in.readInt();
-
-		markLength = 0;
-		markPosition = 0;
+		mark = 0;
 
 		ensureCapacity(position);
 
-		in.read(data, 0, position);
+		for (int i = 0; i < position; i++) {
+			data[i] = in.readShort();
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -290,26 +224,19 @@ implements ValueArray<StringValue> {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public int compareTo(ValueArray<StringValue> o) {
-		StringValueArray other = (StringValueArray) o;
+	public int compareTo(ValueArray<ShortValue> o) {
+		ShortValueArray other = (ShortValueArray) o;
 
-		// sorts first on number of data in the array, then comparison between
-		// the first non-equal element in the arrays
-		int cmp = Integer.compare(position, other.position);
-
-		if (cmp != 0) {
-			return cmp;
-		}
-
-		for (int i = 0; i < position; i++) {
-			cmp = Byte.compare(data[i], other.data[i]);
+		int min = Math.min(position, other.position);
+		for (int i = 0; i < min; i++) {
+			int cmp = Short.compare(data[i], other.data[i]);
 
 			if (cmp != 0) {
 				return cmp;
 			}
 		}
 
-		return 0;
+		return Integer.compare(position, other.position);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -329,12 +256,8 @@ implements ValueArray<StringValue> {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof StringValueArray) {
-			StringValueArray other = (StringValueArray) obj;
-
-			if (length != other.length) {
-				return false;
-			}
+		if (obj instanceof ShortValueArray) {
+			ShortValueArray other = (ShortValueArray) obj;
 
 			if (position != other.position) {
 				return false;
@@ -357,7 +280,7 @@ implements ValueArray<StringValue> {
 	// --------------------------------------------------------------------------------------------
 
 	@Override
-	public void setValue(ValueArray<StringValue> value) {
+	public void setValue(ValueArray<ShortValue> value) {
 		value.copyTo(this);
 	}
 
@@ -371,21 +294,19 @@ implements ValueArray<StringValue> {
 	}
 
 	@Override
-	public void copyTo(ValueArray<StringValue> target) {
-		StringValueArray other = (StringValueArray) target;
+	public void copyTo(ValueArray<ShortValue> target) {
+		ShortValueArray other = (ShortValueArray) target;
 
-		other.length = length;
 		other.position = position;
-		other.markLength = markLength;
-		other.markPosition = markPosition;
+		other.mark = mark;
 
 		other.ensureCapacity(position);
 		System.arraycopy(data, 0, other.data, 0, position);
 	}
 
 	@Override
-	public ValueArray<StringValue> copy() {
-		ValueArray<StringValue> copy = new StringValueArray();
+	public ValueArray<ShortValue> copy() {
+		ValueArray<ShortValue> copy = new ShortValueArray();
 
 		this.copyTo(copy);
 
@@ -398,13 +319,11 @@ implements ValueArray<StringValue> {
 	}
 
 	protected static void copyInternal(DataInputView source, DataOutputView target) throws IOException {
-		int length = source.readInt();
-		target.writeInt(length);
+		int count = source.readInt();
+		target.writeInt(count);
 
-		int position = source.readInt();
-		target.writeInt(position);
-
-		target.write(source, position);
+		int bytes = ELEMENT_LENGTH_IN_BYTES * count;
+		target.write(source, bytes);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -413,73 +332,39 @@ implements ValueArray<StringValue> {
 
 	@Override
 	public int size() {
-		return length;
+		return position;
 	}
 
 	@Override
 	public boolean isFull() {
 		if (isBounded) {
-			return position >= boundedLength;
+			return position == data.length;
 		} else {
 			return position == MAX_ARRAY_SIZE;
 		}
 	}
 
 	@Override
-	public boolean add(StringValue value) {
-		if (isBounded && position >= boundedLength) {
-			return false;
-		}
+	public boolean add(ShortValue value) {
+		int newPosition = position + 1;
 
-		// up to five bytes storing length
-		if (position + 5 > data.length) {
-			ensureCapacity(position + 5);
-		}
-
-		// update local variable until serialization succeeds
-		int newPosition = position;
-
-		// write the length, variable-length encoded
-		int len = value.length();
-
-		while (len >= HIGH_BIT) {
-			data[newPosition++] = (byte) (len | HIGH_BIT);
-			len >>>= 7;
-		}
-		data[newPosition++] = (byte) len;
-
-		// write the char data, variable-length encoded
-		final char[] valueData = value.getCharArray();
-		int remainingCapacity = data.length - newPosition;
-
-		len = value.length();
-		for (int i = 0; i < len; i++) {
-			// up to three bytes storing length
-			if (remainingCapacity < 3) {
-				ensureCapacity(remainingCapacity + 3);
-				remainingCapacity = data.length - newPosition;
+		if (newPosition > data.length) {
+			if (isBounded) {
+				return false;
+			} else {
+				ensureCapacity(newPosition);
 			}
-
-			int c = valueData[i];
-
-			while (c >= HIGH_BIT) {
-				data[newPosition++] = (byte) (c | HIGH_BIT);
-				remainingCapacity--;
-				c >>>= 7;
-			}
-			data[newPosition++] = (byte) c;
-			remainingCapacity--;
 		}
 
-		length++;
+		data[position] = value.getValue();
 		position = newPosition;
 
 		return true;
 	}
 
 	@Override
-	public boolean addAll(ValueArray<StringValue> other) {
-		StringValueArray source = (StringValueArray) other;
+	public boolean addAll(ValueArray<ShortValue> other) {
+		ShortValueArray source = (ShortValueArray) other;
 
 		int sourceSize = source.position;
 		int newPosition = position + sourceSize;
@@ -493,27 +378,23 @@ implements ValueArray<StringValue> {
 		}
 
 		System.arraycopy(source.data, 0, data, position, sourceSize);
-		length += source.length;
-  	    position = newPosition;
+		position = newPosition;
 
 		return true;
 	}
 
 	@Override
 	public void clear() {
-		length = 0;
 		position = 0;
 	}
 
 	@Override
 	public void mark() {
-		markLength = length;
-		markPosition = position;
+		mark = position;
 	}
 
 	@Override
 	public void reset() {
-		length = markLength;
-		position = markPosition;
+		position = mark;
 	}
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ShortValueArrayComparator.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ShortValueArrayComparator.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.types.NormalizableKey;
+
+import java.io.IOException;
+
+/**
+ * Specialized comparator for ShortValueArray based on CopyableValueComparator.
+ *
+ * <p>This can be used for grouping keys but not for sorting keys.
+ */
+@Internal
+public class ShortValueArrayComparator extends TypeComparator<ShortValueArray> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final boolean ascendingComparison;
+
+	private final ShortValueArray reference = new ShortValueArray();
+
+	private final TypeComparator<?>[] comparators = new TypeComparator[] {this};
+
+	public ShortValueArrayComparator(boolean ascending) {
+		this.ascendingComparison = ascending;
+	}
+
+	@Override
+	public int hash(ShortValueArray record) {
+		return record.hashCode();
+	}
+
+	@Override
+	public void setReference(ShortValueArray toCompare) {
+		toCompare.copyTo(reference);
+	}
+
+	@Override
+	public boolean equalToReference(ShortValueArray candidate) {
+		return candidate.equals(this.reference);
+	}
+
+	@Override
+	public int compareToReference(TypeComparator<ShortValueArray> referencedComparator) {
+		int comp = ((ShortValueArrayComparator) referencedComparator).reference.compareTo(reference);
+		return ascendingComparison ? comp : -comp;
+	}
+
+	@Override
+	public int compare(ShortValueArray first, ShortValueArray second) {
+		int comp = first.compareTo(second);
+		return ascendingComparison ? comp : -comp;
+	}
+
+	@Override
+	public int compareSerialized(DataInputView firstSource, DataInputView secondSource) throws IOException {
+		int firstCount = firstSource.readInt();
+		int secondCount = secondSource.readInt();
+
+		int minCount = Math.min(firstCount, secondCount);
+		while (minCount-- > 0) {
+			short firstValue = firstSource.readShort();
+			short secondValue = secondSource.readShort();
+
+			int cmp = Short.compare(firstValue, secondValue);
+			if (cmp != 0) {
+				return ascendingComparison ? cmp : -cmp;
+			}
+		}
+
+		int cmp = Integer.compare(firstCount, secondCount);
+		return ascendingComparison ? cmp : -cmp;
+	}
+
+	@Override
+	public boolean supportsNormalizedKey() {
+		return NormalizableKey.class.isAssignableFrom(ShortValueArray.class);
+	}
+
+	@Override
+	public int getNormalizeKeyLen() {
+		return reference.getMaxNormalizedKeyLen();
+	}
+
+	@Override
+	public boolean isNormalizedKeyPrefixOnly(int keyShorts) {
+		return keyShorts < getNormalizeKeyLen();
+	}
+
+	@Override
+	public void putNormalizedKey(ShortValueArray record, MemorySegment target, int offset, int numShorts) {
+		record.copyNormalizedKey(target, offset, numShorts);
+	}
+
+	@Override
+	public boolean invertNormalizedKey() {
+		return !ascendingComparison;
+	}
+
+	@Override
+	public TypeComparator<ShortValueArray> duplicate() {
+		return new ShortValueArrayComparator(ascendingComparison);
+	}
+
+	@Override
+	public int extractKeys(Object record, Object[] target, int index) {
+		target[index] = record;
+		return 1;
+	}
+
+	@Override
+	public TypeComparator<?>[] getFlatComparators() {
+		return comparators;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// unsupported normalization
+	// --------------------------------------------------------------------------------------------
+
+	@Override
+	public boolean supportsSerializationWithKeyNormalization() {
+		return false;
+	}
+
+	@Override
+	public void writeWithKeyNormalization(ShortValueArray record, DataOutputView target) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ShortValueArray readWithKeyDenormalization(ShortValueArray reuse, DataInputView source) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ShortValueArraySerializer.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ShortValueArraySerializer.java
@@ -7,13 +7,14 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.flink.graph.types.valuearray;
@@ -26,9 +27,9 @@ import org.apache.flink.core.memory.DataOutputView;
 import java.io.IOException;
 
 /**
- * Specialized serializer for {@code LongValueArray}.
+ * Specialized serializer for {@code ShortValueArray}.
  */
-public final class LongValueArraySerializer extends TypeSerializerSingleton<LongValueArray> {
+public final class ShortValueArraySerializer extends TypeSerializerSingleton<ShortValueArray> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -38,17 +39,17 @@ public final class LongValueArraySerializer extends TypeSerializerSingleton<Long
 	}
 
 	@Override
-	public LongValueArray createInstance() {
-		return new LongValueArray();
+	public ShortValueArray createInstance() {
+		return new ShortValueArray();
 	}
 
 	@Override
-	public LongValueArray copy(LongValueArray from) {
-		return copy(from, new LongValueArray());
+	public ShortValueArray copy(ShortValueArray from) {
+		return copy(from, new ShortValueArray());
 	}
 
 	@Override
-	public LongValueArray copy(LongValueArray from, LongValueArray reuse) {
+	public ShortValueArray copy(ShortValueArray from, ShortValueArray reuse) {
 		reuse.setValue(from);
 		return reuse;
 	}
@@ -59,29 +60,29 @@ public final class LongValueArraySerializer extends TypeSerializerSingleton<Long
 	}
 
 	@Override
-	public void serialize(LongValueArray record, DataOutputView target) throws IOException {
+	public void serialize(ShortValueArray record, DataOutputView target) throws IOException {
 		record.write(target);
 	}
 
 	@Override
-	public LongValueArray deserialize(DataInputView source) throws IOException {
-		return deserialize(new LongValueArray(), source);
+	public ShortValueArray deserialize(DataInputView source) throws IOException {
+		return deserialize(new ShortValueArray(), source);
 	}
 
 	@Override
-	public LongValueArray deserialize(LongValueArray reuse, DataInputView source) throws IOException {
+	public ShortValueArray deserialize(ShortValueArray reuse, DataInputView source) throws IOException {
 		reuse.read(source);
 		return reuse;
 	}
 
 	@Override
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
-		LongValueArray.copyInternal(source, target);
+		ShortValueArray.copyInternal(source, target);
 	}
 
 	@Override
 	public boolean canEqual(Object obj) {
-		return obj instanceof LongValueArraySerializer;
+		return obj instanceof ShortValueArraySerializer;
 	}
 
 	@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ValueArrayFactory.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ValueArrayFactory.java
@@ -18,10 +18,15 @@
 
 package org.apache.flink.graph.types.valuearray;
 
+import org.apache.flink.types.ByteValue;
+import org.apache.flink.types.CharValue;
 import org.apache.flink.types.CopyableValue;
+import org.apache.flink.types.DoubleValue;
+import org.apache.flink.types.FloatValue;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
+import org.apache.flink.types.ShortValue;
 import org.apache.flink.types.StringValue;
 import org.apache.flink.types.Value;
 
@@ -43,12 +48,22 @@ public class ValueArrayFactory {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T> ValueArray<T> createValueArray(Class<? extends Value> cls) {
-		if (IntValue.class.isAssignableFrom(cls)) {
+		if (ByteValue.class.isAssignableFrom(cls)) {
+			return (ValueArray<T>) new ByteValueArray();
+		} else if (CharValue.class.isAssignableFrom(cls)) {
+			return (ValueArray<T>) new CharValueArray();
+		} else if (DoubleValue.class.isAssignableFrom(cls)) {
+			return (ValueArray<T>) new DoubleValueArray();
+		} else if (FloatValue.class.isAssignableFrom(cls)) {
+			return (ValueArray<T>) new FloatValueArray();
+		} else if (IntValue.class.isAssignableFrom(cls)) {
 			return (ValueArray<T>) new IntValueArray();
 		} else if (LongValue.class.isAssignableFrom(cls)) {
 			return (ValueArray<T>) new LongValueArray();
 		} else if (NullValue.class.isAssignableFrom(cls)) {
 			return (ValueArray<T>) new NullValueArray();
+		} else if (ShortValue.class.isAssignableFrom(cls)) {
+			return (ValueArray<T>) new ShortValueArray();
 		} else if (StringValue.class.isAssignableFrom(cls)) {
 			return (ValueArray<T>) new StringValueArray();
 		} else {
@@ -66,12 +81,22 @@ public class ValueArrayFactory {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T> ValueArray<T> createValueArray(Class<? extends Value> cls, int bytes) {
-		if (IntValue.class.isAssignableFrom(cls)) {
+		if (ByteValue.class.isAssignableFrom(cls)) {
+			return (ValueArray<T>) new ByteValueArray(bytes);
+		} else if (CharValue.class.isAssignableFrom(cls)) {
+			return (ValueArray<T>) new CharValueArray(bytes);
+		} else if (DoubleValue.class.isAssignableFrom(cls)) {
+			return (ValueArray<T>) new DoubleValueArray(bytes);
+		} else if (FloatValue.class.isAssignableFrom(cls)) {
+			return (ValueArray<T>) new FloatValueArray(bytes);
+		} else if (IntValue.class.isAssignableFrom(cls)) {
 			return (ValueArray<T>) new IntValueArray(bytes);
 		} else if (LongValue.class.isAssignableFrom(cls)) {
 			return (ValueArray<T>) new LongValueArray(bytes);
 		} else if (NullValue.class.isAssignableFrom(cls)) {
 			return (ValueArray<T>) new NullValueArray(bytes);
+		} else if (ShortValue.class.isAssignableFrom(cls)) {
+			return (ValueArray<T>) new ShortValueArray(bytes);
 		} else if (StringValue.class.isAssignableFrom(cls)) {
 			return (ValueArray<T>) new StringValueArray(bytes);
 		} else {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ValueArrayTypeInfo.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/types/valuearray/ValueArrayTypeInfo.java
@@ -25,9 +25,14 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.ValueTypeInfo;
+import org.apache.flink.types.ByteValue;
+import org.apache.flink.types.CharValue;
+import org.apache.flink.types.DoubleValue;
+import org.apache.flink.types.FloatValue;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
+import org.apache.flink.types.ShortValue;
 import org.apache.flink.types.StringValue;
 import org.apache.flink.types.Value;
 import org.apache.flink.util.Preconditions;
@@ -44,6 +49,7 @@ public class ValueArrayTypeInfo<T> extends TypeInformation<ValueArray<T>> implem
 
 	private static final long serialVersionUID = 1L;
 
+	public static final ValueArrayTypeInfo<ByteValue> BYTE_VALUE_ARRAY_TYPE_INFO = new ValueArrayTypeInfo<>(ValueTypeInfo.BYTE_VALUE_TYPE_INFO);
 	public static final ValueArrayTypeInfo<IntValue> INT_VALUE_ARRAY_TYPE_INFO = new ValueArrayTypeInfo<>(ValueTypeInfo.INT_VALUE_TYPE_INFO);
 	public static final ValueArrayTypeInfo<LongValue> LONG_VALUE_ARRAY_TYPE_INFO = new ValueArrayTypeInfo<>(ValueTypeInfo.LONG_VALUE_TYPE_INFO);
 	public static final ValueArrayTypeInfo<NullValue> NULL_VALUE_ARRAY_TYPE_INFO = new ValueArrayTypeInfo<>(ValueTypeInfo.NULL_VALUE_TYPE_INFO);
@@ -96,12 +102,22 @@ public class ValueArrayTypeInfo<T> extends TypeInformation<ValueArray<T>> implem
 	public TypeSerializer<ValueArray<T>> createSerializer(ExecutionConfig executionConfig) {
 		Preconditions.checkNotNull(type, "TypeInformation type class is required");
 
-		if (IntValue.class.isAssignableFrom(type)) {
+		if (ByteValue.class.isAssignableFrom(type)) {
+			return (TypeSerializer<ValueArray<T>>) (TypeSerializer<?>) new ByteValueArraySerializer();
+		} else if (CharValue.class.isAssignableFrom(type)) {
+			return (TypeSerializer<ValueArray<T>>) (TypeSerializer<?>) new CharValueArraySerializer();
+		} else if (DoubleValue.class.isAssignableFrom(type)) {
+			return (TypeSerializer<ValueArray<T>>) (TypeSerializer<?>) new DoubleValueArraySerializer();
+		} else if (FloatValue.class.isAssignableFrom(type)) {
+			return (TypeSerializer<ValueArray<T>>) (TypeSerializer<?>) new FloatValueArraySerializer();
+		} else if (IntValue.class.isAssignableFrom(type)) {
 			return (TypeSerializer<ValueArray<T>>) (TypeSerializer<?>) new IntValueArraySerializer();
 		} else if (LongValue.class.isAssignableFrom(type)) {
 			return (TypeSerializer<ValueArray<T>>) (TypeSerializer<?>) new LongValueArraySerializer();
 		} else if (NullValue.class.isAssignableFrom(type)) {
 			return (TypeSerializer<ValueArray<T>>) (TypeSerializer<?>) new NullValueArraySerializer();
+		} else if (ShortValue.class.isAssignableFrom(type)) {
+			return (TypeSerializer<ValueArray<T>>) (TypeSerializer<?>) new ShortValueArraySerializer();
 		} else if (StringValue.class.isAssignableFrom(type)) {
 			return (TypeSerializer<ValueArray<T>>) (TypeSerializer<?>) new StringValueArraySerializer();
 		} else {
@@ -114,12 +130,22 @@ public class ValueArrayTypeInfo<T> extends TypeInformation<ValueArray<T>> implem
 	public TypeComparator<ValueArray<T>> createComparator(boolean sortOrderAscending, ExecutionConfig executionConfig) {
 		Preconditions.checkNotNull(type, "TypeInformation type class is required");
 
-		if (IntValue.class.isAssignableFrom(type)) {
+		if (ByteValue.class.isAssignableFrom(type)) {
+			return (TypeComparator<ValueArray<T>>) (TypeComparator<?>) new ByteValueArrayComparator(sortOrderAscending);
+		} else if (CharValue.class.isAssignableFrom(type)) {
+			return (TypeComparator<ValueArray<T>>) (TypeComparator<?>) new CharValueArrayComparator(sortOrderAscending);
+		} else if (DoubleValue.class.isAssignableFrom(type)) {
+			return (TypeComparator<ValueArray<T>>) (TypeComparator<?>) new DoubleValueArrayComparator(sortOrderAscending);
+		} else if (FloatValue.class.isAssignableFrom(type)) {
+			return (TypeComparator<ValueArray<T>>) (TypeComparator<?>) new FloatValueArrayComparator(sortOrderAscending);
+		} else if (IntValue.class.isAssignableFrom(type)) {
 			return (TypeComparator<ValueArray<T>>) (TypeComparator<?>) new IntValueArrayComparator(sortOrderAscending);
 		} else if (LongValue.class.isAssignableFrom(type)) {
 			return (TypeComparator<ValueArray<T>>) (TypeComparator<?>) new LongValueArrayComparator(sortOrderAscending);
 		} else if (NullValue.class.isAssignableFrom(type)) {
 			return (TypeComparator<ValueArray<T>>) (TypeComparator<?>) new NullValueArrayComparator(sortOrderAscending);
+		} else if (ShortValue.class.isAssignableFrom(type)) {
+			return (TypeComparator<ValueArray<T>>) (TypeComparator<?>) new ShortValueArrayComparator(sortOrderAscending);
 		} else if (StringValue.class.isAssignableFrom(type)) {
 			return (TypeComparator<ValueArray<T>>) (TypeComparator<?>) new StringValueArrayComparator(sortOrderAscending);
 		} else {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ByteValueArrayComparatorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ByteValueArrayComparatorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.api.common.typeutils.ComparatorTestBase;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.types.ByteValue;
+
+/**
+ * Tests for {@link ByteValueArrayComparator}.
+ */
+public class ByteValueArrayComparatorTest extends ComparatorTestBase<ByteValueArray> {
+
+	@Override
+	protected TypeComparator<ByteValueArray> createComparator(boolean ascending) {
+		return new ByteValueArrayComparator(ascending);
+	}
+
+	@Override
+	protected TypeSerializer<ByteValueArray> createSerializer() {
+		return new ByteValueArraySerializer();
+	}
+
+	@Override
+	protected ByteValueArray[] getSortedTestData() {
+		ByteValueArray lva0 = new ByteValueArray();
+
+		ByteValueArray lva1 = new ByteValueArray();
+		lva1.add(new ByteValue((byte) 5));
+
+		ByteValueArray lva2 = new ByteValueArray();
+		lva2.add(new ByteValue((byte) 5));
+		lva2.add(new ByteValue((byte) 10));
+
+		return new ByteValueArray[]{ lva0, lva1 };
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ByteValueArraySerializerTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ByteValueArraySerializerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.types.ByteValue;
+
+import java.util.Random;
+
+/**
+ * A test for the {@link ByteValueArraySerializer}.
+ */
+public class ByteValueArraySerializerTest extends SerializerTestBase<ByteValueArray> {
+
+	@Override
+	protected TypeSerializer<ByteValueArray> createSerializer() {
+		return new ByteValueArraySerializer();
+	}
+
+	@Override
+	protected int getLength() {
+		return -1;
+	}
+
+	@Override
+	protected Class<ByteValueArray> getTypeClass() {
+		return ByteValueArray.class;
+	}
+
+	@Override
+	protected ByteValueArray[] getTestData() {
+		int defaultElements = ByteValueArray.DEFAULT_CAPACITY_IN_BYTES / ByteValueArray.ELEMENT_LENGTH_IN_BYTES;
+
+		Random rnd = new Random(874597969123412341L);
+		int rndLong = rnd.nextInt();
+
+		ByteValueArray lva0 = new ByteValueArray();
+
+		ByteValueArray lva1 = new ByteValueArray();
+		lva1.addAll(lva0);
+		lva1.add(new ByteValue((byte) 0));
+
+		ByteValueArray lva2 = new ByteValueArray();
+		lva2.addAll(lva1);
+		lva2.add(new ByteValue((byte) 1));
+
+		ByteValueArray lva3 = new ByteValueArray();
+		lva3.addAll(lva2);
+		lva3.add(new ByteValue((byte) -1));
+
+		ByteValueArray lva4 = new ByteValueArray();
+		lva4.addAll(lva3);
+		lva4.add(new ByteValue(Byte.MAX_VALUE));
+
+		ByteValueArray lva5 = new ByteValueArray();
+		lva5.addAll(lva4);
+		lva5.add(new ByteValue(Byte.MIN_VALUE));
+
+		ByteValueArray lva6 = new ByteValueArray();
+		lva6.addAll(lva5);
+		lva6.add(new ByteValue((byte) rndLong));
+
+		ByteValueArray lva7 = new ByteValueArray();
+		lva7.addAll(lva6);
+		lva7.add(new ByteValue((byte) -rndLong));
+
+		ByteValueArray lva8 = new ByteValueArray();
+		lva8.addAll(lva7);
+		for (int i = 0; i < 1.5 * defaultElements; i++) {
+			lva8.add(new ByteValue((byte) i));
+		}
+		lva8.addAll(lva8);
+
+		return new ByteValueArray[] {lva0, lva1, lva2, lva3, lva4, lva5, lva6, lva7, lva8};
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ByteValueArrayTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ByteValueArrayTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.types.ByteValue;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link ByteValueArray}.
+ */
+public class ByteValueArrayTest {
+
+	@Test
+	public void testBoundedArray() {
+		int count = ByteValueArray.DEFAULT_CAPACITY_IN_BYTES / ByteValueArray.ELEMENT_LENGTH_IN_BYTES;
+
+		ValueArray<ByteValue> lva = new ByteValueArray(ByteValueArray.DEFAULT_CAPACITY_IN_BYTES);
+
+		// fill the array
+		for (int i = 0; i < count; i++) {
+			assertFalse(lva.isFull());
+			assertEquals(i, lva.size());
+
+			assertTrue(lva.add(new ByteValue((byte) i)));
+
+			assertEquals(i + 1, lva.size());
+		}
+
+		// array is now full
+		assertTrue(lva.isFull());
+		assertEquals(count, lva.size());
+
+		// verify the array values
+		int idx = 0;
+		for (ByteValue lv : lva) {
+			assertEquals((byte) idx++, lv.getValue());
+		}
+
+		// add element past end of array
+		assertFalse(lva.add(new ByteValue((byte) count)));
+		assertFalse(lva.addAll(lva));
+
+		// test copy
+		assertEquals(lva, lva.copy());
+
+		// test copyTo
+		ByteValueArray lvaTo = new ByteValueArray();
+		lva.copyTo(lvaTo);
+		assertEquals(lva, lvaTo);
+
+		// test clear
+		lva.clear();
+		assertEquals(0, lva.size());
+	}
+
+	@Test
+	public void testUnboundedArray() {
+		int count = 4096;
+
+		ValueArray<ByteValue> lva = new ByteValueArray();
+
+		// add several elements
+		for (int i = 0; i < count; i++) {
+			assertFalse(lva.isFull());
+			assertEquals(i, lva.size());
+
+			assertTrue(lva.add(new ByteValue((byte) i)));
+
+			assertEquals(i + 1, lva.size());
+		}
+
+		// array never fills
+		assertFalse(lva.isFull());
+		assertEquals(count, lva.size());
+
+		// verify the array values
+		int idx = 0;
+		for (ByteValue lv : lva) {
+			assertEquals((byte) idx++, lv.getValue());
+		}
+
+		// add element past end of array
+		assertTrue(lva.add(new ByteValue((byte) count)));
+		assertTrue(lva.addAll(lva));
+
+		// test copy
+		assertEquals(lva, lva.copy());
+
+		// test copyTo
+		ByteValueArray lvaTo = new ByteValueArray();
+		lva.copyTo(lvaTo);
+		assertEquals(lva, lvaTo);
+
+		// test mark/reset
+		int size = lva.size();
+		lva.mark();
+		assertTrue(lva.add(new ByteValue()));
+		assertEquals(size + 1, lva.size());
+		lva.reset();
+		assertEquals(size, lva.size());
+
+		// test clear
+		lva.clear();
+		assertEquals(0, lva.size());
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/CharValueArrayComparatorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/CharValueArrayComparatorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.api.common.typeutils.ComparatorTestBase;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.types.CharValue;
+
+/**
+ * Tests for {@link CharValueArrayComparator}.
+ */
+public class CharValueArrayComparatorTest extends ComparatorTestBase<CharValueArray> {
+
+	@Override
+	protected TypeComparator<CharValueArray> createComparator(boolean ascending) {
+		return new CharValueArrayComparator(ascending);
+	}
+
+	@Override
+	protected TypeSerializer<CharValueArray> createSerializer() {
+		return new CharValueArraySerializer();
+	}
+
+	@Override
+	protected CharValueArray[] getSortedTestData() {
+		CharValueArray lva0 = new CharValueArray();
+
+		CharValueArray lva1 = new CharValueArray();
+		lva1.add(new CharValue((char) 5));
+
+		CharValueArray lva2 = new CharValueArray();
+		lva2.add(new CharValue((char) 5));
+		lva2.add(new CharValue((char) 10));
+
+		return new CharValueArray[]{ lva0, lva1 };
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/CharValueArraySerializerTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/CharValueArraySerializerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.types.CharValue;
+
+import java.util.Random;
+
+/**
+ * A test for the {@link CharValueArraySerializer}.
+ */
+public class CharValueArraySerializerTest extends SerializerTestBase<CharValueArray> {
+
+	@Override
+	protected TypeSerializer<CharValueArray> createSerializer() {
+		return new CharValueArraySerializer();
+	}
+
+	@Override
+	protected int getLength() {
+		return -1;
+	}
+
+	@Override
+	protected Class<CharValueArray> getTypeClass() {
+		return CharValueArray.class;
+	}
+
+	@Override
+	protected CharValueArray[] getTestData() {
+		int defaultElements = CharValueArray.DEFAULT_CAPACITY_IN_BYTES / CharValueArray.ELEMENT_LENGTH_IN_BYTES;
+
+		Random rnd = new Random(874597969123412341L);
+		int rndLong = rnd.nextInt();
+
+		CharValueArray lva0 = new CharValueArray();
+
+		CharValueArray lva1 = new CharValueArray();
+		lva1.addAll(lva0);
+		lva1.add(new CharValue((char) 0));
+
+		CharValueArray lva2 = new CharValueArray();
+		lva2.addAll(lva1);
+		lva2.add(new CharValue((char) 1));
+
+		CharValueArray lva3 = new CharValueArray();
+		lva3.addAll(lva2);
+		lva3.add(new CharValue((char) -1));
+
+		CharValueArray lva4 = new CharValueArray();
+		lva4.addAll(lva3);
+		lva4.add(new CharValue(Character.MAX_VALUE));
+
+		CharValueArray lva5 = new CharValueArray();
+		lva5.addAll(lva4);
+		lva5.add(new CharValue(Character.MIN_VALUE));
+
+		CharValueArray lva6 = new CharValueArray();
+		lva6.addAll(lva5);
+		lva6.add(new CharValue((char) rndLong));
+
+		CharValueArray lva7 = new CharValueArray();
+		lva7.addAll(lva6);
+		lva7.add(new CharValue((char) -rndLong));
+
+		CharValueArray lva8 = new CharValueArray();
+		lva8.addAll(lva7);
+		for (int i = 0; i < 1.5 * defaultElements; i++) {
+			lva8.add(new CharValue((char) i));
+		}
+		lva8.addAll(lva8);
+
+		return new CharValueArray[] {lva0, lva1, lva2, lva3, lva4, lva5, lva6, lva7, lva8};
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/CharValueArrayTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/CharValueArrayTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.types.StringValue;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link StringValueArray}.
+ */
+public class CharValueArrayTest {
+
+	@Test
+	public void testBoundedArray() {
+		// one byte for length and one byte for character
+		int count = StringValueArray.DEFAULT_CAPACITY_IN_BYTES / 2;
+
+		ValueArray<StringValue> sva = new StringValueArray(StringValueArray.DEFAULT_CAPACITY_IN_BYTES);
+
+		// fill the array
+		for (int i = 0; i < count; i++) {
+			assertFalse(sva.isFull());
+			assertEquals(i, sva.size());
+
+			assertTrue(sva.add(new StringValue(Character.toString((char) (i & 0x7F)))));
+
+			assertEquals(i + 1, sva.size());
+		}
+
+		// array is now full
+		assertTrue(sva.isFull());
+		assertEquals(count, sva.size());
+
+		// verify the array values
+		int idx = 0;
+		for (StringValue sv : sva) {
+			assertEquals((idx++) & 0x7F, sv.getValue().charAt(0));
+		}
+
+		// add element past end of array
+		assertFalse(sva.add(new StringValue(String.valueOf((char) count))));
+		assertFalse(sva.addAll(sva));
+
+		// test copy
+		assertEquals(sva, sva.copy());
+
+		// test copyTo
+		StringValueArray svaTo = new StringValueArray();
+		sva.copyTo(svaTo);
+		assertEquals(sva, svaTo);
+
+		// test clear
+		sva.clear();
+		assertEquals(0, sva.size());
+	}
+
+	@Test
+	public void testBoundedArrayWithVariableLengthCharacters() {
+		// characters alternatingly take 1 and 2 bytes (plus one byte for length)
+		int count = 1280;
+
+		ValueArray<StringValue> sva = new StringValueArray(3200);
+
+		// fill the array
+		for (int i = 0; i < count; i++) {
+			assertFalse(sva.isFull());
+			assertEquals(i, sva.size());
+
+			assertTrue(sva.add(new StringValue(Character.toString((char) (i & 0xFF)))));
+
+			assertEquals(i + 1, sva.size());
+		}
+
+		// array is now full
+		assertTrue(sva.isFull());
+		assertEquals(count, sva.size());
+
+		// verify the array values
+		int idx = 0;
+		for (StringValue sv : sva) {
+			assertEquals((idx++) & 0xFF, sv.getValue().charAt(0));
+		}
+
+		// add element past end of array
+		assertFalse(sva.add(new StringValue(String.valueOf((char) count))));
+		assertFalse(sva.addAll(sva));
+
+		// test copy
+		assertEquals(sva, sva.copy());
+
+		// test copyTo
+		StringValueArray svaTo = new StringValueArray();
+		sva.copyTo(svaTo);
+		assertEquals(sva, svaTo);
+
+		// test clear
+		sva.clear();
+		assertEquals(0, sva.size());
+	}
+
+	@Test
+	public void testUnboundedArray() {
+		int count = 4096;
+
+		ValueArray<StringValue> sva = new StringValueArray();
+
+		// add several elements
+		for (int i = 0; i < count; i++) {
+			assertFalse(sva.isFull());
+			assertEquals(i, sva.size());
+
+			assertTrue(sva.add(new StringValue(String.valueOf((char) i))));
+
+			assertEquals(i + 1, sva.size());
+		}
+
+		// array never fills
+		assertFalse(sva.isFull());
+		assertEquals(count, sva.size());
+
+		// verify the array values
+		int idx = 0;
+		for (StringValue sv : sva) {
+			assertEquals(idx++, sv.getValue().charAt(0));
+		}
+
+		// add element past end of array
+		assertTrue(sva.add(new StringValue(String.valueOf((char) count))));
+		assertTrue(sva.addAll(sva));
+
+		// test copy
+		assertEquals(sva, sva.copy());
+
+		// test copyTo
+		StringValueArray svaTo = new StringValueArray();
+		sva.copyTo(svaTo);
+		assertEquals(sva, svaTo);
+
+		// test mark/reset
+		int size = sva.size();
+		sva.mark();
+		assertTrue(sva.add(new StringValue()));
+		assertEquals(size + 1, sva.size());
+		sva.reset();
+		assertEquals(size, sva.size());
+
+		// test clear
+		sva.clear();
+		assertEquals(0, sva.size());
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/DoubleValueArrayComparatorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/DoubleValueArrayComparatorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.api.common.typeutils.ComparatorTestBase;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.types.DoubleValue;
+
+/**
+ * Tests for {@link DoubleValueArrayComparator}.
+ */
+public class DoubleValueArrayComparatorTest extends ComparatorTestBase<DoubleValueArray> {
+
+	@Override
+	protected TypeComparator<DoubleValueArray> createComparator(boolean ascending) {
+		return new DoubleValueArrayComparator(ascending);
+	}
+
+	@Override
+	protected TypeSerializer<DoubleValueArray> createSerializer() {
+		return new DoubleValueArraySerializer();
+	}
+
+	@Override
+	protected DoubleValueArray[] getSortedTestData() {
+		DoubleValueArray lva0 = new DoubleValueArray();
+
+		DoubleValueArray lva1 = new DoubleValueArray();
+		lva1.add(new DoubleValue(5));
+
+		DoubleValueArray lva2 = new DoubleValueArray();
+		lva2.add(new DoubleValue(5));
+		lva2.add(new DoubleValue(10));
+
+		return new DoubleValueArray[]{ lva0, lva1 };
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/DoubleValueArraySerializerTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/DoubleValueArraySerializerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.types.DoubleValue;
+
+import java.util.Random;
+
+/**
+ * A test for the {@link DoubleValueArraySerializer}.
+ */
+public class DoubleValueArraySerializerTest extends SerializerTestBase<DoubleValueArray> {
+
+	@Override
+	protected TypeSerializer<DoubleValueArray> createSerializer() {
+		return new DoubleValueArraySerializer();
+	}
+
+	@Override
+	protected int getLength() {
+		return -1;
+	}
+
+	@Override
+	protected Class<DoubleValueArray> getTypeClass() {
+		return DoubleValueArray.class;
+	}
+
+	@Override
+	protected DoubleValueArray[] getTestData() {
+		int defaultElements = DoubleValueArray.DEFAULT_CAPACITY_IN_BYTES / DoubleValueArray.ELEMENT_LENGTH_IN_BYTES;
+
+		Random rnd = new Random(874597969123412341L);
+		int rndLong = rnd.nextInt();
+
+		DoubleValueArray lva0 = new DoubleValueArray();
+
+		DoubleValueArray lva1 = new DoubleValueArray();
+		lva1.addAll(lva0);
+		lva1.add(new DoubleValue(0));
+
+		DoubleValueArray lva2 = new DoubleValueArray();
+		lva2.addAll(lva1);
+		lva2.add(new DoubleValue(1));
+
+		DoubleValueArray lva3 = new DoubleValueArray();
+		lva3.addAll(lva2);
+		lva3.add(new DoubleValue(-1));
+
+		DoubleValueArray lva4 = new DoubleValueArray();
+		lva4.addAll(lva3);
+		lva4.add(new DoubleValue(Double.MAX_VALUE));
+
+		DoubleValueArray lva5 = new DoubleValueArray();
+		lva5.addAll(lva4);
+		lva5.add(new DoubleValue(Double.MIN_VALUE));
+
+		DoubleValueArray lva6 = new DoubleValueArray();
+		lva6.addAll(lva5);
+		lva6.add(new DoubleValue(rndLong));
+
+		DoubleValueArray lva7 = new DoubleValueArray();
+		lva7.addAll(lva6);
+		lva7.add(new DoubleValue(-rndLong));
+
+		DoubleValueArray lva8 = new DoubleValueArray();
+		lva8.addAll(lva7);
+		for (int i = 0; i < 1.5 * defaultElements; i++) {
+			lva8.add(new DoubleValue(i));
+		}
+		lva8.addAll(lva8);
+
+		return new DoubleValueArray[] {lva0, lva1, lva2, lva3, lva4, lva5, lva6, lva7, lva8};
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/DoubleValueArrayTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/DoubleValueArrayTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.types.DoubleValue;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link DoubleValueArray}.
+ */
+public class DoubleValueArrayTest {
+
+	@Test
+	public void testBoundedArray() {
+		int count = DoubleValueArray.DEFAULT_CAPACITY_IN_BYTES / DoubleValueArray.ELEMENT_LENGTH_IN_BYTES;
+
+		ValueArray<DoubleValue> lva = new DoubleValueArray(DoubleValueArray.DEFAULT_CAPACITY_IN_BYTES);
+
+		// fill the array
+		for (int i = 0; i < count; i++) {
+			assertFalse(lva.isFull());
+			assertEquals(i, lva.size());
+
+			assertTrue(lva.add(new DoubleValue(i)));
+
+			assertEquals(i + 1, lva.size());
+		}
+
+		// array is now full
+		assertTrue(lva.isFull());
+		assertEquals(count, lva.size());
+
+		// verify the array values
+		int idx = 0;
+		for (DoubleValue lv : lva) {
+			assertEquals(idx++, lv.getValue(), 0.000001);
+		}
+
+		// add element past end of array
+		assertFalse(lva.add(new DoubleValue(count)));
+		assertFalse(lva.addAll(lva));
+
+		// test copy
+		assertEquals(lva, lva.copy());
+
+		// test copyTo
+		DoubleValueArray lvaTo = new DoubleValueArray();
+		lva.copyTo(lvaTo);
+		assertEquals(lva, lvaTo);
+
+		// test clear
+		lva.clear();
+		assertEquals(0, lva.size());
+	}
+
+	@Test
+	public void testUnboundedArray() {
+		int count = 4096;
+
+		ValueArray<DoubleValue> lva = new DoubleValueArray();
+
+		// add several elements
+		for (int i = 0; i < count; i++) {
+			assertFalse(lva.isFull());
+			assertEquals(i, lva.size());
+
+			assertTrue(lva.add(new DoubleValue(i)));
+
+			assertEquals(i + 1, lva.size());
+		}
+
+		// array never fills
+		assertFalse(lva.isFull());
+		assertEquals(count, lva.size());
+
+		// verify the array values
+		int idx = 0;
+		for (DoubleValue lv : lva) {
+			assertEquals(idx++, lv.getValue(), 0.000001);
+		}
+
+		// add element past end of array
+		assertTrue(lva.add(new DoubleValue(count)));
+		assertTrue(lva.addAll(lva));
+
+		// test copy
+		assertEquals(lva, lva.copy());
+
+		// test copyTo
+		DoubleValueArray lvaTo = new DoubleValueArray();
+		lva.copyTo(lvaTo);
+		assertEquals(lva, lvaTo);
+
+		// test mark/reset
+		int size = lva.size();
+		lva.mark();
+		assertTrue(lva.add(new DoubleValue()));
+		assertEquals(size + 1, lva.size());
+		lva.reset();
+		assertEquals(size, lva.size());
+
+		// test clear
+		lva.clear();
+		assertEquals(0, lva.size());
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/FloatValueArrayComparatorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/FloatValueArrayComparatorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.api.common.typeutils.ComparatorTestBase;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.types.FloatValue;
+
+/**
+ * Tests for {@link FloatValueArrayComparator}.
+ */
+public class FloatValueArrayComparatorTest extends ComparatorTestBase<FloatValueArray> {
+
+	@Override
+	protected TypeComparator<FloatValueArray> createComparator(boolean ascending) {
+		return new FloatValueArrayComparator(ascending);
+	}
+
+	@Override
+	protected TypeSerializer<FloatValueArray> createSerializer() {
+		return new FloatValueArraySerializer();
+	}
+
+	@Override
+	protected FloatValueArray[] getSortedTestData() {
+		FloatValueArray lva0 = new FloatValueArray();
+
+		FloatValueArray lva1 = new FloatValueArray();
+		lva1.add(new FloatValue(5));
+
+		FloatValueArray lva2 = new FloatValueArray();
+		lva2.add(new FloatValue(5));
+		lva2.add(new FloatValue(10));
+
+		return new FloatValueArray[]{ lva0, lva1 };
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/FloatValueArraySerializerTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/FloatValueArraySerializerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.types.FloatValue;
+
+import java.util.Random;
+
+/**
+ * A test for the {@link FloatValueArraySerializer}.
+ */
+public class FloatValueArraySerializerTest extends SerializerTestBase<FloatValueArray> {
+
+	@Override
+	protected TypeSerializer<FloatValueArray> createSerializer() {
+		return new FloatValueArraySerializer();
+	}
+
+	@Override
+	protected int getLength() {
+		return -1;
+	}
+
+	@Override
+	protected Class<FloatValueArray> getTypeClass() {
+		return FloatValueArray.class;
+	}
+
+	@Override
+	protected FloatValueArray[] getTestData() {
+		int defaultElements = FloatValueArray.DEFAULT_CAPACITY_IN_BYTES / FloatValueArray.ELEMENT_LENGTH_IN_BYTES;
+
+		Random rnd = new Random(874597969123412341L);
+		int rndLong = rnd.nextInt();
+
+		FloatValueArray lva0 = new FloatValueArray();
+
+		FloatValueArray lva1 = new FloatValueArray();
+		lva1.addAll(lva0);
+		lva1.add(new FloatValue(0));
+
+		FloatValueArray lva2 = new FloatValueArray();
+		lva2.addAll(lva1);
+		lva2.add(new FloatValue(1));
+
+		FloatValueArray lva3 = new FloatValueArray();
+		lva3.addAll(lva2);
+		lva3.add(new FloatValue(-1));
+
+		FloatValueArray lva4 = new FloatValueArray();
+		lva4.addAll(lva3);
+		lva4.add(new FloatValue(Float.MAX_VALUE));
+
+		FloatValueArray lva5 = new FloatValueArray();
+		lva5.addAll(lva4);
+		lva5.add(new FloatValue(Float.MIN_VALUE));
+
+		FloatValueArray lva6 = new FloatValueArray();
+		lva6.addAll(lva5);
+		lva6.add(new FloatValue(rndLong));
+
+		FloatValueArray lva7 = new FloatValueArray();
+		lva7.addAll(lva6);
+		lva7.add(new FloatValue(-rndLong));
+
+		FloatValueArray lva8 = new FloatValueArray();
+		lva8.addAll(lva7);
+		for (int i = 0; i < 1.5 * defaultElements; i++) {
+			lva8.add(new FloatValue(i));
+		}
+		lva8.addAll(lva8);
+
+		return new FloatValueArray[] {lva0, lva1, lva2, lva3, lva4, lva5, lva6, lva7, lva8};
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/FloatValueArrayTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/FloatValueArrayTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.types.FloatValue;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link FloatValueArray}.
+ */
+public class FloatValueArrayTest {
+
+	@Test
+	public void testBoundedArray() {
+		int count = FloatValueArray.DEFAULT_CAPACITY_IN_BYTES / FloatValueArray.ELEMENT_LENGTH_IN_BYTES;
+
+		ValueArray<FloatValue> lva = new FloatValueArray(FloatValueArray.DEFAULT_CAPACITY_IN_BYTES);
+
+		// fill the array
+		for (int i = 0; i < count; i++) {
+			assertFalse(lva.isFull());
+			assertEquals(i, lva.size());
+
+			assertTrue(lva.add(new FloatValue((byte) i)));
+
+			assertEquals(i + 1, lva.size());
+		}
+
+		// array is now full
+		assertTrue(lva.isFull());
+		assertEquals(count, lva.size());
+
+		// verify the array values
+		int idx = 0;
+		for (FloatValue lv : lva) {
+			assertEquals((byte) idx++, lv.getValue(), 0.000001);
+		}
+
+		// add element past end of array
+		assertFalse(lva.add(new FloatValue((byte) count)));
+		assertFalse(lva.addAll(lva));
+
+		// test copy
+		assertEquals(lva, lva.copy());
+
+		// test copyTo
+		FloatValueArray lvaTo = new FloatValueArray();
+		lva.copyTo(lvaTo);
+		assertEquals(lva, lvaTo);
+
+		// test clear
+		lva.clear();
+		assertEquals(0, lva.size());
+	}
+
+	@Test
+	public void testUnboundedArray() {
+		int count = 4096;
+
+		ValueArray<FloatValue> lva = new FloatValueArray();
+
+		// add several elements
+		for (int i = 0; i < count; i++) {
+			assertFalse(lva.isFull());
+			assertEquals(i, lva.size());
+
+			assertTrue(lva.add(new FloatValue((byte) i)));
+
+			assertEquals(i + 1, lva.size());
+		}
+
+		// array never fills
+		assertFalse(lva.isFull());
+		assertEquals(count, lva.size());
+
+		// verify the array values
+		int idx = 0;
+		for (FloatValue lv : lva) {
+			assertEquals((byte) idx++, lv.getValue(), 0.000001);
+		}
+
+		// add element past end of array
+		assertTrue(lva.add(new FloatValue((byte) count)));
+		assertTrue(lva.addAll(lva));
+
+		// test copy
+		assertEquals(lva, lva.copy());
+
+		// test copyTo
+		FloatValueArray lvaTo = new FloatValueArray();
+		lva.copyTo(lvaTo);
+		assertEquals(lva, lvaTo);
+
+		// test mark/reset
+		int size = lva.size();
+		lva.mark();
+		assertTrue(lva.add(new FloatValue()));
+		assertEquals(size + 1, lva.size());
+		lva.reset();
+		assertEquals(size, lva.size());
+
+		// test clear
+		lva.clear();
+		assertEquals(0, lva.size());
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/LongValueArrayComparatorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/LongValueArrayComparatorTest.java
@@ -46,8 +46,8 @@ public class LongValueArrayComparatorTest extends ComparatorTestBase<LongValueAr
 		lva1.add(new LongValue(5));
 
 		LongValueArray lva2 = new LongValueArray();
-		lva2.add(new LongValue(50));
-		lva2.add(new LongValue(100));
+		lva2.add(new LongValue(5));
+		lva2.add(new LongValue(10));
 
 		return new LongValueArray[]{ lva0, lva1, lva2 };
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ShortValueArrayComparatorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ShortValueArrayComparatorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.api.common.typeutils.ComparatorTestBase;
+import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.types.ShortValue;
+
+/**
+ * Tests for {@link ShortValueArrayComparator}.
+ */
+public class ShortValueArrayComparatorTest extends ComparatorTestBase<ShortValueArray> {
+
+	@Override
+	protected TypeComparator<ShortValueArray> createComparator(boolean ascending) {
+		return new ShortValueArrayComparator(ascending);
+	}
+
+	@Override
+	protected TypeSerializer<ShortValueArray> createSerializer() {
+		return new ShortValueArraySerializer();
+	}
+
+	@Override
+	protected ShortValueArray[] getSortedTestData() {
+		ShortValueArray lva0 = new ShortValueArray();
+
+		ShortValueArray lva1 = new ShortValueArray();
+		lva1.add(new ShortValue((short) 5));
+
+		ShortValueArray lva2 = new ShortValueArray();
+		lva2.add(new ShortValue((short) 5));
+		lva2.add(new ShortValue((short) 10));
+
+		return new ShortValueArray[]{ lva0, lva1 };
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ShortValueArraySerializerTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ShortValueArraySerializerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.types.ShortValue;
+
+import java.util.Random;
+
+/**
+ * A test for the {@link ShortValueArraySerializer}.
+ */
+public class ShortValueArraySerializerTest extends SerializerTestBase<ShortValueArray> {
+
+	@Override
+	protected TypeSerializer<ShortValueArray> createSerializer() {
+		return new ShortValueArraySerializer();
+	}
+
+	@Override
+	protected int getLength() {
+		return -1;
+	}
+
+	@Override
+	protected Class<ShortValueArray> getTypeClass() {
+		return ShortValueArray.class;
+	}
+
+	@Override
+	protected ShortValueArray[] getTestData() {
+		int defaultElements = ShortValueArray.DEFAULT_CAPACITY_IN_BYTES / ShortValueArray.ELEMENT_LENGTH_IN_BYTES;
+
+		Random rnd = new Random(874597969123412341L);
+		int rndLong = rnd.nextInt();
+
+		ShortValueArray lva0 = new ShortValueArray();
+
+		ShortValueArray lva1 = new ShortValueArray();
+		lva1.addAll(lva0);
+		lva1.add(new ShortValue((short) 0));
+
+		ShortValueArray lva2 = new ShortValueArray();
+		lva2.addAll(lva1);
+		lva2.add(new ShortValue((short) 1));
+
+		ShortValueArray lva3 = new ShortValueArray();
+		lva3.addAll(lva2);
+		lva3.add(new ShortValue((short) -1));
+
+		ShortValueArray lva4 = new ShortValueArray();
+		lva4.addAll(lva3);
+		lva4.add(new ShortValue(Short.MAX_VALUE));
+
+		ShortValueArray lva5 = new ShortValueArray();
+		lva5.addAll(lva4);
+		lva5.add(new ShortValue(Short.MIN_VALUE));
+
+		ShortValueArray lva6 = new ShortValueArray();
+		lva6.addAll(lva5);
+		lva6.add(new ShortValue((short) rndLong));
+
+		ShortValueArray lva7 = new ShortValueArray();
+		lva7.addAll(lva6);
+		lva7.add(new ShortValue((short) -rndLong));
+
+		ShortValueArray lva8 = new ShortValueArray();
+		lva8.addAll(lva7);
+		for (int i = 0; i < 1.5 * defaultElements; i++) {
+			lva8.add(new ShortValue((short) i));
+		}
+		lva8.addAll(lva8);
+
+		return new ShortValueArray[] {lva0, lva1, lva2, lva3, lva4, lva5, lva6, lva7, lva8};
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ShortValueArrayTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/types/valuearray/ShortValueArrayTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.types.valuearray;
+
+import org.apache.flink.types.ShortValue;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link ShortValueArray}.
+ */
+public class ShortValueArrayTest {
+
+	@Test
+	public void testBoundedArray() {
+		int count = ShortValueArray.DEFAULT_CAPACITY_IN_BYTES / ShortValueArray.ELEMENT_LENGTH_IN_BYTES;
+
+		ValueArray<ShortValue> lva = new ShortValueArray(ShortValueArray.DEFAULT_CAPACITY_IN_BYTES);
+
+		// fill the array
+		for (int i = 0; i < count; i++) {
+			assertFalse(lva.isFull());
+			assertEquals(i, lva.size());
+
+			assertTrue(lva.add(new ShortValue((short) i)));
+
+			assertEquals(i + 1, lva.size());
+		}
+
+		// array is now full
+		assertTrue(lva.isFull());
+		assertEquals(count, lva.size());
+
+		// verify the array values
+		int idx = 0;
+		for (ShortValue lv : lva) {
+			assertEquals((short) idx++, lv.getValue());
+		}
+
+		// add element past end of array
+		assertFalse(lva.add(new ShortValue((short) count)));
+		assertFalse(lva.addAll(lva));
+
+		// test copy
+		assertEquals(lva, lva.copy());
+
+		// test copyTo
+		ShortValueArray lvaTo = new ShortValueArray();
+		lva.copyTo(lvaTo);
+		assertEquals(lva, lvaTo);
+
+		// test clear
+		lva.clear();
+		assertEquals(0, lva.size());
+	}
+
+	@Test
+	public void testUnboundedArray() {
+		int count = 4096;
+
+		ValueArray<ShortValue> lva = new ShortValueArray();
+
+		// add several elements
+		for (int i = 0; i < count; i++) {
+			assertFalse(lva.isFull());
+			assertEquals(i, lva.size());
+
+			assertTrue(lva.add(new ShortValue((short) i)));
+
+			assertEquals(i + 1, lva.size());
+		}
+
+		// array never fills
+		assertFalse(lva.isFull());
+		assertEquals(count, lva.size());
+
+		// verify the array values
+		int idx = 0;
+		for (ShortValue lv : lva) {
+			assertEquals((short) idx++, lv.getValue());
+		}
+
+		// add element past end of array
+		assertTrue(lva.add(new ShortValue((short) count)));
+		assertTrue(lva.addAll(lva));
+
+		// test copy
+		assertEquals(lva, lva.copy());
+
+		// test copyTo
+		ShortValueArray lvaTo = new ShortValueArray();
+		lva.copyTo(lvaTo);
+		assertEquals(lva, lvaTo);
+
+		// test mark/reset
+		int size = lva.size();
+		lva.mark();
+		assertTrue(lva.add(new ShortValue()));
+		assertEquals(size + 1, lva.size());
+		lva.reset();
+		assertEquals(size, lva.size());
+
+		// test clear
+		lva.clear();
+		assertEquals(0, lva.size());
+	}
+}


### PR DESCRIPTION
Add implementations of Byte/Char/Double/Float/ShortValueArray. Along with the existing implementations of Int/Long/Null/StringValueArray this covers all 10 CopyableValue types.

Note: the best way to review these files is to diff against the existing `IntValueArray` and `LongValueArray` implementations as the deltas are very small.