### PR TITLE
[FLINK-7101][table] add condition of !stateCleaningEnabled is avoided…

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/GroupAggProcessFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/GroupAggProcessFunction.scala
@@ -131,8 +131,11 @@ class GroupAggProcessFunction(
 
       // if this was not the first row and we have to emit retractions
       if (generateRetraction && !firstRow) {
-        if (prevRow.row.equals(newRow.row)) {
-          // newRow is the same as before. Do not emit retraction and acc messages
+        if (prevRow.row.equals(newRow.row) && !stateCleaningEnabled) {
+          // newRow is the same as before and state cleaning is not enabled.
+          // We do not emit retraction and acc message.
+          // If state cleaning is enabled, we have to emit messages to prevent too early
+          // state eviction of downstream operators.
           return
         } else {
           // retract previous result


### PR DESCRIPTION
- [x] General
  - The pull request references the related JIRA issue ("    [FLINK-7101][table] add condition of !stateCleaningEnabled is avoided non-grouped window state to be cleaned up too early")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [ ] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [ ] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
