### PR TITLE
[FLINK-7110] [client] Add per-job cluster deployment interface

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -83,6 +83,6 @@ public class DefaultCLI implements CustomCommandLine<StandaloneClusterClient> {
 			List<URL> userJarFiles) throws UnsupportedOperationException {
 
 		StandaloneClusterDescriptor descriptor = new StandaloneClusterDescriptor(config);
-		return descriptor.deploySession();
+		return descriptor.deploySessionCluster();
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -83,6 +83,6 @@ public class DefaultCLI implements CustomCommandLine<StandaloneClusterClient> {
 			List<URL> userJarFiles) throws UnsupportedOperationException {
 
 		StandaloneClusterDescriptor descriptor = new StandaloneClusterDescriptor(config);
-		return descriptor.deploy();
+		return descriptor.deploySession();
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDeploymentException.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDeploymentException.java
@@ -16,22 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.yarn;
+package org.apache.flink.client.deployment;
 
-import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.FlinkException;
 
 /**
- * Default implementation of {@link AbstractYarnClusterDescriptor} which starts an {@link YarnApplicationMasterRunner}.
+ * Class which indicates a problem when deploying a Flink cluster.
  */
-public class YarnClusterDescriptor extends AbstractYarnClusterDescriptor {
+public class ClusterDeploymentException extends FlinkException {
 
-	@Override
-	protected Class<?> getApplicationMasterClass() {
-		return YarnApplicationMasterRunner.class;
+	private static final long serialVersionUID = -4327724979766139208L;
+
+	public ClusterDeploymentException(String message) {
+		super(message);
 	}
 
-	@Override
-	public YarnClusterClient deployJobCluster(JobGraph jobGraph) {
-		throw new UnsupportedOperationException("Cannot deploy a per-job yarn cluster yet.");
+	public ClusterDeploymentException(Throwable cause) {
+		super(cause);
+	}
+
+	public ClusterDeploymentException(String message, Throwable cause) {
+		super(message, cause);
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
@@ -19,6 +19,7 @@
 package org.apache.flink.client.deployment;
 
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.runtime.jobgraph.JobGraph;
 
 /**
  * A descriptor to deploy a cluster (e.g. Yarn or Mesos) and return a Client for Cluster communication.
@@ -44,5 +45,12 @@ public interface ClusterDescriptor<ClientType extends ClusterClient> {
 	 * @return Client for the cluster
 	 * @throws UnsupportedOperationException if this cluster descriptor doesn't support the operation
 	 */
-	ClientType deploy() throws UnsupportedOperationException;
+	ClientType deploySession() throws UnsupportedOperationException;
+
+	/**
+	 * Deploys a per-job cluster with the given job on the cluster.
+	 *
+	 * @return Cluster client to talk to the Flink cluster
+	 */
+	ClientType deployJob(final JobGraph jobGraph);
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
@@ -45,12 +45,13 @@ public interface ClusterDescriptor<ClientType extends ClusterClient> {
 	 * @return Client for the cluster
 	 * @throws UnsupportedOperationException if this cluster descriptor doesn't support the operation
 	 */
-	ClientType deploySession() throws UnsupportedOperationException;
+	ClientType deploySessionCluster() throws UnsupportedOperationException;
 
 	/**
 	 * Deploys a per-job cluster with the given job on the cluster.
 	 *
 	 * @return Cluster client to talk to the Flink cluster
+	 * @throws ClusterDeploymentException if the cluster could not be deployed
 	 */
-	ClientType deployJob(final JobGraph jobGraph);
+	ClientType deployJobCluster(final JobGraph jobGraph) throws ClusterDeploymentException;
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
@@ -21,6 +21,7 @@ package org.apache.flink.client.deployment;
 import org.apache.flink.client.program.StandaloneClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
 
 /**
  * A deployment descriptor for an existing cluster.
@@ -50,12 +51,12 @@ public class StandaloneClusterDescriptor implements ClusterDescriptor<Standalone
 	}
 
 	@Override
-	public StandaloneClusterClient deploySession() throws UnsupportedOperationException {
+	public StandaloneClusterClient deploySessionCluster() throws UnsupportedOperationException {
 		throw new UnsupportedOperationException("Can't deploy a standalone cluster.");
 	}
 
 	@Override
-	public StandaloneClusterClient deployJob(JobGraph jobGraph) {
+	public StandaloneClusterClient deployJobCluster(JobGraph jobGraph) throws ClusterDeploymentException {
 		throw new UnsupportedOperationException("Can't deploy a standalone per-job cluster.");
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
@@ -50,7 +50,12 @@ public class StandaloneClusterDescriptor implements ClusterDescriptor<Standalone
 	}
 
 	@Override
-	public StandaloneClusterClient deploy() throws UnsupportedOperationException {
+	public StandaloneClusterClient deploySession() throws UnsupportedOperationException {
 		throw new UnsupportedOperationException("Can't deploy a standalone cluster.");
+	}
+
+	@Override
+	public StandaloneClusterClient deployJob(JobGraph jobGraph) {
+		throw new UnsupportedOperationException("Can't deploy a standalone per-job cluster.");
 	}
 }

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/TestingYarnClusterDescriptor.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/TestingYarnClusterDescriptor.java
@@ -61,7 +61,7 @@ public class TestingYarnClusterDescriptor extends AbstractYarnClusterDescriptor 
 	}
 
 	@Override
-	public YarnClusterClient deployJob(JobGraph jobGraph) {
+	public YarnClusterClient deployJobCluster(JobGraph jobGraph) {
 		throw new UnsupportedOperationException("Cannot deploy a per-job cluster yet.");
 	}
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/TestingYarnClusterDescriptor.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/TestingYarnClusterDescriptor.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.util.Preconditions;
 
 import java.io.File;
@@ -57,6 +58,11 @@ public class TestingYarnClusterDescriptor extends AbstractYarnClusterDescriptor 
 	@Override
 	protected Class<?> getApplicationMasterClass() {
 		return TestingApplicationMaster.class;
+	}
+
+	@Override
+	public YarnClusterClient deployJob(JobGraph jobGraph) {
+		throw new UnsupportedOperationException("Cannot deploy a per-job cluster yet.");
 	}
 
 	private static class TestJarFinder implements FilenameFilter {

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -137,7 +137,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 		HighAvailabilityServices highAvailabilityServices = null;
 
 		try {
-			yarnCluster = flinkYarnClient.deploySession();
+			yarnCluster = flinkYarnClient.deploySessionCluster();
 
 			final ClusterClient finalYarnCluster = yarnCluster;
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -137,7 +137,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 		HighAvailabilityServices highAvailabilityServices = null;
 
 		try {
-			yarnCluster = flinkYarnClient.deploy();
+			yarnCluster = flinkYarnClient.deploySession();
 
 			final ClusterClient finalYarnCluster = yarnCluster;
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -238,7 +238,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		// deploy
 		ClusterClient yarnCluster = null;
 		try {
-			yarnCluster = flinkYarnClient.deploy();
+			yarnCluster = flinkYarnClient.deploySession();
 		} catch (Exception e) {
 			LOG.warn("Failing test", e);
 			Assert.fail("Error while deploying YARN cluster: " + e.getMessage());

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -238,7 +238,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		// deploy
 		ClusterClient yarnCluster = null;
 		try {
-			yarnCluster = flinkYarnClient.deploySession();
+			yarnCluster = flinkYarnClient.deploySessionCluster();
 		} catch (Exception e) {
 			LOG.warn("Failing test", e);
 			Assert.fail("Error while deploying YARN cluster: " + e.getMessage());

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -429,7 +429,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	}
 
 	@Override
-	public YarnClusterClient deploySession() {
+	public YarnClusterClient deploySessionCluster() {
 		try {
 			if (UserGroupInformation.isSecurityEnabled()) {
 				// note: UGI::hasKerberosCredentials inaccurately reports false

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -429,7 +429,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	}
 
 	@Override
-	public YarnClusterClient deploy() {
+	public YarnClusterClient deploySession() {
 		try {
 			if (UserGroupInformation.isSecurityEnabled()) {
 				// note: UGI::hasKerberosCredentials inaccurately reports false

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.runtime.jobgraph.JobGraph;
+
 /**
  * Default implementation of {@link AbstractYarnClusterDescriptor} which starts an {@link YarnApplicationMasterRunner}.
  */
@@ -26,5 +28,10 @@ public class YarnClusterDescriptor extends AbstractYarnClusterDescriptor {
 	@Override
 	protected Class<?> getApplicationMasterClass() {
 		return YarnApplicationMasterRunner.class;
+	}
+
+	@Override
+	public YarnClusterClient deployJob(JobGraph jobGraph) {
+		throw new UnsupportedOperationException("Cannot deploy a per-job yarn cluster yet.");
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptorV2.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptorV2.java
@@ -34,7 +34,7 @@ public class YarnClusterDescriptorV2 extends AbstractYarnClusterDescriptor {
 	}
 
 	@Override
-	public YarnClusterClient deployJob(JobGraph jobGraph) {
+	public YarnClusterClient deployJobCluster(JobGraph jobGraph) {
 		throw new UnsupportedOperationException("Cannot yet deploy a per-job yarn cluster.");
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptorV2.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptorV2.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.runtime.jobgraph.JobGraph;
+
 /**
  * Implementation of {@link org.apache.flink.yarn.AbstractYarnClusterDescriptor} which is used to start the new application master for a job under flip-6.
  * This implementation is now however tricky, since YarnClusterDescriptorV2 is related YarnClusterClientV2, but AbstractYarnClusterDescriptor is related
@@ -31,4 +33,8 @@ public class YarnClusterDescriptorV2 extends AbstractYarnClusterDescriptor {
 		return YarnFlinkApplicationMasterRunner.class;
 	}
 
+	@Override
+	public YarnClusterClient deployJob(JobGraph jobGraph) {
+		throw new UnsupportedOperationException("Cannot yet deploy a per-job yarn cluster.");
+	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -551,7 +551,7 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 		yarnClusterDescriptor.setProvidedUserJarFiles(userJarFiles);
 
 		try {
-			return yarnClusterDescriptor.deploy();
+			return yarnClusterDescriptor.deploySession();
 		} catch (Exception e) {
 			throw new RuntimeException("Error deploying the YARN cluster", e);
 		}
@@ -627,7 +627,7 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 			}
 
 			try {
-				yarnCluster = yarnDescriptor.deploy();
+				yarnCluster = yarnDescriptor.deploySession();
 			} catch (Exception e) {
 				System.err.println("Error while deploying YARN cluster: " + e.getMessage());
 				e.printStackTrace(System.err);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -551,7 +551,7 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 		yarnClusterDescriptor.setProvidedUserJarFiles(userJarFiles);
 
 		try {
-			return yarnClusterDescriptor.deploySession();
+			return yarnClusterDescriptor.deploySessionCluster();
 		} catch (Exception e) {
 			throw new RuntimeException("Error deploying the YARN cluster", e);
 		}
@@ -627,7 +627,7 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 			}
 
 			try {
-				yarnCluster = yarnDescriptor.deploySession();
+				yarnCluster = yarnDescriptor.deploySessionCluster();
 			} catch (Exception e) {
 				System.err.println("Error while deploying YARN cluster: " + e.getMessage());
 				e.printStackTrace(System.err);

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -69,7 +69,7 @@ public class YarnClusterDescriptorTest {
 		clusterDescriptor.setTaskManagerSlots(Integer.MAX_VALUE);
 
 		try {
-			clusterDescriptor.deploy();
+			clusterDescriptor.deploySession();
 
 			fail("The deploy call should have failed.");
 		} catch (RuntimeException e) {
@@ -98,7 +98,7 @@ public class YarnClusterDescriptorTest {
 		clusterDescriptor.setTaskManagerSlots(1);
 
 		try {
-			clusterDescriptor.deploy();
+			clusterDescriptor.deploySession();
 
 			fail("The deploy call should have failed.");
 		} catch (RuntimeException e) {

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -69,7 +69,7 @@ public class YarnClusterDescriptorTest {
 		clusterDescriptor.setTaskManagerSlots(Integer.MAX_VALUE);
 
 		try {
-			clusterDescriptor.deploySession();
+			clusterDescriptor.deploySessionCluster();
 
 			fail("The deploy call should have failed.");
 		} catch (RuntimeException e) {
@@ -98,7 +98,7 @@ public class YarnClusterDescriptorTest {
 		clusterDescriptor.setTaskManagerSlots(1);
 
 		try {
-			clusterDescriptor.deploySession();
+			clusterDescriptor.deploySessionCluster();
 
 			fail("The deploy call should have failed.");
 		} catch (RuntimeException e) {


### PR DESCRIPTION
This PR changes the `ClusterDescriptor` interface such that we have a `deploySession` and a `deployJob` call in order to launch a Flink session cluster and a Flink per-job cluster. The latter receives the `JobGraph` which is supposed to be launched in the per-job cluster.
