### PR TITLE
[FLINK-7098] Adapt startup scripts to start Flip-6 standalone session cluster

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -464,16 +464,17 @@ readSlaves() {
 }
 
 # starts or stops TMs on all slaves
-# TMSlaves start|stop
+# TMSlaves start|stop [flip6]
 TMSlaves() {
     CMD=$1
+    FLIP6=$2
 
     readSlaves
 
     if [ ${SLAVES_ALL_LOCALHOST} = true ] ; then
         # all-local setup
         for slave in ${SLAVES[@]}; do
-            "${FLINK_BIN_DIR}"/taskmanager.sh "${CMD}"
+            "${FLINK_BIN_DIR}"/taskmanager.sh "${CMD}" "${FLIP6}"
         done
     else
         # non-local setup
@@ -481,11 +482,11 @@ TMSlaves() {
         command -v pdsh >/dev/null 2>&1
         if [[ $? -ne 0 ]]; then
             for slave in ${SLAVES[@]}; do
-                ssh -n $FLINK_SSH_OPTS $slave -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" \"${CMD}\" &"
+                ssh -n $FLINK_SSH_OPTS $slave -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" \"${CMD}\" \"${FLIP6}\" &"
             done
         else
             PDSH_SSH_ARGS="" PDSH_SSH_ARGS_APPEND=$FLINK_SSH_OPTS pdsh -w $(IFS=, ; echo "${SLAVES[*]}") \
-                "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" \"${CMD}\""
+                "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" \"${CMD}\" \"${FLIP6}\""
         fi
     fi
 }

--- a/flink-dist/src/main/flink-bin/bin/flink-console.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-console.sh
@@ -46,6 +46,10 @@ case $SERVICE in
         CLASS_TO_RUN=org.apache.flink.runtime.zookeeper.FlinkZooKeeperQuorumPeer
     ;;
 
+    (standalonesession)
+        CLASS_TO_RUN=org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint
+    ;;
+
     (*)
         echo "Unknown service '${SERVICE}'. $USAGE."
         exit 1

--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -50,6 +50,10 @@ case $DAEMON in
         CLASS_TO_RUN=org.apache.flink.runtime.webmonitor.history.HistoryServer
     ;;
 
+    (standalonesession)
+        CLASS_TO_RUN=org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint
+    ;;
+
     (*)
         echo "Unknown daemon '${DAEMON}'. $USAGE."
         exit 1

--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -18,12 +18,18 @@
 ################################################################################
 
 # Start/stop a Flink JobManager.
-USAGE="Usage: jobmanager.sh ((start|start-foreground) (local|cluster) [host] [webui-port])|stop|stop-all"
+USAGE="Usage: jobmanager.sh ((start|start-foreground) (local|cluster|flip6) [host] [webui-port])|stop|stop-all [flip6]"
 
 STARTSTOP=$1
 EXECUTIONMODE=$2
 HOST=$3 # optional when starting multiple instances
 WEBUIPORT=$4 # optional when starting multiple instances
+
+JOBMANAGER_TYPE=jobmanager
+
+if [[ "$EXECUTIONMODE" == "flip6" ]]; then
+    JOBMANAGER_TYPE=standalonesession
+fi
 
 if [[ $STARTSTOP != "start" ]] && [[ $STARTSTOP != "start-foreground" ]] && [[ $STARTSTOP != "stop" ]] && [[ $STARTSTOP != "stop-all" ]]; then
   echo $USAGE
@@ -76,7 +82,7 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
 fi
 
 if [[ $STARTSTOP == "start-foreground" ]]; then
-    exec "${FLINK_BIN_DIR}"/flink-console.sh jobmanager "${args[@]}"
+    exec "${FLINK_BIN_DIR}"/flink-console.sh $JOBMANAGER_TYPE "${args[@]}"
 else
-    "${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP jobmanager "${args[@]}"
+    "${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP $JOBMANAGER_TYPE "${args[@]}"
 fi

--- a/flink-dist/src/main/flink-bin/bin/start-cluster.sh
+++ b/flink-dist/src/main/flink-bin/bin/start-cluster.sh
@@ -22,6 +22,13 @@ bin=`cd "$bin"; pwd`
 
 . "$bin"/config.sh
 
+FLIP6=$1
+CLUSTER_TYPE=cluster
+
+if [[ "$FLIP6" == "flip6" ]]; then
+    CLUSTER_TYPE=flip6
+fi
+
 # Start the JobManager instance(s)
 shopt -s nocasematch
 if [[ $HIGH_AVAILABILITY == "zookeeper" ]]; then
@@ -33,16 +40,16 @@ if [[ $HIGH_AVAILABILITY == "zookeeper" ]]; then
     for ((i=0;i<${#MASTERS[@]};++i)); do
         master=${MASTERS[i]}
         webuiport=${WEBUIPORTS[i]}
-        ssh -n $FLINK_SSH_OPTS $master -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/jobmanager.sh\" start cluster ${master} ${webuiport} &"
+        ssh -n $FLINK_SSH_OPTS $master -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/jobmanager.sh\" start $CLUSTER_TYPE ${master} ${webuiport} &"
     done
 
 else
     echo "Starting cluster."
 
     # Start single JobManager on this machine
-    "$FLINK_BIN_DIR"/jobmanager.sh start cluster
+    "$FLINK_BIN_DIR"/jobmanager.sh start $CLUSTER_TYPE
 fi
 shopt -u nocasematch
 
 # Start TaskManager instance(s)
-TMSlaves start
+TMSlaves start $FLIP6

--- a/flink-dist/src/main/flink-bin/bin/stop-cluster.sh
+++ b/flink-dist/src/main/flink-bin/bin/stop-cluster.sh
@@ -22,8 +22,10 @@ bin=`cd "$bin"; pwd`
 
 . "$bin"/config.sh
 
+FLIP6=$1
+
 # Stop TaskManager instance(s)
-TMSlaves stop
+TMSlaves stop $FLIP6
 
 # Stop JobManager instance(s)
 shopt -s nocasematch
@@ -32,10 +34,10 @@ if [[ $HIGH_AVAILABILITY == "zookeeper" ]]; then
     readMasters
 
     for master in ${MASTERS[@]}; do
-        ssh -n $FLINK_SSH_OPTS $master -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/jobmanager.sh\" stop &"
+        ssh -n $FLINK_SSH_OPTS $master -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/jobmanager.sh\" stop \"${FLIP6}\" &"
     done
 
 else
-	  "$FLINK_BIN_DIR"/jobmanager.sh stop
+	  "$FLINK_BIN_DIR"/jobmanager.sh stop "${FLIP6}"
 fi
 shopt -u nocasematch

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -18,7 +18,7 @@
 ################################################################################
 
 # Start/stop a Flink TaskManager.
-USAGE="Usage: taskmanager.sh (start|start-foreground|stop|stop-all) (flip6)"
+USAGE="Usage: taskmanager.sh (start|start-foreground|stop|stop-all) [flip6]"
 
 STARTSTOP=$1
 TYPE=taskmanager

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/StandaloneSessionClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/StandaloneSessionClusterEntrypoint.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.FlinkResourceManager;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.resourcemanager.ResourceManager;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerConfiguration;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerRuntimeServices;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerRuntimeServicesConfiguration;
+import org.apache.flink.runtime.resourcemanager.StandaloneResourceManager;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+
+/**
+ * Entry point for the standalone session cluster.
+ */
+public class StandaloneSessionClusterEntrypoint extends SessionClusterEntrypoint {
+
+	@Override
+	protected ResourceManager<?> createResourceManager(
+			Configuration configuration,
+			ResourceID resourceId,
+			RpcService rpcService,
+			HighAvailabilityServices highAvailabilityServices,
+			HeartbeatServices heartbeatServices,
+			MetricRegistry metricRegistry,
+			FatalErrorHandler fatalErrorHandler) throws Exception {
+		final ResourceManagerConfiguration resourceManagerConfiguration = ResourceManagerConfiguration.fromConfiguration(configuration);
+		final ResourceManagerRuntimeServicesConfiguration resourceManagerRuntimeServicesConfiguration = ResourceManagerRuntimeServicesConfiguration.fromConfiguration(configuration);
+		final ResourceManagerRuntimeServices resourceManagerRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
+			resourceManagerRuntimeServicesConfiguration,
+			highAvailabilityServices,
+			rpcService.getScheduledExecutor());
+
+		return new StandaloneResourceManager(
+			rpcService,
+			FlinkResourceManager.RESOURCE_MANAGER_NAME,
+			resourceId,
+			resourceManagerConfiguration,
+			highAvailabilityServices,
+			heartbeatServices,
+			resourceManagerRuntimeServices.getSlotManager(),
+			metricRegistry,
+			resourceManagerRuntimeServices.getJobLeaderIdService(),
+			fatalErrorHandler);
+	}
+
+	public static void main(String[] args) {
+		StandaloneSessionClusterEntrypoint entrypoint = new StandaloneSessionClusterEntrypoint();
+
+		entrypoint.startCluster(args);
+	}
+}


### PR DESCRIPTION
This PR is based on #4272, #4261, #4260 and #4259.

Adapt the start up scripts such that we can now use the `jobmanager.sh` script to launch a Flip-6 standalone session cluster with the command `./jobmanager.sh start flip6`. Stopping the standalone session cluster entrypoint is done via `./jobmanager.sh stop flip6`.

In order to start a complete Flip-6 standalone cluster, we can use the `./start-cluster.sh flip6` command. In order to stop the cluster, we have to call `./stop-cluster.sh flip6`.
