### PR TITLE
[FLINK-7074] [tm] Add entry point for the TaskManagerRunner

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -117,16 +117,6 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>com.github.scopt</groupId>
 			<artifactId>scopt_${scala.binary.version}</artifactId>
 			<exclusions>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -117,6 +117,16 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>com.github.scopt</groupId>
 			<artifactId>scopt_${scala.binary.version}</artifactId>
 			<exclusions>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -39,8 +39,10 @@ import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerRunner;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
+import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
 import org.apache.flink.util.ExceptionUtils;
 
@@ -90,7 +92,7 @@ public class MiniCluster {
 	private ResourceManagerRunner[] resourceManagerRunners;
 
 	@GuardedBy("lock")
-	private TaskManagerRunner[] taskManagerRunners;
+	private TaskExecutor[] taskManagers;
 
 	@GuardedBy("lock")
 	private MiniClusterJobDispatcher jobDispatcher;
@@ -253,7 +255,7 @@ public class MiniCluster {
 
 				// bring up the TaskManager(s) for the mini cluster
 				LOG.info("Starting {} TaskManger(s)", numTaskManagers);
-				taskManagerRunners = startTaskManagers(
+				taskManagers = startTaskManagers(
 						configuration, haServices, metricRegistry, numTaskManagers, taskManagerRpcServices);
 
 				// bring up the dispatcher that launches JobManagers when jobs submitted
@@ -338,17 +340,17 @@ public class MiniCluster {
 			resourceManagerRunners = null;
 		}
 
-		if (taskManagerRunners != null) {
-			for (TaskManagerRunner tm : taskManagerRunners) {
+		if (taskManagers != null) {
+			for (TaskExecutor tm : taskManagers) {
 				if (tm != null) {
 					try {
-						tm.shutDown(null);
+						tm.shutDown();
 					} catch (Throwable t) {
 						exception = firstOrSuppressed(t, exception);
 					}
 				}
 			}
-			taskManagerRunners = null;
+			taskManagers = null;
 		}
 
 		// shut down the RpcServices
@@ -402,7 +404,7 @@ public class MiniCluster {
 			final ResourceManagerGateway resourceManager = 
 					commonRpcService.connect(addressAndId.leaderAddress(), ResourceManagerGateway.class).get();
 
-			final int numTaskManagersToWaitFor = taskManagerRunners.length;
+			final int numTaskManagersToWaitFor = taskManagers.length;
 
 			// poll and wait until enough TaskManagers are available
 			while (true) {
@@ -540,30 +542,31 @@ public class MiniCluster {
 		return resourceManagerRunners;
 	}
 
-	protected TaskManagerRunner[] startTaskManagers(
+	protected TaskExecutor[] startTaskManagers(
 			Configuration configuration,
 			HighAvailabilityServices haServices,
 			MetricRegistry metricRegistry,
 			int numTaskManagers,
 			RpcService[] taskManagerRpcServices) throws Exception {
 
-		final TaskManagerRunner[] taskManagerRunners = new TaskManagerRunner[numTaskManagers];
+		final TaskExecutor[] taskExecutors = new TaskExecutor[numTaskManagers];
 		final boolean localCommunication = numTaskManagers == 1;
 
 		for (int i = 0; i < numTaskManagers; i++) {
-			taskManagerRunners[i] = new TaskManagerRunner(
+			taskExecutors[i] = TaskManagerRunner.startTaskManager(
 				configuration,
 				new ResourceID(UUID.randomUUID().toString()),
 				taskManagerRpcServices[i],
 				haServices,
 				heartbeatServices,
 				metricRegistry,
-				localCommunication);
+				localCommunication,
+				new TerminatingFatalErrorHandler(i));
 
-			taskManagerRunners[i].start();
+			taskExecutors[i].start();
 		}
 
-		return taskManagerRunners;
+		return taskExecutors;
 	}
 
 	// ------------------------------------------------------------------------
@@ -613,5 +616,29 @@ public class MiniCluster {
 		}
 
 		return config;
+	}
+
+	private class TerminatingFatalErrorHandler implements FatalErrorHandler {
+
+		private final int index;
+
+		private TerminatingFatalErrorHandler(int index) {
+			this.index = index;
+		}
+
+		@Override
+		public void onFatalError(Throwable exception) {
+			LOG.error("TaskManager #{} failed.", index, exception);
+
+			try {
+				synchronized (lock) {
+					if (taskManagers[index] != null) {
+						taskManagers[index].shutDown();
+					}
+				}
+			} catch (Exception e) {
+				LOG.error("TaskManager #{} could not be properly terminated.", index, e);
+			}
+		}
 	}
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -567,6 +567,12 @@ object AkkaUtils {
     new FiniteDuration(duration.toMillis, TimeUnit.MILLISECONDS)
   }
 
+  def getTimeoutAsTime(config: Configuration): Time = {
+    val duration = Duration(config.getString(AkkaOptions.ASK_TIMEOUT))
+
+    Time.milliseconds(duration.toMillis)
+  }
+
   def getDefaultTimeout: Time = {
     val duration = Duration(AkkaOptions.ASK_TIMEOUT.defaultValue())
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
@@ -25,12 +25,6 @@ import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.heartbeat.HeartbeatServices;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
-import org.apache.flink.runtime.metrics.MetricRegistry;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
-import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
 import org.apache.flink.runtime.util.EnvironmentInformation;
@@ -61,14 +55,6 @@ public class YarnTaskExecutorRunner {
 	/** The exit code returned if the initialization of the yarn task executor runner failed. */
 	private static final int INIT_ERROR_EXIT_CODE = 31;
 
-	private MetricRegistry metricRegistry;
-
-	private HighAvailabilityServices haServices;
-
-	private RpcService taskExecutorRpcService;
-
-	private TaskManagerRunner taskManagerRunner;
-
 	// ------------------------------------------------------------------------
 	//  Program entry point
 	// ------------------------------------------------------------------------
@@ -83,20 +69,17 @@ public class YarnTaskExecutorRunner {
 		SignalHandler.register(LOG);
 		JvmShutdownSafeguard.installAsShutdownHook(LOG);
 
-		// run and exit with the proper return code
-		int returnCode = new YarnTaskExecutorRunner().run(args);
-		System.exit(returnCode);
+		run(args);
 	}
 
 	/**
-	 * The instance entry point for the YARN task executor. Obtains user group
-	 * information and calls the main work method {@link #runTaskExecutor(org.apache.flink.configuration.Configuration)} as a
+	 * The instance entry point for the YARN task executor. Obtains user group information and calls
+	 * the main work method {@link TaskManagerRunner#runTaskManager(Configuration, ResourceID)}  as a
 	 * privileged action.
 	 *
 	 * @param args The command line arguments.
-	 * @return The process exit code.
 	 */
-	protected int run(String[] args) {
+	private static void run(String[] args) {
 		try {
 			LOG.debug("All environment variables: {}", ENV);
 
@@ -166,114 +149,30 @@ public class YarnTaskExecutorRunner {
 				configuration.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, remoteKeytabPrincipal);
 			}
 
-			SecurityUtils.install(sc);
-
-			return SecurityUtils.getInstalledContext().runSecured(new Callable<Integer>() {
-				@Override
-				public Integer call() throws Exception {
-					return runTaskExecutor(configuration);
-				}
-			});
-
-		}
-		catch (Throwable t) {
-			// make sure that everything whatever ends up in the log
-			LOG.error("YARN Application Master initialization failed", t);
-			return INIT_ERROR_EXIT_CODE;
-		}
-	}
-
-	// ------------------------------------------------------------------------
-	//  Core work method
-	// ------------------------------------------------------------------------
-
-	/**
-	 * The main work method, must run as a privileged action.
-	 *
-	 * @return The return code for the Java process.
-	 */
-	protected int runTaskExecutor(Configuration config) {
-
-		try {
-			// ---- (1) create common services
-			// first get the ResouceId, resource id is the container id for yarn.
 			final String containerId = ENV.get(YarnFlinkResourceManager.ENV_FLINK_CONTAINER_ID);
 			Preconditions.checkArgument(containerId != null,
-					"ContainerId variable %s not set", YarnFlinkResourceManager.ENV_FLINK_CONTAINER_ID);
+				"ContainerId variable %s not set", YarnFlinkResourceManager.ENV_FLINK_CONTAINER_ID);
+
 			// use the hostname passed by job manager
 			final String taskExecutorHostname = ENV.get(YarnResourceManager.ENV_FLINK_NODE_ID);
 			if (taskExecutorHostname != null) {
-				config.setString(ConfigConstants.TASK_MANAGER_HOSTNAME_KEY, taskExecutorHostname);
+				configuration.setString(ConfigConstants.TASK_MANAGER_HOSTNAME_KEY, taskExecutorHostname);
 			}
 
-			ResourceID resourceID = new ResourceID(containerId);
-			LOG.info("YARN assigned resource id {} for the task executor.", resourceID.toString());
+			SecurityUtils.install(sc);
 
-			taskExecutorRpcService = TaskManagerRunner.createRpcService(config, haServices);
-
-			haServices = HighAvailabilityServicesUtils.createHighAvailabilityServices(
-				config,
-				taskExecutorRpcService.getExecutor(),
-				HighAvailabilityServicesUtils.AddressResolution.TRY_ADDRESS_RESOLUTION);
-
-			HeartbeatServices heartbeatServices = HeartbeatServices.fromConfiguration(config);
-
-			metricRegistry = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(config));
-
-			// ---- (2) init task manager runner -------
-			taskManagerRunner = new TaskManagerRunner(
-				config,
-				resourceID,
-				taskExecutorRpcService,
-				haServices,
-				heartbeatServices,
-				metricRegistry);
-
-			// ---- (3) start the task manager runner
-			taskManagerRunner.start();
-			LOG.debug("YARN task executor started");
-
-			taskManagerRunner.getTerminationFuture().get();
-			// everything started, we can wait until all is done or the process is killed
-			LOG.info("YARN task manager runner finished");
-			shutdown();
+			SecurityUtils.getInstalledContext().runSecured(new Callable<Void>() {
+				@Override
+				public Void call() throws Exception {
+					TaskManagerRunner.runTaskManager(configuration, new ResourceID(containerId));
+					return null;
+				}
+			});
 		}
 		catch (Throwable t) {
 			// make sure that everything whatever ends up in the log
-			LOG.error("YARN task executor initialization failed", t);
-			shutdown();
-			return INIT_ERROR_EXIT_CODE;
+			LOG.error("YARN TaskManager initialization failed.", t);
+			System.exit(INIT_ERROR_EXIT_CODE);
 		}
-
-		return 0;
 	}
-
-	// ------------------------------------------------------------------------
-	//  Utilities
-	// ------------------------------------------------------------------------
-
-	protected void shutdown() {
-			if (taskExecutorRpcService != null) {
-				try {
-					taskExecutorRpcService.stopService();
-				} catch (Throwable tt) {
-					LOG.error("Error shutting down job master rpc service", tt);
-				}
-			}
-			if (haServices != null) {
-				try {
-					haServices.close();
-				} catch (Throwable tt) {
-					LOG.warn("Failed to stop the HA service", tt);
-				}
-			}
-			if (metricRegistry != null) {
-				try {
-					metricRegistry.shutdown();
-				} catch (Throwable tt) {
-					LOG.warn("Failed to stop the metrics registry", tt);
-				}
-			}
-	}
-
 }


### PR DESCRIPTION
The entry point can be used by the standalone mode to run a TaskManager. Moreover, the
YarnTaskExecutorRunner now reuses some of the start up logic of the TaskManagerRunner.