### PR TITLE
[hotfix] [hadoopCompat] Fix tests to verify results new Hadoop input API.

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/hadoop/mapred/WordCountMapredITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/hadoop/mapred/WordCountMapredITCase.java
@@ -70,6 +70,7 @@ public class WordCountMapredITCase extends JavaProgramTestBase {
 		postSubmit();
 		resultPath = getTempDirPath("result2");
 		internalRun(false);
+		postSubmit();
 	}
 
 	private void internalRun(boolean isTestDeprecatedAPI) throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/hadoop/mapreduce/WordCountMapreduceITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/hadoop/mapreduce/WordCountMapreduceITCase.java
@@ -70,6 +70,7 @@ public class WordCountMapreduceITCase extends JavaProgramTestBase {
 		postSubmit();
 		resultPath = getTempDirPath("result2");
 		internalRun(false);
+		postSubmit();
 	}
 
 	private void internalRun(boolean isTestDeprecatedAPI) throws Exception {

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/hadoop/mapred/WordCountMapredITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/hadoop/mapred/WordCountMapredITCase.scala
@@ -84,6 +84,7 @@ class WordCountMapredITCase extends JavaProgramTestBase {
     postSubmit()
     resultPath = getTempDirPath("result2")
     internalRun(testDeprecatedAPI = false)
+    postSubmit()
   }
 }
 

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/hadoop/mapreduce/WordCountMapreduceITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/hadoop/mapreduce/WordCountMapreduceITCase.scala
@@ -55,6 +55,7 @@ class WordCountMapreduceITCase extends JavaProgramTestBase {
     postSubmit()
     resultPath = getTempDirPath("result2")
     internalRun(testDeprecatedAPI = false)
+    postSubmit()
   }
 
   private def internalRun (testDeprecatedAPI: Boolean): Unit = {


### PR DESCRIPTION
The tests of the reworked Hadoop input API (reworked to remove the Hadoop dependency on `flink-java`) did not validate their result.

This PR adds the result validation.