### PR TITLE
[FLINK-7093] [tm] Send SlotReport as part of the heartbeat payload to the ResourceManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -111,7 +111,7 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 	private final HighAvailabilityServices highAvailabilityServices;
 
 	/** The heartbeat manager with task managers. */
-	private final HeartbeatManager<Void, Void> taskManagerHeartbeatManager;
+	private final HeartbeatManager<SlotReport, Void> taskManagerHeartbeatManager;
 
 	/** The heartbeat manager with job managers. */
 	private final HeartbeatManager<Void, Void> jobManagerHeartbeatManager;
@@ -466,8 +466,8 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 	}
 
 	@RpcMethod
-	public void heartbeatFromTaskManager(final ResourceID resourceID) {
-		taskManagerHeartbeatManager.receiveHeartbeat(resourceID, null);
+	public void heartbeatFromTaskManager(final ResourceID resourceID, final SlotReport slotReport) {
+		taskManagerHeartbeatManager.receiveHeartbeat(resourceID, slotReport);
 	}
 
 	@RpcMethod
@@ -956,7 +956,7 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 		}
 	}
 
-	private class TaskManagerHeartbeatListener implements HeartbeatListener<Void, Void> {
+	private class TaskManagerHeartbeatListener implements HeartbeatListener<SlotReport, Void> {
 
 		@Override
 		public void notifyHeartbeatTimeout(final ResourceID resourceID) {
@@ -973,8 +973,23 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 		}
 
 		@Override
-		public void reportPayload(ResourceID resourceID, Void payload) {
-			// nothing to do since there is no payload
+		public void reportPayload(final ResourceID resourceID, final SlotReport slotReport) {
+			runAsync(new Runnable() {
+				@Override
+				public void run() {
+					log.debug("Received new slot report from TaskManager {}.", resourceID);
+
+					final WorkerRegistration<WorkerType> workerRegistration = taskExecutors.get(resourceID);
+
+					if (workerRegistration == null) {
+						log.debug("Received slot report from TaskManager {} which is no longer registered.", resourceID);
+					} else {
+						InstanceID instanceId = workerRegistration.getInstanceID();
+
+						slotManager.reportSlotStatus(instanceId, slotReport);
+					}
+				}
+			});
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -139,8 +139,9 @@ public interface ResourceManagerGateway extends RpcGateway {
 	 * Sends the heartbeat to resource manager from task manager
 	 *
 	 * @param heartbeatOrigin unique id of the task manager
+	 * @param slotReport Current slot allocation on the originating TaskManager
 	 */
-	void heartbeatFromTaskManager(final ResourceID heartbeatOrigin);
+	void heartbeatFromTaskManager(final ResourceID heartbeatOrigin, final SlotReport slotReport);
 
 	/**
 	 * Sends the heartbeat to resource manager from job manager

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcService.java
@@ -25,14 +25,13 @@ import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 
-import java.net.UnknownHostException;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * An RPC Service implementation for testing. This RPC service acts as a replacement for
- * teh regular RPC service for cases where tests need to return prepared mock gateways instead of
+ * the regular RPC service for cases where tests need to return prepared mock gateways instead of
  * proper RPC gateways.
  * 
  * <p>The TestingRpcService can be used for example in the following fashion,
@@ -58,14 +57,14 @@ public class TestingRpcService extends AkkaRpcService {
 	/**
 	 * Creates a new {@code TestingRpcService}. 
 	 */
-	public TestingRpcService() throws UnknownHostException {
+	public TestingRpcService() {
 		this(new Configuration());
 	}
 
 	/**
 	 * Creates a new {@code TestingRpcService}, using the given configuration. 
 	 */
-	public TestingRpcService(Configuration configuration) throws UnknownHostException {
+	public TestingRpcService(Configuration configuration) {
 		super(AkkaUtils.createLocalActorSystem(configuration), Time.seconds(10));
 
 		this.registeredConnections = new ConcurrentHashMap<>();


### PR DESCRIPTION
The TaskManager sends the SlotReport as part of the heartbeat payload to the ResourceManager.
That way, the ResourceManager can sync its internal view on the slot allocation with the actual
allocation state.
