### PR TITLE
[FLINK-7057][blob] move BLOB ref-counting from LibraryCacheManager to BlobCache

### DIFF
--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -196,6 +196,13 @@ will be used under the directory specified by jobmanager.web.tmpdir.
 
 - `blob.storage.directory`: Directory for storing blobs (such as user JARs) on the TaskManagers.
 
+- `blob.service.cleanup.interval`: Cleanup interval (in seconds) of the blob caches (DEFAULT: 1 hour).
+Whenever a job is not referenced at the cache anymore, we set a TTL and let the periodic cleanup task
+(executed every `blob.service.cleanup.interval` seconds) remove its blob files after this TTL has passed.
+This means that a blob will be retained at most <tt>2 * `blob.service.cleanup.interval`</tt> seconds after
+not being referenced anymore. Therefore, a recovery still has the chance to use existing files rather
+than to download them again.
+
 - `blob.server.port`: Port definition for the blob server (serving user JARs) on the TaskManagers. By default the port is set to 0, which means that the operating system is picking an ephemeral port. Flink also accepts a list of ports ("50100,50101"), ranges ("50100-50200") or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple JobManagers are running on the same machine.
 
 - `blob.service.ssl.enabled`: Flag to enable ssl for the blob client/server communication. This is applicable only when the global ssl flag security.ssl.enabled is set to true (DEFAULT: true).

