### PR TITLE
[FLINK-7067] [jobmanager] Fix side effects after failed cancel-job-with-savepoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1188,6 +1188,15 @@ public class CheckpointCoordinator {
 		return checkpointTimeout;
 	}
 
+	/**
+	 * Returns whether periodic checkpointing has been configured.
+	 *
+	 * @return <code>true</code> if periodic checkpoints have been configured.
+	 */
+	public boolean isPeriodicCheckpointingConfigured() {
+		return baseInterval != Long.MAX_VALUE;
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  Periodic scheduling of checkpoints
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -622,16 +622,16 @@ public class JobManagerHARecoveryTest extends TestLogger {
 			}
 		}
 
-		public static void initializeStaticHelpers(int numSubtasks) {
+		static void initializeStaticHelpers(int numSubtasks) {
 			completedCheckpointsLatch = new CountDownLatch(numSubtasks);
 			recoveredStates = new long[numSubtasks];
 		}
 
-		public static void awaitCompletedCheckpoints() throws InterruptedException {
+		static void awaitCompletedCheckpoints() throws InterruptedException {
 			completedCheckpointsLatch.await();
 		}
 
-		public static long[] getRecoveredStates() {
+		static long[] getRecoveredStates() {
 			return recoveredStates;
 		}
 


### PR DESCRIPTION
If a cancel-job-with-savepoint request fails, this has an unintended side effect on the respective job if it has periodic checkpoints enabled. The periodic checkpoint scheduler is stopped before triggering the savepoint, but not restarted if a savepoint fails and the job is not cancelled.

This fix makes sure that the periodic checkpoint scheduler is restarted iff periodic checkpoints were enabled before.

I have the test in a separate commit, because it uses Reflection to update a private field with a spied upon instance of the CheckpointCoordinator in order to test the expected behaviour. This is super fragile and ugly, but the alternatives require a large refactoring (use factories that can be set during tests) or don't test this corner case behaviour. The separate commit makes it easier to remove/revert it at a future point in time.

I would like to merge this to `release-1.3` and `master`.
