### PR TITLE
FLINK-6557 Fixing tests for RocksDB state backend on Windows

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -881,7 +881,13 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 			// create hard links of living files in the checkpoint path
 			Checkpoint checkpoint = Checkpoint.create(stateBackend.db);
-			checkpoint.createCheckpoint(backupPath.getPath());
+
+			// compensate for the fact that Flink paths are slashed
+			String checkpointPath = backupPath.hasWindowsDrive() ?
+				backupPath.getPath().substring(1) :
+				backupPath.getPath();
+
+			checkpoint.createCheckpoint(checkpointPath);
 		}
 
 		KeyedStateHandle materializeSnapshot() throws Exception {
@@ -1376,8 +1382,13 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 					List<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>();
 
+					// compensate for the fact that Flink paths are slashed
+					String restorePath = restoreInstancePath.hasWindowsDrive() ?
+						restoreInstancePath.getPath().substring(1) :
+						restoreInstancePath.getPath();
+
 					try (RocksDB restoreDb = stateBackend.openDB(
-							restoreInstancePath.getPath(),
+							restorePath,
 							columnFamilyDescriptors,
 							columnFamilyHandles)) {
 


### PR DESCRIPTION
This is an alternate fix for issue FLINK-6557 to https://github.com/apache/flink/pull/3899 which seems to have failed in CI testing. The proposed fix uses the same technique used to solve this issue in other parts of the Flink codebase, making it consistent and easy to refactor in the future.

Description from the commit message:
"Fixing tests for RocksDB state backend on Windows. The original path to RocksDB contains "/" character at the beginning of the String, which is not accepted by the RocksDB implementation. The fix uses logic consistent with existing handling of this issue in other parts of the codebase."