### PR TITLE
[FLINK-7154] [docs] Missing call to build CsvTableSource example

### DIFF
--- a/docs/dev/table/sourceSinks.md
+++ b/docs/dev/table/sourceSinks.md
@@ -173,7 +173,8 @@ CsvTableSource csvTableSource = CsvTableSource
     .lineDelimiter("$")
     .ignoreFirstLine()
     .ignoreParseErrors()
-    .commentPrefix("%");
+    .commentPrefix("%")
+    .build();
 {% endhighlight %}
 </div>
 
@@ -191,6 +192,7 @@ val csvTableSource = CsvTableSource
     .ignoreFirstLine
     .ignoreParseErrors
     .commentPrefix("%")
+    .build
 {% endhighlight %}
 </div>
 </div>


### PR DESCRIPTION
The Java and Scala example code for CsvTableSource create a builder but are missing the final call to build.