### PR TITLE
[FLINK-7197] [gelly] Missing call to GraphAlgorithmWrappingBase#canMergeConfigurationWith()

### DIFF
--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/TranslateGraphIds.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/TranslateGraphIds.java
@@ -56,7 +56,9 @@ extends GraphAlgorithmWrappingGraph<OLD, VV, EV, NEW, VV, EV> {
 
 	@Override
 	protected boolean canMergeConfigurationWith(GraphAlgorithmWrappingBase other) {
-		super.mergeConfiguration(other);
+		if (!super.canMergeConfigurationWith(other)) {
+			return false;
+		}
 
 		TranslateGraphIds rhs = (TranslateGraphIds) other;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/TranslateVertexValues.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/TranslateVertexValues.java
@@ -54,7 +54,9 @@ extends GraphAlgorithmWrappingGraph<K, OLD, EV, K, NEW, EV> {
 
 	@Override
 	protected boolean canMergeConfigurationWith(GraphAlgorithmWrappingBase other) {
-		super.mergeConfiguration(other);
+		if (!super.canMergeConfigurationWith(other)) {
+			return false;
+		}
 
 		TranslateVertexValues rhs = (TranslateVertexValues) other;
 


### PR DESCRIPTION
Fix for methods calling the incorrect super function.