### PR TITLE
[FLINK-7058] Fix scala-2.10 dependencies

### DIFF
--- a/flink-scala-shell/pom.xml
+++ b/flink-scala-shell/pom.xml
@@ -250,10 +250,10 @@ under the License.
 			<id>scala-2.10</id>
 			<activation>
 				<property>
-					<!-- only required for Scala 2.10 -->
-					<name>!scala-2.11</name>
+					<name>scala-2.10</name>
 				</property>
 			</activation>
+			<!-- only required for Scala 2.10 -->
 			<dependencies>
 				<dependency>
 					<groupId>org.scalamacros</groupId>

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -287,10 +287,10 @@ under the License.
 			<id>scala-2.10</id>
 			<activation>
 				<property>
-					<!-- only required for Scala 2.10 -->
-					<name>!scala-2.11</name>
+					<name>scala-2.10</name>
 				</property>
 			</activation>
+			<!-- only required for Scala 2.10 -->
 			<dependencies>
 				<dependency>
 					<groupId>org.scalamacros</groupId>


### PR DESCRIPTION
Before fixup:

```
$mvn dependency:tree -DskipTests -pl flink-scala -Pscala-2.11 | grep quasi
[INFO] +- org.scalamacros:quasiquotes_2.10:jar:2.1.0:compile
$ mvn dependency:tree -DskipTests -pl flink-scala -Dscala-2.11 | grep quasi
$ mvn dependency:tree -DskipTests -pl flink-scala | grep quasi
[INFO] +- org.scalamacros:quasiquotes_2.10:jar:2.1.0:compile
$ mvn dependency:tree -DskipTests -pl flink-scala -Pscala-2.10 | grep quasi
[INFO] +- org.scalamacros:quasiquotes_2.10:jar:2.1.0:compile
$ mvn dependency:tree -DskipTests -pl flink-scala -Dscala-2.10 | grep quasi
[INFO] +- org.scalamacros:quasiquotes_2.10:jar:2.1.0:compile
```

After fixup:
```
$ mvn dependency:tree -DskipTests -pl flink-scala -Pscala-2.11 | grep quasi
$ mvn dependency:tree -DskipTests -pl flink-scala -Dscala-2.11 | grep quasi
$ mvn dependency:tree -DskipTests -pl flink-scala | grep quasi
$mvn dependency:tree -DskipTests -pl flink-scala -Pscala-2.10 | grep quasi
[INFO] +- org.scalamacros:quasiquotes_2.10:jar:2.1.0:compile
$ mvn dependency:tree -DskipTests -pl flink-scala -Dscala-2.10 | grep quasi
[INFO] +- org.scalamacros:quasiquotes_2.10:jar:2.1.0:compile
```
