### PR TITLE
[FLINK-7105] Make ActorSystems non daemonic

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -203,7 +203,7 @@ object AkkaUtils {
     val config =
       s"""
         |akka {
-        | daemonic = on
+        | daemonic = off
         |
         | loggers = ["akka.event.slf4j.Slf4jLogger"]
         | logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"


### PR DESCRIPTION
In order to not having to explicitly wait on the termination of an ActorSystem
in the main thread, we now create the ActorSystems in non-daemonic mode. That
way the process won't terminate if there is still an active actor.