### PR TITLE
[FLINK-7045] [checkpoints] Reduce element count of UdfStreamOperatorC…

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UdfStreamOperatorCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UdfStreamOperatorCheckpointingITCase.java
@@ -52,7 +52,7 @@ import java.util.Random;
 @SuppressWarnings("serial")
 public class UdfStreamOperatorCheckpointingITCase extends StreamFaultToleranceTestBase {
 
-	final private static long NUM_INPUT = 2_500_000L;
+	final private static long NUM_INPUT = 500_000L;
 	final private static int NUM_OUTPUT = 1_000;
 
 	/**


### PR DESCRIPTION
With NUM_INPUT equals to 2,500,000. It costs 33s,556ms on my computer. But I can get 10s, 915ms as I reduce the element number of NUM_INPUTs to 500,000. We did this refactor for reducing quite a long time on travis test.