### PR TITLE
[FLINK-7080] [yarn] Add Yarn per job mode deployment

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
@@ -51,8 +51,12 @@ public interface ClusterDescriptor<ClientType extends ClusterClient> {
 	/**
 	 * Deploys a per-job cluster with the given job on the cluster.
 	 *
+	 * @param clusterSpecification Initial cluster specification with which the Flink cluster is launched
+	 * @param jobGraph JobGraph with which the job cluster is started
 	 * @return Cluster client to talk to the Flink cluster
 	 * @throws ClusterDeploymentException if the cluster could not be deployed
 	 */
-	ClientType deployJobCluster(final JobGraph jobGraph) throws ClusterDeploymentException;
+	ClientType deployJobCluster(
+		final ClusterSpecification clusterSpecification,
+		final JobGraph jobGraph);
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
@@ -56,7 +56,7 @@ public class StandaloneClusterDescriptor implements ClusterDescriptor<Standalone
 	}
 
 	@Override
-	public StandaloneClusterClient deployJobCluster(JobGraph jobGraph) throws ClusterDeploymentException {
+	public StandaloneClusterClient deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
 		throw new UnsupportedOperationException("Can't deploy a standalone per-job cluster.");
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -228,8 +228,14 @@ public class BootstrapTools {
 
 		Configuration cfg = baseConfig.clone();
 
-		cfg.setString(JobManagerOptions.ADDRESS, jobManagerHostname);
-		cfg.setInteger(JobManagerOptions.PORT, jobManagerPort);
+		if (jobManagerHostname != null && !jobManagerHostname.isEmpty()) {
+			cfg.setString(JobManagerOptions.ADDRESS, jobManagerHostname);
+		}
+
+		if (jobManagerPort > 0) {
+			cfg.setInteger(JobManagerOptions.PORT, jobManagerPort);
+		}
+
 		cfg.setString(ConfigConstants.TASK_MANAGER_MAX_REGISTRATION_DURATION, registrationTimeout.toString());
 		if (numSlots != -1){
 			cfg.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlots);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -127,6 +127,10 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 		synchronized (lock) {
 			initializeServices(configuration);
 
+			// write host information into configuration
+			configuration.setString(JobManagerOptions.ADDRESS, commonRpcService.getAddress());
+			configuration.setInteger(JobManagerOptions.PORT, commonRpcService.getPort());
+
 			startClusterComponents(
 				configuration,
 				commonRpcService,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -198,6 +199,20 @@ public class AkkaRpcServiceUtils {
 		} while (!nextNameOffset.compareAndSet(nameOffset, nameOffset + 1L));
 
 		return prefix + '_' + nameOffset;
+	}
+
+	/**
+	 * Extracts the hostname and the port of the remote actor system from the given Akka URL. The
+	 * result is an {@link InetSocketAddress} instance containing the extracted hostname and port. If
+	 * the Akka URL does not contain the hostname and port information, e.g. a local Akka URL is
+	 * provided, then an {@link Exception} is thrown.
+	 *
+	 * @param akkaURL The URL to extract the host and port from.
+	 * @return The InetSocketAddress with teh extracted host and port.
+	 * @throws Exception Thrown, if the given string does not represent a proper url
+	 */
+	public static InetSocketAddress createInetSocketAddressFromAkkaURL(String akkaURL) throws Exception {
+		return AkkaUtils.getInetSockeAddressFromAkkaURL(akkaURL);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/TestingYarnClusterDescriptor.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/TestingYarnClusterDescriptor.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.util.Preconditions;
@@ -58,20 +59,25 @@ public class TestingYarnClusterDescriptor extends AbstractYarnClusterDescriptor 
 	}
 
 	@Override
-	protected Class<?> getApplicationMasterClass() {
-		return TestingApplicationMaster.class;
+	protected String getYarnSessionClusterEntrypoint() {
+		return TestingApplicationMaster.class.getName();
 	}
 
 	@Override
-	public YarnClusterClient deployJobCluster(JobGraph jobGraph) {
+	protected String getYarnJobClusterEntrypoint() {
+		throw new UnsupportedOperationException("Does not support Yarn per-job clusters.");
+	}
+
+	@Override
+	public YarnClusterClient deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
 		throw new UnsupportedOperationException("Cannot deploy a per-job cluster yet.");
 	}
 
-	private static class TestJarFinder implements FilenameFilter {
+	static class TestJarFinder implements FilenameFilter {
 
 		private final String jarName;
 
-		public TestJarFinder(final String jarName) {
+		TestJarFinder(final String jarName) {
 			this.jarName = jarName;
 		}
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
+
+import org.apache.hadoop.fs.Path;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Random;
+
+/**
+ * Test cases for the deployment of Yarn Flink clusters.
+ */
+public class YARNITCase extends YarnTestBase {
+
+	@BeforeClass
+	public static void setup() {
+		YARN_CONFIGURATION.set(YarnTestBase.TEST_CLUSTER_NAME_KEY, "flink-yarn-tests-ha");
+		startYARNWithConfig(YARN_CONFIGURATION);
+	}
+
+	@Ignore("The cluster cannot be stopped yet.")
+	@Test
+	public void testPerJobMode() {
+		Configuration configuration = new Configuration();
+		configuration.setString(AkkaOptions.ASK_TIMEOUT, "30 s");
+		YarnClusterDescriptorV2 yarnClusterDescriptorV2 = new YarnClusterDescriptorV2(configuration, System.getenv(ConfigConstants.ENV_FLINK_CONF_DIR));
+
+		yarnClusterDescriptorV2.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
+		yarnClusterDescriptorV2.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));
+
+		final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
+			.setMasterMemoryMB(768)
+			.setTaskManagerMemoryMB(1024)
+			.setSlotsPerTaskManager(1)
+			.setNumberTaskManagers(1)
+			.createClusterSpecification();
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(2);
+
+		env.addSource(new InfiniteSource())
+			.shuffle()
+			.addSink(new DiscardingSink<Integer>());
+
+		final JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+
+		File testingJar = YarnTestBase.findFile("..", new TestingYarnClusterDescriptor.TestJarFinder("flink-yarn-tests"));
+
+		jobGraph.addJar(new org.apache.flink.core.fs.Path(testingJar.toURI()));
+
+		YarnClusterClient clusterClient = yarnClusterDescriptorV2.deployJobCluster(clusterSpecification, jobGraph);
+	}
+
+	private static class InfiniteSource implements ParallelSourceFunction<Integer> {
+
+		private static final long serialVersionUID = 1642561062000662861L;
+		private volatile boolean running;
+		private final Random random;
+
+		InfiniteSource() {
+			running = true;
+			random = new Random();
+		}
+
+		@Override
+		public void run(SourceContext<Integer> ctx) throws Exception {
+			while (running) {
+				synchronized (ctx.getCheckpointLock()) {
+					ctx.collect(random.nextInt());
+				}
+
+				Thread.sleep(5L);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
@@ -31,12 +32,17 @@ public class YarnClusterDescriptor extends AbstractYarnClusterDescriptor {
 	}
 
 	@Override
-	protected Class<?> getApplicationMasterClass() {
-		return YarnApplicationMasterRunner.class;
+	protected String getYarnSessionClusterEntrypoint() {
+		return YarnApplicationMasterRunner.class.getName();
 	}
 
 	@Override
-	public YarnClusterClient deployJobCluster(JobGraph jobGraph) {
+	protected String getYarnJobClusterEntrypoint() {
+		throw new UnsupportedOperationException("The old Yarn descriptor does not support proper per-job mode.");
+	}
+
+	@Override
+	public YarnClusterClient deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
 		throw new UnsupportedOperationException("Cannot deploy a per-job yarn cluster yet.");
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptorV2.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptorV2.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.yarn.entrypoint.YarnJobClusterEntrypoint;
 import org.apache.flink.yarn.entrypoint.YarnSessionClusterEntrypoint;
 
 /**
@@ -35,12 +37,17 @@ public class YarnClusterDescriptorV2 extends AbstractYarnClusterDescriptor {
 	}
 
 	@Override
-	protected Class<?> getApplicationMasterClass() {
-		return YarnSessionClusterEntrypoint.class;
+	protected String getYarnSessionClusterEntrypoint() {
+		return YarnSessionClusterEntrypoint.class.getName();
 	}
 
 	@Override
-	public YarnClusterClient deployJobCluster(JobGraph jobGraph) {
+	protected String getYarnJobClusterEntrypoint() {
+		return YarnJobClusterEntrypoint.class.getName();
+	}
+
+	@Override
+	public YarnClusterClient deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
 		throw new UnsupportedOperationException("Cannot yet deploy a per-job yarn cluster.");
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
@@ -46,7 +46,7 @@ import java.io.ObjectInputStream;
 import java.util.Map;
 
 /**
- * Entry point ofr Yarn per-job clusters.
+ * Entry point for Yarn per-job clusters.
  */
 public class YarnJobClusterEntrypoint extends JobClusterEntrypoint {
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -134,7 +134,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			"-Dlogback.configurationFile=file:" + FlinkYarnSessionCli.CONFIG_FILE_LOGBACK_NAME; // if set
 		final String log4j =
 			"-Dlog4j.configuration=file:" + FlinkYarnSessionCli.CONFIG_FILE_LOG4J_NAME; // if set
-		final String mainClass = clusterDescriptor.getApplicationMasterClass().getName();
+		final String mainClass = clusterDescriptor.getYarnSessionClusterEntrypoint();
 		final String args = "";
 		final String redirects =
 			"1> " + ApplicationConstants.LOG_DIR_EXPANSION_VAR + "/jobmanager.out " +
@@ -149,6 +149,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				" " + mainClass + " " + args + " " + redirects,
 			clusterDescriptor
 				.setupApplicationMasterContainer(
+					mainClass,
 					false,
 					false,
 					false,
@@ -162,6 +163,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				" " + mainClass + " " + args + " " + redirects,
 			clusterDescriptor
 				.setupApplicationMasterContainer(
+					mainClass,
 					false,
 					false,
 					true,
@@ -176,6 +178,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				" " + mainClass + " " + args + " " + redirects,
 			clusterDescriptor
 				.setupApplicationMasterContainer(
+					mainClass,
 					true,
 					false,
 					false,
@@ -189,6 +192,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				" " + mainClass + " " + args + " " + redirects,
 			clusterDescriptor
 				.setupApplicationMasterContainer(
+					mainClass,
 					true,
 					false,
 					true,
@@ -203,6 +207,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				" " + mainClass + " " + args + " " + redirects,
 			clusterDescriptor
 				.setupApplicationMasterContainer(
+					mainClass,
 					false,
 					true,
 					false,
@@ -216,6 +221,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				" " + mainClass + " " + args + " " + redirects,
 			clusterDescriptor
 				.setupApplicationMasterContainer(
+					mainClass,
 					false,
 					true,
 					true,
@@ -230,6 +236,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				" " + mainClass + " " + args + " " + redirects,
 			clusterDescriptor
 				.setupApplicationMasterContainer(
+					mainClass,
 					true,
 					true,
 					false,
@@ -243,6 +250,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				" " + mainClass + " " + args + " " + redirects,
 			clusterDescriptor
 				.setupApplicationMasterContainer(
+					mainClass,
 					true,
 					true,
 					true,
@@ -260,6 +268,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				" " + mainClass + " "  + args + " " + redirects,
 			clusterDescriptor
 				.setupApplicationMasterContainer(
+					mainClass,
 					true,
 					true,
 					false,
@@ -273,6 +282,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				" " + mainClass + " "  + args + " " + redirects,
 			clusterDescriptor
 				.setupApplicationMasterContainer(
+					mainClass,
 					true,
 					true,
 					true,
@@ -289,6 +299,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				" " + mainClass + " "  + args + " " + redirects,
 			clusterDescriptor
 				.setupApplicationMasterContainer(
+					mainClass,
 					true,
 					true,
 					false,
@@ -302,6 +313,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				" " + mainClass + " "  + args + " " + redirects,
 			clusterDescriptor
 				.setupApplicationMasterContainer(
+					mainClass,
 					true,
 					true,
 					true,
@@ -319,6 +331,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				" 4 " + mainClass + " 5 " + args + " 6 " + redirects,
 			clusterDescriptor
 				.setupApplicationMasterContainer(
+					mainClass,
 					true,
 					true,
 					true,
@@ -336,6 +349,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				" " + mainClass + " " + args + " " + redirects,
 			clusterDescriptor
 				.setupApplicationMasterContainer(
+					mainClass,
 					true,
 					true,
 					true,


### PR DESCRIPTION
This PR is based on #4280, #4270, #4271, #4259, #4260, #4261, #4272 and #4281.

This PR adds the functionality to deploy a Yarn per-job cluster via the `YarnClusterDescriptorV2.deployJob(ClusterSpecification, JobGraph)`. The `JobGraph` has to contain the user code jar which is required to run the job.