### PR TITLE
(release-1.3) [FLINK-7143, FLINK-7195] Collection of Kafka fixes for release-1.3

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -504,7 +504,7 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 	// ------------------------------------------------------------------------
 
 	@Override
-	public void initializeState(FunctionInitializationContext context) throws Exception {
+	public final void initializeState(FunctionInitializationContext context) throws Exception {
 
 		// we might have been restored via restoreState() which restores from legacy operator state
 		if (!restored) {
@@ -532,7 +532,7 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 	}
 
 	@Override
-	public void snapshotState(FunctionSnapshotContext context) throws Exception {
+	public final void snapshotState(FunctionSnapshotContext context) throws Exception {
 		if (!running) {
 			LOG.debug("snapshotState() called on closed source");
 		} else {
@@ -577,7 +577,7 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 	}
 
 	@Override
-	public void restoreState(HashMap<KafkaTopicPartition, Long> restoredOffsets) {
+	public final void restoreState(HashMap<KafkaTopicPartition, Long> restoredOffsets) {
 		LOG.info("{} (taskIdx={}) restoring offsets from an older version.",
 			getClass().getSimpleName(), getRuntimeContext().getIndexOfThisSubtask());
 

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicPartitionAssigner.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicPartitionAssigner.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.internals;
+
+/**
+ * Utility for assigning Kafka partitions to consumer subtasks.
+ */
+public class KafkaTopicPartitionAssigner {
+
+	/**
+	 * Returns the index of the target subtask that a specific Kafka partition should be
+	 * assigned to.
+	 *
+	 * <p>The resulting distribution of partitions of a single topic has the following contract:
+	 * <ul>
+	 *     <li>1. Uniformly distributed across subtasks</li>
+	 *     <li>2. Partitions are round-robin distributed (strictly clockwise w.r.t. ascending
+	 *     subtask indices) by using the partition id as the offset from a starting index
+	 *     (i.e., the index of the subtask which partition 0 of the topic will be assigned to,
+	 *     determined using the topic name).</li>
+	 * </ul>
+	 *
+	 * <p>The above contract is crucial and cannot be broken. Consumer subtasks rely on this
+	 * contract to locally filter out partitions that it should not subscribe to, guaranteeing
+	 * that all partitions of a single topic will always be assigned to some subtask in a
+	 * uniformly distributed manner.
+	 *
+	 * @param partition the Kafka partition
+	 * @param numParallelSubtasks total number of parallel subtasks
+	 *
+	 * @return index of the target subtask that the Kafka partition should be assigned to.
+	 */
+	public static int assign(KafkaTopicPartition partition, int numParallelSubtasks) {
+		int startIndex = ((partition.getTopic().hashCode() * 31) & 0x7FFFFFFF) % numParallelSubtasks;
+
+		// here, the assumption is that the id of Kafka partitions are always ascending
+		// starting from 0, and therefore can be used directly as the offset clockwise from the start index
+		return (startIndex + partition.getPartition()) % numParallelSubtasks;
+	}
+
+}

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseMigrationTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseMigrationTest.java
@@ -202,7 +202,7 @@ public class FlinkKafkaConsumerBaseMigrationTest {
 		assertTrue(consumerFunction.getSubscribedPartitionsToStartOffsets().isEmpty());
 
 		// assert that no state was restored
-		assertTrue(consumerFunction.getRestoredState() == null);
+		assertTrue(consumerFunction.getRestoredState().isEmpty());
 
 		consumerOperator.close();
 		consumerOperator.cancel();
@@ -244,12 +244,9 @@ public class FlinkKafkaConsumerBaseMigrationTest {
 			expectedSubscribedPartitionsWithStartOffsets.put(partition, KafkaTopicPartitionStateSentinel.GROUP_OFFSET);
 		}
 
-		// assert that there are partitions and is identical to expected list
-		assertTrue(consumerFunction.getSubscribedPartitionsToStartOffsets() != null);
-		assertTrue(!consumerFunction.getSubscribedPartitionsToStartOffsets().isEmpty());
-		Assert.assertEquals(expectedSubscribedPartitionsWithStartOffsets, consumerFunction.getSubscribedPartitionsToStartOffsets());
-
-		assertTrue(consumerFunction.getRestoredState() == null);
+		// verify that we do not try to fetch the partitions list and subscribe to them even though we have empty state
+		assertTrue(consumerFunction.getRestoredState().isEmpty());
+		assertTrue(consumerFunction.getSubscribedPartitionsToStartOffsets().isEmpty());
 
 		consumerOperator.close();
 		consumerOperator.cancel();

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerPartitionAssignmentTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerPartitionAssignmentTest.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -56,14 +55,13 @@ public class KafkaConsumerPartitionAssignmentTest {
 			int startIndex = KafkaTopicPartitionAssigner.assign(inPartitions.get(0), numSubtasks);
 
 			for (int subtaskIndex = 0; subtaskIndex < numSubtasks; subtaskIndex++) {
-				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets = new HashMap<>();
-				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-					subscribedPartitionsToStartOffsets,
-					inPartitions,
-					subtaskIndex,
-					inPartitions.size(),
-					StartupMode.GROUP_OFFSETS,
-					null);
+				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets =
+					FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+						inPartitions,
+						subtaskIndex,
+						inPartitions.size(),
+						StartupMode.GROUP_OFFSETS,
+						null);
 
 				List<KafkaTopicPartition> subscribedPartitions = new ArrayList<>(subscribedPartitionsToStartOffsets.keySet());
 
@@ -102,14 +100,13 @@ public class KafkaConsumerPartitionAssignmentTest {
 			int startIndex = KafkaTopicPartitionAssigner.assign(partitions.get(0), numConsumers);
 
 			for (int subtaskIndex = 0; subtaskIndex < numConsumers; subtaskIndex++) {
-				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets = new HashMap<>();
-				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-					subscribedPartitionsToStartOffsets,
-					partitions,
-					subtaskIndex,
-					numConsumers,
-					StartupMode.GROUP_OFFSETS,
-					null);
+				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets =
+					FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+						partitions,
+						subtaskIndex,
+						numConsumers,
+						StartupMode.GROUP_OFFSETS,
+						null);
 
 				List<KafkaTopicPartition> subscribedPartitions = new ArrayList<>(subscribedPartitionsToStartOffsets.keySet());
 
@@ -152,14 +149,13 @@ public class KafkaConsumerPartitionAssignmentTest {
 			int startIndex = KafkaTopicPartitionAssigner.assign(inPartitions.get(0), numConsumers);
 
 			for (int subtaskIndex = 0; subtaskIndex < numConsumers; subtaskIndex++) {
-				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets = new HashMap<>();
-				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-					subscribedPartitionsToStartOffsets,
-					inPartitions,
-					subtaskIndex,
-					numConsumers,
-					StartupMode.GROUP_OFFSETS,
-					null);
+				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets =
+					FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+						inPartitions,
+						subtaskIndex,
+						numConsumers,
+						StartupMode.GROUP_OFFSETS,
+						null);
 
 				List<KafkaTopicPartition> subscribedPartitions = new ArrayList<>(subscribedPartitionsToStartOffsets.keySet());
 
@@ -187,24 +183,22 @@ public class KafkaConsumerPartitionAssignmentTest {
 	public void testAssignEmptyPartitions() {
 		try {
 			List<KafkaTopicPartition> ep = new ArrayList<>();
-			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets = new HashMap<>();
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets,
-				ep,
-				2,
-				4,
-				StartupMode.GROUP_OFFSETS,
-				null);
+			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					ep,
+					2,
+					4,
+					StartupMode.GROUP_OFFSETS,
+					null);
 			assertTrue(subscribedPartitionsToStartOffsets.entrySet().isEmpty());
 
-			subscribedPartitionsToStartOffsets = new HashMap<>();
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets,
-				ep,
-				0,
-				1,
-				StartupMode.GROUP_OFFSETS,
-				null);
+			subscribedPartitionsToStartOffsets =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					ep,
+					0,
+					1,
+					StartupMode.GROUP_OFFSETS,
+					null);
 			assertTrue(subscribedPartitionsToStartOffsets.entrySet().isEmpty());
 		}
 		catch (Exception e) {
@@ -235,33 +229,29 @@ public class KafkaConsumerPartitionAssignmentTest {
 			final int minNewPartitionsPerConsumer = newPartitions.size() / numConsumers;
 			final int maxNewPartitionsPerConsumer = newPartitions.size() / numConsumers + 1;
 
-			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets1 = new HashMap<>();
-			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets2 = new HashMap<>();
-			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets3 = new HashMap<>();
+			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets1 =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					initialPartitions,
+					0,
+					numConsumers,
+					StartupMode.GROUP_OFFSETS,
+					null);
 
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets1,
-				initialPartitions,
-				0,
-				numConsumers,
-				StartupMode.GROUP_OFFSETS,
-				null);
+			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets2 =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					initialPartitions,
+					1,
+					numConsumers,
+					StartupMode.GROUP_OFFSETS,
+					null);
 
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets2,
-				initialPartitions,
-				1,
-				numConsumers,
-				StartupMode.GROUP_OFFSETS,
-				null);
-
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets3,
-				initialPartitions,
-				2,
-				numConsumers,
-				StartupMode.GROUP_OFFSETS,
-				null);
+			Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets3 =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					initialPartitions,
+					2,
+					numConsumers,
+					StartupMode.GROUP_OFFSETS,
+					null);
 
 			List<KafkaTopicPartition> subscribedPartitions1 = new ArrayList<>(subscribedPartitionsToStartOffsets1.keySet());
 			List<KafkaTopicPartition> subscribedPartitions2 = new ArrayList<>(subscribedPartitionsToStartOffsets2.keySet());
@@ -300,33 +290,29 @@ public class KafkaConsumerPartitionAssignmentTest {
 
 			// grow the set of partitions and distribute anew
 
-			subscribedPartitionsToStartOffsets1 = new HashMap<>();
-			subscribedPartitionsToStartOffsets2 = new HashMap<>();
-			subscribedPartitionsToStartOffsets3 = new HashMap<>();
+			subscribedPartitionsToStartOffsets1 =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					newPartitions,
+					0,
+					numConsumers,
+					StartupMode.GROUP_OFFSETS,
+					null);
 
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets1,
-				newPartitions,
-				0,
-				numConsumers,
-				StartupMode.GROUP_OFFSETS,
-				null);
+			subscribedPartitionsToStartOffsets2 =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					newPartitions,
+					1,
+					numConsumers,
+					StartupMode.GROUP_OFFSETS,
+					null);
 
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets2,
-				newPartitions,
-				1,
-				numConsumers,
-				StartupMode.GROUP_OFFSETS,
-				null);
-
-			FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-				subscribedPartitionsToStartOffsets3,
-				newPartitions,
-				2,
-				numConsumers,
-				StartupMode.GROUP_OFFSETS,
-				null);
+			subscribedPartitionsToStartOffsets3 =
+				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+					newPartitions,
+					2,
+					numConsumers,
+					StartupMode.GROUP_OFFSETS,
+					null);
 
 			List<KafkaTopicPartition> subscribedPartitions1New = new ArrayList<>(subscribedPartitionsToStartOffsets1.keySet());
 			List<KafkaTopicPartition> subscribedPartitions2New = new ArrayList<>(subscribedPartitionsToStartOffsets2.keySet());
