### PR TITLE
(release-1.3) [FLINK-7195] [kafka] Remove partition list querying when restoring state in FlinkKafkaConsumer

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -347,24 +347,17 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 						getRuntimeContext().getIndexOfThisSubtask());
 		}
 
-		// initialize subscribed partitions
-		List<KafkaTopicPartition> kafkaTopicPartitions = getKafkaPartitions(topics);
-		Preconditions.checkNotNull(kafkaTopicPartitions, "TopicPartitions must not be null.");
-
-		subscribedPartitionsToStartOffsets = new HashMap<>(kafkaTopicPartitions.size());
-
 		if (restoredState != null) {
-			for (KafkaTopicPartition kafkaTopicPartition : kafkaTopicPartitions) {
-				if (restoredState.containsKey(kafkaTopicPartition)) {
-					subscribedPartitionsToStartOffsets.put(kafkaTopicPartition, restoredState.get(kafkaTopicPartition));
-				}
-			}
+			subscribedPartitionsToStartOffsets = restoredState;
 
 			LOG.info("Consumer subtask {} will start reading {} partitions with offsets in restored state: {}",
 				getRuntimeContext().getIndexOfThisSubtask(), subscribedPartitionsToStartOffsets.size(), subscribedPartitionsToStartOffsets);
 		} else {
-			initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets,
+			// initialize subscribed partitions
+			List<KafkaTopicPartition> kafkaTopicPartitions = getKafkaPartitions(topics);
+			Preconditions.checkNotNull(kafkaTopicPartitions, "TopicPartitions must not be null.");
+
+			subscribedPartitionsToStartOffsets = initializeSubscribedPartitionsToStartOffsets(
 				kafkaTopicPartitions,
 				getRuntimeContext().getIndexOfThisSubtask(),
 				getRuntimeContext().getNumberOfParallelSubtasks(),
@@ -680,7 +673,6 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 	 * values. The method decides which partitions this consumer instance should subscribe to, and also
 	 * sets the initial offset each subscribed partition should be started from based on the configured startup mode.
 	 *
-	 * @param subscribedPartitionsToStartOffsets to subscribedPartitionsToStartOffsets to initialize
 	 * @param kafkaTopicPartitions the complete list of all Kafka partitions
 	 * @param indexOfThisSubtask the index of this consumer instance
 	 * @param numParallelSubtasks total number of parallel consumer instances
@@ -690,13 +682,14 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 	 *
 	 * Note: This method is also exposed for testing.
 	 */
-	protected static void initializeSubscribedPartitionsToStartOffsets(
-			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets,
+	protected static Map<KafkaTopicPartition, Long> initializeSubscribedPartitionsToStartOffsets(
 			List<KafkaTopicPartition> kafkaTopicPartitions,
 			int indexOfThisSubtask,
 			int numParallelSubtasks,
 			StartupMode startupMode,
 			Map<KafkaTopicPartition, Long> specificStartupOffsets) {
+
+		Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets = new HashMap<>(kafkaTopicPartitions.size());
 
 		for (int i = 0; i < kafkaTopicPartitions.size(); i++) {
 			if (i % numParallelSubtasks == indexOfThisSubtask) {
@@ -722,6 +715,8 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 				}
 			}
 		}
+
+		return subscribedPartitionsToStartOffsets;
 	}
 
 	/**

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerPartitionAssignmentTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerPartitionAssignmentTest.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -50,14 +49,13 @@ public class KafkaConsumerPartitionAssignmentTest {
 					new KafkaTopicPartition("test-topic", 1));
 
 			for (int i = 0; i < inPartitions.size(); i++) {
-				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets = new HashMap<>();
-				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-					subscribedPartitionsToStartOffsets,
-					inPartitions,
-					i,
-					inPartitions.size(),
-					StartupMode.GROUP_OFFSETS,
-					null);
+				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets =
+					FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+						inPartitions,
+						i,
+						inPartitions.size(),
+						StartupMode.GROUP_OFFSETS,
+						null);
 
 				List<KafkaTopicPartition> subscribedPartitions = new ArrayList<>(subscribedPartitionsToStartOffsets.keySet());
 
@@ -90,14 +88,13 @@ public class KafkaConsumerPartitionAssignmentTest {
 			final int maxPartitionsPerConsumer = partitions.size() / numConsumers + 1;
 
 			for (int i = 0; i < numConsumers; i++) {
-				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets = new HashMap<>();
-				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-					subscribedPartitionsToStartOffsets,
-					partitions,
-					i,
-					numConsumers,
-					StartupMode.GROUP_OFFSETS,
-					null);
+				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets =
+					FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+						partitions,
+						i,
+						numConsumers,
+						StartupMode.GROUP_OFFSETS,
+						null);
 
 				List<KafkaTopicPartition> subscribedPartitions = new ArrayList<>(subscribedPartitionsToStartOffsets.keySet());
 
@@ -134,14 +131,13 @@ public class KafkaConsumerPartitionAssignmentTest {
 			final int numConsumers = 2 * inPartitions.size() + 3;
 
 			for (int i = 0; i < numConsumers; i++) {
-				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets = new HashMap<>();
-				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-					subscribedPartitionsToStartOffsets,
-					inPartitions,
-					i,
-					numConsumers,
-					StartupMode.GROUP_OFFSETS,
-					null);
+				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets =
+					FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+						inPartitions,
+						i,
+						numConsumers,
+						StartupMode.GROUP_OFFSETS,
+						null);
 
 				List<KafkaTopicPartition> subscribedPartitions = new ArrayList<>(subscribedPartitionsToStartOffsets.keySet());
 
@@ -166,24 +162,22 @@ public class KafkaConsumerPartitionAssignmentTest {
 	public void testAssignEmptyPartitions() {
 		try {
 			List<KafkaTopicPartition> ep = new ArrayList<>();
-			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets = new HashMap<>();
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets,
-				ep,
-				2,
-				4,
-				StartupMode.GROUP_OFFSETS,
-				null);
+			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					ep,
+					2,
+					4,
+					StartupMode.GROUP_OFFSETS,
+					null);
 			assertTrue(subscribedPartitionsToStartOffsets.entrySet().isEmpty());
 
-			subscribedPartitionsToStartOffsets = new HashMap<>();
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets,
-				ep,
-				0,
-				1,
-				StartupMode.GROUP_OFFSETS,
-				null);
+			subscribedPartitionsToStartOffsets =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					ep,
+					0,
+					1,
+					StartupMode.GROUP_OFFSETS,
+					null);
 			assertTrue(subscribedPartitionsToStartOffsets.entrySet().isEmpty());
 		}
 		catch (Exception e) {
@@ -214,33 +208,29 @@ public class KafkaConsumerPartitionAssignmentTest {
 			final int minNewPartitionsPerConsumer = newPartitions.size() / numConsumers;
 			final int maxNewPartitionsPerConsumer = newPartitions.size() / numConsumers + 1;
 
-			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets1 = new HashMap<>();
-			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets2 = new HashMap<>();
-			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets3 = new HashMap<>();
+			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets1 =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					initialPartitions,
+					0,
+					numConsumers,
+					StartupMode.GROUP_OFFSETS,
+					null);
 
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets1,
-				initialPartitions,
-				0,
-				numConsumers,
-				StartupMode.GROUP_OFFSETS,
-				null);
+			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets2 =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					initialPartitions,
+					1,
+					numConsumers,
+					StartupMode.GROUP_OFFSETS,
+					null);
 
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets2,
-				initialPartitions,
-				1,
-				numConsumers,
-				StartupMode.GROUP_OFFSETS,
-				null);
-
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets3,
-				initialPartitions,
-				2,
-				numConsumers,
-				StartupMode.GROUP_OFFSETS,
-				null);
+			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets3 =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					initialPartitions,
+					2,
+					numConsumers,
+					StartupMode.GROUP_OFFSETS,
+					null);
 
 			List<KafkaTopicPartition> subscribedPartitions1 = new ArrayList<>(subscribedPartitionsToStartOffsets1.keySet());
 			List<KafkaTopicPartition> subscribedPartitions2 = new ArrayList<>(subscribedPartitionsToStartOffsets2.keySet());
@@ -273,33 +263,29 @@ public class KafkaConsumerPartitionAssignmentTest {
 
 			// grow the set of partitions and distribute anew
 
-			subscribedPartitionsToStartOffsets1 = new HashMap<>();
-			subscribedPartitionsToStartOffsets2 = new HashMap<>();
-			subscribedPartitionsToStartOffsets3 = new HashMap<>();
+			subscribedPartitionsToStartOffsets1 =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					newPartitions,
+					0,
+					numConsumers,
+					StartupMode.GROUP_OFFSETS,
+					null);
 
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets1,
-				newPartitions,
-				0,
-				numConsumers,
-				StartupMode.GROUP_OFFSETS,
-				null);
+			subscribedPartitionsToStartOffsets2 =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					newPartitions,
+					1,
+					numConsumers,
+					StartupMode.GROUP_OFFSETS,
+					null);
 
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets2,
-				newPartitions,
-				1,
-				numConsumers,
-				StartupMode.GROUP_OFFSETS,
-				null);
-
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets3,
-				newPartitions,
-				2,
-				numConsumers,
-				StartupMode.GROUP_OFFSETS,
-				null);
+			subscribedPartitionsToStartOffsets3 =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					newPartitions,
+					2,
+					numConsumers,
+					StartupMode.GROUP_OFFSETS,
+					null);
 
 			List<KafkaTopicPartition> subscribedPartitions1New = new ArrayList<>(subscribedPartitionsToStartOffsets1.keySet());
 			List<KafkaTopicPartition> subscribedPartitions2New = new ArrayList<>(subscribedPartitionsToStartOffsets2.keySet());


### PR DESCRIPTION
This issue is a re-appearance of FLINK-6006. On restore, we should not respect any fetched partitions list from Kafka and perform any filtering of the restored partition states. There are corner cases where, due to Kafka broker downtime, some partitions may be missing in the fetched partition list. Therefore, we should not respect the fetched partitions list on restore time to manipulate the restored state, which may lead to broken state. To be more precise, we actually should not require fetching partitions on restore.

We've stepped on our own foot again and reintroduced this bug in ed68fedbe90db03823d75a020510ad3c344fa73e. This PR adds proper unit tests for this that does not rely on the internal implementations and test only on public abstractions of `FlinkKafkaConsumerBase`.