### PR TITLE
[FLINK-7150] [elasticsearch connector] Various code cleanups in the ElasticSearch connector

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/BulkProcessorIndexer.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/BulkProcessorIndexer.java
@@ -31,8 +31,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 class BulkProcessorIndexer implements RequestIndexer {
 
-	private static final long serialVersionUID = 6841162943062034253L;
-
 	private final BulkProcessor bulkProcessor;
 	private final boolean flushOnCheckpoint;
 	private final AtomicLong numPendingRequestsRef;

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
@@ -94,7 +94,7 @@ public abstract class ElasticsearchSinkBase<T> extends RichSinkFunction<T> imple
 	 *
 	 * <p>This is a proxy for version specific backoff policies.
 	 */
-	public class BulkFlushBackoffPolicy implements Serializable {
+	public static class BulkFlushBackoffPolicy implements Serializable {
 
 		private static final long serialVersionUID = -6022851996101826049L;
 
@@ -408,7 +408,7 @@ public abstract class ElasticsearchSinkBase<T> extends RichSinkFunction<T> imple
 			LOG.error("Failed Elasticsearch bulk request: {}", failure.getMessage(), failure.getCause());
 
 			try {
-				for (ActionRequest action : request.requests()) {
+				for (ActionRequest<?> action : request.requests()) {
 					failureHandler.onFailure(action, failure, -1, requestIndexer);
 				}
 			} catch (Throwable t) {

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/RequestIndexer.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/RequestIndexer.java
@@ -20,13 +20,11 @@ package org.apache.flink.streaming.connectors.elasticsearch;
 
 import org.elasticsearch.action.ActionRequest;
 
-import java.io.Serializable;
-
 /**
  * Users add multiple {@link ActionRequest ActionRequests} to a {@link RequestIndexer} to prepare
  * them for sending to an Elasticsearch cluster.
  */
-public interface RequestIndexer extends Serializable {
+public interface RequestIndexer {
 
 	/**
 	 * Add multiple {@link ActionRequest} to the indexer to prepare for sending requests to Elasticsearch.

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/NoOpFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/NoOpFailureHandler.java
@@ -30,7 +30,7 @@ public class NoOpFailureHandler implements ActionRequestFailureHandler {
 	private static final long serialVersionUID = 737941343410827885L;
 
 	@Override
-	public void onFailure(ActionRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer) throws Throwable {
+	public void onFailure(ActionRequest<?> action, Throwable failure, int restStatusCode, RequestIndexer indexer) throws Throwable {
 		// simply fail the sink
 		throw failure;
 	}

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/RetryRejectedExecutionFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/RetryRejectedExecutionFailureHandler.java
@@ -35,7 +35,7 @@ public class RetryRejectedExecutionFailureHandler implements ActionRequestFailur
 	private static final long serialVersionUID = -7423562912824511906L;
 
 	@Override
-	public void onFailure(ActionRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer) throws Throwable {
+	public void onFailure(ActionRequest<?> action, Throwable failure, int restStatusCode, RequestIndexer indexer) throws Throwable {
 		if (ExceptionUtils.containsThrowable(failure, EsRejectedExecutionException.class)) {
 			indexer.add(action);
 		} else {

--- a/flink-connectors/flink-connector-elasticsearch/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/examples/ElasticsearchSinkExample.java
+++ b/flink-connectors/flink-connector-elasticsearch/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/examples/ElasticsearchSinkExample.java
@@ -40,6 +40,7 @@ import java.util.Map;
  * This example shows how to use the Elasticsearch Sink. Before running it you must ensure that
  * you have a cluster named "elasticsearch" running or change the cluster name in the config map.
  */
+@SuppressWarnings("serial")
 public class ElasticsearchSinkExample {
 
 	public static void main(String[] args) throws Exception {


### PR DESCRIPTION
 - Removes `Serializable` from the `RequestIndexer`, because they are neither required to be
   serializable (they are created in open()) nor is the main implementation
   (`BulkProcessorIndexer`) actually serializable.

 - Makes `BulkFlushBackoffPolicy` a static inner class, which avoids adding outer class during
   serialization and clears various warnings about raw reference to outer class