@@ -396,24 +382,22 @@ public class KafkaConsumerPartitionAssignmentTest {
 				new KafkaTopicPartition("test-topic", 2));
 
 			for (int subtaskIndex = 0; subtaskIndex < numSubtasks; subtaskIndex++) {
-				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets = new HashMap<>();
-				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsetsOutOfOrder = new HashMap<>();
 
-				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-					subscribedPartitionsToStartOffsets,
-					inPartitions,
-					subtaskIndex,
-					inPartitions.size(),
-					StartupMode.GROUP_OFFSETS,
-					null);
+				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets =
+					FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+						inPartitions,
+						subtaskIndex,
+						inPartitions.size(),
+						StartupMode.GROUP_OFFSETS,
+						null);
 
-				FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
-					subscribedPartitionsToStartOffsetsOutOfOrder,
-					inPartitionsOutOfOrder,
-					subtaskIndex,
-					inPartitions.size(),
-					StartupMode.GROUP_OFFSETS,
-					null);
+				Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsetsOutOfOrder =
+					FlinkKafkaConsumerBase.initializeSubscribedPartitionsToStartOffsets(
+						inPartitionsOutOfOrder,
+						subtaskIndex,
+						inPartitions.size(),
+						StartupMode.GROUP_OFFSETS,
+						null);
 
 				// the subscribed partitions should be identical, regardless of the input partition ordering
 				assertEquals(subscribedPartitionsToStartOffsets, subscribedPartitionsToStartOffsetsOutOfOrder);


### PR DESCRIPTION
This PR subsumes #4344 and #4301, including changes in both PRs merged and conflicts resolved.
Apparently, some new tests added in one of the PRs relies also on the fix of the other PR, so opening this one to have a better overall view of the status of the fixes.