### PR TITLE
[FLINK-7116] [rpc] Add getPort to RpcService

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
@@ -43,6 +43,14 @@ public interface RpcService {
 	String getAddress();
 
 	/**
+	 * Return the port under which the rpc service is reachable. If the rpc service cannot be
+	 * contacted remotely, then it will return -1.
+	 *
+	 * @return Port of the rpc service or -1 if local rpc service
+	 */
+	int getPort();
+
+	/**
 	 * Connect to a remote rpc server under the provided address. Returns a rpc gateway which can
 	 * be used to communicate with the rpc server. If the connection failed, then the returned
 	 * future is failed with a {@link RpcConnectionException}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -87,6 +87,7 @@ public class AkkaRpcService implements RpcService {
 	private final long maximumFramesize;
 
 	private final String address;
+	private final int port;
 
 	private final ScheduledExecutor internalScheduledExecutor;
 
@@ -111,12 +112,23 @@ public class AkkaRpcService implements RpcService {
 			address = "";
 		}
 
+		if (actorSystemAddress.port().isDefined()) {
+			port = (Integer) actorSystemAddress.port().get();
+		} else {
+			port = -1;
+		}
+
 		internalScheduledExecutor = new InternalScheduledExecutorImpl(actorSystem);
 	}
 
 	@Override
 	public String getAddress() {
 		return address;
+	}
+
+	@Override
+	public int getPort() {
+		return port;
 	}
 
 	// this method does not mutate state and is thus thread-safe

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingSerialRpcService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingSerialRpcService.java
@@ -173,6 +173,11 @@ public class TestingSerialRpcService implements RpcService {
 	}
 
 	@Override
+	public int getPort() {
+		return -1;
+	}
+
+	@Override
 	public <C extends RpcGateway> Future<C> connect(String address, Class<C> clazz) {
 		RpcGateway gateway = registeredConnections.get(address);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -129,6 +129,11 @@ public class AkkaRpcServiceTest extends TestLogger {
 		assertEquals(AkkaUtils.getAddress(actorSystem).host().get(), akkaRpcService.getAddress());
 	}
 
+	@Test
+	public void testGetPort() {
+		assertEquals(AkkaUtils.getAddress(actorSystem).port().get(), akkaRpcService.getPort());
+	}
+
 	/**
 	 * Tests that we can wait for the termination of the rpc service
 	 *


### PR DESCRIPTION
The `RpcService` should expose its port it is bound to. That way it is easier to connect to a
remote `RpcService`.