### PR TITLE
[FLINK-7136][docs] Improve search by adding facets and turning off ads

### DIFF
--- a/docs/_includes/sidenav.html
+++ b/docs/_includes/sidenav.html
@@ -133,7 +133,7 @@ level is determined by 'nav-pos'.
 <div class="sidenav-search-box">
   <form class="navbar-form" role="search" action="{{site.baseurl}}/search-results.html">
     <div class="form-group">
-      <input type="text" class="form-control" size="16px" name="q" placeholder="Search Docs">
+      <input type="text" class="form-control" size="16px" name="q" placeholder="Search">
     </div>
     <button type="submit" class="btn btn-default">Go</button>
   </form>

--- a/docs/annotations.xml
+++ b/docs/annotations.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<?ignore
+This is the annotations file for the Google Custom Search Engine
+used by the Apache Flink Documentation after version 1.3.
+After modifying this file it needs to be uploaded to the Custom Search control panel at
+https://cse.google.com/cse/setup/advanced?cx=000322205049649384055%3Aqbxxlwnwoqs
+in order for the changes to take effect.
+The UI is specified separately in cse.xml.
+?>
+<Annotations start="0" num="7" total="7">
+  <Annotation score="1" about="ci.apache.org/projects/flink/flink-docs-master/*" timestamp="0x0005539172a442a2" href="CjBjaS5hcGFjaGUub3JnL3Byb2plY3RzL2ZsaW5rL2ZsaW5rLWRvY3MtbWFzdGVyLyoQooWRlZfy1AI">
+    <Label name="_cse_qbxxlwnwoqs" />
+    <Label name="documentation" />
+    <AdditionalData attribute="original_url" value="https://ci.apache.org/projects/flink/flink-docs-master/" />
+  </Annotation>
+  <Annotation score="0.2" about="issues.apache.org/jira/browse/FLINK-*" timestamp="0x000553938050ff8b" href="CiVpc3N1ZXMuYXBhY2hlLm9yZy9qaXJhL2Jyb3dzZS9GTElOSy0qEIv_w4K48tQC">
+    <Label name="_cse_qbxxlwnwoqs" />
+    <Label name="jira" />
+    <AdditionalData attribute="original_url" value="https://issues.apache.org/jira/browse/FLINK-*" />
+  </Annotation>
+  <Annotation score="0.5" about="mail-archives.apache.org/mod_mbox/flink-*" timestamp="0x000553917ae594ac" href="Ci1tYWlsLWFyY2hpdmVzLmFwYWNoZS5vcmcvbW9kX21ib3gvZmxpbmstZGV2LyoQrKmW15fy1AI">
+    <Label name="_cse_qbxxlwnwoqs" />
+    <Label name="mailing_lists" />
+    <AdditionalData attribute="original_url" value="https://mail-archives.apache.org/mod_mbox/flink-*" />
+  </Annotation>
+  <Annotation score="0.5" about="cwiki.apache.org/confluence/display/FLINK/FLIP-*">
+    <Label name="_cse_qbxxlwnwoqs" />
+    <Label name="flips" />
+    <AdditionalData attribute="original_url" value="https://cwiki.apache.org/confluence/display/FLINK/FLIP-*" />
+  </Annotation>
+  <Annotation score="0.5" about="*.flink-forward.org/*">
+    <Label name="_cse_qbxxlwnwoqs" />
+    <Label name="FF" />
+  </Annotation>
+  <Annotation score="0.001" about="*.stackoverflow.com/*" timestamp="0x000553943f18494c" href="ChUqLnN0YWNrb3ZlcmZsb3cuY29tLyoQzJLh-MPy1AI">
+    <Label name="_cse_qbxxlwnwoqs" />
+    <Label name="stack_overflow" />
+    <AdditionalData attribute="original_url" value="https://stackoverflow.com" />
+  </Annotation>
+  <Annotation about="ci.apache.org/projects/flink/flink-docs-master/api/java/*" timestamp="0x0005539459e4638b" href="CjljaS5hcGFjaGUub3JnL3Byb2plY3RzL2ZsaW5rL2ZsaW5rLWRvY3MtbWFzdGVyL2FwaS9qYXZhLyoQi8eRz8Xy1AI">
+    <Label name="_cse_exclude_qbxxlwnwoqs" />
+    <Label name="javadocs" />
+    <AdditionalData attribute="original_url" value="https://ci.apache.org/projects/flink/flink-docs-master/api/java/" />
+  </Annotation>
+</Annotations>

