### PR TITLE
[FLINK-7032] Overwrite inherited properties from parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,11 @@ under the License.
 		<guava.version>18.0</guava.version>
 		<akka.version>2.3-custom</akka.version>
 		<java.version>1.7</java.version>
+		<!-- Overwrite default values from parent pom.
+			 Intellij is (sometimes?) using those values to choose target language level
+			 and thus is changing back to java 1.6 on each maven re-import -->
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<scala.macros.version>2.1.0</scala.macros.version>
 		<!-- Default scala versions, may be overwritten by build profiles -->
 		<scala.version>2.11.11</scala.version>


### PR DESCRIPTION
Default values for compiler version are 1.6 and were causing Intellij to constantly switch language level to 1.6, which in turn was causing compilation errors. It worked fine for compiling from console using maven, because those values are separetly set in `maven-compiler-plugin` configuration.

