### PR TITLE
[FLINK-7162] [test] Tests should not write outside 'target' directory

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -22,15 +22,15 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 
-import com.google.common.io.Files;
-
 import org.apache.flink.util.OperatingSystem;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Rule;
 
 import java.io.File;
 import java.io.IOException;
+import org.junit.rules.TemporaryFolder;
 
 public class BlobUtilsTest {
 
@@ -38,13 +38,15 @@ public class BlobUtilsTest {
 
 	private File blobUtilsTestDirectory;
 
-	@Before
-	public void before() {
-		// Prepare test directory
-		blobUtilsTestDirectory = Files.createTempDir();
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+	@Before
+	public void before() throws IOException {
 		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
 
+		// Prepare test directory
+		blobUtilsTestDirectory = temporaryFolder.newFolder();
 		assertTrue(blobUtilsTestDirectory.setExecutable(true, false));
 		assertTrue(blobUtilsTestDirectory.setReadable(true, false));
 		assertTrue(blobUtilsTestDirectory.setWritable(false, false));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerStartupTest.java
@@ -22,13 +22,12 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.BindException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.List;
-
-import com.google.common.io.Files;
 
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
@@ -39,7 +38,9 @@ import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.TestLogger;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Tests that verify the startup behavior of the JobManager in failure
@@ -51,13 +52,15 @@ public class JobManagerStartupTest extends TestLogger {
 
 	private File blobStorageDirectory;
 
-	@Before
-	public void before() {
-		
-		// Prepare test directory
-		blobStorageDirectory = Files.createTempDir();
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+	@Before
+	public void before() throws IOException {
 		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
+
+		// Prepare test directory
+		blobStorageDirectory = temporaryFolder.newFolder();
 
 		assertTrue(blobStorageDirectory.setExecutable(true, false));
 		assertTrue(blobStorageDirectory.setReadable(true, false));


### PR DESCRIPTION
A few tests use ```Files.createTempDir()``` from Guava package, but do not set java.io.tmpdir system property. Thus the temp directory is created in unpredictable places and is not being cleaned up by ```mvn clean```.
This was probably introduced in ```JobManagerStartupTest``` and then replicated in ```BlobUtilsTest```.