### PR TITLE
[FLINK-7103] [dispatcher] Add skeletal structure of Dispatcher component

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.BlobService;
+import org.apache.flink.runtime.client.JobSubmissionException;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmanager.SubmittedJobGraph;
+import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcEndpoint;
+import org.apache.flink.runtime.rpc.RpcMethod;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base class for the Dispatcher component. The Dispatcher component is responsible
+ * for receiving job submissions, persisting them, spawning JobManagers to execute
+ * the jobs and to recover them in case of a master failure. Furthermore, it knows
+ * about the state of the Flink session cluster.
+ */
+public abstract class Dispatcher extends RpcEndpoint<DispatcherGateway> {
+
+	public static final String DISPATCHER_NAME = "dispatcher";
+
+	private final SubmittedJobGraphStore submittedJobGraphStore;
+	private final RunningJobsRegistry runningJobsRegistry;
+
+	private final HighAvailabilityServices highAvailabilityServices;
+	private final BlobServer blobServer;
+	private final HeartbeatServices heartbeatServices;
+	private final MetricRegistry metricRegistry;
+
+	private final FatalErrorHandler fatalErrorHandler;
+
+	private final Map<JobID, JobManagerRunner> jobManagerRunners;
+
+	protected Dispatcher(
+			RpcService rpcService,
+			String endpointId,
+			HighAvailabilityServices highAvailabilityServices,
+			BlobServer blobServer,
+			HeartbeatServices heartbeatServices,
+			MetricRegistry metricRegistry,
+			FatalErrorHandler fatalErrorHandler) throws Exception {
+		super(rpcService, endpointId);
+
+		this.highAvailabilityServices = Preconditions.checkNotNull(highAvailabilityServices);
+		this.blobServer = Preconditions.checkNotNull(blobServer);
+		this.heartbeatServices = Preconditions.checkNotNull(heartbeatServices);
+		this.metricRegistry = Preconditions.checkNotNull(metricRegistry);
+		this.fatalErrorHandler = Preconditions.checkNotNull(fatalErrorHandler);
+
+		this.submittedJobGraphStore = highAvailabilityServices.getSubmittedJobGraphStore();
+		this.runningJobsRegistry = highAvailabilityServices.getRunningJobsRegistry();
+
+		jobManagerRunners = new HashMap<>(16);
+	}
+
+	//------------------------------------------------------
+	// Lifecycle methods
+	//------------------------------------------------------
+
+	@Override
+	public void shutDown() throws Exception {
+		Exception exception = null;
+		// stop all currently running JobManagerRunners
+		for (JobManagerRunner jobManagerRunner : jobManagerRunners.values()) {
+			jobManagerRunner.shutdown();
+		}
+
+		jobManagerRunners.clear();
+
+		try {
+			submittedJobGraphStore.stop();
+		} catch (Exception e) {
+			exception = ExceptionUtils.firstOrSuppressed(e, exception);
+		}
+
+		try {
+			super.shutDown();
+		} catch (Exception e) {
+			exception = ExceptionUtils.firstOrSuppressed(e, exception);
+		}
+
+		if (exception != null) {
+			throw new FlinkException("Could not properly terminate the Dispatcher.", exception);
+		}
+	}
+
+	//------------------------------------------------------
+	// RPCs
+	//------------------------------------------------------
+
+	@RpcMethod
+	public Acknowledge submitJob(JobGraph jobGraph) throws JobSubmissionException {
+		final JobID jobId = jobGraph.getJobID();
+
+		log.info("Submitting job {} ({}).", jobGraph.getJobID(), jobGraph.getName());
+
+		final RunningJobsRegistry.JobSchedulingStatus jobSchedulingStatus;
+
+		try {
+			jobSchedulingStatus = runningJobsRegistry.getJobSchedulingStatus(jobId);
+		} catch (IOException e) {
+			log.warn("Cannot retrieve job status for {}.", jobId, e);
+			throw new JobSubmissionException(jobId, "Could not retrieve the job status.", e);
+		}
+
+		if (jobSchedulingStatus == RunningJobsRegistry.JobSchedulingStatus.PENDING) {
+			try {
+				submittedJobGraphStore.putJobGraph(new SubmittedJobGraph(jobGraph, null));
+			} catch (Exception e) {
+				log.warn("Cannot persist JobGraph.", e);
+				throw new JobSubmissionException(jobId, "Could not persist JobGraph.", e);
+			}
+
+			final JobManagerRunner jobManagerRunner;
+
+			try {
+				jobManagerRunner = createJobManagerRunner(
+					ResourceID.generate(),
+					jobGraph,
+					null,
+					getRpcService(),
+					highAvailabilityServices,
+					blobServer,
+					heartbeatServices,
+					metricRegistry,
+					new DispatcherOnCompleteActions(jobGraph.getJobID()),
+					fatalErrorHandler);
+
+				jobManagerRunner.start();
+			} catch (Exception e) {
+				try {
+					// We should only remove a job from the submitted job graph store
+					// if the initial submission failed. Never in case of a recovery
+					submittedJobGraphStore.removeJobGraph(jobId);
+				} catch (Throwable t) {
+					log.warn("Cannot remove job graph from submitted job graph store.", t);
+					e.addSuppressed(t);
+				}
+
+				throw new JobSubmissionException(jobId, "Could not start JobManager.", e);
+			}
+
+			jobManagerRunners.put(jobId, jobManagerRunner);
+
+			return Acknowledge.get();
+		} else {
+			throw new JobSubmissionException(jobId, "Job has already been submitted and " +
+				"is currently in state " + jobSchedulingStatus + '.');
+		}
+	}
+
+	@RpcMethod
+	public Collection<JobID> listJobs() {
+		// TODO: return proper list of running jobs
+		return jobManagerRunners.keySet();
+	}
+
+	/**
+	 * Cleans up the job related data from the dispatcher. If cleanupHA is true, then
+	 * the data will also be removed from HA.
+	 *
+	 * @param jobId JobID identifying the job to clean up
+	 * @param cleanupHA True iff HA data shall also be cleaned up
+	 */
+	private void removeJob(JobID jobId, boolean cleanupHA) throws Exception {
+		JobManagerRunner jobManagerRunner = jobManagerRunners.remove(jobId);
+
+		if (jobManagerRunner != null) {
+			jobManagerRunner.shutdown();
+		}
+
+		if (cleanupHA) {
+			submittedJobGraphStore.removeJobGraph(jobId);
+		}
+
+		// TODO: remove job related files from blob server
+	}
+
+	protected abstract JobManagerRunner createJobManagerRunner(
+		ResourceID resourceId,
+		JobGraph jobGraph,
+		Configuration configuration,
+		RpcService rpcService,
+		HighAvailabilityServices highAvailabilityServices,
+		BlobService blobService,
+		HeartbeatServices heartbeatServices,
+		MetricRegistry metricRegistry,
+		OnCompletionActions onCompleteActions,
+		FatalErrorHandler fatalErrorHandler) throws Exception;
+
+	//------------------------------------------------------
+	// Utility classes
+	//------------------------------------------------------
+
+	private class DispatcherOnCompleteActions implements OnCompletionActions {
+
+		private final JobID jobId;
+
+		private DispatcherOnCompleteActions(JobID jobId) {
+			this.jobId = Preconditions.checkNotNull(jobId);
+		}
+
+		@Override
+		public void jobFinished(JobExecutionResult result) {
+			log.info("Job {} finished.", jobId);
+
+			runAsync(new Runnable() {
+				@Override
+				public void run() {
+					try {
+						removeJob(jobId, true);
+					} catch (Exception e) {
+						log.warn("Could not properly remove job {} from the dispatcher.", jobId, e);
+					}
+				}
+			});
+		}
+
+		@Override
+		public void jobFailed(Throwable cause) {
+			log.info("Job {} failed.", jobId);
+
+			runAsync(new Runnable() {
+				@Override
+				public void run() {
+					try {
+						removeJob(jobId, true);
+					} catch (Exception e) {
+						log.warn("Could not properly remove job {} from the dispatcher.", jobId, e);
+					}
+				}
+			});
+		}
+
+		@Override
+		public void jobFinishedByOther() {
+			log.info("Job {} was finished by other.", jobId);
+
+			runAsync(new Runnable() {
+				@Override
+				public void run() {
+					try {
+						removeJob(jobId, false);
+					} catch (Exception e) {
+						log.warn("Could not properly remove job {} from the dispatcher.", jobId, e);
+					}
+				}
+			});
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.RpcTimeout;
+
+import java.util.Collection;
+
+/**
+ * Gateway for the Dispatcher component.
+ */
+public interface DispatcherGateway extends RpcGateway {
+
+	/**
+	 * Submit a job to the dispatcher.
+	 *
+	 * @param jobGraph JobGraph to submit
+	 * @param timeout RPC timeout
+	 * @return A future acknowledge if the submission succeeded
+	 */
+	Future<Acknowledge> submitJob(
+		JobGraph jobGraph,
+		@RpcTimeout Time timeout);
+
+	/**
+	 * Lists the current set of submitted jobs.
+	 *
+	 * @param timeout RPC timeout
+	 * @return A future collection of currently submitted jobs
+	 */
+	Future<Collection<JobID>> listJobs(
+		@RpcTimeout Time timeout);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.BlobService;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.jobmaster.JobMaster;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+
+/**
+ * Dispatcher implementation which spawns a {@link JobMaster} for each
+ * submitted {@link JobGraph} within in the same process. This dispatcher
+ * can be used as the default for all different session clusters.
+ */
+public class StandaloneDispatcher extends Dispatcher {
+	protected StandaloneDispatcher(
+			RpcService rpcService,
+			String endpointId,
+			HighAvailabilityServices highAvailabilityServices,
+			BlobServer blobServer,
+			HeartbeatServices heartbeatServices,
+			MetricRegistry metricRegistry,
+			FatalErrorHandler fatalErrorHandler) throws Exception {
+		super(
+			rpcService,
+			endpointId,
+			highAvailabilityServices,
+			blobServer,
+			heartbeatServices,
+			metricRegistry,
+			fatalErrorHandler);
+	}
+
+	@Override
+	protected JobManagerRunner createJobManagerRunner(
+			ResourceID resourceId,
+			JobGraph jobGraph,
+			Configuration configuration,
+			RpcService rpcService,
+			HighAvailabilityServices highAvailabilityServices,
+			BlobService blobService,
+			HeartbeatServices heartbeatServices,
+			MetricRegistry metricRegistry,
+			OnCompletionActions onCompleteActions,
+			FatalErrorHandler fatalErrorHandler) throws Exception {
+		// create the standard job manager runner
+		return new JobManagerRunner(
+			resourceId,
+			jobGraph,
+			configuration,
+			rpcService,
+			highAvailabilityServices,
+			blobService,
+			heartbeatServices,
+			metricRegistry,
+			onCompleteActions,
+			fatalErrorHandler);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/SubmittedJobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/SubmittedJobGraph.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.jobmanager;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -44,9 +46,9 @@ public class SubmittedJobGraph implements Serializable {
 	 * @param jobGraph The submitted {@link JobGraph}
 	 * @param jobInfo  The {@link JobInfo}
 	 */
-	public SubmittedJobGraph(JobGraph jobGraph, JobInfo jobInfo) {
+	public SubmittedJobGraph(JobGraph jobGraph, @Nullable JobInfo jobInfo) {
 		this.jobGraph = checkNotNull(jobGraph, "Job graph");
-		this.jobInfo = checkNotNull(jobInfo, "Job info");
+		this.jobInfo = jobInfo;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmaster;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobService;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
@@ -92,6 +93,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			final Configuration configuration,
 			final RpcService rpcService,
 			final HighAvailabilityServices haServices,
+			final BlobService blobService,
 			final HeartbeatServices heartbeatServices,
 			final OnCompletionActions toNotifyOnComplete,
 			final FatalErrorHandler errorHandler) throws Exception {
@@ -101,6 +103,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			configuration,
 			rpcService,
 			haServices,
+			blobService,
 			heartbeatServices,
 			new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(configuration)),
 			toNotifyOnComplete,
@@ -113,6 +116,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			final Configuration configuration,
 			final RpcService rpcService,
 			final HighAvailabilityServices haServices,
+			final BlobService blobService,
 			final HeartbeatServices heartbeatServices,
 			final MetricRegistry metricRegistry,
 			final OnCompletionActions toNotifyOnComplete,
@@ -124,7 +128,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			rpcService,
 			haServices,
 			heartbeatServices,
-			JobManagerServices.fromConfiguration(configuration, haServices),
+			JobManagerServices.fromConfiguration(configuration, blobService),
 			metricRegistry,
 			toNotifyOnComplete,
 			errorHandler);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerServices.java
@@ -23,10 +23,9 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.BlobService;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.runtime.util.Hardware;
 import org.apache.flink.util.ExceptionUtils;
@@ -103,15 +102,13 @@ public class JobManagerServices {
 
 	public static JobManagerServices fromConfiguration(
 			Configuration config,
-			HighAvailabilityServices haServices) throws Exception {
-
-		final BlobServer blobServer = new BlobServer(config, haServices.createBlobStore());
+			BlobService blobService) throws Exception {
 
 		final long cleanupInterval = config.getLong(
 			ConfigConstants.LIBRARY_CACHE_MANAGER_CLEANUP_INTERVAL,
 			ConfigConstants.DEFAULT_LIBRARY_CACHE_MANAGER_CLEANUP_INTERVAL) * 1000;
 
-		final BlobLibraryCacheManager libraryCacheManager = new BlobLibraryCacheManager(blobServer, cleanupInterval);
+		final BlobLibraryCacheManager libraryCacheManager = new BlobLibraryCacheManager(blobService, cleanupInterval);
 
 		final FiniteDuration timeout;
 		try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.BlobService;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneHaServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for the {@link Dispatcher} component.
+ */
+public class DispatcherTest extends TestLogger {
+
+	/**
+	 * Tests that we can submit a job to the Dispatcher which then spawns a
+	 * new JobManagerRunner.
+	 */
+	@Test
+	public void testJobSubmission() throws Exception {
+		TestingFatalErrorHandler fatalErrorHandler = new TestingFatalErrorHandler();
+		RpcService rpcService = new TestingRpcService();
+		HighAvailabilityServices haServices = new StandaloneHaServices("localhost", "localhost");
+		HeartbeatServices heartbeatServices = new HeartbeatServices(1000L, 10000L);
+		JobManagerRunner jobManagerRunner = mock(JobManagerRunner.class);
+
+		final Time timeout = Time.seconds(5L);
+		final JobGraph jobGraph = mock(JobGraph.class);
+		final JobID jobId = new JobID();
+		when(jobGraph.getJobID()).thenReturn(jobId);
+
+		try {
+			final TestingDispatcher dispatcher = new TestingDispatcher(
+				rpcService,
+				Dispatcher.DISPATCHER_NAME,
+				haServices,
+				mock(BlobServer.class),
+				heartbeatServices,
+				mock(MetricRegistry.class),
+				fatalErrorHandler,
+				jobManagerRunner,
+				jobId);
+
+			dispatcher.start();
+
+			DispatcherGateway dispatcherGateway = dispatcher.getSelf();
+
+			Future<Acknowledge> acknowledgeFuture = dispatcherGateway.submitJob(jobGraph, timeout);
+
+			acknowledgeFuture.get();
+
+			verify(jobManagerRunner, Mockito.timeout(timeout.toMilliseconds())).start();
+
+			// check that no error has occurred
+			fatalErrorHandler.rethrowError();
+		} finally {
+			rpcService.stopService();
+		}
+	}
+
+	private static class TestingDispatcher extends Dispatcher {
+
+		private final JobManagerRunner jobManagerRunner;
+		private final JobID expectedJobId;
+
+		protected TestingDispatcher(
+				RpcService rpcService,
+				String endpointId,
+				HighAvailabilityServices highAvailabilityServices,
+				BlobServer blobServer,
+				HeartbeatServices heartbeatServices,
+				MetricRegistry metricRegistry,
+				FatalErrorHandler fatalErrorHandler,
+				JobManagerRunner jobManagerRunner,
+				JobID expectedJobId) throws Exception {
+			super(
+				rpcService,
+				endpointId,
+				highAvailabilityServices,
+				blobServer,
+				heartbeatServices,
+				metricRegistry,
+				fatalErrorHandler);
+
+			this.jobManagerRunner = jobManagerRunner;
+			this.expectedJobId = expectedJobId;
+		}
+
+		@Override
+		protected JobManagerRunner createJobManagerRunner(
+				ResourceID resourceId,
+				JobGraph jobGraph,
+				Configuration configuration,
+				RpcService rpcService,
+				HighAvailabilityServices highAvailabilityServices,
+				BlobService blobService,
+				HeartbeatServices heartbeatServices,
+				MetricRegistry metricRegistry,
+				OnCompletionActions onCompleteActions,
+				FatalErrorHandler fatalErrorHandler) throws Exception {
+			assertEquals(expectedJobId, jobGraph.getJobID());
+
+			return jobManagerRunner;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerMockTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerMockTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmaster;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.BlobStore;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -111,7 +112,7 @@ public class JobManagerRunnerMockTest extends TestLogger {
 			mockRpc,
 			haServices,
 			heartbeatServices,
-			JobManagerServices.fromConfiguration(new Configuration(), haServices),
+			JobManagerServices.fromConfiguration(new Configuration(), mock(BlobServer.class)),
 			new MetricRegistry(MetricRegistryConfiguration.defaultMetricRegistryConfiguration()),
 			jobCompletion,
 			jobCompletion));

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkApplicationMasterRunner.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager;
@@ -99,6 +100,9 @@ public class YarnFlinkApplicationMasterRunner extends AbstractYarnFlinkApplicati
 	private RpcService commonRpcService;
 
 	@GuardedBy("lock")
+	private BlobServer blobServer;
+
+	@GuardedBy("lock")
 	private ResourceManager resourceManager;
 
 	@GuardedBy("lock")
@@ -143,6 +147,8 @@ public class YarnFlinkApplicationMasterRunner extends AbstractYarnFlinkApplicati
 					config,
 					commonRpcService.getExecutor(),
 					HighAvailabilityServicesUtils.AddressResolution.NO_ADDRESS_RESOLUTION);
+
+				blobServer = new BlobServer(config, haServices.createBlobStore());
 
 				heartbeatServices = HeartbeatServices.fromConfiguration(config);
 
@@ -228,6 +234,7 @@ public class YarnFlinkApplicationMasterRunner extends AbstractYarnFlinkApplicati
 			config,
 			commonRpcService,
 			haServices,
+			blobServer,
 			heartbeatServices,
 			this,
 			this);


### PR DESCRIPTION
The Dispatcher is responsible for receiving job submissions, persisting the JobGraphs,
spawning JobManager to execute the jobs and recovering the jobs in case of a master
failure. This commit adds the basic skeleton including the RPC call for job submission.

Add cleanup logic for finished jobs

Pass BlobService to JobManagerRunner
