### PR TITLE
[FLINK-7135] [flip6] Pass in proper configuration to Dispatcher component

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -69,10 +69,10 @@ public class BootstrapTools {
 	 * @throws Exception
 	 */
 	public static ActorSystem startActorSystem(
-				Configuration configuration,
-				String listeningAddress,
-				String portRangeDefinition,
-				Logger logger) throws Exception {
+			Configuration configuration,
+			String listeningAddress,
+			String portRangeDefinition,
+			Logger logger) throws Exception {
 
 		// parse port range definition and create port iterator
 		Iterator<Integer> portsIterator;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -58,6 +58,8 @@ public abstract class Dispatcher extends RpcEndpoint<DispatcherGateway> {
 
 	public static final String DISPATCHER_NAME = "dispatcher";
 
+	private final Configuration configuration;
+
 	private final SubmittedJobGraphStore submittedJobGraphStore;
 	private final RunningJobsRegistry runningJobsRegistry;
 
@@ -73,6 +75,7 @@ public abstract class Dispatcher extends RpcEndpoint<DispatcherGateway> {
 	protected Dispatcher(
 			RpcService rpcService,
 			String endpointId,
+			Configuration configuration,
 			HighAvailabilityServices highAvailabilityServices,
 			BlobServer blobServer,
 			HeartbeatServices heartbeatServices,
@@ -80,6 +83,7 @@ public abstract class Dispatcher extends RpcEndpoint<DispatcherGateway> {
 			FatalErrorHandler fatalErrorHandler) throws Exception {
 		super(rpcService, endpointId);
 
+		this.configuration = Preconditions.checkNotNull(configuration);
 		this.highAvailabilityServices = Preconditions.checkNotNull(highAvailabilityServices);
 		this.blobServer = Preconditions.checkNotNull(blobServer);
 		this.heartbeatServices = Preconditions.checkNotNull(heartbeatServices);
@@ -153,10 +157,11 @@ public abstract class Dispatcher extends RpcEndpoint<DispatcherGateway> {
 			final JobManagerRunner jobManagerRunner;
 
 			try {
+				log.info("Create JobManager runner.");
 				jobManagerRunner = createJobManagerRunner(
 					ResourceID.generate(),
 					jobGraph,
-					null,
+					configuration,
 					getRpcService(),
 					highAvailabilityServices,
 					blobServer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.BlobService;
+import org.apache.flink.runtime.client.JobSubmissionException;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmanager.SubmittedJobGraph;
+import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcEndpoint;
+import org.apache.flink.runtime.rpc.RpcMethod;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base class for the Dispatcher component. The Dispatcher component is responsible
+ * for receiving job submissions, persisting them, spawning JobManagers to execute
+ * the jobs and to recover them in case of a master failure. Furthermore, it knows
+ * about the state of the Flink session cluster.
+ */
+public abstract class Dispatcher extends RpcEndpoint<DispatcherGateway> {
+
+	public static final String DISPATCHER_NAME = "dispatcher";
+
+	private final SubmittedJobGraphStore submittedJobGraphStore;
+	private final RunningJobsRegistry runningJobsRegistry;
+
+	private final HighAvailabilityServices highAvailabilityServices;
+	private final BlobServer blobServer;
+	private final HeartbeatServices heartbeatServices;
+	private final MetricRegistry metricRegistry;
+
+	private final FatalErrorHandler fatalErrorHandler;
+
+	private final Map<JobID, JobManagerRunner> jobManagerRunners;
+
+	protected Dispatcher(
+			RpcService rpcService,
+			String endpointId,
+			HighAvailabilityServices highAvailabilityServices,
+			BlobServer blobServer,
+			HeartbeatServices heartbeatServices,
+			MetricRegistry metricRegistry,
+			FatalErrorHandler fatalErrorHandler) throws Exception {
+		super(rpcService, endpointId);
+
+		this.highAvailabilityServices = Preconditions.checkNotNull(highAvailabilityServices);
+		this.blobServer = Preconditions.checkNotNull(blobServer);
+		this.heartbeatServices = Preconditions.checkNotNull(heartbeatServices);
+		this.metricRegistry = Preconditions.checkNotNull(metricRegistry);
+		this.fatalErrorHandler = Preconditions.checkNotNull(fatalErrorHandler);
+
+		this.submittedJobGraphStore = highAvailabilityServices.getSubmittedJobGraphStore();
+		this.runningJobsRegistry = highAvailabilityServices.getRunningJobsRegistry();
+
+		jobManagerRunners = new HashMap<>(16);
+	}
+
+	//------------------------------------------------------
+	// Lifecycle methods
+	//------------------------------------------------------
+
+	@Override
+	public void shutDown() throws Exception {
+		Exception exception = null;
+		// stop all currently running JobManagerRunners
+		for (JobManagerRunner jobManagerRunner : jobManagerRunners.values()) {
+			jobManagerRunner.shutdown();
+		}
+
+		jobManagerRunners.clear();
+
+		try {
+			submittedJobGraphStore.stop();
+		} catch (Exception e) {
+			exception = ExceptionUtils.firstOrSuppressed(e, exception);
+		}
+
+		try {
+			super.shutDown();
+		} catch (Exception e) {
+			exception = ExceptionUtils.firstOrSuppressed(e, exception);
+		}
+
+		if (exception != null) {
+			throw new FlinkException("Could not properly terminate the Dispatcher.", exception);
+		}
+	}
+
+	//------------------------------------------------------
+	// RPCs
+	//------------------------------------------------------
+
+	@RpcMethod
+	public Acknowledge submitJob(JobGraph jobGraph) throws JobSubmissionException {
+		final JobID jobId = jobGraph.getJobID();
+
+		log.info("Submitting job {} ({}).", jobGraph.getJobID(), jobGraph.getName());
+
+		final RunningJobsRegistry.JobSchedulingStatus jobSchedulingStatus;
+
+		try {
+			jobSchedulingStatus = runningJobsRegistry.getJobSchedulingStatus(jobId);
+		} catch (IOException e) {
+			log.warn("Cannot retrieve job status for {}.", jobId, e);
+			throw new JobSubmissionException(jobId, "Could not retrieve the job status.", e);
+		}
+
+		if (jobSchedulingStatus == RunningJobsRegistry.JobSchedulingStatus.PENDING) {
+			try {
+				submittedJobGraphStore.putJobGraph(new SubmittedJobGraph(jobGraph, null));
+			} catch (Exception e) {
+				log.warn("Cannot persist JobGraph.", e);
+				throw new JobSubmissionException(jobId, "Could not persist JobGraph.", e);
+			}
+
+			final JobManagerRunner jobManagerRunner;
+
+			try {
+				jobManagerRunner = createJobManagerRunner(
+					ResourceID.generate(),
+					jobGraph,
+					null,
+					getRpcService(),
+					highAvailabilityServices,
+					blobServer,
+					heartbeatServices,
+					metricRegistry,
+					new DispatcherOnCompleteActions(jobGraph.getJobID()),
+					fatalErrorHandler);
+
+				jobManagerRunner.start();
+			} catch (Exception e) {
+				try {
+					// We should only remove a job from the submitted job graph store
+					// if the initial submission failed. Never in case of a recovery
+					submittedJobGraphStore.removeJobGraph(jobId);
+				} catch (Throwable t) {
+					log.warn("Cannot remove job graph from submitted job graph store.", t);
+					e.addSuppressed(t);
+				}
+
+				throw new JobSubmissionException(jobId, "Could not start JobManager.", e);
+			}
+
+			jobManagerRunners.put(jobId, jobManagerRunner);
+
+			return Acknowledge.get();
+		} else {
+			throw new JobSubmissionException(jobId, "Job has already been submitted and " +
+				"is currently in state " + jobSchedulingStatus + '.');
+		}
+	}
+
+	@RpcMethod
+	public Collection<JobID> listJobs() {
+		// TODO: return proper list of running jobs
+		return jobManagerRunners.keySet();
+	}
+
+	/**
+	 * Cleans up the job related data from the dispatcher. If cleanupHA is true, then
+	 * the data will also be removed from HA.
+	 *
+	 * @param jobId JobID identifying the job to clean up
+	 * @param cleanupHA True iff HA data shall also be cleaned up
+	 */
+	private void removeJob(JobID jobId, boolean cleanupHA) throws Exception {
+		JobManagerRunner jobManagerRunner = jobManagerRunners.remove(jobId);
+
+		if (jobManagerRunner != null) {
+			jobManagerRunner.shutdown();
+		}
+
+		if (cleanupHA) {
+			submittedJobGraphStore.removeJobGraph(jobId);
+		}
+
+		// TODO: remove job related files from blob server
+	}
+
+	protected abstract JobManagerRunner createJobManagerRunner(
+		ResourceID resourceId,
+		JobGraph jobGraph,
+		Configuration configuration,
+		RpcService rpcService,
+		HighAvailabilityServices highAvailabilityServices,
+		BlobService blobService,
+		HeartbeatServices heartbeatServices,
+		MetricRegistry metricRegistry,
+		OnCompletionActions onCompleteActions,
+		FatalErrorHandler fatalErrorHandler) throws Exception;
+
+	//------------------------------------------------------
+	// Utility classes
+	//------------------------------------------------------
+
+	private class DispatcherOnCompleteActions implements OnCompletionActions {
+
+		private final JobID jobId;
+
+		private DispatcherOnCompleteActions(JobID jobId) {
+			this.jobId = Preconditions.checkNotNull(jobId);
+		}
+
+		@Override
+		public void jobFinished(JobExecutionResult result) {
+			log.info("Job {} finished.", jobId);
+
+			runAsync(new Runnable() {
+				@Override
+				public void run() {
+					try {
+						removeJob(jobId, true);
+					} catch (Exception e) {
+						log.warn("Could not properly remove job {} from the dispatcher.", jobId, e);
+					}
+				}
+			});
+		}
+
+		@Override
+		public void jobFailed(Throwable cause) {
+			log.info("Job {} failed.", jobId);
+
+			runAsync(new Runnable() {
+				@Override
+				public void run() {
+					try {
+						removeJob(jobId, true);
+					} catch (Exception e) {
+						log.warn("Could not properly remove job {} from the dispatcher.", jobId, e);
+					}
+				}
+			});
+		}
+
+		@Override
+		public void jobFinishedByOther() {
+			log.info("Job {} was finished by other.", jobId);
+
+			runAsync(new Runnable() {
+				@Override
+				public void run() {
+					try {
+						removeJob(jobId, false);
+					} catch (Exception e) {
+						log.warn("Could not properly remove job {} from the dispatcher.", jobId, e);
+					}
+				}
+			});
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.RpcTimeout;
+
+import java.util.Collection;
+
+/**
+ * Gateway for the Dispatcher component.
+ */
+public interface DispatcherGateway extends RpcGateway {
+
+	/**
+	 * Submit a job to the dispatcher.
+	 *
+	 * @param jobGraph JobGraph to submit
+	 * @param timeout RPC timeout
+	 * @return A future acknowledge if the submission succeeded
+	 */
+	Future<Acknowledge> submitJob(
+		JobGraph jobGraph,
+		@RpcTimeout Time timeout);
+
+	/**
+	 * Lists the current set of submitted jobs.
+	 *
+	 * @param timeout RPC timeout
+	 * @return A future collection of currently submitted jobs
+	 */
+	Future<Collection<JobID>> listJobs(
+		@RpcTimeout Time timeout);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
@@ -38,7 +38,7 @@ import org.apache.flink.runtime.rpc.RpcService;
  * can be used as the default for all different session clusters.
  */
 public class StandaloneDispatcher extends Dispatcher {
-	protected StandaloneDispatcher(
+	public StandaloneDispatcher(
 			RpcService rpcService,
 			String endpointId,
 			HighAvailabilityServices highAvailabilityServices,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.BlobService;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.jobmaster.JobMaster;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+
+/**
+ * Dispatcher implementation which spawns a {@link JobMaster} for each
+ * submitted {@link JobGraph} within in the same process. This dispatcher
+ * can be used as the default for all different session clusters.
+ */
+public class StandaloneDispatcher extends Dispatcher {
+	protected StandaloneDispatcher(
+			RpcService rpcService,
+			String endpointId,
+			HighAvailabilityServices highAvailabilityServices,
+			BlobServer blobServer,
+			HeartbeatServices heartbeatServices,
+			MetricRegistry metricRegistry,
+			FatalErrorHandler fatalErrorHandler) throws Exception {
+		super(
+			rpcService,
+			endpointId,
+			highAvailabilityServices,
+			blobServer,
+			heartbeatServices,
+			metricRegistry,
+			fatalErrorHandler);
+	}
+
+	@Override
+	protected JobManagerRunner createJobManagerRunner(
+			ResourceID resourceId,
+			JobGraph jobGraph,
+			Configuration configuration,
+			RpcService rpcService,
+			HighAvailabilityServices highAvailabilityServices,
+			BlobService blobService,
+			HeartbeatServices heartbeatServices,
+			MetricRegistry metricRegistry,
+			OnCompletionActions onCompleteActions,
+			FatalErrorHandler fatalErrorHandler) throws Exception {
+		// create the standard job manager runner
+		return new JobManagerRunner(
+			resourceId,
+			jobGraph,
+			configuration,
+			rpcService,
+			highAvailabilityServices,
+			blobService,
+			heartbeatServices,
+			metricRegistry,
+			onCompleteActions,
+			fatalErrorHandler);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
@@ -41,6 +41,7 @@ public class StandaloneDispatcher extends Dispatcher {
 	public StandaloneDispatcher(
 			RpcService rpcService,
 			String endpointId,
+			Configuration configuration,
 			HighAvailabilityServices highAvailabilityServices,
 			BlobServer blobServer,
 			HeartbeatServices heartbeatServices,
@@ -49,6 +50,7 @@ public class StandaloneDispatcher extends Dispatcher {
 		super(
 			rpcService,
 			endpointId,
+			configuration,
 			highAvailabilityServices,
 			blobServer,
 			heartbeatServices,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Configuration class which contains the parsed command line arguments for
+ * the {@link ClusterEntrypoint}.
+ */
+public class ClusterConfiguration {
+	private final String configDir;
+
+	public ClusterConfiguration(String configDir) {
+		this.configDir = Preconditions.checkNotNull(configDir);
+	}
+
+	public String getConfigDir() {
+		return configDir;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.clusterframework.BootstrapTools;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
+import org.apache.flink.runtime.security.SecurityContext;
+import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+
+import akka.actor.ActorSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+
+import scala.concurrent.duration.FiniteDuration;
+
+/**
+ * Base class for the Flink cluster entry points.
+ *
+ * <p>Specialization of this class can be used for the session mode and the per-job mode
+ */
+public abstract class ClusterEntrypoint implements FatalErrorHandler {
+
+	protected static final Logger LOG = LoggerFactory.getLogger(ClusterEntrypoint.class);
+
+	protected static final int SUCCESS_RETURN_CODE = 0;
+	protected static final int STARTUP_FAILURE_RETURN_CODE = 1;
+	protected static final int RUNTIME_FAILURE_RETURN_CODE = 2;
+
+	/** The lock to guard startup / shutdown / manipulation methods. */
+	private final Object lock = new Object();
+
+	@GuardedBy("lock")
+	private MetricRegistry metricRegistry = null;
+
+	@GuardedBy("lock")
+	private HighAvailabilityServices haServices = null;
+
+	@GuardedBy("lock")
+	private BlobServer blobServer = null;
+
+	@GuardedBy("lock")
+	private HeartbeatServices heartbeatServices = null;
+
+	@GuardedBy("lock")
+	private RpcService commonRpcService = null;
+
+	protected void startCluster(String[] args) {
+		final ClusterConfiguration clusterConfiguration = parseArguments(args);
+
+		final Configuration configuration = loadConfiguration(clusterConfiguration);
+
+		try {
+			SecurityContext securityContext = installSecurityContext(configuration);
+
+			securityContext.runSecured(new Callable<Void>() {
+				@Override
+				public Void call() throws Exception {
+					runCluster(configuration);
+
+					return null;
+				}
+			});
+		} catch (Throwable t) {
+			LOG.error("Cluster initialization failed.", t);
+
+			try {
+				shutDown(false);
+			} catch (Throwable st) {
+				LOG.error("Could not properly shut down cluster entrypoint.", st);
+			}
+
+			System.exit(STARTUP_FAILURE_RETURN_CODE);
+		}
+	}
+
+	protected ClusterConfiguration parseArguments(String[] args) {
+		ParameterTool parameterTool = ParameterTool.fromArgs(args);
+
+		final String configDir = parameterTool.get("configDir", "");
+
+		return new ClusterConfiguration(configDir);
+	}
+
+	protected Configuration loadConfiguration(ClusterConfiguration clusterConfiguration) {
+		return GlobalConfiguration.loadConfiguration(clusterConfiguration.getConfigDir());
+	}
+
+	protected SecurityContext installSecurityContext(Configuration configuration) throws Exception {
+		SecurityUtils.install(new SecurityUtils.SecurityConfiguration(configuration));
+
+		return SecurityUtils.getInstalledContext();
+	}
+
+	protected void runCluster(Configuration configuration) throws Exception {
+		synchronized (lock) {
+			initializeServices(configuration);
+
+			startClusterComponents(
+				configuration,
+				commonRpcService,
+				haServices,
+				blobServer,
+				heartbeatServices,
+				metricRegistry);
+		}
+	}
+
+	protected void initializeServices(Configuration configuration) throws Exception {
+		assert(Thread.holdsLock(lock));
+
+		LOG.info("Initializing cluster services.");
+
+		final String bindAddress = configuration.getString(JobManagerOptions.ADDRESS);
+		// TODO: Add support for port ranges
+		final String portRange = String.valueOf(configuration.getInteger(JobManagerOptions.PORT));
+
+		commonRpcService = createRpcService(configuration, bindAddress, portRange);
+		haServices = createHaServices(configuration, commonRpcService.getExecutor());
+		blobServer = new BlobServer(configuration, haServices.createBlobStore());
+		heartbeatServices = createHeartbeatServices(configuration);
+		metricRegistry = createMetricRegistry(configuration);
+	}
+
+	protected RpcService createRpcService(
+			Configuration configuration,
+			String bindAddress,
+			String portRange) throws Exception {
+		ActorSystem actorSystem = BootstrapTools.startActorSystem(configuration, bindAddress, portRange, LOG);
+		FiniteDuration duration = AkkaUtils.getTimeout(configuration);
+		return new AkkaRpcService(actorSystem, Time.of(duration.length(), duration.unit()));
+	}
+
+	protected HighAvailabilityServices createHaServices(
+		Configuration configuration,
+		Executor executor) throws Exception {
+		return HighAvailabilityServicesUtils.createHighAvailabilityServices(
+			configuration,
+			executor,
+			HighAvailabilityServicesUtils.AddressResolution.NO_ADDRESS_RESOLUTION);
+	}
+
+	protected HeartbeatServices createHeartbeatServices(Configuration configuration) {
+		return HeartbeatServices.fromConfiguration(configuration);
+	}
+
+	protected MetricRegistry createMetricRegistry(Configuration configuration) {
+		return new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(configuration));
+	}
+
+	protected void shutDown(boolean cleanupHaData) throws FlinkException {
+		Throwable exception = null;
+
+		synchronized (lock) {
+			if (metricRegistry != null) {
+				try {
+					metricRegistry.shutdown();
+				} catch (Throwable t) {
+					exception = t;
+				}
+			}
+
+			if (blobServer != null) {
+				try {
+					blobServer.close();
+				} catch (Throwable t) {
+					exception = ExceptionUtils.firstOrSuppressed(t, exception);
+				}
+			}
+
+			if (haServices != null) {
+				try {
+					if (cleanupHaData) {
+						haServices.closeAndCleanupAllData();
+					} else {
+						haServices.close();
+					}
+				} catch (Throwable t) {
+					exception = ExceptionUtils.firstOrSuppressed(t, exception);
+				}
+			}
+
+			if (commonRpcService != null) {
+				try {
+					commonRpcService.stopService();
+				} catch (Throwable t) {
+					exception = ExceptionUtils.firstOrSuppressed(t, exception);
+				}
+			}
+		}
+
+		if (exception != null) {
+			throw new FlinkException("Could not properly shut down the cluster services.", exception);
+		}
+	}
+
+	@Override
+	public void onFatalError(Throwable exception) {
+		LOG.error("Fatal error occurred in the cluster entrypoint.", exception);
+
+		System.exit(RUNTIME_FAILURE_RETURN_CODE);
+	}
+
+	protected abstract void startClusterComponents(
+		Configuration configuration,
+		RpcService rpcService,
+		HighAvailabilityServices highAvailabilityServices,
+		BlobServer blobServer,
+		HeartbeatServices heartbeatServices,
+		MetricRegistry metricRegistry) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/JobClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/JobClusterEntrypoint.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.BlobService;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.resourcemanager.ResourceManager;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Base class for per-job cluster entry points.
+ */
+public abstract class JobClusterEntrypoint extends ClusterEntrypoint {
+
+	private ResourceManager<?> resourceManager;
+
+	private JobManagerRunner jobManagerRunner;
+
+	@Override
+	protected void startClusterComponents(
+			Configuration configuration,
+			RpcService rpcService,
+			HighAvailabilityServices highAvailabilityServices,
+			BlobServer blobServer,
+			HeartbeatServices heartbeatServices,
+			MetricRegistry metricRegistry) throws Exception {
+
+		resourceManager = createResourceManager(
+			configuration,
+			ResourceID.generate(),
+			rpcService,
+			highAvailabilityServices,
+			heartbeatServices,
+			metricRegistry);
+
+		jobManagerRunner = createJobManagerRunner(
+			configuration,
+			ResourceID.generate(),
+			rpcService,
+			highAvailabilityServices,
+			blobServer,
+			heartbeatServices,
+			metricRegistry);
+
+		LOG.debug("Starting ResourceManager.");
+		resourceManager.start();
+
+		LOG.debug("Starting JobManager.");
+		jobManagerRunner.start();
+	}
+
+	protected JobManagerRunner createJobManagerRunner(
+			Configuration configuration,
+			ResourceID resourceId,
+			RpcService rpcService,
+			HighAvailabilityServices highAvailabilityServices,
+			BlobService blobService,
+			HeartbeatServices heartbeatServices,
+			MetricRegistry metricRegistry) throws Exception {
+
+		JobGraph jobGraph = retrieveJobGraph(configuration);
+
+		return new JobManagerRunner(
+			resourceId,
+			jobGraph,
+			configuration,
+			rpcService,
+			highAvailabilityServices,
+			blobService,
+			heartbeatServices,
+			metricRegistry,
+			new TerminatingOnCompleteActions(jobGraph.getJobID()),
+			this);
+	}
+
+	@Override
+	protected void shutDown(boolean cleanupHaData) throws FlinkException {
+		Throwable exception = null;
+
+		if (jobManagerRunner != null) {
+			try {
+				jobManagerRunner.shutdown();
+			} catch (Throwable t) {
+				exception = t;
+			}
+		}
+
+		if (resourceManager != null) {
+			try {
+				resourceManager.shutDown();
+			} catch (Throwable t) {
+				exception = ExceptionUtils.firstOrSuppressed(t, exception);
+			}
+		}
+
+		try {
+			super.shutDown(cleanupHaData);
+		} catch (Throwable t) {
+			exception = ExceptionUtils.firstOrSuppressed(t, exception);
+		}
+
+		if (exception != null) {
+			throw new FlinkException("Could not properly shut down the session cluster entry point.", exception);
+		}
+	}
+
+	private void shutDownAndTerminate(boolean cleanupHaData) {
+		try {
+			shutDown(cleanupHaData);
+		} catch (Throwable t) {
+			LOG.error("Could not properly shut down cluster entrypoint.", t);
+		}
+
+		System.exit(SUCCESS_RETURN_CODE);
+	}
+
+	protected abstract ResourceManager<?> createResourceManager(
+		Configuration configuration,
+		ResourceID resourceId,
+		RpcService rpcService,
+		HighAvailabilityServices highAvailabilityServices,
+		HeartbeatServices heartbeatServices,
+		MetricRegistry metricRegistry) throws Exception;
+
+	protected abstract JobGraph retrieveJobGraph(Configuration configuration);
+
+	private final class TerminatingOnCompleteActions implements OnCompletionActions {
+
+		private final JobID jobId;
+
+		private TerminatingOnCompleteActions(JobID jobId) {
+			this.jobId = Preconditions.checkNotNull(jobId);
+		}
+
+		@Override
+		public void jobFinished(JobExecutionResult result) {
+			LOG.info("Job({}) finished.", jobId);
+
+			shutDownAndTerminate(true);
+		}
+
+		@Override
+		public void jobFailed(Throwable cause) {
+			LOG.info("Job({}) failed.", jobId, cause);
+
+			shutDownAndTerminate(false);
+		}
+
+		@Override
+		public void jobFinishedByOther() {
+			LOG.info("Job({}) was finished by another JobManager.", jobId);
+
+			shutDownAndTerminate(false);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.dispatcher.Dispatcher;
+import org.apache.flink.runtime.dispatcher.StandaloneDispatcher;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.resourcemanager.ResourceManager;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+
+/**
+ * Base class for session cluster entry points.
+ */
+public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
+
+	private ResourceManager<?> resourceManager;
+
+	private Dispatcher dispatcher;
+
+	@Override
+	protected void startClusterComponents(
+			Configuration configuration,
+			RpcService rpcService,
+			HighAvailabilityServices highAvailabilityServices,
+			BlobServer blobServer,
+			HeartbeatServices heartbeatServices,
+			MetricRegistry metricRegistry) throws Exception {
+
+		resourceManager = createResourceManager(
+			configuration,
+			ResourceID.generate(),
+			rpcService,
+			highAvailabilityServices,
+			heartbeatServices,
+			metricRegistry,
+			this);
+
+		dispatcher = createDispatcher(
+			rpcService,
+			highAvailabilityServices,
+			blobServer,
+			heartbeatServices,
+			metricRegistry,
+			this);
+
+		LOG.debug("Starting ResourceManager.");
+		resourceManager.start();
+
+		LOG.debug("Starting Dispatcher.");
+		dispatcher.start();
+	}
+
+	@Override
+	protected void shutDown(boolean cleanupHaData) throws FlinkException {
+		Throwable exception = null;
+
+		if (dispatcher != null) {
+			try {
+				dispatcher.shutDown();
+			} catch (Throwable t) {
+				exception = t;
+			}
+		}
+
+		if (resourceManager != null) {
+			try {
+				resourceManager.shutDown();
+			} catch (Throwable t) {
+				exception = ExceptionUtils.firstOrSuppressed(t, exception);
+			}
+		}
+
+		try {
+			super.shutDown(cleanupHaData);
+		} catch (Throwable t) {
+			exception = ExceptionUtils.firstOrSuppressed(t, exception);
+		}
+
+		if (exception != null) {
+			throw new FlinkException("Could not properly shut down the session cluster entry point.", exception);
+		}
+	}
+
+	protected Dispatcher createDispatcher(
+		RpcService rpcService,
+		HighAvailabilityServices highAvailabilityServices,
+		BlobServer blobServer,
+		HeartbeatServices heartbeatServices,
+		MetricRegistry metricRegistry,
+		FatalErrorHandler fatalErrorHandler) throws Exception {
+
+		// create the default dispatcher
+		return new StandaloneDispatcher(
+			rpcService,
+			Dispatcher.DISPATCHER_NAME,
+			highAvailabilityServices,
+			blobServer,
+			heartbeatServices,
+			metricRegistry,
+			fatalErrorHandler);
+	}
+
+	protected abstract ResourceManager<?> createResourceManager(
+		Configuration configuration,
+		ResourceID resourceId,
+		RpcService rpcService,
+		HighAvailabilityServices highAvailabilityServices,
+		HeartbeatServices heartbeatServices,
+		MetricRegistry metricRegistry,
+		FatalErrorHandler fatalErrorHandler) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
@@ -60,6 +60,7 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 			this);
 
 		dispatcher = createDispatcher(
+			configuration,
 			rpcService,
 			highAvailabilityServices,
 			blobServer,
@@ -106,6 +107,7 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 	}
 
 	protected Dispatcher createDispatcher(
+		Configuration configuration,
 		RpcService rpcService,
 		HighAvailabilityServices highAvailabilityServices,
 		BlobServer blobServer,
@@ -117,6 +119,7 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 		return new StandaloneDispatcher(
 			rpcService,
 			Dispatcher.DISPATCHER_NAME,
+			configuration,
 			highAvailabilityServices,
 			blobServer,
 			heartbeatServices,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/SubmittedJobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/SubmittedJobGraph.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.jobmanager;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -44,9 +46,9 @@ public class SubmittedJobGraph implements Serializable {
 	 * @param jobGraph The submitted {@link JobGraph}
 	 * @param jobInfo  The {@link JobInfo}
 	 */
-	public SubmittedJobGraph(JobGraph jobGraph, JobInfo jobInfo) {
+	public SubmittedJobGraph(JobGraph jobGraph, @Nullable JobInfo jobInfo) {
 		this.jobGraph = checkNotNull(jobGraph, "Job graph");
-		this.jobInfo = checkNotNull(jobInfo, "Job info");
+		this.jobInfo = jobInfo;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmaster;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobService;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
@@ -92,6 +93,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			final Configuration configuration,
 			final RpcService rpcService,
 			final HighAvailabilityServices haServices,
+			final BlobService blobService,
 			final HeartbeatServices heartbeatServices,
 			final OnCompletionActions toNotifyOnComplete,
 			final FatalErrorHandler errorHandler) throws Exception {
@@ -101,6 +103,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			configuration,
 			rpcService,
 			haServices,
+			blobService,
 			heartbeatServices,
 			new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(configuration)),
 			toNotifyOnComplete,
@@ -113,6 +116,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			final Configuration configuration,
 			final RpcService rpcService,
 			final HighAvailabilityServices haServices,
+			final BlobService blobService,
 			final HeartbeatServices heartbeatServices,
 			final MetricRegistry metricRegistry,
 			final OnCompletionActions toNotifyOnComplete,
@@ -124,7 +128,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			rpcService,
 			haServices,
 			heartbeatServices,
-			JobManagerServices.fromConfiguration(configuration, haServices),
+			JobManagerServices.fromConfiguration(configuration, blobService),
 			metricRegistry,
 			toNotifyOnComplete,
 			errorHandler);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -228,6 +228,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 	//----------------------------------------------------------------------------------------------
 
 	public void start() throws Exception {
+		log.info("Start JobManagerRunner.");
 		try {
 			leaderElectionService.start(this);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerServices.java
@@ -23,10 +23,9 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.BlobService;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.runtime.util.Hardware;
 import org.apache.flink.util.ExceptionUtils;
@@ -103,15 +102,13 @@ public class JobManagerServices {
 
 	public static JobManagerServices fromConfiguration(
 			Configuration config,
-			HighAvailabilityServices haServices) throws Exception {
-
-		final BlobServer blobServer = new BlobServer(config, haServices.createBlobStore());
+			BlobService blobService) throws Exception {
 
 		final long cleanupInterval = config.getLong(
 			ConfigConstants.LIBRARY_CACHE_MANAGER_CLEANUP_INTERVAL,
 			ConfigConstants.DEFAULT_LIBRARY_CACHE_MANAGER_CLEANUP_INTERVAL) * 1000;
 
-		final BlobLibraryCacheManager libraryCacheManager = new BlobLibraryCacheManager(blobServer, cleanupInterval);
+		final BlobLibraryCacheManager libraryCacheManager = new BlobLibraryCacheManager(blobService, cleanupInterval);
 
 		final FiniteDuration timeout;
 		try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerServices.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.executiongraph.restart.RestartStrategyFactory;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.runtime.util.Hardware;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.Preconditions;
 
 import scala.concurrent.duration.FiniteDuration;
 
@@ -103,6 +104,9 @@ public class JobManagerServices {
 	public static JobManagerServices fromConfiguration(
 			Configuration config,
 			BlobService blobService) throws Exception {
+
+		Preconditions.checkNotNull(config);
+		Preconditions.checkNotNull(blobService);
 
 		final long cleanupInterval = config.getLong(
 			ConfigConstants.LIBRARY_CACHE_MANAGER_CLEANUP_INTERVAL,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -224,6 +224,12 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 		}
 
 		try {
+			jobLeaderIdService.stop();
+		} catch (Exception e) {
+			exception = ExceptionUtils.firstOrSuppressed(e, exception);
+		}
+
+		try {
 			super.shutDown();
 		} catch (Exception e) {
 			exception = ExceptionUtils.firstOrSuppressed(e, exception);

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -203,7 +203,7 @@ object AkkaUtils {
     val config =
       s"""
         |akka {
-        | daemonic = on
+        | daemonic = off
         |
         | loggers = ["akka.event.slf4j.Slf4jLogger"]
         | logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.BlobService;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneHaServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for the {@link Dispatcher} component.
+ */
+public class DispatcherTest extends TestLogger {
+
+	/**
+	 * Tests that we can submit a job to the Dispatcher which then spawns a
+	 * new JobManagerRunner.
+	 */
+	@Test
+	public void testJobSubmission() throws Exception {
+		TestingFatalErrorHandler fatalErrorHandler = new TestingFatalErrorHandler();
+		RpcService rpcService = new TestingRpcService();
+		HighAvailabilityServices haServices = new StandaloneHaServices("localhost", "localhost");
+		HeartbeatServices heartbeatServices = new HeartbeatServices(1000L, 10000L);
+		JobManagerRunner jobManagerRunner = mock(JobManagerRunner.class);
+
+		final Time timeout = Time.seconds(5L);
+		final JobGraph jobGraph = mock(JobGraph.class);
+		final JobID jobId = new JobID();
+		when(jobGraph.getJobID()).thenReturn(jobId);
+
+		try {
+			final TestingDispatcher dispatcher = new TestingDispatcher(
+				rpcService,
+				Dispatcher.DISPATCHER_NAME,
+				haServices,
+				mock(BlobServer.class),
+				heartbeatServices,
+				mock(MetricRegistry.class),
+				fatalErrorHandler,
+				jobManagerRunner,
+				jobId);
+
+			dispatcher.start();
+
+			DispatcherGateway dispatcherGateway = dispatcher.getSelf();
+
+			Future<Acknowledge> acknowledgeFuture = dispatcherGateway.submitJob(jobGraph, timeout);
+
+			acknowledgeFuture.get();
+
+			verify(jobManagerRunner, Mockito.timeout(timeout.toMilliseconds())).start();
+
+			// check that no error has occurred
+			fatalErrorHandler.rethrowError();
+		} finally {
+			rpcService.stopService();
+		}
+	}
+
+	private static class TestingDispatcher extends Dispatcher {
+
+		private final JobManagerRunner jobManagerRunner;
+		private final JobID expectedJobId;
+
+		protected TestingDispatcher(
+				RpcService rpcService,
+				String endpointId,
+				HighAvailabilityServices highAvailabilityServices,
+				BlobServer blobServer,
+				HeartbeatServices heartbeatServices,
+				MetricRegistry metricRegistry,
+				FatalErrorHandler fatalErrorHandler,
+				JobManagerRunner jobManagerRunner,
+				JobID expectedJobId) throws Exception {
+			super(
+				rpcService,
+				endpointId,
+				highAvailabilityServices,
+				blobServer,
+				heartbeatServices,
+				metricRegistry,
+				fatalErrorHandler);
+
+			this.jobManagerRunner = jobManagerRunner;
+			this.expectedJobId = expectedJobId;
+		}
+
+		@Override
+		protected JobManagerRunner createJobManagerRunner(
+				ResourceID resourceId,
+				JobGraph jobGraph,
+				Configuration configuration,
+				RpcService rpcService,
+				HighAvailabilityServices highAvailabilityServices,
+				BlobService blobService,
+				HeartbeatServices heartbeatServices,
+				MetricRegistry metricRegistry,
+				OnCompletionActions onCompleteActions,
+				FatalErrorHandler fatalErrorHandler) throws Exception {
+			assertEquals(expectedJobId, jobGraph.getJobID());
+
+			return jobManagerRunner;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerMockTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerMockTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmaster;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.BlobStore;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -111,7 +112,7 @@ public class JobManagerRunnerMockTest extends TestLogger {
 			mockRpc,
 			haServices,
 			heartbeatServices,
-			JobManagerServices.fromConfiguration(new Configuration(), haServices),
+			JobManagerServices.fromConfiguration(new Configuration(), mock(BlobServer.class)),
 			new MetricRegistry(MetricRegistryConfiguration.defaultMetricRegistryConfiguration()),
 			jobCompletion,
 			jobCompletion));

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkApplicationMasterRunner.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager;
@@ -99,6 +100,9 @@ public class YarnFlinkApplicationMasterRunner extends AbstractYarnFlinkApplicati
 	private RpcService commonRpcService;
 
 	@GuardedBy("lock")
+	private BlobServer blobServer;
+
+	@GuardedBy("lock")
 	private ResourceManager resourceManager;
 
 	@GuardedBy("lock")
@@ -143,6 +147,8 @@ public class YarnFlinkApplicationMasterRunner extends AbstractYarnFlinkApplicati
 					config,
 					commonRpcService.getExecutor(),
 					HighAvailabilityServicesUtils.AddressResolution.NO_ADDRESS_RESOLUTION);
+
+				blobServer = new BlobServer(config, haServices.createBlobStore());
 
 				heartbeatServices = HeartbeatServices.fromConfiguration(config);
 
@@ -228,6 +234,7 @@ public class YarnFlinkApplicationMasterRunner extends AbstractYarnFlinkApplicati
 			config,
 			commonRpcService,
 			haServices,
+			blobServer,
 			heartbeatServices,
 			this,
 			this);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFlinkApplicationMasterRunner.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
@@ -70,9 +71,9 @@ import scala.concurrent.duration.FiniteDuration;
  * <p>It starts actor system and the actors for {@link JobManagerRunner}
  * and {@link YarnResourceManager}.
  *
- * <p>The JobManagerRunner start a {@link org.apache.flink.runtime.jobmaster.JobMaster}
- * JobMaster handles Flink job execution, while the YarnResourceManager handles container
- * allocation and failure detection.
+ * <p>The JobManagerRunner start a {@link JobMaster} JobMaster handles Flink job
+ * execution, while the YarnResourceManager handles container allocation and failure
+ * detection.
  */
 public class YarnFlinkApplicationMasterRunner extends AbstractYarnFlinkApplicationMasterRunner
 		implements OnCompletionActions, FatalErrorHandler {


### PR DESCRIPTION
This PR is based on #4259, #4260 and #4261.

The `Dispatcher` component should get passed in the proper `Configuration` instance from the `SessionClusterEntrypoint`.