### PR TITLE
[FLINK-7069] [metrics] Granular exception catching in MetricRegistry

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistry.java
@@ -287,19 +287,27 @@ public class MetricRegistry {
 			if (isShutdown()) {
 				LOG.warn("Cannot register metric, because the MetricRegistry has already been shut down.");
 			} else {
-				try {
-					if (reporters != null) {
-						for (int i = 0; i < reporters.size(); i++) {
-							MetricReporter reporter = reporters.get(i);
+				if (reporters != null) {
+					for (int i = 0; i < reporters.size(); i++) {
+						MetricReporter reporter = reporters.get(i);
+						try {
 							if (reporter != null) {
 								FrontMetricGroup front = new FrontMetricGroup<AbstractMetricGroup<?>>(i, group);
 								reporter.notifyOfAddedMetric(metric, metricName, front);
 							}
+						} catch (Exception e) {
+							LOG.warn("Error while registering metric.", e);
 						}
 					}
+				}
+				try {
 					if (queryService != null) {
 						MetricQueryService.notifyOfAddedMetric(queryService, metric, metricName, group);
 					}
+				} catch (Exception e) {
+					LOG.warn("Error while registering metric.", e);
+				}
+				try {
 					if (metric instanceof View) {
 						if (viewUpdater == null) {
 							viewUpdater = new ViewUpdater(executor);
@@ -307,7 +315,7 @@ public class MetricRegistry {
 						viewUpdater.notifyOfAddedView((View) metric);
 					}
 				} catch (Exception e) {
-					LOG.error("Error while registering metric.", e);
+					LOG.warn("Error while registering metric.", e);
 				}
 			}
 		}
@@ -325,26 +333,34 @@ public class MetricRegistry {
 			if (isShutdown()) {
 				LOG.warn("Cannot unregister metric, because the MetricRegistry has already been shut down.");
 			} else {
-				try {
-					if (reporters != null) {
-						for (int i = 0; i < reporters.size(); i++) {
-							MetricReporter reporter = reporters.get(i);
+				if (reporters != null) {
+					for (int i = 0; i < reporters.size(); i++) {
+						try {
+						MetricReporter reporter = reporters.get(i);
 							if (reporter != null) {
 								FrontMetricGroup front = new FrontMetricGroup<AbstractMetricGroup<?>>(i, group);
 								reporter.notifyOfRemovedMetric(metric, metricName, front);
 							}
+						} catch (Exception e) {
+							LOG.warn("Error while registering metric.", e);
 						}
 					}
+				}
+				try {
 					if (queryService != null) {
 						MetricQueryService.notifyOfRemovedMetric(queryService, metric);
 					}
+				} catch (Exception e) {
+					LOG.warn("Error while registering metric.", e);
+				}
+				try {
 					if (metric instanceof View) {
 						if (viewUpdater != null) {
 							viewUpdater.notifyOfRemovedView((View) metric);
 						}
 					}
 				} catch (Exception e) {
-					LOG.error("Error while registering metric.", e);
+					LOG.warn("Error while registering metric.", e);
 				}
 			}
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryTest.java
@@ -25,9 +25,11 @@ import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.Scheduled;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.metrics.groups.MetricGroupTest;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.metrics.scope.ScopeFormats;
 import org.apache.flink.runtime.metrics.util.TestReporter;
@@ -446,6 +448,45 @@ public class MetricRegistryTest extends TestLogger {
 			assertEquals(expectedMetric, group.getMetricIdentifier(metricName, this));
 			assertEquals(expectedMetric, group.getMetricIdentifier(metricName));
 			numCorrectDelimitersForUnregister++;
+		}
+	}
+
+	@Test
+	public void testExceptionIsolation() throws Exception {
+
+		Configuration config = new Configuration();
+		config.setString(MetricOptions.REPORTERS_LIST, "test1,test2");
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, FailingReporter.class.getName());
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter7.class.getName());
+
+		MetricRegistry registry = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(config));
+
+		Counter metric = new SimpleCounter();
+		registry.register(metric, "counter", new MetricGroupTest.DummyAbstractMetricGroup(registry));
+
+		assertEquals(metric, TestReporter7.addedMetric);
+		assertEquals("counter", TestReporter7.addedMetricName);
+
+		registry.unregister(metric, "counter", new MetricGroupTest.DummyAbstractMetricGroup(registry));
+
+		assertEquals(metric, TestReporter7.removedMetric);
+		assertEquals("counter", TestReporter7.removedMetricName);
+
+		registry.shutdown();
+	}
+
+	/**
+	 * Reporter that throws an exception when it is notified of an added or removed metric.
+	 */
+	protected static class FailingReporter extends TestReporter {
+		@Override
+		public void notifyOfAddedMetric(Metric metric, String metricName, MetricGroup group) {
+			throw new RuntimeException();
+		}
+
+		@Override
+		public void notifyOfRemovedMetric(Metric metric, String metricName, MetricGroup group) {
+			throw new RuntimeException();
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
@@ -174,7 +174,10 @@ public class MetricGroupTest extends TestLogger {
 
 	// ------------------------------------------------------------------------
 
-	private static class DummyAbstractMetricGroup extends AbstractMetricGroup {
+	/**
+	 * A dummy {@link AbstractMetricGroup} to be used when a group is required as an argument but not actually used.
+	 */
+	public static class DummyAbstractMetricGroup extends AbstractMetricGroup {
 
 		public DummyAbstractMetricGroup(MetricRegistry registry) {
 			super(registry, new String[0], null);


### PR DESCRIPTION
This PR makes the exception catching in the MetricRegistry more granular when adding or removing metrics.

A reporter that throws an exception prevented other reporters, the MetricQueryService and the ViewUpdater from being notified about added or removed metrics.