--- a/flink-core/src/main/java/org/apache/flink/configuration/BlobServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/BlobServerOptions.java
@@ -74,6 +74,15 @@ public class BlobServerOptions {
 		key("blob.service.ssl.enabled")
 			.defaultValue(true);
 
+	/**
+	 * Cleanup interval of the blob caches at the task managers (in seconds).
+	 *
+	 * <p>Whenever a job is not referenced at the cache anymore, we set a TTL and let the periodic
+	 * cleanup task (executed every CLEANUP_INTERVAL seconds) remove its blob files after this TTL
+	 * has passed. This means that a blob will be retained at most <tt>2 * CLEANUP_INTERVAL</tt>
+	 * seconds after not being referenced anymore. Therefore, a recovery still has the chance to use
+	 * existing files rather than to download them again.
+	 */
 	public static final ConfigOption<Long> CLEANUP_INTERVAL =
 		key("blob.service.cleanup.interval")
 			.defaultValue(3_600L) // once per hour

--- a/flink-core/src/main/java/org/apache/flink/configuration/BlobServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/BlobServerOptions.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import static org.apache.flink.configuration.ConfigOptions.key;
 
 /**
- * Configuration options for the BlobServer.
+ * Configuration options for the BlobServer and BlobCache.
  */
 @PublicEvolving
 public class BlobServerOptions {
@@ -73,4 +73,9 @@ public class BlobServerOptions {
 	public static final ConfigOption<Boolean> SSL_ENABLED =
 		key("blob.service.ssl.enabled")
 			.defaultValue(true);
+
+	public static final ConfigOption<Long> CLEANUP_INTERVAL =
+		key("blob.service.cleanup.interval")
+			.defaultValue(3_600L) // once per hour
+			.withDeprecatedKeys("library-cache-manager.cleanup.interval");
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -178,7 +178,10 @@ public final class ConfigConstants {
 
 	/**
 	 * The config parameter defining the cleanup interval of the library cache manager.
+	 *
+	 * @deprecated use {@link BlobServerOptions#CLEANUP_INTERVAL} instead
 	 */
+	@Deprecated
 	public static final String LIBRARY_CACHE_MANAGER_CLEANUP_INTERVAL = "library-cache-manager.cleanup.interval";
 
 	/**
@@ -1253,8 +1256,12 @@ public final class ConfigConstants {
 
 	/**
 	 * The default library cache manager cleanup interval in seconds
+	 *
+	 * @deprecated use {@link BlobServerOptions#CLEANUP_INTERVAL} instead
 	 */
-	public static final long DEFAULT_LIBRARY_CACHE_MANAGER_CLEANUP_INTERVAL = 3600;
+	@Deprecated
+	public static final long DEFAULT_LIBRARY_CACHE_MANAGER_CLEANUP_INTERVAL =
+		BlobServerOptions.CLEANUP_INTERVAL.defaultValue();
 	
 	/**
 	 * The default network port to connect to for communication with the job manager.

--- a/flink-mesos/src/main/scala/org/apache/flink/mesos/runtime/clusterframework/MesosJobManager.scala
+++ b/flink-mesos/src/main/scala/org/apache/flink/mesos/runtime/clusterframework/MesosJobManager.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.{Executor, ScheduledExecutorService}
 
 import akka.actor.ActorRef
 import org.apache.flink.configuration.{Configuration => FlinkConfiguration}
+import org.apache.flink.runtime.blob.BlobServer
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory
 import org.apache.flink.runtime.clusterframework.ContaineredJobManager
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager
@@ -34,7 +35,7 @@ import org.apache.flink.runtime.metrics.{MetricRegistry => FlinkMetricRegistry}
 
 import scala.concurrent.duration._
 
-/** JobManager actor for execution on Mesos. .
+/** JobManager actor for execution on Mesos.
   *
   * @param flinkConfiguration Configuration object for the actor
   * @param futureExecutor Execution context which is used to execute concurrent tasks in the
@@ -43,7 +44,8 @@ import scala.concurrent.duration._
   * @param instanceManager Instance manager to manage the registered
   *                        [[org.apache.flink.runtime.taskmanager.TaskManager]]
   * @param scheduler Scheduler to schedule Flink jobs
-  * @param libraryCacheManager Manager to manage uploaded jar files
+  * @param blobServer BLOB store for file uploads
+  * @param libraryCacheManager manages uploaded jar files and class paths
   * @param archive Archive for finished Flink jobs
   * @param restartStrategyFactory Restart strategy to be used in case of a job recovery
   * @param timeout Timeout for futures
@@ -55,6 +57,7 @@ class MesosJobManager(
     ioExecutor: Executor,
     instanceManager: InstanceManager,
     scheduler: FlinkScheduler,
+    blobServer: BlobServer,
     libraryCacheManager: BlobLibraryCacheManager,
     archive: ActorRef,
     restartStrategyFactory: RestartStrategyFactory,
@@ -70,6 +73,7 @@ class MesosJobManager(
     ioExecutor,
     instanceManager,
     scheduler,
+    blobServer,
     libraryCacheManager,
     archive,
     restartStrategyFactory,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
@@ -431,12 +431,13 @@ public class BlobCache extends TimerTask implements BlobService {
 	public void run() {
 		synchronized (jobRefCounters) {
 			Iterator<Map.Entry<JobID, RefCount>> entryIter = jobRefCounters.entrySet().iterator();
+			final long currentTimeMillis = System.currentTimeMillis();
 
 			while (entryIter.hasNext()) {
 				Map.Entry<JobID, RefCount> entry = entryIter.next();
 				RefCount ref = entry.getValue();
 
-				if (ref.references <= 0 && ref.keepUntil > 0 && System.currentTimeMillis() >= ref.keepUntil) {
+				if (ref.references <= 0 && ref.keepUntil > 0 && currentTimeMillis >= ref.keepUntil) {
 					JobID jobId = entry.getKey();
 
 					final File localFile =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
@@ -25,7 +26,6 @@ import org.apache.flink.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -33,6 +33,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -47,7 +52,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * download it from a distributed file system (if available) or the BLOB
  * server.</p>
  */
-public final class BlobCache implements BlobService {
+public class BlobCache extends TimerTask implements BlobService {
 
 	/** The log object used for debugging. */
 	private static final Logger LOG = LoggerFactory.getLogger(BlobCache.class);
@@ -70,6 +75,32 @@ public final class BlobCache implements BlobService {
 
 	/** Configuration for the blob client like ssl parameters required to connect to the blob server */
 	private final Configuration blobClientConfig;
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Job reference counters with a time-to-live (TTL).
+	 */
+	private static class RefCount {
+		/**
+		 * Number of references to a job.
+		 */
+		public int references = 0;
+		
+		/**
+		 * Timestamp in milliseconds when any job data should be cleaned up (no cleanup for
+		 * non-positive values).
+		 */
+		public long keepUntil = -1;
+	}
+
+	/** Map to store the number of references to a specific job */
+	private final Map<JobID, RefCount> jobRefCounters = new HashMap<>();
+
+	/** Time interval (ms) to run the cleanup task; also used as the default TTL. */
+	private final long cleanupInterval;
+
+	private final Timer cleanupTimer;
 
 	/**
 	 * Instantiates a new BLOB cache.
@@ -108,8 +139,60 @@ public final class BlobCache implements BlobService {
 			this.numFetchRetries = 0;
 		}
 
+		// Initializing the clean up task
+		this.cleanupTimer = new Timer(true);
+
+		cleanupInterval = blobClientConfig.getLong(BlobServerOptions.CLEANUP_INTERVAL) * 1000;
+		this.cleanupTimer.schedule(this, cleanupInterval, cleanupInterval);
+
 		// Add shutdown hook to delete storage directory
 		shutdownHook = BlobUtils.addShutdownHook(this, LOG);
+	}
+
+	/**
+	 * Registers use of job-related BLOBs.
+	 * <p>
+	 * Using any other method to access BLOBs, e.g. {@link #getFile}, is only valid within calls
+	 * to {@link #registerJob(JobID)} and {@link #releaseJob(JobID)}.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to
+	 *
+	 * @see #releaseJob(JobID)
+	 */
+	public void registerJob(JobID jobId) {
+		synchronized (jobRefCounters) {
+			RefCount ref = jobRefCounters.get(jobId);
+			if (ref == null) {
+				ref = new RefCount();
+				jobRefCounters.put(jobId, ref);
+			}
+			++ref.references;
+		}
+	}
+
+	/**
+	 * Unregisters use of job-related BLOBs and allow them to be released.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to
+	 *
+	 * @see #registerJob(JobID)
+	 */
+	public void releaseJob(JobID jobId) {
+		synchronized (jobRefCounters) {
+			RefCount ref = jobRefCounters.get(jobId);
+
+			if (ref == null) {
+				LOG.warn("improper use of releaseJob() without a matching number of registerJob() calls");
+				return;
+			}
+
+			--ref.references;
+			if (ref.references == 0) {
+				ref.keepUntil = System.currentTimeMillis() + cleanupInterval;
+			}
+		}
 	}
 
 	/**
@@ -148,7 +231,7 @@ public final class BlobCache implements BlobService {
 	 * 		Thrown if an I/O error occurs while downloading the BLOBs from the BLOB server.
 	 */
 	@Override
-	public File getFile(@Nonnull JobID jobId, BlobKey key) throws IOException {
+	public File getFile(JobID jobId, BlobKey key) throws IOException {
 		checkNotNull(jobId);
 		return getFileInternal(jobId, key);
 	}
@@ -258,7 +341,7 @@ public final class BlobCache implements BlobService {
 	 * @throws IOException
 	 */
 	@Override
-	public void delete(@Nonnull JobID jobId, BlobKey key) throws IOException {
+	public void delete(JobID jobId, BlobKey key) throws IOException {
 		checkNotNull(jobId);
 		deleteInternal(jobId, key);
 	}
@@ -307,7 +390,7 @@ public final class BlobCache implements BlobService {
 	 * 		thrown if an I/O error occurs while transferring the request to the BLOB server or if the
 	 * 		BLOB server cannot delete the file
 	 */
-	public void deleteGlobal(@Nonnull JobID jobId, BlobKey key) throws IOException {
+	public void deleteGlobal(JobID jobId, BlobKey key) throws IOException {
 		checkNotNull(jobId);
 		deleteGlobalInternal(jobId, key);
 	}
@@ -341,8 +424,39 @@ public final class BlobCache implements BlobService {
 		return serverAddress.getPort();
 	}
 
+	/**
+	 * Cleans up BLOBs which are not referenced anymore.
+	 */
+	@Override
+	public void run() {
+		synchronized (jobRefCounters) {
+			Iterator<Map.Entry<JobID, RefCount>> entryIter = jobRefCounters.entrySet().iterator();
+
+			while (entryIter.hasNext()) {
+				Map.Entry<JobID, RefCount> entry = entryIter.next();
+				RefCount ref = entry.getValue();
+
+				if (ref.references <= 0 && ref.keepUntil > 0 && System.currentTimeMillis() >= ref.keepUntil) {
+					JobID jobId = entry.getKey();
+
+					final File localFile =
+						new File(BlobUtils.getStorageLocationPath(storageDir.getAbsolutePath(), jobId));
+					try {
+						FileUtils.deleteDirectory(localFile);
+						// let's only remove this directory from cleanup if the cleanup was successful
+						entryIter.remove();
+					} catch (Throwable t) {
+						LOG.warn("Failed to locally delete job directory " + localFile.getAbsolutePath(), t);
+					}
+				}
+			}
+		}
+	}
+
 	@Override
 	public void close() throws IOException {
+		cleanupTimer.cancel();
+
 		if (shutdownRequested.compareAndSet(false, true)) {
 			LOG.info("Shutting down BlobCache");
 
@@ -369,8 +483,19 @@ public final class BlobCache implements BlobService {
 		return new BlobClient(serverAddress, blobClientConfig);
 	}
 
-	public File getStorageDir() {
-		return this.storageDir;
+	/**
+	 * Returns a file handle to the file associated with the given blob key on the blob
+	 * server.
+	 *
+	 * <p><strong>This is only called from the {@link BlobServerConnection}</strong>
+	 *
+	 * @param jobId ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
+	 * @param key identifying the file
+	 * @return file handle to the file
+	 */
+	@VisibleForTesting
+	public File getStorageLocation(JobID jobId, BlobKey key) {
+		return BlobUtils.getStorageLocation(storageDir, jobId, key);
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -30,7 +30,6 @@ import org.apache.flink.util.InstantiationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
@@ -166,7 +165,7 @@ public final class BlobClient implements Closeable {
 	 * @throws IOException
 	 * 		if an I/O error occurs during the download
 	 */
-	public InputStream get(@Nonnull JobID jobId, BlobKey blobKey) throws IOException {
+	public InputStream get(JobID jobId, BlobKey blobKey) throws IOException {
 		checkNotNull(jobId);
 		return getInternal(jobId, blobKey);
 	}
@@ -339,7 +338,7 @@ public final class BlobClient implements Closeable {
 	 * 		thrown if an I/O error occurs while reading the data from the input stream or uploading the
 	 * 		data to the BLOB server
 	 */
-	public BlobKey put(@Nonnull JobID jobId, InputStream inputStream) throws IOException {
+	public BlobKey put(JobID jobId, InputStream inputStream) throws IOException {
 		checkNotNull(jobId);
 		return putInputStream(jobId, inputStream);
 	}
@@ -369,7 +368,7 @@ public final class BlobClient implements Closeable {
 		checkNotNull(value);
 
 		if (LOG.isDebugEnabled()) {
-			LOG.debug("PUT BLOB buffer ({} bytes) to {}.", len, socket.getLocalSocketAddress());
+			LOG.debug("PUT BLOB buffer (" + len + " bytes) to " + socket.getLocalSocketAddress() + ".");
 		}
 
 		try {
@@ -556,7 +555,7 @@ public final class BlobClient implements Closeable {
 	 * 		thrown if an I/O error occurs while transferring the request to the BLOB server or if the
 	 * 		BLOB server cannot delete the file
 	 */
-	public void delete(@Nonnull JobID jobId, BlobKey key) throws IOException {
+	public void delete(JobID jobId, BlobKey key) throws IOException {
 		checkNotNull(jobId);
 		deleteInternal(jobId, key);
 	}
@@ -603,23 +602,21 @@ public final class BlobClient implements Closeable {
 
 	/**
 	 * Uploads the JAR files to a {@link BlobServer} at the given address.
-	 * <p>
-	 * TODO: add jobId to signature after adapting the BlobLibraryCacheManager
 	 *
 	 * @param serverAddress
 	 * 		Server address of the {@link BlobServer}
 	 * @param clientConfig
 	 * 		Any additional configuration for the blob client
+	 * @param jobId
+	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param jars
 	 * 		List of JAR files to upload
 	 *
 	 * @throws IOException
 	 * 		if the upload fails
 	 */
-	public static List<BlobKey> uploadJarFiles(
-			InetSocketAddress serverAddress,
-			Configuration clientConfig,
-			List<Path> jars) throws IOException {
+	public static List<BlobKey> uploadJarFiles(InetSocketAddress serverAddress,
+			Configuration clientConfig, JobID jobId, List<Path> jars) throws IOException {checkNotNull(jobId);
 		if (jars.isEmpty()) {
 			return Collections.emptyList();
 		} else {
@@ -631,7 +628,7 @@ public final class BlobClient implements Closeable {
 					FSDataInputStream is = null;
 					try {
 						is = fs.open(jar);
-						final BlobKey key = blobClient.putInputStream(null, is);
+						final BlobKey key = blobClient.putInputStream(jobId, is);
 						blobKeys.add(key);
 					} finally {
 						if (is != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerConnection.java
@@ -139,14 +139,7 @@ class BlobServerConnection extends Thread {
 			LOG.error("Error while executing BLOB connection.", t);
 		}
 		finally {
-			try {
-				if (clientSocket != null) {
-					clientSocket.close();
-				}
-			} catch (Throwable t) {
-				LOG.debug("Exception while closing BLOB server connection socket.", t);
-			}
-
+			closeSilently(clientSocket, LOG);
 			blobServer.unregisterConnection(this);
 		}
 	}
@@ -433,9 +426,8 @@ class BlobServerConnection extends Thread {
 			final InputStream inputStream, final File incomingFile, final byte[] buf)
 			throws IOException {
 		MessageDigest md = BlobUtils.createMessageDigest();
-		FileOutputStream fos = new FileOutputStream(incomingFile);
 
-		try {
+		try (FileOutputStream fos = new FileOutputStream(incomingFile)) {
 			while (true) {
 				final int bytesExpected = readLength(inputStream);
 				if (bytesExpected == -1) {
@@ -453,12 +445,6 @@ class BlobServerConnection extends Thread {
 				md.update(buf, 0, bytesExpected);
 			}
 			return new BlobKey(md.digest());
-		} finally {
-			try {
-				fos.close();
-			} catch (Throwable t) {
-				LOG.warn("Cannot close stream to BLOB staging file", t);
-			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.blob;
 
 import org.apache.flink.api.common.JobID;
 
-import javax.annotation.Nonnull;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -50,7 +49,7 @@ public interface BlobService extends Closeable {
 	 * @throws java.io.FileNotFoundException when the path does not exist;
 	 * @throws IOException if any other error occurs when retrieving the file
 	 */
-	File getFile(@Nonnull JobID jobId, BlobKey key) throws IOException;
+	File getFile(JobID jobId, BlobKey key) throws IOException;
 
 	/**
 	 * Deletes the (job-unrelated) file associated with the provided blob key.
@@ -67,7 +66,7 @@ public interface BlobService extends Closeable {
 	 * @param key associated with the file to be deleted
 	 * @throws IOException
 	 */
-	void delete(@Nonnull JobID jobId, BlobKey key) throws IOException;
+	void delete(JobID jobId, BlobKey key) throws IOException;
 
 	/**
 	 * Returns the port of the blob service.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
@@ -234,8 +234,7 @@ public class JobClient {
 			int pos = 0;
 			for (BlobKey blobKey : props.requiredJarFiles()) {
 				try {
-					// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
-					allURLs[pos++] = blobClient.getFile(blobKey).toURI().toURL();
+					allURLs[pos++] = blobClient.getFile(jobID, blobKey).toURI().toURL();
 				} catch (Exception e) {
 					try {
 						blobClient.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
-import org.apache.flink.runtime.blob.BlobService;
 import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -231,7 +230,7 @@ public abstract class Dispatcher extends RpcEndpoint implements DispatcherGatewa
 		Configuration configuration,
 		RpcService rpcService,
 		HighAvailabilityServices highAvailabilityServices,
-		BlobService blobService,
+		BlobServer blobServer,
 		HeartbeatServices heartbeatServices,
 		MetricRegistry metricRegistry,
 		OnCompletionActions onCompleteActions,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
-import org.apache.flink.runtime.blob.BlobService;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -65,7 +64,7 @@ public class StandaloneDispatcher extends Dispatcher {
 			Configuration configuration,
 			RpcService rpcService,
 			HighAvailabilityServices highAvailabilityServices,
-			BlobService blobService,
+			BlobServer blobServer,
 			HeartbeatServices heartbeatServices,
 			MetricRegistry metricRegistry,
 			OnCompletionActions onCompleteActions,
@@ -77,7 +76,7 @@ public class StandaloneDispatcher extends Dispatcher {
 			configuration,
 			rpcService,
 			highAvailabilityServices,
-			blobService,
+			blobServer,
 			heartbeatServices,
 			metricRegistry,
 			onCompleteActions,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/JobClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/JobClusterEntrypoint.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
-import org.apache.flink.runtime.blob.BlobService;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -90,7 +89,7 @@ public abstract class JobClusterEntrypoint extends ClusterEntrypoint {
 			ResourceID resourceId,
 			RpcService rpcService,
 			HighAvailabilityServices highAvailabilityServices,
-			BlobService blobService,
+			BlobServer blobService,
 			HeartbeatServices heartbeatServices,
 			MetricRegistry metricRegistry,
 			FatalErrorHandler fatalErrorHandler) throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -26,6 +26,7 @@ import org.apache.flink.util.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
@@ -33,72 +34,51 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * For each job graph that is submitted to the system the library cache manager maintains
- * a set of libraries (typically JAR files) which the job requires to run. The library cache manager
- * caches library files in order to avoid unnecessary retransmission of data. It is based on a singleton
- * programming pattern, so there exists at most one library manager at a time.
- * <p>
- * All files registered via {@link #registerJob(JobID, Collection, Collection)} are reference-counted
- * and are removed by a timer-based cleanup task if their reference counter is zero.
+ * Provides facilities to download a set of libraries (typically JAR files) for a job from a
+ * {@link BlobService} and create a class loader with references to them.
  */
-public final class BlobLibraryCacheManager extends TimerTask implements LibraryCacheManager {
+public class BlobLibraryCacheManager implements LibraryCacheManager {
 
 	private static Logger LOG = LoggerFactory.getLogger(BlobLibraryCacheManager.class);
-	
+
 	private static ExecutionAttemptID JOB_ATTEMPT_ID = new ExecutionAttemptID(-1, -1);
-	
+
 	// --------------------------------------------------------------------------------------------
-	
+
 	/** The global lock to synchronize operations */
 	private final Object lockObject = new Object();
 
 	/** Registered entries per job */
-	private final Map<JobID, LibraryCacheEntry> cacheEntries = new HashMap<JobID, LibraryCacheEntry>();
-	
-	/** Map to store the number of reference to a specific file */
-	private final Map<BlobKey, Integer> blobKeyReferenceCounters = new HashMap<BlobKey, Integer>();
+	private final Map<JobID, LibraryCacheEntry> cacheEntries = new HashMap<>();
 
 	/** The blob service to download libraries */
 	private final BlobService blobService;
-	
-	private final Timer cleanupTimer;
-	
+
 	// --------------------------------------------------------------------------------------------
 
-	/**
-	 * Creates the blob library cache manager.
-	 *
-	 * @param blobService blob file retrieval service to use
-	 * @param cleanupInterval cleanup interval in milliseconds
-	 */
-	public BlobLibraryCacheManager(BlobService blobService, long cleanupInterval) {
+	public BlobLibraryCacheManager(BlobService blobService) {
 		this.blobService = checkNotNull(blobService);
-
-		// Initializing the clean up task
-		this.cleanupTimer = new Timer(true);
-		this.cleanupTimer.schedule(this, cleanupInterval, cleanupInterval);
 	}
 
-	// --------------------------------------------------------------------------------------------
-	
 	@Override
 	public void registerJob(JobID id, Collection<BlobKey> requiredJarFiles, Collection<URL> requiredClasspaths)
-			throws IOException {
+		throws IOException {
 		registerTask(id, JOB_ATTEMPT_ID, requiredJarFiles, requiredClasspaths);
 	}
-	
+
 	@Override
-	public void registerTask(JobID jobId, ExecutionAttemptID task, Collection<BlobKey> requiredJarFiles,
-			Collection<URL> requiredClasspaths) throws IOException {
+	public void registerTask(
+		JobID jobId,
+		ExecutionAttemptID task,
+		@Nullable Collection<BlobKey> requiredJarFiles,
+		@Nullable Collection<URL> requiredClasspaths) throws IOException {
+
 		checkNotNull(jobId, "The JobId must not be null.");
 		checkNotNull(task, "The task execution id must not be null.");
 
@@ -113,43 +93,31 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 			LibraryCacheEntry entry = cacheEntries.get(jobId);
 
 			if (entry == null) {
-				// create a new entry in the library cache
-				BlobKey[] keys = requiredJarFiles.toArray(new BlobKey[requiredJarFiles.size()]);
-				URL[] urls = new URL[keys.length + requiredClasspaths.size()];
-
+				URL[] urls = new URL[requiredJarFiles.size() + requiredClasspaths.size()];
 				int count = 0;
 				try {
-					for (; count < keys.length; count++) {
-						BlobKey blobKey = keys[count];
-						urls[count] = registerReferenceToBlobKeyAndGetURL(blobKey);
-					}
-				}
-				catch (Throwable t) {
-					// undo the reference count increases
-					try {
-						for (int i = 0; i < count; i++) {
-							unregisterReferenceToBlobKey(keys[i]);
-						}
-					}
-					catch (Throwable tt) {
-						LOG.error("Error while updating library reference counters.", tt);
+					// add URLs to locally cached JAR files
+					for (BlobKey key : requiredJarFiles) {
+						urls[count] = blobService.getFile(jobId, key).toURI().toURL();
+						++count;
 					}
 
+					// add classpaths
+					for (URL url : requiredClasspaths) {
+						urls[count] = url;
+						++count;
+					}
+
+					cacheEntries.put(jobId, new LibraryCacheEntry(
+						requiredJarFiles, requiredClasspaths, urls, task));
+				} catch (Throwable t) {
 					// rethrow or wrap
 					ExceptionUtils.tryRethrowIOException(t);
-					throw new IOException("Library cache could not register the user code libraries.", t);
+					throw new IOException(
+						"Library cache could not register the user code libraries.", t);
 				}
-
-				// add classpaths
-				for (URL url : requiredClasspaths) {
-					urls[count] = url;
-					count++;
-				}
-
-				cacheEntries.put(jobId, new LibraryCacheEntry(requiredJarFiles, urls, task));
-			}
-			else {
-				entry.register(task, requiredJarFiles);
+			} else {
+				entry.register(task, requiredJarFiles, requiredClasspaths);
 			}
 		}
 	}
@@ -158,7 +126,7 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 	public void unregisterJob(JobID id) {
 		unregisterTask(id, JOB_ATTEMPT_ID);
 	}
-	
+
 	@Override
 	public void unregisterTask(JobID jobId, ExecutionAttemptID task) {
 		checkNotNull(jobId, "The JobId must not be null.");
@@ -172,162 +140,121 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 					cacheEntries.remove(jobId);
 
 					entry.releaseClassLoader();
-
-					for (BlobKey key : entry.getLibraries()) {
-						unregisterReferenceToBlobKey(key);
-					}
 				}
 			}
 			// else has already been unregistered
 		}
 	}
-
-	@Override
-	public ClassLoader getClassLoader(JobID id) {
-		if (id == null) {
-			throw new IllegalArgumentException("The JobId must not be null.");
-		}
-		
-		synchronized (lockObject) {
-			LibraryCacheEntry entry = cacheEntries.get(id);
-			if (entry != null) {
-				return entry.getClassLoader();
-			} else {
-				throw new IllegalStateException("No libraries are registered for job " + id);
-			}
-		}
-	}
-
-	public int getBlobServerPort() {
-		return blobService.getPort();
-	}
-
-	@Override
-	public void shutdown() throws IOException{
-		try {
-			run();
-		} catch (Throwable t) {
-			LOG.warn("Failed to run clean up task before shutdown", t);
-		}
-
-		blobService.close();
-		cleanupTimer.cancel();
-	}
 	
+	@Override
+	public ClassLoader getClassLoader(JobID jobId) {
+		checkNotNull(jobId, "The JobId must not be null.");
+
+		synchronized (lockObject) {
+			LibraryCacheEntry entry = cacheEntries.get(jobId);
+			if (entry == null) {
+				throw new IllegalStateException("No libraries are registered for job " + jobId);
+			}
+			return entry.getClassLoader();
+		}
+	}
+
 	/**
-	 * Cleans up blobs which are not referenced anymore
+	 * Gets the number of tasks holding {@link ClassLoader} references for the given job.
+	 *
+	 * @param jobId ID of a job
+	 *
+	 * @return number of reference holders
 	 */
-	@Override
-	public void run() {
-		synchronized (lockObject) {
-			Iterator<Map.Entry<BlobKey, Integer>> entryIter = blobKeyReferenceCounters.entrySet().iterator();
-			
-			while (entryIter.hasNext()) {
-				Map.Entry<BlobKey, Integer> entry = entryIter.next();
-				BlobKey key = entry.getKey();
-				int references = entry.getValue();
-				
-				try {
-					if (references <= 0) {
-						blobService.delete(key);
-						entryIter.remove();
-					}
-				} catch (Throwable t) {
-					LOG.warn("Could not delete file with blob key" + key, t);
-				}
-			}
-		}
-	}
-	
-	public int getNumberOfReferenceHolders(JobID jobId) {
+	int getNumberOfReferenceHolders(JobID jobId) {
 		synchronized (lockObject) {
 			LibraryCacheEntry entry = cacheEntries.get(jobId);
 			return entry == null ? 0 : entry.getNumberOfReferenceHolders();
 		}
 	}
-	
-	int getNumberOfCachedLibraries() {
-		return blobKeyReferenceCounters.size();
-	}
-	
-	private URL registerReferenceToBlobKeyAndGetURL(BlobKey key) throws IOException {
-		// it is important that we fetch the URL before increasing the counter.
-		// in case the URL cannot be created (failed to fetch the BLOB), we have no stale counter
-		try {
-			URL url = blobService.getFile(key).toURI().toURL();
 
-			Integer references = blobKeyReferenceCounters.get(key);
-			int newReferences = references == null ? 1 : references + 1;
-			blobKeyReferenceCounters.put(key, newReferences);
-
-			return url;
-		}
-		catch (IOException e) {
-			throw new IOException("Cannot get library with hash " + key, e);
-		}
-	}
-	
-	private void unregisterReferenceToBlobKey(BlobKey key) {
-		Integer references = blobKeyReferenceCounters.get(key);
-		if (references != null) {
-			int newReferences = Math.max(references - 1, 0);
-			blobKeyReferenceCounters.put(key, newReferences);
-		}
-		else {
-			// make sure we have an entry in any case, that the cleanup timer removes any
-			// present libraries
-			blobKeyReferenceCounters.put(key, 0);
-		}
+	/**
+	 * Returns the number of registered jobs that this library cache manager handles.
+	 *
+	 * @return number of jobs (irrespective of the actual number of tasks per job)
+	 */
+	int getNumberOfManagedJobs() {
+		// no synchronisation necessary
+		return cacheEntries.size();
 	}
 
+	@Override
+	public void shutdown() {
+		synchronized (lockObject) {
+			for (LibraryCacheEntry entry : cacheEntries.values()) {
+				entry.releaseClassLoader();
+			}
+		}
+	}
 
 	// --------------------------------------------------------------------------------------------
 
 	/**
 	 * An entry in the per-job library cache. Tracks which execution attempts
 	 * still reference the libraries. Once none reference it any more, the
-	 * libraries can be cleaned up.
+	 * class loaders can be cleaned up.
 	 */
 	private static class LibraryCacheEntry {
-		
+
 		private final FlinkUserCodeClassLoader classLoader;
-		
+
 		private final Set<ExecutionAttemptID> referenceHolders;
-		
+
 		private final Set<BlobKey> libraries;
-		
-		
-		public LibraryCacheEntry(Collection<BlobKey> libraries, URL[] libraryURLs, ExecutionAttemptID initialReference) {
+
+		private final Set<URL> classPaths;
+
+		LibraryCacheEntry(
+				Collection<BlobKey> requiredLibraries,
+				Collection<URL> requiredClasspaths,
+				URL[] libraryURLs,
+				ExecutionAttemptID initialReference) {
+
 			this.classLoader = new FlinkUserCodeClassLoader(libraryURLs);
-			this.libraries = new HashSet<>(libraries);
+			this.classPaths= new HashSet<>(requiredClasspaths);
+			this.libraries = new HashSet<>(requiredLibraries);
 			this.referenceHolders = new HashSet<>();
 			this.referenceHolders.add(initialReference);
 		}
-		
-		
+
+
 		public ClassLoader getClassLoader() {
 			return classLoader;
 		}
-		
+
 		public Set<BlobKey> getLibraries() {
 			return libraries;
 		}
-		
-		public void register(ExecutionAttemptID task, Collection<BlobKey> keys) {
-			if (!libraries.containsAll(keys)) {
+
+		public void register(
+			ExecutionAttemptID task, Collection<BlobKey> requiredLibraries, Collection<URL> requiredClasspaths) {
+			if (libraries.size() != requiredLibraries.size() || !libraries.containsAll(requiredLibraries)) {
 				throw new IllegalStateException(
-						"The library registration references a different set of libraries than previous registrations for this job.");
+					"The library registration references a different set of library BLOBs than " +
+						" previous registrations for this job:\nold:" + libraries.toString() +
+						"\nnew:" + requiredLibraries.toString());
 			}
-			
+			if (classPaths.size() != requiredClasspaths.size() || !classPaths.containsAll(requiredClasspaths)) {
+				throw new IllegalStateException(
+					"The library registration references a different set of library BLOBs than " +
+						" previous registrations for this job:\nold:" + classPaths.toString() +
+						"\nnew:" + requiredClasspaths.toString());
+			}
+
 			this.referenceHolders.add(task);
 		}
-		
+
 		public boolean unregister(ExecutionAttemptID task) {
 			referenceHolders.remove(task);
 			return referenceHolders.isEmpty();
 		}
-		
-		public int getNumberOfReferenceHolders() {
+
+		int getNumberOfReferenceHolders() {
 			return referenceHolders.size();
 		}
 
@@ -343,5 +270,4 @@ public final class BlobLibraryCacheManager extends TimerTask implements LibraryC
 			}
 		}
 	}
-
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FallbackLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FallbackLibraryCacheManager.java
@@ -28,7 +28,7 @@ import java.net.URL;
 import java.util.Collection;
 
 public class FallbackLibraryCacheManager implements LibraryCacheManager {
-	
+
 	private static Logger LOG = LoggerFactory.getLogger(FallbackLibraryCacheManager.class);
 
 	@Override
@@ -40,10 +40,10 @@ public class FallbackLibraryCacheManager implements LibraryCacheManager {
 	public void registerJob(JobID id, Collection<BlobKey> requiredJarFiles, Collection<URL> requiredClasspaths) {
 		LOG.warn("FallbackLibraryCacheManager cannot download files associated with blob keys.");
 	}
-	
+
 	@Override
 	public void registerTask(JobID id, ExecutionAttemptID execution, Collection<BlobKey> requiredJarFiles,
-			Collection<URL> requiredClasspaths) {
+		Collection<URL> requiredClasspaths) {
 		LOG.warn("FallbackLibraryCacheManager cannot download files associated with blob keys.");
 	}
 
@@ -51,7 +51,7 @@ public class FallbackLibraryCacheManager implements LibraryCacheManager {
 	public void unregisterJob(JobID id) {
 		LOG.warn("FallbackLibraryCacheManager does not book keeping of job IDs.");
 	}
-	
+
 	@Override
 	public void unregisterTask(JobID id, ExecutionAttemptID execution) {
 		LOG.warn("FallbackLibraryCacheManager does not book keeping of job IDs.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
@@ -19,14 +19,15 @@
 package org.apache.flink.runtime.execution.librarycache;
 
 import org.apache.flink.runtime.blob.BlobKey;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 
 import java.io.IOException;
 import java.net.URL;
 import java.util.Collection;
 
 public interface LibraryCacheManager {
+
 	/**
 	 * Returns the user code class loader associated with id.
 	 *
@@ -36,30 +37,34 @@ public interface LibraryCacheManager {
 	ClassLoader getClassLoader(JobID id);
 
 	/**
-	 * Registers a job with its required jar files and classpaths. The jar files are identified by their blob keys.
+	 * Registers a job with its required jar files and classpaths. The jar files are identified by
+	 * their blob keys and downloaded for use by a {@link ClassLoader}.
 	 *
 	 * @param id job ID
 	 * @param requiredJarFiles collection of blob keys identifying the required jar files
 	 * @param requiredClasspaths collection of classpaths that are added to the user code class loader
+	 *
 	 * @throws IOException if any error occurs when retrieving the required jar files
 	 *
 	 * @see #unregisterJob(JobID) counterpart of this method
 	 */
 	void registerJob(JobID id, Collection<BlobKey> requiredJarFiles, Collection<URL> requiredClasspaths)
-			throws IOException;
-	
+		throws IOException;
+
 	/**
-	 * Registers a job task execution with its required jar files and classpaths. The jar files are identified by their blob keys.
+	 * Registers a job task execution with its required jar files and classpaths. The jar files are
+	 * identified by their blob keys and downloaded for use by a {@link ClassLoader}.
 	 *
 	 * @param id job ID
 	 * @param requiredJarFiles collection of blob keys identifying the required jar files
 	 * @param requiredClasspaths collection of classpaths that are added to the user code class loader
-	 * @throws IOException
+	 *
+	 * @throws IOException if any error occurs when retrieving the required jar files
 	 *
 	 * @see #unregisterTask(JobID, ExecutionAttemptID) counterpart of this method
 	 */
 	void registerTask(JobID id, ExecutionAttemptID execution, Collection<BlobKey> requiredJarFiles,
-			Collection<URL> requiredClasspaths) throws IOException;
+		Collection<URL> requiredClasspaths) throws IOException;
 
 	/**
 	 * Unregisters a job task execution from the library cache manager.
@@ -88,9 +93,7 @@ public interface LibraryCacheManager {
 	void unregisterJob(JobID id);
 
 	/**
-	 * Shutdown method
-	 *
-	 * @throws IOException
+	 * Shutdown method which may release created class loaders.
 	 */
-	void shutdown() throws IOException;
+	void shutdown();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -536,7 +536,7 @@ public class JobGraph implements Serializable {
 			Configuration blobClientConfig) throws IOException {
 		if (!userJars.isEmpty()) {
 			// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
-			List<BlobKey> blobKeys = BlobClient.uploadJarFiles(blobServerAddress, blobClientConfig, userJars);
+			List<BlobKey> blobKeys = BlobClient.uploadJarFiles(blobServerAddress, blobClientConfig, jobID, userJars);
 
 			for (BlobKey blobKey : blobKeys) {
 				if (!userJarBlobKeys.contains(blobKey)) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.jobmaster;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobService;
+import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
@@ -93,7 +93,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			final Configuration configuration,
 			final RpcService rpcService,
 			final HighAvailabilityServices haServices,
-			final BlobService blobService,
+			final BlobServer blobService,
 			final HeartbeatServices heartbeatServices,
 			final OnCompletionActions toNotifyOnComplete,
 			final FatalErrorHandler errorHandler) throws Exception {
@@ -116,7 +116,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			final Configuration configuration,
 			final RpcService rpcService,
 			final HighAvailabilityServices haServices,
-			final BlobService blobService,
+			final BlobServer blobService,
 			final HeartbeatServices heartbeatServices,
 			final MetricRegistry metricRegistry,
 			final OnCompletionActions toNotifyOnComplete,
@@ -199,6 +199,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 				haServices,
 				heartbeatServices,
 				jobManagerServices.executorService,
+				jobManagerServices.blobServer,
 				jobManagerServices.libraryCacheManager,
 				jobManagerServices.restartStrategyFactory,
 				jobManagerServices.rpcAskTimeout,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerServices.java
@@ -19,11 +19,10 @@
 package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.blob.BlobService;
+import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
@@ -45,6 +44,7 @@ public class JobManagerServices {
 
 	public final ScheduledExecutorService executorService;
 
+	public final BlobServer blobServer;
 	public final BlobLibraryCacheManager libraryCacheManager;
 
 	public final RestartStrategyFactory restartStrategyFactory;
@@ -53,11 +53,13 @@ public class JobManagerServices {
 
 	public JobManagerServices(
 			ScheduledExecutorService executorService,
+			BlobServer blobServer,
 			BlobLibraryCacheManager libraryCacheManager,
 			RestartStrategyFactory restartStrategyFactory,
 			Time rpcAskTimeout) {
 
 		this.executorService = checkNotNull(executorService);
+		this.blobServer = checkNotNull(blobServer);
 		this.libraryCacheManager = checkNotNull(libraryCacheManager);
 		this.restartStrategyFactory = checkNotNull(restartStrategyFactory);
 		this.rpcAskTimeout = checkNotNull(rpcAskTimeout);
@@ -80,8 +82,9 @@ public class JobManagerServices {
 			firstException = t;
 		}
 
+		libraryCacheManager.shutdown();
 		try {
-			libraryCacheManager.shutdown();
+			blobServer.close();
 		}
 		catch (Throwable t) {
 			if (firstException == null) {
@@ -103,16 +106,12 @@ public class JobManagerServices {
 
 	public static JobManagerServices fromConfiguration(
 			Configuration config,
-			BlobService blobService) throws Exception {
+			BlobServer blobServer) throws Exception {
 
 		Preconditions.checkNotNull(config);
-		Preconditions.checkNotNull(blobService);
+		Preconditions.checkNotNull(blobServer);
 
-		final long cleanupInterval = config.getLong(
-			ConfigConstants.LIBRARY_CACHE_MANAGER_CLEANUP_INTERVAL,
-			ConfigConstants.DEFAULT_LIBRARY_CACHE_MANAGER_CLEANUP_INTERVAL) * 1000;
-
-		final BlobLibraryCacheManager libraryCacheManager = new BlobLibraryCacheManager(blobService, cleanupInterval);
+		final BlobLibraryCacheManager libraryCacheManager = new BlobLibraryCacheManager(blobServer);
 
 		final FiniteDuration timeout;
 		try {
@@ -127,6 +126,7 @@ public class JobManagerServices {
 
 		return new JobManagerServices(
 			futureExecutor,
+			blobServer,
 			libraryCacheManager,
 			RestartStrategyFactory.createRestartStrategyFactory(config),
 			Time.of(timeout.length(), timeout.unit()));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobManagerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobManagerConnection.java
@@ -67,15 +67,15 @@ public class JobManagerConnection {
 	private final PartitionProducerStateChecker partitionStateChecker;
 
 	public JobManagerConnection(
-			JobID jobID,
-			ResourceID resourceID,
-			JobMasterGateway jobMasterGateway,
-			UUID leaderId,
-			TaskManagerActions taskManagerActions,
-			CheckpointResponder checkpointResponder,
-			BlobCache blobCache, LibraryCacheManager libraryCacheManager,
-			ResultPartitionConsumableNotifier resultPartitionConsumableNotifier,
-			PartitionProducerStateChecker partitionStateChecker) {
+				JobID jobID,
+				ResourceID resourceID,
+				JobMasterGateway jobMasterGateway,
+				UUID leaderId,
+				TaskManagerActions taskManagerActions,
+				CheckpointResponder checkpointResponder,
+				BlobCache blobCache, LibraryCacheManager libraryCacheManager,
+				ResultPartitionConsumableNotifier resultPartitionConsumableNotifier,
+				PartitionProducerStateChecker partitionStateChecker) {
 		this.jobID = Preconditions.checkNotNull(jobID);
 		this.resourceID = Preconditions.checkNotNull(resourceID);
 		this.leaderId = Preconditions.checkNotNull(leaderId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobManagerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobManagerConnection.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.io.network.netty.PartitionProducerStateChecker;
@@ -53,6 +54,9 @@ public class JobManagerConnection {
 	// Checkpoint responder for the specific job manager
 	private final CheckpointResponder checkpointResponder;
 
+	// BLOB cache connected to the BLOB server at the specific job manager
+	private final BlobCache blobCache;
+
 	// Library cache manager connected to the specific job manager
 	private final LibraryCacheManager libraryCacheManager;
 
@@ -63,21 +67,22 @@ public class JobManagerConnection {
 	private final PartitionProducerStateChecker partitionStateChecker;
 
 	public JobManagerConnection(
-		JobID jobID,
-		ResourceID resourceID,
-		JobMasterGateway jobMasterGateway,
-		UUID leaderId,
-		TaskManagerActions taskManagerActions,
-		CheckpointResponder checkpointResponder,
-		LibraryCacheManager libraryCacheManager,
-		ResultPartitionConsumableNotifier resultPartitionConsumableNotifier,
-		PartitionProducerStateChecker partitionStateChecker) {
+			JobID jobID,
+			ResourceID resourceID,
+			JobMasterGateway jobMasterGateway,
+			UUID leaderId,
+			TaskManagerActions taskManagerActions,
+			CheckpointResponder checkpointResponder,
+			BlobCache blobCache, LibraryCacheManager libraryCacheManager,
+			ResultPartitionConsumableNotifier resultPartitionConsumableNotifier,
+			PartitionProducerStateChecker partitionStateChecker) {
 		this.jobID = Preconditions.checkNotNull(jobID);
 		this.resourceID = Preconditions.checkNotNull(resourceID);
 		this.leaderId = Preconditions.checkNotNull(leaderId);
 		this.jobMasterGateway = Preconditions.checkNotNull(jobMasterGateway);
 		this.taskManagerActions = Preconditions.checkNotNull(taskManagerActions);
 		this.checkpointResponder = Preconditions.checkNotNull(checkpointResponder);
+		this.blobCache = Preconditions.checkNotNull(blobCache);
 		this.libraryCacheManager = Preconditions.checkNotNull(libraryCacheManager);
 		this.resultPartitionConsumableNotifier = Preconditions.checkNotNull(resultPartitionConsumableNotifier);
 		this.partitionStateChecker = Preconditions.checkNotNull(partitionStateChecker);
@@ -109,6 +114,15 @@ public class JobManagerConnection {
 
 	public LibraryCacheManager getLibraryCacheManager() {
 		return libraryCacheManager;
+	}
+
+	/**
+	 * Gets the BLOB cache connected to the respective BLOB server instance at the job manager.
+	 *
+	 * @return BLOB cache
+	 */
+	public BlobCache getBlobCache() {
+		return blobCache;
 	}
 
 	public ResultPartitionConsumableNotifier getResultPartitionConsumableNotifier() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -53,8 +54,6 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 	private final Time maxRegistrationPause;
 	private final Time refusedRegistrationPause;
 
-	private final long cleanupInterval;
-
 	private final UnmodifiableConfiguration configuration;
 
 	private final boolean exitJvmOnOutOfMemory;
@@ -78,7 +77,6 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 		this.initialRegistrationPause = Preconditions.checkNotNull(initialRegistrationPause);
 		this.maxRegistrationPause = Preconditions.checkNotNull(maxRegistrationPause);
 		this.refusedRegistrationPause = Preconditions.checkNotNull(refusedRegistrationPause);
-		this.cleanupInterval = Preconditions.checkNotNull(cleanupInterval);
 		this.configuration = new UnmodifiableConfiguration(Preconditions.checkNotNull(configuration));
 		this.exitJvmOnOutOfMemory = exitJvmOnOutOfMemory;
 	}
@@ -105,10 +103,6 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 
 	public Time getRefusedRegistrationPause() {
 		return refusedRegistrationPause;
-	}
-
-	public long getCleanupInterval() {
-		return cleanupInterval;
 	}
 
 	@Override
@@ -153,9 +147,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 
 		LOG.info("Messages have a max timeout of " + timeout);
 
-		final long cleanupInterval = configuration.getLong(
-			ConfigConstants.LIBRARY_CACHE_MANAGER_CLEANUP_INTERVAL,
-			ConfigConstants.DEFAULT_LIBRARY_CACHE_MANAGER_CLEANUP_INTERVAL) * 1000;
+		final long cleanupInterval = configuration.getLong(BlobServerOptions.CLEANUP_INTERVAL) * 1000;
 
 		final Time finiteRegistrationDuration;
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/clusterframework/ContaineredJobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/clusterframework/ContaineredJobManager.scala
@@ -18,11 +18,12 @@
 
 package org.apache.flink.runtime.clusterframework
 
-import java.util.concurrent.{ScheduledExecutorService, Executor}
+import java.util.concurrent.{Executor, ScheduledExecutorService}
 
 import akka.actor.ActorRef
 import org.apache.flink.api.common.JobID
 import org.apache.flink.configuration.Configuration
+import org.apache.flink.runtime.blob.BlobServer
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory
 import org.apache.flink.runtime.clusterframework.messages._
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager
@@ -51,6 +52,7 @@ import scala.language.postfixOps
   * @param instanceManager Instance manager to manage the registered
   *                        [[org.apache.flink.runtime.taskmanager.TaskManager]]
   * @param scheduler Scheduler to schedule Flink jobs
+  * @param blobServer Server instance to store BLOBs for the individual tasks
   * @param libraryCacheManager Manager to manage uploaded jar files
   * @param archive Archive for finished Flink jobs
   * @param restartStrategyFactory Restart strategy to be used in case of a job recovery
@@ -63,6 +65,7 @@ abstract class ContaineredJobManager(
     ioExecutor: Executor,
     instanceManager: InstanceManager,
     scheduler: FlinkScheduler,
+    blobServer: BlobServer,
     libraryCacheManager: BlobLibraryCacheManager,
     archive: ActorRef,
     restartStrategyFactory: RestartStrategyFactory,
@@ -78,6 +81,7 @@ abstract class ContaineredJobManager(
     ioExecutor,
     instanceManager,
     scheduler,
+    blobServer,
     libraryCacheManager,
     archive,
     restartStrategyFactory,

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.JobID
 import org.apache.flink.api.common.io.FileOutputFormat
 import org.apache.flink.configuration.{ConfigConstants, Configuration, JobManagerOptions, QueryableStateOptions, ResourceManagerOptions, TaskManagerOptions}
 import org.apache.flink.core.fs.Path
+import org.apache.flink.runtime.blob.BlobServer
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager
 import org.apache.flink.runtime.clusterframework.standalone.StandaloneResourceManager
@@ -133,6 +134,7 @@ class LocalFlinkMiniCluster(
 
     val (instanceManager,
     scheduler,
+    blobServer,
     libraryCacheManager,
     restartStrategyFactory,
     timeout,
@@ -164,6 +166,7 @@ class LocalFlinkMiniCluster(
         ioExecutor,
         instanceManager,
         scheduler,
+        blobServer,
         libraryCacheManager,
         archive,
         restartStrategyFactory,
@@ -279,6 +282,7 @@ class LocalFlinkMiniCluster(
       ioExecutor: Executor,
       instanceManager: InstanceManager,
       scheduler: Scheduler,
+      blobServer: BlobServer,
       libraryCacheManager: BlobLibraryCacheManager,
       archive: ActorRef,
       restartStrategyFactory: RestartStrategyFactory,
@@ -297,6 +301,7 @@ class LocalFlinkMiniCluster(
       ioExecutor,
       instanceManager,
       scheduler,
+      blobServer,
       libraryCacheManager,
       archive,
       restartStrategyFactory,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCleanupTest.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.TestLogger;
+
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,7 +42,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * A few tests for the deferred ref-counting based cleanup inside the {@link BlobCache}.
  */
-public class BlobCacheCleanupTest {
+public class BlobCacheCleanupTest extends TestLogger {
 
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -66,14 +68,15 @@ public class BlobCacheCleanupTest {
 
 			server = new BlobServer(config, new VoidBlobStore());
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
-			BlobClient bc = new BlobClient(serverAddress, config);
+
+			// upload blobs
+			try (BlobClient bc = new BlobClient(serverAddress, config)) {
+				keys.add(bc.put(jobId, buf));
+				buf[0] += 1;
+				keys.add(bc.put(jobId, buf));
+			}
+
 			cache = new BlobCache(serverAddress, config, new VoidBlobStore());
-
-			keys.add(bc.put(jobId, buf));
-			buf[0] += 1;
-			keys.add(bc.put(jobId, buf));
-
-			bc.close();
 
 			checkFileCountForJob(2, jobId, server);
 			checkFileCountForJob(0, jobId, cache);
@@ -163,14 +166,15 @@ public class BlobCacheCleanupTest {
 
 			server = new BlobServer(config, new VoidBlobStore());
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
-			BlobClient bc = new BlobClient(serverAddress, config);
+
+			// upload blobs
+			try (BlobClient bc = new BlobClient(serverAddress, config)) {
+				keys.add(bc.put(jobId, buf));
+				buf[0] += 1;
+				keys.add(bc.put(jobId, buf));
+			}
+
 			cache = new BlobCache(serverAddress, config, new VoidBlobStore());
-
-			keys.add(bc.put(jobId, buf));
-			buf[0] += 1;
-			keys.add(bc.put(jobId, buf));
-
-			bc.close();
 
 			checkFileCountForJob(2, jobId, server);
 			checkFileCountForJob(0, jobId, cache);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCleanupTest.java
@@ -1,0 +1,324 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * A few tests for the deferred ref-counting based cleanup inside the {@link BlobCache}.
+ */
+public class BlobCacheCleanupTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	/**
+	 * Tests that {@link BlobCache} cleans up after calling {@link BlobCache#releaseJob(JobID)}.
+	 */
+	@Test
+	public void testJobCleanup() throws IOException, InterruptedException {
+
+		JobID jobId = new JobID();
+		List<BlobKey> keys = new ArrayList<BlobKey>();
+		BlobServer server = null;
+		BlobCache cache = null;
+
+		final byte[] buf = new byte[128];
+
+		try {
+			Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+				temporaryFolder.newFolder().getAbsolutePath());
+			config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1L);
+
+			server = new BlobServer(config, new VoidBlobStore());
+			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
+			BlobClient bc = new BlobClient(serverAddress, config);
+			cache = new BlobCache(serverAddress, config, new VoidBlobStore());
+
+			keys.add(bc.put(jobId, buf));
+			buf[0] += 1;
+			keys.add(bc.put(jobId, buf));
+
+			bc.close();
+
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(0, jobId, cache);
+
+			// register once
+			cache.registerJob(jobId);
+
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(0, jobId, cache);
+
+			for (BlobKey key : keys) {
+				cache.getFile(jobId, key);
+			}
+
+			// register again (let's say, from another thread or so)
+			cache.registerJob(jobId);
+			for (BlobKey key : keys) {
+				cache.getFile(jobId, key);
+			}
+
+			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(2, jobId, cache);
+
+			// after releasing once, nothing should change
+			cache.releaseJob(jobId);
+
+			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(2, jobId, cache);
+
+			// after releasing the second time, the job is up for deferred cleanup
+			cache.releaseJob(jobId);
+
+			// because we cannot guarantee that there are not thread races in the build system, we
+			// loop for a certain while until the references disappear
+			{
+				long deadline = System.currentTimeMillis() + 30_000L;
+				do {
+					Thread.sleep(100);
+				}
+				while (checkFilesExist(jobId, keys, cache, false) != 0 &&
+					System.currentTimeMillis() < deadline);
+			}
+
+			// the blob cache should no longer contain the files
+			// this fails if we exited via a timeout
+			checkFileCountForJob(0, jobId, cache);
+			// server should be unaffected
+			checkFileCountForJob(2, jobId, server);
+		}
+		finally {
+			if (cache != null) {
+				cache.close();
+			}
+
+			if (server != null) {
+				server.close();
+			}
+			// now everything should be cleaned up
+			checkFileCountForJob(0, jobId, server);
+		}
+	}
+
+	/**
+	 * Tests that {@link BlobCache} cleans up after calling {@link BlobCache#releaseJob(JobID)}
+	 * but only after preserving the file for a bit longer.
+	 */
+	@Test
+	@Ignore("manual test due to stalling: ensures a BLOB is retained first and only deleted after the (long) timeout ")
+	public void testJobDeferredCleanup() throws IOException, InterruptedException {
+		// file should be deleted between 5 and 10s after last job release
+		long cleanupInterval = 5L;
+
+		JobID jobId = new JobID();
+		List<BlobKey> keys = new ArrayList<BlobKey>();
+		BlobServer server = null;
+		BlobCache cache = null;
+
+		final byte[] buf = new byte[128];
+
+		try {
+			Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+				temporaryFolder.newFolder().getAbsolutePath());
+			config.setLong(BlobServerOptions.CLEANUP_INTERVAL, cleanupInterval);
+
+			server = new BlobServer(config, new VoidBlobStore());
+			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
+			BlobClient bc = new BlobClient(serverAddress, config);
+			cache = new BlobCache(serverAddress, config, new VoidBlobStore());
+
+			keys.add(bc.put(jobId, buf));
+			buf[0] += 1;
+			keys.add(bc.put(jobId, buf));
+
+			bc.close();
+
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(0, jobId, cache);
+
+			// register once
+			cache.registerJob(jobId);
+
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(0, jobId, cache);
+
+			for (BlobKey key : keys) {
+				cache.getFile(jobId, key);
+			}
+
+			// register again (let's say, from another thread or so)
+			cache.registerJob(jobId);
+			for (BlobKey key : keys) {
+				cache.getFile(jobId, key);
+			}
+
+			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(2, jobId, cache);
+
+			// after releasing once, nothing should change
+			cache.releaseJob(jobId);
+
+			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(2, jobId, cache);
+
+			// after releasing the second time, the job is up for deferred cleanup
+			cache.releaseJob(jobId);
+
+			// files should still be accessible for now
+			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
+			checkFileCountForJob(2, jobId, cache);
+
+			Thread.sleep(cleanupInterval / 5);
+			// still accessible...
+			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
+			checkFileCountForJob(2, jobId, cache);
+
+			Thread.sleep((cleanupInterval * 4) / 5);
+
+			// files are up for cleanup now...wait for it:
+			// because we cannot guarantee that there are not thread races in the build system, we
+			// loop for a certain while until the references disappear
+			{
+				long deadline = System.currentTimeMillis() + 30_000L;
+				do {
+					Thread.sleep(100);
+				}
+				while (checkFilesExist(jobId, keys, cache, false) != 0 &&
+					System.currentTimeMillis() < deadline);
+			}
+
+			// the blob cache should no longer contain the files
+			// this fails if we exited via a timeout
+			checkFileCountForJob(0, jobId, cache);
+			// server should be unaffected
+			checkFileCountForJob(2, jobId, server);
+		}
+		finally {
+			if (cache != null) {
+				cache.close();
+			}
+
+			if (server != null) {
+				server.close();
+			}
+			// now everything should be cleaned up
+			checkFileCountForJob(0, jobId, server);
+		}
+	}
+
+	/**
+	 * Checks how many of the files given by blob keys are accessible.
+	 *
+	 * @param jobId
+	 * 		ID of a job
+	 * @param keys
+	 * 		blob keys to check
+	 * @param blobService
+	 * 		BLOB store to use
+	 * @param doThrow
+	 * 		whether exceptions should be ignored (<tt>false</tt>), or thrown (<tt>true</tt>)
+	 *
+	 * @return number of files we were able to retrieve via {@link BlobService#getFile}
+	 */
+	public static int checkFilesExist(
+		JobID jobId, Collection<BlobKey> keys, BlobService blobService, boolean doThrow)
+		throws IOException {
+
+		int numFiles = 0;
+
+		for (BlobKey key : keys) {
+			final File blobFile;
+			if (blobService instanceof BlobServer) {
+				BlobServer server = (BlobServer) blobService;
+				blobFile = server.getStorageLocation(jobId, key);
+			} else {
+				BlobCache cache = (BlobCache) blobService;
+				blobFile = cache.getStorageLocation(jobId, key);
+			}
+			if (blobFile.exists()) {
+				++numFiles;
+			} else if (doThrow) {
+				throw new IOException("File " + blobFile + " does not exist.");
+			}
+		}
+
+		return numFiles;
+	}
+
+	/**
+	 * Checks how many of the files given by blob keys are accessible.
+	 *
+	 * @param expectedCount
+	 * 		number of expected files in the blob service for the given job
+	 * @param jobId
+	 * 		ID of a job
+	 * @param blobService
+	 * 		BLOB store to use
+	 *
+	 * @return number of files we were able to retrieve via {@link BlobService#getFile}
+	 */
+	public static void checkFileCountForJob(
+		int expectedCount, JobID jobId, BlobService blobService)
+		throws IOException {
+
+		final File jobDir;
+		if (blobService instanceof BlobServer) {
+			BlobServer server = (BlobServer) blobService;
+			jobDir = server.getStorageLocation(jobId, new BlobKey()).getParentFile();
+		} else {
+			BlobCache cache = (BlobCache) blobService;
+			jobDir = cache.getStorageLocation(jobId, new BlobKey()).getParentFile();
+		}
+		File[] blobsForJob = jobDir.listFiles();
+		if (blobsForJob == null) {
+			if (expectedCount != 0) {
+				throw new IOException("File " + jobDir + " does not exist.");
+			}
+		} else {
+			assertEquals("Too many/few files in job dir: " +
+					Arrays.asList(blobsForJob).toString(), expectedCount,
+				blobsForJob.length);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.util.TestLogger;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -37,7 +39,7 @@ import static org.junit.Assert.*;
 /**
  * Unit tests for the blob cache retrying the connection to the server.
  */
-public class BlobCacheRetriesTest {
+public class BlobCacheRetriesTest extends TestLogger {
 
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -39,6 +39,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.util.TestLogger;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -46,7 +48,7 @@ import static org.junit.Assert.fail;
 /**
  * This class contains unit tests for the {@link BlobClient}.
  */
-public class BlobClientTest {
+public class BlobClientTest extends TestLogger {
 
 	/** The buffer size used during the tests in bytes. */
 	private static final int TEST_BUFFER_SIZE = 17 * 1000;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -145,7 +145,7 @@ public class BlobClientTest {
 	 * @throws IOException
 	 *         thrown if an I/O error occurs while reading the input stream
 	 */
-	static void validateGet(final InputStream inputStream, final byte[] buf) throws IOException {
+	static void validateGetAndClose(final InputStream inputStream, final byte[] buf) throws IOException {
 		try {
 			byte[] receivedBuffer = new byte[buf.length];
 
@@ -182,7 +182,7 @@ public class BlobClientTest {
 	 * @throws IOException
 	 *         thrown if an I/O error occurs while reading the input stream or the file
 	 */
-	private static void validateGet(final InputStream inputStream, final File file) throws IOException {
+	private static void validateGetAndClose(final InputStream inputStream, final File file) throws IOException {
 
 		InputStream inputStream2 = null;
 		try {
@@ -237,8 +237,8 @@ public class BlobClientTest {
 			assertEquals(origKey, receivedKey);
 
 			// Retrieve the data
-			validateGet(client.get(receivedKey), testBuffer);
-			validateGet(client.get(jobId, receivedKey), testBuffer);
+			validateGetAndClose(client.get(receivedKey), testBuffer);
+			validateGetAndClose(client.get(jobId, receivedKey), testBuffer);
 
 			// Check reaction to invalid keys
 			try (InputStream ignored = client.get(new BlobKey())) {
@@ -310,8 +310,8 @@ public class BlobClientTest {
 			is = null;
 
 			// Retrieve the data
-			validateGet(client.get(receivedKey), testFile);
-			validateGet(client.get(jobId, receivedKey), testFile);
+			validateGetAndClose(client.get(receivedKey), testFile);
+			validateGetAndClose(client.get(jobId, receivedKey), testFile);
 		}
 		catch (Exception e) {
 			e.printStackTrace();
@@ -362,7 +362,7 @@ public class BlobClientTest {
 		assertEquals(1, blobKeys.size());
 
 		try (BlobClient blobClient = new BlobClient(serverAddress, blobClientConfig)) {
-			validateGet(blobClient.get(blobKeys.get(0)), testFile);
+			validateGetAndClose(blobClient.get(blobKeys.get(0)), testFile);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -214,7 +214,7 @@ public class BlobClientTest {
 	 * Tests the PUT/GET operations for content-addressable buffers.
 	 */
 	@Test
-	public void testContentAddressableBuffer() {
+	public void testContentAddressableBuffer() throws IOException {
 
 		BlobClient client = null;
 
@@ -256,10 +256,6 @@ public class BlobClientTest {
 				// expected
 			}
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
 		finally {
 			if (client != null) {
 				try {
@@ -281,7 +277,7 @@ public class BlobClientTest {
 	 * Tests the PUT/GET operations for content-addressable streams.
 	 */
 	@Test
-	public void testContentAddressableStream() {
+	public void testContentAddressableStream() throws IOException {
 
 		BlobClient client = null;
 		InputStream is = null;
@@ -313,10 +309,6 @@ public class BlobClientTest {
 			validateGetAndClose(client.get(receivedKey), testFile);
 			validateGetAndClose(client.get(jobId, receivedKey), testFile);
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
 		finally {
 			if (is != null) {
 				try {
@@ -332,7 +324,7 @@ public class BlobClientTest {
 	}
 
 	/**
-	 * Tests the static {@link BlobClient#uploadJarFiles(InetSocketAddress, Configuration, List)} helper.
+	 * Tests the static {@link BlobClient#uploadJarFiles(InetSocketAddress, Configuration, JobID, List)} helper.
 	 */
 	@Test
 	public void testUploadJarFilesHelper() throws Exception {
@@ -340,7 +332,7 @@ public class BlobClientTest {
 	}
 
 	/**
-	 * Tests the static {@link BlobClient#uploadJarFiles(InetSocketAddress, Configuration, List)} helper.
+	 * Tests the static {@link BlobClient#uploadJarFiles(InetSocketAddress, Configuration, JobID, List)}} helper.
 	 */
 	static void uploadJarFile(BlobServer blobServer, Configuration blobClientConfig) throws Exception {
 		final File testFile = File.createTempFile("testfile", ".dat");
@@ -354,15 +346,16 @@ public class BlobClientTest {
 	}
 
 	private static void uploadJarFile(
-		final InetSocketAddress serverAddress, final Configuration blobClientConfig,
-		final File testFile) throws IOException {
+			final InetSocketAddress serverAddress, final Configuration blobClientConfig,
+			final File testFile) throws IOException {
+		JobID jobId = new JobID();
 		List<BlobKey> blobKeys = BlobClient.uploadJarFiles(serverAddress, blobClientConfig,
-			Collections.singletonList(new Path(testFile.toURI())));
+			jobId, Collections.singletonList(new Path(testFile.toURI())));
 
 		assertEquals(1, blobKeys.size());
 
 		try (BlobClient blobClient = new BlobClient(serverAddress, blobClientConfig)) {
-			validateGetAndClose(blobClient.get(blobKeys.get(0)), testFile);
+			validateGetAndClose(blobClient.get(jobId, blobKeys.get(0)), testFile);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobKeyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobKeyTest.java
@@ -29,12 +29,14 @@ import java.io.IOException;
 
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.util.StringUtils;
+import org.apache.flink.util.TestLogger;
+
 import org.junit.Test;
 
 /**
  * This class contains unit tests for the {@link BlobKey} class.
  */
-public final class BlobKeyTest {
+public final class BlobKeyTest extends TestLogger {
 	/**
 	 * The first key array to be used during the unit tests.
 	 */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.apache.flink.runtime.blob.BlobClientTest.validateGetAndClose;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -113,7 +114,7 @@ public class BlobServerDeleteTest extends TestLogger {
 			try {
 				// NOTE: the server will stall in its send operation until either the data is fully
 				//       read or the socket is closed, e.g. via a client.close() call
-				BlobClientTest.validateGet(client.get(jobId, key1), data);
+				validateGetAndClose(client.get(jobId, key1), data);
 			}
 			catch (IOException e) {
 				fail("Deleting a job-unrelated BLOB should not affect a job-related BLOB with the same key");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -49,7 +49,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.apache.flink.runtime.blob.BlobClientTest.validateGet;
+import static org.apache.flink.runtime.blob.BlobClientTest.validateGetAndClose;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -123,7 +123,7 @@ public class BlobServerGetTest extends TestLogger {
 			assertNotNull(key);
 			assertEquals(key, key2);
 			// request for jobId2 should succeed
-			validateGet(getFileHelper(client, jobId2, key), data);
+			validateGetAndClose(getFileHelper(client, jobId2, key), data);
 			// request for jobId1 should still fail
 			client = verifyDeleted(client, jobId1, key, serverAddress, config);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.apache.flink.runtime.blob.BlobClientTest.validateGet;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -122,7 +123,7 @@ public class BlobServerGetTest extends TestLogger {
 			assertNotNull(key);
 			assertEquals(key, key2);
 			// request for jobId2 should succeed
-			getFileHelper(client, jobId2, key);
+			validateGet(getFileHelper(client, jobId2, key), data);
 			// request for jobId1 should still fail
 			client = verifyDeleted(client, jobId1, key, serverAddress, config);
 
@@ -160,8 +161,7 @@ public class BlobServerGetTest extends TestLogger {
 	private static BlobClient verifyDeleted(
 			BlobClient client, JobID jobId, BlobKey key,
 			InetSocketAddress serverAddress, Configuration config) throws IOException {
-		try {
-			getFileHelper(client, jobId, key);
+		try (InputStream ignored = getFileHelper(client, jobId, key)) {
 			fail("This should not succeed.");
 		} catch (IOException e) {
 			// expected
@@ -227,6 +227,7 @@ public class BlobServerGetTest extends TestLogger {
 			catch (IOException e) {
 				// expected
 			}
+			is.close();
 		} finally {
 			if (client != null) {
 				client.close();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.apache.flink.runtime.blob.BlobClientTest.validateGetAndClose;
 import static org.apache.flink.runtime.blob.BlobServerGetTest.getFileHelper;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -255,7 +256,7 @@ public class BlobServerPutTest extends TestLogger {
 			client.close();
 			client = new BlobClient(serverAddress, config);
 
-			BlobClientTest.validateGet(getFileHelper(client, jobId, key1), data);
+			validateGetAndClose(getFileHelper(client, jobId, key1), data);
 		} finally {
 			client.close();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -47,7 +47,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.apache.flink.runtime.blob.BlobServerGetTest.getFileHelper;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -226,9 +225,9 @@ public class BlobServerPutTest extends TestLogger {
 	 * @param jobId
 	 * 		job ID or <tt>null</tt> if job-unrelated
 	 * @param key1
-	 * 		first key
+	 * 		first key for 44 bytes starting at byte 10 of data in the BLOB
 	 * @param key2
-	 * 		second key
+	 * 		second key for the complete data in the BLOB
 	 * @param data
 	 * 		expected data
 	 * @param serverAddress
@@ -241,12 +240,9 @@ public class BlobServerPutTest extends TestLogger {
 			InetSocketAddress serverAddress, Configuration config) throws IOException {
 
 		BlobClient client = new BlobClient(serverAddress, config);
-		InputStream is1 = null;
-		InputStream is2 = null;
 
-		try {
-			// one get request on the same client
-			is1 = getFileHelper(client, jobId, key2);
+		// one get request on the same client
+		try (InputStream is1 = getFileHelper(client, jobId, key2)) {
 			byte[] result1 = new byte[44];
 			BlobUtils.readFully(is1, result1, 0, result1.length, null);
 			is1.close();
@@ -255,20 +251,12 @@ public class BlobServerPutTest extends TestLogger {
 				assertEquals(data[j], result1[i]);
 			}
 
-			// close the client and create a new one for the remaining requests
+			// close the client and create a new one for the remaining request
 			client.close();
 			client = new BlobClient(serverAddress, config);
 
-			is2 = getFileHelper(client, jobId, key1);
-			BlobClientTest.validateGet(is2, data);
-			is2.close();
+			BlobClientTest.validateGet(getFileHelper(client, jobId, key1), data);
 		} finally {
-			if (is1 != null) {
-				is1.close();
-			}
-			if (is2 != null) {
-				is1.close();
-			}
 			client.close();
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.blob;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
 import org.junit.Before;
@@ -34,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 
-public class BlobUtilsTest {
+public class BlobUtilsTest extends TestLogger {
 
 	private final static String CANNOT_CREATE_THIS = "cannot-create-this";
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CoordinatorShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CoordinatorShutdownTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 
+import org.apache.flink.runtime.testtasks.FailingBlockingInvokable;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
@@ -190,26 +191,4 @@ public class CoordinatorShutdownTest extends TestLogger {
 		}
 	}
 
-	public static class FailingBlockingInvokable extends AbstractInvokable {
-		private static boolean blocking = true;
-		private static final Object lock = new Object();
-
-		@Override
-		public void invoke() throws Exception {
-			while (blocking) {
-				synchronized (lock) {
-					lock.wait();
-				}
-			}
-			throw new RuntimeException("This exception is expected.");
-		}
-
-		public static void unblock() {
-			blocking = false;
-
-			synchronized (lock) {
-				lock.notifyAll();
-			}
-		}
-	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
-import org.apache.flink.runtime.blob.BlobService;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -137,7 +136,7 @@ public class DispatcherTest extends TestLogger {
 				Configuration configuration,
 				RpcService rpcService,
 				HighAvailabilityServices highAvailabilityServices,
-				BlobService blobService,
+				BlobServer blobServer,
 				HeartbeatServices heartbeatServices,
 				MetricRegistry metricRegistry,
 				OnCompletionActions onCompleteActions,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -18,32 +18,39 @@
 
 package org.apache.flink.runtime.execution.librarycache;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobClient;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.BlobServer;
-import org.apache.flink.runtime.blob.BlobService;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.util.OperatingSystem;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+
+import static org.apache.flink.runtime.blob.BlobCacheCleanupTest.checkFileCountForJob;
+import static org.apache.flink.runtime.blob.BlobCacheCleanupTest.checkFilesExist;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 public class BlobLibraryCacheManagerTest {
 
@@ -57,10 +64,13 @@ public class BlobLibraryCacheManagerTest {
 	@Test
 	public void testLibraryCacheManagerJobCleanup() throws IOException, InterruptedException {
 
-		JobID jid = new JobID();
-		List<BlobKey> keys = new ArrayList<BlobKey>();
+		JobID jobId1 = new JobID();
+		JobID jobId2 = new JobID();
+		List<BlobKey> keys1 = new ArrayList<>();
+		List<BlobKey> keys2 = new ArrayList<>();
 		BlobServer server = null;
-		BlobLibraryCacheManager libraryCacheManager = null;
+		BlobCache cache = null;
+		BlobLibraryCacheManager libCache = null;
 
 		final byte[] buf = new byte[128];
 
@@ -68,122 +78,116 @@ public class BlobLibraryCacheManagerTest {
 			Configuration config = new Configuration();
 			config.setString(BlobServerOptions.STORAGE_DIRECTORY,
 				temporaryFolder.newFolder().getAbsolutePath());
+			config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1L);
 
 			server = new BlobServer(config, new VoidBlobStore());
-			InetSocketAddress blobSocketAddress = new InetSocketAddress(server.getPort());
-			BlobClient bc = new BlobClient(blobSocketAddress, config);
+			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
+			BlobClient bc = new BlobClient(serverAddress, config);
+			cache = new BlobCache(serverAddress, config, new VoidBlobStore());
 
-			// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
-			JobID jobId = null;
-
-			keys.add(bc.put(jobId, buf));
+			keys1.add(bc.put(jobId1, buf));
 			buf[0] += 1;
-			keys.add(bc.put(jobId, buf));
+			keys1.add(bc.put(jobId1, buf));
+			keys2.add(bc.put(jobId2, buf));
 
 			bc.close();
 
-			long cleanupInterval = 1000L;
-			libraryCacheManager = new BlobLibraryCacheManager(server, cleanupInterval);
-			libraryCacheManager.registerJob(jid, keys, Collections.<URL>emptyList());
+			libCache = new BlobLibraryCacheManager(cache);
+			cache.registerJob(jobId1);
+			cache.registerJob(jobId2);
 
-			assertEquals(2, checkFilesExist(jobId, keys, server, true));
-			assertEquals(2, libraryCacheManager.getNumberOfCachedLibraries());
-			assertEquals(1, libraryCacheManager.getNumberOfReferenceHolders(jid));
+			assertEquals(0, libCache.getNumberOfManagedJobs());
+			assertEquals(0, libCache.getNumberOfReferenceHolders(jobId1));
+			checkFileCountForJob(2, jobId1, server);
+			checkFileCountForJob(0, jobId1, cache);
+			checkFileCountForJob(1, jobId2, server);
+			checkFileCountForJob(0, jobId2, cache);
 
-			libraryCacheManager.unregisterJob(jid);
+			libCache.registerJob(jobId1, keys1, Collections.<URL>emptyList());
+			ClassLoader classLoader1 = libCache.getClassLoader(jobId1);
 
-			// because we cannot guarantee that there are not thread races in the build system, we
-			// loop for a certain while until the references disappear
-			{
-				long deadline = System.currentTimeMillis() + 30000;
-				do {
-					Thread.sleep(500);
-				}
-				while (libraryCacheManager.getNumberOfCachedLibraries() > 0 &&
-					System.currentTimeMillis() < deadline);
-			}
+			assertEquals(1, libCache.getNumberOfManagedJobs());
+			assertEquals(1, libCache.getNumberOfReferenceHolders(jobId1));
+			assertEquals(0, libCache.getNumberOfReferenceHolders(jobId2));
+			assertEquals(2, checkFilesExist(jobId1, keys1, cache, true));
+			checkFileCountForJob(2, jobId1, server);
+			checkFileCountForJob(2, jobId1, cache);
+			assertEquals(0, checkFilesExist(jobId2, keys2, cache, false));
+			checkFileCountForJob(1, jobId2, server);
+			checkFileCountForJob(0, jobId2, cache);
 
-			// this fails if we exited via a timeout
-			assertEquals(0, libraryCacheManager.getNumberOfCachedLibraries());
-			assertEquals(0, libraryCacheManager.getNumberOfReferenceHolders(jid));
-
-			// the blob cache should no longer contain the files
-			assertEquals(0, checkFilesExist(jobId, keys, server, false));
+			libCache.registerJob(jobId2, keys2, Collections.<URL>emptyList());
+			ClassLoader classLoader2 = libCache.getClassLoader(jobId2);
+			assertNotEquals(classLoader1, classLoader2);
 
 			try {
-				if (jobId == null) {
-					server.getFile(keys.get(0));
-				} else {
-					server.getFile(jobId, keys.get(0));
-				}
-				fail("BLOB should have been deleted");
-			} catch (IOException e) {
-				// expected
+				libCache.registerJob(jobId2, keys1, Collections.<URL>emptyList());
+				fail("Should fail with an IllegalStateException");
 			}
+			catch (IllegalStateException e) {
+				// that's what we want
+			}
+
 			try {
-				if (jobId == null) {
-					server.getFile(keys.get(1));
-				} else {
-					server.getFile(jobId, keys.get(1));
-				}
-				fail("BLOB should have been deleted");
-			} catch (IOException e) {
-				// expected
+				libCache.registerJob(
+					jobId2, keys2,
+					Collections.singletonList(new URL("file:///tmp/does-not-exist")));
+				fail("Should fail with an IllegalStateException");
 			}
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
+			catch (IllegalStateException e) {
+				// that's what we want
+			}
+
+			assertEquals(2, libCache.getNumberOfManagedJobs());
+			assertEquals(1, libCache.getNumberOfReferenceHolders(jobId1));
+			assertEquals(1, libCache.getNumberOfReferenceHolders(jobId2));
+			assertEquals(2, checkFilesExist(jobId1, keys1, cache, true));
+			checkFileCountForJob(2, jobId1, server);
+			checkFileCountForJob(2, jobId1, cache);
+			assertEquals(1, checkFilesExist(jobId2, keys2, cache, true));
+			checkFileCountForJob(1, jobId2, server);
+			checkFileCountForJob(1, jobId2, cache);
+
+			libCache.unregisterJob(jobId1);
+
+			assertEquals(1, libCache.getNumberOfManagedJobs());
+			assertEquals(0, libCache.getNumberOfReferenceHolders(jobId1));
+			assertEquals(1, libCache.getNumberOfReferenceHolders(jobId2));
+			assertEquals(2, checkFilesExist(jobId1, keys1, cache, true));
+			checkFileCountForJob(2, jobId1, server);
+			checkFileCountForJob(2, jobId1, cache);
+			assertEquals(1, checkFilesExist(jobId2, keys2, cache, true));
+			checkFileCountForJob(1, jobId2, server);
+			checkFileCountForJob(1, jobId2, cache);
+
+			libCache.unregisterJob(jobId2);
+
+			assertEquals(0, libCache.getNumberOfManagedJobs());
+			assertEquals(0, libCache.getNumberOfReferenceHolders(jobId1));
+			assertEquals(0, libCache.getNumberOfReferenceHolders(jobId2));
+			assertEquals(2, checkFilesExist(jobId1, keys1, cache, true));
+			checkFileCountForJob(2, jobId1, server);
+			checkFileCountForJob(2, jobId1, cache);
+			assertEquals(1, checkFilesExist(jobId2, keys2, cache, true));
+			checkFileCountForJob(1, jobId2, server);
+			checkFileCountForJob(1, jobId2, cache);
+
+			// only BlobCache#releaseJob() calls clean up files (tested in BlobCacheCleanupTest etc.
 		}
 		finally {
+			if (libCache != null) {
+				libCache.shutdown();
+			}
+
+			// should have been closed by the libraryCacheManager, but just in case
+			if (cache != null) {
+				cache.close();
+			}
+
 			if (server != null) {
 				server.close();
 			}
-
-			if (libraryCacheManager != null) {
-				try {
-					libraryCacheManager.shutdown();
-				}
-				catch (IOException e) {
-					e.printStackTrace();
-				}
-			}
 		}
-	}
-
-	/**
-	 * Checks how many of the files given by blob keys are accessible.
-	 *
-	 * @param keys
-	 * 		blob keys to check
-	 * @param blobService
-	 * 		BLOB store to use
-	 * @param doThrow
-	 * 		whether exceptions should be ignored (<tt>false</tt>), or throws (<tt>true</tt>)
-	 *
-	 * @return number of files we were able to retrieve via {@link BlobService#getFile}
-	 */
-	private static int checkFilesExist(
-			JobID jobId, List<BlobKey> keys, BlobService blobService, boolean doThrow)
-			throws IOException {
-		int numFiles = 0;
-
-		for (BlobKey key : keys) {
-			try {
-				if (jobId == null) {
-					blobService.getFile(key);
-				} else {
-					blobService.getFile(jobId, key);
-				}
-				++numFiles;
-			} catch (IOException e) {
-				if (doThrow) {
-					throw e;
-				}
-			}
-		}
-
-		return numFiles;
 	}
 
 	/**
@@ -193,12 +197,13 @@ public class BlobLibraryCacheManagerTest {
 	@Test
 	public void testLibraryCacheManagerTaskCleanup() throws IOException, InterruptedException {
 
-		JobID jid = new JobID();
-		ExecutionAttemptID executionId1 = new ExecutionAttemptID();
-		ExecutionAttemptID executionId2 = new ExecutionAttemptID();
-		List<BlobKey> keys = new ArrayList<BlobKey>();
+		JobID jobId = new JobID();
+		ExecutionAttemptID attempt1 = new ExecutionAttemptID();
+		ExecutionAttemptID attempt2 = new ExecutionAttemptID();
+		List<BlobKey> keys = new ArrayList<>();
 		BlobServer server = null;
-		BlobLibraryCacheManager libraryCacheManager = null;
+		BlobCache cache = null;
+		BlobLibraryCacheManager libCache = null;
 
 		final byte[] buf = new byte[128];
 
@@ -206,67 +211,210 @@ public class BlobLibraryCacheManagerTest {
 			Configuration config = new Configuration();
 			config.setString(BlobServerOptions.STORAGE_DIRECTORY,
 				temporaryFolder.newFolder().getAbsolutePath());
+			config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1L);
 
 			server = new BlobServer(config, new VoidBlobStore());
-			InetSocketAddress blobSocketAddress = new InetSocketAddress(server.getPort());
-			BlobClient bc = new BlobClient(blobSocketAddress, config);
-
-			// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
-//			JobID jobId = new JobID();
-			JobID jobId = null;
+			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
+			BlobClient bc = new BlobClient(serverAddress, config);
+			cache = new BlobCache(serverAddress, config, new VoidBlobStore());
 
 			keys.add(bc.put(jobId, buf));
 			buf[0] += 1;
 			keys.add(bc.put(jobId, buf));
 
-			long cleanupInterval = 1000L;
-			libraryCacheManager = new BlobLibraryCacheManager(server, cleanupInterval);
-			libraryCacheManager.registerTask(jid, executionId1, keys, Collections.<URL>emptyList());
-			libraryCacheManager.registerTask(jid, executionId2, keys, Collections.<URL>emptyList());
+			bc.close();
 
-			assertEquals(2, checkFilesExist(jobId, keys, server, true));
-			assertEquals(2, libraryCacheManager.getNumberOfCachedLibraries());
-			assertEquals(2, libraryCacheManager.getNumberOfReferenceHolders(jid));
+			libCache = new BlobLibraryCacheManager(cache);
+			cache.registerJob(jobId);
 
-			libraryCacheManager.unregisterTask(jid, executionId1);
+			assertEquals(0, libCache.getNumberOfManagedJobs());
+			assertEquals(0, libCache.getNumberOfReferenceHolders(jobId));
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(0, jobId, cache);
 
-			assertEquals(2, checkFilesExist(jobId, keys, server, true));
-			assertEquals(2, libraryCacheManager.getNumberOfCachedLibraries());
-			assertEquals(1, libraryCacheManager.getNumberOfReferenceHolders(jid));
+			libCache.registerTask(jobId, attempt1, keys, Collections.<URL>emptyList());
+			ClassLoader classLoader1 = libCache.getClassLoader(jobId);
 
-			libraryCacheManager.unregisterTask(jid, executionId2);
+			assertEquals(1, libCache.getNumberOfManagedJobs());
+			assertEquals(1, libCache.getNumberOfReferenceHolders(jobId));
+			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(2, jobId, cache);
 
-			// because we cannot guarantee that there are not thread races in the build system, we
-			// loop for a certain while until the references disappear
-			{
-				long deadline = System.currentTimeMillis() + 30000;
-				do {
-					Thread.sleep(100);
-				}
-				while (libraryCacheManager.getNumberOfCachedLibraries() > 0 &&
-						System.currentTimeMillis() < deadline);
+			libCache.registerTask(jobId, attempt2, keys, Collections.<URL>emptyList());
+			ClassLoader classLoader2 = libCache.getClassLoader(jobId);
+			assertEquals(classLoader1, classLoader2);
+
+			try {
+				libCache.registerTask(
+					jobId, new ExecutionAttemptID(), Collections.<BlobKey>emptyList(),
+					Collections.<URL>emptyList());
+				fail("Should fail with an IllegalStateException");
+			}
+			catch (IllegalStateException e) {
+				// that's what we want
 			}
 
-			// this fails if we exited via a timeout
-			assertEquals(0, libraryCacheManager.getNumberOfCachedLibraries());
-			assertEquals(0, libraryCacheManager.getNumberOfReferenceHolders(jid));
+			try {
+				libCache.registerTask(
+					jobId, new ExecutionAttemptID(), keys,
+					Collections.singletonList(new URL("file:///tmp/does-not-exist")));
+				fail("Should fail with an IllegalStateException");
+			}
+			catch (IllegalStateException e) {
+				// that's what we want
+			}
 
-			// the blob cache should no longer contain the files
-			assertEquals(0, checkFilesExist(jobId, keys, server, false));
+			assertEquals(1, libCache.getNumberOfManagedJobs());
+			assertEquals(2, libCache.getNumberOfReferenceHolders(jobId));
+			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(2, jobId, cache);
 
-			bc.close();
-		} finally {
+			libCache.unregisterTask(jobId, attempt1);
+
+			assertEquals(1, libCache.getNumberOfManagedJobs());
+			assertEquals(1, libCache.getNumberOfReferenceHolders(jobId));
+			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(2, jobId, cache);
+
+			libCache.unregisterTask(jobId, attempt2);
+
+			assertEquals(0, libCache.getNumberOfManagedJobs());
+			assertEquals(0, libCache.getNumberOfReferenceHolders(jobId));
+			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(2, jobId, cache);
+
+			// only BlobCache#releaseJob() calls clean up files (tested in BlobCacheCleanupTest etc.
+		}
+		finally {
+			if (libCache != null) {
+				libCache.shutdown();
+			}
+
+			// should have been closed by the libraryCacheManager, but just in case
+			if (cache != null) {
+				cache.close();
+			}
+
 			if (server != null) {
 				server.close();
 			}
+		}
+	}
 
-			if (libraryCacheManager != null) {
-				try {
-					libraryCacheManager.shutdown();
-				}
-				catch (IOException e) {
-					e.printStackTrace();
-				}
+	/**
+	 * Tests that the {@link BlobLibraryCacheManager} cleans up after calling {@link
+	 * BlobLibraryCacheManager#unregisterTask(JobID, ExecutionAttemptID)}.
+	 */
+	@Test
+	public void testLibraryCacheManagerMixedJobTaskCleanup() throws IOException, InterruptedException {
+
+		JobID jobId = new JobID();
+		ExecutionAttemptID attempt1 = new ExecutionAttemptID();
+		List<BlobKey> keys = new ArrayList<>();
+		BlobServer server = null;
+		BlobCache cache = null;
+		BlobLibraryCacheManager libCache = null;
+
+		final byte[] buf = new byte[128];
+
+		try {
+			Configuration config = new Configuration();
+			config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+				temporaryFolder.newFolder().getAbsolutePath());
+			config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1L);
+
+			server = new BlobServer(config, new VoidBlobStore());
+			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
+			BlobClient bc = new BlobClient(serverAddress, config);
+			cache = new BlobCache(serverAddress, config, new VoidBlobStore());
+
+			keys.add(bc.put(jobId, buf));
+			buf[0] += 1;
+			keys.add(bc.put(jobId, buf));
+
+			bc.close();
+
+			libCache = new BlobLibraryCacheManager(cache);
+			cache.registerJob(jobId);
+
+			assertEquals(0, libCache.getNumberOfManagedJobs());
+			assertEquals(0, libCache.getNumberOfReferenceHolders(jobId));
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(0, jobId, cache);
+
+			libCache.registerJob(jobId, keys, Collections.<URL>emptyList());
+			ClassLoader classLoader1 = libCache.getClassLoader(jobId);
+
+			assertEquals(1, libCache.getNumberOfManagedJobs());
+			assertEquals(1, libCache.getNumberOfReferenceHolders(jobId));
+			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(2, jobId, cache);
+
+			libCache.registerTask(jobId, attempt1, keys, Collections.<URL>emptyList());
+			ClassLoader classLoader2 = libCache.getClassLoader(jobId);
+			assertEquals(classLoader1, classLoader2);
+
+			try {
+				libCache.registerTask(
+					jobId, new ExecutionAttemptID(), Collections.<BlobKey>emptyList(),
+					Collections.<URL>emptyList());
+				fail("Should fail with an IllegalStateException");
+			}
+			catch (IllegalStateException e) {
+				// that's what we want
+			}
+
+			try {
+				libCache.registerTask(
+					jobId, new ExecutionAttemptID(), keys,
+					Collections.singletonList(new URL("file:///tmp/does-not-exist")));
+				fail("Should fail with an IllegalStateException");
+			}
+			catch (IllegalStateException e) {
+				// that's what we want
+			}
+
+			assertEquals(1, libCache.getNumberOfManagedJobs());
+			assertEquals(2, libCache.getNumberOfReferenceHolders(jobId));
+			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(2, jobId, cache);
+
+			libCache.unregisterJob(jobId);
+
+			assertEquals(1, libCache.getNumberOfManagedJobs());
+			assertEquals(1, libCache.getNumberOfReferenceHolders(jobId));
+			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(2, jobId, cache);
+
+			libCache.unregisterTask(jobId, attempt1);
+
+			assertEquals(0, libCache.getNumberOfManagedJobs());
+			assertEquals(0, libCache.getNumberOfReferenceHolders(jobId));
+			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(2, jobId, cache);
+
+			// only BlobCache#releaseJob() calls clean up files (tested in BlobCacheCleanupTest etc.
+		}
+		finally {
+			if (libCache != null) {
+				libCache.shutdown();
+			}
+
+			// should have been closed by the libraryCacheManager, but just in case
+			if (cache != null) {
+				cache.close();
+			}
+
+			if (server != null) {
+				server.close();
 			}
 		}
 	}
@@ -275,21 +423,22 @@ public class BlobLibraryCacheManagerTest {
 	public void testRegisterAndDownload() throws IOException {
 		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
 
+		JobID jobId = new JobID();
 		BlobServer server = null;
 		BlobCache cache = null;
+		BlobLibraryCacheManager libCache = null;
 		File cacheDir = null;
 		try {
 			// create the blob transfer services
 			Configuration config = new Configuration();
 			config.setString(BlobServerOptions.STORAGE_DIRECTORY,
 				temporaryFolder.newFolder().getAbsolutePath());
+			config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1_000_000L);
+
 
 			server = new BlobServer(config, new VoidBlobStore());
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
 			cache = new BlobCache(serverAddress, config, new VoidBlobStore());
-
-			// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
-			JobID jobId = null;
 
 			// upload some meaningless data to the server
 			BlobClient uploader = new BlobClient(serverAddress, config);
@@ -297,53 +446,81 @@ public class BlobLibraryCacheManagerTest {
 			BlobKey dataKey2 = uploader.put(jobId, new byte[]{11, 12, 13, 14, 15, 16, 17, 18});
 			uploader.close();
 
-			BlobLibraryCacheManager libCache = new BlobLibraryCacheManager(cache, 1000000000L);
-
-			assertEquals(0, libCache.getNumberOfCachedLibraries());
+			libCache = new BlobLibraryCacheManager(cache);
+			assertEquals(0, libCache.getNumberOfManagedJobs());
+			checkFileCountForJob(2, jobId, server);
+			checkFileCountForJob(0, jobId, cache);
 
 			// first try to access a non-existing entry
+			assertEquals(0, libCache.getNumberOfReferenceHolders(new JobID()));
 			try {
 				libCache.getClassLoader(new JobID());
 				fail("Should fail with an IllegalStateException");
 			}
 			catch (IllegalStateException e) {
-				// that#s what we want
+				// that's what we want
 			}
 
-			// now register some BLOBs as libraries
+			// register some BLOBs as libraries
 			{
-				JobID jid = new JobID();
-				ExecutionAttemptID executionId = new ExecutionAttemptID();
 				Collection<BlobKey> keys = Collections.singleton(dataKey1);
 
-				libCache.registerTask(jid, executionId, keys, Collections.<URL>emptyList());
-				assertEquals(1, libCache.getNumberOfReferenceHolders(jid));
-				assertEquals(1, libCache.getNumberOfCachedLibraries());
-				assertNotNull(libCache.getClassLoader(jid));
+				cache.registerJob(jobId);
+				ExecutionAttemptID executionId = new ExecutionAttemptID();
+				libCache.registerTask(jobId, executionId, keys, Collections.<URL>emptyList());
+				ClassLoader classLoader1 = libCache.getClassLoader(jobId);
+				assertEquals(1, libCache.getNumberOfManagedJobs());
+				assertEquals(1, libCache.getNumberOfReferenceHolders(jobId));
+				assertEquals(1, checkFilesExist(jobId, keys, cache, true));
+				checkFileCountForJob(2, jobId, server);
+				checkFileCountForJob(1, jobId, cache);
+				assertNotNull(libCache.getClassLoader(jobId));
 
-				// un-register them again
-				libCache.unregisterTask(jid, executionId);
+				libCache.registerJob(jobId, keys, Collections.<URL>emptyList());
+				ClassLoader classLoader2 = libCache.getClassLoader(jobId);
+				assertEquals(classLoader1, classLoader2);
+				assertEquals(1, libCache.getNumberOfManagedJobs());
+				assertEquals(2, libCache.getNumberOfReferenceHolders(jobId));
+				assertEquals(1, checkFilesExist(jobId, keys, cache, true));
+				checkFileCountForJob(2, jobId, server);
+				checkFileCountForJob(1, jobId, cache);
+				assertNotNull(libCache.getClassLoader(jobId));
+
+				// un-register the job
+				libCache.unregisterJob(jobId);
+				// still one task
+				assertEquals(1, libCache.getNumberOfManagedJobs());
+				assertEquals(1, libCache.getNumberOfReferenceHolders(jobId));
+				assertEquals(1, checkFilesExist(jobId, keys, cache, true));
+				checkFileCountForJob(2, jobId, server);
+				checkFileCountForJob(1, jobId, cache);
+
+				// unregister the task registration
+				libCache.unregisterTask(jobId, executionId);
+				assertEquals(0, libCache.getNumberOfManagedJobs());
+				assertEquals(0, libCache.getNumberOfReferenceHolders(jobId));
+				// changing the libCache registration does not influence the BLOB stores...
+				checkFileCountForJob(2, jobId, server);
+				checkFileCountForJob(1, jobId, cache);
 
 				// Don't fail if called again
-				libCache.unregisterTask(jid, executionId);
+				libCache.unregisterJob(jobId);
+				assertEquals(0, libCache.getNumberOfManagedJobs());
+				assertEquals(0, libCache.getNumberOfReferenceHolders(jobId));
 
-				assertEquals(0, libCache.getNumberOfReferenceHolders(jid));
+				libCache.unregisterTask(jobId, executionId);
+				assertEquals(0, libCache.getNumberOfManagedJobs());
+				assertEquals(0, libCache.getNumberOfReferenceHolders(jobId));
+
+				cache.releaseJob(jobId);
 
 				// library is still cached (but not associated with job any more)
-				assertEquals(1, libCache.getNumberOfCachedLibraries());
-
-				// should not be able to access the classloader any more
-				try {
-					libCache.getClassLoader(jid);
-					fail("Should fail with an IllegalStateException");
-				}
-				catch (IllegalStateException e) {
-					// that's what we want
-				}
+				checkFileCountForJob(2, jobId, server);
+				checkFileCountForJob(1, jobId, cache);
 			}
 
 			// see BlobUtils for the directory layout
-			cacheDir = new File(cache.getStorageDir(), "no_job");
+			cacheDir = cache.getStorageLocation(jobId, new BlobKey()).getParentFile();
 			assertTrue(cacheDir.exists());
 
 			// make sure no further blobs can be downloaded by removing the write
@@ -352,12 +529,14 @@ public class BlobLibraryCacheManagerTest {
 
 			// since we cannot download this library any more, this call should fail
 			try {
-				libCache.registerTask(new JobID(), new ExecutionAttemptID(), Collections.singleton(dataKey2),
-						Collections.<URL>emptyList());
+				cache.registerJob(jobId);
+				libCache.registerTask(jobId, new ExecutionAttemptID(), Collections.singleton(dataKey2),
+					Collections.<URL>emptyList());
 				fail("This should fail with an IOException");
 			}
 			catch (IOException e) {
 				// splendid!
+				cache.releaseJob(jobId);
 			}
 		} finally {
 			if (cacheDir != null) {
@@ -367,6 +546,9 @@ public class BlobLibraryCacheManagerTest {
 			}
 			if (cache != null) {
 				cache.close();
+			}
+			if (libCache != null) {
+				libCache.shutdown();
 			}
 			if (server != null) {
 				server.close();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,7 +55,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  * Tests for {@link BlobLibraryCacheManager}.
  */
-public class BlobLibraryCacheManagerTest {
+public class BlobLibraryCacheManagerTest extends TestLogger {
 
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.execution.librarycache;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobClient;
@@ -29,6 +28,7 @@ import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.util.OperatingSystem;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -52,6 +51,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
+/**
+ * Tests for {@link BlobLibraryCacheManager}.
+ */
 public class BlobLibraryCacheManagerTest {
 
 	@Rule
@@ -434,7 +436,6 @@ public class BlobLibraryCacheManagerTest {
 			config.setString(BlobServerOptions.STORAGE_DIRECTORY,
 				temporaryFolder.newFolder().getAbsolutePath());
 			config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1_000_000L);
-
 
 			server = new BlobServer(config, new VoidBlobStore());
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.execution.librarycache;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -33,6 +32,7 @@ import org.apache.flink.runtime.blob.BlobUtils;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.util.TestLogger;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -50,6 +50,9 @@ import java.util.Random;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+/**
+ * Integration test for {@link BlobLibraryCacheManager}.
+ */
 public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 
 	@Rule
@@ -76,7 +79,6 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
 			temporaryFolder.newFolder().getAbsolutePath());
 		config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 3_600L);
-
 
 		try {
 			blobStoreService = BlobUtils.createBlobStoreFromConfig(config);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.execution.librarycache;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -65,7 +66,6 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 		InetSocketAddress[] serverAddress = new InetSocketAddress[2];
 		BlobLibraryCacheManager[] libServer = new BlobLibraryCacheManager[2];
 		BlobCache cache = null;
-		BlobLibraryCacheManager libCache = null;
 		BlobStoreService blobStoreService = null;
 
 		Configuration config = new Configuration();
@@ -75,6 +75,8 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
 			temporaryFolder.newFolder().getAbsolutePath());
+		config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 3_600L);
+
 
 		try {
 			blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
@@ -82,7 +84,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			for (int i = 0; i < server.length; i++) {
 				server[i] = new BlobServer(config, blobStoreService);
 				serverAddress[i] = new InetSocketAddress("localhost", server[i].getPort());
-				libServer[i] = new BlobLibraryCacheManager(server[i], 3600 * 1000);
+				libServer[i] = new BlobLibraryCacheManager(server[i]);
 			}
 
 			// Random data
@@ -92,25 +94,22 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			List<BlobKey> keys = new ArrayList<>(2);
 
 			JobID jobId = new JobID();
-			// TODO: replace+adapt by jobId after adapting the BlobLibraryCacheManager
-			JobID blobJobId = null;
 
 			// Upload some data (libraries)
 			try (BlobClient client = new BlobClient(serverAddress[0], config)) {
-				keys.add(client.put(blobJobId, expected)); // Request 1
-				keys.add(client.put(blobJobId, expected, 32, 256)); // Request 2
+				keys.add(client.put(jobId, expected)); // Request 1
+				keys.add(client.put(jobId, expected, 32, 256)); // Request 2
 			}
 
 			// The cache
 			cache = new BlobCache(serverAddress[0], config, blobStoreService);
-			libCache = new BlobLibraryCacheManager(cache, 3600 * 1000);
 
 			// Register uploaded libraries
 			ExecutionAttemptID executionId = new ExecutionAttemptID();
 			libServer[0].registerTask(jobId, executionId, keys, Collections.<URL>emptyList());
 
 			// Verify key 1
-			File f = cache.getFile(keys.get(0));
+			File f = cache.getFile(jobId, keys.get(0));
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -123,13 +122,11 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 
 			// Shutdown cache and start with other server
 			cache.close();
-			libCache.shutdown();
 
 			cache = new BlobCache(serverAddress[1], config, blobStoreService);
-			libCache = new BlobLibraryCacheManager(cache, 3600 * 1000);
 
 			// Verify key 1
-			f = cache.getFile(keys.get(0));
+			f = cache.getFile(jobId, keys.get(0));
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -141,7 +138,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			}
 
 			// Verify key 2
-			f = cache.getFile(keys.get(1));
+			f = cache.getFile(jobId, keys.get(1));
 			assertEquals(256, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -154,8 +151,8 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 
 			// Remove blobs again
 			try (BlobClient client = new BlobClient(serverAddress[1], config)) {
-				client.delete(keys.get(0));
-				client.delete(keys.get(1));
+				client.delete(jobId, keys.get(0));
+				client.delete(jobId, keys.get(1));
 			}
 
 			// Verify everything is clean below recoveryDir/<cluster_id>
@@ -167,6 +164,11 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			assertEquals("Unclean state backend: " + Arrays.toString(recoveryFiles), 0, recoveryFiles.length);
 		}
 		finally {
+			for (BlobLibraryCacheManager s : libServer) {
+				if (s != null) {
+					s.shutdown();
+				}
+			}
 			for (BlobServer s : server) {
 				if (s != null) {
 					s.close();
@@ -175,10 +177,6 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 
 			if (cache != null) {
 				cache.close();
-			}
-
-			if (libCache != null) {
-				libCache.shutdown();
 			}
 
 			if (blobStoreService != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerCleanupITCase.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager;
+
+import akka.actor.ActorSystem;
+import akka.testkit.JavaTestKit;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.akka.ListeningBehaviour;
+import org.apache.flink.runtime.blob.BlobClient;
+import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.instance.AkkaActorGateway;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.testingUtils.TestingCluster;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.testtasks.FailingBlockingInvokable;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+
+import static org.apache.flink.runtime.testingUtils.TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Small test to check that the {@link org.apache.flink.runtime.blob.BlobServer} cleanup is executed
+ * after job termination.
+ */
+public class JobManagerCleanupITCase {
+
+	@Rule
+	public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+	private static ActorSystem system;
+
+	@BeforeClass
+	public static void setup() {
+		system = AkkaUtils.createLocalActorSystem(new Configuration());
+	}
+
+	@AfterClass
+	public static void teardown() {
+		JavaTestKit.shutdownActorSystem(system);
+	}
+
+	/**
+	 * Specifies which test case to run in {@link #testBlobServerCleanup(TestCase)}.
+	 */
+	private enum TestCase {
+		JOB_FINISHES_SUCESSFULLY,
+		JOB_IS_CANCELLED,
+		JOB_FAILS,
+		JOB_SUBMISSION_FAILS
+	}
+
+	/**
+	 * Test cleanup for a job that finishes ordinarily.
+	 */
+	@Test
+	public void testBlobServerCleanupFinishedJob() throws IOException {
+		testBlobServerCleanup(TestCase.JOB_FINISHES_SUCESSFULLY);
+	}
+
+	/**
+	 * Test cleanup for a job which is cancelled after submission.
+	 */
+	@Test
+	public void testBlobServerCleanupCancelledJob() throws IOException {
+		testBlobServerCleanup(TestCase.JOB_IS_CANCELLED);
+	}
+
+	/**
+	 * Test cleanup for a job that fails (first a task fails, then the job recovers, then the whole
+	 * job fails due to a limited restart policy).
+	 */
+	@Test
+	public void testBlobServerCleanupFailedJob() throws IOException {
+		testBlobServerCleanup(TestCase.JOB_FAILS);
+	}
+
+	/**
+	 * Test cleanup for a job that fails job submission (emulated by an additional BLOB not being
+	 * present).
+	 */
+	@Test
+	public void testBlobServerCleanupFailedSubmission() throws IOException {
+		testBlobServerCleanup(TestCase.JOB_SUBMISSION_FAILS);
+	}
+
+	private void testBlobServerCleanup(final TestCase testCase) throws IOException {
+		final int num_tasks = 2;
+		final File blobBaseDir = tmpFolder.newFolder();
+
+		new JavaTestKit(system) {{
+			new Within(duration("30 seconds")) {
+				@Override
+				protected void run() {
+					// Setup
+
+					TestingCluster cluster = null;
+					BlobClient bc = null;
+
+					try {
+						Configuration config = new Configuration();
+						config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 2);
+						config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
+						config.setString(AkkaOptions.ASK_TIMEOUT, DEFAULT_AKKA_ASK_TIMEOUT());
+						config.setString(BlobServerOptions.STORAGE_DIRECTORY, blobBaseDir.getAbsolutePath());
+
+						config.setString(ConfigConstants.RESTART_STRATEGY, "fixeddelay");
+						config.setInteger(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
+						config.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "1 s");
+						// BLOBs are deleted from BlobCache between 1s and 2s after last reference
+						// -> the BlobCache may still have the BLOB or not (let's test both cases randomly)
+						config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1L);
+
+						cluster = new TestingCluster(config);
+						cluster.start();
+
+						final ActorGateway jobManagerGateway = cluster.getLeaderGateway(
+							TestingUtils.TESTING_DURATION());
+
+						// we can set the leader session ID to None because we don't use this gateway to send messages
+						final ActorGateway testActorGateway = new AkkaActorGateway(getTestActor(),
+							HighAvailabilityServices.DEFAULT_LEADER_ID);
+
+						// Create a task
+
+						JobVertex source = new JobVertex("Source");
+						if (testCase == TestCase.JOB_FAILS || testCase == TestCase.JOB_IS_CANCELLED) {
+							source.setInvokableClass(FailingBlockingInvokable.class);
+						} else {
+							source.setInvokableClass(NoOpInvokable.class);
+						}
+						source.setParallelism(num_tasks);
+
+						JobGraph jobGraph = new JobGraph("BlobCleanupTest", source);
+						final JobID jid = jobGraph.getJobID();
+
+						// request the blob port from the job manager
+						Future<Object> future = jobManagerGateway
+							.ask(JobManagerMessages.getRequestBlobManagerPort(), remaining());
+						int blobPort = (Integer) Await.result(future, remaining());
+
+						// upload a blob
+						BlobKey key1;
+						bc = new BlobClient(new InetSocketAddress("localhost", blobPort),
+							config);
+						try {
+							key1 = bc.put(jid, new byte[10]);
+						} finally {
+							bc.close();
+						}
+						jobGraph.addBlob(key1);
+
+						if (testCase == TestCase.JOB_SUBMISSION_FAILS) {
+							// add an invalid key so that the submission fails
+							jobGraph.addBlob(new BlobKey());
+						}
+
+						// Submit the job and wait for all vertices to be running
+						jobManagerGateway.tell(
+							new JobManagerMessages.SubmitJob(
+								jobGraph,
+								ListeningBehaviour.EXECUTION_RESULT),
+							testActorGateway);
+						if (testCase == TestCase.JOB_SUBMISSION_FAILS) {
+							expectMsgClass(JobManagerMessages.JobResultFailure.class);
+						} else {
+							expectMsgClass(JobManagerMessages.JobSubmitSuccess.class);
+
+							if (testCase == TestCase.JOB_FAILS) {
+								// fail a task so that the job is going to be recovered (we actually do not
+								// need the blocking part of the invokable and can start throwing right away)
+								FailingBlockingInvokable.unblock();
+
+								// job will get restarted, BlobCache may re-download the BLOB if already deleted
+								// then the tasks will fail again and the restart strategy will finalise the job
+
+								expectMsgClass(JobManagerMessages.JobResultFailure.class);
+							} else if (testCase == TestCase.JOB_IS_CANCELLED) {
+								jobManagerGateway.tell(
+									new JobManagerMessages.CancelJob(jid),
+									testActorGateway);
+								expectMsgClass(JobManagerMessages.CancellationResponse.class);
+
+								// job will be cancelled and everything should be cleaned up
+
+								expectMsgClass(JobManagerMessages.JobResultFailure.class);
+							} else {
+								expectMsgClass(JobManagerMessages.JobResultSuccess.class);
+							}
+						}
+
+						// both BlobServer and BlobCache should eventually delete all files
+
+						File[] blobDirs = blobBaseDir.listFiles(new FilenameFilter() {
+							@Override
+							public boolean accept(File dir, String name) {
+								return name.startsWith("blobStore-");
+							}
+						});
+						assertNotNull(blobDirs);
+						for (File blobDir : blobDirs) {
+							waitForEmptyBlobDir(blobDir, remaining());
+						}
+
+					} catch (Exception e) {
+						e.printStackTrace();
+						fail(e.getMessage());
+					} finally {
+						if (bc != null) {
+							try {
+								bc.close();
+							} catch (IOException ignored) {
+							}
+						}
+						if (cluster != null) {
+							cluster.shutdown();
+						}
+					}
+				}
+			};
+		}};
+
+		// after everything has been shut down, the storage directory itself should be empty
+		assertArrayEquals(new File[] {}, blobBaseDir.listFiles());
+	}
+
+	/**
+	 * Waits until the given {@link org.apache.flink.runtime.blob.BlobService} storage directory
+	 * does not contain any job-related folders any more.
+	 *
+	 * @param blobDir
+	 * 		directory of a {@link org.apache.flink.runtime.blob.BlobServer} or {@link
+	 * 		org.apache.flink.runtime.blob.BlobCache}
+	 * @param remaining
+	 * 		remaining time for this test
+	 *
+	 * @see org.apache.flink.runtime.blob.BlobUtils
+	 */
+	private static void waitForEmptyBlobDir(File blobDir, FiniteDuration remaining)
+		throws InterruptedException {
+		long deadline = System.currentTimeMillis() + remaining.toMillis();
+		String[] blobDirContents;
+		do {
+			blobDirContents = blobDir.list(new FilenameFilter() {
+				@Override
+				public boolean accept(File dir, String name) {
+					return name.startsWith("job_");
+				}
+			});
+			if (blobDirContents == null || blobDirContents.length == 0) {
+				return;
+			}
+			Thread.sleep(100);
+		} while (System.currentTimeMillis() < deadline);
+
+		fail("Timeout while waiting for " + blobDir.getAbsolutePath() + " to become empty. Current contents: " + Arrays.toString(blobDirContents));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerCleanupITCase.java
@@ -39,6 +39,8 @@ import org.apache.flink.runtime.testingUtils.TestingCluster;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.FailingBlockingInvokable;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.util.TestLogger;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -63,7 +65,7 @@ import static org.junit.Assert.fail;
  * Small test to check that the {@link org.apache.flink.runtime.blob.BlobServer} cleanup is executed
  * after job termination.
  */
-public class JobManagerCleanupITCase {
+public class JobManagerCleanupITCase extends TestLogger {
 
 	@Rule
 	public TemporaryFolder tmpFolder = new TemporaryFolder();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
@@ -137,14 +137,13 @@ public class JobSubmitTest {
 			// upload two dummy bytes and add their keys to the job graph as dependencies
 			BlobKey key1, key2;
 			BlobClient bc = new BlobClient(new InetSocketAddress("localhost", blobPort), jmConfig);
-			// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
-			JobID jobId = null;
+			JobID jobId = jg.getJobID();
 			try {
 				key1 = bc.put(jobId, new byte[10]);
 				key2 = bc.put(jobId, new byte[10]);
 
 				// delete one of the blobs to make sure that the startup failed
-				bc.delete(key2);
+				bc.delete(jobId, key2);
 			}
 			finally {
 				bc.close();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmaster;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
@@ -92,8 +93,8 @@ public class JobMasterTest extends TestLogger {
 
 		final ScheduledExecutor scheduledExecutor = mock(ScheduledExecutor.class);
 		final HeartbeatServices heartbeatServices = new TestingHeartbeatServices(heartbeatInterval, heartbeatTimeout, scheduledExecutor);
-		final BlobLibraryCacheManager libraryCacheManager = mock(BlobLibraryCacheManager.class);
-		when(libraryCacheManager.getBlobServerPort()).thenReturn(1337);
+		BlobServer blobServer = mock(BlobServer.class);
+		when(blobServer.getPort()).thenReturn(1337);
 
 		final JobGraph jobGraph = new JobGraph();
 
@@ -106,7 +107,8 @@ public class JobMasterTest extends TestLogger {
 				haServices,
 				heartbeatServices,
 				Executors.newScheduledThreadPool(1),
-				libraryCacheManager,
+				blobServer,
+				mock(BlobLibraryCacheManager.class),
 				mock(RestartStrategyFactory.class),
 				Time.of(10, TimeUnit.SECONDS),
 				null,
@@ -204,6 +206,7 @@ public class JobMasterTest extends TestLogger {
 				haServices,
 				heartbeatServices,
 				Executors.newScheduledThreadPool(1),
+				mock(BlobServer.class),
 				mock(BlobLibraryCacheManager.class),
 				mock(RestartStrategyFactory.class),
 				Time.of(10, TimeUnit.SECONDS),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
@@ -25,9 +25,10 @@ import akka.actor.Props;
 import akka.pattern.Patterns;
 import akka.testkit.JavaTestKit;
 import akka.util.Timeout;
-
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.test.TestingServer;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.BlobServer;
@@ -47,13 +48,11 @@ import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.TestLogger;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
 import scala.Option;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
@@ -178,6 +177,9 @@ public class JobManagerLeaderElectionTest extends TestLogger {
 		SubmittedJobGraphStore submittedJobGraphStore = new StandaloneSubmittedJobGraphStore();
 		CheckpointRecoveryFactory checkpointRecoveryFactory = new StandaloneCheckpointRecoveryFactory();
 
+		configuration.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1L);
+
+		BlobServer blobServer = new BlobServer(configuration, new VoidBlobStore());
 		return Props.create(
 			TestingJobManager.class,
 			configuration,
@@ -185,7 +187,8 @@ public class JobManagerLeaderElectionTest extends TestLogger {
 			TestingUtils.defaultExecutor(),
 			new InstanceManager(),
 			new Scheduler(TestingUtils.defaultExecutionContext()),
-			new BlobLibraryCacheManager(new BlobServer(configuration, new VoidBlobStore()), 10L),
+			blobServer,
+			new BlobLibraryCacheManager(blobServer),
 			ActorRef.noSender(),
 			new NoRestartStrategy.NoRestartStrategyFactory(),
 			AkkaUtils.getDefaultTimeoutAsFiniteDuration(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -668,7 +669,7 @@ public class TaskExecutorTest extends TestLogger {
 				Collections.<InputGateDeploymentDescriptor>emptyList());
 
 		final LibraryCacheManager libraryCacheManager = mock(LibraryCacheManager.class);
-		when(libraryCacheManager.getClassLoader(eq(jobId))).thenReturn(getClass().getClassLoader());
+		when(libraryCacheManager.getClassLoader(any(JobID.class))).thenReturn(ClassLoader.getSystemClassLoader());
 
 		final JobManagerConnection jobManagerConnection = new JobManagerConnection(
 			jobId,
@@ -677,6 +678,7 @@ public class TaskExecutorTest extends TestLogger {
 			jobManagerLeaderId,
 			mock(TaskManagerActions.class),
 			mock(CheckpointResponder.class),
+			mock(BlobCache.class),
 			libraryCacheManager,
 			mock(ResultPartitionConsumableNotifier.class),
 			mock(PartitionProducerStateChecker.class));
@@ -1191,6 +1193,7 @@ public class TaskExecutorTest extends TestLogger {
 			jobManagerLeaderId,
 			mock(TaskManagerActions.class),
 			mock(CheckpointResponder.class),
+			mock(BlobCache.class),
 			libraryCacheManager,
 			mock(ResultPartitionConsumableNotifier.class),
 			mock(PartitionProducerStateChecker.class));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
@@ -145,6 +146,7 @@ public class TaskAsyncCallTest {
 	}
 	
 	private static Task createTask() throws Exception {
+		BlobCache blobCache = mock(BlobCache.class);
 		LibraryCacheManager libCache = mock(LibraryCacheManager.class);
 		when(libCache.getClassLoader(any(JobID.class))).thenReturn(ClassLoader.getSystemClassLoader());
 		
@@ -195,6 +197,7 @@ public class TaskAsyncCallTest {
 			mock(TaskManagerActions.class),
 			mock(InputSplitProvider.class),
 			mock(CheckpointResponder.class),
+			blobCache,
 			libCache,
 			mock(FileCache.class),
 			new TestingTaskManagerRuntimeInfo(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskmanager;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -98,6 +99,7 @@ public class TaskStopTest {
 			mock(TaskManagerActions.class),
 			mock(InputSplitProvider.class),
 			mock(CheckpointResponder.class),
+			mock(BlobCache.class),
 			mock(LibraryCacheManager.class),
 			mock(FileCache.class),
 			tmRuntimeInfo,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testtasks/FailingBlockingInvokable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testtasks/FailingBlockingInvokable.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.testtasks;
+
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+
+/**
+ * Task which blocks until the (static) {@link #unblock()} method is called and then fails with an
+ * exception.
+ */
+public class FailingBlockingInvokable extends AbstractInvokable {
+	private static boolean blocking = true;
+	private static final Object lock = new Object();
+
+	@Override
+	public void invoke() throws Exception {
+		while (blocking) {
+			synchronized (lock) {
+				lock.wait();
+			}
+		}
+		throw new RuntimeException("This exception is expected.");
+	}
+
+	public static void unblock() {
+		blocking = false;
+
+		synchronized (lock) {
+			lock.notifyAll();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testtasks/FailingBlockingInvokable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testtasks/FailingBlockingInvokable.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
  * exception.
  */
 public class FailingBlockingInvokable extends AbstractInvokable {
-	private static boolean blocking = true;
+	private static volatile boolean blocking = true;
 	private static final Object lock = new Object();
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
@@ -178,6 +179,7 @@ public class JvmExitOnFatalErrorTest {
 						new NoOpTaskManagerActions(),
 						new NoOpInputSplitProvider(),
 						new NoOpCheckpointResponder(),
+						mock(BlobCache.class),
 						new FallbackLibraryCacheManager(),
 						new FileCache(tmInfo.getTmpDirectories()),
 						tmInfo,

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerRegistrationTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerRegistrationTest.scala
@@ -264,14 +264,15 @@ ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll with Befor
       components._1,
       components._2,
       components._3,
-      ActorRef.noSender,
       components._4,
+      ActorRef.noSender,
       components._5,
+      components._6,
       highAvailabilityServices.getJobManagerLeaderElectionService(
         HighAvailabilityServices.DEFAULT_JOB_ID),
       highAvailabilityServices.getSubmittedJobGraphStore(),
       highAvailabilityServices.getCheckpointRecoveryFactory(),
-      components._8,
+      components._9,
       None)
 
     _system.actorOf(props)

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
@@ -28,6 +28,7 @@ import akka.testkit.CallingThreadDispatcher
 import org.apache.flink.api.common.JobID
 import org.apache.flink.configuration.{Configuration, JobManagerOptions}
 import org.apache.flink.runtime.akka.AkkaUtils
+import org.apache.flink.runtime.blob.BlobServer
 import org.apache.flink.runtime.checkpoint.savepoint.Savepoint
 import org.apache.flink.runtime.checkpoint.{CheckpointOptions, CheckpointRecoveryFactory}
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager
@@ -110,6 +111,7 @@ class TestingCluster(
     ioExecutor: Executor,
     instanceManager: InstanceManager,
     scheduler: Scheduler,
+    blobServer: BlobServer,
     libraryCacheManager: BlobLibraryCacheManager,
     archive: ActorRef,
     restartStrategyFactory: RestartStrategyFactory,
@@ -127,6 +129,7 @@ class TestingCluster(
       ioExecutor,
       instanceManager,
       scheduler,
+      blobServer,
       libraryCacheManager,
       archive,
       restartStrategyFactory,

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManager.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.{Executor, ScheduledExecutorService}
 
 import akka.actor.ActorRef
 import org.apache.flink.configuration.Configuration
+import org.apache.flink.runtime.blob.BlobServer
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory
@@ -34,15 +35,16 @@ import org.apache.flink.runtime.metrics.MetricRegistry
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-/** JobManager implementation extended by testing messages
-  *
-  */
+/**
+ * JobManager implementation extended by testing messages
+ */
 class TestingJobManager(
     flinkConfiguration: Configuration,
     futureExecutor: ScheduledExecutorService,
     ioExecutor: Executor,
     instanceManager: InstanceManager,
     scheduler: Scheduler,
+    blobServer: BlobServer,
     libraryCacheManager: BlobLibraryCacheManager,
     archive: ActorRef,
     restartStrategyFactory: RestartStrategyFactory,
@@ -58,6 +60,7 @@ class TestingJobManager(
     ioExecutor,
     instanceManager,
     scheduler,
+    blobServer,
     libraryCacheManager,
     archive,
     restartStrategyFactory,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
@@ -156,6 +157,7 @@ public class BlockingCheckpointsTest {
 				mock(TaskManagerActions.class),
 				mock(InputSplitProvider.class),
 				mock(CheckpointResponder.class),
+				mock(BlobCache.class),
 				new FallbackLibraryCacheManager(),
 				new FileCache(new String[] { EnvironmentInformation.getTemporaryFileDirectory() }),
 				new TestingTaskManagerRuntimeInfo(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
@@ -274,6 +275,7 @@ public class InterruptSensitiveRestoreTest {
 			mock(TaskManagerActions.class),
 			mock(InputSplitProvider.class),
 			mock(CheckpointResponder.class),
+			mock(BlobCache.class),
 			new FallbackLibraryCacheManager(),
 			new FileCache(new String[] { EnvironmentInformation.getTemporaryFileDirectory() }),
 			new TestingTaskManagerRuntimeInfo(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -153,6 +154,7 @@ public class StreamTaskTerminationTest extends TestLogger {
 			mock(TaskManagerActions.class),
 			mock(InputSplitProvider.class),
 			mock(CheckpointResponder.class),
+			mock(BlobCache.class),
 			new FallbackLibraryCacheManager(),
 			mock(FileCache.class),
 			taskManagerRuntimeInfo,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
@@ -796,6 +797,7 @@ public class StreamTaskTest extends TestLogger {
 			StreamConfig taskConfig,
 			Configuration taskManagerConfig) throws Exception {
 
+		BlobCache blobCache = mock(BlobCache.class);
 		LibraryCacheManager libCache = mock(LibraryCacheManager.class);
 		when(libCache.getClassLoader(any(JobID.class))).thenReturn(StreamTaskTest.class.getClassLoader());
 
@@ -844,6 +846,7 @@ public class StreamTaskTest extends TestLogger {
 			mock(TaskManagerActions.class),
 			mock(InputSplitProvider.class),
 			mock(CheckpointResponder.class),
+			blobCache,
 			libCache,
 			mock(FileCache.class),
 			new TestingTaskManagerRuntimeInfo(taskManagerConfig, new String[] {System.getProperty("java.io.tmpdir")}),

--- a/flink-yarn-tests/src/test/scala/org/apache/flink/yarn/TestingYarnJobManager.scala
+++ b/flink-yarn-tests/src/test/scala/org/apache/flink/yarn/TestingYarnJobManager.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.{Executor, ScheduledExecutorService}
 
 import akka.actor.ActorRef
 import org.apache.flink.configuration.Configuration
+import org.apache.flink.runtime.blob.BlobServer
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory
@@ -58,6 +59,7 @@ class TestingYarnJobManager(
     ioExecutor: Executor,
     instanceManager: InstanceManager,
     scheduler: Scheduler,
+    blobServer: BlobServer,
     libraryCacheManager: BlobLibraryCacheManager,
     archive: ActorRef,
     restartStrategyFactory: RestartStrategyFactory,
@@ -73,6 +75,7 @@ class TestingYarnJobManager(
     ioExecutor,
     instanceManager,
     scheduler,
+    blobServer,
     libraryCacheManager,
     archive,
     restartStrategyFactory,

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnJobManager.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnJobManager.scala
@@ -24,6 +24,7 @@ import java.util.concurrent.{Executor, ScheduledExecutorService, TimeUnit}
 import akka.actor.ActorRef
 import org.apache.flink.configuration.{Configuration => FlinkConfiguration}
 import org.apache.flink.core.fs.Path
+import org.apache.flink.runtime.blob.BlobServer
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory
 import org.apache.flink.runtime.clusterframework.ContaineredJobManager
 import org.apache.flink.runtime.clusterframework.messages.StopCluster
@@ -49,7 +50,8 @@ import scala.language.postfixOps
   * @param instanceManager Instance manager to manage the registered
   *                        [[org.apache.flink.runtime.taskmanager.TaskManager]]
   * @param scheduler Scheduler to schedule Flink jobs
-  * @param libraryCacheManager Manager to manage uploaded jar files
+  * @param blobServer BLOB store for file uploads
+  * @param libraryCacheManager manages uploaded jar files and class paths
   * @param archive Archive for finished Flink jobs
   * @param restartStrategyFactory Restart strategy to be used in case of a job recovery
   * @param timeout Timeout for futures
@@ -61,6 +63,7 @@ class YarnJobManager(
     ioExecutor: Executor,
     instanceManager: InstanceManager,
     scheduler: FlinkScheduler,
+    blobServer: BlobServer,
     libraryCacheManager: BlobLibraryCacheManager,
     archive: ActorRef,
     restartStrategyFactory: RestartStrategyFactory,
@@ -76,6 +79,7 @@ class YarnJobManager(
     ioExecutor,
     instanceManager,
     scheduler,
+    blobServer,
     libraryCacheManager,
     archive,
     restartStrategyFactory,

--- a/tools/maven/scalastyle-config.xml
+++ b/tools/maven/scalastyle-config.xml
@@ -86,7 +86,7 @@
  <!-- </check> -->
  <check level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
   <parameters>
-   <parameter name="maxParameters"><![CDATA[15]]></parameter>
+   <parameter name="maxParameters"><![CDATA[20]]></parameter>
   </parameters>
  </check>
  <!-- <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true"> -->


### PR DESCRIPTION
Currently, the `LibraryCacheManager` is doing some ref-counting for JAR files managed by it. Instead, we want the `BlobCache` to do that itself for **all** job-related BLOBs. Also, we do not want to operate on a per-BlobKey level but rather per job. Job-unrelated BLOBs should be cleaned manually as done for the Web-UI logs. A future API change will reflect the different use cases in a better way. For now, we need to also adapt the cleanup appropriately.

On the `BlobServer`, the JAR files should remain locally as well as in the HA store until the job enters a final state. Then they can be deleted.

With this intermediate state, job-unrelated BLOBs will remain in the file system until deleted manually. This is the same as the previous API use when working with a `BlobService` directly instead of going through the `LibraryCacheManager`. The aforementioned API extension will include TTL fields for those BLOBs in order to have a proper cleanup, too.

This PR is based upon #4237 in a series to implement FLINK-6916.