### PR TITLE
[FLINK-7037] Remove scala suffic from flink-examples module

### DIFF
--- a/flink-examples/flink-examples-batch/pom.xml
+++ b/flink-examples/flink-examples-batch/pom.xml
@@ -23,7 +23,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-examples_${scala.binary.version}</artifactId>
+		<artifactId>flink-examples</artifactId>
 		<version>1.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -24,7 +24,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-examples_${scala.binary.version}</artifactId>
+		<artifactId>flink-examples</artifactId>
 		<version>1.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -24,7 +24,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-examples}</artifactId>
+		<artifactId>flink-examples</artifactId>
 		<version>1.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -24,7 +24,7 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-examples_${scala.binary.version}</artifactId>
+		<artifactId>flink-examples}</artifactId>
 		<version>1.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>

--- a/flink-examples/pom.xml
+++ b/flink-examples/pom.xml
@@ -28,7 +28,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-examples_${scala.binary.version}</artifactId>
+	<artifactId>flink-examples</artifactId>
 	<name>flink-examples</name>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
This PR removes the scala version suffix from the flink-examples module.

The suffix prevented building single modules that rely on any example module. This does not cause issues when building flink completely as we traverse the modules from the parent, allowing the scala version to be resolved for all modules.

When building a single module, in order to resolve the scala version we have to traverse from the target module towards the parent, which isn't possible since the scala version isn't resolved, i.e. we cant resolve the scala version since we can't find the parent, and we can't fine the parent since the scala version wasn't resolved.