### PR TITLE
[FLINK-6975][table]Add CONCAT/CONCAT_WS supported in TableAPI

### DIFF
--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -2256,6 +2256,27 @@ STRING.initCap()
         <p>Converts the initial letter of each word in a string to uppercase. Assumes a string containing only [A-Za-z0-9], everything else is treated as whitespace.</p>
       </td>
     </tr>
+    <tr>
+      <td>
+        {% highlight text %}
+concat(string1, string2,...)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the string that results from concatenating the arguments. Returns NULL if any argument is NULL. E.g. <code>concat("AA", "BB", "CC")</code> returns <code>AABBCC</code>.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight text %}
+concat_ws(separator, string1, string2,...)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the string that results from concatenating the arguments using a separator. The separator is added between the strings to be concatenated. Returns NULL If the separator is NULL. concat_ws() does not skip empty strings. However, it does skip any NULL argument. E.g. <code>concat_ws("~", "AA", "BB", "", "CC")</code> returns <code>AA~BB~~CC</code></p>
+      </td>
+    </tr>
 
   </tbody>
 </table>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -987,8 +987,8 @@ object randInteger {
   * Returns NULL if any argument is NULL.
   */
 object concat {
-  def apply(strings: Expression*): Expression = {
-    new Concat(strings)
+  def apply(string: Expression, strings: Expression*): Expression = {
+    new Concat(Seq(string) ++ strings)
   }
 }
 
@@ -1000,8 +1000,8 @@ object concat {
   * values after the separator argument.
   **/
 object concat_ws {
-  def apply(separator: Expression, strings: Expression*): Expression = {
-    new ConcatWs(separator, strings)
+  def apply(separator: Expression, string: Expression, strings: Expression*): Expression = {
+    new ConcatWs(separator, Seq(string) ++ strings)
   }
 }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -982,4 +982,27 @@ object randInteger {
   }
 }
 
+/**
+  * Returns the string that results from concatenating the arguments.
+  * Returns NULL if any argument is NULL.
+  */
+object concat {
+  def apply(strings: Expression*): Expression = {
+    new Concat(strings)
+  }
+}
+
+/**
+  * Returns the string that results from concatenating the arguments and separator.
+  * Returns NULL If the separator is NULL.
+  *
+  * Note: this user-defined function does not skip empty strings. However, it does skip any NULL
+  * values after the separator argument.
+  **/
+object concat_ws {
+  def apply(separator: Expression, strings: Expression*): Expression = {
+    new ConcatWs(separator, strings)
+  }
+}
+
 // scalastyle:on object.name

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/InputTypeSpec.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/InputTypeSpec.scala
@@ -40,6 +40,14 @@ trait InputTypeSpec extends Expression {
 
   override private[flink] def validateInput(): ValidationResult = {
     val typeMismatches = mutable.ArrayBuffer.empty[String]
+
+    if(expectedTypes.size != children.size){
+      return ValidationFailure(
+        s"""|$this fails on input type size checking: expected types size[${expectedTypes.size}].
+            |Operands types size[${children.size}].
+            |""".stripMargin)
+    }
+
     children.zip(expectedTypes).zipWithIndex.foreach { case ((e, tpe), i) =>
       if (e.resultType != tpe) {
         typeMismatches += s"expecting $tpe on ${i}th input, get ${e.resultType}"

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
@@ -289,10 +289,10 @@ case class Concat(strings: Seq[Expression]) extends Expression with InputTypeSpe
 
   override private[flink] def resultType: TypeInformation[_] = BasicTypeInfo.STRING_TYPE_INFO
 
-  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = STRING_TYPE_INFO :: Nil
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] =
+    children.map(_ => STRING_TYPE_INFO)
 
-  override def toString: String = s"Concat($strings)"
-
+  override def toString: String = s"concat($strings)"
 
   override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
     relBuilder.call(ScalarSqlFunctions.CONCAT, children.map(_.toRexNode))
@@ -313,10 +313,10 @@ case class ConcatWs(separator: Expression, strings: Seq[Expression])
 
   override private[flink] def resultType: TypeInformation[_] = BasicTypeInfo.STRING_TYPE_INFO
 
-  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = STRING_TYPE_INFO :: Nil
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] =
+    children.map(_ => STRING_TYPE_INFO)
 
-  override def toString: String = s"ConcatWs($separator, $strings)"
-
+  override def toString: String = s"concat_ws($separator, $strings)"
 
   override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
     relBuilder.call(ScalarSqlFunctions.CONCAT_WS, children.map(_.toRexNode))

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
@@ -22,8 +22,9 @@ import org.apache.calcite.rex.RexNode
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.tools.RelBuilder
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
-import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.table.expressions.TrimMode.TrimMode
+import org.apache.flink.table.functions.sql.ScalarSqlFunctions
 import org.apache.flink.table.validate._
 
 /**
@@ -275,5 +276,49 @@ case class Overlay(
       replacement.toRexNode,
       starting.toRexNode,
       position.toRexNode)
+  }
+}
+
+/**
+  * Returns the string that results from concatenating the arguments.
+  * Returns NULL if any argument is NULL.
+  */
+case class Concat(strings: Seq[Expression]) extends Expression with InputTypeSpec {
+
+  override private[flink] def children: Seq[Expression] = strings
+
+  override private[flink] def resultType: TypeInformation[_] = BasicTypeInfo.STRING_TYPE_INFO
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = STRING_TYPE_INFO :: Nil
+
+  override def toString: String = s"Concat($strings)"
+
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(ScalarSqlFunctions.CONCAT, children.map(_.toRexNode))
+  }
+}
+
+/**
+  * Returns the string that results from concatenating the arguments and separator.
+  * Returns NULL If the separator is NULL.
+  *
+  * Note: this user-defined function does not skip empty strings. However, it does skip any NULL
+  * values after the separator argument.
+  **/
+case class ConcatWs(separator: Expression, strings: Seq[Expression])
+  extends Expression with InputTypeSpec {
+
+  override private[flink] def children: Seq[Expression] = Seq(separator) ++ strings
+
+  override private[flink] def resultType: TypeInformation[_] = BasicTypeInfo.STRING_TYPE_INFO
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = STRING_TYPE_INFO :: Nil
+
+  override def toString: String = s"ConcatWs($separator, $strings)"
+
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(ScalarSqlFunctions.CONCAT_WS, children.map(_.toRexNode))
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -107,6 +107,18 @@ class FunctionCatalog {
         val function = aggregateFunction.getFunction
         AggFunctionCall(function, children)
 
+      // concat_ws
+      case concat_ws if classOf[ConcatWs].isAssignableFrom(concat_ws) =>
+        Try(funcClass.getDeclaredConstructor(classOf[Expression], classOf[Seq[_]])) match {
+          case Success(ctor) =>
+            Try(ctor.newInstance(children.head, children.tail).asInstanceOf[Expression]) match {
+              case Success(expr) => expr
+              case Failure(e) => throw new ValidationException(e.getMessage)
+            }
+          case _ =>
+            throw ValidationException("Never be here.")
+        }
+
       // general expression call
       case expression if classOf[Expression].isAssignableFrom(expression) =>
         // try to find a constructor accepts `Seq[Expression]`
@@ -195,6 +207,8 @@ object FunctionCatalog {
     "upperCase" -> classOf[Upper],
     "position" -> classOf[Position],
     "overlay" -> classOf[Overlay],
+    "concat" -> classOf[Concat],
+    "concat_ws" -> classOf[ConcatWs],
 
     // math functions
     "plus" -> classOf[Plus],

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -327,18 +327,46 @@ class ScalarFunctionsTest extends ExpressionTestBase {
 
   @Test
   def testMultiConcat(): Unit = {
-   testSqlApi("CONCAT('xx', f33)","null")
-   testSqlApi("CONCAT('AA','BB','CC','---')","AABBCC---")
-   testSqlApi("CONCAT('x~x','b~b','c~~~~c','---')","x~xb~bc~~~~c---")
+    testAllApis(concat("xx", 'f33), "concat('xx', f33)", "CONCAT('xx', f33)", "null")
+    testAllApis(
+      concat("AA", "BB", "CC", "---"),
+      "concat('AA','BB','CC','---')",
+      "CONCAT('AA','BB','CC','---')",
+      "AABBCC---")
+    testAllApis(
+      concat("x~x", "b~b", "c~~~~c", "---"),
+      "concat('x~x','b~b','c~~~~c','---')",
+      "CONCAT('x~x','b~b','c~~~~c','---')",
+      "x~xb~bc~~~~c---")
   }
 
   @Test
   def testConcatWs(): Unit = {
-    testSqlApi("CONCAT_WS(f33, 'AA')", "null")
-    testSqlApi("concat_ws('~~~~','AA')", "AA")
-    testSqlApi("concat_ws('~','AA','BB')", "AA~BB")
-    testSqlApi("concat_ws('~',f33, 'AA','BB','',f33, 'CC')", "AA~BB~~CC")
-    testSqlApi("CONCAT_WS('~~~~','Flink', f33, 'xx', f33, f33)", "Flink~~~~xx")
+    testAllApis(
+      concat_ws('f33, "AA"),
+      "concat_ws(f33, 'AA')",
+      "CONCAT_WS(f33, 'AA')",
+      "null")
+    testAllApis(
+      concat_ws("~~~~", "AA"),
+      "concat_ws('~~~~','AA')",
+      "concat_ws('~~~~','AA')",
+      "AA")
+    testAllApis(
+      concat_ws("~", "AA", "BB"),
+      "concat_ws('~','AA','BB')",
+      "concat_ws('~','AA','BB')",
+      "AA~BB")
+    testAllApis(
+      concat_ws("~", 'f33, "AA", "BB", "", 'f33, "CC"),
+      "concat_ws('~',f33, 'AA','BB','',f33, 'CC')",
+      "concat_ws('~',f33, 'AA','BB','',f33, 'CC')",
+      "AA~BB~~CC")
+    testAllApis(
+      concat_ws("~~~~", "Flink", 'f33, "xx", 'f33, 'f33),
+      "concat_ws('~~~~','Flink', f33, 'xx', f33, f33)",
+      "CONCAT_WS('~~~~','Flink', f33, 'xx', f33, f33)",
+      "Flink~~~~xx")
   }
 
   // ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
In this PR. I have Add CONCAT/CONCAT_WS supported in TableAPI.
- [x] General
  - The pull request references the related JIRA issue ("[FLINK-6975][table]Add CONCAT/CONCAT_WS supported in TableAPI")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [x] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [x] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
