### PR TITLE
[FLINK-7012] remove user-JAR upload when disposing a savepoint the old way

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -25,8 +25,6 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.blob.BlobClient;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.messages.JobManagerMessages;
@@ -59,7 +57,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
@@ -340,11 +337,6 @@ public class ClassLoaderITCase extends TestLogger {
 		}
 
 		assertNotNull("Failed to trigger savepoint", savepointPath);
-
-		// Upload JAR
-		LOG.info("Uploading JAR " + CUSTOM_KV_STATE_JAR_PATH + " for savepoint disposal.");
-		List<BlobKey> blobKeys = BlobClient.uploadJarFiles(jm, deadline.timeLeft(), testCluster.userConfiguration(),
-				Collections.singletonList(new Path(CUSTOM_KV_STATE_JAR_PATH)));
 
 		// Dispose savepoint
 		LOG.info("Disposing savepoint at " + savepointPath);


### PR DESCRIPTION
Inside `CliFrontend#disposeSavepoint()`, user JAR files are being uploaded to the `BlobServer` but they are actually not used (also also not cleaned up) in the job manager's handling of the `DisposeSavepoint` message.

Since removing new savepoints is as simple as deleting files and old savepoints have always worked without these user JARs, we should remove the upload to be able to make the JAR file upload jobId-dependent for FLINK-6916.
