### PR TITLE
[FLINK-7113] Make ClusterDescriptor independent of cluster size

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -90,7 +90,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -126,16 +125,27 @@ public class CliFrontend {
 
 	// --------------------------------------------------------------------------------------------
 
-	private static final List<CustomCommandLine> customCommandLine = new LinkedList<>();
+	private static final List<CustomCommandLine<?>> customCommandLines = new ArrayList<>(3);
 
 	static {
 		//	Command line interface of the YARN session, with a special initialization here
 		//	to prefix all options with y/yarn.
 		//	Tips: DefaultCLI must be added at last, because getActiveCustomCommandLine(..) will get the
 		//	      active CustomCommandLine in order and DefaultCLI isActive always return true.
-		loadCustomCommandLine("org.apache.flink.yarn.cli.FlinkYarnSessionCli", "y", "yarn");
-		loadCustomCommandLine("org.apache.flink.yarn.cli.FlinkYarnCLI", "y", "yarn");
-		customCommandLine.add(new DefaultCLI());
+		final String flinkYarnSessionCLI = "org.apache.flink.yarn.cli.FlinkYarnSessionCli";
+		final String flinkYarnCLI = "org.apache.flink.yarn.cli.FlinkYarnCLI";
+		try {
+			customCommandLines.add(loadCustomCommandLine(flinkYarnSessionCLI, "y", "yarn"));
+		} catch (Exception e) {
+			LOG.warn("Could not load CLI class {}.", flinkYarnSessionCLI, e);
+		}
+
+		try {
+			customCommandLines.add(loadCustomCommandLine(flinkYarnCLI, "y", "yarn"));
+		} catch (Exception e) {
+			LOG.warn("Could not load CLI class {}.", flinkYarnCLI, e);
+		}
+		customCommandLines.add(new DefaultCLI());
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -1172,7 +1182,7 @@ public class CliFrontend {
 	 * @return custom command-line which is active (may only be one at a time)
 	 */
 	public CustomCommandLine getActiveCustomCommandLine(CommandLine commandLine) {
-		for (CustomCommandLine cli : customCommandLine) {
+		for (CustomCommandLine cli : customCommandLines) {
 			if (cli.isActive(commandLine, config)) {
 				return cli;
 			}
@@ -1184,8 +1194,8 @@ public class CliFrontend {
 	 * Retrieves the loaded custom command-lines.
 	 * @return An unmodifiyable list of loaded custom command-lines.
 	 */
-	public static List<CustomCommandLine> getCustomCommandLineList() {
-		return Collections.unmodifiableList(customCommandLine);
+	public static List<CustomCommandLine<?>> getCustomCommandLineList() {
+		return Collections.unmodifiableList(customCommandLines);
 	}
 
 	/**
@@ -1193,29 +1203,21 @@ public class CliFrontend {
 	 * @param className The fully-qualified class name to load.
 	 * @param params The constructor parameters
 	 */
-	private static void loadCustomCommandLine(String className, Object... params) {
+	private static CustomCommandLine<?> loadCustomCommandLine(String className, Object... params) throws IllegalAccessException, InvocationTargetException, InstantiationException, ClassNotFoundException, NoSuchMethodException {
 
-		try {
-			Class<? extends CustomCommandLine> customCliClass =
-				Class.forName(className).asSubclass(CustomCommandLine.class);
+		Class<? extends CustomCommandLine> customCliClass =
+			Class.forName(className).asSubclass(CustomCommandLine.class);
 
-			// construct class types from the parameters
-			Class<?>[] types = new Class<?>[params.length];
-			for (int i = 0; i < params.length; i++) {
-				Preconditions.checkNotNull(params[i], "Parameters for custom command-lines may not be null.");
-				types[i] = params[i].getClass();
-			}
-
-			Constructor<? extends CustomCommandLine> constructor = customCliClass.getConstructor(types);
-			final CustomCommandLine cli = constructor.newInstance(params);
-
-			customCommandLine.add(cli);
-
-		} catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InstantiationException
-			| InvocationTargetException e) {
-			LOG.warn("Unable to locate custom CLI class {}. " +
-				"Flink is not compiled with support for this class.", className, e);
+		// construct class types from the parameters
+		Class<?>[] types = new Class<?>[params.length];
+		for (int i = 0; i < params.length; i++) {
+			Preconditions.checkNotNull(params[i], "Parameters for custom command-lines may not be null.");
+			types[i] = params[i].getClass();
 		}
+
+		Constructor<? extends CustomCommandLine> constructor = customCliClass.getConstructor(types);
+
+		return constructor.newInstance(params);
 	}
 
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -19,6 +19,7 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.client.ClientUtils;
+import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.StandaloneClusterDescriptor;
 import org.apache.flink.client.program.StandaloneClusterClient;
 import org.apache.flink.configuration.Configuration;
@@ -83,6 +84,8 @@ public class DefaultCLI implements CustomCommandLine<StandaloneClusterClient> {
 			List<URL> userJarFiles) throws UnsupportedOperationException {
 
 		StandaloneClusterDescriptor descriptor = new StandaloneClusterDescriptor(config);
-		return descriptor.deploySessionCluster();
+		ClusterSpecification clusterSpecification = ClusterSpecification.fromConfiguration(config);
+
+		return descriptor.deploySessionCluster(clusterSpecification);
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
@@ -42,10 +42,11 @@ public interface ClusterDescriptor<ClientType extends ClusterClient> {
 
 	/**
 	 * Triggers deployment of a cluster.
+	 * @param clusterSpecification Cluster specification defining the cluster to deploy
 	 * @return Client for the cluster
 	 * @throws UnsupportedOperationException if this cluster descriptor doesn't support the operation
 	 */
-	ClientType deploySessionCluster() throws UnsupportedOperationException;
+	ClientType deploySessionCluster(ClusterSpecification clusterSpecification) throws UnsupportedOperationException;
 
 	/**
 	 * Deploys a per-job cluster with the given job on the cluster.

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterSpecification.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterSpecification.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+
+/**
+ * Description of the cluster to start by the {@link ClusterDescriptor}.
+ */
+public final class ClusterSpecification {
+	private final int masterMemoryMB;
+	private final int taskManagerMemoryMB;
+	private final int numberTaskManagers;
+	private final int slotsPerTaskManager;
+
+	private ClusterSpecification(int masterMemoryMB, int taskManagerMemoryMB, int numberTaskManagers, int slotsPerTaskManager) {
+		this.masterMemoryMB = masterMemoryMB;
+		this.taskManagerMemoryMB = taskManagerMemoryMB;
+		this.numberTaskManagers = numberTaskManagers;
+		this.slotsPerTaskManager = slotsPerTaskManager;
+	}
+
+	public int getMasterMemoryMB() {
+		return masterMemoryMB;
+	}
+
+	public int getTaskManagerMemoryMB() {
+		return taskManagerMemoryMB;
+	}
+
+	public int getNumberTaskManagers() {
+		return numberTaskManagers;
+	}
+
+	public int getSlotsPerTaskManager() {
+		return slotsPerTaskManager;
+	}
+
+	@Override
+	public String toString() {
+		return "ClusterSpecification{" +
+			"masterMemoryMB=" + masterMemoryMB +
+			", taskManagerMemoryMB=" + taskManagerMemoryMB +
+			", numberTaskManagers=" + numberTaskManagers +
+			", slotsPerTaskManager=" + slotsPerTaskManager +
+			'}';
+	}
+
+	public static ClusterSpecification fromConfiguration(Configuration configuration) {
+		int slots = configuration.getInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 1);
+
+		int jobManagerMemoryMb = configuration.getInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY);
+		int taskManagerMemoryMb = configuration.getInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY);
+
+		return new ClusterSpecificationBuilder()
+			.setMasterMemoryMB(jobManagerMemoryMb)
+			.setTaskManagerMemoryMB(taskManagerMemoryMb)
+			.setNumberTaskManagers(1)
+			.setSlotsPerTaskManager(slots)
+			.createClusterSpecification();
+	}
+
+	/**
+	 * Builder for the {@link ClusterSpecification} instance.
+	 */
+	public static class ClusterSpecificationBuilder {
+		private int masterMemoryMB = 768;
+		private int taskManagerMemoryMB = 768;
+		private int numberTaskManagers = 1;
+		private int slotsPerTaskManager = 1;
+
+		public ClusterSpecificationBuilder setMasterMemoryMB(int masterMemoryMB) {
+			this.masterMemoryMB = masterMemoryMB;
+			return this;
+		}
+
+		public ClusterSpecificationBuilder setTaskManagerMemoryMB(int taskManagerMemoryMB) {
+			this.taskManagerMemoryMB = taskManagerMemoryMB;
+			return this;
+		}
+
+		public ClusterSpecificationBuilder setNumberTaskManagers(int numberTaskManagers) {
+			this.numberTaskManagers = numberTaskManagers;
+			return this;
+		}
+
+		public ClusterSpecificationBuilder setSlotsPerTaskManager(int slotsPerTaskManager) {
+			this.slotsPerTaskManager = slotsPerTaskManager;
+			return this;
+		}
+
+		public ClusterSpecification createClusterSpecification() {
+			return new ClusterSpecification(
+				masterMemoryMB,
+				taskManagerMemoryMB,
+				numberTaskManagers,
+				slotsPerTaskManager);
+		}
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
@@ -51,7 +51,7 @@ public class StandaloneClusterDescriptor implements ClusterDescriptor<Standalone
 	}
 
 	@Override
-	public StandaloneClusterClient deploySessionCluster() throws UnsupportedOperationException {
+	public StandaloneClusterClient deploySessionCluster(ClusterSpecification clusterSpecification) throws UnsupportedOperationException {
 		throw new UnsupportedOperationException("Can't deploy a standalone cluster.");
 	}
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendYarnAddressConfigurationTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendYarnAddressConfigurationTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.test.util.TestBaseUtils;
+import org.apache.flink.util.TestLogger;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 
 import org.apache.commons.cli.CommandLine;
@@ -66,7 +67,7 @@ import static org.junit.Assert.assertEquals;
  * Tests that verify that the CLI client picks up the correct address for the JobManager
  * from configuration and configs.
  */
-public class CliFrontendYarnAddressConfigurationTest {
+public class CliFrontendYarnAddressConfigurationTest extends TestLogger {
 
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -378,6 +379,8 @@ public class CliFrontendYarnAddressConfigurationTest {
 				@Override
 				protected YarnClusterClient createYarnClusterClient(
 						AbstractYarnClusterDescriptor descriptor,
+						int numberTaskManagers,
+						int slotsPerTaskManager,
 						YarnClient yarnClient,
 						ApplicationReport report,
 						Configuration flinkConfiguration,

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.CoreOptions;
@@ -107,9 +108,6 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 		TestingYarnClusterDescriptor flinkYarnClient = new TestingYarnClusterDescriptor();
 
 		Assert.assertNotNull("unable to get yarn client", flinkYarnClient);
-		flinkYarnClient.setTaskManagerCount(1);
-		flinkYarnClient.setJobManagerMemory(768);
-		flinkYarnClient.setTaskManagerMemory(1024);
 		flinkYarnClient.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
 		flinkYarnClient.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));
 
@@ -136,8 +134,15 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 
 		HighAvailabilityServices highAvailabilityServices = null;
 
+		final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
+			.setMasterMemoryMB(768)
+			.setTaskManagerMemoryMB(1024)
+			.setNumberTaskManagers(1)
+			.setSlotsPerTaskManager(1)
+			.createClusterSpecification();
+
 		try {
-			yarnCluster = flinkYarnClient.deploySessionCluster();
+			yarnCluster = flinkYarnClient.deploySessionCluster(clusterSpecification);
 
 			final ClusterClient finalYarnCluster = yarnCluster;
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -136,6 +136,8 @@ public abstract class YarnTestBase extends TestLogger {
 	 */
 	protected static File tempConfPathForSecureRun = null;
 
+	protected static org.apache.flink.configuration.Configuration flinkConfiguration = new org.apache.flink.configuration.Configuration();
+
 	static {
 		YARN_CONFIGURATION = new YarnConfiguration();
 		YARN_CONFIGURATION.setInt(YarnConfiguration.RM_SCHEDULER_MINIMUM_ALLOCATION_MB, 512);
@@ -631,6 +633,7 @@ public abstract class YarnTestBase extends TestLogger {
 	protected static class Runner extends Thread {
 		private final String[] args;
 		private final int expectedReturnValue;
+
 		private RunTypes type;
 		private FlinkYarnSessionCli yCli;
 		private Throwable runnerError;
@@ -647,7 +650,10 @@ public abstract class YarnTestBase extends TestLogger {
 				int returnValue;
 				switch (type) {
 					case YARN_SESSION:
-						yCli = new FlinkYarnSessionCli("", "", false);
+						yCli = new FlinkYarnSessionCli(
+							"",
+							"",
+							false);
 						returnValue = yCli.run(args);
 						break;
 					case CLI_FRONTEND:

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientV2.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientV2.java
@@ -26,10 +26,7 @@ import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusRespon
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
 import org.apache.hadoop.yarn.api.records.ApplicationId;
-import org.apache.hadoop.yarn.api.records.ApplicationReport;
-import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.client.api.YarnClient;
-import org.apache.hadoop.yarn.client.api.YarnClientApplication;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,7 +76,7 @@ public class YarnClusterClientV2 extends ClusterClient {
 
 	@Override
 	public int getMaxSlots() {
-        // Now need not set max slot
+        // No need not set max slot
 		return 0;
 	}
 
@@ -90,25 +87,7 @@ public class YarnClusterClientV2 extends ClusterClient {
 
 	@Override
 	protected JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader) throws ProgramInvocationException {
-		try {
-			// Create application via yarnClient
-			final YarnClientApplication yarnApplication = yarnClient.createApplication();
-			ApplicationReport report = this.clusterDescriptor.startAppMaster(jobGraph, yarnClient, yarnApplication);
-			if (report.getYarnApplicationState().equals(YarnApplicationState.RUNNING)) {
-				appId = report.getApplicationId();
-				trackingURL = report.getTrackingUrl();
-				logAndSysout("Please refer to " + getWebInterfaceURL()
-						+ " for the running status of job " +  jobGraph.getJobID().toString());
-				//TODO: not support attach mode now
-				return new JobSubmissionResult(jobGraph.getJobID());
-			}
-			else {
-				throw new ProgramInvocationException("Fail to submit the job.");
-			}
-		}
-		catch (Exception e) {
-			throw new ProgramInvocationException("Fail to submit the job", e.getCause());
-		}
+		throw new UnsupportedOperationException("Not yet implemented.");
 	}
 
 	@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnCLI.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnCLI.java
@@ -144,12 +144,6 @@ public class FlinkYarnCLI implements CustomCommandLine<YarnClusterClientV2> {
 			yarnClusterDescriptor.setQueue(cmd.getOptionValue(queue.getOpt()));
 		}
 
-		// JobManager Memory
-		if (cmd.hasOption(jmMemory.getOpt())) {
-			int jmMemory = Integer.valueOf(cmd.getOptionValue(this.jmMemory.getOpt()));
-			yarnClusterDescriptor.setJobManagerMemory(jmMemory);
-		}
-
 		String[] dynamicProperties = null;
 		if (cmd.hasOption(this.dynamicProperties.getOpt())) {
 			dynamicProperties = cmd.getOptionValues(this.dynamicProperties.getOpt());
@@ -232,7 +226,9 @@ public class FlinkYarnCLI implements CustomCommandLine<YarnClusterClientV2> {
 		yarnClusterDescriptor.setFlinkConfiguration(config);
 		yarnClusterDescriptor.setProvidedUserJarFiles(userJarFiles);
 
-		return new YarnClusterClientV2(yarnClusterDescriptor, config);
+		return new YarnClusterClientV2(
+			yarnClusterDescriptor,
+			config);
 	}
 
 	private void logAndSysout(String message) {


### PR DESCRIPTION
This PR is based on #4270.

In order to pull some of the cluster deployment logic out of the `AbstractYarnClusterDescriptor`, this PR introduces a `ClusterSpecification`. This specification contains information about the size of the cluster to be started. Instead of setting these values via setters directly on the `ClusterDescriptor`, we provide the information at deployment time via the `ClusterSpecification`.

The way I envision the `ClusterDescriptor` to work, is to only contain information which is necessary to talk to a resource manager, such as Mesos or Yarn. All Flink cluster specific information should be provided to the `deploy` methods. This also allows us better share code between different `ClusterDescriptor`, e.g. Mesos and Yarn.

This is only the start of a refactoring of the `ClusterDescriptor`. Much more information can be pulled out of the `AbstractYarnClusterDescriptor`.