### PR TITLE
[misc] Commit read offsets in Kafka integration tests

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -123,23 +123,26 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 	@Override
 	public <K, V> Collection<ConsumerRecord<K, V>> getAllRecordsFromTopic(Properties properties, String topic, int partition, long timeout) {
 		List<ConsumerRecord<K, V>> result = new ArrayList<>();
-		KafkaConsumer<K, V> consumer = new KafkaConsumer<>(properties);
-		consumer.assign(Arrays.asList(new TopicPartition(topic, partition)));
 
-		while (true) {
-			boolean processedAtLeastOneRecord = false;
+		try (KafkaConsumer<K, V> consumer = new KafkaConsumer<>(properties)) {
+			consumer.assign(Arrays.asList(new TopicPartition(topic, partition)));
 
-			// wait for new records with timeout and break the loop if we didn't get any
-			Iterator<ConsumerRecord<K, V>> iterator = consumer.poll(timeout).iterator();
-			while (iterator.hasNext()) {
-				ConsumerRecord<K, V> record = iterator.next();
-				result.add(record);
-				processedAtLeastOneRecord = true;
+			while (true) {
+				boolean processedAtLeastOneRecord = false;
+
+				// wait for new records with timeout and break the loop if we didn't get any
+				Iterator<ConsumerRecord<K, V>> iterator = consumer.poll(timeout).iterator();
+				while (iterator.hasNext()) {
+					ConsumerRecord<K, V> record = iterator.next();
+					result.add(record);
+					processedAtLeastOneRecord = true;
+				}
+
+				if (!processedAtLeastOneRecord) {
+					break;
+				}
 			}
-
-			if (!processedAtLeastOneRecord) {
-				break;
-			}
+			consumer.commitSync();
 		}
 
 		return UnmodifiableList.decorate(result);

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -110,22 +110,24 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 	@Override
 	public <K, V> Collection<ConsumerRecord<K, V>> getAllRecordsFromTopic(Properties properties, String topic, int partition, long timeout) {
 		List<ConsumerRecord<K, V>> result = new ArrayList<>();
-		KafkaConsumer<K, V> consumer = new KafkaConsumer<>(properties);
-		consumer.assign(Arrays.asList(new TopicPartition(topic, partition)));
+		try (KafkaConsumer<K, V> consumer = new KafkaConsumer<>(properties)) {
+			consumer.assign(Arrays.asList(new TopicPartition(topic, partition)));
 
-		while (true) {
-			boolean processedAtLeastOneRecord = false;
+			while (true) {
+				boolean processedAtLeastOneRecord = false;
 
-			Iterator<ConsumerRecord<K, V>> iterator = consumer.poll(timeout).iterator();
-			while (iterator.hasNext()) {
-				ConsumerRecord<K, V> record = iterator.next();
-				result.add(record);
-				processedAtLeastOneRecord = true;
+				Iterator<ConsumerRecord<K, V>> iterator = consumer.poll(timeout).iterator();
+				while (iterator.hasNext()) {
+					ConsumerRecord<K, V> record = iterator.next();
+					result.add(record);
+					processedAtLeastOneRecord = true;
+				}
+
+				if (!processedAtLeastOneRecord) {
+					break;
+				}
 			}
-
-			if (!processedAtLeastOneRecord) {
-				break;
-			}
+			consumer.commitSync();
 		}
 
 		return UnmodifiableList.decorate(result);


### PR DESCRIPTION
Previously offsets were not committed so the same records could be read more then once.
It was not a big issue, because so far this methods were used only for at-least-once tests.