### PR TITLE
[FLINK-7055][blob] refactor BlobService#getURL() methods to return a File object

### DIFF
--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
 import org.apache.flink.api.java.LocalEnvironment;
 import org.apache.flink.api.java.io.AvroOutputFormat;
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -48,7 +49,9 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
@@ -69,6 +72,9 @@ public class HDFSTest {
 	private MiniDFSCluster hdfsCluster;
 	private org.apache.hadoop.fs.Path hdPath;
 	protected org.apache.hadoop.fs.FileSystem hdfs;
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	@BeforeClass
 	public static void verifyOS() {
@@ -242,6 +248,8 @@ public class HDFSTest {
 			config = new org.apache.flink.configuration.Configuration();
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
 		config.setString(CoreOptions.STATE_BACKEND, "ZOOKEEPER");
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
 
 		BlobStoreService blobStoreService = null;

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagerLogHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagerLogHandler.java
@@ -238,7 +238,7 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 								lastSubmittedFile.put(taskManagerID, blobKey);
 							}
 							try {
-								return FlinkCompletableFuture.completed(blobCache.getURL(blobKey).getFile());
+								return FlinkCompletableFuture.completed(blobCache.getFile(blobKey).getAbsolutePath());
 							} catch (IOException e) {
 								return FlinkCompletableFuture.completedExceptionally(
 									new Exception("Could not retrieve blob for " + blobKey + '.', e));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -34,7 +34,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -334,22 +333,23 @@ public class BlobServer extends Thread implements BlobService {
 	}
 
 	/**
-	 * Method which retrieves the URL of a file associated with a blob key. The blob server looks
-	 * the blob key up in its local storage. If the file exists, then the URL is returned. If the
-	 * file does not exist, then a FileNotFoundException is thrown.
+	 * Method which retrieves the local path of a file associated with a blob key. The blob server
+	 * looks the blob key up in its local storage. If the file exists, it is returned. If the
+	 * file does not exist, it is retrieved from the HA blob store (if available) or a
+	 * FileNotFoundException is thrown.
 	 *
 	 * @param requiredBlob blob key associated with the requested file
-	 * @return URL of the file
-	 * @throws IOException
+	 * @return file referring to the local storage location of the BLOB.
+	 * @throws IOException Thrown if the file retrieval failed.
 	 */
 	@Override
-	public URL getURL(BlobKey requiredBlob) throws IOException {
+	public File getFile(BlobKey requiredBlob) throws IOException {
 		checkArgument(requiredBlob != null, "BLOB key cannot be null.");
 
 		final File localFile = BlobUtils.getStorageLocation(storageDir, requiredBlob);
 
 		if (localFile.exists()) {
-			return localFile.toURI().toURL();
+			return localFile;
 		}
 		else {
 			try {
@@ -361,7 +361,7 @@ public class BlobServer extends Thread implements BlobService {
 			}
 
 			if (localFile.exists()) {
-				return localFile.toURI().toURL();
+				return localFile;
 			}
 			else {
 				throw new FileNotFoundException("Local file " + localFile + " does not exist " +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
@@ -19,8 +19,8 @@
 package org.apache.flink.runtime.blob;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 
 /**
  * A simple store and retrieve binary large objects (BLOBs).
@@ -28,14 +28,14 @@ import java.net.URL;
 public interface BlobService extends Closeable {
 
 	/**
-	 * Returns the URL of the file associated with the provided blob key.
+	 * Returns the path to a local copy of the file associated with the provided blob key.
 	 *
 	 * @param key blob key associated with the requested file
-	 * @return The URL to the file.
+	 * @return The path to the file.
 	 * @throws java.io.FileNotFoundException when the path does not exist;
 	 * @throws IOException if any other error occurs when retrieving the file
 	 */
-	URL getURL(BlobKey key) throws IOException;
+	File getFile(BlobKey key) throws IOException;
 
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
@@ -229,7 +229,7 @@ public class JobClient {
 			int pos = 0;
 			for (BlobKey blobKey : props.requiredJarFiles()) {
 				try {
-					allURLs[pos++] = blobClient.getURL(blobKey);
+					allURLs[pos++] = blobClient.getFile(blobKey).toURI().toURL();
 				} catch (Exception e) {
 					try {
 						blobClient.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -18,7 +18,14 @@
 
 package org.apache.flink.runtime.execution.librarycache;
 
-import java.io.File;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.BlobService;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.util.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
@@ -32,15 +39,6 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import org.apache.flink.runtime.blob.BlobKey;
-import org.apache.flink.runtime.blob.BlobService;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.util.ExceptionUtils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -51,8 +49,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>
  * All files registered via {@link #registerJob(JobID, Collection, Collection)} are reference-counted
  * and are removed by a timer-based cleanup task if their reference counter is zero.
- * <strong>NOTE:</strong> this does not apply to files that enter the blob service via
- * {@link #getFile(BlobKey)}!
  */
 public final class BlobLibraryCacheManager extends TimerTask implements LibraryCacheManager {
 
@@ -200,22 +196,6 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 				throw new IllegalStateException("No libraries are registered for job " + id);
 			}
 		}
-	}
-
-	/**
-	 * Returns a file handle to the file identified by the blob key.
-	 * <p>
-	 * <strong>NOTE:</strong> if not already registered during
-	 * {@link #registerJob(JobID, Collection, Collection)}, files that enter the library cache /
-	 * backing blob store using this method will not be reference-counted and garbage-collected!
-	 *
-	 * @param blobKey identifying the requested file
-	 * @return File handle
-	 * @throws IOException if any error occurs when retrieving the file
-	 */
-	@Override
-	public File getFile(BlobKey blobKey) throws IOException {
-		return new File(blobService.getURL(blobKey).getFile());
 	}
 
 	public int getBlobServerPort() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -254,7 +254,7 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 		// it is important that we fetch the URL before increasing the counter.
 		// in case the URL cannot be created (failed to fetch the BLOB), we have no stale counter
 		try {
-			URL url = blobService.getURL(key);
+			URL url = blobService.getFile(key).toURI().toURL();
 
 			Integer references = blobKeyReferenceCounters.get(key);
 			int newReferences = references == null ? 1 : references + 1;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FallbackLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FallbackLibraryCacheManager.java
@@ -18,14 +18,12 @@
 
 package org.apache.flink.runtime.execution.librarycache;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.api.common.JobID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
 import java.net.URL;
 import java.util.Collection;
 
@@ -36,11 +34,6 @@ public class FallbackLibraryCacheManager implements LibraryCacheManager {
 	@Override
 	public ClassLoader getClassLoader(JobID id) {
 		return getClass().getClassLoader();
-	}
-
-	@Override
-	public File getFile(BlobKey blobKey) throws IOException {
-		throw new IOException("There is no file associated to the blob key " + blobKey);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
@@ -37,15 +37,6 @@ public interface LibraryCacheManager {
 	ClassLoader getClassLoader(JobID id);
 
 	/**
-	 * Returns a file handle to the file identified by the blob key.
-	 *
-	 * @param blobKey identifying the requested file
-	 * @return File handle
-	 * @throws IOException if any error occurs when retrieving the file
-	 */
-	File getFile(BlobKey blobKey) throws IOException;
-
-	/**
 	 * Registers a job with its required jar files and classpaths. The jar files are identified by their blob keys.
 	 *
 	 * @param id job ID

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
@@ -22,7 +22,6 @@ import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.api.common.JobID;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Collection;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.junit.Rule;
@@ -45,6 +46,8 @@ public class BlobCacheRetriesTest {
 	@Test
 	public void testBlobFetchRetries() throws IOException {
 		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
 
 		testBlobFetchRetries(config, new VoidBlobStore());
 	}
@@ -56,9 +59,11 @@ public class BlobCacheRetriesTest {
 	@Test
 	public void testBlobFetchRetriesHa() throws IOException {
 		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
-			temporaryFolder.getRoot().getPath());
+			temporaryFolder.newFolder().getPath());
 
 		BlobStoreService blobStoreService = null;
 
@@ -136,6 +141,8 @@ public class BlobCacheRetriesTest {
 	@Test
 	public void testBlobFetchWithTooManyFailures() throws IOException {
 		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
 
 		testBlobFetchWithTooManyFailures(config, new VoidBlobStore());
 	}
@@ -147,6 +154,8 @@ public class BlobCacheRetriesTest {
 	@Test
 	public void testBlobFetchWithTooManyFailuresHa() throws IOException {
 		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
 			temporaryFolder.getRoot().getPath());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
@@ -115,7 +115,7 @@ public class BlobCacheRetriesTest {
 			cache = new BlobCache(serverAddress, config, new VoidBlobStore());
 
 			// trigger a download - it should fail the first two times, but retry, and succeed eventually
-			URL url = cache.getURL(key);
+			URL url = cache.getFile(key).toURI().toURL();
 			InputStream is = url.openStream();
 			try {
 				byte[] received = new byte[data.length];
@@ -211,7 +211,7 @@ public class BlobCacheRetriesTest {
 
 			// trigger a download - it should fail eventually
 			try {
-				cache.getURL(key);
+				cache.getFile(key);
 				fail("This should fail");
 			}
 			catch (IOException e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
@@ -28,15 +28,12 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * This class contains unit tests for the {@link BlobCache}.
@@ -141,7 +138,7 @@ public class BlobCacheSuccessTest {
 			blobCache = new BlobCache(serverAddress, cacheConfig, blobStoreService);
 
 			for (BlobKey blobKey : blobKeys) {
-				blobCache.getURL(blobKey);
+				blobCache.getFile(blobKey);
 			}
 
 			if (blobServer != null) {
@@ -150,28 +147,20 @@ public class BlobCacheSuccessTest {
 				blobServer = null;
 			}
 
-			final URL[] urls = new URL[blobKeys.size()];
+			final File[] files = new File[blobKeys.size()];
 
 			for(int i = 0; i < blobKeys.size(); i++){
-				urls[i] = blobCache.getURL(blobKeys.get(i));
+				files[i] = blobCache.getFile(blobKeys.get(i));
 			}
 
 			// Verify the result
-			assertEquals(blobKeys.size(), urls.length);
+			assertEquals(blobKeys.size(), files.length);
 
-			for (final URL url : urls) {
+			for (final File file : files) {
+				assertNotNull(file);
 
-				assertNotNull(url);
-
-				try {
-					final File cachedFile = new File(url.toURI());
-
-					assertTrue(cachedFile.exists());
-					assertEquals(buf.length, cachedFile.length());
-
-				} catch (URISyntaxException e) {
-					fail(e.getMessage());
-				}
+				assertTrue(file.exists());
+				assertEquals(buf.length, file.length());
 			}
 		} finally {
 			if (blobServer != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
@@ -23,11 +23,11 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SecurityOptions;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
-
-import static org.junit.Assert.fail;
 
 /**
  * This class contains unit tests for the {@link BlobClient} with ssl enabled.
@@ -46,12 +46,17 @@ public class BlobClientSslTest extends BlobClientTest {
 	/** The non-SSL blob service client configuration with SSL-enabled security options. */
 	private static Configuration nonSslClientConfig;
 
+	@ClassRule
+	public static TemporaryFolder temporarySslFolder = new TemporaryFolder();
+
 	/**
 	 * Starts the SSL enabled BLOB server.
 	 */
 	@BeforeClass
 	public static void startSSLServer() throws IOException {
 		Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporarySslFolder.newFolder().getAbsolutePath());
 		config.setBoolean(SecurityOptions.SSL_ENABLED, true);
 		config.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
 		config.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
@@ -67,6 +72,8 @@ public class BlobClientSslTest extends BlobClientTest {
 	@BeforeClass
 	public static void startNonSSLServer() throws IOException {
 		Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporarySslFolder.newFolder().getAbsolutePath());
 		config.setBoolean(SecurityOptions.SSL_ENABLED, true);
 		config.setBoolean(BlobServerOptions.SSL_ENABLED, false);
 		config.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
@@ -18,48 +18,33 @@
 
 package org.apache.flink.runtime.blob;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.InetSocketAddress;
-import java.security.MessageDigest;
-import java.util.Collections;
-import java.util.List;
-
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.SecurityOptions;
-import org.apache.flink.core.fs.Path;
-import org.apache.flink.util.TestLogger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.IOException;
+
+import static org.junit.Assert.fail;
+
 /**
  * This class contains unit tests for the {@link BlobClient} with ssl enabled.
  */
-public class BlobClientSslTest extends TestLogger {
-
-	/** The buffer size used during the tests in bytes. */
-	private static final int TEST_BUFFER_SIZE = 17 * 1000;
+public class BlobClientSslTest extends BlobClientTest {
 
 	/** The instance of the SSL BLOB server used during the tests. */
 	private static BlobServer BLOB_SSL_SERVER;
 
-	/** The SSL blob service client configuration */
+	/** Instance of a non-SSL BLOB server with SSL-enabled security options. */
+	private static BlobServer BLOB_NON_SSL_SERVER;
+
+	/** The SSL blob service client configuration. */
 	private static Configuration sslClientConfig;
 
-	/** The instance of the non-SSL BLOB server used during the tests. */
-	private static BlobServer BLOB_SERVER;
-
-	/** The non-ssl blob service client configuration */
-	private static Configuration clientConfig;
+	/** The non-SSL blob service client configuration with SSL-enabled security options. */
+	private static Configuration nonSslClientConfig;
 
 	/**
 	 * Starts the SSL enabled BLOB server.
@@ -79,9 +64,6 @@ public class BlobClientSslTest extends TestLogger {
 		sslClientConfig.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
 	}
 
-	/**
-	 * Starts the SSL disabled BLOB server.
-	 */
 	@BeforeClass
 	public static void startNonSSLServer() throws IOException {
 		Configuration config = new Configuration();
@@ -90,13 +72,13 @@ public class BlobClientSslTest extends TestLogger {
 		config.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
 		config.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
 		config.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
-		BLOB_SERVER = new BlobServer(config, new VoidBlobStore());
+		BLOB_NON_SSL_SERVER = new BlobServer(config, new VoidBlobStore());
 
-		clientConfig = new Configuration();
-		clientConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		clientConfig.setBoolean(BlobServerOptions.SSL_ENABLED, false);
-		clientConfig.setString(SecurityOptions.SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
-		clientConfig.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
+		nonSslClientConfig = new Configuration();
+		nonSslClientConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
+		nonSslClientConfig.setBoolean(BlobServerOptions.SSL_ENABLED, false);
+		nonSslClientConfig.setString(SecurityOptions.SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
+		nonSslClientConfig.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
 	}
 
 	/**
@@ -107,154 +89,14 @@ public class BlobClientSslTest extends TestLogger {
 		if (BLOB_SSL_SERVER != null) {
 			BLOB_SSL_SERVER.close();
 		}
-
-		if (BLOB_SERVER != null) {
-			BLOB_SERVER.close();
-		}
 	}
 
-	/**
-	 * Prepares a test file for the unit tests, i.e. the methods fills the file with a particular byte patterns and
-	 * computes the file's BLOB key.
-	 *
-	 * @param file
-	 *        the file to prepare for the unit tests
-	 * @return the BLOB key of the prepared file
-	 * @throws IOException
-	 *         thrown if an I/O error occurs while writing to the test file
-	 */
-	private static BlobKey prepareTestFile(File file) throws IOException {
-
-		MessageDigest md = BlobUtils.createMessageDigest();
-
-		final byte[] buf = new byte[TEST_BUFFER_SIZE];
-		for (int i = 0; i < buf.length; ++i) {
-			buf[i] = (byte) (i % 128);
-		}
-
-		FileOutputStream fos = null;
-		try {
-			fos = new FileOutputStream(file);
-
-			for (int i = 0; i < 20; ++i) {
-				fos.write(buf);
-				md.update(buf);
-			}
-
-		} finally {
-			if (fos != null) {
-				fos.close();
-			}
-		}
-
-		return new BlobKey(md.digest());
+	protected Configuration getBlobClientConfig() {
+		return sslClientConfig;
 	}
 
-	/**
-	 * Validates the result of a GET operation by comparing the data from the retrieved input stream to the content of
-	 * the specified file.
-	 *
-	 * @param inputStream
-	 *        the input stream returned from the GET operation
-	 * @param file
-	 *        the file to compare the input stream's data to
-	 * @throws IOException
-	 *         thrown if an I/O error occurs while reading the input stream or the file
-	 */
-	private static void validateGet(final InputStream inputStream, final File file) throws IOException {
-
-		InputStream inputStream2 = null;
-		try {
-
-			inputStream2 = new FileInputStream(file);
-
-			while (true) {
-
-				final int r1 = inputStream.read();
-				final int r2 = inputStream2.read();
-
-				assertEquals(r2, r1);
-
-				if (r1 < 0) {
-					break;
-				}
-			}
-
-		} finally {
-			if (inputStream2 != null) {
-				inputStream2.close();
-			}
-		}
-
-	}
-
-	/**
-	 * Tests the PUT/GET operations for content-addressable streams.
-	 */
-	@Test
-	public void testContentAddressableStream() {
-
-		BlobClient client = null;
-		InputStream is = null;
-
-		try {
-			File testFile = File.createTempFile("testfile", ".dat");
-			testFile.deleteOnExit();
-
-			BlobKey origKey = prepareTestFile(testFile);
-
-			InetSocketAddress serverAddress = new InetSocketAddress("localhost", BLOB_SSL_SERVER.getPort());
-			client = new BlobClient(serverAddress, sslClientConfig);
-
-			// Store the data
-			is = new FileInputStream(testFile);
-			BlobKey receivedKey = client.put(is);
-			assertEquals(origKey, receivedKey);
-
-			is.close();
-			is = null;
-
-			// Retrieve the data
-			is = client.get(receivedKey);
-			validateGet(is, testFile);
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-		finally {
-			if (is != null) {
-				try {
-					is.close();
-				} catch (Throwable t) {}
-			}
-			if (client != null) {
-				try {
-					client.close();
-				} catch (Throwable t) {}
-			}
-		}
-	}
-
-	/**
-	 * Tests the static {@link BlobClient#uploadJarFiles(InetSocketAddress, Configuration, List)} helper.
-	 */
-	private void uploadJarFile(BlobServer blobServer, Configuration blobClientConfig) throws Exception {
-		final File testFile = File.createTempFile("testfile", ".dat");
-		testFile.deleteOnExit();
-		prepareTestFile(testFile);
-
-		InetSocketAddress serverAddress = new InetSocketAddress("localhost", blobServer.getPort());
-
-		List<BlobKey> blobKeys = BlobClient.uploadJarFiles(serverAddress, blobClientConfig,
-			Collections.singletonList(new Path(testFile.toURI())));
-
-		assertEquals(1, blobKeys.size());
-
-		try (BlobClient blobClient = new BlobClient(serverAddress, blobClientConfig)) {
-			InputStream is = blobClient.get(blobKeys.get(0));
-			validateGet(is, testFile);
-		}
+	protected BlobServer getBlobServer() {
+		return BLOB_SSL_SERVER;
 	}
 
 	/**
@@ -268,27 +110,37 @@ public class BlobClientSslTest extends TestLogger {
 	/**
 	 * Verify ssl client to non-ssl server failure
 	 */
-	@Test
+	@Test(expected = IOException.class)
 	public void testSSLClientFailure() throws Exception {
-		try {
-			uploadJarFile(BLOB_SERVER, sslClientConfig);
-			fail("SSL client connected to non-ssl server");
-		} catch (Exception e) {
-			// Exception expected
-		}
+		// SSL client connected to non-ssl server
+		uploadJarFile(BLOB_SERVER, sslClientConfig);
+	}
+
+	/**
+	 * Verify ssl client to non-ssl server failure
+	 */
+	@Test(expected = IOException.class)
+	public void testSSLClientFailure2() throws Exception {
+		// SSL client connected to non-ssl server
+		uploadJarFile(BLOB_NON_SSL_SERVER, sslClientConfig);
 	}
 
 	/**
 	 * Verify non-ssl client to ssl server failure
 	 */
-	@Test
+	@Test(expected = IOException.class)
 	public void testSSLServerFailure() throws Exception {
-		try {
-			uploadJarFile(BLOB_SSL_SERVER, clientConfig);
-			fail("Non-SSL client connected to ssl server");
-		} catch (Exception e) {
-			// Exception expected
-		}
+		// Non-SSL client connected to ssl server
+		uploadJarFile(BLOB_SSL_SERVER, clientConfig);
+	}
+
+	/**
+	 * Verify non-ssl client to ssl server failure
+	 */
+	@Test(expected = IOException.class)
+	public void testSSLServerFailure2() throws Exception {
+		// Non-SSL client connected to ssl server
+		uploadJarFile(BLOB_SSL_SERVER, nonSslClientConfig);
 	}
 
 	/**
@@ -297,5 +149,29 @@ public class BlobClientSslTest extends TestLogger {
 	@Test
 	public void testNonSSLConnection() throws Exception {
 		uploadJarFile(BLOB_SERVER, clientConfig);
+	}
+
+	/**
+	 * Verify non-ssl connection sanity
+	 */
+	@Test
+	public void testNonSSLConnection2() throws Exception {
+		uploadJarFile(BLOB_SERVER, nonSslClientConfig);
+	}
+
+	/**
+	 * Verify non-ssl connection sanity
+	 */
+	@Test
+	public void testNonSSLConnection3() throws Exception {
+		uploadJarFile(BLOB_NON_SSL_SERVER, clientConfig);
+	}
+
+	/**
+	 * Verify non-ssl connection sanity
+	 */
+	@Test
+	public void testNonSSLConnection4() throws Exception {
+		uploadJarFile(BLOB_NON_SSL_SERVER, nonSslClientConfig);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -35,6 +35,7 @@ import java.security.MessageDigest;
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -135,19 +136,21 @@ public class BlobClientTest {
 	 *         thrown if an I/O error occurs while reading the input stream
 	 */
 	private static void validateGet(final InputStream inputStream, final byte[] buf) throws IOException {
+		byte[] receivedBuffer = new byte[buf.length];
 
 		int bytesReceived = 0;
 
 		while (true) {
 
-			final int read = inputStream.read(buf, bytesReceived, buf.length - bytesReceived);
+			final int read = inputStream.read(receivedBuffer, bytesReceived, receivedBuffer.length - bytesReceived);
 			if (read < 0) {
 				throw new EOFException();
 			}
 			bytesReceived += read;
 
-			if (bytesReceived == buf.length) {
+			if (bytesReceived == receivedBuffer.length) {
 				assertEquals(-1, inputStream.read());
+				assertArrayEquals(buf, receivedBuffer);
 				return;
 			}
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.EOFException;
 import java.io.File;
@@ -53,12 +56,18 @@ public class BlobClientTest {
 	/** The blob service (non-ssl) client configuration */
 	static Configuration clientConfig;
 
+	@ClassRule
+	public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
 	/**
 	 * Starts the BLOB server.
 	 */
 	@BeforeClass
 	public static void startServer() throws IOException {
 		Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
+
 		BLOB_SERVER = new BlobServer(config, new VoidBlobStore());
 
 		clientConfig = new Configuration();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.blob;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -54,7 +55,8 @@ public class BlobRecoveryITCase extends TestLogger {
 		Configuration config = new Configuration();
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
 		config.setString(CoreOptions.STATE_BACKEND, "FILESYSTEM");
-		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.getRoot().getPath());
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getPath());
 
 		BlobStoreService blobStoreService = null;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
@@ -110,7 +110,7 @@ public class BlobServerDeleteTest extends TestLogger {
 			// delete a file directly on the server
 			server.delete(key2);
 			try {
-				server.getURL(key2);
+				server.getFile(key2);
 				fail("BLOB should have been deleted");
 			}
 			catch (IOException e) {
@@ -210,7 +210,7 @@ public class BlobServerDeleteTest extends TestLogger {
 			server.delete(key);
 
 			// the file should still be there
-			server.getURL(key);
+			server.getFile(key);
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
@@ -18,13 +18,16 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.TestLogger;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
@@ -52,6 +55,9 @@ public class BlobServerDeleteTest extends TestLogger {
 
 	private final Random rnd = new Random();
 
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
 	@Test
 	public void testDeleteSingleByBlobKey() {
 		BlobServer server = null;
@@ -59,7 +65,9 @@ public class BlobServerDeleteTest extends TestLogger {
 		BlobStore blobStore = new VoidBlobStore();
 
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, blobStore);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -125,7 +133,9 @@ public class BlobServerDeleteTest extends TestLogger {
 		BlobStore blobStore = new VoidBlobStore();
 
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, blobStore);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -172,7 +182,9 @@ public class BlobServerDeleteTest extends TestLogger {
 		File blobFile = null;
 		File directory = null;
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, blobStore);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -223,7 +235,9 @@ public class BlobServerDeleteTest extends TestLogger {
 	 */
 	@Test
 	public void testConcurrentDeleteOperations() throws IOException, ExecutionException, InterruptedException {
-		final Configuration configuration = new Configuration();
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 		final BlobStore blobStore = mock(BlobStore.class);
 
 		final int concurrentDeleteOperations = 3;
@@ -233,7 +247,7 @@ public class BlobServerDeleteTest extends TestLogger {
 
 		final byte[] data = {1, 2, 3};
 
-		try (final BlobServer blobServer = new BlobServer(configuration, blobStore)) {
+		try (final BlobServer blobServer = new BlobServer(config, blobStore)) {
 
 			final BlobKey blobKey;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -75,7 +75,9 @@ public class BlobServerGetTest extends TestLogger {
 		BlobClient client = null;
 
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -115,7 +117,9 @@ public class BlobServerGetTest extends TestLogger {
 		BlobClient client = null;
 
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -167,9 +171,9 @@ public class BlobServerGetTest extends TestLogger {
 	 */
 	@Test
 	public void testConcurrentGetOperations() throws IOException, ExecutionException, InterruptedException {
-		final Configuration configuration = new Configuration();
 
-		configuration.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
 		final BlobStore blobStore = mock(BlobStore.class);
 
@@ -199,7 +203,7 @@ public class BlobServerGetTest extends TestLogger {
 
 		final ExecutorService executor = Executors.newFixedThreadPool(numberConcurrentGetOperations);
 
-		try (final BlobServer blobServer = new BlobServer(configuration, blobStore)) {
+		try (final BlobServer blobServer = new BlobServer(config, blobStore)) {
 			for (int i = 0; i < numberConcurrentGetOperations; i++) {
 				Future<InputStream> getOperation = FlinkCompletableFuture.supplyAsync(new Callable<InputStream>() {
 					@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -131,9 +131,10 @@ public class BlobServerGetTest extends TestLogger {
 			// issue a GET request that succeeds
 			InputStream is = client.get(key);
 
-			byte[] receiveBuffer = new byte[50000];
-			BlobUtils.readFully(is, receiveBuffer, 0, receiveBuffer.length, null);
-			BlobUtils.readFully(is, receiveBuffer, 0, receiveBuffer.length, null);
+			byte[] receiveBuffer = new byte[data.length];
+			int firstChunkLen = 50000;
+			BlobUtils.readFully(is, receiveBuffer, 0, firstChunkLen, null);
+			BlobUtils.readFully(is, receiveBuffer, firstChunkLen, firstChunkLen, null);
 
 			// shut down the server
 			for (BlobServerConnection conn : server.getCurrentActiveConnections()) {
@@ -141,10 +142,10 @@ public class BlobServerGetTest extends TestLogger {
 			}
 
 			try {
-				byte[] remainder = new byte[data.length - 2*receiveBuffer.length];
-				BlobUtils.readFully(is, remainder, 0, remainder.length, null);
+				BlobUtils.readFully(is, receiveBuffer, 2 * firstChunkLen, data.length - 2 * firstChunkLen, null);
 				// we tolerate that this succeeds, as the receiver socket may have buffered
-				// everything already
+				// everything already, but in this case, also verify the contents
+				assertArrayEquals(data, receiveBuffer);
 			}
 			catch (IOException e) {
 				// expected

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.runtime.concurrent.Future;
@@ -26,7 +27,9 @@ import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -63,6 +66,8 @@ public class BlobServerPutTest extends TestLogger {
 
 	private final Random rnd = new Random();
 
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	// --- concurrency tests for utility methods which could fail during the put operation ---
 
@@ -89,7 +94,10 @@ public class BlobServerPutTest extends TestLogger {
 	 */
 	@Test
 	public void testServerContentAddressableGetStorageLocationConcurrent() throws Exception {
-		BlobServer server = new BlobServer(new Configuration(), new VoidBlobStore());
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
+		BlobServer server = new BlobServer(config, new VoidBlobStore());
 
 		try {
 			BlobKey key = new BlobKey();
@@ -132,7 +140,9 @@ public class BlobServerPutTest extends TestLogger {
 		BlobClient client = null;
 
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -186,7 +196,9 @@ public class BlobServerPutTest extends TestLogger {
 		BlobClient client = null;
 
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -220,7 +232,9 @@ public class BlobServerPutTest extends TestLogger {
 		BlobClient client = null;
 
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -253,7 +267,9 @@ public class BlobServerPutTest extends TestLogger {
 
 		File tempFileDir = null;
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 
 			// make sure the blob server cannot create any files in its storage dir
@@ -306,7 +322,9 @@ public class BlobServerPutTest extends TestLogger {
 	 */
 	@Test
 	public void testConcurrentPutOperations() throws IOException, ExecutionException, InterruptedException {
-		final Configuration configuration = new Configuration();
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 		BlobStore blobStore = mock(BlobStore.class);
 		int concurrentPutOperations = 2;
 		int dataSize = 1024;
@@ -319,7 +337,7 @@ public class BlobServerPutTest extends TestLogger {
 		ExecutorService executor = Executors.newFixedThreadPool(concurrentPutOperations);
 
 		try (
-			final BlobServer blobServer = new BlobServer(configuration, blobStore)) {
+			final BlobServer blobServer = new BlobServer(config, blobStore)) {
 
 			for (int i = 0; i < concurrentPutOperations; i++) {
 				Future<BlobKey> putFuture = FlinkCompletableFuture.supplyAsync(new Callable<BlobKey>() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRangeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRangeTest.java
@@ -23,7 +23,9 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.TestLogger;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -32,6 +34,10 @@ import java.net.ServerSocket;
  * Tests to ensure that the BlobServer properly starts on a specified range of available ports.
  */
 public class BlobServerRangeTest extends TestLogger {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
 	/**
 	 * Start blob server on 0 = pick an ephemeral port
 	 */
@@ -39,6 +45,8 @@ public class BlobServerRangeTest extends TestLogger {
 	public void testOnEphemeralPort() throws IOException {
 		Configuration conf = new Configuration();
 		conf.setString(BlobServerOptions.PORT, "0");
+		conf.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 		BlobServer srv = new BlobServer(conf, new VoidBlobStore());
 		srv.close();
 	}
@@ -60,6 +68,7 @@ public class BlobServerRangeTest extends TestLogger {
 
 		Configuration conf = new Configuration();
 		conf.setString(BlobServerOptions.PORT, String.valueOf(socket.getLocalPort()));
+		conf.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
 		// this thing is going to throw an exception
 		try {
@@ -89,6 +98,7 @@ public class BlobServerRangeTest extends TestLogger {
 		int availablePort = NetUtils.getAvailablePort();
 		Configuration conf = new Configuration();
 		conf.setString(BlobServerOptions.PORT, sockets[0].getLocalPort() + "," + sockets[1].getLocalPort() + "," + availablePort);
+		conf.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
 		// this thing is going to throw an exception
 		try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -27,7 +27,9 @@ import com.google.common.io.Files;
 import org.apache.flink.util.OperatingSystem;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,24 +38,21 @@ public class BlobUtilsTest {
 
 	private final static String CANNOT_CREATE_THIS = "cannot-create-this";
 
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
 	private File blobUtilsTestDirectory;
 
 	@Before
-	public void before() {
-		// Prepare test directory
-		blobUtilsTestDirectory = Files.createTempDir();
-
+	public void before() throws IOException {
 		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
+
+		// Prepare test directory
+		blobUtilsTestDirectory = temporaryFolder.newFolder();
 
 		assertTrue(blobUtilsTestDirectory.setExecutable(true, false));
 		assertTrue(blobUtilsTestDirectory.setReadable(true, false));
 		assertTrue(blobUtilsTestDirectory.setWritable(false, false));
-	}
-
-	@After
-	public void after() {
-		// Cleanup test directory
-		assertTrue(blobUtilsTestDirectory.delete());
 	}
 
 	@Test(expected = IOException.class)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -108,13 +108,13 @@ public class BlobLibraryCacheManagerTest {
 			assertEquals(0, checkFilesExist(keys, server, false));
 
 			try {
-				server.getURL(keys.get(0));
+				server.getFile(keys.get(0));
 				fail("name-addressable BLOB should have been deleted");
 			} catch (IOException e) {
 				// expected
 			}
 			try {
-				server.getURL(keys.get(1));
+				server.getFile(keys.get(1));
 				fail("name-addressable BLOB should have been deleted");
 			} catch (IOException e) {
 				// expected
@@ -150,7 +150,7 @@ public class BlobLibraryCacheManagerTest {
 	 * @param doThrow
 	 * 		whether exceptions should be ignored (<tt>false</tt>), or throws (<tt>true</tt>)
 	 *
-	 * @return number of files we were able to retrieve via {@link BlobService#getURL(BlobKey)}
+	 * @return number of files we were able to retrieve via {@link BlobService#getFile(BlobKey)}
 	 */
 	private static int checkFilesExist(
 		List<BlobKey> keys, BlobService blobService, boolean doThrow)
@@ -159,7 +159,7 @@ public class BlobLibraryCacheManagerTest {
 
 		for (BlobKey key : keys) {
 			try {
-				blobService.getURL(key);
+				blobService.getFile(key);
 				++numFiles;
 			} catch (IOException e) {
 				if (doThrow) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.execution.librarycache;
 
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobClient;
@@ -27,7 +28,9 @@ import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.util.OperatingSystem;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
@@ -42,6 +45,9 @@ import java.util.Collections;
 import java.util.List;
 
 public class BlobLibraryCacheManagerTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	/**
 	 * Tests that the {@link BlobLibraryCacheManager} cleans up after calling {@link
@@ -59,6 +65,9 @@ public class BlobLibraryCacheManagerTest {
 
 		try {
 			Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+				temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 			InetSocketAddress blobSocketAddress = new InetSocketAddress(server.getPort());
 			BlobClient bc = new BlobClient(blobSocketAddress, config);
@@ -179,6 +188,9 @@ public class BlobLibraryCacheManagerTest {
 
 		try {
 			Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+				temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 			InetSocketAddress blobSocketAddress = new InetSocketAddress(server.getPort());
 			BlobClient bc = new BlobClient(blobSocketAddress, config);
@@ -249,6 +261,9 @@ public class BlobLibraryCacheManagerTest {
 		try {
 			// create the blob transfer services
 			Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+				temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
 			cache = new BlobCache(serverAddress, config, new VoidBlobStore());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.execution.librarycache;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -70,7 +71,10 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 		Configuration config = new Configuration();
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
 		config.setString(CoreOptions.STATE_BACKEND, "FILESYSTEM");
-		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.getRoot().getAbsolutePath());
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
+			temporaryFolder.newFolder().getAbsolutePath());
 
 		try {
 			blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
@@ -153,7 +157,8 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 
 			// Verify everything is clean below recoveryDir/<cluster_id>
 			final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
-			File haBlobStoreDir = new File(temporaryFolder.getRoot(), clusterId);
+			String haBlobStorePath = config.getString(HighAvailabilityOptions.HA_STORAGE_PATH);
+			File haBlobStoreDir = new File(haBlobStorePath, clusterId);
 			File[] recoveryFiles = haBlobStoreDir.listFiles();
 			assertNotNull("HA storage directory does not exist", recoveryFiles);
 			assertEquals("Unclean state backend: " + Arrays.toString(recoveryFiles), 0, recoveryFiles.length);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -107,7 +107,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			libServer[0].registerTask(jobId, executionId, keys, Collections.<URL>emptyList());
 
 			// Verify key 1
-			File f = libCache.getFile(keys.get(0));
+			File f = new File(cache.getURL(keys.get(0)).toURI());
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -126,7 +126,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			libCache = new BlobLibraryCacheManager(cache, 3600 * 1000);
 
 			// Verify key 1
-			f = libCache.getFile(keys.get(0));
+			f = new File(cache.getURL(keys.get(0)).toURI());
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -138,7 +138,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			}
 
 			// Verify key 2
-			f = libCache.getFile(keys.get(1));
+			f = new File(cache.getURL(keys.get(1)).toURI());
 			assertEquals(256, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -107,7 +107,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			libServer[0].registerTask(jobId, executionId, keys, Collections.<URL>emptyList());
 
 			// Verify key 1
-			File f = new File(cache.getURL(keys.get(0)).toURI());
+			File f = cache.getFile(keys.get(0));
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -126,7 +126,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			libCache = new BlobLibraryCacheManager(cache, 3600 * 1000);
 
 			// Verify key 1
-			f = new File(cache.getURL(keys.get(0)).toURI());
+			f = cache.getFile(keys.get(0));
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -138,7 +138,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			}
 
 			// Verify key 2
-			f = new File(cache.getURL(keys.get(1)).toURI());
+			f = cache.getFile(keys.get(1));
 			assertEquals(256, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {


### PR DESCRIPTION
As a relic from its use by the `URLClassLoader`, `BlobService#getURL()` methods always returned URL objects although they were always pointing to locally cached files. As a step towards a better architecture and API, these should be renamed and return a File object instead.

This PR is based upon #4235  in a series to implement FLINK-6916.