### PR TITLE
[FLINK-7166][avro] cleanup generated test classes in the cleanup phase

### DIFF
--- a/flink-connectors/flink-avro/pom.xml
+++ b/flink-connectors/flink-avro/pom.xml
@@ -135,6 +135,13 @@ under the License.
 						</configuration>
 					</execution>
 				</executions>
+				<configuration>
+					<filesets>
+						<fileset>
+							<directory>${project.basedir}/src/test/java/org/apache/flink/api/io/avro/generated</directory>
+						</fileset>
+					</filesets>
+				</configuration>
 			</plugin>
 			<!-- Generate Test class from avro schema -->
 			<plugin>


### PR DESCRIPTION
Maven neither cleaned up generated avro classes used by tests nor did it replace
them with new ones after the avro dependency change causing troubles to build
the project. Although the target directory inside `src` is unusual, we keep it
for now but at least delete these files in the cleanup stage so that a
`mvn clean install` always works.