### PR TITLE
[FLINK-7038] [docs] Correct misused term to KeyedStream

### DIFF
--- a/docs/dev/datastream_api.md
+++ b/docs/dev/datastream_api.md
@@ -211,7 +211,7 @@ dataStream.filter(new FilterFunction<Integer>() {
           <td>
             <p>Logically partitions a stream into disjoint partitions, each partition containing elements of the same key.
             Internally, this is implemented with hash partitioning. See <a href="{{ site.baseurl }}/dev/api_concepts.html#specifying-keys">keys</a> on how to specify keys.
-            This transformation returns a KeyedDataStream.</p>
+            This transformation returns a KeyedStream.</p>
     {% highlight java %}
 dataStream.keyBy("someKey") // Key by field "someKey"
 dataStream.keyBy(0) // Key by the first element of a Tuple
@@ -607,7 +607,7 @@ dataStream.filter { _ != 0 }
           <td>
             <p>Logically partitions a stream into disjoint partitions, each partition containing elements of the same key.
             Internally, this is implemented with hash partitioning. See <a href="{{ site.baseurl }}/dev/api_concepts.html#specifying-keys">keys</a> on how to specify keys.
-            This transformation returns a KeyedDataStream.</p>
+            This transformation returns a KeyedStream.</p>
     {% highlight scala %}
 dataStream.keyBy("someKey") // Key by field "someKey"
 dataStream.keyBy(0) // Key by the first element of a Tuple

--- a/docs/dev/scala_api_extensions.md
+++ b/docs/dev/scala_api_extensions.md
@@ -316,7 +316,7 @@ data.keyingBy(
     </tr>
     <tr>
       <td><strong>reduceWith</strong></td>
-      <td><strong>reduce (KeyedDataStream, WindowedDataStream)</strong></td>
+      <td><strong>reduce (KeyedStream, WindowedDataStream)</strong></td>
       <td>
 {% highlight scala %}
 data.reduceWith {
@@ -327,7 +327,7 @@ data.reduceWith {
     </tr>
     <tr>
       <td><strong>foldWith</strong></td>
-      <td><strong>fold (KeyedDataStream, WindowedDataStream)</strong></td>
+      <td><strong>fold (KeyedStream, WindowedDataStream)</strong></td>
       <td>
 {% highlight scala %}
 data.foldWith(User(bought = 0)) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/AggregatingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/AggregatingState.java
@@ -33,7 +33,7 @@ import org.apache.flink.api.common.functions.AggregateFunction;
  * <p>The state is accessed and modified by user functions, and checkpointed consistently
  * by the system as part of the distributed snapshots.
  * 
- * <p>The state is only accessible by functions applied on a KeyedDataStream. The key is
+ * <p>The state is only accessible by functions applied on a {@code KeyedStream}. The key is
  * automatically supplied by the system, so the function always sees the value mapped to the
  * key of the current element. That way, the system can handle stream and state partitioning
  * consistently together.

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  * <p>The state is accessed and modified by user functions, and checkpointed consistently
  * by the system as part of the distributed snapshots.
  * 
- * <p>The state is only accessible by functions applied on a KeyedDataStream. The key is
+ * <p>The state is only accessible by functions applied on a {@code KeyedStream}. The key is
  * automatically supplied by the system, so the function always sees the value mapped to the
  * key of the current element. That way, the system can handle stream and state partitioning
  * consistently together.

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/FoldingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/FoldingState.java
@@ -28,7 +28,7 @@ import org.apache.flink.annotation.PublicEvolving;
  * <p>The state is accessed and modified by user functions, and checkpointed consistently
  * by the system as part of the distributed snapshots.
  * 
- * <p>The state is only accessible by functions applied on a KeyedDataStream. The key is
+ * <p>The state is only accessible by functions applied on a {@code KeyedStream}. The key is
  * automatically supplied by the system, so the function always sees the value mapped to the
  * key of the current element. That way, the system can handle stream and state partitioning
  * consistently together.

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ListState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ListState.java
@@ -25,7 +25,7 @@ import org.apache.flink.annotation.PublicEvolving;
  * The state is accessed and modified by user functions, and checkpointed consistently
  * by the system as part of the distributed snapshots.
  * 
- * <p>The state is only accessible by functions applied on a KeyedDataStream. The key is
+ * <p>The state is only accessible by functions applied on a {@code KeyedStream}. The key is
  * automatically supplied by the system, so the function always sees the value mapped to the
  * key of the current element. That way, the system can handle stream and state partitioning
  * consistently together.

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/MapState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/MapState.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * <p>The state is accessed and modified by user functions, and checkpointed consistently
  * by the system as part of the distributed snapshots.
  *
- * <p>The state is only accessible by functions applied on a KeyedDataStream. The key is
+ * <p>The state is only accessible by functions applied on a {@code KeyedStream}. The key is
  * automatically supplied by the system, so the function always sees the value mapped to the
  * key of the current element. That way, the system can handle stream and state partitioning
  * consistently together.

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ReducingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ReducingState.java
@@ -27,7 +27,7 @@ import org.apache.flink.annotation.PublicEvolving;
  * <p>The state is accessed and modified by user functions, and checkpointed consistently
  * by the system as part of the distributed snapshots.
  * 
- * <p>The state is only accessible by functions applied on a KeyedDataStream. The key is
+ * <p>The state is only accessible by functions applied on a {@code KeyedStream}. The key is
  * automatically supplied by the system, so the function always sees the value mapped to the
  * key of the current element. That way, the system can handle stream and state partitioning
  * consistently together.

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/State.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/State.java
@@ -23,7 +23,7 @@ import org.apache.flink.annotation.PublicEvolving;
 /**
  * Interface that different types of partitioned state must implement.
  *
- * <p>The state is only accessible by functions applied on a KeyedDataStream. The key is
+ * <p>The state is only accessible by functions applied on a {@code KeyedStream}. The key is
  * automatically supplied by the system, so the function always sees the value mapped to the
  * key of the current element. That way, the system can handle stream and state partitioning
  * consistently together.

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ValueState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ValueState.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  * <p>The state is accessed and modified by user functions, and checkpointed consistently
  * by the system as part of the distributed snapshots.
  * 
- * <p>The state is only accessible by functions applied on a KeyedDataStream. The key is
+ * <p>The state is only accessible by functions applied on a {@code KeyedStream}. The key is
  * automatically supplied by the system, so the function always sees the value mapped to the
  * key of the current element. That way, the system can handle stream and state partitioning
  * consistently together.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -75,7 +75,7 @@ import java.util.Stack;
 import java.util.UUID;
 
 /**
- * A {@code KeyedStream} represents a {@link DataStream} on which operator state is
+ * A {@link KeyedStream} represents a {@link DataStream} on which operator state is
  * partitioned by key using a provided {@link KeySelector}. Typical operations supported by a
  * {@code DataStream} are also possible on a {@code KeyedStream}, with the exception of
  * partitioning methods such as shuffle, forward and keyBy.

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnKeyedDataStreamTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/extensions/impl/acceptPartialFunctions/OnKeyedDataStreamTest.scala
@@ -24,7 +24,7 @@ import org.apache.flink.streaming.api.scala.extensions.base.AcceptPFTestBase
 import org.apache.flink.streaming.api.scala.extensions.data.KeyValuePair
 import org.junit.Test
 
-class OnKeyedDataStreamTest extends AcceptPFTestBase {
+class OnKeyedStreamTest extends AcceptPFTestBase {
 
   @Test
   def testReduceWithOnTuple(): Unit = {


### PR DESCRIPTION
Correct misused term to KeyedStream.