### PR TITLE
[FLINK-7125] [yarn] Remove Configuration loading from AbstractYarnClusterDescriptor

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -152,6 +152,8 @@ public class CliFrontend {
 
 	private final Configuration config;
 
+	private final String configurationDirectory;
+
 	private final FiniteDuration clientTimeout;
 
 	private final int defaultParallelism;
@@ -165,6 +167,7 @@ public class CliFrontend {
 	}
 
 	public CliFrontend(String configDir) throws Exception {
+		configurationDirectory = Preconditions.checkNotNull(configDir);
 
 		// configure the config directory
 		File configDirectory = new File(configDir);
@@ -906,7 +909,7 @@ public class CliFrontend {
 	protected ClusterClient retrieveClient(CommandLineOptions options) {
 		CustomCommandLine customCLI = getActiveCustomCommandLine(options.getCommandLine());
 		try {
-			ClusterClient client = customCLI.retrieveCluster(options.getCommandLine(), config);
+			ClusterClient client = customCLI.retrieveCluster(options.getCommandLine(), config, configurationDirectory);
 			logAndSysout("Using address " + client.getJobManagerAddress() + " to connect to JobManager.");
 			return client;
 		} catch (Exception e) {
@@ -943,7 +946,7 @@ public class CliFrontend {
 
 		ClusterClient client;
 		try {
-			client = activeCommandLine.retrieveCluster(options.getCommandLine(), config);
+			client = activeCommandLine.retrieveCluster(options.getCommandLine(), config, configurationDirectory);
 			logAndSysout("Cluster configuration: " + client.getClusterIdentifier());
 		} catch (UnsupportedOperationException e) {
 			try {
@@ -952,6 +955,7 @@ public class CliFrontend {
 					applicationName,
 					options.getCommandLine(),
 					config,
+					configurationDirectory,
 					program.getAllLibraries());
 				logAndSysout("Cluster started: " + client.getClusterIdentifier());
 			} catch (UnsupportedOperationException e2) {

--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -207,6 +207,15 @@ public class CliFrontend {
 		return copiedConfiguration;
 	}
 
+	/**
+	 * Returns the configuration directory for the CLI frontend.
+	 *
+	 * @return Configuration directory
+	 */
+	public String getConfigurationDirectory() {
+		return configurationDirectory;
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  Execute Actions
 	// --------------------------------------------------------------------------------------------

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
@@ -62,7 +62,7 @@ public interface CustomCommandLine<ClusterType extends ClusterClient> {
 	 * Retrieves a client for a running cluster.
 	 * @param commandLine The command-line parameters from the CliFrontend
 	 * @param config The Flink config
-	 * @param configurationDirectory Direcotry for configuration files
+	 * @param configurationDirectory Directory for configuration files
 	 * @return Client if a cluster could be retrieved
 	 * @throws UnsupportedOperationException if the operation is not supported
 	 */
@@ -76,7 +76,7 @@ public interface CustomCommandLine<ClusterType extends ClusterClient> {
 	 * @param applicationName The application name to use
 	 * @param commandLine The command-line options parsed by the CliFrontend
 	 * @param config The Flink config to use
-	 * @param configurationDirectory
+	 * @param configurationDirectory Directory for configuration files
 	 *@param userJarFiles User jar files to include in the classpath of the cluster.  @return The client to communicate with the cluster which the CustomCommandLine brought up.
 	 * @throws Exception if the cluster could not be created
 	 */
@@ -84,5 +84,6 @@ public interface CustomCommandLine<ClusterType extends ClusterClient> {
 		String applicationName,
 		CommandLine commandLine,
 		Configuration config,
-		String configurationDirectory, List<URL> userJarFiles) throws Exception;
+		String configurationDirectory,
+		List<URL> userJarFiles) throws Exception;
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
@@ -62,25 +62,27 @@ public interface CustomCommandLine<ClusterType extends ClusterClient> {
 	 * Retrieves a client for a running cluster.
 	 * @param commandLine The command-line parameters from the CliFrontend
 	 * @param config The Flink config
+	 * @param configurationDirectory Direcotry for configuration files
 	 * @return Client if a cluster could be retrieved
 	 * @throws UnsupportedOperationException if the operation is not supported
 	 */
 	ClusterType retrieveCluster(
-			CommandLine commandLine,
-			Configuration config) throws UnsupportedOperationException;
+		CommandLine commandLine,
+		Configuration config,
+		String configurationDirectory) throws UnsupportedOperationException;
 
 	/**
 	 * Creates the client for the cluster.
 	 * @param applicationName The application name to use
 	 * @param commandLine The command-line options parsed by the CliFrontend
 	 * @param config The Flink config to use
-	 * @param userJarFiles User jar files to include in the classpath of the cluster.
-	 * @return The client to communicate with the cluster which the CustomCommandLine brought up.
+	 * @param configurationDirectory
+	 *@param userJarFiles User jar files to include in the classpath of the cluster.  @return The client to communicate with the cluster which the CustomCommandLine brought up.
 	 * @throws Exception if the cluster could not be created
 	 */
 	ClusterType createCluster(
-			String applicationName,
-			CommandLine commandLine,
-			Configuration config,
-			List<URL> userJarFiles) throws Exception;
+		String applicationName,
+		CommandLine commandLine,
+		Configuration config,
+		String configurationDirectory, List<URL> userJarFiles) throws Exception;
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -59,7 +59,7 @@ public class DefaultCLI implements CustomCommandLine<StandaloneClusterClient> {
 	}
 
 	@Override
-	public StandaloneClusterClient retrieveCluster(CommandLine commandLine, Configuration config) {
+	public StandaloneClusterClient retrieveCluster(CommandLine commandLine, Configuration config, String configurationDirectory) {
 
 		if (commandLine.hasOption(CliFrontendParser.ADDRESS_OPTION.getOpt())) {
 			String addressWithPort = commandLine.getOptionValue(CliFrontendParser.ADDRESS_OPTION.getOpt());
@@ -78,10 +78,10 @@ public class DefaultCLI implements CustomCommandLine<StandaloneClusterClient> {
 
 	@Override
 	public StandaloneClusterClient createCluster(
-			String applicationName,
-			CommandLine commandLine,
-			Configuration config,
-			List<URL> userJarFiles) throws UnsupportedOperationException {
+		String applicationName,
+		CommandLine commandLine,
+		Configuration config,
+		String configurationDirectory, List<URL> userJarFiles) throws UnsupportedOperationException {
 
 		StandaloneClusterDescriptor descriptor = new StandaloneClusterDescriptor(config);
 		ClusterSpecification clusterSpecification = ClusterSpecification.fromConfiguration(config);

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -59,7 +59,10 @@ public class DefaultCLI implements CustomCommandLine<StandaloneClusterClient> {
 	}
 
 	@Override
-	public StandaloneClusterClient retrieveCluster(CommandLine commandLine, Configuration config, String configurationDirectory) {
+	public StandaloneClusterClient retrieveCluster(
+			CommandLine commandLine,
+			Configuration config,
+			String configurationDirectory) {
 
 		if (commandLine.hasOption(CliFrontendParser.ADDRESS_OPTION.getOpt())) {
 			String addressWithPort = commandLine.getOptionValue(CliFrontendParser.ADDRESS_OPTION.getOpt());
@@ -78,10 +81,11 @@ public class DefaultCLI implements CustomCommandLine<StandaloneClusterClient> {
 
 	@Override
 	public StandaloneClusterClient createCluster(
-		String applicationName,
-		CommandLine commandLine,
-		Configuration config,
-		String configurationDirectory, List<URL> userJarFiles) throws UnsupportedOperationException {
+			String applicationName,
+			CommandLine commandLine,
+			Configuration config,
+			String configurationDirectory,
+			List<URL> userJarFiles) throws UnsupportedOperationException {
 
 		StandaloneClusterDescriptor descriptor = new StandaloneClusterDescriptor(config);
 		ClusterSpecification clusterSpecification = ClusterSpecification.fromConfiguration(config);

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -257,6 +257,7 @@ object FlinkShell {
       "Flink Scala Shell",
       options.getCommandLine,
       config,
+      frontend.getConfigurationDirectory,
       Collections.emptyList())
 
     val address = cluster.getJobManagerAddress.getAddress.getHostAddress
@@ -277,7 +278,10 @@ object FlinkShell {
     val config = frontend.getConfiguration
     val customCLI = frontend.getActiveCustomCommandLine(options.getCommandLine)
 
-    val cluster = customCLI.retrieveCluster(options.getCommandLine, config)
+    val cluster = customCLI.retrieveCluster(
+      options.getCommandLine,
+      config,
+      frontend.getConfigurationDirectory)
 
     if (cluster == null) {
       throw new RuntimeException("Yarn Cluster could not be retrieved.")

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendYarnAddressConfigurationTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendYarnAddressConfigurationTest.java
@@ -362,14 +362,20 @@ public class CliFrontendYarnAddressConfigurationTest extends TestLogger {
 
 			@Override
 			// override cluster descriptor to replace the YarnClient
-			protected AbstractYarnClusterDescriptor getClusterDescriptor() {
-				return new TestingYarnClusterDescriptor();
+			protected AbstractYarnClusterDescriptor getClusterDescriptor(
+					Configuration configuration,
+					String configurationDirecotry) {
+				return new TestingYarnClusterDescriptor(configuration, configurationDirecotry);
 			}
 
 			/**
 			 * Replace the YarnClient for this test.
 			 */
 			private class TestingYarnClusterDescriptor extends YarnClusterDescriptor {
+
+				public TestingYarnClusterDescriptor(Configuration flinkConfiguration, String configurationDirectory) {
+					super(flinkConfiguration, configurationDirectory);
+				}
 
 				@Override
 				protected YarnClient getYarnClient() {

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.TestLogger;
-import org.apache.flink.util.TestLogger;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 
 import org.apache.commons.cli.CommandLine;
@@ -70,7 +69,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		AbstractYarnClusterDescriptor flinkYarnDescriptor = cli.createDescriptor(
 			new Configuration(),
-			tmpFolder.getAbsolutePath(),
+			tmp.getRoot().getAbsolutePath(),
 			null,
 			cmd);
 
@@ -85,12 +84,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 	@Test
 	public void testNotEnoughTaskSlots() throws Exception {
-
-		File confFile = tmp.newFile("flink-conf.yaml");
 		File jarFile = tmp.newFile("test.jar");
-		CliFrontend cliFrontend = new CliFrontend(tmp.getRoot().getAbsolutePath());
-
-		final Configuration configuration = cliFrontend.getConfiguration();
 
 		String[] params =
 			new String[] {"-yn", "2", "-ys", "3", "-p", "7", jarFile.getAbsolutePath()};
@@ -121,7 +115,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		RunOptions runOptions = CliFrontendParser.parseRunCommand(params);
 
 		FlinkYarnSessionCli yarnCLI = new TestCLI("y", "yarn");
-		
+
 		final Configuration configuration = new Configuration();
 
 		AbstractYarnClusterDescriptor descriptor = yarnCLI.createDescriptor(
@@ -129,7 +123,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			tmp.getRoot().getAbsolutePath(),
 			"",
 			runOptions.getCommandLine());
-			
+
 		final ClusterSpecification clusterSpecification = yarnCLI.createClusterSpecification(
 			configuration,
 			runOptions.getCommandLine());
@@ -149,6 +143,7 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 	@Test
 	public void testZookeeperNamespaceProperty() throws Exception {
+
 		File confFile = tmp.newFile("flink-conf.yaml");
 		File jarFile = tmp.newFile("test.jar");
 		CliFrontend cliFrontend = new CliFrontend(tmp.getRoot().getAbsolutePath());

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.client.cli.RunOptions;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.test.util.TestBaseUtils;
+import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 
@@ -43,7 +43,6 @@ import org.mockito.Mockito;
 
 import java.io.File;
 import java.net.InetSocketAddress;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -57,8 +56,6 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 	@Test
 	public void testDynamicProperties() throws Exception {
 
-		Map<String, String> map = new HashMap<String, String>(System.getenv());
-		TestBaseUtils.setEnv(map);
 		FlinkYarnSessionCli cli = new FlinkYarnSessionCli(
 			"",
 			"",
@@ -71,7 +68,11 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		CommandLine cmd = parser.parse(options, new String[]{"run", "-j", "fake.jar", "-n", "15",
 				"-D", "akka.ask.timeout=5 min", "-D", "env.java.opts=-DappName=foobar"});
 
-		AbstractYarnClusterDescriptor flinkYarnDescriptor = cli.createDescriptor(null, cmd);
+		AbstractYarnClusterDescriptor flinkYarnDescriptor = cli.createDescriptor(
+			new Configuration(),
+			tmpFolder.getAbsolutePath(),
+			null,
+			cmd);
 
 		Assert.assertNotNull(flinkYarnDescriptor);
 
@@ -87,7 +88,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		File confFile = tmp.newFile("flink-conf.yaml");
 		File jarFile = tmp.newFile("test.jar");
-		new CliFrontend(tmp.getRoot().getAbsolutePath());
+		CliFrontend cliFrontend = new CliFrontend(tmp.getRoot().getAbsolutePath());
+
+		final Configuration configuration = cliFrontend.getConfiguration();
 
 		String[] params =
 			new String[] {"-yn", "2", "-ys", "3", "-p", "7", jarFile.getAbsolutePath()};
@@ -108,7 +111,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		File confFile = tmp.newFile("flink-conf.yaml");
 		File jarFile = tmp.newFile("test.jar");
-		new CliFrontend(tmp.getRoot().getAbsolutePath());
+		CliFrontend cliFrontend = new CliFrontend(tmp.getRoot().getAbsolutePath());
+
+		final Configuration config = cliFrontend.getConfiguration();
 
 		String[] params =
 			new String[] {"-yn", "2", "-ys", "3", jarFile.getAbsolutePath()};
@@ -116,15 +121,23 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		RunOptions runOptions = CliFrontendParser.parseRunCommand(params);
 
 		FlinkYarnSessionCli yarnCLI = new TestCLI("y", "yarn");
+		
+		final Configuration configuration = new Configuration();
 
-		AbstractYarnClusterDescriptor descriptor = yarnCLI.createDescriptor("", runOptions.getCommandLine());
-		final ClusterSpecification clusterSpecification = yarnCLI.createClusterSpecification(new Configuration(), runOptions.getCommandLine());
+		AbstractYarnClusterDescriptor descriptor = yarnCLI.createDescriptor(
+			configuration,
+			tmp.getRoot().getAbsolutePath(),
+			"",
+			runOptions.getCommandLine());
+			
+		final ClusterSpecification clusterSpecification = yarnCLI.createClusterSpecification(
+			configuration,
+			runOptions.getCommandLine());
 
 		// each task manager has 3 slots but the parallelism is 7. Thus the slots should be increased.
 		Assert.assertEquals(3, clusterSpecification.getSlotsPerTaskManager());
 		Assert.assertEquals(2, clusterSpecification.getNumberTaskManagers());
 
-		Configuration config = new Configuration();
 		CliFrontend.setJobManagerAddressInConfig(config, new InetSocketAddress("localhost", 9000));
 		ClusterClient client = new TestingYarnClusterClient(
 			descriptor,
@@ -136,10 +149,10 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 	@Test
 	public void testZookeeperNamespaceProperty() throws Exception {
-
 		File confFile = tmp.newFile("flink-conf.yaml");
 		File jarFile = tmp.newFile("test.jar");
-		new CliFrontend(tmp.getRoot().getAbsolutePath());
+		CliFrontend cliFrontend = new CliFrontend(tmp.getRoot().getAbsolutePath());
+		final Configuration configuration = cliFrontend.getConfiguration();
 
 		String zkNamespaceCliInput = "flink_test_namespace";
 
@@ -149,7 +162,11 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		RunOptions runOptions = CliFrontendParser.parseRunCommand(params);
 
 		FlinkYarnSessionCli yarnCLI = new TestCLI("y", "yarn");
-		AbstractYarnClusterDescriptor descriptor = yarnCLI.createDescriptor("", runOptions.getCommandLine());
+		AbstractYarnClusterDescriptor descriptor = yarnCLI.createDescriptor(
+			configuration,
+			tmp.getRoot().getAbsolutePath(),
+			"",
+			runOptions.getCommandLine());
 
 		Assert.assertEquals(zkNamespaceCliInput, descriptor.getZookeeperNamespace());
 	}
@@ -161,6 +178,10 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		}
 
 		private static class JarAgnosticClusterDescriptor extends YarnClusterDescriptor {
+			public JarAgnosticClusterDescriptor(Configuration flinkConfiguration, String configurationDirectory) {
+				super(flinkConfiguration, configurationDirectory);
+			}
+
 			@Override
 			public void setLocalJarPath(Path localJarPath) {
 				// add nothing
@@ -168,8 +189,8 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		}
 
 		@Override
-		protected AbstractYarnClusterDescriptor getClusterDescriptor() {
-			return new JarAgnosticClusterDescriptor();
+		protected AbstractYarnClusterDescriptor getClusterDescriptor(Configuration configuration, String configurationDirectory) {
+			return new JarAgnosticClusterDescriptor(configuration, configurationDirectory);
 		}
 	}
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/TestingYarnClusterDescriptor.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/TestingYarnClusterDescriptor.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.util.Preconditions;
 
@@ -33,7 +34,8 @@ import java.util.List;
  */
 public class TestingYarnClusterDescriptor extends AbstractYarnClusterDescriptor {
 
-	public TestingYarnClusterDescriptor() {
+	public TestingYarnClusterDescriptor(Configuration configuration, String configurationDirectory) {
+		super(configuration, configurationDirectory);
 		List<File> filesToShip = new ArrayList<>();
 
 		File testingJar = YarnTestBase.findFile("..", new TestJarFinder("flink-yarn-tests"));

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.yarn;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -104,15 +105,13 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 	@Test
 	public void testMultipleAMKill() throws Exception {
 		final int numberKillingAttempts = numberApplicationAttempts - 1;
-
-		TestingYarnClusterDescriptor flinkYarnClient = new TestingYarnClusterDescriptor();
+		String confDirPath = System.getenv(ConfigConstants.ENV_FLINK_CONF_DIR);
+		final Configuration configuration = GlobalConfiguration.loadConfiguration();
+		TestingYarnClusterDescriptor flinkYarnClient = new TestingYarnClusterDescriptor(configuration, confDirPath);
 
 		Assert.assertNotNull("unable to get yarn client", flinkYarnClient);
 		flinkYarnClient.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
 		flinkYarnClient.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));
-
-		String confDirPath = System.getenv(ConfigConstants.ENV_FLINK_CONF_DIR);
-		flinkYarnClient.setConfigurationDirectory(confDirPath);
 
 		String fsStateHandlePath = temp.getRoot().getPath();
 
@@ -120,13 +119,11 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 		File configDirectory = new File(confDirPath);
 		GlobalConfiguration.loadConfiguration(configDirectory.getAbsolutePath());
 
-		flinkYarnClient.setFlinkConfiguration(GlobalConfiguration.loadConfiguration());
 		flinkYarnClient.setDynamicPropertiesEncoded("recovery.mode=zookeeper@@recovery.zookeeper.quorum=" +
 			zkServer.getConnectString() + "@@yarn.application-attempts=" + numberApplicationAttempts +
 			"@@" + CoreOptions.STATE_BACKEND + "=FILESYSTEM" +
 			"@@" + FsStateBackendFactory.CHECKPOINT_DIRECTORY_URI_CONF_KEY + "=" + fsStateHandlePath + "/checkpoints" +
 			"@@" + HighAvailabilityOptions.HA_STORAGE_PATH.key() + "=" + fsStateHandlePath + "/recovery");
-		flinkYarnClient.setConfigurationFilePath(new Path(confDirPath + File.separator + "flink-conf.yaml"));
 
 		ClusterClient yarnCluster = null;
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.yarn;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
@@ -224,14 +225,12 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		final int waitTime = 15;
 		LOG.info("Starting testJavaAPI()");
 
-		AbstractYarnClusterDescriptor flinkYarnClient = new YarnClusterDescriptor();
+		String confDirPath = System.getenv(ConfigConstants.ENV_FLINK_CONF_DIR);
+		Configuration configuration = GlobalConfiguration.loadConfiguration();
+		AbstractYarnClusterDescriptor flinkYarnClient = new YarnClusterDescriptor(configuration, confDirPath);
 		Assert.assertNotNull("unable to get yarn client", flinkYarnClient);
 		flinkYarnClient.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
 		flinkYarnClient.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));
-		String confDirPath = System.getenv(ConfigConstants.ENV_FLINK_CONF_DIR);
-		flinkYarnClient.setConfigurationDirectory(confDirPath);
-		flinkYarnClient.setFlinkConfiguration(GlobalConfiguration.loadConfiguration());
-		flinkYarnClient.setConfigurationFilePath(new Path(confDirPath + File.separator + "flink-conf.yaml"));
 
 		final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
 			.setMasterMemoryMB(768)

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.yarn;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.test.util.TestBaseUtils;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
@@ -39,7 +40,7 @@ import java.util.Set;
 /**
  * Tests for the YarnClusterDescriptor.
  */
-public class YarnClusterDescriptorTest {
+public class YarnClusterDescriptorTest extends TestLogger {
 
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -49,12 +50,8 @@ public class YarnClusterDescriptorTest {
 	 */
 	@Test
 	public void testExplicitLibShipping() throws Exception {
-		AbstractYarnClusterDescriptor descriptor = new YarnClusterDescriptor();
+		AbstractYarnClusterDescriptor descriptor = new YarnClusterDescriptor(new Configuration(), temporaryFolder.getRoot().getAbsolutePath());
 		descriptor.setLocalJarPath(new Path("/path/to/flink.jar"));
-
-		descriptor.setConfigurationDirectory(temporaryFolder.getRoot().getAbsolutePath());
-		descriptor.setConfigurationFilePath(new Path(temporaryFolder.getRoot().getPath()));
-		descriptor.setFlinkConfiguration(new Configuration());
 
 		File libFile = temporaryFolder.newFile("libFile.jar");
 		File libFolder = temporaryFolder.newFolder().getAbsoluteFile();
@@ -86,11 +83,7 @@ public class YarnClusterDescriptorTest {
 	 */
 	@Test
 	public void testEnvironmentLibShipping() throws Exception {
-		AbstractYarnClusterDescriptor descriptor = new YarnClusterDescriptor();
-
-		descriptor.setConfigurationDirectory(temporaryFolder.getRoot().getAbsolutePath());
-		descriptor.setConfigurationFilePath(new Path(temporaryFolder.getRoot().getPath()));
-		descriptor.setFlinkConfiguration(new Configuration());
+		AbstractYarnClusterDescriptor descriptor = new YarnClusterDescriptor(new Configuration(), temporaryFolder.getRoot().getAbsolutePath());
 
 		File libFolder = temporaryFolder.newFolder().getAbsoluteFile();
 		File libFile = new File(libFolder, "libFile.jar");

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -137,8 +137,6 @@ public abstract class YarnTestBase extends TestLogger {
 	 */
 	protected static File tempConfPathForSecureRun = null;
 
-	protected static org.apache.flink.configuration.Configuration flinkConfiguration = new org.apache.flink.configuration.Configuration();
-
 	static {
 		YARN_CONFIGURATION = new YarnConfiguration();
 		YARN_CONFIGURATION.setInt(YarnConfiguration.RM_SCHEDULER_MINIMUM_ALLOCATION_MB, 512);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -18,12 +18,10 @@
 
 package org.apache.flink.yarn;
 
-import org.apache.flink.client.CliFrontend;
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -119,8 +117,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 	private String configurationDirectory;
 
-	private Path flinkConfigurationPath;
-
 	private Path flinkJarPath;
 
 	private String dynamicPropertiesEncoded;
@@ -128,7 +124,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	/** Lazily initialized list of files to ship. */
 	protected List<File> shipFiles = new LinkedList<>();
 
-	private org.apache.flink.configuration.Configuration flinkConfiguration;
+	private final org.apache.flink.configuration.Configuration flinkConfiguration;
 
 	private boolean detached;
 
@@ -142,7 +138,9 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 	private YarnConfigOptions.UserJarInclusion userJarInclusion;
 
-	public AbstractYarnClusterDescriptor() {
+	public AbstractYarnClusterDescriptor(
+		org.apache.flink.configuration.Configuration flinkConfiguration,
+		String configurationDirectory) {
 		// for unit tests only
 		if (System.getenv("IN_TESTS") != null) {
 			try {
@@ -152,18 +150,13 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			}
 		}
 
+		this.flinkConfiguration = Preconditions.checkNotNull(flinkConfiguration);
+		userJarInclusion = getUserJarInclusionMode(flinkConfiguration);
+
+		this.configurationDirectory = Preconditions.checkNotNull(configurationDirectory);
+
 		// tries to load the config through the environment, if it fails it can still be set through the setters
 		try {
-			this.configurationDirectory = CliFrontend.getConfigurationDirectoryFromEnv();
-			this.flinkConfiguration = GlobalConfiguration.loadConfiguration(configurationDirectory);
-
-			File confFile = new File(configurationDirectory + File.separator + GlobalConfiguration.FLINK_CONF_FILENAME);
-			if (!confFile.exists()) {
-				throw new RuntimeException("Unable to locate configuration file in " + confFile);
-			}
-			flinkConfigurationPath = new Path(confFile.getAbsolutePath());
-
-			userJarInclusion = getUserJarInclusionMode(flinkConfiguration);
 		} catch (Exception e) {
 			LOG.debug("Config couldn't be loaded from environment variable.", e);
 		}
@@ -173,12 +166,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	 * The class to bootstrap the application master of the Yarn cluster (runs main method).
 	 */
 	protected abstract Class<?> getApplicationMasterClass();
-
-	public void setFlinkConfiguration(org.apache.flink.configuration.Configuration conf) {
-		this.flinkConfiguration = conf;
-
-		userJarInclusion = getUserJarInclusionMode(flinkConfiguration);
-	}
 
 	public org.apache.flink.configuration.Configuration getFlinkConfiguration() {
 		return flinkConfiguration;
@@ -193,14 +180,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			throw new IllegalArgumentException("The passed jar path ('" + localJarPath + "') does not end with the 'jar' extension");
 		}
 		this.flinkJarPath = localJarPath;
-	}
-
-	public void setConfigurationFilePath(Path confPath) {
-		flinkConfigurationPath = confPath;
-	}
-
-	public void setConfigurationDirectory(String configurationDirectory) {
-		this.configurationDirectory = configurationDirectory;
 	}
 
 	public void addShipFiles(List<File> shipFiles) {
@@ -267,9 +246,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		}
 		if (this.configurationDirectory == null) {
 			throw new YarnDeploymentException("Configuration directory not set");
-		}
-		if (this.flinkConfigurationPath == null) {
-			throw new YarnDeploymentException("Configuration path not set");
 		}
 		if (this.flinkConfiguration == null) {
 			throw new YarnDeploymentException("Flink configuration object has not been set");
@@ -734,12 +710,30 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 		// Setup jar for ApplicationMaster
 		LocalResource appMasterJar = Records.newRecord(LocalResource.class);
-		LocalResource flinkConf = Records.newRecord(LocalResource.class);
-		Path remotePathJar =
-			Utils.setupLocalResource(fs, appId.toString(), flinkJarPath, appMasterJar, fs.getHomeDirectory());
-		Path remotePathConf =
-			Utils.setupLocalResource(fs, appId.toString(), flinkConfigurationPath, flinkConf, fs.getHomeDirectory());
+		Path remotePathJar = Utils.setupLocalResource(
+			fs,
+			appId.toString(),
+			flinkJarPath,
+			appMasterJar,
+			fs.getHomeDirectory());
+
 		localResources.put("flink.jar", appMasterJar);
+
+		// Upload the flink configuration
+		LocalResource flinkConf = Records.newRecord(LocalResource.class);
+
+		// write out configuration file
+		File tmpConfigurationFile = File.createTempFile(appId + "-flink-conf.yaml", null);
+		tmpConfigurationFile.deleteOnExit();
+		BootstrapTools.writeConfiguration(flinkConfiguration, tmpConfigurationFile);
+
+		Path remotePathConf = Utils.setupLocalResource(
+			fs,
+			appId.toString(),
+			new Path(tmpConfigurationFile.getAbsolutePath()),
+			flinkConf,
+			fs.getHomeDirectory());
+
 		localResources.put("flink-conf.yaml", flinkConf);
 
 		paths.add(remotePathJar);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -154,12 +154,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		userJarInclusion = getUserJarInclusionMode(flinkConfiguration);
 
 		this.configurationDirectory = Preconditions.checkNotNull(configurationDirectory);
-
-		// tries to load the config through the environment, if it fails it can still be set through the setters
-		try {
-		} catch (Exception e) {
-			LOG.debug("Config couldn't be loaded from environment variable.", e);
-		}
 	}
 
 	/**

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -18,12 +18,17 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
 /**
  * Default implementation of {@link AbstractYarnClusterDescriptor} which starts an {@link YarnApplicationMasterRunner}.
  */
 public class YarnClusterDescriptor extends AbstractYarnClusterDescriptor {
+
+	public YarnClusterDescriptor(Configuration flinkConfiguration, String configurationDirectory) {
+		super(flinkConfiguration, configurationDirectory);
+	}
 
 	@Override
 	protected Class<?> getApplicationMasterClass() {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptorV2.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptorV2.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
 /**
@@ -27,6 +28,10 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
  * However, in order to use the code in AbstractYarnClusterDescriptor for setting environments and so on, we make YarnClusterDescriptorV2 as now.
  */
 public class YarnClusterDescriptorV2 extends AbstractYarnClusterDescriptor {
+
+	public YarnClusterDescriptorV2(Configuration flinkConfiguration, String configurationDirectory) {
+		super(flinkConfiguration, configurationDirectory);
+	}
 
 	@Override
 	protected Class<?> getApplicationMasterClass() {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnCLI.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnCLI.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn.cli;
 
+import org.apache.flink.client.CliFrontend;
 import org.apache.flink.client.cli.CliFrontendParser;
 import org.apache.flink.client.cli.CustomCommandLine;
 import org.apache.flink.configuration.Configuration;
@@ -96,9 +97,12 @@ public class FlinkYarnCLI implements CustomCommandLine<YarnClusterClientV2> {
 		allOptions.addOption(zookeeperNamespace);
 	}
 
-	public YarnClusterDescriptorV2 createDescriptor(String defaultApplicationName, CommandLine cmd) {
+	public YarnClusterDescriptorV2 createDescriptor(
+			Configuration configuration,
+			String defaultApplicationName,
+			CommandLine cmd) {
 
-		YarnClusterDescriptorV2 yarnClusterDescriptor = new YarnClusterDescriptorV2();
+		YarnClusterDescriptorV2 yarnClusterDescriptor = new YarnClusterDescriptorV2(configuration, CliFrontend.getConfigurationDirectoryFromEnv());
 
 		// Jar Path
 		Path localJarPath;
@@ -208,22 +212,21 @@ public class FlinkYarnCLI implements CustomCommandLine<YarnClusterClientV2> {
 
 	@Override
 	public YarnClusterClientV2 retrieveCluster(
-			CommandLine cmdLine,
-			Configuration config) throws UnsupportedOperationException {
+		CommandLine cmdLine,
+		Configuration config, String configurationDirectory) throws UnsupportedOperationException {
 
 		throw new UnsupportedOperationException("Not support retrieveCluster since Flip-6.");
 	}
 
 	@Override
 	public YarnClusterClientV2 createCluster(
-			String applicationName,
-			CommandLine cmdLine,
-			Configuration config,
-			List<URL> userJarFiles) throws Exception {
+		String applicationName,
+		CommandLine cmdLine,
+		Configuration config,
+		String configurationDirectory, List<URL> userJarFiles) throws Exception {
 		Preconditions.checkNotNull(userJarFiles, "User jar files should not be null.");
 
-		YarnClusterDescriptorV2 yarnClusterDescriptor = createDescriptor(applicationName, cmdLine);
-		yarnClusterDescriptor.setFlinkConfiguration(config);
+		YarnClusterDescriptorV2 yarnClusterDescriptor = createDescriptor(config, applicationName, cmdLine);
 		yarnClusterDescriptor.setProvidedUserJarFiles(userJarFiles);
 
 		return new YarnClusterClientV2(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnCLI.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnCLI.java
@@ -212,18 +212,20 @@ public class FlinkYarnCLI implements CustomCommandLine<YarnClusterClientV2> {
 
 	@Override
 	public YarnClusterClientV2 retrieveCluster(
-		CommandLine cmdLine,
-		Configuration config, String configurationDirectory) throws UnsupportedOperationException {
+			CommandLine cmdLine,
+			Configuration config,
+			String configurationDirectory) throws UnsupportedOperationException {
 
 		throw new UnsupportedOperationException("Not support retrieveCluster since Flip-6.");
 	}
 
 	@Override
 	public YarnClusterClientV2 createCluster(
-		String applicationName,
-		CommandLine cmdLine,
-		Configuration config,
-		String configurationDirectory, List<URL> userJarFiles) throws Exception {
+			String applicationName,
+			CommandLine cmdLine,
+			Configuration config,
+			String configurationDirectory,
+			List<URL> userJarFiles) throws Exception {
 		Preconditions.checkNotNull(userJarFiles, "User jar files should not be null.");
 
 		YarnClusterDescriptorV2 yarnClusterDescriptor = createDescriptor(config, applicationName, cmdLine);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn.cli;
 
+import org.apache.flink.client.CliFrontend;
 import org.apache.flink.client.cli.CliFrontendParser;
 import org.apache.flink.client.cli.CustomCommandLine;
 import org.apache.flink.client.deployment.ClusterSpecification;
@@ -257,9 +258,15 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 		return applicationID;
 	}
 
-	public AbstractYarnClusterDescriptor createDescriptor(String defaultApplicationName, CommandLine cmd) {
+	public AbstractYarnClusterDescriptor createDescriptor(
+		Configuration configuration,
+		String configurationDirectory,
+		String defaultApplicationName,
+		CommandLine cmd) {
 
-		AbstractYarnClusterDescriptor yarnClusterDescriptor = getClusterDescriptor();
+		AbstractYarnClusterDescriptor yarnClusterDescriptor = getClusterDescriptor(
+			configuration,
+			configurationDirectory);
 
 		// Jar Path
 		Path localJarPath;
@@ -488,13 +495,16 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 	}
 
 	public static void main(final String[] args) throws Exception {
-		Configuration flinkConfiguration = GlobalConfiguration.loadConfiguration();
 		final FlinkYarnSessionCli cli = new FlinkYarnSessionCli("", ""); // no prefix for the YARN session
+
+		final String configurationDirectory = CliFrontend.getConfigurationDirectoryFromEnv();
+
+		final Configuration flinkConfiguration = GlobalConfiguration.loadConfiguration();
 		SecurityUtils.install(new SecurityUtils.SecurityConfiguration(flinkConfiguration));
 		int retCode = SecurityUtils.getInstalledContext().runSecured(new Callable<Integer>() {
 			@Override
 			public Integer call() {
-				return cli.run(args);
+				return cli.run(args, flinkConfiguration, configurationDirectory);
 			}
 		});
 		System.exit(retCode);
@@ -528,7 +538,8 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 	@Override
 	public YarnClusterClient retrieveCluster(
 			CommandLine cmdLine,
-			Configuration config) throws UnsupportedOperationException {
+			Configuration config,
+			String configurationDirectory) throws UnsupportedOperationException {
 
 		// first check for an application id, then try to load from yarn properties
 		String applicationID = cmdLine.hasOption(applicationId.getOpt()) ?
@@ -541,8 +552,7 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 					: config.getString(HighAvailabilityOptions.HA_CLUSTER_ID, applicationID);
 			config.setString(HighAvailabilityOptions.HA_CLUSTER_ID, zkNamespace);
 
-			AbstractYarnClusterDescriptor yarnDescriptor = getClusterDescriptor();
-			yarnDescriptor.setFlinkConfiguration(config);
+			AbstractYarnClusterDescriptor yarnDescriptor = getClusterDescriptor(config, configurationDirectory);
 			return yarnDescriptor.retrieve(applicationID);
 		} else {
 			throw new UnsupportedOperationException("Could not resume a Yarn cluster.");
@@ -554,12 +564,18 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 			String applicationName,
 			CommandLine cmdLine,
 			Configuration config,
+			String configurationDirectory,
 			List<URL> userJarFiles) {
 		Preconditions.checkNotNull(userJarFiles, "User jar files should not be null.");
 
-		AbstractYarnClusterDescriptor yarnClusterDescriptor = createDescriptor(applicationName, cmdLine);
-		ClusterSpecification clusterSpecification = createClusterSpecification(config, cmdLine);
-		yarnClusterDescriptor.setFlinkConfiguration(config);
+		AbstractYarnClusterDescriptor yarnClusterDescriptor = createDescriptor(
+			config,
+			configurationDirectory,
+			applicationName,
+			cmdLine);
+		
+		final ClusterSpecification clusterSpecification = createClusterSpecification(config, cmdLine);
+		
 		yarnClusterDescriptor.setProvidedUserJarFiles(userJarFiles);
 
 		try {
@@ -570,7 +586,10 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 
 	}
 
-	public int run(String[] args) {
+	public int run(
+			String[] args,
+			Configuration configuration,
+			String configurationDirectory) {
 		//
 		//	Command Line Options
 		//
@@ -590,7 +609,7 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 
 		// Query cluster for metrics
 		if (cmd.hasOption(query.getOpt())) {
-			AbstractYarnClusterDescriptor yarnDescriptor = getClusterDescriptor();
+			AbstractYarnClusterDescriptor yarnDescriptor = getClusterDescriptor(configuration, configurationDirectory);
 			String description;
 			try {
 				description = yarnDescriptor.getClusterDescription();
@@ -603,7 +622,7 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 			return 0;
 		} else if (cmd.hasOption(applicationId.getOpt())) {
 
-			AbstractYarnClusterDescriptor yarnDescriptor = getClusterDescriptor();
+			AbstractYarnClusterDescriptor yarnDescriptor = getClusterDescriptor(configuration, configurationDirectory);
 
 			//configure ZK namespace depending on the value passed
 			String zkNamespace = cmd.hasOption(zookeeperNamespace.getOpt()) ?
@@ -631,7 +650,7 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 
 			AbstractYarnClusterDescriptor yarnDescriptor;
 			try {
-				yarnDescriptor = createDescriptor(null, cmd);
+				yarnDescriptor = createDescriptor(configuration, configurationDirectory, null, cmd);
 			} catch (Exception e) {
 				System.err.println("Error while starting the YARN Client: " + e.getMessage());
 				e.printStackTrace(System.err);
@@ -745,7 +764,7 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 		return new File(propertiesFileLocation, YARN_PROPERTIES_FILE + currentUser);
 	}
 
-	protected AbstractYarnClusterDescriptor getClusterDescriptor() {
-		return new YarnClusterDescriptor();
+	protected AbstractYarnClusterDescriptor getClusterDescriptor(Configuration configuration, String configurationDirectory) {
+		return new YarnClusterDescriptor(configuration, configurationDirectory);
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -573,9 +573,9 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 			configurationDirectory,
 			applicationName,
 			cmdLine);
-		
+
 		final ClusterSpecification clusterSpecification = createClusterSpecification(config, cmdLine);
-		
+
 		yarnClusterDescriptor.setProvidedUserJarFiles(userJarFiles);
 
 		try {

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -250,7 +250,8 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				.getCommands().get(0));
 
 		// logback + log4j, with/out krb5, different JVM opts
-		// IMPORTANT: Beaware that we are using side effects here to modify the created YarnClusterDescriptor
+		// IMPORTANT: Be aware that we are using side effects here to modify the created YarnClusterDescriptor,
+		// because we have a reference to the ClusterDescriptor's configuration which we modify continuously
 		cfg.setString(CoreOptions.FLINK_JVM_OPTIONS, jvmOpts);
 		assertEquals(
 			java + " " + jvmmem +


### PR DESCRIPTION
Instead the AbstractYarnClusterDescriptor is passed in a Configuration instance which
is sent to the started application master.