### PR TITLE
[FLINK-7056][blob] add API to allow job-related BLOBs to be stored

### DIFF
--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
 import org.apache.flink.api.java.LocalEnvironment;
 import org.apache.flink.api.java.io.AvroOutputFormat;
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -48,7 +49,9 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
@@ -69,6 +72,9 @@ public class HDFSTest {
 	private MiniDFSCluster hdfsCluster;
 	private org.apache.hadoop.fs.Path hdPath;
 	protected org.apache.hadoop.fs.FileSystem hdfs;
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	@BeforeClass
 	public static void verifyOS() {
@@ -242,6 +248,8 @@ public class HDFSTest {
 			config = new org.apache.flink.configuration.Configuration();
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
 		config.setString(CoreOptions.STATE_BACKEND, "ZOOKEEPER");
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
 
 		BlobStoreService blobStoreService = null;

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagerLogHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagerLogHandler.java
@@ -238,7 +238,7 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 								lastSubmittedFile.put(taskManagerID, blobKey);
 							}
 							try {
-								return FlinkCompletableFuture.completed(blobCache.getURL(blobKey).getFile());
+								return FlinkCompletableFuture.completed(blobCache.getFile(blobKey).getAbsolutePath());
 							} catch (IOException e) {
 								return FlinkCompletableFuture.completedExceptionally(
 									new Exception("Could not retrieve blob for " + blobKey + '.', e));

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagerLogHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagerLogHandler.java
@@ -227,7 +227,7 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 							if (lastSubmittedFile.containsKey(taskManagerID)) {
 								if (!blobKey.equals(lastSubmittedFile.get(taskManagerID))) {
 									try {
-										blobCache.deleteGlobal(null, lastSubmittedFile.get(taskManagerID));
+										blobCache.deleteGlobal(lastSubmittedFile.get(taskManagerID));
 									} catch (IOException e) {
 										return FlinkCompletableFuture.completedExceptionally(
 											new Exception("Could not delete file for " + taskManagerID + '.', e));
@@ -238,7 +238,7 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 								lastSubmittedFile.put(taskManagerID, blobKey);
 							}
 							try {
-								return FlinkCompletableFuture.completed(blobCache.getFile(null, blobKey).getAbsolutePath());
+								return FlinkCompletableFuture.completed(blobCache.getFile(blobKey).getAbsolutePath());
 							} catch (IOException e) {
 								return FlinkCompletableFuture.completedExceptionally(
 									new Exception("Could not retrieve blob for " + blobKey + '.', e));

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagerLogHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagerLogHandler.java
@@ -227,7 +227,7 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 							if (lastSubmittedFile.containsKey(taskManagerID)) {
 								if (!blobKey.equals(lastSubmittedFile.get(taskManagerID))) {
 									try {
-										blobCache.deleteGlobal(lastSubmittedFile.get(taskManagerID));
+										blobCache.deleteGlobal(null, lastSubmittedFile.get(taskManagerID));
 									} catch (IOException e) {
 										return FlinkCompletableFuture.completedExceptionally(
 											new Exception("Could not delete file for " + taskManagerID + '.', e));
@@ -238,7 +238,7 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 								lastSubmittedFile.put(taskManagerID, blobKey);
 							}
 							try {
-								return FlinkCompletableFuture.completed(blobCache.getFile(blobKey).getAbsolutePath());
+								return FlinkCompletableFuture.completed(blobCache.getFile(null, blobKey).getAbsolutePath());
 							} catch (IOException e) {
 								return FlinkCompletableFuture.completedExceptionally(
 									new Exception("Could not retrieve blob for " + blobKey + '.', e));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -35,6 +35,7 @@ import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
 
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
@@ -52,7 +53,8 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.runtime.blob.BlobServerProtocol.BUFFER_SIZE;
-import static org.apache.flink.runtime.blob.BlobServerProtocol.CONTENT_ADDRESSABLE;
+import static org.apache.flink.runtime.blob.BlobServerProtocol.CONTENT_FOR_JOB;
+import static org.apache.flink.runtime.blob.BlobServerProtocol.CONTENT_NO_JOB;
 import static org.apache.flink.runtime.blob.BlobServerProtocol.DELETE_OPERATION;
 import static org.apache.flink.runtime.blob.BlobServerProtocol.GET_OPERATION;
 import static org.apache.flink.runtime.blob.BlobServerProtocol.PUT_OPERATION;
@@ -61,7 +63,7 @@ import static org.apache.flink.runtime.blob.BlobServerProtocol.RETURN_OKAY;
 import static org.apache.flink.runtime.blob.BlobUtils.readFully;
 import static org.apache.flink.runtime.blob.BlobUtils.readLength;
 import static org.apache.flink.runtime.blob.BlobUtils.writeLength;
-import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * The BLOB client can communicate with the BLOB server and either upload (PUT), download (GET),
@@ -81,6 +83,7 @@ public final class BlobClient implements Closeable {
 	 *        the network address of the BLOB server
 	 * @param clientConfig
 	 *        additional configuration like SSL parameters required to connect to the blob server
+	 *
 	 * @throws IOException
 	 *         thrown if the connection to the BLOB server could not be established
 	 */
@@ -136,22 +139,28 @@ public final class BlobClient implements Closeable {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Downloads the BLOB identified by the given BLOB key from the BLOB server. If no such BLOB exists on the server, a
-	 * {@link FileNotFoundException} is thrown.
-	 * 
+	 * Downloads the BLOB identified by the given BLOB key from the BLOB server.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param blobKey
-	 *        the BLOB key identifying the BLOB to download
+	 * 		blob key associated with the requested file
+	 *
 	 * @return an input stream to read the retrieved data from
+	 *
+	 * @throws FileNotFoundException
+	 * 		if there is no such file;
 	 * @throws IOException
-	 *         thrown if an I/O error occurs during the download
+	 * 		if an I/O error occurs during the download
 	 */
-	public InputStream get(BlobKey blobKey) throws IOException {
+	public InputStream get(@Nullable JobID jobId, BlobKey blobKey) throws IOException {
 		if (this.socket.isClosed()) {
 			throw new IllegalStateException("BLOB Client is not connected. " +
 					"Client has been shut down or encountered an error before.");
 		}
 		if (LOG.isDebugEnabled()) {
-			LOG.debug(String.format("GET content addressable BLOB %s from %s", blobKey, socket.getLocalSocketAddress()));
+			LOG.debug("GET BLOB {}/{} from {}.", jobId, blobKey,
+				socket.getLocalSocketAddress());
 		}
 
 		try {
@@ -159,8 +168,8 @@ public final class BlobClient implements Closeable {
 			InputStream is = this.socket.getInputStream();
 
 			// Send GET header
-			sendGetHeader(os, null, blobKey);
-			receiveAndCheckResponse(is);
+			sendGetHeader(os, jobId, blobKey);
+			receiveAndCheckGetResponse(is);
 
 			return new BlobInputStream(is, blobKey);
 		}
@@ -175,29 +184,40 @@ public final class BlobClient implements Closeable {
 	 *
 	 * @param outputStream
 	 *        the output stream to write the header data to
-	 * @param jobID
-	 *        the job ID identifying the BLOB to download or <code>null</code> to indicate the BLOB key should be used
-	 *        to identify the BLOB on the server instead
+	 * @param jobId
+	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param blobKey
-	 *        the BLOB key to identify the BLOB to download if either the job ID or the regular key are
-	 *        <code>null</code>
+	 * 		blob key associated with the requested file
+	 *
 	 * @throws IOException
 	 *         thrown if an I/O error occurs while writing the header data to the output stream
 	 */
-	private void sendGetHeader(OutputStream outputStream, JobID jobID, BlobKey blobKey) throws IOException {
-		checkArgument(jobID == null);
+	private static void sendGetHeader(OutputStream outputStream, @Nullable JobID jobId, BlobKey blobKey) throws IOException {
+		checkNotNull(blobKey);
 
 		// Signal type of operation
 		outputStream.write(GET_OPERATION);
 
-		// Check if GET should be done in content-addressable manner
-		if (jobID == null) {
-			outputStream.write(CONTENT_ADDRESSABLE);
-			blobKey.writeToOutputStream(outputStream);
+		// Send job ID and key
+		if (jobId == null) {
+			outputStream.write(CONTENT_NO_JOB);
+		} else {
+			outputStream.write(CONTENT_FOR_JOB);
+			outputStream.write(jobId.getBytes());
 		}
+		blobKey.writeToOutputStream(outputStream);
 	}
 
-	private void receiveAndCheckResponse(InputStream is) throws IOException {
+	/**
+	 * Reads the response from the input stream and throws in case of errors
+	 *
+	 * @param is
+	 * 		stream to read from
+	 *
+	 * @throws IOException
+	 * 		if the response is an error or reading the response failed
+	 */
+	private static void receiveAndCheckGetResponse(InputStream is) throws IOException {
 		int response = is.read();
 		if (response < 0) {
 			throw new EOFException("Premature end of response");
@@ -217,82 +237,92 @@ public final class BlobClient implements Closeable {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Uploads the data of the given byte array to the BLOB server in a content-addressable manner.
+	 * Uploads the data of the given byte array for the given job to the BLOB server.
 	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param value
-	 *        the buffer to upload
+	 * 		the buffer to upload
+	 *
 	 * @return the computed BLOB key identifying the BLOB on the server
+	 *
 	 * @throws IOException
-	 *         thrown if an I/O error occurs while uploading the data to the BLOB server
+	 * 		thrown if an I/O error occurs while uploading the data to the BLOB server
 	 */
-	public BlobKey put(byte[] value) throws IOException {
-		return put(value, 0, value.length);
+	public BlobKey put(@Nullable JobID jobId, byte[] value) throws IOException {
+		return put(jobId, value, 0, value.length);
 	}
 
 	/**
-	 * Uploads data from the given byte array to the BLOB server in a content-addressable manner.
+	 * Uploads data from the given byte array for the given job to the BLOB server.
 	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param value
-	 *        the buffer to upload data from
+	 * 		the buffer to upload data from
 	 * @param offset
-	 *        the read offset within the buffer
+	 * 		the read offset within the buffer
 	 * @param len
-	 *        the number of bytes to upload from the buffer
+	 * 		the number of bytes to upload from the buffer
+	 *
 	 * @return the computed BLOB key identifying the BLOB on the server
+	 *
 	 * @throws IOException
-	 *         thrown if an I/O error occurs while uploading the data to the BLOB server
+	 * 		thrown if an I/O error occurs while uploading the data to the BLOB server
 	 */
-	public BlobKey put(byte[] value, int offset, int len) throws IOException {
-		return putBuffer(null, value, offset, len);
+	public BlobKey put(@Nullable JobID jobId, byte[] value, int offset, int len) throws IOException {
+		return putBuffer(jobId, value, offset, len);
 	}
 
 	/**
-	 * Uploads the data from the given input stream to the BLOB server in a content-addressable manner.
+	 * Uploads the data from the given input stream for the given job to the BLOB server.
 	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param inputStream
-	 *        the input stream to read the data from
+	 * 		the input stream to read the data from
+	 *
 	 * @return the computed BLOB key identifying the BLOB on the server
+	 *
 	 * @throws IOException
-	 *         thrown if an I/O error occurs while reading the data from the input stream or uploading the data to the
-	 *         BLOB server
+	 * 		thrown if an I/O error occurs while reading the data from the input stream or uploading the
+	 * 		data to the BLOB server
 	 */
-	public BlobKey put(InputStream inputStream) throws IOException {
-		return putInputStream(null, inputStream);
+	public BlobKey put(@Nullable JobID jobId, InputStream inputStream) throws IOException {
+		return putInputStream(jobId, inputStream);
 	}
 
 	/**
 	 * Uploads data from the given byte buffer to the BLOB server.
 	 *
 	 * @param jobId
-	 *        the ID of the job the BLOB belongs to or <code>null</code> to store the BLOB in a content-addressable
-	 *        manner
+	 * 		the ID of the job the BLOB belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param value
-	 *        the buffer to read the data from
+	 * 		the buffer to read the data from
 	 * @param offset
-	 *        the read offset within the buffer
+	 * 		the read offset within the buffer
 	 * @param len
-	 *        the number of bytes to read from the buffer
-	 * @return the computed BLOB key if the BLOB has been stored in a content-addressable manner, <code>null</code>
-	 *         otherwise
+	 * 		the number of bytes to read from the buffer
+	 *
+	 * @return the computed BLOB key of the uploaded BLOB
+	 *
 	 * @throws IOException
-	 *         thrown if an I/O error occurs while uploading the data to the BLOB server
+	 * 		thrown if an I/O error occurs while uploading the data to the BLOB server
 	 */
-	private BlobKey putBuffer(JobID jobId, byte[] value, int offset, int len) throws IOException {
+	private BlobKey putBuffer(@Nullable JobID jobId, byte[] value, int offset, int len) throws IOException {
 		if (this.socket.isClosed()) {
 			throw new IllegalStateException("BLOB Client is not connected. " +
 					"Client has been shut down or encountered an error before.");
 		}
+		checkNotNull(value);
 
 		if (LOG.isDebugEnabled()) {
-			if (jobId == null) {
-				LOG.debug(String.format("PUT content addressable BLOB buffer (%d bytes) to %s",
-						len, socket.getLocalSocketAddress()));
-			}
+			LOG.debug("PUT BLOB buffer ({} bytes) to {}.", len, socket.getLocalSocketAddress());
 		}
 
 		try {
 			final OutputStream os = this.socket.getOutputStream();
-			final MessageDigest md = jobId == null ? BlobUtils.createMessageDigest() : null;
+			final MessageDigest md = BlobUtils.createMessageDigest();
 
 			// Send the PUT header
 			sendPutHeader(os, jobId);
@@ -301,15 +331,15 @@ public final class BlobClient implements Closeable {
 			int remainingBytes = len;
 
 			while (remainingBytes > 0) {
+				// want a common code path for byte[] and InputStream at the BlobServer
+				// -> since for InputStream we don't know a total size beforehand, send lengths iteratively
 				final int bytesToSend = Math.min(BUFFER_SIZE, remainingBytes);
 				writeLength(bytesToSend, os);
 
 				os.write(value, offset, bytesToSend);
 
-				// Update the message digest if necessary
-				if (md != null) {
-					md.update(value, offset, bytesToSend);
-				}
+				// Update the message digest
+				md.update(value, offset, bytesToSend);
 
 				remainingBytes -= bytesToSend;
 				offset += bytesToSend;
@@ -319,7 +349,7 @@ public final class BlobClient implements Closeable {
 
 			// Receive blob key and compare
 			final InputStream is = this.socket.getInputStream();
-			return receivePutResponseAndCompare(is, md);
+			return receiveAndCheckPutResponse(is, md);
 		}
 		catch (Throwable t) {
 			BlobUtils.closeSilently(socket, LOG);
@@ -331,37 +361,36 @@ public final class BlobClient implements Closeable {
 	 * Uploads data from the given input stream to the BLOB server.
 	 *
 	 * @param jobId
-	 *        the ID of the job the BLOB belongs to or <code>null</code> to store the BLOB in a content-addressable
-	 *        manner
+	 * 		the ID of the job the BLOB belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param inputStream
-	 *        the input stream to read the data from
-	 * @return he computed BLOB key if the BLOB has been stored in a content-addressable manner, <code>null</code>
-	 *         otherwise
+	 * 		the input stream to read the data from
+	 *
+	 * @return the computed BLOB key of the uploaded BLOB
+	 *
 	 * @throws IOException
-	 *         thrown if an I/O error occurs while uploading the data to the BLOB server
+	 * 		thrown if an I/O error occurs while uploading the data to the BLOB server
 	 */
-	private BlobKey putInputStream(JobID jobId, InputStream inputStream) throws IOException {
+	private BlobKey putInputStream(@Nullable JobID jobId, InputStream inputStream) throws IOException {
 		if (this.socket.isClosed()) {
 			throw new IllegalStateException("BLOB Client is not connected. " +
 					"Client has been shut down or encountered an error before.");
 		}
+		checkNotNull(inputStream);
 
 		if (LOG.isDebugEnabled()) {
-			if (jobId == null) {
-				LOG.debug(String.format("PUT content addressable BLOB stream to %s",
-						socket.getLocalSocketAddress()));
-			}
+			LOG.debug("PUT BLOB stream to {}.", socket.getLocalSocketAddress());
 		}
 
 		try {
 			final OutputStream os = this.socket.getOutputStream();
-			final MessageDigest md = jobId == null ? BlobUtils.createMessageDigest() : null;
+			final MessageDigest md = BlobUtils.createMessageDigest();
 			final byte[] xferBuf = new byte[BUFFER_SIZE];
 
 			// Send the PUT header
 			sendPutHeader(os, jobId);
 
 			while (true) {
+				// since we don't know a total size here, send lengths iteratively
 				final int read = inputStream.read(xferBuf);
 				if (read < 0) {
 					// we are done. send a -1 and be done
@@ -371,15 +400,13 @@ public final class BlobClient implements Closeable {
 				if (read > 0) {
 					writeLength(read, os);
 					os.write(xferBuf, 0, read);
-					if (md != null) {
-						md.update(xferBuf, 0, read);
-					}
+					md.update(xferBuf, 0, read);
 				}
 			}
 
 			// Receive blob key and compare
 			final InputStream is = this.socket.getInputStream();
-			return receivePutResponseAndCompare(is, md);
+			return receiveAndCheckPutResponse(is, md);
 		}
 		catch (Throwable t) {
 			BlobUtils.closeSilently(socket, LOG);
@@ -387,16 +414,25 @@ public final class BlobClient implements Closeable {
 		}
 	}
 
-	private BlobKey receivePutResponseAndCompare(InputStream is, MessageDigest md) throws IOException {
+	/**
+	 * Reads the response from the input stream and throws in case of errors
+	 *
+	 * @param is
+	 * 		stream to read from
+	 * @param md
+	 * 		message digest to check the response against
+	 *
+	 * @throws IOException
+	 * 		if the response is an error, the message digest does not match or reading the response
+	 * 		failed
+	 */
+	private static BlobKey receiveAndCheckPutResponse(InputStream is, MessageDigest md)
+			throws IOException {
 		int response = is.read();
 		if (response < 0) {
 			throw new EOFException("Premature end of response");
 		}
 		else if (response == RETURN_OKAY) {
-			if (md == null) {
-				// not content addressable
-				return null;
-			}
 
 			BlobKey remoteKey = BlobKey.readFromInputStream(is);
 			BlobKey localKey = new BlobKey(md.digest());
@@ -418,24 +454,24 @@ public final class BlobClient implements Closeable {
 
 	/**
 	 * Constructs and writes the header data for a PUT request to the given output stream.
-	 * NOTE: If the jobId and key are null, we send the data to the content addressable section.
 	 *
 	 * @param outputStream
-	 *        the output stream to write the PUT header data to
-	 * @param jobID
-	 *        the ID of job the BLOB belongs to or <code>null</code> to indicate the upload of a
-	 *        content-addressable BLOB
+	 * 		the output stream to write the PUT header data to
+	 * @param jobId
+	 * 		the ID of job the BLOB belongs to (or <tt>null</tt> if job-unrelated)
+	 *
 	 * @throws IOException
-	 *         thrown if an I/O error occurs while writing the header data to the output stream
+	 * 		thrown if an I/O error occurs while writing the header data to the output stream
 	 */
-	private void sendPutHeader(OutputStream outputStream, JobID jobID) throws IOException {
-		checkArgument(jobID == null);
-
+	private static void sendPutHeader(OutputStream outputStream, @Nullable JobID jobId) throws IOException {
 		// Signal type of operation
 		outputStream.write(PUT_OPERATION);
-
-		// Check if PUT should be done in content-addressable manner
-		outputStream.write(CONTENT_ADDRESSABLE);
+		if (jobId == null) {
+			outputStream.write(CONTENT_NO_JOB);
+		} else {
+			outputStream.write(CONTENT_FOR_JOB);
+			outputStream.write(jobId.getBytes());
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -443,16 +479,19 @@ public final class BlobClient implements Closeable {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Deletes the BLOB identified by the given BLOB key from the BLOB server.
+	 * Deletes the BLOB identified by the given BLOB key and job ID from the BLOB server.
 	 *
-	 * @param blobKey
-	 *        the key to identify the BLOB
+	 * @param jobId
+	 * 		the ID of job the BLOB belongs to (or <tt>null</tt> if job-unrelated)
+	 * @param key
+	 * 		the key to identify the BLOB
+	 *
 	 * @throws IOException
-	 *         thrown if an I/O error occurs while transferring the request to
-	 *         the BLOB server or if the BLOB server cannot delete the file
+	 * 		thrown if an I/O error occurs while transferring the request to the BLOB server or if the
+	 * 		BLOB server cannot delete the file
 	 */
-	public void delete(BlobKey blobKey) throws IOException {
-		checkArgument(blobKey != null, "BLOB key must not be null.");
+	public void delete(@Nullable JobID jobId, BlobKey key) throws IOException {
+		checkNotNull(key);
 
 		try {
 			final OutputStream outputStream = this.socket.getOutputStream();
@@ -462,20 +501,16 @@ public final class BlobClient implements Closeable {
 			outputStream.write(DELETE_OPERATION);
 
 			// delete blob key
-			outputStream.write(CONTENT_ADDRESSABLE);
-			blobKey.writeToOutputStream(outputStream);
+			if (jobId == null) {
+				outputStream.write(CONTENT_NO_JOB);
+			} else {
+				outputStream.write(CONTENT_FOR_JOB);
+				outputStream.write(jobId.getBytes());
+			}
+			key.writeToOutputStream(outputStream);
 
-			int response = inputStream.read();
-			if (response < 0) {
-				throw new EOFException("Premature end of response");
-			}
-			if (response == RETURN_ERROR) {
-				Throwable cause = readExceptionFromStream(inputStream);
-				throw new IOException("Server side error: " + cause.getMessage(), cause);
-			}
-			else if (response != RETURN_OKAY) {
-				throw new IOException("Unrecognized response");
-			}
+			// the response is the same as for a GET request
+			receiveAndCheckGetResponse(inputStream);
 		}
 		catch (Throwable t) {
 			BlobUtils.closeSilently(socket, LOG);
@@ -487,16 +522,25 @@ public final class BlobClient implements Closeable {
 	 * Retrieves the {@link BlobServer} address from the JobManager and uploads
 	 * the JAR files to it.
 	 *
-	 * @param jobManager   Server address of the {@link BlobServer}
-	 * @param askTimeout   Ask timeout for blob server address retrieval
-	 * @param clientConfig Any additional configuration for the blob client
-	 * @param jars         List of JAR files to upload
-	 * @throws IOException Thrown if the address retrieval or upload fails
+	 * @param jobManager
+	 * 		Server address of the {@link BlobServer}
+	 * @param askTimeout
+	 * 		Ask timeout for blob server address retrieval
+	 * @param clientConfig
+	 * 		Any additional configuration for the blob client
+	 * @param jobId
+	 * 		the ID of job the BLOBs belong to
+	 * @param jars
+	 * 		List of JAR files to upload
+	 *
+	 * @throws IOException
+	 * 		if the address retrieval or upload fails
 	 */
 	public static List<BlobKey> uploadJarFiles(
 			ActorGateway jobManager,
 			FiniteDuration askTimeout,
 			Configuration clientConfig,
+			JobID jobId,
 			List<Path> jars) throws IOException {
 
 		if (jars.isEmpty()) {
@@ -517,7 +561,7 @@ public final class BlobClient implements Closeable {
 					InetSocketAddress serverAddress = new InetSocketAddress(jmHostname, port);
 
 					// Now, upload
-					return uploadJarFiles(serverAddress, clientConfig, jars);
+					return uploadJarFiles(serverAddress, clientConfig, jobId, jars);
 				} else {
 					throw new Exception("Expected port number (int) as answer, received " + result);
 				}
@@ -530,13 +574,20 @@ public final class BlobClient implements Closeable {
 	/**
 	 * Uploads the JAR files to a {@link BlobServer} at the given address.
 	 *
-	 * @param serverAddress Server address of the {@link BlobServer}
-	 * @param clientConfig Any additional configuration for the blob client
-	 * @param jars List of JAR files to upload
-	 * @throws IOException Thrown if the upload fails
+	 * @param serverAddress
+	 * 		Server address of the {@link BlobServer}
+	 * @param clientConfig
+	 * 		Any additional configuration for the blob client
+	 * @param jobId
+	 * 		the ID of job the BLOBs belong to
+	 * @param jars
+	 * 		List of JAR files to upload
+	 *
+	 * @throws IOException
+	 * 		if the upload fails
 	 */
 	public static List<BlobKey> uploadJarFiles(InetSocketAddress serverAddress,
-			Configuration clientConfig, List<Path> jars) throws IOException {
+			Configuration clientConfig, JobID jobId, List<Path> jars) throws IOException {
 		if (jars.isEmpty()) {
 			return Collections.emptyList();
 		} else {
@@ -548,7 +599,7 @@ public final class BlobClient implements Closeable {
 					FSDataInputStream is = null;
 					try {
 						is = fs.open(jar);
-						final BlobKey key = blobClient.put(is);
+						final BlobKey key = blobClient.put(jobId, is);
 						blobKeys.add(key);
 					} finally {
 						if (is != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -34,7 +34,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -334,22 +333,23 @@ public class BlobServer extends Thread implements BlobService {
 	}
 
 	/**
-	 * Method which retrieves the URL of a file associated with a blob key. The blob server looks
-	 * the blob key up in its local storage. If the file exists, then the URL is returned. If the
-	 * file does not exist, then a FileNotFoundException is thrown.
+	 * Method which retrieves the local path of a file associated with a blob key. The blob server
+	 * looks the blob key up in its local storage. If the file exists, it is returned. If the
+	 * file does not exist, it is retrieved from the HA blob store (if available) or a
+	 * FileNotFoundException is thrown.
 	 *
 	 * @param requiredBlob blob key associated with the requested file
-	 * @return URL of the file
-	 * @throws IOException
+	 * @return file referring to the local storage location of the BLOB.
+	 * @throws IOException Thrown if the file retrieval failed.
 	 */
 	@Override
-	public URL getURL(BlobKey requiredBlob) throws IOException {
+	public File getFile(BlobKey requiredBlob) throws IOException {
 		checkArgument(requiredBlob != null, "BLOB key cannot be null.");
 
 		final File localFile = BlobUtils.getStorageLocation(storageDir, requiredBlob);
 
 		if (localFile.exists()) {
-			return localFile.toURI().toURL();
+			return localFile;
 		}
 		else {
 			try {
@@ -361,7 +361,7 @@ public class BlobServer extends Thread implements BlobService {
 			}
 
 			if (localFile.exists()) {
-				return localFile.toURI().toURL();
+				return localFile;
 			}
 			else {
 				throw new FileNotFoundException("Local file " + localFile + " does not exist " +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
@@ -39,7 +39,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 
 import static org.apache.flink.runtime.blob.BlobServerProtocol.BUFFER_SIZE;
-import static org.apache.flink.runtime.blob.BlobServerProtocol.CONTENT_ADDRESSABLE;
+import static org.apache.flink.runtime.blob.BlobServerProtocol.CONTENT_FOR_JOB;
+import static org.apache.flink.runtime.blob.BlobServerProtocol.CONTENT_NO_JOB;
 import static org.apache.flink.runtime.blob.BlobServerProtocol.DELETE_OPERATION;
 import static org.apache.flink.runtime.blob.BlobServerProtocol.GET_OPERATION;
 import static org.apache.flink.runtime.blob.BlobServerProtocol.PUT_OPERATION;
@@ -49,6 +50,7 @@ import static org.apache.flink.runtime.blob.BlobUtils.closeSilently;
 import static org.apache.flink.runtime.blob.BlobUtils.readFully;
 import static org.apache.flink.runtime.blob.BlobUtils.readLength;
 import static org.apache.flink.runtime.blob.BlobUtils.writeLength;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A BLOB connection handles a series of requests from a particular BLOB client.
@@ -83,12 +85,8 @@ class BlobServerConnection extends Thread {
 		super("BLOB connection for " + clientSocket.getRemoteSocketAddress());
 		setDaemon(true);
 
-		if (blobServer == null) {
-			throw new NullPointerException();
-		}
-
 		this.clientSocket = clientSocket;
-		this.blobServer = blobServer;
+		this.blobServer = checkNotNull(blobServer);
 		this.blobStore = blobServer.getBlobStore();
 
 		ReadWriteLock readWriteLock = blobServer.getReadWriteLock();
@@ -167,15 +165,16 @@ class BlobServerConnection extends Thread {
 
 	/**
 	 * Handles an incoming GET request from a BLOB client.
-	 * 
+	 *
 	 * @param inputStream
-	 *        the input stream to read incoming data from
+	 * 		the input stream to read incoming data from
 	 * @param outputStream
-	 *        the output stream to send data back to the client
+	 * 		the output stream to send data back to the client
 	 * @param buf
-	 *        an auxiliary buffer for data serialization/deserialization
+	 * 		an auxiliary buffer for data serialization/deserialization
+	 *
 	 * @throws IOException
-	 *         thrown if an I/O error occurs while reading/writing data from/to the respective streams
+	 * 		thrown if an I/O error occurs while reading/writing data from/to the respective streams
 	 */
 	private void get(InputStream inputStream, OutputStream outputStream, byte[] buf) throws IOException {
 		/*
@@ -187,24 +186,35 @@ class BlobServerConnection extends Thread {
 		 * so a local cache makes more sense.
 		 */
 
-		File blobFile;
-		int contentAddressable = -1;
-		JobID jobId = null;
-		BlobKey blobKey = null;
+		final File blobFile;
+		final JobID jobId;
+		final BlobKey blobKey;
 
 		try {
-			contentAddressable = inputStream.read();
+			final int mode = inputStream.read();
 
-			if (contentAddressable < 0) {
+			if (mode < 0) {
 				throw new EOFException("Premature end of GET request");
 			}
-			if (contentAddressable == CONTENT_ADDRESSABLE) {
-				blobKey = BlobKey.readFromInputStream(inputStream);
-				blobFile = blobServer.getStorageLocation(blobKey);
+
+			// Receive the job ID and key
+			if (mode == CONTENT_NO_JOB) {
+				jobId = null;
+			} else if (mode == CONTENT_FOR_JOB) {
+				byte[] jidBytes = new byte[JobID.SIZE];
+				readFully(inputStream, jidBytes, 0, JobID.SIZE, "JobID");
+				jobId = JobID.fromByteArray(jidBytes);
+			} else {
+				throw new IOException("Unknown type of BLOB addressing: " + mode + '.');
 			}
-			else {
-				throw new IOException("Unknown type of BLOB addressing: " + contentAddressable + '.');
+			blobKey = BlobKey.readFromInputStream(inputStream);
+
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Received GET request for BLOB {}/{} from {}.", jobId,
+					blobKey, clientSocket.getInetAddress());
 			}
+
+			blobFile = blobServer.getStorageLocation(jobId, blobKey);
 
 			// up to here, an error can give a good message
 		}
@@ -214,7 +224,7 @@ class BlobServerConnection extends Thread {
 				writeErrorToStream(outputStream, t);
 			}
 			catch (IOException e) {
-				// since we are in an exception case, it means not much that we could not send the error
+				// since we are in an exception case, it means that we could not send the error
 				// ignore this
 			}
 			clientSocket.close();
@@ -224,6 +234,7 @@ class BlobServerConnection extends Thread {
 		readLock.lock();
 
 		try {
+			// copy the file to local store if it does not exist yet
 			try {
 				if (!blobFile.exists()) {
 					// first we have to release the read lock in order to acquire the write lock
@@ -232,9 +243,9 @@ class BlobServerConnection extends Thread {
 
 					try {
 						if (blobFile.exists()) {
-							LOG.debug("Blob file {} has downloaded from the BlobStore by a different connection.", blobFile);
+							LOG.debug("Blob file {} has been downloaded from the (distributed) blob store by a different connection.", blobFile);
 						} else {
-							blobStore.get(blobKey, blobFile);
+							blobStore.get(jobId, blobKey, blobFile);
 						}
 					} finally {
 						writeLock.unlock();
@@ -248,6 +259,7 @@ class BlobServerConnection extends Thread {
 					}
 				}
 
+				// enforce a 2GB max for now (otherwise the protocol's length field needs to be increased)
 				if (blobFile.length() > Integer.MAX_VALUE) {
 					throw new IOException("BLOB size exceeds the maximum size (2 GB).");
 				}
@@ -259,7 +271,7 @@ class BlobServerConnection extends Thread {
 					writeErrorToStream(outputStream, t);
 				}
 				catch (IOException e) {
-					// since we are in an exception case, it means not much that we could not send the error
+					// since we are in an exception case, it means that we could not send the error
 					// ignore this
 				}
 				clientSocket.close();
@@ -294,59 +306,48 @@ class BlobServerConnection extends Thread {
 
 	/**
 	 * Handles an incoming PUT request from a BLOB client.
-	 * 
-	 * @param inputStream The input stream to read incoming data from.
-	 * @param outputStream The output stream to send data back to the client.
-	 * @param buf An auxiliary buffer for data serialization/deserialization.
+	 *
+	 * @param inputStream
+	 * 		The input stream to read incoming data from
+	 * @param outputStream
+	 * 		The output stream to send data back to the client
+	 * @param buf
+	 * 		An auxiliary buffer for data serialization/deserialization
+	 *
+	 * @throws IOException
+	 * 		thrown if an I/O error occurs while reading/writing data from/to the respective streams
 	 */
 	private void put(InputStream inputStream, OutputStream outputStream, byte[] buf) throws IOException {
-		JobID jobID = null;
-		MessageDigest md = null;
-
 		File incomingFile = null;
-		FileOutputStream fos = null;
 
 		try {
-			final int contentAddressable = inputStream.read();
-			if (contentAddressable < 0) {
+			final int mode = inputStream.read();
+
+			if (mode < 0) {
 				throw new EOFException("Premature end of PUT request");
 			}
 
-			if (contentAddressable == CONTENT_ADDRESSABLE) {
-				md = BlobUtils.createMessageDigest();
-			}
-			else {
+			// Receive the job ID and key
+			final JobID jobId;
+			if (mode == CONTENT_NO_JOB) {
+				jobId = null;
+			} else if (mode == CONTENT_FOR_JOB) {
+				byte[] jidBytes = new byte[JobID.SIZE];
+				readFully(inputStream, jidBytes, 0, JobID.SIZE, "JobID");
+				jobId = JobID.fromByteArray(jidBytes);
+			} else {
 				throw new IOException("Unknown type of BLOB addressing.");
 			}
 
 			if (LOG.isDebugEnabled()) {
-				LOG.debug("Received PUT request for content addressable BLOB");
+				LOG.debug("Received PUT request for BLOB of job {} with from {}.", jobId,
+					clientSocket.getInetAddress());
 			}
 
 			incomingFile = blobServer.createTemporaryFilename();
-			fos = new FileOutputStream(incomingFile);
+			BlobKey blobKey = readFileFully(inputStream, incomingFile, buf);
 
-			while (true) {
-				final int bytesExpected = readLength(inputStream);
-				if (bytesExpected == -1) {
-					// done
-					break;
-				}
-				if (bytesExpected > BUFFER_SIZE) {
-					throw new IOException("Unexpected number of incoming bytes: " + bytesExpected);
-				}
-
-				readFully(inputStream, buf, 0, bytesExpected, "buffer");
-				fos.write(buf, 0, bytesExpected);
-
-				if (md != null) {
-					md.update(buf, 0, bytesExpected);
-				}
-			}
-			fos.close();
-
-			BlobKey blobKey = new BlobKey(md.digest());
-			File storageFile = blobServer.getStorageLocation(blobKey);
+			File storageFile = blobServer.getStorageLocation(jobId, blobKey);
 
 			writeLock.lock();
 
@@ -369,13 +370,15 @@ class BlobServerConnection extends Thread {
 
 					// only the one moving the incoming file to its final destination is allowed to upload the
 					// file to the blob store
-					blobStore.put(storageFile, blobKey);
+					blobStore.put(storageFile, jobId, blobKey);
+				} else {
+					LOG.warn("File upload for an existing file with key {} for job {}. This may indicate a duplicate upload or a hash collision. Ignoring newest upload.", blobKey, jobId);
 				}
 			} catch(IOException ioe) {
 				// we failed to either create the local storage file or to upload it --> try to delete the local file
 				// while still having the write lock
-				if (storageFile.exists() && !storageFile.delete()) {
-					LOG.warn("Could not delete the storage file.");
+				if (!storageFile.delete() && storageFile.exists()) {
+					LOG.warn("Could not delete the storage file with key {} and job {}.", blobKey, jobId);
 				}
 
 				throw ioe;
@@ -403,15 +406,8 @@ class BlobServerConnection extends Thread {
 			clientSocket.close();
 		}
 		finally {
-			if (fos != null) {
-				try {
-					fos.close();
-				} catch (Throwable t) {
-					LOG.warn("Cannot close stream to BLOB staging file", t);
-				}
-			}
 			if (incomingFile != null) {
-				if (!incomingFile.delete()) {
+				if (!incomingFile.delete() && incomingFile.exists()) {
 					LOG.warn("Cannot delete BLOB server staging file " + incomingFile.getAbsolutePath());
 				}
 			}
@@ -419,27 +415,87 @@ class BlobServerConnection extends Thread {
 	}
 
 	/**
+	 * Reads a full file from <tt>inputStream</tt> into <tt>incomingFile</tt> returning its checksum.
+	 *
+	 * @param inputStream
+	 * 		stream to read from
+	 * @param incomingFile
+	 * 		file to write to
+	 * @param buf
+	 * 		An auxiliary buffer for data serialization/deserialization
+	 *
+	 * @return the received file's content hash as a BLOB key
+	 *
+	 * @throws IOException
+	 * 		thrown if an I/O error occurs while reading/writing data from/to the respective streams
+	 */
+	private static BlobKey readFileFully(
+			final InputStream inputStream, final File incomingFile, final byte[] buf)
+			throws IOException {
+		MessageDigest md = BlobUtils.createMessageDigest();
+		FileOutputStream fos = new FileOutputStream(incomingFile);
+
+		try {
+			while (true) {
+				final int bytesExpected = readLength(inputStream);
+				if (bytesExpected == -1) {
+					// done
+					break;
+				}
+				if (bytesExpected > BUFFER_SIZE) {
+					throw new IOException(
+						"Unexpected number of incoming bytes: " + bytesExpected);
+				}
+
+				readFully(inputStream, buf, 0, bytesExpected, "buffer");
+				fos.write(buf, 0, bytesExpected);
+
+				md.update(buf, 0, bytesExpected);
+			}
+			return new BlobKey(md.digest());
+		} finally {
+			try {
+				fos.close();
+			} catch (Throwable t) {
+				LOG.warn("Cannot close stream to BLOB staging file", t);
+			}
+		}
+	}
+
+	/**
 	 * Handles an incoming DELETE request from a BLOB client.
-	 * 
-	 * @param inputStream The input stream to read the request from.
-	 * @param outputStream The output stream to write the response to.
-	 * @throws java.io.IOException Thrown if an I/O error occurs while reading the request data from the input stream.
+	 *
+	 * @param inputStream
+	 * 		The input stream to read the request from.
+	 * @param outputStream
+	 * 		The output stream to write the response to.
+	 *
+	 * @throws IOException
+	 * 		Thrown if an I/O error occurs while reading the request data from the input stream.
 	 */
 	private void delete(InputStream inputStream, OutputStream outputStream) throws IOException {
 
 		try {
-			int type = inputStream.read();
-			if (type < 0) {
+			final int mode = inputStream.read();
+
+			if (mode < 0) {
 				throw new EOFException("Premature end of DELETE request");
 			}
 
-			if (type == CONTENT_ADDRESSABLE) {
-				BlobKey key = BlobKey.readFromInputStream(inputStream);
-				blobServer.delete(key);
+			// Receive the job ID and key
+			final JobID jobId;
+			if (mode == CONTENT_NO_JOB) {
+				jobId = null;
+			} else if (mode == CONTENT_FOR_JOB) {
+				byte[] jidBytes = new byte[JobID.SIZE];
+				readFully(inputStream, jidBytes, 0, JobID.SIZE, "JobID");
+				jobId = JobID.fromByteArray(jidBytes);
+			} else {
+				throw new IOException("Unknown type of BLOB addressing.");
 			}
-			else {
-				throw new IOException("Unrecognized addressing type: " + type);
-			}
+			BlobKey key = BlobKey.readFromInputStream(inputStream);
+
+			blobServer.delete(jobId, key);
 
 			outputStream.write(RETURN_OKAY);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
@@ -495,7 +495,7 @@ class BlobServerConnection extends Thread {
 			}
 			BlobKey key = BlobKey.readFromInputStream(inputStream);
 
-			blobServer.delete(jobId, key);
+			blobServer.deleteInternal(jobId, key);
 
 			outputStream.write(RETURN_OKAY);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerProtocol.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerProtocol.java
@@ -42,12 +42,20 @@ public class BlobServerProtocol {
 	static final byte RETURN_ERROR = 1;
 
 	/**
-	 * Internal code to identify a reference via content hash as the key.
+	 * Internal code to identify a job-unrelated reference via content hash as the key.
 	 * <p>
 	 * Note: previously, there was also <tt>NAME_ADDRESSABLE</tt> (code <tt>1</tt>) and
 	 * <tt>JOB_ID_SCOPE</tt> (code <tt>2</tt>).
 	 */
-	static final byte CONTENT_ADDRESSABLE = 0;
+	static final byte CONTENT_NO_JOB = 0;
+
+	/**
+	 * Internal code to identify a job-related reference via content hash as the key.
+	 * <p>
+	 * Note: previously, there was also <tt>NAME_ADDRESSABLE</tt> (code <tt>1</tt>) and
+	 * <tt>JOB_ID_SCOPE</tt> (code <tt>2</tt>).
+	 */
+	static final byte CONTENT_FOR_JOB = 3;
 
 	// --------------------------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.api.common.JobID;
+
+import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -28,29 +31,30 @@ import java.io.IOException;
 public interface BlobService extends Closeable {
 
 	/**
-	 * Returns the path to a local copy of the file associated with the provided blob key.
+	 * Returns the path to a local copy of the file associated with the provided job ID and blob key.
 	 *
+	 * @param jobId ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param key blob key associated with the requested file
 	 * @return The path to the file.
 	 * @throws java.io.FileNotFoundException when the path does not exist;
 	 * @throws IOException if any other error occurs when retrieving the file
 	 */
-	File getFile(BlobKey key) throws IOException;
-
+	File getFile(@Nullable JobID jobId, BlobKey key) throws IOException;
 
 	/**
-	 * Deletes the file associated with the provided blob key.
+	 * Deletes the file associated with the provided job ID and blob key.
 	 *
+	 * @param jobId ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param key associated with the file to be deleted
 	 * @throws IOException
 	 */
-	void delete(BlobKey key) throws IOException;
+	void delete(@Nullable JobID jobId, BlobKey key) throws IOException;
 
 	/**
 	 * Returns the port of the blob service.
 	 * @return the port of the blob service.
 	 */
 	int getPort();
-	
+
 	BlobClient createClient() throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
@@ -19,8 +19,8 @@
 package org.apache.flink.runtime.blob;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 
 /**
  * A simple store and retrieve binary large objects (BLOBs).
@@ -28,14 +28,14 @@ import java.net.URL;
 public interface BlobService extends Closeable {
 
 	/**
-	 * Returns the URL of the file associated with the provided blob key.
+	 * Returns the path to a local copy of the file associated with the provided blob key.
 	 *
 	 * @param key blob key associated with the requested file
-	 * @return The URL to the file.
+	 * @return The path to the file.
 	 * @throws java.io.FileNotFoundException when the path does not exist;
 	 * @throws IOException if any other error occurs when retrieving the file
 	 */
-	URL getURL(BlobKey key) throws IOException;
+	File getFile(BlobKey key) throws IOException;
 
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.api.common.JobID;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.blob;
 
 import org.apache.flink.api.common.JobID;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.File;
@@ -31,24 +32,43 @@ import java.io.IOException;
 public interface BlobService extends Closeable {
 
 	/**
-	 * Returns the path to a local copy of the file associated with the provided job ID and blob key.
+	 * Returns the path to a local copy of the (job-unrelated) file associated with the provided
+	 * blob key.
 	 *
-	 * @param jobId ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param key blob key associated with the requested file
 	 * @return The path to the file.
 	 * @throws java.io.FileNotFoundException when the path does not exist;
 	 * @throws IOException if any other error occurs when retrieving the file
 	 */
-	File getFile(@Nullable JobID jobId, BlobKey key) throws IOException;
+	File getFile(BlobKey key) throws IOException;
+
+	/**
+	 * Returns the path to a local copy of the file associated with the provided job ID and blob key.
+	 *
+	 * @param jobId ID of the job this blob belongs to
+	 * @param key blob key associated with the requested file
+	 * @return The path to the file.
+	 * @throws java.io.FileNotFoundException when the path does not exist;
+	 * @throws IOException if any other error occurs when retrieving the file
+	 */
+	File getFile(@Nonnull JobID jobId, BlobKey key) throws IOException;
+
+	/**
+	 * Deletes the (job-unrelated) file associated with the provided blob key.
+	 *
+	 * @param key associated with the file to be deleted
+	 * @throws IOException
+	 */
+	void delete(BlobKey key) throws IOException;
 
 	/**
 	 * Deletes the file associated with the provided job ID and blob key.
 	 *
-	 * @param jobId ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
+	 * @param jobId ID of the job this blob belongs to
 	 * @param key associated with the file to be deleted
 	 * @throws IOException
 	 */
-	void delete(@Nullable JobID jobId, BlobKey key) throws IOException;
+	void delete(@Nonnull JobID jobId, BlobKey key) throws IOException;
 
 	/**
 	 * Returns the port of the blob service.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobStore.java
@@ -32,19 +32,21 @@ public interface BlobStore extends BlobView {
 	 * Copies the local file to the blob store.
 	 *
 	 * @param localFile The file to copy
+	 * @param jobId ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param blobKey   The ID for the file in the blob store
 	 * @throws IOException If the copy fails
 	 */
-	void put(File localFile, BlobKey blobKey) throws IOException;
+	void put(File localFile, JobID jobId, BlobKey blobKey) throws IOException;
 
 	/**
 	 * Tries to delete a blob from storage.
 	 *
 	 * <p>NOTE: This also tries to delete any created directories if empty.</p>
 	 *
+	 * @param jobId ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param blobKey The blob ID
 	 */
-	void delete(BlobKey blobKey);
+	void delete(JobID jobId, BlobKey blobKey);
 
 	/**
 	 * Tries to delete all blobs for the given job from storage.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -28,6 +28,8 @@ import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.util.StringUtils;
 import org.slf4j.Logger;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
@@ -60,6 +62,11 @@ public class BlobUtils {
 	 * The prefix of all job-specific directories created by the BLOB server.
 	 */
 	private static final String JOB_DIR_PREFIX = "job_";
+
+	/**
+	 * The prefix of all job-unrelated directories created by the BLOB server.
+	 */
+	private static final String NO_JOB_DIR_PREFIX = "no_job";
 
 	/**
 	 * Creates a BlobStore based on the parameters set in the configuration.
@@ -116,26 +123,29 @@ public class BlobUtils {
 	}
 
 	/**
-	 * Creates a storage directory for a blob service.
+	 * Creates a local storage directory for a blob service under the given parent directory.
 	 *
-	 * @return the storage directory used by a BLOB service
+	 * @param basePath
+	 * 		base path, i.e. parent directory, of the storage directory to use (if <tt>null</tt> or
+	 * 		empty, the path in <tt>java.io.tmpdir</tt> will be used)
+	 *
+	 * @return a new local storage directory
 	 *
 	 * @throws IOException
-	 * 		thrown if the (local or distributed) file storage cannot be created or
-	 * 		is not usable
+	 * 		thrown if the local file storage cannot be created or is not usable
 	 */
-	static File initStorageDirectory(String storageDirectory) throws
-		IOException {
+	static File initLocalStorageDirectory(String basePath) throws IOException {
 		File baseDir;
-		if (StringUtils.isNullOrWhitespaceOnly(storageDirectory)) {
+		if (StringUtils.isNullOrWhitespaceOnly(basePath)) {
 			baseDir = new File(System.getProperty("java.io.tmpdir"));
 		}
 		else {
-			baseDir = new File(storageDirectory);
+			baseDir = new File(basePath);
 		}
 
 		File storageDir;
 
+		// NOTE: although we will be using UUIDs, there may be collisions
 		final int MAX_ATTEMPTS = 10;
 		for(int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
 			storageDir = new File(baseDir, String.format(
@@ -143,7 +153,7 @@ public class BlobUtils {
 
 			// Create the storage dir if it doesn't exist. Only return it when the operation was
 			// successful.
-			if (!storageDir.exists() && storageDir.mkdirs()) {
+			if (storageDir.mkdirs()) {
 				return storageDir;
 			}
 		}
@@ -153,46 +163,108 @@ public class BlobUtils {
 	}
 
 	/**
-	 * Returns the BLOB service's directory for incoming files. The directory is created if it did
-	 * not exist so far.
+	 * Returns the BLOB service's directory for incoming (job-unrelated) files. The directory is
+	 * created if it does not exist yet.
 	 *
-	 * @return the BLOB server's directory for incoming files
+	 * @param storageDir
+	 * 		storage directory used be the BLOB service
+	 *
+	 * @return the BLOB service's directory for incoming files
 	 */
 	static File getIncomingDirectory(File storageDir) {
 		final File incomingDir = new File(storageDir, "incoming");
 
-		if (!incomingDir.mkdirs() && !incomingDir.exists()) {
-			throw new RuntimeException("Cannot create directory for incoming files " + incomingDir.getAbsolutePath());
-		}
+		mkdirTolerateExisting(incomingDir, "incoming");
 
 		return incomingDir;
 	}
 
 	/**
-	 * Returns the BLOB service's directory for cached files. The directory is created if it did
-	 * not exist so far.
+	 * Makes sure a given directory exists by creating it if necessary.
 	 *
-	 * @return the BLOB server's directory for cached files
+	 * @param dir
+	 * 		directory to create
+	 * @param dirType
+	 * 		the type of the directory (included in error message if something fails)
 	 */
-	private static File getCacheDirectory(File storageDir) {
-		final File cacheDirectory = new File(storageDir, "cache");
-
-		if (!cacheDirectory.mkdirs() && !cacheDirectory.exists()) {
-			throw new RuntimeException("Could not create cache directory '" + cacheDirectory.getAbsolutePath() + "'.");
+	private static void mkdirTolerateExisting(final File dir, final String dirType) {
+		// note: thread-safe create should try to mkdir first and then ignore the case that the
+		//       directory already existed
+		if (!dir.mkdirs() && !dir.exists()) {
+			throw new RuntimeException(
+				"Cannot create " + dirType + " directory '" + dir.getAbsolutePath() + "'.");
 		}
-
-		return cacheDirectory;
 	}
 
 	/**
 	 * Returns the (designated) physical storage location of the BLOB with the given key.
 	 *
+	 * @param storageDir
+	 * 		storage directory used be the BLOB service
 	 * @param key
-	 *        the key identifying the BLOB
+	 * 		the key identifying the BLOB
+	 * @param jobId
+	 * 		ID of the job for the incoming files (or <tt>null</tt> if job-unrelated)
+	 *
 	 * @return the (designated) physical storage location of the BLOB
 	 */
-	static File getStorageLocation(File storageDir, BlobKey key) {
-		return new File(getCacheDirectory(storageDir), BLOB_FILE_PREFIX + key.toString());
+	static File getStorageLocation(
+			@Nonnull File storageDir, @Nullable JobID jobId, @Nonnull BlobKey key) {
+		File file = new File(getStorageLocationPath(storageDir.getAbsolutePath(), jobId, key));
+
+		mkdirTolerateExisting(file.getParentFile(), "cache");
+
+		return file;
+	}
+
+	/**
+	 * Returns the BLOB server's storage directory for BLOBs belonging to the job with the given ID
+	 * <em>without</em> creating the directory.
+	 *
+	 * @param storageDir
+	 * 		storage directory used be the BLOB service
+	 * @param jobId
+	 * 		the ID of the job to return the storage directory for
+	 *
+	 * @return the storage directory for BLOBs belonging to the job with the given ID
+	 */
+	static String getStorageLocationPath(@Nonnull String storageDir, @Nullable JobID jobId) {
+		if (jobId == null) {
+			// format: $base/no_job
+			return String.format("%s/%s", storageDir, NO_JOB_DIR_PREFIX);
+		} else {
+			// format: $base/job_$jobId
+			return String.format("%s/%s%s", storageDir, JOB_DIR_PREFIX, jobId.toString());
+		}
+	}
+
+	/**
+	 * Returns the path for the given blob key.
+	 * <p>
+	 * The returned path can be used with the (local or HA) BLOB store file system back-end for
+	 * recovery purposes and follows the same scheme as {@link #getStorageLocation(File, JobID,
+	 * BlobKey)}.
+	 *
+	 * @param storageDir
+	 * 		storage directory used be the BLOB service
+	 * @param key
+	 * 		the key identifying the BLOB
+	 * @param jobId
+	 * 		ID of the job for the incoming files
+	 *
+	 * @return the path to the given BLOB
+	 */
+	static String getStorageLocationPath(
+			@Nonnull String storageDir, @Nullable JobID jobId, @Nonnull BlobKey key) {
+		if (jobId == null) {
+			// format: $base/no_job/blob_$key
+			return String.format("%s/%s/%s%s",
+				storageDir, NO_JOB_DIR_PREFIX, BLOB_FILE_PREFIX, key.toString());
+		} else {
+			// format: $base/job_$jobId/blob_$key
+			return String.format("%s/%s%s/%s%s",
+				storageDir, JOB_DIR_PREFIX, jobId.toString(), BLOB_FILE_PREFIX, key.toString());
+		}
 	}
 
 	/**
@@ -200,6 +272,7 @@ public class BlobUtils {
 	 *
 	 * @return a new instance of the message digest to use for the BLOB key computation
 	 */
+	@Nonnull
 	static MessageDigest createMessageDigest() {
 		try {
 			return MessageDigest.getInstance(HASHING_ALGORITHM);
@@ -330,28 +403,6 @@ public class BlobUtils {
 				}
 			}
 		}
-	}
-
-	/**
-	 * Returns the path for the given blob key.
-	 *
-	 * <p>The returned path can be used with the state backend for recovery purposes.
-	 *
-	 * <p>This follows the same scheme as {@link #getStorageLocation(File, BlobKey)}
-	 * and is used for HA.
-	 */
-	static String getRecoveryPath(String basePath, BlobKey blobKey) {
-		// format: $base/cache/blob_$key
-		return String.format("%s/cache/%s%s", basePath, BLOB_FILE_PREFIX, blobKey.toString());
-	}
-
-	/**
-	 * Returns the path for the given job ID.
-	 *
-	 * <p>The returned path can be used with the state backend for recovery purposes.
-	 */
-	static String getRecoveryPath(String basePath, JobID jobId) {
-		return String.format("%s/%s%s", basePath, JOB_DIR_PREFIX, jobId.toString());
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobView.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.api.common.JobID;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -29,9 +31,10 @@ public interface BlobView {
 	/**
 	 * Copies a blob to a local file.
 	 *
+	 * @param jobId     ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param blobKey   The blob ID
 	 * @param localFile The local file to copy to
 	 * @throws IOException If the copy fails
 	 */
-	void get(BlobKey blobKey, File localFile) throws IOException;
+	void get(JobID jobId, BlobKey blobKey, File localFile) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -64,8 +64,8 @@ public class FileSystemBlobStore implements BlobStoreService {
 	// - Put ------------------------------------------------------------------
 
 	@Override
-	public void put(File localFile, BlobKey blobKey) throws IOException {
-		put(localFile, BlobUtils.getRecoveryPath(basePath, blobKey));
+	public void put(File localFile, JobID jobId, BlobKey blobKey) throws IOException {
+		put(localFile, BlobUtils.getStorageLocationPath(basePath, jobId, blobKey));
 	}
 
 	private void put(File fromFile, String toBlobPath) throws IOException {
@@ -78,8 +78,8 @@ public class FileSystemBlobStore implements BlobStoreService {
 	// - Get ------------------------------------------------------------------
 
 	@Override
-	public void get(BlobKey blobKey, File localFile) throws IOException {
-		get(BlobUtils.getRecoveryPath(basePath, blobKey), localFile);
+	public void get(JobID jobId, BlobKey blobKey, File localFile) throws IOException {
+		get(BlobUtils.getStorageLocationPath(basePath, jobId, blobKey), localFile);
 	}
 
 	private void get(String fromBlobPath, File toFile) throws IOException {
@@ -112,13 +112,13 @@ public class FileSystemBlobStore implements BlobStoreService {
 	// - Delete ---------------------------------------------------------------
 
 	@Override
-	public void delete(BlobKey blobKey) {
-		delete(BlobUtils.getRecoveryPath(basePath, blobKey));
+	public void delete(JobID jobId, BlobKey blobKey) {
+		delete(BlobUtils.getStorageLocationPath(basePath, jobId, blobKey));
 	}
 
 	@Override
 	public void deleteAll(JobID jobId) {
-		delete(BlobUtils.getRecoveryPath(basePath, jobId));
+		delete(BlobUtils.getStorageLocationPath(basePath, jobId));
 	}
 
 	private void delete(String blobPath) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/VoidBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/VoidBlobStore.java
@@ -29,16 +29,15 @@ import java.io.IOException;
 public class VoidBlobStore implements BlobStoreService {
 
 	@Override
-	public void put(File localFile, BlobKey blobKey) throws IOException {
-	}
-
-
-	@Override
-	public void get(BlobKey blobKey, File localFile) throws IOException {
+	public void put(File localFile, JobID jobId, BlobKey blobKey) throws IOException {
 	}
 
 	@Override
-	public void delete(BlobKey blobKey) {
+	public void get(JobID jobId, BlobKey blobKey, File localFile) throws IOException {
+	}
+
+	@Override
+	public void delete(JobID jobId, BlobKey blobKey) {
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
@@ -229,7 +229,7 @@ public class JobClient {
 			int pos = 0;
 			for (BlobKey blobKey : props.requiredJarFiles()) {
 				try {
-					allURLs[pos++] = blobClient.getURL(blobKey);
+					allURLs[pos++] = blobClient.getFile(blobKey).toURI().toURL();
 				} catch (Exception e) {
 					try {
 						blobClient.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
@@ -229,7 +229,8 @@ public class JobClient {
 			int pos = 0;
 			for (BlobKey blobKey : props.requiredJarFiles()) {
 				try {
-					allURLs[pos++] = blobClient.getFile(blobKey).toURI().toURL();
+					// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
+					allURLs[pos++] = blobClient.getFile(null, blobKey).toURI().toURL();
 				} catch (Exception e) {
 					try {
 						blobClient.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
@@ -230,7 +230,7 @@ public class JobClient {
 			for (BlobKey blobKey : props.requiredJarFiles()) {
 				try {
 					// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
-					allURLs[pos++] = blobClient.getFile(null, blobKey).toURI().toURL();
+					allURLs[pos++] = blobClient.getFile(blobKey).toURI().toURL();
 				} catch (Exception e) {
 					try {
 						blobClient.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -229,7 +229,7 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 				
 				try {
 					if (references <= 0) {
-						blobService.delete(null, key);
+						blobService.delete(key);
 						entryIter.remove();
 					}
 				} catch (Throwable t) {
@@ -254,7 +254,7 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 		// it is important that we fetch the URL before increasing the counter.
 		// in case the URL cannot be created (failed to fetch the BLOB), we have no stale counter
 		try {
-			URL url = blobService.getFile(null, key).toURI().toURL();
+			URL url = blobService.getFile(key).toURI().toURL();
 
 			Integer references = blobKeyReferenceCounters.get(key);
 			int newReferences = references == null ? 1 : references + 1;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -229,7 +229,7 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 				
 				try {
 					if (references <= 0) {
-						blobService.delete(key);
+						blobService.delete(null, key);
 						entryIter.remove();
 					}
 				} catch (Throwable t) {
@@ -254,7 +254,7 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 		// it is important that we fetch the URL before increasing the counter.
 		// in case the URL cannot be created (failed to fetch the BLOB), we have no stale counter
 		try {
-			URL url = blobService.getFile(key).toURI().toURL();
+			URL url = blobService.getFile(null, key).toURI().toURL();
 
 			Integer references = blobKeyReferenceCounters.get(key);
 			int newReferences = references == null ? 1 : references + 1;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -18,7 +18,14 @@
 
 package org.apache.flink.runtime.execution.librarycache;
 
-import java.io.File;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.BlobService;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.util.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
@@ -32,15 +39,6 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import org.apache.flink.runtime.blob.BlobKey;
-import org.apache.flink.runtime.blob.BlobService;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.util.ExceptionUtils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -51,8 +49,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>
  * All files registered via {@link #registerJob(JobID, Collection, Collection)} are reference-counted
  * and are removed by a timer-based cleanup task if their reference counter is zero.
- * <strong>NOTE:</strong> this does not apply to files that enter the blob service via
- * {@link #getFile(BlobKey)}!
  */
 public final class BlobLibraryCacheManager extends TimerTask implements LibraryCacheManager {
 
@@ -200,22 +196,6 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 				throw new IllegalStateException("No libraries are registered for job " + id);
 			}
 		}
-	}
-
-	/**
-	 * Returns a file handle to the file identified by the blob key.
-	 * <p>
-	 * <strong>NOTE:</strong> if not already registered during
-	 * {@link #registerJob(JobID, Collection, Collection)}, files that enter the library cache /
-	 * backing blob store using this method will not be reference-counted and garbage-collected!
-	 *
-	 * @param blobKey identifying the requested file
-	 * @return File handle
-	 * @throws IOException if any error occurs when retrieving the file
-	 */
-	@Override
-	public File getFile(BlobKey blobKey) throws IOException {
-		return new File(blobService.getURL(blobKey).getFile());
 	}
 
 	public int getBlobServerPort() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -254,7 +254,7 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 		// it is important that we fetch the URL before increasing the counter.
 		// in case the URL cannot be created (failed to fetch the BLOB), we have no stale counter
 		try {
-			URL url = blobService.getURL(key);
+			URL url = blobService.getFile(key).toURI().toURL();
 
 			Integer references = blobKeyReferenceCounters.get(key);
 			int newReferences = references == null ? 1 : references + 1;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FallbackLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FallbackLibraryCacheManager.java
@@ -18,14 +18,12 @@
 
 package org.apache.flink.runtime.execution.librarycache;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.api.common.JobID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
 import java.net.URL;
 import java.util.Collection;
 
@@ -36,11 +34,6 @@ public class FallbackLibraryCacheManager implements LibraryCacheManager {
 	@Override
 	public ClassLoader getClassLoader(JobID id) {
 		return getClass().getClassLoader();
-	}
-
-	@Override
-	public File getFile(BlobKey blobKey) throws IOException {
-		throw new IOException("There is no file associated to the blob key " + blobKey);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
@@ -37,15 +37,6 @@ public interface LibraryCacheManager {
 	ClassLoader getClassLoader(JobID id);
 
 	/**
-	 * Returns a file handle to the file identified by the blob key.
-	 *
-	 * @param blobKey identifying the requested file
-	 * @return File handle
-	 * @throws IOException if any error occurs when retrieving the file
-	 */
-	File getFile(BlobKey blobKey) throws IOException;
-
-	/**
 	 * Registers a job with its required jar files and classpaths. The jar files are identified by their blob keys.
 	 *
 	 * @param id job ID

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
@@ -22,7 +22,6 @@ import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.api.common.JobID;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Collection;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -552,7 +552,8 @@ public class JobGraph implements Serializable {
 				FSDataInputStream is = null;
 				try {
 					is = fs.open(jar);
-					final BlobKey key = bc.put(is);
+					// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
+					final BlobKey key = bc.put(null, is);
 					this.userJarBlobKeys.add(key);
 				}
 				finally {
@@ -581,7 +582,8 @@ public class JobGraph implements Serializable {
 	 */
 	public void uploadUserJars(ActorGateway jobManager, FiniteDuration askTimeout,
 			Configuration blobClientConfig) throws IOException {
-		List<BlobKey> blobKeys = BlobClient.uploadJarFiles(jobManager, askTimeout, blobClientConfig, userJars);
+		// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
+		List<BlobKey> blobKeys = BlobClient.uploadJarFiles(jobManager, askTimeout, blobClientConfig, null, userJars);
 
 		for (BlobKey blobKey : blobKeys) {
 			if (!userJarBlobKeys.contains(blobKey)) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -553,7 +553,7 @@ public class JobGraph implements Serializable {
 				try {
 					is = fs.open(jar);
 					// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
-					final BlobKey key = bc.put(null, is);
+					final BlobKey key = bc.put(is);
 					this.userJarBlobKeys.add(key);
 				}
 				finally {
@@ -582,8 +582,7 @@ public class JobGraph implements Serializable {
 	 */
 	public void uploadUserJars(ActorGateway jobManager, FiniteDuration askTimeout,
 			Configuration blobClientConfig) throws IOException {
-		// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
-		List<BlobKey> blobKeys = BlobClient.uploadJarFiles(jobManager, askTimeout, blobClientConfig, null, userJars);
+		List<BlobKey> blobKeys = BlobClient.uploadJarFiles(jobManager, askTimeout, blobClientConfig, userJars);
 
 		for (BlobKey blobKey : blobKeys) {
 			if (!userJarBlobKeys.contains(blobKey)) {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -841,7 +841,7 @@ class TaskManager(
           val fis = new FileInputStream(file);
           Future {
             val client: BlobClient = blobService.get.createClient()
-            client.put(null, fis);
+            client.put(fis);
           }(context.dispatcher)
             .onComplete {
               case scala.util.Success(value) =>

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -841,7 +841,7 @@ class TaskManager(
           val fis = new FileInputStream(file);
           Future {
             val client: BlobClient = blobService.get.createClient()
-            client.put(fis);
+            client.put(null, fis);
           }(context.dispatcher)
             .onComplete {
               case scala.util.Success(value) =>

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.junit.Rule;
@@ -45,6 +46,8 @@ public class BlobCacheRetriesTest {
 	@Test
 	public void testBlobFetchRetries() throws IOException {
 		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
 
 		testBlobFetchRetries(config, new VoidBlobStore());
 	}
@@ -56,9 +59,11 @@ public class BlobCacheRetriesTest {
 	@Test
 	public void testBlobFetchRetriesHa() throws IOException {
 		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
-			temporaryFolder.getRoot().getPath());
+			temporaryFolder.newFolder().getPath());
 
 		BlobStoreService blobStoreService = null;
 
@@ -136,6 +141,8 @@ public class BlobCacheRetriesTest {
 	@Test
 	public void testBlobFetchWithTooManyFailures() throws IOException {
 		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
 
 		testBlobFetchWithTooManyFailures(config, new VoidBlobStore());
 	}
@@ -147,6 +154,8 @@ public class BlobCacheRetriesTest {
 	@Test
 	public void testBlobFetchWithTooManyFailuresHa() throws IOException {
 		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
 			temporaryFolder.getRoot().getPath());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
@@ -146,7 +146,7 @@ public class BlobCacheRetriesTest {
 			cache = new BlobCache(serverAddress, config, new VoidBlobStore());
 
 			// trigger a download - it should fail the first two times, but retry, and succeed eventually
-			File file = cache.getFile(jobId, key);
+			File file = jobId == null ? cache.getFile(key) : cache.getFile(jobId, key);
 			URL url = file.toURI().toURL();
 			try (InputStream is = url.openStream()) {
 				byte[] received = new byte[data.length];
@@ -268,7 +268,11 @@ public class BlobCacheRetriesTest {
 
 			// trigger a download - it should fail eventually
 			try {
-				cache.getFile(jobId, key);
+				if (jobId == null) {
+					cache.getFile(key);
+				} else {
+					cache.getFile(jobId, key);
+				}
 				fail("This should fail");
 			}
 			catch (IOException e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
@@ -115,7 +115,7 @@ public class BlobCacheRetriesTest {
 			cache = new BlobCache(serverAddress, config, new VoidBlobStore());
 
 			// trigger a download - it should fail the first two times, but retry, and succeed eventually
-			URL url = cache.getURL(key);
+			URL url = cache.getFile(key).toURI().toURL();
 			InputStream is = url.openStream();
 			try {
 				byte[] received = new byte[data.length];
@@ -211,7 +211,7 @@ public class BlobCacheRetriesTest {
 
 			// trigger a download - it should fail eventually
 			try {
-				cache.getURL(key);
+				cache.getFile(key);
 				fail("This should fail");
 			}
 			catch (IOException e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
@@ -28,15 +28,12 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * This class contains unit tests for the {@link BlobCache}.
@@ -141,7 +138,7 @@ public class BlobCacheSuccessTest {
 			blobCache = new BlobCache(serverAddress, cacheConfig, blobStoreService);
 
 			for (BlobKey blobKey : blobKeys) {
-				blobCache.getURL(blobKey);
+				blobCache.getFile(blobKey);
 			}
 
 			if (blobServer != null) {
@@ -150,28 +147,20 @@ public class BlobCacheSuccessTest {
 				blobServer = null;
 			}
 
-			final URL[] urls = new URL[blobKeys.size()];
+			final File[] files = new File[blobKeys.size()];
 
 			for(int i = 0; i < blobKeys.size(); i++){
-				urls[i] = blobCache.getURL(blobKeys.get(i));
+				files[i] = blobCache.getFile(blobKeys.get(i));
 			}
 
 			// Verify the result
-			assertEquals(blobKeys.size(), urls.length);
+			assertEquals(blobKeys.size(), files.length);
 
-			for (final URL url : urls) {
+			for (final File file : files) {
+				assertNotNull(file);
 
-				assertNotNull(url);
-
-				try {
-					final File cachedFile = new File(url.toURI());
-
-					assertTrue(cachedFile.exists());
-					assertEquals(buf.length, cachedFile.length());
-
-				} catch (URISyntaxException e) {
-					fail(e.getMessage());
-				}
+				assertTrue(file.exists());
+				assertEquals(buf.length, file.length());
 			}
 		} finally {
 			if (blobServer != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
@@ -179,7 +179,11 @@ public class BlobCacheSuccessTest {
 			blobCache = new BlobCache(serverAddress, cacheConfig, blobStoreService);
 
 			for (BlobKey blobKey : blobKeys) {
-				blobCache.getFile(jobId, blobKey);
+				if (jobId == null) {
+					blobCache.getFile(blobKey);
+				} else {
+					blobCache.getFile(jobId, blobKey);
+				}
 			}
 
 			if (blobServer != null) {
@@ -191,7 +195,11 @@ public class BlobCacheSuccessTest {
 			final File[] files = new File[blobKeys.size()];
 
 			for(int i = 0; i < blobKeys.size(); i++){
-				files[i] = blobCache.getFile(jobId, blobKeys.get(i));
+				if (jobId == null) {
+					files[i] = blobCache.getFile(blobKeys.get(i));
+				} else {
+					files[i] = blobCache.getFile(jobId, blobKeys.get(i));
+				}
 			}
 
 			// Verify the result

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
@@ -23,11 +23,11 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SecurityOptions;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
-
-import static org.junit.Assert.fail;
 
 /**
  * This class contains unit tests for the {@link BlobClient} with ssl enabled.
@@ -46,12 +46,17 @@ public class BlobClientSslTest extends BlobClientTest {
 	/** The non-SSL blob service client configuration with SSL-enabled security options. */
 	private static Configuration nonSslClientConfig;
 
+	@ClassRule
+	public static TemporaryFolder temporarySslFolder = new TemporaryFolder();
+
 	/**
 	 * Starts the SSL enabled BLOB server.
 	 */
 	@BeforeClass
 	public static void startSSLServer() throws IOException {
 		Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporarySslFolder.newFolder().getAbsolutePath());
 		config.setBoolean(SecurityOptions.SSL_ENABLED, true);
 		config.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
 		config.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
@@ -67,6 +72,8 @@ public class BlobClientSslTest extends BlobClientTest {
 	@BeforeClass
 	public static void startNonSSLServer() throws IOException {
 		Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporarySslFolder.newFolder().getAbsolutePath());
 		config.setBoolean(SecurityOptions.SSL_ENABLED, true);
 		config.setBoolean(BlobServerOptions.SSL_ENABLED, false);
 		config.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
@@ -18,48 +18,33 @@
 
 package org.apache.flink.runtime.blob;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.InetSocketAddress;
-import java.security.MessageDigest;
-import java.util.Collections;
-import java.util.List;
-
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.SecurityOptions;
-import org.apache.flink.core.fs.Path;
-import org.apache.flink.util.TestLogger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.IOException;
+
+import static org.junit.Assert.fail;
+
 /**
  * This class contains unit tests for the {@link BlobClient} with ssl enabled.
  */
-public class BlobClientSslTest extends TestLogger {
-
-	/** The buffer size used during the tests in bytes. */
-	private static final int TEST_BUFFER_SIZE = 17 * 1000;
+public class BlobClientSslTest extends BlobClientTest {
 
 	/** The instance of the SSL BLOB server used during the tests. */
 	private static BlobServer BLOB_SSL_SERVER;
 
-	/** The SSL blob service client configuration */
+	/** Instance of a non-SSL BLOB server with SSL-enabled security options. */
+	private static BlobServer BLOB_NON_SSL_SERVER;
+
+	/** The SSL blob service client configuration. */
 	private static Configuration sslClientConfig;
 
-	/** The instance of the non-SSL BLOB server used during the tests. */
-	private static BlobServer BLOB_SERVER;
-
-	/** The non-ssl blob service client configuration */
-	private static Configuration clientConfig;
+	/** The non-SSL blob service client configuration with SSL-enabled security options. */
+	private static Configuration nonSslClientConfig;
 
 	/**
 	 * Starts the SSL enabled BLOB server.
@@ -79,9 +64,6 @@ public class BlobClientSslTest extends TestLogger {
 		sslClientConfig.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
 	}
 
-	/**
-	 * Starts the SSL disabled BLOB server.
-	 */
 	@BeforeClass
 	public static void startNonSSLServer() throws IOException {
 		Configuration config = new Configuration();
@@ -90,13 +72,13 @@ public class BlobClientSslTest extends TestLogger {
 		config.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
 		config.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
 		config.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
-		BLOB_SERVER = new BlobServer(config, new VoidBlobStore());
+		BLOB_NON_SSL_SERVER = new BlobServer(config, new VoidBlobStore());
 
-		clientConfig = new Configuration();
-		clientConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		clientConfig.setBoolean(BlobServerOptions.SSL_ENABLED, false);
-		clientConfig.setString(SecurityOptions.SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
-		clientConfig.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
+		nonSslClientConfig = new Configuration();
+		nonSslClientConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
+		nonSslClientConfig.setBoolean(BlobServerOptions.SSL_ENABLED, false);
+		nonSslClientConfig.setString(SecurityOptions.SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
+		nonSslClientConfig.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
 	}
 
 	/**
@@ -107,154 +89,14 @@ public class BlobClientSslTest extends TestLogger {
 		if (BLOB_SSL_SERVER != null) {
 			BLOB_SSL_SERVER.close();
 		}
-
-		if (BLOB_SERVER != null) {
-			BLOB_SERVER.close();
-		}
 	}
 
-	/**
-	 * Prepares a test file for the unit tests, i.e. the methods fills the file with a particular byte patterns and
-	 * computes the file's BLOB key.
-	 *
-	 * @param file
-	 *        the file to prepare for the unit tests
-	 * @return the BLOB key of the prepared file
-	 * @throws IOException
-	 *         thrown if an I/O error occurs while writing to the test file
-	 */
-	private static BlobKey prepareTestFile(File file) throws IOException {
-
-		MessageDigest md = BlobUtils.createMessageDigest();
-
-		final byte[] buf = new byte[TEST_BUFFER_SIZE];
-		for (int i = 0; i < buf.length; ++i) {
-			buf[i] = (byte) (i % 128);
-		}
-
-		FileOutputStream fos = null;
-		try {
-			fos = new FileOutputStream(file);
-
-			for (int i = 0; i < 20; ++i) {
-				fos.write(buf);
-				md.update(buf);
-			}
-
-		} finally {
-			if (fos != null) {
-				fos.close();
-			}
-		}
-
-		return new BlobKey(md.digest());
+	protected Configuration getBlobClientConfig() {
+		return sslClientConfig;
 	}
 
-	/**
-	 * Validates the result of a GET operation by comparing the data from the retrieved input stream to the content of
-	 * the specified file.
-	 *
-	 * @param inputStream
-	 *        the input stream returned from the GET operation
-	 * @param file
-	 *        the file to compare the input stream's data to
-	 * @throws IOException
-	 *         thrown if an I/O error occurs while reading the input stream or the file
-	 */
-	private static void validateGet(final InputStream inputStream, final File file) throws IOException {
-
-		InputStream inputStream2 = null;
-		try {
-
-			inputStream2 = new FileInputStream(file);
-
-			while (true) {
-
-				final int r1 = inputStream.read();
-				final int r2 = inputStream2.read();
-
-				assertEquals(r2, r1);
-
-				if (r1 < 0) {
-					break;
-				}
-			}
-
-		} finally {
-			if (inputStream2 != null) {
-				inputStream2.close();
-			}
-		}
-
-	}
-
-	/**
-	 * Tests the PUT/GET operations for content-addressable streams.
-	 */
-	@Test
-	public void testContentAddressableStream() {
-
-		BlobClient client = null;
-		InputStream is = null;
-
-		try {
-			File testFile = File.createTempFile("testfile", ".dat");
-			testFile.deleteOnExit();
-
-			BlobKey origKey = prepareTestFile(testFile);
-
-			InetSocketAddress serverAddress = new InetSocketAddress("localhost", BLOB_SSL_SERVER.getPort());
-			client = new BlobClient(serverAddress, sslClientConfig);
-
-			// Store the data
-			is = new FileInputStream(testFile);
-			BlobKey receivedKey = client.put(is);
-			assertEquals(origKey, receivedKey);
-
-			is.close();
-			is = null;
-
-			// Retrieve the data
-			is = client.get(receivedKey);
-			validateGet(is, testFile);
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-		finally {
-			if (is != null) {
-				try {
-					is.close();
-				} catch (Throwable t) {}
-			}
-			if (client != null) {
-				try {
-					client.close();
-				} catch (Throwable t) {}
-			}
-		}
-	}
-
-	/**
-	 * Tests the static {@link BlobClient#uploadJarFiles(InetSocketAddress, Configuration, List)} helper.
-	 */
-	private void uploadJarFile(BlobServer blobServer, Configuration blobClientConfig) throws Exception {
-		final File testFile = File.createTempFile("testfile", ".dat");
-		testFile.deleteOnExit();
-		prepareTestFile(testFile);
-
-		InetSocketAddress serverAddress = new InetSocketAddress("localhost", blobServer.getPort());
-
-		List<BlobKey> blobKeys = BlobClient.uploadJarFiles(serverAddress, blobClientConfig,
-			Collections.singletonList(new Path(testFile.toURI())));
-
-		assertEquals(1, blobKeys.size());
-
-		try (BlobClient blobClient = new BlobClient(serverAddress, blobClientConfig)) {
-			InputStream is = blobClient.get(blobKeys.get(0));
-			validateGet(is, testFile);
-		}
+	protected BlobServer getBlobServer() {
+		return BLOB_SSL_SERVER;
 	}
 
 	/**
@@ -268,27 +110,37 @@ public class BlobClientSslTest extends TestLogger {
 	/**
 	 * Verify ssl client to non-ssl server failure
 	 */
-	@Test
+	@Test(expected = IOException.class)
 	public void testSSLClientFailure() throws Exception {
-		try {
-			uploadJarFile(BLOB_SERVER, sslClientConfig);
-			fail("SSL client connected to non-ssl server");
-		} catch (Exception e) {
-			// Exception expected
-		}
+		// SSL client connected to non-ssl server
+		uploadJarFile(BLOB_SERVER, sslClientConfig);
+	}
+
+	/**
+	 * Verify ssl client to non-ssl server failure
+	 */
+	@Test(expected = IOException.class)
+	public void testSSLClientFailure2() throws Exception {
+		// SSL client connected to non-ssl server
+		uploadJarFile(BLOB_NON_SSL_SERVER, sslClientConfig);
 	}
 
 	/**
 	 * Verify non-ssl client to ssl server failure
 	 */
-	@Test
+	@Test(expected = IOException.class)
 	public void testSSLServerFailure() throws Exception {
-		try {
-			uploadJarFile(BLOB_SSL_SERVER, clientConfig);
-			fail("Non-SSL client connected to ssl server");
-		} catch (Exception e) {
-			// Exception expected
-		}
+		// Non-SSL client connected to ssl server
+		uploadJarFile(BLOB_SSL_SERVER, clientConfig);
+	}
+
+	/**
+	 * Verify non-ssl client to ssl server failure
+	 */
+	@Test(expected = IOException.class)
+	public void testSSLServerFailure2() throws Exception {
+		// Non-SSL client connected to ssl server
+		uploadJarFile(BLOB_SSL_SERVER, nonSslClientConfig);
 	}
 
 	/**
@@ -297,5 +149,29 @@ public class BlobClientSslTest extends TestLogger {
 	@Test
 	public void testNonSSLConnection() throws Exception {
 		uploadJarFile(BLOB_SERVER, clientConfig);
+	}
+
+	/**
+	 * Verify non-ssl connection sanity
+	 */
+	@Test
+	public void testNonSSLConnection2() throws Exception {
+		uploadJarFile(BLOB_SERVER, nonSslClientConfig);
+	}
+
+	/**
+	 * Verify non-ssl connection sanity
+	 */
+	@Test
+	public void testNonSSLConnection3() throws Exception {
+		uploadJarFile(BLOB_NON_SSL_SERVER, clientConfig);
+	}
+
+	/**
+	 * Verify non-ssl connection sanity
+	 */
+	@Test
+	public void testNonSSLConnection4() throws Exception {
+		uploadJarFile(BLOB_NON_SSL_SERVER, nonSslClientConfig);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -35,6 +35,7 @@ import java.security.MessageDigest;
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -135,19 +136,21 @@ public class BlobClientTest {
 	 *         thrown if an I/O error occurs while reading the input stream
 	 */
 	private static void validateGet(final InputStream inputStream, final byte[] buf) throws IOException {
+		byte[] receivedBuffer = new byte[buf.length];
 
 		int bytesReceived = 0;
 
 		while (true) {
 
-			final int read = inputStream.read(buf, bytesReceived, buf.length - bytesReceived);
+			final int read = inputStream.read(receivedBuffer, bytesReceived, receivedBuffer.length - bytesReceived);
 			if (read < 0) {
 				throw new EOFException();
 			}
 			bytesReceived += read;
 
-			if (bytesReceived == buf.length) {
+			if (bytesReceived == receivedBuffer.length) {
 				assertEquals(-1, inputStream.read());
+				assertArrayEquals(buf, receivedBuffer);
 				return;
 			}
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -231,14 +231,14 @@ public class BlobClientTest {
 			assertEquals(origKey, receivedKey);
 
 			// Retrieve the data
-			InputStream is = client.get(null, receivedKey);
+			InputStream is = client.get(receivedKey);
 			validateGet(is, testBuffer);
 			is = client.get(jobId, receivedKey);
 			validateGet(is, testBuffer);
 
 			// Check reaction to invalid keys
 			try {
-				client.get(null, new BlobKey());
+				client.get(new BlobKey());
 				fail("Expected IOException did not occur");
 			}
 			catch (IOException fnfe) {
@@ -297,7 +297,7 @@ public class BlobClientTest {
 
 			// Store the data
 			is = new FileInputStream(testFile);
-			BlobKey receivedKey = client.put(null, is);
+			BlobKey receivedKey = client.put(is);
 			assertEquals(origKey, receivedKey);
 			// try again with a job-related BLOB:
 			is = new FileInputStream(testFile);
@@ -308,7 +308,7 @@ public class BlobClientTest {
 			is = null;
 
 			// Retrieve the data
-			is = client.get(null, receivedKey);
+			is = client.get(receivedKey);
 			validateGet(is, testFile);
 			is = client.get(jobId, receivedKey);
 			validateGet(is, testFile);
@@ -332,7 +332,7 @@ public class BlobClientTest {
 	}
 
 	/**
-	 * Tests the static {@link BlobClient#uploadJarFiles(InetSocketAddress, Configuration, JobID, List)} helper.
+	 * Tests the static {@link BlobClient#uploadJarFiles(InetSocketAddress, Configuration, List)} helper.
 	 */
 	@Test
 	public void testUploadJarFilesHelper() throws Exception {
@@ -340,7 +340,7 @@ public class BlobClientTest {
 	}
 
 	/**
-	 * Tests the static {@link BlobClient#uploadJarFiles(InetSocketAddress, Configuration, JobID, List)} helper.
+	 * Tests the static {@link BlobClient#uploadJarFiles(InetSocketAddress, Configuration, List)} helper.
 	 */
 	static void uploadJarFile(BlobServer blobServer, Configuration blobClientConfig) throws Exception {
 		final File testFile = File.createTempFile("testfile", ".dat");
@@ -349,20 +349,20 @@ public class BlobClientTest {
 
 		InetSocketAddress serverAddress = new InetSocketAddress("localhost", blobServer.getPort());
 
-		uploadJarFile(serverAddress, blobClientConfig, testFile, null);
-		uploadJarFile(serverAddress, blobClientConfig, testFile, new JobID());
+		uploadJarFile(serverAddress, blobClientConfig, testFile);
+		uploadJarFile(serverAddress, blobClientConfig, testFile);
 	}
 
 	private static void uploadJarFile(
 		final InetSocketAddress serverAddress, final Configuration blobClientConfig,
-		final File testFile, final JobID jobId) throws IOException {
-		List<BlobKey> blobKeys = BlobClient.uploadJarFiles(serverAddress, blobClientConfig, jobId,
+		final File testFile) throws IOException {
+		List<BlobKey> blobKeys = BlobClient.uploadJarFiles(serverAddress, blobClientConfig,
 			Collections.singletonList(new Path(testFile.toURI())));
 
 		assertEquals(1, blobKeys.size());
 
 		try (BlobClient blobClient = new BlobClient(serverAddress, blobClientConfig)) {
-			InputStream is = blobClient.get(jobId, blobKeys.get(0));
+			InputStream is = blobClient.get(blobKeys.get(0));
 			validateGet(is, testFile);
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.EOFException;
 import java.io.File;
@@ -53,12 +56,18 @@ public class BlobClientTest {
 	/** The blob service (non-ssl) client configuration */
 	static Configuration clientConfig;
 
+	@ClassRule
+	public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
 	/**
 	 * Starts the BLOB server.
 	 */
 	@BeforeClass
 	public static void startServer() throws IOException {
 		Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
+
 		BLOB_SERVER = new BlobServer(config, new VoidBlobStore());
 
 		clientConfig = new Configuration();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
@@ -116,7 +116,7 @@ public class BlobRecoveryITCase extends TestLogger {
 			client = new BlobClient(serverAddress[1], config);
 
 			// Verify request 1
-			try (InputStream is = client.get(null, keys[0])) {
+			try (InputStream is = client.get(keys[0])) {
 				byte[] actual = new byte[expected.length];
 
 				BlobUtils.readFully(is, actual, 0, expected.length, null);
@@ -127,7 +127,7 @@ public class BlobRecoveryITCase extends TestLogger {
 			}
 
 			// Verify request 2
-			try (InputStream is = client.get(null, keys[1])) {
+			try (InputStream is = client.get(keys[1])) {
 				byte[] actual = new byte[256];
 				BlobUtils.readFully(is, actual, 0, 256, null);
 
@@ -157,8 +157,8 @@ public class BlobRecoveryITCase extends TestLogger {
 			}
 
 			// Remove again
-			client.delete(null, keys[0]);
-			client.delete(null, keys[1]);
+			client.delete(keys[0]);
+			client.delete(keys[1]);
 			client.delete(jobId[0], keys[0]);
 			client.delete(jobId[1], keys[1]);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.blob;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -54,7 +55,8 @@ public class BlobRecoveryITCase extends TestLogger {
 		Configuration config = new Configuration();
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
 		config.setString(CoreOptions.STATE_BACKEND, "FILESYSTEM");
-		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.getRoot().getPath());
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getPath());
 
 		BlobStoreService blobStoreService = null;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobRecoveryITCase.java
@@ -94,11 +94,17 @@ public class BlobRecoveryITCase extends TestLogger {
 
 			BlobKey[] keys = new BlobKey[2];
 
-			// Put data
-			keys[0] = client.put(expected); // Request 1
-			keys[1] = client.put(expected, 32, 256); // Request 2
+			// Put job-unrelated data
+			keys[0] = client.put(null, expected); // Request 1
+			keys[1] = client.put(null, expected, 32, 256); // Request 2
 
+			// Put job-related data, verify that the checksums match
 			JobID[] jobId = new JobID[] { new JobID(), new JobID() };
+			BlobKey key;
+			key = client.put(jobId[0], expected); // Request 3
+			assertEquals(keys[0], key);
+			key = client.put(jobId[1], expected, 32, 256); // Request 4
+			assertEquals(keys[1], key);
 
 			// check that the storage directory exists
 			final Path blobServerPath = new Path(storagePath, "blob");
@@ -110,7 +116,7 @@ public class BlobRecoveryITCase extends TestLogger {
 			client = new BlobClient(serverAddress[1], config);
 
 			// Verify request 1
-			try (InputStream is = client.get(keys[0])) {
+			try (InputStream is = client.get(null, keys[0])) {
 				byte[] actual = new byte[expected.length];
 
 				BlobUtils.readFully(is, actual, 0, expected.length, null);
@@ -121,7 +127,27 @@ public class BlobRecoveryITCase extends TestLogger {
 			}
 
 			// Verify request 2
-			try (InputStream is = client.get(keys[1])) {
+			try (InputStream is = client.get(null, keys[1])) {
+				byte[] actual = new byte[256];
+				BlobUtils.readFully(is, actual, 0, 256, null);
+
+				for (int i = 32, j = 0; i < 256; i++, j++) {
+					assertEquals(expected[i], actual[j]);
+				}
+			}
+
+			// Verify request 3
+			try (InputStream is = client.get(jobId[0], keys[0])) {
+				byte[] actual = new byte[expected.length];
+				BlobUtils.readFully(is, actual, 0, expected.length, null);
+
+				for (int i = 0; i < expected.length; i++) {
+					assertEquals(expected[i], actual[i]);
+				}
+			}
+
+			// Verify request 4
+			try (InputStream is = client.get(jobId[1], keys[1])) {
 				byte[] actual = new byte[256];
 				BlobUtils.readFully(is, actual, 0, 256, null);
 
@@ -131,8 +157,10 @@ public class BlobRecoveryITCase extends TestLogger {
 			}
 
 			// Remove again
-			client.delete(keys[0]);
-			client.delete(keys[1]);
+			client.delete(null, keys[0]);
+			client.delete(null, keys[1]);
+			client.delete(jobId[0], keys[0]);
+			client.delete(jobId[1], keys[1]);
 
 			// Verify everything is clean
 			assertTrue("HA storage directory does not exist", fs.exists(new Path(storagePath)));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
@@ -110,7 +110,7 @@ public class BlobServerDeleteTest extends TestLogger {
 			// delete a file directly on the server
 			server.delete(key2);
 			try {
-				server.getURL(key2);
+				server.getFile(key2);
 				fail("BLOB should have been deleted");
 			}
 			catch (IOException e) {
@@ -210,7 +210,7 @@ public class BlobServerDeleteTest extends TestLogger {
 			server.delete(key);
 
 			// the file should still be there
-			server.getURL(key);
+			server.getFile(key);
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
@@ -18,13 +18,16 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.TestLogger;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
@@ -52,6 +55,9 @@ public class BlobServerDeleteTest extends TestLogger {
 
 	private final Random rnd = new Random();
 
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
 	@Test
 	public void testDeleteSingleByBlobKey() {
 		BlobServer server = null;
@@ -59,7 +65,9 @@ public class BlobServerDeleteTest extends TestLogger {
 		BlobStore blobStore = new VoidBlobStore();
 
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, blobStore);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -125,7 +133,9 @@ public class BlobServerDeleteTest extends TestLogger {
 		BlobStore blobStore = new VoidBlobStore();
 
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, blobStore);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -172,7 +182,9 @@ public class BlobServerDeleteTest extends TestLogger {
 		File blobFile = null;
 		File directory = null;
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, blobStore);
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -223,7 +235,9 @@ public class BlobServerDeleteTest extends TestLogger {
 	 */
 	@Test
 	public void testConcurrentDeleteOperations() throws IOException, ExecutionException, InterruptedException {
-		final Configuration configuration = new Configuration();
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 		final BlobStore blobStore = mock(BlobStore.class);
 
 		final int concurrentDeleteOperations = 3;
@@ -233,7 +247,7 @@ public class BlobServerDeleteTest extends TestLogger {
 
 		final byte[] data = {1, 2, 3};
 
-		try (final BlobServer blobServer = new BlobServer(configuration, blobStore)) {
+		try (final BlobServer blobServer = new BlobServer(config, blobStore)) {
 
 			final BlobKey blobKey;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
@@ -96,12 +96,12 @@ public class BlobServerDeleteTest extends TestLogger {
 			assertEquals(key1, key1b);
 
 			// issue a DELETE request via the client
-			client.delete(null, key1);
+			client.delete(key1);
 			client.close();
 
 			client = new BlobClient(serverAddress, config);
 			try {
-				client.get(null, key1);
+				client.get(key1);
 				fail("BLOB should have been deleted");
 			}
 			catch (IOException e) {
@@ -120,9 +120,9 @@ public class BlobServerDeleteTest extends TestLogger {
 			}
 
 			// delete a file directly on the server
-			server.delete(null, key2);
+			server.delete(key2);
 			try {
-				server.getFile(null, key2);
+				server.getFile(key2);
 				fail("BLOB should have been deleted");
 			}
 			catch (IOException e) {
@@ -186,14 +186,18 @@ public class BlobServerDeleteTest extends TestLogger {
 
 			// issue a DELETE request via the client
 			try {
-				client.delete(jobId, key);
+				deleteHelper(client, jobId, key);
 			}
 			catch (IOException e) {
 				fail("DELETE operation should not fail if file is already deleted");
 			}
 
 			// issue a DELETE request on the server
-			server.delete(jobId, key);
+			if (jobId == null) {
+				server.delete(key);
+			} else {
+				server.delete(jobId, key);
+			}
 		}
 		catch (Exception e) {
 			e.printStackTrace();
@@ -201,6 +205,14 @@ public class BlobServerDeleteTest extends TestLogger {
 		}
 		finally {
 			cleanup(server, client);
+		}
+	}
+
+	private static void deleteHelper(BlobClient client, JobID jobId, BlobKey key) throws IOException {
+		if (jobId == null) {
+			client.delete(key);
+		} else {
+			client.delete(jobId, key);
 		}
 	}
 
@@ -246,13 +258,21 @@ public class BlobServerDeleteTest extends TestLogger {
 			assertTrue(directory.setWritable(false, false));
 
 			// issue a DELETE request via the client
-			client.delete(jobId, key);
+			deleteHelper(client, jobId, key);
 
 			// issue a DELETE request on the server
-			server.delete(jobId, key);
+			if (jobId == null) {
+				server.delete(key);
+			} else {
+				server.delete(jobId, key);
+			}
 
 			// the file should still be there
-			server.getFile(jobId, key);
+			if (jobId == null) {
+				server.getFile(key);
+			} else {
+				server.getFile(jobId, key);
+			}
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
@@ -325,7 +345,7 @@ public class BlobServerDeleteTest extends TestLogger {
 					@Override
 					public Void call() throws Exception {
 						try (BlobClient blobClient = blobServer.createClient()) {
-							blobClient.delete(jobId, blobKey);
+							deleteHelper(blobClient, jobId, blobKey);
 						}
 
 						return null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.blob;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.concurrent.Future;
@@ -70,7 +71,28 @@ public class BlobServerGetTest extends TestLogger {
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	@Test
-	public void testGetFailsDuringLookup() throws IOException {
+	public void testGetFailsDuringLookup1() throws IOException {
+		testGetFailsDuringLookup(null, new JobID());
+	}
+
+	@Test
+	public void testGetFailsDuringLookup2() throws IOException {
+		testGetFailsDuringLookup(new JobID(), new JobID());
+	}
+
+	@Test
+	public void testGetFailsDuringLookup3() throws IOException {
+		testGetFailsDuringLookup(new JobID(), null);
+	}
+
+	/**
+	 * Checks the correct result if a GET operation fails during the lookup of the file.
+	 *
+	 * @param jobId1 first job ID or <tt>null</tt> if job-unrelated
+	 * @param jobId2 second job ID different to <tt>jobId1</tt>
+	 */
+	private void testGetFailsDuringLookup(final JobID jobId1, final JobID jobId2)
+		throws IOException {
 		BlobServer server = null;
 		BlobClient client = null;
 
@@ -87,20 +109,29 @@ public class BlobServerGetTest extends TestLogger {
 			rnd.nextBytes(data);
 
 			// put content addressable (like libraries)
-			BlobKey key = client.put(data);
+			BlobKey key = client.put(jobId1, data);
 			assertNotNull(key);
 
-			// delete all files to make sure that GET requests fail
-			File blobFile = server.getStorageLocation(key);
+			// delete file to make sure that GET requests fail
+			File blobFile = server.getStorageLocation(jobId1, key);
 			assertTrue(blobFile.delete());
 
 			// issue a GET request that fails
-			try {
-				client.get(key);
-				fail("This should not succeed.");
-			} catch (IOException e) {
-				// expected
-			}
+			client = verifyDeleted(client, jobId1, key, serverAddress, config);
+
+			BlobKey key2 = client.put(jobId2, data);
+			assertNotNull(key);
+			assertEquals(key, key2);
+			// request for jobId2 should succeed
+			client.get(jobId2, key);
+			// request for jobId1 should still fail
+			client = verifyDeleted(client, jobId1, key, serverAddress, config);
+
+			// same checks as for jobId1 but for jobId2 should also work:
+			blobFile = server.getStorageLocation(jobId2, key);
+			assertTrue(blobFile.delete());
+			client = verifyDeleted(client, jobId2, key, serverAddress, config);
+
 		} finally {
 			if (client != null) {
 				client.close();
@@ -111,8 +142,51 @@ public class BlobServerGetTest extends TestLogger {
 		}
 	}
 
+	/**
+	 * Checks that the given blob does not exist anymore.
+	 *
+	 * @param client
+	 * 		BLOB client to use for connecting to the BLOB server
+	 * @param jobId
+	 * 		job ID or <tt>null</tt> if job-unrelated
+	 * @param key
+	 * 		key identifying the BLOB to request
+	 * @param serverAddress
+	 * 		BLOB server address
+	 * @param config
+	 * 		client config
+	 *
+	 * @return a new client (since the old one is being closed on failure)
+	 */
+	private static BlobClient verifyDeleted(
+			BlobClient client, JobID jobId, BlobKey key,
+			InetSocketAddress serverAddress, Configuration config) throws IOException {
+		try {
+			client.get(jobId, key);
+			fail("This should not succeed.");
+		} catch (IOException e) {
+			// expected
+		}
+		// need a new client (old ony closed due to failure
+		return new BlobClient(serverAddress, config);
+	}
+
 	@Test
-	public void testGetFailsDuringStreaming() throws IOException {
+	public void testGetFailsDuringStreamingNoJob() throws IOException {
+		testGetFailsDuringStreaming(null);
+	}
+
+	@Test
+	public void testGetFailsDuringStreamingForJob() throws IOException {
+		testGetFailsDuringStreaming(new JobID());
+	}
+
+	/**
+	 * Checks the correct result if a GET operation fails during the file download.
+	 *
+	 * @param jobId job ID or <tt>null</tt> if job-unrelated
+	 */
+	private void testGetFailsDuringStreaming(final JobID jobId) throws IOException {
 		BlobServer server = null;
 		BlobClient client = null;
 
@@ -129,11 +203,11 @@ public class BlobServerGetTest extends TestLogger {
 			rnd.nextBytes(data);
 
 			// put content addressable (like libraries)
-			BlobKey key = client.put(data);
+			BlobKey key = client.put(jobId, data);
 			assertNotNull(key);
 
 			// issue a GET request that succeeds
-			InputStream is = client.get(key);
+			InputStream is = client.get(jobId, key);
 
 			byte[] receiveBuffer = new byte[data.length];
 			int firstChunkLen = 50000;
@@ -170,8 +244,22 @@ public class BlobServerGetTest extends TestLogger {
 	 * Tests that concurrent get operations don't concurrently access the BlobStore to download a blob.
 	 */
 	@Test
-	public void testConcurrentGetOperations() throws IOException, ExecutionException, InterruptedException {
+	public void testConcurrentGetOperationsNoJob() throws IOException, ExecutionException, InterruptedException {
+		testConcurrentGetOperations(null);
+	}
 
+	/**
+	 * FLINK-6020
+	 *
+	 * Tests that concurrent get operations don't concurrently access the BlobStore to download a blob.
+	 */
+	@Test
+	public void testConcurrentGetOperationsForJob() throws IOException, ExecutionException, InterruptedException {
+		testConcurrentGetOperations(new JobID());
+	}
+
+	private void testConcurrentGetOperations(final JobID jobId)
+			throws IOException, InterruptedException, ExecutionException {
 		final Configuration config = new Configuration();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
@@ -192,24 +280,25 @@ public class BlobServerGetTest extends TestLogger {
 			new Answer() {
 				@Override
 				public Object answer(InvocationOnMock invocation) throws Throwable {
-					File targetFile = (File) invocation.getArguments()[1];
+					File targetFile = (File) invocation.getArguments()[2];
 
 					FileUtils.copyInputStreamToFile(bais, targetFile);
 
 					return null;
 				}
 			}
-		).when(blobStore).get(any(BlobKey.class), any(File.class));
+		).when(blobStore).get(any(JobID.class), any(BlobKey.class), any(File.class));
 
 		final ExecutorService executor = Executors.newFixedThreadPool(numberConcurrentGetOperations);
 
 		try (final BlobServer blobServer = new BlobServer(config, blobStore)) {
 			for (int i = 0; i < numberConcurrentGetOperations; i++) {
-				Future<InputStream> getOperation = FlinkCompletableFuture.supplyAsync(new Callable<InputStream>() {
+				Future<InputStream> getOperation = FlinkCompletableFuture
+					.supplyAsync(new Callable<InputStream>() {
 					@Override
 					public InputStream call() throws Exception {
 						try (BlobClient blobClient = blobServer.createClient();
-							 InputStream inputStream = blobClient.get(blobKey)) {
+							 InputStream inputStream = blobClient.get(jobId, blobKey)) {
 							byte[] buffer = new byte[data.length];
 
 							IOUtils.readFully(inputStream, buffer);
@@ -241,7 +330,7 @@ public class BlobServerGetTest extends TestLogger {
 			}
 
 			// verify that we downloaded the requested blob exactly once from the BlobStore
-			verify(blobStore, times(1)).get(eq(blobKey), any(File.class));
+			verify(blobStore, times(1)).get(eq(jobId), eq(blobKey), any(File.class));
 		} finally {
 			executor.shutdownNow();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -75,7 +75,9 @@ public class BlobServerGetTest extends TestLogger {
 		BlobClient client = null;
 
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -115,7 +117,9 @@ public class BlobServerGetTest extends TestLogger {
 		BlobClient client = null;
 
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -167,9 +171,9 @@ public class BlobServerGetTest extends TestLogger {
 	 */
 	@Test
 	public void testConcurrentGetOperations() throws IOException, ExecutionException, InterruptedException {
-		final Configuration configuration = new Configuration();
 
-		configuration.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
 		final BlobStore blobStore = mock(BlobStore.class);
 
@@ -199,7 +203,7 @@ public class BlobServerGetTest extends TestLogger {
 
 		final ExecutorService executor = Executors.newFixedThreadPool(numberConcurrentGetOperations);
 
-		try (final BlobServer blobServer = new BlobServer(configuration, blobStore)) {
+		try (final BlobServer blobServer = new BlobServer(config, blobStore)) {
 			for (int i = 0; i < numberConcurrentGetOperations; i++) {
 				Future<InputStream> getOperation = FlinkCompletableFuture.supplyAsync(new Callable<InputStream>() {
 					@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -123,7 +123,7 @@ public class BlobServerGetTest extends TestLogger {
 			assertNotNull(key);
 			assertEquals(key, key2);
 			// request for jobId2 should succeed
-			client.get(jobId2, key);
+			getFileHelper(client, jobId2, key);
 			// request for jobId1 should still fail
 			client = verifyDeleted(client, jobId1, key, serverAddress, config);
 
@@ -162,7 +162,7 @@ public class BlobServerGetTest extends TestLogger {
 			BlobClient client, JobID jobId, BlobKey key,
 			InetSocketAddress serverAddress, Configuration config) throws IOException {
 		try {
-			client.get(jobId, key);
+			getFileHelper(client, jobId, key);
 			fail("This should not succeed.");
 		} catch (IOException e) {
 			// expected
@@ -207,7 +207,7 @@ public class BlobServerGetTest extends TestLogger {
 			assertNotNull(key);
 
 			// issue a GET request that succeeds
-			InputStream is = client.get(jobId, key);
+			InputStream is = getFileHelper(client, jobId, key);
 
 			byte[] receiveBuffer = new byte[data.length];
 			int firstChunkLen = 50000;
@@ -298,7 +298,7 @@ public class BlobServerGetTest extends TestLogger {
 					@Override
 					public InputStream call() throws Exception {
 						try (BlobClient blobClient = blobServer.createClient();
-							 InputStream inputStream = blobClient.get(jobId, blobKey)) {
+							InputStream inputStream = getFileHelper(blobClient, jobId, blobKey)) {
 							byte[] buffer = new byte[data.length];
 
 							IOUtils.readFully(inputStream, buffer);
@@ -333,6 +333,15 @@ public class BlobServerGetTest extends TestLogger {
 			verify(blobStore, times(1)).get(eq(jobId), eq(blobKey), any(File.class));
 		} finally {
 			executor.shutdownNow();
+		}
+	}
+
+	static InputStream getFileHelper(BlobClient blobClient, JobID jobId, BlobKey blobKey)
+		throws IOException {
+		if (jobId == null) {
+			return blobClient.get(blobKey);
+		} else {
+			return blobClient.get(jobId, blobKey);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -131,9 +131,10 @@ public class BlobServerGetTest extends TestLogger {
 			// issue a GET request that succeeds
 			InputStream is = client.get(key);
 
-			byte[] receiveBuffer = new byte[50000];
-			BlobUtils.readFully(is, receiveBuffer, 0, receiveBuffer.length, null);
-			BlobUtils.readFully(is, receiveBuffer, 0, receiveBuffer.length, null);
+			byte[] receiveBuffer = new byte[data.length];
+			int firstChunkLen = 50000;
+			BlobUtils.readFully(is, receiveBuffer, 0, firstChunkLen, null);
+			BlobUtils.readFully(is, receiveBuffer, firstChunkLen, firstChunkLen, null);
 
 			// shut down the server
 			for (BlobServerConnection conn : server.getCurrentActiveConnections()) {
@@ -141,10 +142,10 @@ public class BlobServerGetTest extends TestLogger {
 			}
 
 			try {
-				byte[] remainder = new byte[data.length - 2*receiveBuffer.length];
-				BlobUtils.readFully(is, remainder, 0, remainder.length, null);
+				BlobUtils.readFully(is, receiveBuffer, 2 * firstChunkLen, data.length - 2 * firstChunkLen, null);
 				// we tolerate that this succeeds, as the receiver socket may have buffered
-				// everything already
+				// everything already, but in this case, also verify the contents
+				assertArrayEquals(data, receiveBuffer);
 			}
 			catch (IOException e) {
 				// expected

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.CheckedThread;
@@ -72,28 +73,43 @@ public class BlobServerPutTest extends TestLogger {
 	// --- concurrency tests for utility methods which could fail during the put operation ---
 
 	/**
-	 * Checked thread that calls {@link BlobServer#getStorageLocation(BlobKey)}
+	 * Checked thread that calls {@link BlobServer#getStorageLocation(JobID, BlobKey)}.
 	 */
 	public static class ContentAddressableGetStorageLocation extends CheckedThread {
 		private final BlobServer server;
+		private final JobID jobId;
 		private final BlobKey key;
 
-		public ContentAddressableGetStorageLocation(BlobServer server, BlobKey key) {
+		public ContentAddressableGetStorageLocation(BlobServer server, JobID jobId, BlobKey key) {
 			this.server = server;
+			this.jobId = jobId;
 			this.key = key;
 		}
 
 		@Override
 		public void go() throws Exception {
-			server.getStorageLocation(key);
+			server.getStorageLocation(jobId, key);
 		}
 	}
 
 	/**
-	 * Tests concurrent calls to {@link BlobServer#getStorageLocation(BlobKey)}.
+	 * Tests concurrent calls to {@link BlobServer#getStorageLocation(JobID, BlobKey)}.
 	 */
 	@Test
-	public void testServerContentAddressableGetStorageLocationConcurrent() throws Exception {
+	public void testServerContentAddressableGetStorageLocationConcurrentNoJob() throws Exception {
+		testServerContentAddressableGetStorageLocationConcurrent(null);
+	}
+
+	/**
+	 * Tests concurrent calls to {@link BlobServer#getStorageLocation(JobID, BlobKey)}.
+	 */
+	@Test
+	public void testServerContentAddressableGetStorageLocationConcurrentForJob() throws Exception {
+		testServerContentAddressableGetStorageLocationConcurrent(new JobID());
+	}
+
+	private void testServerContentAddressableGetStorageLocationConcurrent(final JobID jobId)
+		throws Exception {
 		final Configuration config = new Configuration();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
@@ -102,9 +118,9 @@ public class BlobServerPutTest extends TestLogger {
 		try {
 			BlobKey key = new BlobKey();
 			CheckedThread[] threads = new CheckedThread[] {
-				new ContentAddressableGetStorageLocation(server, key),
-				new ContentAddressableGetStorageLocation(server, key),
-				new ContentAddressableGetStorageLocation(server, key)
+				new ContentAddressableGetStorageLocation(server, jobId, key),
+				new ContentAddressableGetStorageLocation(server, jobId, key),
+				new ContentAddressableGetStorageLocation(server, jobId, key)
 			};
 			checkedThreadSimpleTest(threads);
 		} finally {
@@ -135,7 +151,27 @@ public class BlobServerPutTest extends TestLogger {
 	// --------------------------------------------------------------------------------------------
 
 	@Test
-	public void testPutBufferSuccessful() throws IOException {
+	public void testPutBufferSuccessfulGet1() throws IOException {
+		testPutBufferSuccessfulGet(null, null);
+	}
+
+	@Test
+	public void testPutBufferSuccessfulGet2() throws IOException {
+		testPutBufferSuccessfulGet(null, new JobID());
+	}
+
+	@Test
+	public void testPutBufferSuccessfulGet3() throws IOException {
+		testPutBufferSuccessfulGet(new JobID(), new JobID());
+	}
+
+	@Test
+	public void testPutBufferSuccessfulGet4() throws IOException {
+		testPutBufferSuccessfulGet(new JobID(), null);
+	}
+
+	private void testPutBufferSuccessfulGet(final JobID jobId1, final JobID jobId2)
+		throws IOException {
 		BlobServer server = null;
 		BlobClient client = null;
 
@@ -151,17 +187,66 @@ public class BlobServerPutTest extends TestLogger {
 			byte[] data = new byte[2000000];
 			rnd.nextBytes(data);
 
-			// put content addressable (like libraries)
-			BlobKey key1 = client.put(data);
-			assertNotNull(key1);
+			// put data for jobId1 and verify
+			BlobKey key1a = client.put(jobId1, data);
+			assertNotNull(key1a);
 
-			BlobKey key2 = client.put(data, 10, 44);
-			assertNotNull(key2);
+			BlobKey key1b = client.put(jobId1, data, 10, 44);
+			assertNotNull(key1b);
 
-			// --- GET the data and check that it is equal ---
+			testPutBufferSuccessfulGet(jobId1, key1a, key1b, data, serverAddress, config);
 
+			// now put data for jobId2 and verify that both are ok
+			BlobKey key2a = client.put(jobId2, data);
+			assertNotNull(key2a);
+			assertEquals(key1a, key2a);
+
+			BlobKey key2b = client.put(jobId2, data, 10, 44);
+			assertNotNull(key2b);
+			assertEquals(key1b, key2b);
+
+
+			testPutBufferSuccessfulGet(jobId1, key1a, key1b, data, serverAddress, config);
+			testPutBufferSuccessfulGet(jobId2, key2a, key2b, data, serverAddress, config);
+
+
+		} finally {
+			if (client != null) {
+				client.close();
+			}
+			if (server != null) {
+				server.close();
+			}
+		}
+	}
+
+	/**
+	 * GET the data stored at the two keys and check that it is equal to <tt>data</tt>.
+	 *
+	 * @param jobId
+	 * 		job ID or <tt>null</tt> if job-unrelated
+	 * @param key1
+	 * 		first key
+	 * @param key2
+	 * 		second key
+	 * @param data
+	 * 		expected data
+	 * @param serverAddress
+	 * 		BlobServer address to connect to
+	 * @param config
+	 * 		client configuration
+	 */
+	private static void testPutBufferSuccessfulGet(
+			JobID jobId, BlobKey key1, BlobKey key2, byte[] data,
+			InetSocketAddress serverAddress, Configuration config) throws IOException {
+
+		BlobClient client = new BlobClient(serverAddress, config);
+		InputStream is1 = null;
+		InputStream is2 = null;
+
+		try {
 			// one get request on the same client
-			InputStream is1 = client.get(key2);
+			is1 = client.get(jobId, key2);
 			byte[] result1 = new byte[44];
 			BlobUtils.readFully(is1, result1, 0, result1.length, null);
 			is1.close();
@@ -174,24 +259,31 @@ public class BlobServerPutTest extends TestLogger {
 			client.close();
 			client = new BlobClient(serverAddress, config);
 
-			InputStream is2 = client.get(key1);
-			byte[] result2 = new byte[data.length];
-			BlobUtils.readFully(is2, result2, 0, result2.length, null);
+			is2 = client.get(jobId, key1);
+			BlobClientTest.validateGet(is2, data);
 			is2.close();
-			assertArrayEquals(data, result2);
 		} finally {
-			if (client != null) {
-				client.close();
+			if (is1 != null) {
+				is1.close();
 			}
-			if (server != null) {
-				server.close();
+			if (is2 != null) {
+				is1.close();
 			}
+			client.close();
 		}
 	}
 
+	@Test
+	public void testPutStreamSuccessfulNoJob() throws IOException {
+		testPutStreamSuccessful(null);
+	}
 
 	@Test
-	public void testPutStreamSuccessful() throws IOException {
+	public void testPutStreamSuccessfulForJob() throws IOException {
+		testPutStreamSuccessful(new JobID());
+	}
+
+	private void testPutStreamSuccessful(final JobID jobId) throws IOException {
 		BlobServer server = null;
 		BlobClient client = null;
 
@@ -209,7 +301,7 @@ public class BlobServerPutTest extends TestLogger {
 
 			// put content addressable (like libraries)
 			{
-				BlobKey key1 = client.put(new ByteArrayInputStream(data));
+				BlobKey key1 = client.put(jobId, new ByteArrayInputStream(data));
 				assertNotNull(key1);
 			}
 		} finally {
@@ -227,7 +319,16 @@ public class BlobServerPutTest extends TestLogger {
 	}
 
 	@Test
-	public void testPutChunkedStreamSuccessful() throws IOException {
+	public void testPutChunkedStreamSuccessfulNoJob() throws IOException {
+		testPutChunkedStreamSuccessful(null);
+	}
+
+	@Test
+	public void testPutChunkedStreamSuccessfulForJob() throws IOException {
+		testPutChunkedStreamSuccessful(new JobID());
+	}
+
+	private void testPutChunkedStreamSuccessful(final JobID jobId) throws IOException {
 		BlobServer server = null;
 		BlobClient client = null;
 
@@ -245,7 +346,7 @@ public class BlobServerPutTest extends TestLogger {
 
 			// put content addressable (like libraries)
 			{
-				BlobKey key1 = client.put(new ChunkedInputStream(data, 19));
+				BlobKey key1 = client.put(jobId, new ChunkedInputStream(data, 19));
 				assertNotNull(key1);
 			}
 		} finally {
@@ -259,7 +360,16 @@ public class BlobServerPutTest extends TestLogger {
 	}
 
 	@Test
-	public void testPutBufferFails() throws IOException {
+	public void testPutBufferFailsNoJob() throws IOException {
+		testPutBufferFails(null);
+	}
+
+	@Test
+	public void testPutBufferFailsForJob() throws IOException {
+		testPutBufferFails(new JobID());
+	}
+
+	private void testPutBufferFails(final JobID jobId) throws IOException {
 		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
 
 		BlobServer server = null;
@@ -286,7 +396,7 @@ public class BlobServerPutTest extends TestLogger {
 
 			// put content addressable (like libraries)
 			try {
-				client.put(data);
+				client.put(jobId, data);
 				fail("This should fail.");
 			}
 			catch (IOException e) {
@@ -294,7 +404,7 @@ public class BlobServerPutTest extends TestLogger {
 			}
 
 			try {
-				client.put(data);
+				client.put(jobId, data);
 				fail("Client should be closed");
 			}
 			catch (IllegalStateException e) {
@@ -321,7 +431,22 @@ public class BlobServerPutTest extends TestLogger {
 	 * Tests that concurrent put operations will only upload the file once to the {@link BlobStore}.
 	 */
 	@Test
-	public void testConcurrentPutOperations() throws IOException, ExecutionException, InterruptedException {
+	public void testConcurrentPutOperationsNoJob() throws IOException, ExecutionException, InterruptedException {
+		testConcurrentPutOperations(null);
+	}
+
+	/**
+	 * FLINK-6020
+	 *
+	 * Tests that concurrent put operations will only upload the file once to the {@link BlobStore}.
+	 */
+	@Test
+	public void testConcurrentPutOperationsForJob() throws IOException, ExecutionException, InterruptedException {
+		testConcurrentPutOperations(new JobID());
+	}
+
+	private void testConcurrentPutOperations(final JobID jobId)
+			throws IOException, InterruptedException, ExecutionException {
 		final Configuration config = new Configuration();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
@@ -332,7 +457,7 @@ public class BlobServerPutTest extends TestLogger {
 		final CountDownLatch countDownLatch = new CountDownLatch(concurrentPutOperations);
 		final byte[] data = new byte[dataSize];
 
-		ArrayList<Future<BlobKey>> allFutures = new ArrayList(concurrentPutOperations);
+		ArrayList<Future<BlobKey>> allFutures = new ArrayList<>(concurrentPutOperations);
 
 		ExecutorService executor = Executors.newFixedThreadPool(concurrentPutOperations);
 
@@ -340,11 +465,12 @@ public class BlobServerPutTest extends TestLogger {
 			final BlobServer blobServer = new BlobServer(config, blobStore)) {
 
 			for (int i = 0; i < concurrentPutOperations; i++) {
-				Future<BlobKey> putFuture = FlinkCompletableFuture.supplyAsync(new Callable<BlobKey>() {
+				Future<BlobKey> putFuture = FlinkCompletableFuture
+					.supplyAsync(new Callable<BlobKey>() {
 					@Override
 					public BlobKey call() throws Exception {
 						try (BlobClient blobClient = blobServer.createClient()) {
-							return blobClient.put(new BlockingInputStream(countDownLatch, data));
+							return blobClient.put(jobId, new BlockingInputStream(countDownLatch, data));
 						}
 					}
 				}, executor);
@@ -369,7 +495,7 @@ public class BlobServerPutTest extends TestLogger {
 			}
 
 			// check that we only uploaded the file once to the blob store
-			verify(blobStore, times(1)).put(any(File.class), eq(blobKey));
+			verify(blobStore, times(1)).put(any(File.class), eq(jobId), eq(blobKey));
 		} finally {
 			executor.shutdownNow();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.runtime.concurrent.Future;
@@ -26,7 +27,9 @@ import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -63,6 +66,8 @@ public class BlobServerPutTest extends TestLogger {
 
 	private final Random rnd = new Random();
 
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	// --- concurrency tests for utility methods which could fail during the put operation ---
 
@@ -89,7 +94,10 @@ public class BlobServerPutTest extends TestLogger {
 	 */
 	@Test
 	public void testServerContentAddressableGetStorageLocationConcurrent() throws Exception {
-		BlobServer server = new BlobServer(new Configuration(), new VoidBlobStore());
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
+		BlobServer server = new BlobServer(config, new VoidBlobStore());
 
 		try {
 			BlobKey key = new BlobKey();
@@ -132,7 +140,9 @@ public class BlobServerPutTest extends TestLogger {
 		BlobClient client = null;
 
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -186,7 +196,9 @@ public class BlobServerPutTest extends TestLogger {
 		BlobClient client = null;
 
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -220,7 +232,9 @@ public class BlobServerPutTest extends TestLogger {
 		BlobClient client = null;
 
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
@@ -253,7 +267,9 @@ public class BlobServerPutTest extends TestLogger {
 
 		File tempFileDir = null;
 		try {
-			Configuration config = new Configuration();
+			final Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 
 			// make sure the blob server cannot create any files in its storage dir
@@ -306,7 +322,9 @@ public class BlobServerPutTest extends TestLogger {
 	 */
 	@Test
 	public void testConcurrentPutOperations() throws IOException, ExecutionException, InterruptedException {
-		final Configuration configuration = new Configuration();
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 		BlobStore blobStore = mock(BlobStore.class);
 		int concurrentPutOperations = 2;
 		int dataSize = 1024;
@@ -319,7 +337,7 @@ public class BlobServerPutTest extends TestLogger {
 		ExecutorService executor = Executors.newFixedThreadPool(concurrentPutOperations);
 
 		try (
-			final BlobServer blobServer = new BlobServer(configuration, blobStore)) {
+			final BlobServer blobServer = new BlobServer(config, blobStore)) {
 
 			for (int i = 0; i < concurrentPutOperations; i++) {
 				Future<BlobKey> putFuture = FlinkCompletableFuture.supplyAsync(new Callable<BlobKey>() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRangeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRangeTest.java
@@ -23,7 +23,9 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.TestLogger;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -32,6 +34,10 @@ import java.net.ServerSocket;
  * Tests to ensure that the BlobServer properly starts on a specified range of available ports.
  */
 public class BlobServerRangeTest extends TestLogger {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
 	/**
 	 * Start blob server on 0 = pick an ephemeral port
 	 */
@@ -39,6 +45,8 @@ public class BlobServerRangeTest extends TestLogger {
 	public void testOnEphemeralPort() throws IOException {
 		Configuration conf = new Configuration();
 		conf.setString(BlobServerOptions.PORT, "0");
+		conf.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
 		BlobServer srv = new BlobServer(conf, new VoidBlobStore());
 		srv.close();
 	}
@@ -60,6 +68,7 @@ public class BlobServerRangeTest extends TestLogger {
 
 		Configuration conf = new Configuration();
 		conf.setString(BlobServerOptions.PORT, String.valueOf(socket.getLocalPort()));
+		conf.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
 		// this thing is going to throw an exception
 		try {
@@ -89,6 +98,7 @@ public class BlobServerRangeTest extends TestLogger {
 		int availablePort = NetUtils.getAvailablePort();
 		Configuration conf = new Configuration();
 		conf.setString(BlobServerOptions.PORT, sockets[0].getLocalPort() + "," + sockets[1].getLocalPort() + "," + availablePort);
+		conf.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
 		// this thing is going to throw an exception
 		try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -27,7 +27,9 @@ import com.google.common.io.Files;
 import org.apache.flink.util.OperatingSystem;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,24 +38,21 @@ public class BlobUtilsTest {
 
 	private final static String CANNOT_CREATE_THIS = "cannot-create-this";
 
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
 	private File blobUtilsTestDirectory;
 
 	@Before
-	public void before() {
-		// Prepare test directory
-		blobUtilsTestDirectory = Files.createTempDir();
-
+	public void before() throws IOException {
 		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
+
+		// Prepare test directory
+		blobUtilsTestDirectory = temporaryFolder.newFolder();
 
 		assertTrue(blobUtilsTestDirectory.setExecutable(true, false));
 		assertTrue(blobUtilsTestDirectory.setReadable(true, false));
 		assertTrue(blobUtilsTestDirectory.setWritable(false, false));
-	}
-
-	@After
-	public void after() {
-		// Cleanup test directory
-		assertTrue(blobUtilsTestDirectory.delete());
 	}
 
 	@Test(expected = IOException.class)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -18,14 +18,8 @@
 
 package org.apache.flink.runtime.blob;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
-import static org.mockito.Mockito.mock;
-
-import com.google.common.io.Files;
-
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.util.OperatingSystem;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,6 +27,10 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.mock;
 
 public class BlobUtilsTest {
 
@@ -59,12 +57,18 @@ public class BlobUtilsTest {
 	public void testExceptionOnCreateStorageDirectoryFailure() throws
 		IOException {
 		// Should throw an Exception
-		BlobUtils.initStorageDirectory(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS).getAbsolutePath());
+		BlobUtils.initLocalStorageDirectory(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS).getAbsolutePath());
 	}
 
 	@Test(expected = Exception.class)
-	public void testExceptionOnCreateCacheDirectoryFailure() {
+	public void testExceptionOnCreateCacheDirectoryFailureNoJob() {
 		// Should throw an Exception
-		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), mock(BlobKey.class));
+		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), null, mock(BlobKey.class));
+	}
+
+	@Test(expected = Exception.class)
+	public void testExceptionOnCreateCacheDirectoryFailureForJob() {
+		// Should throw an Exception
+		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), new JobID(), mock(BlobKey.class));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -113,13 +113,21 @@ public class BlobLibraryCacheManagerTest {
 			assertEquals(0, checkFilesExist(jobId, keys, server, false));
 
 			try {
-				server.getFile(jobId, keys.get(0));
+				if (jobId == null) {
+					server.getFile(keys.get(0));
+				} else {
+					server.getFile(jobId, keys.get(0));
+				}
 				fail("BLOB should have been deleted");
 			} catch (IOException e) {
 				// expected
 			}
 			try {
-				server.getFile(jobId, keys.get(1));
+				if (jobId == null) {
+					server.getFile(keys.get(1));
+				} else {
+					server.getFile(jobId, keys.get(1));
+				}
 				fail("BLOB should have been deleted");
 			} catch (IOException e) {
 				// expected
@@ -155,7 +163,7 @@ public class BlobLibraryCacheManagerTest {
 	 * @param doThrow
 	 * 		whether exceptions should be ignored (<tt>false</tt>), or throws (<tt>true</tt>)
 	 *
-	 * @return number of files we were able to retrieve via {@link BlobService#getFile(JobID, BlobKey)}
+	 * @return number of files we were able to retrieve via {@link BlobService#getFile}
 	 */
 	private static int checkFilesExist(
 			JobID jobId, List<BlobKey> keys, BlobService blobService, boolean doThrow)
@@ -164,7 +172,11 @@ public class BlobLibraryCacheManagerTest {
 
 		for (BlobKey key : keys) {
 			try {
-				blobService.getFile(jobId, key);
+				if (jobId == null) {
+					blobService.getFile(key);
+				} else {
+					blobService.getFile(jobId, key);
+				}
 				++numFiles;
 			} catch (IOException e) {
 				if (doThrow) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.blob.BlobClient;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.BlobService;
+import org.apache.flink.runtime.blob.BlobUtils;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.api.common.JobID;
@@ -73,17 +74,21 @@ public class BlobLibraryCacheManagerTest {
 			InetSocketAddress blobSocketAddress = new InetSocketAddress(server.getPort());
 			BlobClient bc = new BlobClient(blobSocketAddress, config);
 
-			keys.add(bc.put(buf));
+			// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
+//			JobID jobId = new JobID();
+			JobID jobId = null;
+
+			keys.add(bc.put(jobId, buf));
 			buf[0] += 1;
-			keys.add(bc.put(buf));
+			keys.add(bc.put(jobId, buf));
 
 			bc.close();
 
-			long cleanupInterval = 1000l;
+			long cleanupInterval = 1000L;
 			libraryCacheManager = new BlobLibraryCacheManager(server, cleanupInterval);
 			libraryCacheManager.registerJob(jid, keys, Collections.<URL>emptyList());
 
-			assertEquals(2, checkFilesExist(keys, server, true));
+			assertEquals(2, checkFilesExist(jobId, keys, server, true));
 			assertEquals(2, libraryCacheManager.getNumberOfCachedLibraries());
 			assertEquals(1, libraryCacheManager.getNumberOfReferenceHolders(jid));
 
@@ -105,17 +110,17 @@ public class BlobLibraryCacheManagerTest {
 			assertEquals(0, libraryCacheManager.getNumberOfReferenceHolders(jid));
 
 			// the blob cache should no longer contain the files
-			assertEquals(0, checkFilesExist(keys, server, false));
+			assertEquals(0, checkFilesExist(jobId, keys, server, false));
 
 			try {
-				server.getFile(keys.get(0));
-				fail("name-addressable BLOB should have been deleted");
+				server.getFile(jobId, keys.get(0));
+				fail("BLOB should have been deleted");
 			} catch (IOException e) {
 				// expected
 			}
 			try {
-				server.getFile(keys.get(1));
-				fail("name-addressable BLOB should have been deleted");
+				server.getFile(jobId, keys.get(1));
+				fail("BLOB should have been deleted");
 			} catch (IOException e) {
 				// expected
 			}
@@ -150,16 +155,16 @@ public class BlobLibraryCacheManagerTest {
 	 * @param doThrow
 	 * 		whether exceptions should be ignored (<tt>false</tt>), or throws (<tt>true</tt>)
 	 *
-	 * @return number of files we were able to retrieve via {@link BlobService#getFile(BlobKey)}
+	 * @return number of files we were able to retrieve via {@link BlobService#getFile(JobID, BlobKey)}
 	 */
 	private static int checkFilesExist(
-		List<BlobKey> keys, BlobService blobService, boolean doThrow)
+			JobID jobId, List<BlobKey> keys, BlobService blobService, boolean doThrow)
 			throws IOException {
 		int numFiles = 0;
 
 		for (BlobKey key : keys) {
 			try {
-				blobService.getFile(key);
+				blobService.getFile(jobId, key);
 				++numFiles;
 			} catch (IOException e) {
 				if (doThrow) {
@@ -196,22 +201,26 @@ public class BlobLibraryCacheManagerTest {
 			InetSocketAddress blobSocketAddress = new InetSocketAddress(server.getPort());
 			BlobClient bc = new BlobClient(blobSocketAddress, config);
 
-			keys.add(bc.put(buf));
-			buf[0] += 1;
-			keys.add(bc.put(buf));
+			// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
+//			JobID jobId = new JobID();
+			JobID jobId = null;
 
-			long cleanupInterval = 1000l;
+			keys.add(bc.put(jobId, buf));
+			buf[0] += 1;
+			keys.add(bc.put(jobId, buf));
+
+			long cleanupInterval = 1000L;
 			libraryCacheManager = new BlobLibraryCacheManager(server, cleanupInterval);
 			libraryCacheManager.registerTask(jid, executionId1, keys, Collections.<URL>emptyList());
 			libraryCacheManager.registerTask(jid, executionId2, keys, Collections.<URL>emptyList());
 
-			assertEquals(2, checkFilesExist(keys, server, true));
+			assertEquals(2, checkFilesExist(jobId, keys, server, true));
 			assertEquals(2, libraryCacheManager.getNumberOfCachedLibraries());
 			assertEquals(2, libraryCacheManager.getNumberOfReferenceHolders(jid));
 
 			libraryCacheManager.unregisterTask(jid, executionId1);
 
-			assertEquals(2, checkFilesExist(keys, server, true));
+			assertEquals(2, checkFilesExist(jobId, keys, server, true));
 			assertEquals(2, libraryCacheManager.getNumberOfCachedLibraries());
 			assertEquals(1, libraryCacheManager.getNumberOfReferenceHolders(jid));
 
@@ -233,7 +242,7 @@ public class BlobLibraryCacheManagerTest {
 			assertEquals(0, libraryCacheManager.getNumberOfReferenceHolders(jid));
 
 			// the blob cache should no longer contain the files
-			assertEquals(0, checkFilesExist(keys, server, false));
+			assertEquals(0, checkFilesExist(jobId, keys, server, false));
 
 			bc.close();
 		} finally {
@@ -269,10 +278,14 @@ public class BlobLibraryCacheManagerTest {
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
 			cache = new BlobCache(serverAddress, config, new VoidBlobStore());
 
+			// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
+//			JobID jobId = new JobID();
+			JobID jobId = null;
+
 			// upload some meaningless data to the server
 			BlobClient uploader = new BlobClient(serverAddress, config);
-			BlobKey dataKey1 = uploader.put(new byte[]{1, 2, 3, 4, 5, 6, 7, 8});
-			BlobKey dataKey2 = uploader.put(new byte[]{11, 12, 13, 14, 15, 16, 17, 18});
+			BlobKey dataKey1 = uploader.put(jobId, new byte[]{1, 2, 3, 4, 5, 6, 7, 8});
+			BlobKey dataKey2 = uploader.put(jobId, new byte[]{11, 12, 13, 14, 15, 16, 17, 18});
 			uploader.close();
 
 			BlobLibraryCacheManager libCache = new BlobLibraryCacheManager(cache, 1000000000L);
@@ -316,11 +329,12 @@ public class BlobLibraryCacheManagerTest {
 					fail("Should fail with an IllegalStateException");
 				}
 				catch (IllegalStateException e) {
-					// that#s what we want
+					// that's what we want
 				}
 			}
 
-			cacheDir = new File(cache.getStorageDir(), "cache");
+			// see BlobUtils for the directory layout
+			cacheDir = new File(cache.getStorageDir(), "no_job");
 			assertTrue(cacheDir.exists());
 
 			// make sure no further blobs can be downloaded by removing the write

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -108,13 +108,13 @@ public class BlobLibraryCacheManagerTest {
 			assertEquals(0, checkFilesExist(keys, server, false));
 
 			try {
-				server.getURL(keys.get(0));
+				server.getFile(keys.get(0));
 				fail("name-addressable BLOB should have been deleted");
 			} catch (IOException e) {
 				// expected
 			}
 			try {
-				server.getURL(keys.get(1));
+				server.getFile(keys.get(1));
 				fail("name-addressable BLOB should have been deleted");
 			} catch (IOException e) {
 				// expected
@@ -150,7 +150,7 @@ public class BlobLibraryCacheManagerTest {
 	 * @param doThrow
 	 * 		whether exceptions should be ignored (<tt>false</tt>), or throws (<tt>true</tt>)
 	 *
-	 * @return number of files we were able to retrieve via {@link BlobService#getURL(BlobKey)}
+	 * @return number of files we were able to retrieve via {@link BlobService#getFile(BlobKey)}
 	 */
 	private static int checkFilesExist(
 		List<BlobKey> keys, BlobService blobService, boolean doThrow)
@@ -159,7 +159,7 @@ public class BlobLibraryCacheManagerTest {
 
 		for (BlobKey key : keys) {
 			try {
-				blobService.getURL(key);
+				blobService.getFile(key);
 				++numFiles;
 			} catch (IOException e) {
 				if (doThrow) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.execution.librarycache;
 
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobClient;
@@ -27,7 +28,9 @@ import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.util.OperatingSystem;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
@@ -42,6 +45,9 @@ import java.util.Collections;
 import java.util.List;
 
 public class BlobLibraryCacheManagerTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	/**
 	 * Tests that the {@link BlobLibraryCacheManager} cleans up after calling {@link
@@ -59,6 +65,9 @@ public class BlobLibraryCacheManagerTest {
 
 		try {
 			Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+				temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 			InetSocketAddress blobSocketAddress = new InetSocketAddress(server.getPort());
 			BlobClient bc = new BlobClient(blobSocketAddress, config);
@@ -179,6 +188,9 @@ public class BlobLibraryCacheManagerTest {
 
 		try {
 			Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+				temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 			InetSocketAddress blobSocketAddress = new InetSocketAddress(server.getPort());
 			BlobClient bc = new BlobClient(blobSocketAddress, config);
@@ -249,6 +261,9 @@ public class BlobLibraryCacheManagerTest {
 		try {
 			// create the blob transfer services
 			Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+				temporaryFolder.newFolder().getAbsolutePath());
+
 			server = new BlobServer(config, new VoidBlobStore());
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
 			cache = new BlobCache(serverAddress, config, new VoidBlobStore());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.execution.librarycache;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -70,7 +71,10 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 		Configuration config = new Configuration();
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
 		config.setString(CoreOptions.STATE_BACKEND, "FILESYSTEM");
-		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.getRoot().getAbsolutePath());
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
+			temporaryFolder.newFolder().getAbsolutePath());
 
 		try {
 			blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
@@ -153,7 +157,8 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 
 			// Verify everything is clean below recoveryDir/<cluster_id>
 			final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
-			File haBlobStoreDir = new File(temporaryFolder.getRoot(), clusterId);
+			String haBlobStorePath = config.getString(HighAvailabilityOptions.HA_STORAGE_PATH);
+			File haBlobStoreDir = new File(haBlobStorePath, clusterId);
 			File[] recoveryFiles = haBlobStoreDir.listFiles();
 			assertNotNull("HA storage directory does not exist", recoveryFiles);
 			assertEquals("Unclean state backend: " + Arrays.toString(recoveryFiles), 0, recoveryFiles.length);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -92,7 +92,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			List<BlobKey> keys = new ArrayList<>(2);
 
 			JobID jobId = new JobID();
-			// TODO: replace by jobId after adapting the BlobLibraryCacheManager
+			// TODO: replace+adapt by jobId after adapting the BlobLibraryCacheManager
 			JobID blobJobId = null;
 
 			// Upload some data (libraries)
@@ -110,7 +110,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			libServer[0].registerTask(jobId, executionId, keys, Collections.<URL>emptyList());
 
 			// Verify key 1
-			File f = cache.getFile(blobJobId, keys.get(0));
+			File f = cache.getFile(keys.get(0));
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -129,7 +129,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			libCache = new BlobLibraryCacheManager(cache, 3600 * 1000);
 
 			// Verify key 1
-			f = cache.getFile(blobJobId, keys.get(0));
+			f = cache.getFile(keys.get(0));
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -141,7 +141,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			}
 
 			// Verify key 2
-			f = cache.getFile(blobJobId, keys.get(1));
+			f = cache.getFile(keys.get(1));
 			assertEquals(256, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -154,8 +154,8 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 
 			// Remove blobs again
 			try (BlobClient client = new BlobClient(serverAddress[1], config)) {
-				client.delete(blobJobId, keys.get(0));
-				client.delete(blobJobId, keys.get(1));
+				client.delete(keys.get(0));
+				client.delete(keys.get(1));
 			}
 
 			// Verify everything is clean below recoveryDir/<cluster_id>

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -107,7 +107,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			libServer[0].registerTask(jobId, executionId, keys, Collections.<URL>emptyList());
 
 			// Verify key 1
-			File f = libCache.getFile(keys.get(0));
+			File f = new File(cache.getURL(keys.get(0)).toURI());
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -126,7 +126,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			libCache = new BlobLibraryCacheManager(cache, 3600 * 1000);
 
 			// Verify key 1
-			f = libCache.getFile(keys.get(0));
+			f = new File(cache.getURL(keys.get(0)).toURI());
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -138,7 +138,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			}
 
 			// Verify key 2
-			f = libCache.getFile(keys.get(1));
+			f = new File(cache.getURL(keys.get(1)).toURI());
 			assertEquals(256, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -107,7 +107,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			libServer[0].registerTask(jobId, executionId, keys, Collections.<URL>emptyList());
 
 			// Verify key 1
-			File f = new File(cache.getURL(keys.get(0)).toURI());
+			File f = cache.getFile(keys.get(0));
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -126,7 +126,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			libCache = new BlobLibraryCacheManager(cache, 3600 * 1000);
 
 			// Verify key 1
-			f = new File(cache.getURL(keys.get(0)).toURI());
+			f = cache.getFile(keys.get(0));
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -138,7 +138,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			}
 
 			// Verify key 2
-			f = new File(cache.getURL(keys.get(1)).toURI());
+			f = cache.getFile(keys.get(1));
 			assertEquals(256, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobmanager;
 
 import akka.actor.ActorSystem;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -136,12 +137,15 @@ public class JobSubmitTest {
 			// upload two dummy bytes and add their keys to the job graph as dependencies
 			BlobKey key1, key2;
 			BlobClient bc = new BlobClient(new InetSocketAddress("localhost", blobPort), jmConfig);
+			// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
+//			JobID jobId = jg.getJobID();
+			JobID jobId = null;
 			try {
-				key1 = bc.put(new byte[10]);
-				key2 = bc.put(new byte[10]);
+				key1 = bc.put(jobId, new byte[10]);
+				key2 = bc.put(jobId, new byte[10]);
 
 				// delete one of the blobs to make sure that the startup failed
-				bc.delete(key2);
+				bc.delete(jobId, key2);
 			}
 			finally {
 				bc.close();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
@@ -145,7 +145,7 @@ public class JobSubmitTest {
 				key2 = bc.put(jobId, new byte[10]);
 
 				// delete one of the blobs to make sure that the startup failed
-				bc.delete(jobId, key2);
+				bc.delete(key2);
 			}
 			finally {
 				bc.close();


### PR DESCRIPTION
To ease cleanup, we will make job-related BLOBs be reflected in the blob storage so that they may be removed along with the job. This adds the `jobId` to many methods similar to the previous code from the `NAME_ADDRESSABLE` mode. This job-based BLOB mode will become the future default for JARs, `TaskDeploymentDescriptor` data, and `DistributedCache` data.

Please note that we will rework/reorganise the whole BLOB store APIs completely in a future request. This PR focusses on the added functionality. 

This PR is based upon #4236  in a series to implement FLINK-6916.