--- a/docs/cse.xml
+++ b/docs/cse.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<?ignore
+This file specifies the refinements (facets) and look and feel of the Google Custom Search Engine
+used by the Apache Flink Documentation after version 1.3.
+After modifying this file it needs to be uploaded to the Custom Search control panel at
+https://cse.google.com/cse/setup/advanced?cx=000322205049649384055%3Aqbxxlwnwoqs
+in order for the changes to take effect.
+The sites to be searched are specified separately in annotations.xml.
+?>
+<CustomSearchEngine id="qbxxlwnwoqs" creator="000322205049649384055" language="en" top_refinements="2147483647" encoding="UTF-8" enable_suggest="true">
+  <Title>flink-test</Title>
+  <Context>
+    <Facet>
+      <FacetItem>
+        <Label name="documentation" mode="FILTER">
+          <Rewrite></Rewrite>
+        </Label>
+        <Title>Docs</Title>
+      </FacetItem>
+      <FacetItem>
+        <Label name="mailing_lists" mode="FILTER">
+          <Rewrite></Rewrite>
+        </Label>
+        <Title>Mailing Lists</Title>
+      </FacetItem>
+      <FacetItem>
+        <Label name="jira" mode="FILTER">
+          <Rewrite></Rewrite>
+        </Label>
+        <Title>Issues</Title>
+      </FacetItem>
+      <FacetItem>
+        <Label name="stack_overflow" mode="FILTER">
+          <Rewrite></Rewrite>
+        </Label>
+        <Title>Stack Overflow</Title>
+      </FacetItem>
+      <FacetItem>
+        <Label name="flips" mode="FILTER">
+          <Rewrite></Rewrite>
+        </Label>
+        <Title>FLIPs</Title>
+      </FacetItem>
+    </Facet>
+    <BackgroundLabels>
+      <Label name="_cse_qbxxlwnwoqs" mode="FILTER" />
+      <Label name="_cse_exclude_qbxxlwnwoqs" mode="ELIMINATE" />
+    </BackgroundLabels>
+  </Context>
+  <LookAndFeel nonprofit="true" element_layout="5" theme="1" custom_theme="true" text_font="Arial, sans-serif" url_length="full" element_branding="show" enable_cse_thumbnail="true" promotion_url_length="full" ads_layout="1">
+    <Logo />
+    <Colors url="#008000" background="#FFFFFF" border="#FFFFFF" title="#0000CC" text="#000000" visited="#0000CC" title_hover="#0000CC" title_active="#0000CC" />
+    <Promotions title_color="#0000CC" title_visited_color="#0000CC" url_color="#008000" background_color="#FFFFFF" border_color="#336699" snippet_color="#000000" title_hover_color="#0000CC" title_active_color="#0000CC" />
+    <SearchControls input_border_color="#D9D9D9" button_border_color="#666666" button_background_color="#CECECE" tab_border_color="#E9E9E9" tab_background_color="#E9E9E9" tab_selected_border_color="#FF9900" tab_selected_background_color="#FFFFFF" />
+    <Results border_color="#FFFFFF" border_hover_color="#FFFFFF" background_color="#FFFFFF" background_hover_color="#FFFFFF" ads_background_color="#fff7f5" ads_border_color="#FFFFFF" />
+  </LookAndFeel>
+  <AdSense />
+  <EnterpriseAccount />
+  <ImageSearchSettings enable="false" />
+  <autocomplete_settings />
+  <sort_by_keys label="Relevance" key="" />
+  <sort_by_keys label="Date" key="date" />
+  <cse_advance_settings enable_speech="true" enable_facet_search="true" />
+</CustomSearchEngine>

--- a/docs/search-results.md
+++ b/docs/search-results.md
@@ -21,15 +21,14 @@ under the License.
 -->
 <script>
   (function() {
-    var cx = '000888944958067045520:z90hn2izm0k';
+    var cx = '000322205049649384055:qbxxlwnwoqs';
     var gcse = document.createElement('script');
     gcse.type = 'text/javascript';
     gcse.async = true;
-    gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
-        '//www.google.com/cse/cse.js?cx=' + cx;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
     var s = document.getElementsByTagName('script')[0];
     s.parentNode.insertBefore(gcse, s);
   })();
 </script>
-
-<gcse:searchresults-only></gcse:searchresults-only>
+<!-- add the keyword flink to every search -->
+<gcse:search as_oq="flink"></gcse:search>


### PR DESCRIPTION
This PR expands the custom search engine used by the documentation to include some additional sources, and expands the UI to include tabs for breaking out the results by source, and turns off ads (which we are entitled to do, since the ASF is a non-profit org).

The specifications for the list of sites to be searched, their weights, and the UI are checked in as XML files. However, editing these files won't have any direct impact. Instead, they must be re-uploaded to the google custom search console. The reason to check them in is to make the search settings visible, and to preserve a copy of all the settings within the project.

Before and after screenshots when searching for "timers":

<img width="930" alt="screen shot 2017-07-10 at 10 11 39 am" src="https://user-images.githubusercontent.com/43608/28008542-3ae67428-6558-11e7-881a-5e79369ef9d3.png">

<img width="868" alt="screen shot 2017-07-10 at 10 12 44 am" src="https://user-images.githubusercontent.com/43608/28008577-60e11fca-6558-11e7-82f5-e28c7c9f364a.png">


