### PR TITLE
[FLINK-7068][blob] change BlobService sub-classes for permanent and transient BLOBs

### DIFF
--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
@@ -292,7 +292,7 @@ public class HDFSTest {
 
 	/**
 	 * Tests that with {@link HighAvailabilityMode#ZOOKEEPER} distributed JARs are recoverable from any
-	 * participating BlobServer when uploaded via a {@link org.apache.flink.runtime.blob.BlobCache}.
+	 * participating BlobServer when uploaded via a BLOB cache.
 	 */
 	@Test
 	public void testBlobCacheRecovery() throws Exception {
@@ -314,7 +314,7 @@ public class HDFSTest {
 
 	/**
 	 * Tests that with {@link HighAvailabilityMode#ZOOKEEPER} distributed corrupted JARs are
-	 * recognised during the download via a {@link org.apache.flink.runtime.blob.BlobCache}.
+	 * recognised during the download via a BLOB cache.
 	 */
 	@Test
 	public void testBlobCacheCorruptedFile() throws Exception {

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.hdfstests;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.io.FileOutputFormat;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
@@ -30,7 +31,10 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.examples.java.wordcount.WordCount;
-import org.apache.flink.runtime.blob.BlobRecoveryITCase;
+import org.apache.flink.runtime.blob.BlobCacheCorruptionTest;
+import org.apache.flink.runtime.blob.BlobCacheRecoveryTest;
+import org.apache.flink.runtime.blob.BlobServerCorruptionTest;
+import org.apache.flink.runtime.blob.BlobServerRecoveryTest;
 import org.apache.flink.runtime.blob.BlobStoreService;
 import org.apache.flink.runtime.blob.BlobUtils;
 import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
@@ -51,6 +55,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
@@ -75,6 +80,9 @@ public class HDFSTest {
 
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
 
 	@BeforeClass
 	public static void verifyOS() {
@@ -240,7 +248,7 @@ public class HDFSTest {
 
 	/**
 	 * Tests that with {@link HighAvailabilityMode#ZOOKEEPER} distributed JARs are recoverable from any
-	 * participating BlobServer.
+	 * participating BlobServer when talking to the {@link org.apache.flink.runtime.blob.BlobServer} directly.
 	 */
 	@Test
 	public void testBlobServerRecovery() throws Exception {
@@ -257,7 +265,88 @@ public class HDFSTest {
 		try {
 			blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
-			BlobRecoveryITCase.testBlobServerRecovery(config, blobStoreService);
+			BlobServerRecoveryTest.testBlobServerRecovery(config, blobStoreService);
+		} finally {
+			if (blobStoreService != null) {
+				blobStoreService.closeAndCleanupAllData();
+			}
+		}
+	}
+
+	/**
+	 * Tests that with {@link HighAvailabilityMode#ZOOKEEPER} distributed corrupted JARs are
+	 * recognised during the download via a {@link org.apache.flink.runtime.blob.BlobServer}.
+	 */
+	@Test
+	public void testBlobServerCorruptedFile() throws Exception {
+		org.apache.flink.configuration.Configuration
+			config = new org.apache.flink.configuration.Configuration();
+		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+		config.setString(CoreOptions.STATE_BACKEND, "ZOOKEEPER");
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
+
+		BlobStoreService blobStoreService = null;
+
+		try {
+			blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
+
+			BlobServerCorruptionTest.testGetFailsFromCorruptFile(config, blobStoreService, exception);
+		} finally {
+			if (blobStoreService != null) {
+				blobStoreService.closeAndCleanupAllData();
+			}
+		}
+	}
+
+	/**
+	 * Tests that with {@link HighAvailabilityMode#ZOOKEEPER} distributed JARs are recoverable from any
+	 * participating BlobServer when uploaded via a {@link org.apache.flink.runtime.blob.BlobCache}.
+	 */
+	@Test
+	public void testBlobCacheRecovery() throws Exception {
+		org.apache.flink.configuration.Configuration
+			config = new org.apache.flink.configuration.Configuration();
+		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+		config.setString(CoreOptions.STATE_BACKEND, "ZOOKEEPER");
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
+
+		BlobStoreService blobStoreService = null;
+
+		try {
+			blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
+
+			BlobCacheRecoveryTest.testBlobCacheRecovery(config, blobStoreService);
+		} finally {
+			if (blobStoreService != null) {
+				blobStoreService.closeAndCleanupAllData();
+			}
+		}
+	}
+
+	/**
+	 * Tests that with {@link HighAvailabilityMode#ZOOKEEPER} distributed corrupted JARs are
+	 * recognised during the download via a {@link org.apache.flink.runtime.blob.BlobCache}.
+	 */
+	@Test
+	public void testBlobCacheCorruptedFile() throws Exception {
+		org.apache.flink.configuration.Configuration
+			config = new org.apache.flink.configuration.Configuration();
+		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+		config.setString(CoreOptions.STATE_BACKEND, "ZOOKEEPER");
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
+
+		BlobStoreService blobStoreService = null;
+
+		try {
+			blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
+
+			BlobCacheCorruptionTest.testGetFailsFromCorruptFile(new JobID(), true, true, config, blobStoreService, exception);
 		} finally {
 			if (blobStoreService != null) {
 				blobStoreService.closeAndCleanupAllData();

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.java.LocalEnvironment;
 import org.apache.flink.api.java.io.AvroOutputFormat;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
@@ -64,6 +63,7 @@ import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.UUID;
 
+import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -255,21 +255,16 @@ public class HDFSTest {
 		org.apache.flink.configuration.Configuration
 			config = new org.apache.flink.configuration.Configuration();
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-		config.setString(CoreOptions.STATE_BACKEND, "ZOOKEEPER");
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
 			temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
 
-		BlobStoreService blobStoreService = null;
+		BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
 		try {
-			blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
-
 			BlobServerRecoveryTest.testBlobServerRecovery(config, blobStoreService);
 		} finally {
-			if (blobStoreService != null) {
-				blobStoreService.closeAndCleanupAllData();
-			}
+			blobStoreService.closeAndCleanupAllData();
 		}
 	}
 
@@ -282,21 +277,16 @@ public class HDFSTest {
 		org.apache.flink.configuration.Configuration
 			config = new org.apache.flink.configuration.Configuration();
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-		config.setString(CoreOptions.STATE_BACKEND, "ZOOKEEPER");
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
 			temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
 
-		BlobStoreService blobStoreService = null;
+		BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
 		try {
-			blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
-
 			BlobServerCorruptionTest.testGetFailsFromCorruptFile(config, blobStoreService, exception);
 		} finally {
-			if (blobStoreService != null) {
-				blobStoreService.closeAndCleanupAllData();
-			}
+			blobStoreService.closeAndCleanupAllData();
 		}
 	}
 
@@ -309,21 +299,16 @@ public class HDFSTest {
 		org.apache.flink.configuration.Configuration
 			config = new org.apache.flink.configuration.Configuration();
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-		config.setString(CoreOptions.STATE_BACKEND, "ZOOKEEPER");
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
 			temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
 
-		BlobStoreService blobStoreService = null;
+		BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
 		try {
-			blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
-
 			BlobCacheRecoveryTest.testBlobCacheRecovery(config, blobStoreService);
 		} finally {
-			if (blobStoreService != null) {
-				blobStoreService.closeAndCleanupAllData();
-			}
+			blobStoreService.closeAndCleanupAllData();
 		}
 	}
 
@@ -336,21 +321,18 @@ public class HDFSTest {
 		org.apache.flink.configuration.Configuration
 			config = new org.apache.flink.configuration.Configuration();
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-		config.setString(CoreOptions.STATE_BACKEND, "ZOOKEEPER");
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
 			temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
 
-		BlobStoreService blobStoreService = null;
+		BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
 		try {
-			blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
-
-			BlobCacheCorruptionTest.testGetFailsFromCorruptFile(new JobID(), true, true, config, blobStoreService, exception);
+			BlobCacheCorruptionTest
+				.testGetFailsFromCorruptFile(new JobID(), PERMANENT_BLOB, true, config,
+					blobStoreService, exception);
 		} finally {
-			if (blobStoreService != null) {
-				blobStoreService.closeAndCleanupAllData();
-			}
+			blobStoreService.closeAndCleanupAllData();
 		}
 	}
 

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
@@ -63,7 +63,6 @@ import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.UUID;
 
-import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -329,8 +328,7 @@ public class HDFSTest {
 
 		try {
 			BlobCacheCorruptionTest
-				.testGetFailsFromCorruptFile(new JobID(), PERMANENT_BLOB, true, config,
-					blobStoreService, exception);
+				.testGetFailsFromCorruptFile(new JobID(), config, blobStoreService, exception);
 		} finally {
 			blobStoreService.closeAndCleanupAllData();
 		}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.WebOptions;
-import org.apache.flink.runtime.blob.BlobView;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.jobmanager.MemoryArchivist;
 import org.apache.flink.runtime.jobmaster.JobManagerGateway;
@@ -156,7 +155,6 @@ public class WebRuntimeMonitor implements WebMonitor {
 	public WebRuntimeMonitor(
 			Configuration config,
 			LeaderRetrievalService leaderRetrievalService,
-			BlobView blobView,
 			LeaderGatewayRetriever<JobManagerGateway> jobManagerRetriever,
 			MetricQueryServiceRetriever queryServiceRetriever,
 			Time timeout,
@@ -297,8 +295,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 				localRestAddress,
 				timeout,
 				TaskManagerLogHandler.FileMode.LOG,
-				config,
-				blobView));
+				config));
 		get(router,
 			new TaskManagerLogHandler(
 				retriever,
@@ -306,8 +303,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 				localRestAddress,
 				timeout,
 				TaskManagerLogHandler.FileMode.STDOUT,
-				config,
-				blobView));
+				config));
 		get(router, new TaskManagerMetricsHandler(scheduledExecutor, metricFetcher));
 
 		router

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitorITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitorITCase.java
@@ -23,7 +23,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.blob.BlobView;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.jobmanager.JobManager;
@@ -175,7 +174,6 @@ public class WebRuntimeMonitorITCase extends TestLogger {
 				webMonitor[i] = new WebRuntimeMonitor(
 					config,
 					highAvailabilityServices.getJobManagerLeaderRetriever(HighAvailabilityServices.DEFAULT_JOB_ID),
-					highAvailabilityServices.createBlobStore(),
 					jobManagerRetrievers[i],
 					new AkkaQueryServiceRetriever(jobManagerSystem[i], TIMEOUT),
 					TIMEOUT,
@@ -319,7 +317,6 @@ public class WebRuntimeMonitorITCase extends TestLogger {
 			webRuntimeMonitor = new WebRuntimeMonitor(
 				config,
 				mock(LeaderRetrievalService.class),
-				mock(BlobView.class),
 				new AkkaJobManagerRetriever(actorSystem, TIMEOUT, 0, Time.milliseconds(50L)),
 				new AkkaQueryServiceRetriever(actorSystem, TIMEOUT),
 				TIMEOUT,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/AbstractBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/AbstractBlobCache.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.FileUtils;
+
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Abstract base class for permanent and transient BLOB files.
+ */
+public abstract class AbstractBlobCache implements Closeable {
+
+	/**
+	 * The log object used for debugging.
+	 */
+	protected final Logger LOG;
+
+	/**
+	 * Counter to generate unique names for temporary files.
+	 */
+	protected final AtomicLong tempFileCounter = new AtomicLong(0);
+
+	protected final InetSocketAddress serverAddress;
+
+	/**
+	 * Root directory for local file storage.
+	 */
+	protected final File storageDir;
+
+	/**
+	 * Blob store for distributed file storage, e.g. in HA.
+	 */
+	protected final BlobView blobView;
+
+	protected final AtomicBoolean shutdownRequested = new AtomicBoolean();
+
+	/**
+	 * Shutdown hook thread to ensure deletion of the local storage directory.
+	 */
+	protected final Thread shutdownHook;
+
+	/**
+	 * The number of retries when the transfer fails.
+	 */
+	protected final int numFetchRetries;
+
+	/**
+	 * Configuration for the blob client like ssl parameters required to connect to the blob
+	 * server.
+	 */
+	protected final Configuration blobClientConfig;
+
+	/**
+	 * Lock guarding concurrent file accesses.
+	 */
+	protected final ReadWriteLock readWriteLock;
+
+	public AbstractBlobCache(
+			final InetSocketAddress serverAddress,
+			final Configuration blobClientConfig,
+			final BlobView blobView,
+			final Logger logger) throws IOException {
+
+		this.LOG = logger;
+
+		this.serverAddress = checkNotNull(serverAddress);
+		this.blobClientConfig = checkNotNull(blobClientConfig);
+		this.blobView = checkNotNull(blobView, "blobStore");
+		this.readWriteLock = new ReentrantReadWriteLock();
+
+		// configure and create the storage directory
+		String storageDirectory = blobClientConfig.getString(BlobServerOptions.STORAGE_DIRECTORY);
+		this.storageDir = BlobUtils.initLocalStorageDirectory(storageDirectory);
+		LOG.info("Created BLOB cache storage directory " + storageDir);
+
+		// configure the number of fetch retries
+		final int fetchRetries = blobClientConfig.getInteger(BlobServerOptions.FETCH_RETRIES);
+		if (fetchRetries >= 0) {
+			this.numFetchRetries = fetchRetries;
+		} else {
+			LOG.warn("Invalid value for {}. System will attempt no retries on failed fetch operations of BLOBs.",
+				BlobServerOptions.FETCH_RETRIES.key());
+			this.numFetchRetries = 0;
+		}
+
+		// Add shutdown hook to delete storage directory
+		shutdownHook = BlobUtils.addShutdownHook(this, LOG);
+	}
+
+	/**
+	 * Returns local copy of the file for the BLOB with the given key.
+	 *
+	 * <p>The method will first attempt to serve the BLOB from its local cache. If the BLOB is not
+	 * in the cache, the method will try to download it from this cache's BLOB server via a
+	 * distributed BLOB store (if available) or direct end-to-end download.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
+	 * @param blobKey
+	 * 		The key of the desired BLOB.
+	 *
+	 * @return file referring to the local storage location of the BLOB.
+	 *
+	 * @throws IOException
+	 * 		Thrown if an I/O error occurs while downloading the BLOBs from the BLOB server.
+	 */
+	protected File getTransientFileInternal(@Nullable JobID jobId, BlobKey blobKey) throws IOException {
+		checkArgument(blobKey != null, "BLOB key cannot be null.");
+
+		final File localFile = BlobUtils.getStorageLocation(storageDir, jobId, blobKey);
+		readWriteLock.readLock().lock();
+
+		try {
+			if (localFile.exists()) {
+				return localFile;
+			}
+		} finally {
+			readWriteLock.readLock().unlock();
+		}
+
+		// first try the distributed blob store (if available)
+		// use a temporary file (thread-safe without locking)
+		File incomingFile = createTemporaryFilename();
+		try {
+			try {
+				if (blobView.get(jobId, blobKey, incomingFile)) {
+					// now move the temp file to our local cache atomically
+					BlobUtils.moveTempFileToStore(
+						incomingFile, jobId, blobKey, localFile, readWriteLock.writeLock(), LOG, null);
+
+					return localFile;
+				}
+			} catch (Exception e) {
+				LOG.info("Failed to copy from blob store. Downloading from BLOB server instead.", e);
+			}
+
+			// fallback: download from the BlobServer
+			BlobClient.downloadFromBlobServer(
+				jobId, blobKey, incomingFile, serverAddress, blobClientConfig, numFetchRetries);
+
+			BlobUtils.moveTempFileToStore(
+				incomingFile, jobId, blobKey, localFile, readWriteLock.writeLock(), LOG, null);
+
+			return localFile;
+		} finally {
+			// delete incomingFile from a failed download
+			if (!incomingFile.delete() && incomingFile.exists()) {
+				LOG.warn("Could not delete the staging file {} for blob key {} and job {}.",
+					incomingFile, blobKey, jobId);
+			}
+		}
+	}
+
+	/**
+	 * Returns the port the BLOB server is listening on.
+	 *
+	 * @return BLOB server port
+	 */
+	public int getPort() {
+		return serverAddress.getPort();
+	}
+
+	/**
+	 * Returns a temporary file inside the BLOB server's incoming directory.
+	 *
+	 * @return a temporary file inside the BLOB server's incoming directory
+	 *
+	 * @throws IOException
+	 * 		if creating the directory fails
+	 */
+	File createTemporaryFilename() throws IOException {
+		return new File(BlobUtils.getIncomingDirectory(storageDir),
+			String.format("temp-%08d", tempFileCounter.getAndIncrement()));
+	}
+
+	@Override
+	public void close() throws IOException {
+		cancelCleanupTask();
+
+		if (shutdownRequested.compareAndSet(false, true)) {
+			LOG.info("Shutting down BLOB cache");
+
+			// Clean up the storage directory
+			try {
+				FileUtils.deleteDirectory(storageDir);
+			} finally {
+				// Remove shutdown hook to prevent resource leaks, unless this is invoked by the shutdown hook itself
+				if (shutdownHook != null && shutdownHook != Thread.currentThread()) {
+					try {
+						Runtime.getRuntime().removeShutdownHook(shutdownHook);
+					} catch (IllegalStateException e) {
+						// race, JVM is in shutdown already, we can safely ignore this
+					} catch (Throwable t) {
+						LOG.warn("Exception while unregistering BLOB cache's cleanup shutdown hook.");
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Cancels any cleanup task that subclasses may be executing.
+	 *
+	 * <p>This is called during {@link #close()}.
+	 */
+	protected abstract void cancelCleanupTask();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
@@ -18,90 +18,21 @@
 
 package org.apache.flink.runtime.blob;
 
-import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.util.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.InetSocketAddress;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * The BLOB cache implements a local cache for content-addressable BLOBs.
- *
- * <p>When requesting BLOBs through the {@link BlobCache#getFile} methods, the
- * BLOB cache will first attempt to serve the file from its local cache. Only if
- * the local cache does not contain the desired BLOB, the BLOB cache will try to
- * download it from a distributed file system (if available) or the BLOB
- * server.</p>
+ * The BLOB cache provides access to BLOB services for permanent and transient BLOBs.
  */
-public class BlobCache extends TimerTask implements BlobService {
+public class BlobCache implements BlobService {
 
-	/** The log object used for debugging. */
-	private static final Logger LOG = LoggerFactory.getLogger(BlobCache.class);
+	/** Caching store for permanent BLOBs. */
+	private final PermanentBlobCache permanentBlobStore;
 
-	private final InetSocketAddress serverAddress;
-
-	/** Root directory for local file storage */
-	private final File storageDir;
-
-	/** Blob store for distributed file storage, e.g. in HA */
-	private final BlobView blobView;
-
-	private final AtomicBoolean shutdownRequested = new AtomicBoolean();
-
-	/** Shutdown hook thread to ensure deletion of the storage directory. */
-	private final Thread shutdownHook;
-
-	/** The number of retries when the transfer fails */
-	private final int numFetchRetries;
-
-	/** Configuration for the blob client like ssl parameters required to connect to the blob server */
-	private final Configuration blobClientConfig;
-
-	// --------------------------------------------------------------------------------------------
-
-	/**
-	 * Job reference counters with a time-to-live (TTL).
-	 */
-	@VisibleForTesting
-	static class RefCount {
-		/**
-		 * Number of references to a job.
-		 */
-		public int references = 0;
-		
-		/**
-		 * Timestamp in milliseconds when any job data should be cleaned up (no cleanup for
-		 * non-positive values).
-		 */
-		public long keepUntil = -1;
-	}
-
-	/** Map to store the number of references to a specific job */
-	private final Map<JobID, RefCount> jobRefCounters = new HashMap<>();
-
-	/** Time interval (ms) to run the cleanup task; also used as the default TTL. */
-	private final long cleanupInterval;
-
-	private final Timer cleanupTimer;
+	/** Store for transient BLOB files. */
+	private final TransientBlobCache transientBlobStore;
 
 	/**
 	 * Instantiates a new BLOB cache.
@@ -120,397 +51,30 @@ public class BlobCache extends TimerTask implements BlobService {
 			final InetSocketAddress serverAddress,
 			final Configuration blobClientConfig,
 			final BlobView blobView) throws IOException {
-		this.serverAddress = checkNotNull(serverAddress);
-		this.blobClientConfig = checkNotNull(blobClientConfig);
-		this.blobView = checkNotNull(blobView, "blobStore");
 
-		// configure and create the storage directory
-		String storageDirectory = blobClientConfig.getString(BlobServerOptions.STORAGE_DIRECTORY);
-		this.storageDir = BlobUtils.initLocalStorageDirectory(storageDirectory);
-		LOG.info("Created BLOB cache storage directory " + storageDir);
-
-		// configure the number of fetch retries
-		final int fetchRetries = blobClientConfig.getInteger(BlobServerOptions.FETCH_RETRIES);
-		if (fetchRetries >= 0) {
-			this.numFetchRetries = fetchRetries;
-		}
-		else {
-			LOG.warn("Invalid value for {}. System will attempt no retires on failed fetches of BLOBs.",
-				BlobServerOptions.FETCH_RETRIES.key());
-			this.numFetchRetries = 0;
-		}
-
-		// Initializing the clean up task
-		this.cleanupTimer = new Timer(true);
-
-		cleanupInterval = blobClientConfig.getLong(BlobServerOptions.CLEANUP_INTERVAL) * 1000;
-		this.cleanupTimer.schedule(this, cleanupInterval, cleanupInterval);
-
-		// Add shutdown hook to delete storage directory
-		shutdownHook = BlobUtils.addShutdownHook(this, LOG);
-	}
-
-	/**
-	 * Registers use of job-related BLOBs.
-	 * <p>
-	 * Using any other method to access BLOBs, e.g. {@link #getFile}, is only valid within calls
-	 * to {@link #registerJob(JobID)} and {@link #releaseJob(JobID)}.
-	 *
-	 * @param jobId
-	 * 		ID of the job this blob belongs to
-	 *
-	 * @see #releaseJob(JobID)
-	 */
-	public void registerJob(JobID jobId) {
-		synchronized (jobRefCounters) {
-			RefCount ref = jobRefCounters.get(jobId);
-			if (ref == null) {
-				ref = new RefCount();
-				jobRefCounters.put(jobId, ref);
-			} else {
-				// reset cleanup timeout
-				ref.keepUntil = -1;
-			}
-			++ref.references;
-		}
-	}
-
-	/**
-	 * Unregisters use of job-related BLOBs and allow them to be released.
-	 *
-	 * @param jobId
-	 * 		ID of the job this blob belongs to
-	 *
-	 * @see #registerJob(JobID)
-	 */
-	public void releaseJob(JobID jobId) {
-		synchronized (jobRefCounters) {
-			RefCount ref = jobRefCounters.get(jobId);
-
-			if (ref == null) {
-				LOG.warn("improper use of releaseJob() without a matching number of registerJob() calls for jobId " + jobId);
-				return;
-			}
-
-			--ref.references;
-			if (ref.references == 0) {
-				ref.keepUntil = System.currentTimeMillis() + cleanupInterval;
-			}
-		}
-	}
-
-	/**
-	 * Returns local copy of the (job-unrelated) file for the BLOB with the given key.
-	 * <p>
-	 * The method will first attempt to serve the BLOB from its local cache. If the BLOB is not in
-	 * the cache, the method will try to download it from this cache's BLOB server.
-	 *
-	 * @param key
-	 * 		The key of the desired BLOB.
-	 *
-	 * @return file referring to the local storage location of the BLOB.
-	 *
-	 * @throws IOException
-	 * 		Thrown if an I/O error occurs while downloading the BLOBs from the BLOB server.
-	 */
-	@Override
-	public File getFile(BlobKey key) throws IOException {
-		return getFileInternal(null, key);
-	}
-
-	/**
-	 * Returns local copy of the file for the BLOB with the given key.
-	 * <p>
-	 * The method will first attempt to serve the BLOB from its local cache. If the BLOB is not in
-	 * the cache, the method will try to download it from this cache's BLOB server.
-	 *
-	 * @param jobId
-	 * 		ID of the job this blob belongs to
-	 * @param key
-	 * 		The key of the desired BLOB.
-	 *
-	 * @return file referring to the local storage location of the BLOB.
-	 *
-	 * @throws IOException
-	 * 		Thrown if an I/O error occurs while downloading the BLOBs from the BLOB server.
-	 */
-	@Override
-	public File getFile(JobID jobId, BlobKey key) throws IOException {
-		checkNotNull(jobId);
-		return getFileInternal(jobId, key);
-	}
-
-	/**
-	 * Returns local copy of the file for the BLOB with the given key.
-	 * <p>
-	 * The method will first attempt to serve the BLOB from its local cache. If the BLOB is not in
-	 * the cache, the method will try to download it from this cache's BLOB server.
-	 *
-	 * @param jobId
-	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
-	 * @param requiredBlob
-	 * 		The key of the desired BLOB.
-	 *
-	 * @return file referring to the local storage location of the BLOB.
-	 *
-	 * @throws IOException
-	 * 		Thrown if an I/O error occurs while downloading the BLOBs from the BLOB server.
-	 */
-	private File getFileInternal(@Nullable JobID jobId, BlobKey requiredBlob) throws IOException {
-		checkArgument(requiredBlob != null, "BLOB key cannot be null.");
-
-		final File localJarFile = BlobUtils.getStorageLocation(storageDir, jobId, requiredBlob);
-
-		if (localJarFile.exists()) {
-			return localJarFile;
-		}
-
-		// first try the distributed blob store (if available)
-		try {
-			blobView.get(jobId, requiredBlob, localJarFile);
-		} catch (Exception e) {
-			LOG.info("Failed to copy from blob store. Downloading from BLOB server instead.", e);
-		}
-
-		if (localJarFile.exists()) {
-			return localJarFile;
-		}
-
-		// fallback: download from the BlobServer
-		final byte[] buf = new byte[BlobServerProtocol.BUFFER_SIZE];
-		LOG.info("Downloading {}/{} from {}", jobId, requiredBlob, serverAddress);
-
-		// loop over retries
-		int attempt = 0;
-		while (true) {
-			try (
-				final BlobClient bc = new BlobClient(serverAddress, blobClientConfig);
-				final InputStream is = bc.getInternal(jobId, requiredBlob);
-				final OutputStream os = new FileOutputStream(localJarFile)
-			) {
-				while (true) {
-					final int read = is.read(buf);
-					if (read < 0) {
-						break;
-					}
-					os.write(buf, 0, read);
-				}
-
-				// success, we finished
-				return localJarFile;
-			}
-			catch (Throwable t) {
-				String message = "Failed to fetch BLOB " + jobId + "/" + requiredBlob + " from " + serverAddress +
-					" and store it under " + localJarFile.getAbsolutePath();
-				if (attempt < numFetchRetries) {
-					if (LOG.isDebugEnabled()) {
-						LOG.debug(message + " Retrying...", t);
-					} else {
-						LOG.error(message + " Retrying...");
-					}
-				}
-				else {
-					LOG.error(message + " No retries left.", t);
-					throw new IOException(message, t);
-				}
-
-				// retry
-				++attempt;
-				LOG.info("Downloading {}/{} from {} (retry {})", jobId, requiredBlob, serverAddress, attempt);
-			}
-		} // end loop over retries
-	}
-
-	/**
-	 * Deletes the (job-unrelated) file associated with the blob key in this BLOB cache.
-	 *
-	 * @param key
-	 * 		blob key associated with the file to be deleted
-	 *
-	 * @throws IOException
-	 */
-	@Override
-	public void delete(BlobKey key) throws IOException {
-		deleteInternal(null, key);
-	}
-
-	/**
-	 * Deletes the file associated with the blob key in this BLOB cache.
-	 *
-	 * @param jobId
-	 * 		ID of the job this blob belongs to
-	 * @param key
-	 * 		blob key associated with the file to be deleted
-	 *
-	 * @throws IOException
-	 */
-	@Override
-	public void delete(JobID jobId, BlobKey key) throws IOException {
-		checkNotNull(jobId);
-		deleteInternal(jobId, key);
-	}
-
-	/**
-	 * Deletes the file associated with the blob key in this BLOB cache.
-	 *
-	 * @param jobId
-	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
-	 * @param key
-	 * 		blob key associated with the file to be deleted
-	 *
-	 * @throws IOException
-	 */
-	private void deleteInternal(@Nullable JobID jobId, BlobKey key) throws IOException{
-		final File localFile = BlobUtils.getStorageLocation(storageDir, jobId, key);
-		if (!localFile.delete() && localFile.exists()) {
-			LOG.warn("Failed to delete locally cached BLOB {} at {}", key, localFile.getAbsolutePath());
-		}
-	}
-
-	/**
-	 * Deletes the (job-unrelated) file associated with the given key from the BLOB cache and
-	 * BLOB server.
-	 *
-	 * @param key
-	 * 		referring to the file to be deleted
-	 *
-	 * @throws IOException
-	 * 		thrown if an I/O error occurs while transferring the request to the BLOB server or if the
-	 * 		BLOB server cannot delete the file
-	 */
-	public void deleteGlobal(BlobKey key) throws IOException {
-		deleteGlobalInternal(null, key);
-	}
-
-	/**
-	 * Deletes the file associated with the given key from the BLOB cache and BLOB server.
-	 *
-	 * @param jobId
-	 * 		ID of the job this blob belongs to
-	 * @param key
-	 * 		referring to the file to be deleted
-	 *
-	 * @throws IOException
-	 * 		thrown if an I/O error occurs while transferring the request to the BLOB server or if the
-	 * 		BLOB server cannot delete the file
-	 */
-	public void deleteGlobal(JobID jobId, BlobKey key) throws IOException {
-		checkNotNull(jobId);
-		deleteGlobalInternal(jobId, key);
-	}
-
-	/**
-	 * Deletes the file associated with the given key from the BLOB cache and
-	 * BLOB server.
-	 *
-	 * @param jobId
-	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
-	 * @param key
-	 * 		referring to the file to be deleted
-	 *
-	 * @throws IOException
-	 * 		thrown if an I/O error occurs while transferring the request to the BLOB server or if the
-	 * 		BLOB server cannot delete the file
-	 */
-	private void deleteGlobalInternal(@Nullable JobID jobId, BlobKey key) throws IOException {
-		// delete locally
-		deleteInternal(jobId, key);
-		// then delete on the BLOB server
-		// (don't use the distributed storage directly - this way the blob
-		// server is aware of the delete operation, too)
-		try (BlobClient bc = createClient()) {
-			bc.deleteInternal(jobId, key);
-		}
+		this.permanentBlobStore = new PermanentBlobCache(serverAddress, blobClientConfig, blobView);
+		this.transientBlobStore = new TransientBlobCache(serverAddress, blobClientConfig);
 	}
 
 	@Override
-	public int getPort() {
-		return serverAddress.getPort();
+	public PermanentBlobCache getPermanentBlobStore() {
+		return permanentBlobStore;
 	}
 
-	/**
-	 * Cleans up BLOBs which are not referenced anymore.
-	 */
 	@Override
-	public void run() {
-		synchronized (jobRefCounters) {
-			Iterator<Map.Entry<JobID, RefCount>> entryIter = jobRefCounters.entrySet().iterator();
-			final long currentTimeMillis = System.currentTimeMillis();
-
-			while (entryIter.hasNext()) {
-				Map.Entry<JobID, RefCount> entry = entryIter.next();
-				RefCount ref = entry.getValue();
-
-				if (ref.references <= 0 && ref.keepUntil > 0 && currentTimeMillis >= ref.keepUntil) {
-					JobID jobId = entry.getKey();
-
-					final File localFile =
-						new File(BlobUtils.getStorageLocationPath(storageDir.getAbsolutePath(), jobId));
-					try {
-						FileUtils.deleteDirectory(localFile);
-						// let's only remove this directory from cleanup if the cleanup was successful
-						entryIter.remove();
-					} catch (Throwable t) {
-						LOG.warn("Failed to locally delete job directory " + localFile.getAbsolutePath(), t);
-					}
-				}
-			}
-		}
+	public TransientBlobCache getTransientBlobStore() {
+		return transientBlobStore;
 	}
 
 	@Override
 	public void close() throws IOException {
-		cleanupTimer.cancel();
-
-		if (shutdownRequested.compareAndSet(false, true)) {
-			LOG.info("Shutting down BlobCache");
-
-			// Clean up the storage directory
-			try {
-				FileUtils.deleteDirectory(storageDir);
-			} finally {
-				// Remove shutdown hook to prevent resource leaks, unless this is invoked by the shutdown hook itself
-				if (shutdownHook != null && shutdownHook != Thread.currentThread()) {
-					try {
-						Runtime.getRuntime().removeShutdownHook(shutdownHook);
-					} catch (IllegalStateException e) {
-						// race, JVM is in shutdown already, we can safely ignore this
-					} catch (Throwable t) {
-						LOG.warn("Exception while unregistering BLOB cache's cleanup shutdown hook.");
-					}
-				}
-			}
-		}
+		permanentBlobStore.close();
+		transientBlobStore.close();
 	}
 
 	@Override
-	public BlobClient createClient() throws IOException {
-		return new BlobClient(serverAddress, blobClientConfig);
+	public int getPort() {
+		// NOTE: both blob stores connect to the same server!
+		return permanentBlobStore.getPort();
 	}
-
-	/**
-	 * Returns the job reference counters - for testing purposes only!
-	 *
-	 * @return job reference counters (internal state!)
-	 */
-	@VisibleForTesting
-	Map<JobID, RefCount> getJobRefCounters() {
-		return jobRefCounters;
-	}
-
-	/**
-	 * Returns a file handle to the file associated with the given blob key on the blob
-	 * server.
-	 *
-	 * <p><strong>This is only called from the {@link BlobServerConnection}</strong>
-	 *
-	 * @param jobId ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
-	 * @param key identifying the file
-	 * @return file handle to the file
-	 */
-	@VisibleForTesting
-	public File getStorageLocation(JobID jobId, BlobKey key) {
-		return BlobUtils.getStorageLocation(storageDir, jobId, key);
-	}
-
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCache.java
@@ -57,12 +57,12 @@ public class BlobCache implements BlobService {
 	}
 
 	@Override
-	public PermanentBlobCache getPermanentBlobStore() {
+	public PermanentBlobCache getPermanentBlobService() {
 		return permanentBlobStore;
 	}
 
 	@Override
-	public TransientBlobCache getTransientBlobStore() {
+	public TransientBlobCache getTransientBlobService() {
 		return transientBlobStore;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCacheService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobCacheService.java
@@ -23,16 +23,18 @@ import org.apache.flink.configuration.Configuration;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * The BLOB cache provides access to BLOB services for permanent and transient BLOBs.
  */
-public class BlobCache implements BlobService {
+public class BlobCacheService implements BlobService {
 
 	/** Caching store for permanent BLOBs. */
-	private final PermanentBlobCache permanentBlobStore;
+	private final PermanentBlobCache permanentBlobCache;
 
 	/** Store for transient BLOB files. */
-	private final TransientBlobCache transientBlobStore;
+	private final TransientBlobCache transientBlobCache;
 
 	/**
 	 * Instantiates a new BLOB cache.
@@ -47,34 +49,48 @@ public class BlobCache implements BlobService {
 	 * @throws IOException
 	 * 		thrown if the (local or distributed) file storage cannot be created or is not usable
 	 */
-	public BlobCache(
+	public BlobCacheService(
 			final InetSocketAddress serverAddress,
 			final Configuration blobClientConfig,
 			final BlobView blobView) throws IOException {
 
-		this.permanentBlobStore = new PermanentBlobCache(serverAddress, blobClientConfig, blobView);
-		this.transientBlobStore = new TransientBlobCache(serverAddress, blobClientConfig);
+		this(new PermanentBlobCache(serverAddress, blobClientConfig, blobView),
+			new TransientBlobCache(serverAddress, blobClientConfig));
+	}
+
+	/**
+	 * Instantiates a new BLOB cache.
+	 *
+	 * @param permanentBlobCache
+	 * 		BLOB cache to use for permanent BLOBs
+	 * @param transientBlobCache
+	 * 		BLOB cache to use for transient BLOBs
+	 */
+	public BlobCacheService(
+			PermanentBlobCache permanentBlobCache, TransientBlobCache transientBlobCache) {
+		this.permanentBlobCache = checkNotNull(permanentBlobCache);
+		this.transientBlobCache = checkNotNull(transientBlobCache);
 	}
 
 	@Override
 	public PermanentBlobCache getPermanentBlobService() {
-		return permanentBlobStore;
+		return permanentBlobCache;
 	}
 
 	@Override
 	public TransientBlobCache getTransientBlobService() {
-		return transientBlobStore;
+		return transientBlobCache;
 	}
 
 	@Override
 	public void close() throws IOException {
-		permanentBlobStore.close();
-		transientBlobStore.close();
+		permanentBlobCache.close();
+		transientBlobCache.close();
 	}
 
 	@Override
 	public int getPort() {
 		// NOTE: both blob stores connect to the same server!
-		return permanentBlobStore.getPort();
+		return permanentBlobCache.getPort();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.InstantiationUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +34,7 @@ import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
+
 import java.io.Closeable;
 import java.io.EOFException;
 import java.io.File;
@@ -49,14 +51,15 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.runtime.blob.BlobServerProtocol.BUFFER_SIZE;
-import static org.apache.flink.runtime.blob.BlobServerProtocol.CONTENT_FOR_JOB;
-import static org.apache.flink.runtime.blob.BlobServerProtocol.CONTENT_NO_JOB;
 import static org.apache.flink.runtime.blob.BlobServerProtocol.DELETE_OPERATION;
 import static org.apache.flink.runtime.blob.BlobServerProtocol.GET_OPERATION;
-import static org.apache.flink.runtime.blob.BlobServerProtocol.CONTENT_FOR_JOB_HA;
+import static org.apache.flink.runtime.blob.BlobServerProtocol.JOB_RELATED_CONTENT;
+import static org.apache.flink.runtime.blob.BlobServerProtocol.JOB_UNRELATED_CONTENT;
 import static org.apache.flink.runtime.blob.BlobServerProtocol.PUT_OPERATION;
 import static org.apache.flink.runtime.blob.BlobServerProtocol.RETURN_ERROR;
 import static org.apache.flink.runtime.blob.BlobServerProtocol.RETURN_OKAY;
+import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
+import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
 import static org.apache.flink.runtime.blob.BlobUtils.readFully;
 import static org.apache.flink.runtime.blob.BlobUtils.readLength;
 import static org.apache.flink.runtime.blob.BlobUtils.writeLength;
@@ -76,7 +79,7 @@ public final class BlobClient implements Closeable {
 
 	/**
 	 * Instantiates a new BLOB client.
-	 * 
+	 *
 	 * @param serverAddress
 	 *        the network address of the BLOB server
 	 * @param clientConfig
@@ -130,8 +133,6 @@ public final class BlobClient implements Closeable {
 	 * 		job ID the BLOB belongs to or <tt>null</tt> if job-unrelated
 	 * @param blobKey
 	 * 		BLOB key
-	 * @param permanentBlob
-	 * 		whether the BLOB is permanent (<tt>true</tt>) or transient (<tt>false</tt>)
 	 * @param localJarFile
 	 * 		the local file to write to
 	 * @param serverAddress
@@ -145,7 +146,7 @@ public final class BlobClient implements Closeable {
 	 * 		if an I/O error occurs during the download
 	 */
 	static void downloadFromBlobServer(
-			@Nullable JobID jobId, BlobKey blobKey, boolean permanentBlob, File localJarFile,
+			@Nullable JobID jobId, BlobKey blobKey, File localJarFile,
 			InetSocketAddress serverAddress, Configuration blobClientConfig, int numFetchRetries)
 			throws IOException {
 
@@ -157,7 +158,7 @@ public final class BlobClient implements Closeable {
 		while (true) {
 			try (
 				final BlobClient bc = new BlobClient(serverAddress, blobClientConfig);
-				final InputStream is = bc.getInternal(jobId, blobKey, permanentBlob);
+				final InputStream is = bc.getInternal(jobId, blobKey);
 				final OutputStream os = new FileOutputStream(localJarFile)
 			) {
 				while (true) {
@@ -213,8 +214,6 @@ public final class BlobClient implements Closeable {
 	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param blobKey
 	 * 		blob key associated with the requested file
-	 * @param permanentBlob
-	 * 		whether the BLOB is permanent (<tt>true</tt>) or transient (<tt>false</tt>)
 	 *
 	 * @return an input stream to read the retrieved data from
 	 *
@@ -223,7 +222,7 @@ public final class BlobClient implements Closeable {
 	 * @throws IOException
 	 * 		if an I/O error occurs during the download
 	 */
-	InputStream getInternal(@Nullable JobID jobId, BlobKey blobKey, boolean permanentBlob)
+	InputStream getInternal(@Nullable JobID jobId, BlobKey blobKey)
 			throws IOException {
 
 		if (this.socket.isClosed()) {
@@ -240,7 +239,7 @@ public final class BlobClient implements Closeable {
 			InputStream is = this.socket.getInputStream();
 
 			// Send GET header
-			sendGetHeader(os, jobId, blobKey, permanentBlob);
+			sendGetHeader(os, jobId, blobKey);
 			receiveAndCheckGetResponse(is);
 
 			return new BlobInputStream(is, blobKey);
@@ -260,36 +259,32 @@ public final class BlobClient implements Closeable {
 	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param blobKey
 	 * 		blob key associated with the requested file
-	 * @param permanentBlob
-	 * 		whether the BLOB is permanent (<tt>true</tt>) or transient (<tt>false</tt>)
 	 *
 	 * @throws IOException
 	 *         thrown if an I/O error occurs while writing the header data to the output stream
 	 */
 	private static void sendGetHeader(
-			OutputStream outputStream, @Nullable JobID jobId, BlobKey blobKey, boolean permanentBlob)
+			OutputStream outputStream, @Nullable JobID jobId, BlobKey blobKey)
 			throws IOException {
 		checkNotNull(blobKey);
-		checkArgument(jobId != null || !permanentBlob, "permanent BLOBs must be job-related");
+		checkArgument(jobId != null || blobKey.getType() == TRANSIENT_BLOB,
+			"permanent BLOBs must be job-related");
 
 		// Signal type of operation
 		outputStream.write(GET_OPERATION);
 
 		// Send job ID and key
 		if (jobId == null) {
-			outputStream.write(CONTENT_NO_JOB);
-		} else if (permanentBlob) {
-			outputStream.write(CONTENT_FOR_JOB_HA);
-			outputStream.write(jobId.getBytes());
+			outputStream.write(JOB_UNRELATED_CONTENT);
 		} else {
-			outputStream.write(CONTENT_FOR_JOB);
+			outputStream.write(JOB_RELATED_CONTENT);
 			outputStream.write(jobId.getBytes());
 		}
 		blobKey.writeToOutputStream(outputStream);
 	}
 
 	/**
-	 * Reads the response from the input stream and throws in case of errors
+	 * Reads the response from the input stream and throws in case of errors.
 	 *
 	 * @param is
 	 * 		stream to read from
@@ -327,8 +322,8 @@ public final class BlobClient implements Closeable {
 	 * 		the read offset within the buffer
 	 * @param len
 	 * 		the number of bytes to read from the buffer
-	 * @param permanentBlob
-	 * 		whether the BLOB is permanent (<tt>true</tt>) or transient (<tt>false</tt>)
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 *
 	 * @return the computed BLOB key of the uploaded BLOB
 	 *
@@ -336,7 +331,7 @@ public final class BlobClient implements Closeable {
 	 * 		thrown if an I/O error occurs while uploading the data to the BLOB server
 	 */
 	BlobKey putBuffer(
-			@Nullable JobID jobId, byte[] value, int offset, int len, boolean permanentBlob)
+			@Nullable JobID jobId, byte[] value, int offset, int len, BlobType blobType)
 			throws IOException {
 
 		if (this.socket.isClosed()) {
@@ -354,7 +349,7 @@ public final class BlobClient implements Closeable {
 			final MessageDigest md = BlobUtils.createMessageDigest();
 
 			// Send the PUT header
-			sendPutHeader(os, jobId, permanentBlob);
+			sendPutHeader(os, jobId, blobType);
 
 			// Send the value in iterations of BUFFER_SIZE
 			int remainingBytes = len;
@@ -378,7 +373,7 @@ public final class BlobClient implements Closeable {
 
 			// Receive blob key and compare
 			final InputStream is = this.socket.getInputStream();
-			return receiveAndCheckPutResponse(is, md);
+			return receiveAndCheckPutResponse(is, md, blobType);
 		}
 		catch (Throwable t) {
 			BlobUtils.closeSilently(socket, LOG);
@@ -393,15 +388,15 @@ public final class BlobClient implements Closeable {
 	 * 		the ID of the job the BLOB belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param inputStream
 	 * 		the input stream to read the data from
-	 * @param permanentBlob
-	 * 		whether the BLOB is permanent (<tt>true</tt>) or transient (<tt>false</tt>)
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 *
 	 * @return the computed BLOB key of the uploaded BLOB
 	 *
 	 * @throws IOException
 	 * 		thrown if an I/O error occurs while uploading the data to the BLOB server
 	 */
-	BlobKey putInputStream(@Nullable JobID jobId, InputStream inputStream, boolean permanentBlob)
+	BlobKey putInputStream(@Nullable JobID jobId, InputStream inputStream, BlobType blobType)
 			throws IOException {
 
 		if (this.socket.isClosed()) {
@@ -420,7 +415,7 @@ public final class BlobClient implements Closeable {
 			final byte[] xferBuf = new byte[BUFFER_SIZE];
 
 			// Send the PUT header
-			sendPutHeader(os, jobId, permanentBlob);
+			sendPutHeader(os, jobId, blobType);
 
 			while (true) {
 				// since we don't know a total size here, send lengths iteratively
@@ -439,7 +434,7 @@ public final class BlobClient implements Closeable {
 
 			// Receive blob key and compare
 			final InputStream is = this.socket.getInputStream();
-			return receiveAndCheckPutResponse(is, md);
+			return receiveAndCheckPutResponse(is, md, blobType);
 		}
 		catch (Throwable t) {
 			BlobUtils.closeSilently(socket, LOG);
@@ -454,41 +449,42 @@ public final class BlobClient implements Closeable {
 	 * 		the output stream to write the PUT header data to
 	 * @param jobId
 	 * 		the ID of job the BLOB belongs to (or <tt>null</tt> if job-unrelated)
-	 * @param permanentBlob
-	 * 		whether the BLOB is permanent (<tt>true</tt>) or transient (<tt>false</tt>)
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 *
 	 * @throws IOException
 	 * 		thrown if an I/O error occurs while writing the header data to the output stream
 	 */
 	private static void sendPutHeader(
-			OutputStream outputStream, @Nullable JobID jobId, boolean permanentBlob)
+			OutputStream outputStream, @Nullable JobID jobId, BlobType blobType)
 			throws IOException {
 		// Signal type of operation
 		outputStream.write(PUT_OPERATION);
 		if (jobId == null) {
-			outputStream.write(CONTENT_NO_JOB);
-		} else if (permanentBlob) {
-			outputStream.write(CONTENT_FOR_JOB_HA);
-			outputStream.write(jobId.getBytes());
+			outputStream.write(JOB_UNRELATED_CONTENT);
 		} else {
-			outputStream.write(CONTENT_FOR_JOB);
+			outputStream.write(JOB_RELATED_CONTENT);
 			outputStream.write(jobId.getBytes());
 		}
+		outputStream.write(blobType.ordinal());
 	}
 
 	/**
-	 * Reads the response from the input stream and throws in case of errors
+	 * Reads the response from the input stream and throws in case of errors.
 	 *
 	 * @param is
 	 * 		stream to read from
 	 * @param md
 	 * 		message digest to check the response against
+	 * @param blobType
+	 * 		whether the BLOB should be permanent or transient
 	 *
 	 * @throws IOException
 	 * 		if the response is an error, the message digest does not match or reading the response
 	 * 		failed
 	 */
-	private static BlobKey receiveAndCheckPutResponse(InputStream is, MessageDigest md)
+	private static BlobKey receiveAndCheckPutResponse(
+			InputStream is, MessageDigest md, BlobType blobType)
 			throws IOException {
 		int response = is.read();
 		if (response < 0) {
@@ -497,7 +493,7 @@ public final class BlobClient implements Closeable {
 		else if (response == RETURN_OKAY) {
 
 			BlobKey remoteKey = BlobKey.readFromInputStream(is);
-			BlobKey localKey = new BlobKey(md.digest());
+			BlobKey localKey = new BlobKey(blobType, md.digest());
 
 			if (!localKey.equals(remoteKey)) {
 				throw new IOException("Detected data corruption during transfer");
@@ -534,8 +530,7 @@ public final class BlobClient implements Closeable {
 	 * 		thrown if an I/O error occurs while transferring the request to the BLOB server or if the
 	 * 		BLOB server throws an exception while processing the request
 	 */
-	boolean deleteInternal(@Nullable JobID jobId, BlobKey key)
-			throws IOException {
+	boolean deleteInternal(@Nullable JobID jobId, BlobKey key) throws IOException {
 
 		checkNotNull(key);
 
@@ -548,9 +543,9 @@ public final class BlobClient implements Closeable {
 
 			// delete blob key
 			if (jobId == null) {
-				outputStream.write(CONTENT_NO_JOB);
+				outputStream.write(JOB_UNRELATED_CONTENT);
 			} else {
-				outputStream.write(CONTENT_FOR_JOB);
+				outputStream.write(JOB_RELATED_CONTENT);
 				outputStream.write(jobId.getBytes());
 			}
 			key.writeToOutputStream(outputStream);
@@ -564,7 +559,7 @@ public final class BlobClient implements Closeable {
 	}
 
 	/**
-	 * Reads the response from the input stream and throws in case of errors
+	 * Reads the response from the input stream and throws in case of errors.
 	 *
 	 * @param is
 	 * 		stream to read from
@@ -610,8 +605,12 @@ public final class BlobClient implements Closeable {
 	 * @throws IOException
 	 * 		if the upload fails
 	 */
-	public static List<BlobKey> uploadJarFiles(InetSocketAddress serverAddress,
-			Configuration clientConfig, JobID jobId, List<Path> jars) throws IOException {checkNotNull(jobId);
+	public static List<BlobKey> uploadJarFiles(
+			InetSocketAddress serverAddress, Configuration clientConfig, JobID jobId, List<Path> jars)
+			throws IOException {
+
+		checkNotNull(jobId);
+
 		if (jars.isEmpty()) {
 			return Collections.emptyList();
 		} else {
@@ -623,7 +622,7 @@ public final class BlobClient implements Closeable {
 					FSDataInputStream is = null;
 					try {
 						is = fs.open(jar);
-						final BlobKey key = blobClient.putInputStream(jobId, is, true);
+						final BlobKey key = blobClient.putInputStream(jobId, is, PERMANENT_BLOB);
 						blobKeys.add(key);
 					} finally {
 						if (is != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -148,9 +148,12 @@ public final class BlobClient implements Closeable {
 	 * 		if an I/O error occurs during the download
 	 */
 	static void downloadFromBlobServer(
-			@Nullable JobID jobId, BlobKey blobKey, File localJarFile,
-			InetSocketAddress serverAddress, Configuration blobClientConfig, int numFetchRetries)
-			throws IOException {
+			@Nullable JobID jobId,
+			BlobKey blobKey,
+			File localJarFile,
+			InetSocketAddress serverAddress,
+			Configuration blobClientConfig,
+			int numFetchRetries) throws IOException {
 
 		final byte[] buf = new byte[BUFFER_SIZE];
 		LOG.info("Downloading {}/{} from {}", jobId, blobKey, serverAddress);
@@ -178,7 +181,7 @@ public final class BlobClient implements Closeable {
 					" and store it under " + localJarFile.getAbsolutePath();
 				if (attempt < numFetchRetries) {
 					if (LOG.isDebugEnabled()) {
-						LOG.debug(message + " Retrying...", t);
+						LOG.error(message + " Retrying...", t);
 					} else {
 						LOG.error(message + " Retrying...");
 					}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobInputStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobInputStream.java
@@ -22,9 +22,12 @@ import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.security.MessageDigest;
 import java.util.Arrays;
 
+import static org.apache.flink.runtime.blob.BlobServerProtocol.RETURN_ERROR;
+import static org.apache.flink.runtime.blob.BlobServerProtocol.RETURN_OKAY;
 import static org.apache.flink.runtime.blob.BlobUtils.readLength;
 
 /**
@@ -37,6 +40,14 @@ final class BlobInputStream extends InputStream {
 	 * The wrapped input stream from the underlying TCP connection.
 	 */
 	private final InputStream wrappedInputStream;
+
+	/**
+	 * The wrapped output stream from the underlying TCP connection.
+	 *
+	 * <p>This is used to signal the success or failure of the read operation after receiving the
+	 * whole BLOB and verifying the checksum.
+	 */
+	private final OutputStream wrappedOutputStream;
 
 	/**
 	 * The BLOB key if the GET operation has been performed on a content-addressable BLOB, otherwise <code>null<code>.
@@ -66,12 +77,17 @@ final class BlobInputStream extends InputStream {
 	 *        the underlying input stream to read from
 	 * @param blobKey
 	 *        the expected BLOB key for content-addressable BLOBs, <code>null</code> for non-content-addressable BLOBs.
+	 * @param wrappedOutputStream
+	 *        the underlying output stream to write the result to
+	 *
 	 * @throws IOException
 	 *         throws if an I/O error occurs while reading the BLOB data from the BLOB server
 	 */
-	BlobInputStream(final InputStream wrappedInputStream, final BlobKey blobKey) throws IOException {
+	BlobInputStream(
+		final InputStream wrappedInputStream, final BlobKey blobKey, OutputStream wrappedOutputStream) throws IOException {
 		this.wrappedInputStream = wrappedInputStream;
 		this.blobKey = blobKey;
+		this.wrappedOutputStream = wrappedOutputStream;
 		this.bytesToReceive = readLength(wrappedInputStream);
 		if (this.bytesToReceive < 0) {
 			throw new FileNotFoundException();
@@ -109,8 +125,10 @@ final class BlobInputStream extends InputStream {
 			if (this.bytesReceived == this.bytesToReceive) {
 				final byte[] computedKey = this.md.digest();
 				if (!Arrays.equals(computedKey, this.blobKey.getHash())) {
+					this.wrappedOutputStream.write(RETURN_ERROR);
 					throw new IOException("Detected data corruption during transfer");
 				}
+				this.wrappedOutputStream.write(RETURN_OKAY);
 			}
 		}
 
@@ -143,8 +161,10 @@ final class BlobInputStream extends InputStream {
 			if (this.bytesReceived == this.bytesToReceive) {
 				final byte[] computedKey = this.md.digest();
 				if (!Arrays.equals(computedKey, this.blobKey.getHash())) {
+					this.wrappedOutputStream.write(RETURN_ERROR);
 					throw new IOException("Detected data corruption during transfer");
 				}
+				this.wrappedOutputStream.write(RETURN_OKAY);
 			}
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobInputStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobInputStream.java
@@ -23,6 +23,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.MessageDigest;
+import java.util.Arrays;
 
 import static org.apache.flink.runtime.blob.BlobUtils.readLength;
 
@@ -106,8 +107,8 @@ final class BlobInputStream extends InputStream {
 		if (this.md != null) {
 			this.md.update((byte) read);
 			if (this.bytesReceived == this.bytesToReceive) {
-				final BlobKey computedKey = new BlobKey(this.md.digest());
-				if (!computedKey.equals(this.blobKey)) {
+				final byte[] computedKey = this.md.digest();
+				if (!Arrays.equals(computedKey, this.blobKey.getHash())) {
 					throw new IOException("Detected data corruption during transfer");
 				}
 			}
@@ -140,8 +141,8 @@ final class BlobInputStream extends InputStream {
 		if (this.md != null) {
 			this.md.update(b, off, read);
 			if (this.bytesReceived == this.bytesToReceive) {
-				final BlobKey computedKey = new BlobKey(this.md.digest());
-				if (!computedKey.equals(this.blobKey)) {
+				final byte[] computedKey = this.md.digest();
+				if (!Arrays.equals(computedKey, this.blobKey.getHash())) {
 					throw new IOException("Detected data corruption during transfer");
 				}
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobKey.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobKey.java
@@ -118,7 +118,9 @@ public final class BlobKey implements Serializable, Comparable<BlobKey> {
 
 	@Override
 	public int hashCode() {
-		return Arrays.hashCode(this.key) + this.type.hashCode();
+		int result = Arrays.hashCode(this.key);
+		result = 37 * result + this.type.hashCode();
+		return result;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -692,7 +692,7 @@ public class BlobServer extends Thread implements BlobService, PermanentBlobServ
 	 *          <tt>false</tt> otherwise
 	 */
 	@Override
-	public boolean deleteTransient(BlobKey key) {
+	public boolean deleteTransientFromCache(BlobKey key) {
 		return deleteInternal(null, key);
 	}
 
@@ -708,7 +708,7 @@ public class BlobServer extends Thread implements BlobService, PermanentBlobServ
 	 *          <tt>false</tt> otherwise
 	 */
 	@Override
-	public boolean deleteTransient(JobID jobId, BlobKey key) {
+	public boolean deleteTransientFromCache(JobID jobId, BlobKey key) {
 		checkNotNull(jobId);
 		return deleteInternal(jobId, key);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerProtocol.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerProtocol.java
@@ -42,22 +42,18 @@ public class BlobServerProtocol {
 	static final byte RETURN_ERROR = 1;
 
 	/**
-	 * Internal code to identify a job-unrelated transient BLOB.
-	 * <p>
-	 * Note: previously, there was also <tt>NAME_ADDRESSABLE</tt> (code <tt>1</tt>) and
-	 * <tt>JOB_ID_SCOPE</tt> (code <tt>2</tt>).
+	 * Internal code to identify a job-unrelated BLOBs (only for transient BLOBs!).
+	 *
+	 * <p>Note: previously, there was also <tt>NAME_ADDRESSABLE</tt> (code <tt>1</tt>).
 	 */
-	static final byte CONTENT_NO_JOB = 0;
+	static final byte JOB_UNRELATED_CONTENT = 0;
 
 	/**
-	 * Internal code to identify a job-related transient BLOB.
+	 * Internal code to identify a job-related (permanent or transient) BLOBs.
+	 *
+	 * <p>Note: This is equal to the previous <tt>JOB_ID_SCOPE</tt> (code <tt>2</tt>).
 	 */
-	static final byte CONTENT_FOR_JOB = 3;
-
-	/**
-	 * Internal code to identify a job-related permanent BLOB.
-	 */
-	static final byte CONTENT_FOR_JOB_HA = 4;
+	static final byte JOB_RELATED_CONTENT = 2;
 
 	// --------------------------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerProtocol.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerProtocol.java
@@ -26,14 +26,19 @@ public class BlobServerProtocol {
 	/** The buffer size in bytes for network transfers. */
 	static final int BUFFER_SIZE = 65536; // 64 K
 
-	/** Internal code to identify a PUT operation. */
+	/**
+	 * Internal code to identify a PUT operation.
+	 *
+	 * <p>Note: previously, there was also <tt>DELETE_OPERATION</tt> (code <tt>2</tt>).
+	 */
 	static final byte PUT_OPERATION = 0;
 
-	/** Internal code to identify a GET operation. */
+	/**
+	 * Internal code to identify a GET operation.
+	 *
+	 * <p>Note: previously, there was also <tt>DELETE_OPERATION</tt> (code <tt>2</tt>).
+	 */
 	static final byte GET_OPERATION = 1;
-
-	/** Internal code to identify a DELETE operation. */
-	static final byte DELETE_OPERATION = 2;
 
 	/** Internal code to identify a successful operation. */
 	static final byte RETURN_OKAY = 0;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerProtocol.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServerProtocol.java
@@ -42,7 +42,7 @@ public class BlobServerProtocol {
 	static final byte RETURN_ERROR = 1;
 
 	/**
-	 * Internal code to identify a job-unrelated reference via content hash as the key.
+	 * Internal code to identify a job-unrelated transient BLOB.
 	 * <p>
 	 * Note: previously, there was also <tt>NAME_ADDRESSABLE</tt> (code <tt>1</tt>) and
 	 * <tt>JOB_ID_SCOPE</tt> (code <tt>2</tt>).
@@ -50,12 +50,14 @@ public class BlobServerProtocol {
 	static final byte CONTENT_NO_JOB = 0;
 
 	/**
-	 * Internal code to identify a job-related reference via content hash as the key.
-	 * <p>
-	 * Note: previously, there was also <tt>NAME_ADDRESSABLE</tt> (code <tt>1</tt>) and
-	 * <tt>JOB_ID_SCOPE</tt> (code <tt>2</tt>).
+	 * Internal code to identify a job-related transient BLOB.
 	 */
 	static final byte CONTENT_FOR_JOB = 3;
+
+	/**
+	 * Internal code to identify a job-related permanent BLOB.
+	 */
+	static final byte CONTENT_FOR_JOB_HA = 4;
 
 	// --------------------------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobService.java
@@ -18,11 +18,7 @@
 
 package org.apache.flink.runtime.blob;
 
-import org.apache.flink.api.common.JobID;
-
 import java.io.Closeable;
-import java.io.File;
-import java.io.IOException;
 
 /**
  * A simple store and retrieve binary large objects (BLOBs).
@@ -30,49 +26,23 @@ import java.io.IOException;
 public interface BlobService extends Closeable {
 
 	/**
-	 * Returns the path to a local copy of the (job-unrelated) file associated with the provided
-	 * blob key.
+	 * Returns a BLOB service for accessing permanent BLOBs.
 	 *
-	 * @param key blob key associated with the requested file
-	 * @return The path to the file.
-	 * @throws java.io.FileNotFoundException when the path does not exist;
-	 * @throws IOException if any other error occurs when retrieving the file
+	 * @return BLOB service
 	 */
-	File getFile(BlobKey key) throws IOException;
+	PermanentBlobService getPermanentBlobStore();
 
 	/**
-	 * Returns the path to a local copy of the file associated with the provided job ID and blob key.
+	 * Returns a BLOB service for accessing transient BLOBs.
 	 *
-	 * @param jobId ID of the job this blob belongs to
-	 * @param key blob key associated with the requested file
-	 * @return The path to the file.
-	 * @throws java.io.FileNotFoundException when the path does not exist;
-	 * @throws IOException if any other error occurs when retrieving the file
+	 * @return BLOB service
 	 */
-	File getFile(JobID jobId, BlobKey key) throws IOException;
+	TransientBlobService getTransientBlobStore();
 
 	/**
-	 * Deletes the (job-unrelated) file associated with the provided blob key.
+	 * Returns the port of the BLOB server that this BLOB service is working with.
 	 *
-	 * @param key associated with the file to be deleted
-	 * @throws IOException
-	 */
-	void delete(BlobKey key) throws IOException;
-
-	/**
-	 * Deletes the file associated with the provided job ID and blob key.
-	 *
-	 * @param jobId ID of the job this blob belongs to
-	 * @param key associated with the file to be deleted
-	 * @throws IOException
-	 */
-	void delete(JobID jobId, BlobKey key) throws IOException;
-
-	/**
-	 * Returns the port of the blob service.
-	 * @return the port of the blob service.
+	 * @return the port the blob server.
 	 */
 	int getPort();
-
-	BlobClient createClient() throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobStore.java
@@ -45,8 +45,11 @@ public interface BlobStore extends BlobView {
 	 *
 	 * @param jobId ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param blobKey The blob ID
+	 *
+	 * @return  <tt>true</tt> if the given blob is successfully deleted or non-existing;
+	 *          <tt>false</tt> otherwise
 	 */
-	void delete(JobID jobId, BlobKey blobKey);
+	boolean delete(JobID jobId, BlobKey blobKey);
 
 	/**
 	 * Tries to delete all blobs for the given job from storage.
@@ -54,6 +57,9 @@ public interface BlobStore extends BlobView {
 	 * <p>NOTE: This also tries to delete any created directories if empty.</p>
 	 *
 	 * @param jobId The JobID part of all blobs to delete
+	 *
+	 * @return  <tt>true</tt> if the job directory is successfully deleted or non-existing;
+	 *          <tt>false</tt> otherwise
 	 */
-	void deleteAll(JobID jobId);
+	boolean deleteAll(JobID jobId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobStore.java
@@ -34,9 +34,11 @@ public interface BlobStore extends BlobView {
 	 * @param localFile The file to copy
 	 * @param jobId ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param blobKey   The ID for the file in the blob store
+	 *
+	 * @return whether the file was copied (<tt>true</tt>) or not (<tt>false</tt>)
 	 * @throws IOException If the copy fails
 	 */
-	void put(File localFile, JobID jobId, BlobKey blobKey) throws IOException;
+	boolean put(File localFile, JobID jobId, BlobKey blobKey) throws IOException;
 
 	/**
 	 * Tries to delete a blob from storage.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobType.java
@@ -18,31 +18,18 @@
 
 package org.apache.flink.runtime.blob;
 
-import java.io.Closeable;
-
 /**
- * A simple store and retrieve binary large objects (BLOBs).
+ * BLOB type, i.e. permanent or transient.
  */
-public interface BlobService extends Closeable {
-
+public enum BlobType {
 	/**
-	 * Returns a BLOB service for accessing permanent BLOBs.
-	 *
-	 * @return BLOB service
+	 * Indicates a permanent BLOB whose lifecycle is that of a job and which is made highly
+	 * available.
 	 */
-	PermanentBlobService getPermanentBlobService();
-
+	PERMANENT_BLOB,
 	/**
-	 * Returns a BLOB service for accessing transient BLOBs.
-	 *
-	 * @return BLOB service
+	 * Indicates a transient BLOB whose lifecycle is managed by the user and which is not made
+	 * highly available.
 	 */
-	TransientBlobService getTransientBlobService();
-
-	/**
-	 * Returns the port of the BLOB server that this BLOB service is working with.
-	 *
-	 * @return the port the blob server.
-	 */
-	int getPort();
+	TRANSIENT_BLOB
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -37,9 +37,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
+import java.util.concurrent.locks.Lock;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly;
@@ -62,12 +65,12 @@ public class BlobUtils {
 	/**
 	 * The prefix of all job-specific directories created by the BLOB server.
 	 */
-	private static final String JOB_DIR_PREFIX = "job_";
+	static final String JOB_DIR_PREFIX = "job_";
 
 	/**
 	 * The prefix of all job-unrelated directories created by the BLOB server.
 	 */
-	private static final String NO_JOB_DIR_PREFIX = "no_job";
+	static final String NO_JOB_DIR_PREFIX = "no_job";
 
 	/**
 	 * Creates a BlobStore based on the parameters set in the configuration.
@@ -171,8 +174,11 @@ public class BlobUtils {
 	 * 		storage directory used be the BLOB service
 	 *
 	 * @return the BLOB service's directory for incoming files
+	 *
+	 * @throws IOException
+	 * 		if creating the directory fails
 	 */
-	static File getIncomingDirectory(File storageDir) {
+	static File getIncomingDirectory(File storageDir) throws IOException {
 		final File incomingDir = new File(storageDir, "incoming");
 
 		mkdirTolerateExisting(incomingDir);
@@ -185,12 +191,15 @@ public class BlobUtils {
 	 *
 	 * @param dir
 	 * 		directory to create
+	 *
+	 * @throws IOException
+	 * 		if creating the directory fails
 	 */
-	private static void mkdirTolerateExisting(final File dir) {
+	private static void mkdirTolerateExisting(final File dir) throws IOException {
 		// note: thread-safe create should try to mkdir first and then ignore the case that the
 		//       directory already existed
 		if (!dir.mkdirs() && !dir.exists()) {
-			throw new RuntimeException(
+			throw new IOException(
 				"Cannot create directory '" + dir.getAbsolutePath() + "'.");
 		}
 	}
@@ -206,9 +215,12 @@ public class BlobUtils {
 	 * 		ID of the job for the incoming files (or <tt>null</tt> if job-unrelated)
 	 *
 	 * @return the (designated) physical storage location of the BLOB
+	 *
+	 * @throws IOException
+	 * 		if creating the directory fails
 	 */
 	static File getStorageLocation(
-			File storageDir, @Nullable JobID jobId, BlobKey key) {
+			File storageDir, @Nullable JobID jobId, BlobKey key) throws IOException {
 		File file = new File(getStorageLocationPath(storageDir.getAbsolutePath(), jobId, key));
 
 		mkdirTolerateExisting(file.getParentFile());
@@ -406,5 +418,73 @@ public class BlobUtils {
 	 */
 	private BlobUtils() {
 		throw new RuntimeException();
+	}
+
+	/**
+	 * Moves the temporary <tt>incomingFile</tt> to its permanent location where it is available for
+	 * use.
+	 *
+	 * @param incomingFile
+	 * 		temporary file created during transfer
+	 * @param jobId
+	 * 		ID of the job this blob belongs to or <tt>null</tt> if job-unrelated
+	 * @param blobKey
+	 * 		BLOB key identifying the file
+	 * @param storageFile
+	 *      (local) file where the blob is/should be stored
+	 * @param writeLock
+	 *      lock to acquire before doing the move
+	 * @param log
+	 *      logger for debug information
+	 * @param blobStore
+	 *      HA store (or <tt>null</tt> if unavailable)
+	 *
+	 * @throws IOException
+	 * 		thrown if an I/O error occurs while moving the file or uploading it to the HA store
+	 */
+	static void moveTempFileToStore(
+			File incomingFile, @Nullable JobID jobId, BlobKey blobKey, File storageFile,
+			Lock writeLock, Logger log, @Nullable BlobStore blobStore) throws IOException {
+
+		writeLock.lock();
+
+		try {
+			// first check whether the file already exists
+			if (!storageFile.exists()) {
+				try {
+					// only move the file if it does not yet exist
+					Files.move(incomingFile.toPath(), storageFile.toPath());
+
+					incomingFile = null;
+
+				} catch (FileAlreadyExistsException ignored) {
+					log.warn("Detected concurrent file modifications. This should only happen if multiple" +
+						"BlobServer use the same storage directory.");
+					// we cannot be sure at this point whether the file has already been uploaded to the blob
+					// store or not. Even if the blobStore might shortly be in an inconsistent state, we have
+					// persist the blob. Otherwise we might not be able to recover the job.
+				}
+
+				if (blobStore != null) {
+					// only the one moving the incoming file to its final destination is allowed to upload the
+					// file to the blob store
+					blobStore.put(storageFile, jobId, blobKey);
+				}
+			} else {
+				log.warn("File upload for an existing file with key {} for job {}. This may indicate a duplicate upload or a hash collision. Ignoring newest upload.", blobKey, jobId);
+			}
+			storageFile = null;
+		} finally {
+			// we failed to either create the local storage file or to upload it --> try to delete the local file
+			// while still having the write lock
+			if (storageFile != null && !storageFile.delete() && storageFile.exists()) {
+				log.warn("Could not delete the storage file {}.", storageFile);
+			}
+			if (incomingFile != null && !incomingFile.delete() && incomingFile.exists()) {
+				log.warn("Could not delete the staging file {} for blob key {} and job {}.", incomingFile, blobKey, jobId);
+			}
+
+			writeLock.unlock();
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -462,7 +462,7 @@ public class BlobUtils {
 						"BlobServer use the same storage directory.");
 					// we cannot be sure at this point whether the file has already been uploaded to the blob
 					// store or not. Even if the blobStore might shortly be in an inconsistent state, we have
-					// persist the blob. Otherwise we might not be able to recover the job.
+					// to persist the blob. Otherwise we might not be able to recover the job.
 				}
 
 				if (blobStore != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobView.java
@@ -34,7 +34,9 @@ public interface BlobView {
 	 * @param jobId     ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
 	 * @param blobKey   The blob ID
 	 * @param localFile The local file to copy to
+	 *
+	 * @return whether the file was copied (<tt>true</tt>) or not (<tt>false</tt>)
 	 * @throws IOException If the copy fails
 	 */
-	void get(JobID jobId, BlobKey blobKey, File localFile) throws IOException;
+	boolean get(JobID jobId, BlobKey blobKey, File localFile) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.MessageDigest;
+import java.util.Arrays;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -113,8 +114,8 @@ public class FileSystemBlobStore implements BlobStoreService {
 			}
 
 			// verify that file contents are correct
-			final BlobKey computedKey = new BlobKey(md.digest());
-			if (!computedKey.equals(blobKey)) {
+			final byte[] computedKey = md.digest();
+			if (!Arrays.equals(computedKey, blobKey.getHash())) {
 				throw new IOException("Detected data corruption during transfer");
 			}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -64,25 +64,26 @@ public class FileSystemBlobStore implements BlobStoreService {
 	// - Put ------------------------------------------------------------------
 
 	@Override
-	public void put(File localFile, JobID jobId, BlobKey blobKey) throws IOException {
-		put(localFile, BlobUtils.getStorageLocationPath(basePath, jobId, blobKey));
+	public boolean put(File localFile, JobID jobId, BlobKey blobKey) throws IOException {
+		return put(localFile, BlobUtils.getStorageLocationPath(basePath, jobId, blobKey));
 	}
 
-	private void put(File fromFile, String toBlobPath) throws IOException {
+	private boolean put(File fromFile, String toBlobPath) throws IOException {
 		try (OutputStream os = fileSystem.create(new Path(toBlobPath), FileSystem.WriteMode.OVERWRITE)) {
 			LOG.debug("Copying from {} to {}.", fromFile, toBlobPath);
 			Files.copy(fromFile, os);
 		}
+		return true;
 	}
 
 	// - Get ------------------------------------------------------------------
 
 	@Override
-	public void get(JobID jobId, BlobKey blobKey, File localFile) throws IOException {
-		get(BlobUtils.getStorageLocationPath(basePath, jobId, blobKey), localFile, blobKey);
+	public boolean get(JobID jobId, BlobKey blobKey, File localFile) throws IOException {
+		return get(BlobUtils.getStorageLocationPath(basePath, jobId, blobKey), localFile, blobKey);
 	}
 
-	private void get(String fromBlobPath, File toFile, BlobKey blobKey) throws IOException {
+	private boolean get(String fromBlobPath, File toFile, BlobKey blobKey) throws IOException {
 		checkNotNull(fromBlobPath, "Blob path");
 		checkNotNull(toFile, "File");
 		checkNotNull(blobKey, "Blob key");
@@ -127,6 +128,8 @@ public class FileSystemBlobStore implements BlobStoreService {
 				} catch (Throwable ignored) {}
 			}
 		}
+
+		return true; // success is always true here
 	}
 
 	// - Delete ---------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/FileSystemBlobStore.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.util.IOUtils;
 
 import org.apache.flink.shaded.guava18.com.google.common.io.Files;
 
@@ -33,6 +32,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.MessageDigest;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -79,24 +79,44 @@ public class FileSystemBlobStore implements BlobStoreService {
 
 	@Override
 	public void get(JobID jobId, BlobKey blobKey, File localFile) throws IOException {
-		get(BlobUtils.getStorageLocationPath(basePath, jobId, blobKey), localFile);
+		get(BlobUtils.getStorageLocationPath(basePath, jobId, blobKey), localFile, blobKey);
 	}
 
-	private void get(String fromBlobPath, File toFile) throws IOException {
+	private void get(String fromBlobPath, File toFile, BlobKey blobKey) throws IOException {
 		checkNotNull(fromBlobPath, "Blob path");
 		checkNotNull(toFile, "File");
+		checkNotNull(blobKey, "Blob key");
 
 		if (!toFile.exists() && !toFile.createNewFile()) {
 			throw new IOException("Failed to create target file to copy to");
 		}
 
 		final Path fromPath = new Path(fromBlobPath);
+		MessageDigest md = BlobUtils.createMessageDigest();
+
+		final int buffSize = 4096; // like IOUtils#BLOCKSIZE, for chunked file copying
 
 		boolean success = false;
 		try (InputStream is = fileSystem.open(fromPath);
 			FileOutputStream fos = new FileOutputStream(toFile)) {
 			LOG.debug("Copying from {} to {}.", fromBlobPath, toFile);
-			IOUtils.copyBytes(is, fos); // closes the streams
+
+			// not using IOUtils.copyBytes(is, fos) here to be able to create a hash on-the-fly
+			final byte[] buf = new byte[buffSize];
+			int bytesRead = is.read(buf);
+			while (bytesRead >= 0) {
+				fos.write(buf, 0, bytesRead);
+				md.update(buf, 0, bytesRead);
+
+				bytesRead = is.read(buf);
+			}
+
+			// verify that file contents are correct
+			final BlobKey computedKey = new BlobKey(md.digest());
+			if (!computedKey.equals(blobKey)) {
+				throw new IOException("Detected data corruption during transfer");
+			}
+
 			success = true;
 		} finally {
 			// if the copy fails, we need to remove the target file because
@@ -112,22 +132,22 @@ public class FileSystemBlobStore implements BlobStoreService {
 	// - Delete ---------------------------------------------------------------
 
 	@Override
-	public void delete(JobID jobId, BlobKey blobKey) {
-		delete(BlobUtils.getStorageLocationPath(basePath, jobId, blobKey));
+	public boolean delete(JobID jobId, BlobKey blobKey) {
+		return delete(BlobUtils.getStorageLocationPath(basePath, jobId, blobKey));
 	}
 
 	@Override
-	public void deleteAll(JobID jobId) {
-		delete(BlobUtils.getStorageLocationPath(basePath, jobId));
+	public boolean deleteAll(JobID jobId) {
+		return delete(BlobUtils.getStorageLocationPath(basePath, jobId));
 	}
 
-	private void delete(String blobPath) {
+	private boolean delete(String blobPath) {
 		try {
 			LOG.debug("Deleting {}.", blobPath);
 			
 			Path path = new Path(blobPath);
 
-			fileSystem.delete(path, true);
+			boolean result = fileSystem.delete(path, true);
 
 			// send a call to delete the directory containing the file. This will
 			// fail (and be ignored) when some files still exist.
@@ -135,9 +155,11 @@ public class FileSystemBlobStore implements BlobStoreService {
 				fileSystem.delete(path.getParent(), false);
 				fileSystem.delete(new Path(basePath), false);
 			} catch (IOException ignored) {}
+			return result;
 		}
 		catch (Exception e) {
 			LOG.warn("Failed to delete blob at " + blobPath);
+			return false;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
@@ -23,10 +23,9 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.FileUtils;
-import org.slf4j.Logger;
+
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -35,55 +34,20 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Provides a cache for permanent BLOB files including a per-job ref-counting and a staged cleanup.
- * <p>
- * When requesting BLOBs via {@link #getHAFile(JobID, BlobKey)}, the cache will first attempt to
+ *
+ * <p>When requesting BLOBs via {@link #getPermanentFile(JobID, BlobKey)}, the cache will first attempt to
  * serve the file from its local cache. Only if the local cache does not contain the desired BLOB,
  * it will try to download it from a distributed HA file system (if available) or the BLOB server.
- * <p>
- * If files for a job are not needed any more, they will enter a staged, i.e. deferred, cleanup.
+ *
+ * <p>If files for a job are not needed any more, they will enter a staged, i.e. deferred, cleanup.
  * Files may thus still be be accessible upon recovery and do not need to be re-downloaded.
  */
-public class PermanentBlobCache extends TimerTask implements PermanentBlobService {
-
-	/** The log object used for debugging. */
-	private static final Logger LOG = LoggerFactory.getLogger(PermanentBlobCache.class);
-
-	/** Counter to generate unique names for temporary files. */
-	private final AtomicLong tempFileCounter = new AtomicLong(0);
-
-	private final InetSocketAddress serverAddress;
-
-	/** Root directory for local file storage */
-	private final File storageDir;
-
-	/** Blob store for distributed file storage, e.g. in HA */
-	private final BlobView blobView;
-
-	private final AtomicBoolean shutdownRequested = new AtomicBoolean();
-
-	/** Shutdown hook thread to ensure deletion of the storage directory. */
-	private final Thread shutdownHook;
-
-	/** The number of retries when the transfer fails */
-	private final int numFetchRetries;
-
-	/** Configuration for the blob client like ssl parameters required to connect to the blob server */
-	private final Configuration blobClientConfig;
-
-	/** Lock guarding concurrent file accesses */
-	private final ReadWriteLock readWriteLock;
-
-	// --------------------------------------------------------------------------------------------
+public class PermanentBlobCache extends AbstractBlobCache implements PermanentBlobService {
 
 	/**
 	 * Job reference counters with a time-to-live (TTL).
@@ -102,10 +66,14 @@ public class PermanentBlobCache extends TimerTask implements PermanentBlobServic
 		public long keepUntil = -1;
 	}
 
-	/** Map to store the number of references to a specific job */
+	/**
+	 * Map to store the number of references to a specific job.
+	 */
 	private final Map<JobID, RefCount> jobRefCounters = new HashMap<>();
 
-	/** Time interval (ms) to run the cleanup task; also used as the default TTL. */
+	/**
+	 * Time interval (ms) to run the cleanup task; also used as the default TTL.
+	 */
 	private final long cleanupInterval;
 
 	private final Timer cleanupTimer;
@@ -124,45 +92,25 @@ public class PermanentBlobCache extends TimerTask implements PermanentBlobServic
 	 * 		thrown if the (local or distributed) file storage cannot be created or is not usable
 	 */
 	public PermanentBlobCache(
-		final InetSocketAddress serverAddress,
-		final Configuration blobClientConfig,
-		final BlobView blobView) throws IOException {
+			final InetSocketAddress serverAddress,
+			final Configuration blobClientConfig,
+			final BlobView blobView) throws IOException {
 
-		this.serverAddress = checkNotNull(serverAddress);
-		this.blobClientConfig = checkNotNull(blobClientConfig);
-		this.blobView = checkNotNull(blobView, "blobStore");
-		this.readWriteLock = new ReentrantReadWriteLock();
-
-		// configure and create the storage directory
-		String storageDirectory = blobClientConfig.getString(BlobServerOptions.STORAGE_DIRECTORY);
-		this.storageDir = BlobUtils.initLocalStorageDirectory(storageDirectory);
-		LOG.info("Created permanent BLOB cache storage directory " + storageDir);
-
-		// configure the number of fetch retries
-		final int fetchRetries = blobClientConfig.getInteger(BlobServerOptions.FETCH_RETRIES);
-		if (fetchRetries >= 0) {
-			this.numFetchRetries = fetchRetries;
-		} else {
-			LOG.warn("Invalid value for {}. System will attempt no retries on failed fetch operations of BLOBs.",
-				BlobServerOptions.FETCH_RETRIES.key());
-			this.numFetchRetries = 0;
-		}
+		super(serverAddress, blobClientConfig, blobView,
+			LoggerFactory.getLogger(PermanentBlobCache.class));
 
 		// Initializing the clean up task
 		this.cleanupTimer = new Timer(true);
 
 		this.cleanupInterval = blobClientConfig.getLong(BlobServerOptions.CLEANUP_INTERVAL) * 1000;
-		this.cleanupTimer.schedule(this, cleanupInterval, cleanupInterval);
-
-		// Add shutdown hook to delete storage directory
-		shutdownHook = BlobUtils.addShutdownHook(this, LOG);
+		this.cleanupTimer.schedule(new PermanentBlobCleanupTask(), cleanupInterval, cleanupInterval);
 	}
 
 	/**
 	 * Registers use of job-related BLOBs.
-	 * <p>
-	 * Using any other method to access BLOBs, e.g. {@link #getHAFile}, is only valid within calls
-	 * to <tt>registerJob(JobID)</tt> and {@link #releaseJob(JobID)}.
+	 *
+	 * <p>Using any other method to access BLOBs, e.g. {@link #getPermanentFile}, is only valid within
+	 * calls to <tt>registerJob(JobID)</tt> and {@link #releaseJob(JobID)}.
 	 *
 	 * @param jobId
 	 * 		ID of the job this blob belongs to
@@ -170,6 +118,8 @@ public class PermanentBlobCache extends TimerTask implements PermanentBlobServic
 	 * @see #releaseJob(JobID)
 	 */
 	public void registerJob(JobID jobId) {
+		checkNotNull(jobId);
+
 		synchronized (jobRefCounters) {
 			RefCount ref = jobRefCounters.get(jobId);
 			if (ref == null) {
@@ -192,10 +142,12 @@ public class PermanentBlobCache extends TimerTask implements PermanentBlobServic
 	 * @see #registerJob(JobID)
 	 */
 	public void releaseJob(JobID jobId) {
+		checkNotNull(jobId);
+
 		synchronized (jobRefCounters) {
 			RefCount ref = jobRefCounters.get(jobId);
 
-			if (ref == null) {
+			if (ref == null || ref.references == 0) {
 				LOG.warn("improper use of releaseJob() without a matching number of registerJob() calls for jobId " + jobId);
 				return;
 			}
@@ -208,6 +160,8 @@ public class PermanentBlobCache extends TimerTask implements PermanentBlobServic
 	}
 
 	public int getNumberOfReferenceHolders(JobID jobId) {
+		checkNotNull(jobId);
+
 		synchronized (jobRefCounters) {
 			RefCount ref = jobRefCounters.get(jobId);
 			if (ref == null) {
@@ -225,8 +179,8 @@ public class PermanentBlobCache extends TimerTask implements PermanentBlobServic
 	/**
 	 * Returns the path to a local copy of the file associated with the provided job ID and blob
 	 * key.
-	 * <p>
-	 * We will first attempt to serve the BLOB from the local storage. If the BLOB is not in
+	 *
+	 * <p>We will first attempt to serve the BLOB from the local storage. If the BLOB is not in
 	 * there, we will try to download it from the HA store, or directly from the {@link BlobServer}.
 	 *
 	 * @param jobId
@@ -242,85 +196,9 @@ public class PermanentBlobCache extends TimerTask implements PermanentBlobServic
 	 * 		if any other error occurs when retrieving the file
 	 */
 	@Override
-	public File getHAFile(JobID jobId, BlobKey key) throws IOException {
+	public File getPermanentFile(JobID jobId, BlobKey key) throws IOException {
 		checkNotNull(jobId);
-		return getHAFileInternal(jobId, key);
-	}
-
-	/**
-	 * Returns local copy of the file for the BLOB with the given key.
-	 * <p>
-	 * The method will first attempt to serve the BLOB from its local cache. If the BLOB is not in
-	 * the cache, the method will try to download it from this cache's BLOB server.
-	 *
-	 * @param jobId
-	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
-	 * @param blobKey
-	 * 		The key of the desired BLOB.
-	 *
-	 * @return file referring to the local storage location of the BLOB.
-	 *
-	 * @throws IOException
-	 * 		Thrown if an I/O error occurs while downloading the BLOBs from the BLOB server.
-	 */
-	private File getHAFileInternal(@Nullable JobID jobId, BlobKey blobKey) throws IOException {
-		checkArgument(blobKey != null, "BLOB key cannot be null.");
-
-		final File localFile = BlobUtils.getStorageLocation(storageDir, jobId, blobKey);
-		readWriteLock.readLock().lock();
-
-		try {
-			if (localFile.exists()) {
-				return localFile;
-			}
-		} finally {
-			readWriteLock.readLock().unlock();
-		}
-
-		// first try the distributed blob store (if available)
-		// use a temporary file (thread-safe without locking)
-		File incomingFile = createTemporaryFilename();
-		try {
-			try {
-				if (blobView.get(jobId, blobKey, incomingFile)) {
-					// now move the temp file to our local cache atomically
-					BlobUtils.moveTempFileToStore(
-						incomingFile, jobId, blobKey, localFile, readWriteLock.writeLock(), LOG, null);
-
-					return localFile;
-				}
-			} catch (Exception e) {
-				LOG.info("Failed to copy from blob store. Downloading from BLOB server instead.", e);
-			}
-
-			// fallback: download from the BlobServer
-			BlobClient.downloadFromBlobServer(
-				jobId, blobKey, true, incomingFile, serverAddress, blobClientConfig, numFetchRetries);
-			BlobUtils.moveTempFileToStore(
-				incomingFile, jobId, blobKey, localFile, readWriteLock.writeLock(), LOG, null);
-
-			return localFile;
-		} finally {
-			// delete incomingFile from a failed download
-			if (!incomingFile.delete() && incomingFile.exists()) {
-				LOG.warn("Could not delete the staging file {} for blob key {} and job {}.",
-					incomingFile, blobKey, jobId);
-			}
-		}
-	}
-
-	public int getPort() {
-		return serverAddress.getPort();
-	}
-
-	/**
-	 * Returns the job reference counters - for testing purposes only!
-	 *
-	 * @return job reference counters (internal state!)
-	 */
-	@VisibleForTesting
-	Map<JobID, RefCount> getJobRefCounters() {
-		return jobRefCounters;
+		return getTransientFileInternal(jobId, key);
 	}
 
 	/**
@@ -344,58 +222,61 @@ public class PermanentBlobCache extends TimerTask implements PermanentBlobServic
 	}
 
 	/**
-	 * Returns a temporary file inside the BLOB server's incoming directory.
+	 * Returns the job reference counters - for testing purposes only!
 	 *
-	 * @return a temporary file inside the BLOB server's incoming directory
-	 *
-	 * @throws IOException
-	 * 		if creating the directory fails
+	 * @return job reference counters (internal state!)
 	 */
-	File createTemporaryFilename() throws IOException {
-		return new File(BlobUtils.getIncomingDirectory(storageDir),
-			String.format("temp-%08d", tempFileCounter.getAndIncrement()));
+	@VisibleForTesting
+	Map<JobID, RefCount> getJobRefCounters() {
+		return jobRefCounters;
 	}
 
 	/**
-	 * Cleans up BLOBs which are not referenced anymore.
+	 * Cleanup task which is executed periodically to delete BLOBs whose ref-counter reached
+	 * <tt>0</tt>.
 	 */
-	@Override
-	public void run() {
-		synchronized (jobRefCounters) {
-			Iterator<Map.Entry<JobID, RefCount>> entryIter = jobRefCounters.entrySet().iterator();
-			final long currentTimeMillis = System.currentTimeMillis();
+	class PermanentBlobCleanupTask extends TimerTask {
+		/**
+		 * Cleans up BLOBs which are not referenced anymore.
+		 */
+		@Override
+		public void run() {
+			synchronized (jobRefCounters) {
+				Iterator<Map.Entry<JobID, RefCount>> entryIter = jobRefCounters.entrySet().iterator();
+				final long currentTimeMillis = System.currentTimeMillis();
 
-			while (entryIter.hasNext()) {
-				Map.Entry<JobID, RefCount> entry = entryIter.next();
-				RefCount ref = entry.getValue();
+				while (entryIter.hasNext()) {
+					Map.Entry<JobID, RefCount> entry = entryIter.next();
+					RefCount ref = entry.getValue();
 
-				if (ref.references <= 0 && ref.keepUntil > 0 && currentTimeMillis >= ref.keepUntil) {
-					JobID jobId = entry.getKey();
+					if (ref.references <= 0 && ref.keepUntil > 0 && currentTimeMillis >= ref.keepUntil) {
+						JobID jobId = entry.getKey();
 
-					final File localFile =
-						new File(BlobUtils.getStorageLocationPath(storageDir.getAbsolutePath(), jobId));
+						final File localFile =
+							new File(BlobUtils.getStorageLocationPath(storageDir.getAbsolutePath(), jobId));
 
 					/*
 					 * NOTE: normally it is not required to acquire the write lock to delete the job's
 					 *       storage directory since there should be noone accessing it with the ref
 					 *       counter being 0 - acquire it just in case, to always be on the safe side
 					 */
-					readWriteLock.writeLock().lock();
+						readWriteLock.writeLock().lock();
 
-					boolean success = false;
-					try {
-						FileUtils.deleteDirectory(localFile);
-						success = true;
-					} catch (Throwable t) {
-						LOG.warn("Failed to locally delete job directory " + localFile.getAbsolutePath(), t);
-					} finally {
-						readWriteLock.writeLock().unlock();
-					}
+						boolean success = false;
+						try {
+							FileUtils.deleteDirectory(localFile);
+							success = true;
+						} catch (Throwable t) {
+							LOG.warn("Failed to locally delete job directory " + localFile.getAbsolutePath(), t);
+						} finally {
+							readWriteLock.writeLock().unlock();
+						}
 
-					// let's only remove this directory from cleanup if the cleanup was successful
-					// (does not need the write lock)
-					if (success) {
-						entryIter.remove();
+						// let's only remove this directory from cleanup if the cleanup was successful
+						// (does not need the write lock)
+						if (success) {
+							entryIter.remove();
+						}
 					}
 				}
 			}
@@ -403,27 +284,7 @@ public class PermanentBlobCache extends TimerTask implements PermanentBlobServic
 	}
 
 	@Override
-	public void close() throws IOException {
+	protected void cancelCleanupTask() {
 		cleanupTimer.cancel();
-
-		if (shutdownRequested.compareAndSet(false, true)) {
-			LOG.info("Shutting down permanent BlobCache");
-
-			// Clean up the storage directory
-			try {
-				FileUtils.deleteDirectory(storageDir);
-			} finally {
-				// Remove shutdown hook to prevent resource leaks, unless this is invoked by the shutdown hook itself
-				if (shutdownHook != null && shutdownHook != Thread.currentThread()) {
-					try {
-						Runtime.getRuntime().removeShutdownHook(shutdownHook);
-					} catch (IllegalStateException e) {
-						// race, JVM is in shutdown already, we can safely ignore this
-					} catch (Throwable t) {
-						LOG.warn("Exception while unregistering BLOB cache's cleanup shutdown hook.");
-					}
-				}
-			}
-		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
@@ -148,7 +148,7 @@ public class PermanentBlobCache extends AbstractBlobCache implements PermanentBl
 			RefCount ref = jobRefCounters.get(jobId);
 
 			if (ref == null || ref.references == 0) {
-				LOG.warn("improper use of releaseJob() without a matching number of registerJob() calls for jobId " + jobId);
+				log.warn("improper use of releaseJob() without a matching number of registerJob() calls for jobId " + jobId);
 				return;
 			}
 
@@ -198,7 +198,7 @@ public class PermanentBlobCache extends AbstractBlobCache implements PermanentBl
 	@Override
 	public File getPermanentFile(JobID jobId, BlobKey key) throws IOException {
 		checkNotNull(jobId);
-		return getTransientFileInternal(jobId, key);
+		return getFileInternal(jobId, key);
 	}
 
 	/**
@@ -267,7 +267,7 @@ public class PermanentBlobCache extends AbstractBlobCache implements PermanentBl
 							FileUtils.deleteDirectory(localFile);
 							success = true;
 						} catch (Throwable t) {
-							LOG.warn("Failed to locally delete job directory " + localFile.getAbsolutePath(), t);
+							log.warn("Failed to locally delete job directory " + localFile.getAbsolutePath(), t);
 						} finally {
 							readWriteLock.writeLock().unlock();
 						}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
@@ -282,11 +282,13 @@ public class PermanentBlobCache extends TimerTask implements PermanentBlobServic
 		File incomingFile = createTemporaryFilename();
 		try {
 			try {
-				blobView.get(jobId, blobKey, incomingFile);
-				BlobUtils.moveTempFileToStore(
-					incomingFile, jobId, blobKey, localFile, readWriteLock.writeLock(), LOG, null);
+				if (blobView.get(jobId, blobKey, incomingFile)) {
+					// now move the temp file to our local cache atomically
+					BlobUtils.moveTempFileToStore(
+						incomingFile, jobId, blobKey, localFile, readWriteLock.writeLock(), LOG, null);
 
-				return localFile;
+					return localFile;
+				}
 			} catch (Exception e) {
 				LOG.info("Failed to copy from blob store. Downloading from BLOB server instead.", e);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
@@ -109,7 +109,7 @@ public class PermanentBlobCache extends AbstractBlobCache implements PermanentBl
 	/**
 	 * Registers use of job-related BLOBs.
 	 *
-	 * <p>Using any other method to access BLOBs, e.g. {@link #getPermanentFile}, is only valid within
+	 * <p>Using any other method to access BLOBs, e.g. {@link #getFile}, is only valid within
 	 * calls to <tt>registerJob(JobID)</tt> and {@link #releaseJob(JobID)}.
 	 *
 	 * @param jobId
@@ -196,7 +196,7 @@ public class PermanentBlobCache extends AbstractBlobCache implements PermanentBl
 	 * 		if any other error occurs when retrieving the file
 	 */
 	@Override
-	public File getPermanentFile(JobID jobId, BlobKey key) throws IOException {
+	public File getFile(JobID jobId, PermanentBlobKey key) throws IOException {
 		checkNotNull(jobId);
 		return getFileInternal(jobId, key);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
@@ -1,0 +1,427 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Provides a cache for permanent BLOB files including a per-job ref-counting and a staged cleanup.
+ * <p>
+ * When requesting BLOBs via {@link #getHAFile(JobID, BlobKey)}, the cache will first attempt to
+ * serve the file from its local cache. Only if the local cache does not contain the desired BLOB,
+ * it will try to download it from a distributed HA file system (if available) or the BLOB server.
+ * <p>
+ * If files for a job are not needed any more, they will enter a staged, i.e. deferred, cleanup.
+ * Files may thus still be be accessible upon recovery and do not need to be re-downloaded.
+ */
+public class PermanentBlobCache extends TimerTask implements PermanentBlobService {
+
+	/** The log object used for debugging. */
+	private static final Logger LOG = LoggerFactory.getLogger(PermanentBlobCache.class);
+
+	/** Counter to generate unique names for temporary files. */
+	private final AtomicLong tempFileCounter = new AtomicLong(0);
+
+	private final InetSocketAddress serverAddress;
+
+	/** Root directory for local file storage */
+	private final File storageDir;
+
+	/** Blob store for distributed file storage, e.g. in HA */
+	private final BlobView blobView;
+
+	private final AtomicBoolean shutdownRequested = new AtomicBoolean();
+
+	/** Shutdown hook thread to ensure deletion of the storage directory. */
+	private final Thread shutdownHook;
+
+	/** The number of retries when the transfer fails */
+	private final int numFetchRetries;
+
+	/** Configuration for the blob client like ssl parameters required to connect to the blob server */
+	private final Configuration blobClientConfig;
+
+	/** Lock guarding concurrent file accesses */
+	private final ReadWriteLock readWriteLock;
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Job reference counters with a time-to-live (TTL).
+	 */
+	@VisibleForTesting
+	static class RefCount {
+		/**
+		 * Number of references to a job.
+		 */
+		public int references = 0;
+
+		/**
+		 * Timestamp in milliseconds when any job data should be cleaned up (no cleanup for
+		 * non-positive values).
+		 */
+		public long keepUntil = -1;
+	}
+
+	/** Map to store the number of references to a specific job */
+	private final Map<JobID, RefCount> jobRefCounters = new HashMap<>();
+
+	/** Time interval (ms) to run the cleanup task; also used as the default TTL. */
+	private final long cleanupInterval;
+
+	private final Timer cleanupTimer;
+
+	/**
+	 * Instantiates a new cache for permanent BLOBs which are also available in an HA store.
+	 *
+	 * @param serverAddress
+	 * 		address of the {@link BlobServer} to use for fetching files from
+	 * @param blobClientConfig
+	 * 		global configuration
+	 * @param blobView
+	 * 		(distributed) HA blob store file system to retrieve files from first
+	 *
+	 * @throws IOException
+	 * 		thrown if the (local or distributed) file storage cannot be created or is not usable
+	 */
+	public PermanentBlobCache(
+		final InetSocketAddress serverAddress,
+		final Configuration blobClientConfig,
+		final BlobView blobView) throws IOException {
+
+		this.serverAddress = checkNotNull(serverAddress);
+		this.blobClientConfig = checkNotNull(blobClientConfig);
+		this.blobView = checkNotNull(blobView, "blobStore");
+		this.readWriteLock = new ReentrantReadWriteLock();
+
+		// configure and create the storage directory
+		String storageDirectory = blobClientConfig.getString(BlobServerOptions.STORAGE_DIRECTORY);
+		this.storageDir = BlobUtils.initLocalStorageDirectory(storageDirectory);
+		LOG.info("Created permanent BLOB cache storage directory " + storageDir);
+
+		// configure the number of fetch retries
+		final int fetchRetries = blobClientConfig.getInteger(BlobServerOptions.FETCH_RETRIES);
+		if (fetchRetries >= 0) {
+			this.numFetchRetries = fetchRetries;
+		} else {
+			LOG.warn("Invalid value for {}. System will attempt no retries on failed fetch operations of BLOBs.",
+				BlobServerOptions.FETCH_RETRIES.key());
+			this.numFetchRetries = 0;
+		}
+
+		// Initializing the clean up task
+		this.cleanupTimer = new Timer(true);
+
+		this.cleanupInterval = blobClientConfig.getLong(BlobServerOptions.CLEANUP_INTERVAL) * 1000;
+		this.cleanupTimer.schedule(this, cleanupInterval, cleanupInterval);
+
+		// Add shutdown hook to delete storage directory
+		shutdownHook = BlobUtils.addShutdownHook(this, LOG);
+	}
+
+	/**
+	 * Registers use of job-related BLOBs.
+	 * <p>
+	 * Using any other method to access BLOBs, e.g. {@link #getHAFile}, is only valid within calls
+	 * to <tt>registerJob(JobID)</tt> and {@link #releaseJob(JobID)}.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to
+	 *
+	 * @see #releaseJob(JobID)
+	 */
+	public void registerJob(JobID jobId) {
+		synchronized (jobRefCounters) {
+			RefCount ref = jobRefCounters.get(jobId);
+			if (ref == null) {
+				ref = new RefCount();
+				jobRefCounters.put(jobId, ref);
+			} else {
+				// reset cleanup timeout
+				ref.keepUntil = -1;
+			}
+			++ref.references;
+		}
+	}
+
+	/**
+	 * Unregisters use of job-related BLOBs and allow them to be released.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to
+	 *
+	 * @see #registerJob(JobID)
+	 */
+	public void releaseJob(JobID jobId) {
+		synchronized (jobRefCounters) {
+			RefCount ref = jobRefCounters.get(jobId);
+
+			if (ref == null) {
+				LOG.warn("improper use of releaseJob() without a matching number of registerJob() calls for jobId " + jobId);
+				return;
+			}
+
+			--ref.references;
+			if (ref.references == 0) {
+				ref.keepUntil = System.currentTimeMillis() + cleanupInterval;
+			}
+		}
+	}
+
+	public int getNumberOfReferenceHolders(JobID jobId) {
+		synchronized (jobRefCounters) {
+			RefCount ref = jobRefCounters.get(jobId);
+			if (ref == null) {
+				return 0;
+			} else {
+				return ref.references;
+			}
+		}
+	}
+
+	public int getNumberOfCachedJobs() {
+		return jobRefCounters.size();
+	}
+
+	/**
+	 * Returns the path to a local copy of the file associated with the provided job ID and blob
+	 * key.
+	 * <p>
+	 * We will first attempt to serve the BLOB from the local storage. If the BLOB is not in
+	 * there, we will try to download it from the HA store, or directly from the {@link BlobServer}.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to
+	 * @param key
+	 * 		blob key associated with the requested file
+	 *
+	 * @return The path to the file.
+	 *
+	 * @throws java.io.FileNotFoundException
+	 * 		if the BLOB does not exist;
+	 * @throws IOException
+	 * 		if any other error occurs when retrieving the file
+	 */
+	@Override
+	public File getHAFile(JobID jobId, BlobKey key) throws IOException {
+		checkNotNull(jobId);
+		return getHAFileInternal(jobId, key);
+	}
+
+	/**
+	 * Returns local copy of the file for the BLOB with the given key.
+	 * <p>
+	 * The method will first attempt to serve the BLOB from its local cache. If the BLOB is not in
+	 * the cache, the method will try to download it from this cache's BLOB server.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
+	 * @param blobKey
+	 * 		The key of the desired BLOB.
+	 *
+	 * @return file referring to the local storage location of the BLOB.
+	 *
+	 * @throws IOException
+	 * 		Thrown if an I/O error occurs while downloading the BLOBs from the BLOB server.
+	 */
+	private File getHAFileInternal(@Nullable JobID jobId, BlobKey blobKey) throws IOException {
+		checkArgument(blobKey != null, "BLOB key cannot be null.");
+
+		final File localFile = BlobUtils.getStorageLocation(storageDir, jobId, blobKey);
+		readWriteLock.readLock().lock();
+
+		try {
+			if (localFile.exists()) {
+				return localFile;
+			}
+		} finally {
+			readWriteLock.readLock().unlock();
+		}
+
+		// first try the distributed blob store (if available)
+		// use a temporary file (thread-safe without locking)
+		File incomingFile = createTemporaryFilename();
+		try {
+			try {
+				blobView.get(jobId, blobKey, incomingFile);
+				BlobUtils.moveTempFileToStore(
+					incomingFile, jobId, blobKey, localFile, readWriteLock.writeLock(), LOG, null);
+
+				return localFile;
+			} catch (Exception e) {
+				LOG.info("Failed to copy from blob store. Downloading from BLOB server instead.", e);
+			}
+
+			// fallback: download from the BlobServer
+			BlobClient.downloadFromBlobServer(
+				jobId, blobKey, true, incomingFile, serverAddress, blobClientConfig, numFetchRetries);
+			BlobUtils.moveTempFileToStore(
+				incomingFile, jobId, blobKey, localFile, readWriteLock.writeLock(), LOG, null);
+
+			return localFile;
+		} finally {
+			// delete incomingFile from a failed download
+			if (!incomingFile.delete() && incomingFile.exists()) {
+				LOG.warn("Could not delete the staging file {} for blob key {} and job {}.",
+					incomingFile, blobKey, jobId);
+			}
+		}
+	}
+
+	public int getPort() {
+		return serverAddress.getPort();
+	}
+
+	/**
+	 * Returns the job reference counters - for testing purposes only!
+	 *
+	 * @return job reference counters (internal state!)
+	 */
+	@VisibleForTesting
+	Map<JobID, RefCount> getJobRefCounters() {
+		return jobRefCounters;
+	}
+
+	/**
+	 * Returns a file handle to the file associated with the given blob key on the blob
+	 * server.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
+	 * @param key
+	 * 		identifying the file
+	 *
+	 * @return file handle to the file
+	 *
+	 * @throws IOException
+	 * 		if creating the directory fails
+	 */
+	@VisibleForTesting
+	public File getStorageLocation(JobID jobId, BlobKey key) throws IOException {
+		checkNotNull(jobId);
+		return BlobUtils.getStorageLocation(storageDir, jobId, key);
+	}
+
+	/**
+	 * Returns a temporary file inside the BLOB server's incoming directory.
+	 *
+	 * @return a temporary file inside the BLOB server's incoming directory
+	 *
+	 * @throws IOException
+	 * 		if creating the directory fails
+	 */
+	File createTemporaryFilename() throws IOException {
+		return new File(BlobUtils.getIncomingDirectory(storageDir),
+			String.format("temp-%08d", tempFileCounter.getAndIncrement()));
+	}
+
+	/**
+	 * Cleans up BLOBs which are not referenced anymore.
+	 */
+	@Override
+	public void run() {
+		synchronized (jobRefCounters) {
+			Iterator<Map.Entry<JobID, RefCount>> entryIter = jobRefCounters.entrySet().iterator();
+			final long currentTimeMillis = System.currentTimeMillis();
+
+			while (entryIter.hasNext()) {
+				Map.Entry<JobID, RefCount> entry = entryIter.next();
+				RefCount ref = entry.getValue();
+
+				if (ref.references <= 0 && ref.keepUntil > 0 && currentTimeMillis >= ref.keepUntil) {
+					JobID jobId = entry.getKey();
+
+					final File localFile =
+						new File(BlobUtils.getStorageLocationPath(storageDir.getAbsolutePath(), jobId));
+
+					/*
+					 * NOTE: normally it is not required to acquire the write lock to delete the job's
+					 *       storage directory since there should be noone accessing it with the ref
+					 *       counter being 0 - acquire it just in case, to always be on the safe side
+					 */
+					readWriteLock.writeLock().lock();
+
+					boolean success = false;
+					try {
+						FileUtils.deleteDirectory(localFile);
+						success = true;
+					} catch (Throwable t) {
+						LOG.warn("Failed to locally delete job directory " + localFile.getAbsolutePath(), t);
+					} finally {
+						readWriteLock.writeLock().unlock();
+					}
+
+					// let's only remove this directory from cleanup if the cleanup was successful
+					// (does not need the write lock)
+					if (success) {
+						entryIter.remove();
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		cleanupTimer.cancel();
+
+		if (shutdownRequested.compareAndSet(false, true)) {
+			LOG.info("Shutting down permanent BlobCache");
+
+			// Clean up the storage directory
+			try {
+				FileUtils.deleteDirectory(storageDir);
+			} finally {
+				// Remove shutdown hook to prevent resource leaks, unless this is invoked by the shutdown hook itself
+				if (shutdownHook != null && shutdownHook != Thread.currentThread()) {
+					try {
+						Runtime.getRuntime().removeShutdownHook(shutdownHook);
+					} catch (IllegalStateException e) {
+						// race, JVM is in shutdown already, we can safely ignore this
+					} catch (Throwable t) {
+						LOG.warn("Exception while unregistering BLOB cache's cleanup shutdown hook.");
+					}
+				}
+			}
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobKey.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobKey.java
@@ -18,18 +18,28 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.annotation.VisibleForTesting;
+
 /**
- * BLOB type, i.e. permanent or transient.
+ * BLOB key referencing permanent BLOB files.
  */
-public enum BlobType {
+public final class PermanentBlobKey extends BlobKey {
+
 	/**
-	 * Indicates a permanent BLOB whose lifecycle is that of a job and which is made highly
-	 * available.
+	 * Constructs a new BLOB key.
 	 */
-	PERMANENT_BLOB,
+	@VisibleForTesting
+	public PermanentBlobKey() {
+		super(BlobType.PERMANENT_BLOB);
+	}
+
 	/**
-	 * Indicates a transient BLOB whose lifecycle is managed by the user and which is not made
-	 * highly available.
+	 * Constructs a new BLOB key from the given byte array.
+	 *
+	 * @param key
+	 *        the actual key data
 	 */
-	TRANSIENT_BLOB
+	PermanentBlobKey(byte[] key) {
+		super(BlobType.PERMANENT_BLOB, key);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobService.java
@@ -20,35 +20,35 @@ package org.apache.flink.runtime.blob;
 
 import org.apache.flink.api.common.JobID;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 
 /**
- * A blob store doing nothing.
+ * A service to retrieve permanent binary large objects (BLOBs).
+ * <p>
+ * These include per-job BLOBs that are covered by high-availability (HA) mode, e.g. a job's JAR
+ * files, parts of an off-loaded {@link org.apache.flink.runtime.deployment.TaskDeploymentDescriptor}
+ * or files in the {@link org.apache.flink.api.common.cache.DistributedCache}.
  */
-public class VoidBlobStore implements BlobStoreService {
+public interface PermanentBlobService extends Closeable {
 
-	@Override
-	public void put(File localFile, JobID jobId, BlobKey blobKey) throws IOException {
-	}
+	/**
+	 * Returns the path to a local copy of the file associated with the provided job ID and blob
+	 * key.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to
+	 * @param key
+	 * 		BLOB key associated with the requested file
+	 *
+	 * @return The path to the file.
+	 *
+	 * @throws java.io.FileNotFoundException
+	 * 		if the BLOB does not exist;
+	 * @throws IOException
+	 * 		if any other error occurs when retrieving the file
+	 */
+	File getHAFile(JobID jobId, BlobKey key) throws IOException;
 
-	@Override
-	public void get(JobID jobId, BlobKey blobKey, File localFile) throws IOException {
-	}
-
-	@Override
-	public boolean delete(JobID jobId, BlobKey blobKey) {
-		return true;
-	}
-
-	@Override
-	public boolean deleteAll(JobID jobId) {
-		return true;
-	}
-
-	@Override
-	public void closeAndCleanupAllData() {}
-
-	@Override
-	public void close() throws IOException {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobService.java
@@ -49,6 +49,6 @@ public interface PermanentBlobService extends Closeable {
 	 * @throws IOException
 	 * 		if any other error occurs when retrieving the file
 	 */
-	File getPermanentFile(JobID jobId, BlobKey key) throws IOException;
+	File getFile(JobID jobId, PermanentBlobKey key) throws IOException;
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobService.java
@@ -26,9 +26,9 @@ import java.io.IOException;
 
 /**
  * A service to retrieve permanent binary large objects (BLOBs).
- * <p>
- * These include per-job BLOBs that are covered by high-availability (HA) mode, e.g. a job's JAR
- * files, parts of an off-loaded {@link org.apache.flink.runtime.deployment.TaskDeploymentDescriptor}
+ *
+ * <p>These may include per-job BLOBs that are covered by high-availability (HA) mode, e.g. a job's
+ * JAR files or (parts of) an off-loaded {@link org.apache.flink.runtime.deployment.TaskDeploymentDescriptor}
  * or files in the {@link org.apache.flink.api.common.cache.DistributedCache}.
  */
 public interface PermanentBlobService extends Closeable {
@@ -49,6 +49,6 @@ public interface PermanentBlobService extends Closeable {
 	 * @throws IOException
 	 * 		if any other error occurs when retrieving the file
 	 */
-	File getHAFile(JobID jobId, BlobKey key) throws IOException;
+	File getPermanentFile(JobID jobId, BlobKey key) throws IOException;
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobCache.java
@@ -63,13 +63,13 @@ public class TransientBlobCache extends AbstractBlobCache implements TransientBl
 
 	@Override
 	public File getTransientFile(BlobKey key) throws IOException {
-		return getTransientFileInternal(null, key);
+		return getFileInternal(null, key);
 	}
 
 	@Override
 	public File getTransientFile(JobID jobId, BlobKey key) throws IOException {
 		checkNotNull(jobId);
-		return getTransientFileInternal(jobId, key);
+		return getFileInternal(jobId, key);
 	}
 
 	@Override
@@ -131,7 +131,7 @@ public class TransientBlobCache extends AbstractBlobCache implements TransientBl
 		readWriteLock.writeLock().lock();
 		try {
 			if (!localFile.delete() && localFile.exists()) {
-				LOG.warn("Failed to delete locally cached BLOB {} at {}", key,
+				log.warn("Failed to delete locally cached BLOB {} at {}", key,
 					localFile.getAbsolutePath());
 				return false;
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobCache.java
@@ -20,58 +20,27 @@ package org.apache.flink.runtime.blob;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.util.FileUtils;
-import org.slf4j.Logger;
+
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Provides access to transient BLOB files stored at the {@link BlobServer}.
  *
- * TODO: currently, this is still cache-based with local copies - make this truly transient, i.e. return file streams with no local copy
+ * <p>TODO: make this truly transient by returning file streams to a local copy with the remote
+ * being removed upon retrieval and the local copy being deleted at the end of the stream.
  */
-public class TransientBlobCache implements TransientBlobService {
-
-	/** The log object used for debugging. */
-	private static final Logger LOG = LoggerFactory.getLogger(TransientBlobCache.class);
-
-	/** Counter to generate unique names for temporary files. */
-	private final AtomicLong tempFileCounter = new AtomicLong(0);
-
-	private final InetSocketAddress serverAddress;
-
-	/**
-	 * Root directory for local file storage
-	 */
-	private final File storageDir;
-
-	private final AtomicBoolean shutdownRequested = new AtomicBoolean();
-
-	/** Shutdown hook thread to ensure deletion of the local storage directory. */
-	private final Thread shutdownHook;
-
-	/** The number of retries when the transfer fails */
-	private final int numFetchRetries;
-
-	/** Configuration for the blob client like ssl parameters required to connect to the blob server */
-	private final Configuration blobClientConfig;
-
-	/** Lock guarding concurrent file accesses */
-	private final ReadWriteLock readWriteLock;
+public class TransientBlobCache extends AbstractBlobCache implements TransientBlobService {
 
 	/**
 	 * Instantiates a new BLOB cache.
@@ -88,127 +57,58 @@ public class TransientBlobCache implements TransientBlobService {
 			final InetSocketAddress serverAddress,
 			final Configuration blobClientConfig) throws IOException {
 
-		this.serverAddress = checkNotNull(serverAddress);
-		this.blobClientConfig = checkNotNull(blobClientConfig);
-		this.readWriteLock = new ReentrantReadWriteLock();
-
-		// configure and create the storage directory
-		String storageDirectory = blobClientConfig.getString(BlobServerOptions.STORAGE_DIRECTORY);
-		this.storageDir = BlobUtils.initLocalStorageDirectory(storageDirectory);
-		LOG.info("Created transient BLOB cache storage directory " + storageDir);
-
-		// configure the number of fetch retries
-		final int fetchRetries = blobClientConfig.getInteger(BlobServerOptions.FETCH_RETRIES);
-		if (fetchRetries >= 0) {
-			this.numFetchRetries = fetchRetries;
-		} else {
-			LOG.warn("Invalid value for {}. System will attempt no retries on failed fetches of BLOBs.",
-				BlobServerOptions.FETCH_RETRIES.key());
-			this.numFetchRetries = 0;
-		}
-
-		// Add shutdown hook to delete storage directory
-		shutdownHook = BlobUtils.addShutdownHook(this, LOG);
+		super(serverAddress, blobClientConfig, new VoidBlobStore(),
+			LoggerFactory.getLogger(TransientBlobCache.class));
 	}
 
 	@Override
-	public File getFile(BlobKey key) throws IOException {
-		return getFileInternal(null, key);
+	public File getTransientFile(BlobKey key) throws IOException {
+		return getTransientFileInternal(null, key);
 	}
 
 	@Override
-	public File getFile(JobID jobId, BlobKey key) throws IOException {
+	public File getTransientFile(JobID jobId, BlobKey key) throws IOException {
 		checkNotNull(jobId);
-		return getFileInternal(jobId, key);
-	}
-
-	/**
-	 * Returns local copy of the file for the BLOB with the given key.
-	 * <p>
-	 * The method will first attempt to serve the BLOB from its local cache. If the BLOB is not in
-	 * the cache, the method will try to download it from this cache's BLOB server.
-	 *
-	 * @param jobId
-	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
-	 * @param blobKey
-	 * 		The key of the desired BLOB.
-	 *
-	 * @return file referring to the local storage location of the BLOB.
-	 *
-	 * @throws IOException
-	 * 		Thrown if an I/O error occurs while downloading the BLOBs from the BLOB server.
-	 */
-	private File getFileInternal(@Nullable JobID jobId, BlobKey blobKey) throws IOException {
-		checkArgument(blobKey != null, "BLOB key cannot be null.");
-
-		final File localFile = BlobUtils.getStorageLocation(storageDir, jobId, blobKey);
-		readWriteLock.readLock().lock();
-
-		try {
-			if (localFile.exists()) {
-				return localFile;
-			}
-		} finally {
-			readWriteLock.readLock().unlock();
-		}
-
-		// download from the BlobServer directly
-		// use a temporary file (thread-safe without locking)
-		File incomingFile = createTemporaryFilename();
-		try {
-			BlobClient.downloadFromBlobServer(jobId, blobKey, false, incomingFile, serverAddress,
-				blobClientConfig, numFetchRetries);
-
-			BlobUtils.moveTempFileToStore(
-				incomingFile, jobId, blobKey, localFile, readWriteLock.writeLock(), LOG, null);
-
-			return localFile;
-		} finally {
-			// delete incomingFile from a failed download
-			if (!incomingFile.delete() && incomingFile.exists()) {
-				LOG.warn("Could not delete the staging file {} for blob key {} and job {}.",
-					incomingFile, blobKey, jobId);
-			}
-		}
+		return getTransientFileInternal(jobId, key);
 	}
 
 	@Override
-	public BlobKey put(byte[] value) throws IOException {
+	public BlobKey putTransient(byte[] value) throws IOException {
 		try (BlobClient bc = new BlobClient(serverAddress, blobClientConfig)) {
-			return bc.putBuffer(null, value, 0, value.length, false);
+			return bc.putBuffer(null, value, 0, value.length, TRANSIENT_BLOB);
 		}
 	}
 
 	@Override
-	public BlobKey put(JobID jobId, byte[] value) throws IOException {
+	public BlobKey putTransient(JobID jobId, byte[] value) throws IOException {
 		checkNotNull(jobId);
 		try (BlobClient bc = new BlobClient(serverAddress, blobClientConfig)) {
-			return bc.putBuffer(jobId, value, 0, value.length, false);
+			return bc.putBuffer(jobId, value, 0, value.length, TRANSIENT_BLOB);
 		}
 	}
 
 	@Override
-	public BlobKey put(InputStream inputStream) throws IOException {
+	public BlobKey putTransient(InputStream inputStream) throws IOException {
 		try (BlobClient bc = new BlobClient(serverAddress, blobClientConfig)) {
-			return bc.putInputStream(null, inputStream, false);
+			return bc.putInputStream(null, inputStream, TRANSIENT_BLOB);
 		}
 	}
 
 	@Override
-	public BlobKey put(JobID jobId, InputStream inputStream) throws IOException {
+	public BlobKey putTransient(JobID jobId, InputStream inputStream) throws IOException {
 		checkNotNull(jobId);
 		try (BlobClient bc = new BlobClient(serverAddress, blobClientConfig)) {
-			return bc.putInputStream(jobId, inputStream, false);
+			return bc.putInputStream(jobId, inputStream, TRANSIENT_BLOB);
 		}
 	}
 
 	@Override
-	public boolean delete(BlobKey key) {
+	public boolean deleteTransient(BlobKey key) {
 		return deleteInternal(null, key);
 	}
 
 	@Override
-	public boolean delete(JobID jobId, BlobKey key) {
+	public boolean deleteTransient(JobID jobId, BlobKey key) {
 		checkNotNull(jobId);
 		return deleteInternal(jobId, key);
 	}
@@ -253,14 +153,6 @@ public class TransientBlobCache implements TransientBlobService {
 		return deleteLocal && deletedGlobal;
 	}
 
-	public File getStorageDir() {
-		return this.storageDir;
-	}
-
-	public int getPort() {
-		return serverAddress.getPort();
-	}
-
 	/**
 	 * Returns a file handle to the file associated with the given blob key on the blob
 	 * server.
@@ -280,43 +172,12 @@ public class TransientBlobCache implements TransientBlobService {
 		return BlobUtils.getStorageLocation(storageDir, jobId, key);
 	}
 
-	/**
-	 * Returns a temporary file inside the BLOB server's incoming directory.
-	 *
-	 * @return a temporary file inside the BLOB server's incoming directory
-	 *
-	 * @throws IOException
-	 * 		if creating the directory fails
-	 */
-	File createTemporaryFilename() throws IOException {
-		return new File(BlobUtils.getIncomingDirectory(storageDir),
-			String.format("temp-%08d", tempFileCounter.getAndIncrement()));
-	}
-
 	private BlobClient createClient() throws IOException {
 		return new BlobClient(serverAddress, blobClientConfig);
 	}
 
 	@Override
-	public void close() throws IOException {
-		if (shutdownRequested.compareAndSet(false, true)) {
-			LOG.info("Shutting down transient BlobCache");
-
-			// Clean up the storage directory
-			try {
-				FileUtils.deleteDirectory(storageDir);
-			} finally {
-				// Remove shutdown hook to prevent resource leaks, unless this is invoked by the shutdown hook itself
-				if (shutdownHook != null && shutdownHook != Thread.currentThread()) {
-					try {
-						Runtime.getRuntime().removeShutdownHook(shutdownHook);
-					} catch (IllegalStateException e) {
-						// race, JVM is in shutdown already, we can safely ignore this
-					} catch (Throwable t) {
-						LOG.warn("Exception while unregistering BLOB cache's cleanup shutdown hook.");
-					}
-				}
-			}
-		}
+	protected void cancelCleanupTask() {
+		// nothing to do here
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobCache.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Provides access to transient BLOB files stored at the {@link BlobServer}.
+ *
+ * TODO: currently, this is still cache-based with local copies - make this truly transient, i.e. return file streams with no local copy
+ */
+public class TransientBlobCache implements TransientBlobService {
+
+	/** The log object used for debugging. */
+	private static final Logger LOG = LoggerFactory.getLogger(TransientBlobCache.class);
+
+	/** Counter to generate unique names for temporary files. */
+	private final AtomicLong tempFileCounter = new AtomicLong(0);
+
+	private final InetSocketAddress serverAddress;
+
+	/**
+	 * Root directory for local file storage
+	 */
+	private final File storageDir;
+
+	private final AtomicBoolean shutdownRequested = new AtomicBoolean();
+
+	/** Shutdown hook thread to ensure deletion of the local storage directory. */
+	private final Thread shutdownHook;
+
+	/** The number of retries when the transfer fails */
+	private final int numFetchRetries;
+
+	/** Configuration for the blob client like ssl parameters required to connect to the blob server */
+	private final Configuration blobClientConfig;
+
+	/** Lock guarding concurrent file accesses */
+	private final ReadWriteLock readWriteLock;
+
+	/**
+	 * Instantiates a new BLOB cache.
+	 *
+	 * @param serverAddress
+	 * 		address of the {@link BlobServer} to use for fetching files from
+	 * @param blobClientConfig
+	 * 		global configuration
+	 *
+	 * @throws IOException
+	 * 		thrown if the (local or distributed) file storage cannot be created or is not usable
+	 */
+	public TransientBlobCache(
+			final InetSocketAddress serverAddress,
+			final Configuration blobClientConfig) throws IOException {
+
+		this.serverAddress = checkNotNull(serverAddress);
+		this.blobClientConfig = checkNotNull(blobClientConfig);
+		this.readWriteLock = new ReentrantReadWriteLock();
+
+		// configure and create the storage directory
+		String storageDirectory = blobClientConfig.getString(BlobServerOptions.STORAGE_DIRECTORY);
+		this.storageDir = BlobUtils.initLocalStorageDirectory(storageDirectory);
+		LOG.info("Created transient BLOB cache storage directory " + storageDir);
+
+		// configure the number of fetch retries
+		final int fetchRetries = blobClientConfig.getInteger(BlobServerOptions.FETCH_RETRIES);
+		if (fetchRetries >= 0) {
+			this.numFetchRetries = fetchRetries;
+		} else {
+			LOG.warn("Invalid value for {}. System will attempt no retries on failed fetches of BLOBs.",
+				BlobServerOptions.FETCH_RETRIES.key());
+			this.numFetchRetries = 0;
+		}
+
+		// Add shutdown hook to delete storage directory
+		shutdownHook = BlobUtils.addShutdownHook(this, LOG);
+	}
+
+	@Override
+	public File getFile(BlobKey key) throws IOException {
+		return getFileInternal(null, key);
+	}
+
+	@Override
+	public File getFile(JobID jobId, BlobKey key) throws IOException {
+		checkNotNull(jobId);
+		return getFileInternal(jobId, key);
+	}
+
+	/**
+	 * Returns local copy of the file for the BLOB with the given key.
+	 * <p>
+	 * The method will first attempt to serve the BLOB from its local cache. If the BLOB is not in
+	 * the cache, the method will try to download it from this cache's BLOB server.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
+	 * @param blobKey
+	 * 		The key of the desired BLOB.
+	 *
+	 * @return file referring to the local storage location of the BLOB.
+	 *
+	 * @throws IOException
+	 * 		Thrown if an I/O error occurs while downloading the BLOBs from the BLOB server.
+	 */
+	private File getFileInternal(@Nullable JobID jobId, BlobKey blobKey) throws IOException {
+		checkArgument(blobKey != null, "BLOB key cannot be null.");
+
+		final File localFile = BlobUtils.getStorageLocation(storageDir, jobId, blobKey);
+		readWriteLock.readLock().lock();
+
+		try {
+			if (localFile.exists()) {
+				return localFile;
+			}
+		} finally {
+			readWriteLock.readLock().unlock();
+		}
+
+		// download from the BlobServer directly
+		// use a temporary file (thread-safe without locking)
+		File incomingFile = createTemporaryFilename();
+		try {
+			BlobClient.downloadFromBlobServer(jobId, blobKey, false, incomingFile, serverAddress,
+				blobClientConfig, numFetchRetries);
+
+			BlobUtils.moveTempFileToStore(
+				incomingFile, jobId, blobKey, localFile, readWriteLock.writeLock(), LOG, null);
+
+			return localFile;
+		} finally {
+			// delete incomingFile from a failed download
+			if (!incomingFile.delete() && incomingFile.exists()) {
+				LOG.warn("Could not delete the staging file {} for blob key {} and job {}.",
+					incomingFile, blobKey, jobId);
+			}
+		}
+	}
+
+	@Override
+	public BlobKey put(byte[] value) throws IOException {
+		try (BlobClient bc = new BlobClient(serverAddress, blobClientConfig)) {
+			return bc.putBuffer(null, value, 0, value.length, false);
+		}
+	}
+
+	@Override
+	public BlobKey put(JobID jobId, byte[] value) throws IOException {
+		checkNotNull(jobId);
+		try (BlobClient bc = new BlobClient(serverAddress, blobClientConfig)) {
+			return bc.putBuffer(jobId, value, 0, value.length, false);
+		}
+	}
+
+	@Override
+	public BlobKey put(InputStream inputStream) throws IOException {
+		try (BlobClient bc = new BlobClient(serverAddress, blobClientConfig)) {
+			return bc.putInputStream(null, inputStream, false);
+		}
+	}
+
+	@Override
+	public BlobKey put(JobID jobId, InputStream inputStream) throws IOException {
+		checkNotNull(jobId);
+		try (BlobClient bc = new BlobClient(serverAddress, blobClientConfig)) {
+			return bc.putInputStream(jobId, inputStream, false);
+		}
+	}
+
+	@Override
+	public boolean delete(BlobKey key) {
+		return deleteInternal(null, key);
+	}
+
+	@Override
+	public boolean delete(JobID jobId, BlobKey key) {
+		checkNotNull(jobId);
+		return deleteInternal(jobId, key);
+	}
+
+	/**
+	 * Deletes the file associated with the blob key in this BLOB cache.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
+	 * @param key
+	 * 		blob key associated with the file to be deleted
+	 *
+	 * @return  <tt>true</tt> if the given blob is successfully deleted or non-existing;
+	 *          <tt>false</tt> otherwise
+	 */
+	private boolean deleteInternal(@Nullable JobID jobId, BlobKey key) {
+
+		// delete locally
+		final File localFile =
+			new File(BlobUtils.getStorageLocationPath(storageDir.getAbsolutePath(), jobId, key));
+
+		readWriteLock.writeLock().lock();
+
+		boolean deleteLocal = true;
+		try {
+			if (!localFile.delete() && localFile.exists()) {
+				LOG.warn("Failed to delete locally cached BLOB {} at {}", key,
+					localFile.getAbsolutePath());
+				deleteLocal = false;
+			}
+		} finally {
+			readWriteLock.writeLock().unlock();
+		}
+
+		// then delete on the BLOB server
+		boolean deletedGlobal;
+		try (BlobClient bc = createClient()) {
+			deletedGlobal = bc.deleteInternal(jobId, key);
+		} catch (Throwable t) {
+			deletedGlobal = false;
+		}
+		return deleteLocal && deletedGlobal;
+	}
+
+	public File getStorageDir() {
+		return this.storageDir;
+	}
+
+	public int getPort() {
+		return serverAddress.getPort();
+	}
+
+	/**
+	 * Returns a file handle to the file associated with the given blob key on the blob
+	 * server.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to (or <tt>null</tt> if job-unrelated)
+	 * @param key
+	 * 		identifying the file
+	 *
+	 * @return file handle to the file
+	 *
+	 * @throws IOException
+	 * 		if creating the directory fails
+	 */
+	@VisibleForTesting
+	public File getStorageLocation(@Nullable JobID jobId, BlobKey key) throws IOException {
+		return BlobUtils.getStorageLocation(storageDir, jobId, key);
+	}
+
+	/**
+	 * Returns a temporary file inside the BLOB server's incoming directory.
+	 *
+	 * @return a temporary file inside the BLOB server's incoming directory
+	 *
+	 * @throws IOException
+	 * 		if creating the directory fails
+	 */
+	File createTemporaryFilename() throws IOException {
+		return new File(BlobUtils.getIncomingDirectory(storageDir),
+			String.format("temp-%08d", tempFileCounter.getAndIncrement()));
+	}
+
+	private BlobClient createClient() throws IOException {
+		return new BlobClient(serverAddress, blobClientConfig);
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (shutdownRequested.compareAndSet(false, true)) {
+			LOG.info("Shutting down transient BlobCache");
+
+			// Clean up the storage directory
+			try {
+				FileUtils.deleteDirectory(storageDir);
+			} finally {
+				// Remove shutdown hook to prevent resource leaks, unless this is invoked by the shutdown hook itself
+				if (shutdownHook != null && shutdownHook != Thread.currentThread()) {
+					try {
+						Runtime.getRuntime().removeShutdownHook(shutdownHook);
+					} catch (IllegalStateException e) {
+						// race, JVM is in shutdown already, we can safely ignore this
+					} catch (Throwable t) {
+						LOG.warn("Exception while unregistering BLOB cache's cleanup shutdown hook.");
+					}
+				}
+			}
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobCache.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 
-import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
+import static org.apache.flink.runtime.blob.BlobKey.BlobType.TRANSIENT_BLOB;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -62,53 +62,53 @@ public class TransientBlobCache extends AbstractBlobCache implements TransientBl
 	}
 
 	@Override
-	public File getTransientFile(BlobKey key) throws IOException {
+	public File getFile(TransientBlobKey key) throws IOException {
 		return getFileInternal(null, key);
 	}
 
 	@Override
-	public File getTransientFile(JobID jobId, BlobKey key) throws IOException {
+	public File getFile(JobID jobId, TransientBlobKey key) throws IOException {
 		checkNotNull(jobId);
 		return getFileInternal(jobId, key);
 	}
 
 	@Override
-	public BlobKey putTransient(byte[] value) throws IOException {
+	public TransientBlobKey putTransient(byte[] value) throws IOException {
 		try (BlobClient bc = new BlobClient(serverAddress, blobClientConfig)) {
-			return bc.putBuffer(null, value, 0, value.length, TRANSIENT_BLOB);
+			return (TransientBlobKey) bc.putBuffer(null, value, 0, value.length, TRANSIENT_BLOB);
 		}
 	}
 
 	@Override
-	public BlobKey putTransient(JobID jobId, byte[] value) throws IOException {
+	public TransientBlobKey putTransient(JobID jobId, byte[] value) throws IOException {
 		checkNotNull(jobId);
 		try (BlobClient bc = new BlobClient(serverAddress, blobClientConfig)) {
-			return bc.putBuffer(jobId, value, 0, value.length, TRANSIENT_BLOB);
+			return (TransientBlobKey) bc.putBuffer(jobId, value, 0, value.length, TRANSIENT_BLOB);
 		}
 	}
 
 	@Override
-	public BlobKey putTransient(InputStream inputStream) throws IOException {
+	public TransientBlobKey putTransient(InputStream inputStream) throws IOException {
 		try (BlobClient bc = new BlobClient(serverAddress, blobClientConfig)) {
-			return bc.putInputStream(null, inputStream, TRANSIENT_BLOB);
+			return (TransientBlobKey) bc.putInputStream(null, inputStream, TRANSIENT_BLOB);
 		}
 	}
 
 	@Override
-	public BlobKey putTransient(JobID jobId, InputStream inputStream) throws IOException {
+	public TransientBlobKey putTransient(JobID jobId, InputStream inputStream) throws IOException {
 		checkNotNull(jobId);
 		try (BlobClient bc = new BlobClient(serverAddress, blobClientConfig)) {
-			return bc.putInputStream(jobId, inputStream, TRANSIENT_BLOB);
+			return (TransientBlobKey) bc.putInputStream(jobId, inputStream, TRANSIENT_BLOB);
 		}
 	}
 
 	@Override
-	public boolean deleteTransientFromCache(BlobKey key) {
+	public boolean deleteFromCache(TransientBlobKey key) {
 		return deleteInternal(null, key);
 	}
 
 	@Override
-	public boolean deleteTransientFromCache(JobID jobId, BlobKey key) {
+	public boolean deleteFromCache(JobID jobId, TransientBlobKey key) {
 		checkNotNull(jobId);
 		return deleteInternal(jobId, key);
 	}
@@ -124,7 +124,7 @@ public class TransientBlobCache extends AbstractBlobCache implements TransientBl
 	 * @return  <tt>true</tt> if the given blob is successfully deleted or non-existing;
 	 *          <tt>false</tt> otherwise
 	 */
-	private boolean deleteInternal(@Nullable JobID jobId, BlobKey key) {
+	private boolean deleteInternal(@Nullable JobID jobId, TransientBlobKey key) {
 		final File localFile =
 			new File(BlobUtils.getStorageLocationPath(storageDir.getAbsolutePath(), jobId, key));
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobKey.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobKey.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.annotation.VisibleForTesting;
+
+/**
+ * BLOB key referencing transient BLOB files.
+ */
+public final class TransientBlobKey extends BlobKey {
+
+	/**
+	 * Constructs a new BLOB key.
+	 */
+	@VisibleForTesting
+	public TransientBlobKey() {
+		super(BlobType.TRANSIENT_BLOB);
+	}
+
+	/**
+	 * Constructs a new BLOB key from the given byte array.
+	 *
+	 * @param key
+	 *        the actual key data
+	 */
+	TransientBlobKey(byte[] key) {
+		super(BlobType.TRANSIENT_BLOB, key);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobService.java
@@ -57,7 +57,7 @@ public interface TransientBlobService extends Closeable {
 	 * @throws IOException
 	 * 		if any other error occurs when retrieving the file
 	 */
-	File getTransientFile(BlobKey key) throws IOException;
+	File getFile(TransientBlobKey key) throws IOException;
 
 	/**
 	 * Returns the path to a local copy of the file associated with the provided job ID and blob
@@ -75,7 +75,7 @@ public interface TransientBlobService extends Closeable {
 	 * @throws IOException
 	 * 		if any other error occurs when retrieving the file
 	 */
-	File getTransientFile(JobID jobId, BlobKey key) throws IOException;
+	File getFile(JobID jobId, TransientBlobKey key) throws IOException;
 
 	// --------------------------------------------------------------------------------------------
 	//  PUT
@@ -92,7 +92,7 @@ public interface TransientBlobService extends Closeable {
 	 * @throws IOException
 	 * 		thrown if an I/O error occurs while uploading the data to the BLOB server
 	 */
-	BlobKey putTransient(byte[] value) throws IOException;
+	TransientBlobKey putTransient(byte[] value) throws IOException;
 
 	/**
 	 * Uploads the data of the given byte array for the given job to the BLOB server.
@@ -107,7 +107,7 @@ public interface TransientBlobService extends Closeable {
 	 * @throws IOException
 	 * 		thrown if an I/O error occurs while uploading the data to the BLOB server
 	 */
-	BlobKey putTransient(JobID jobId, byte[] value) throws IOException;
+	TransientBlobKey putTransient(JobID jobId, byte[] value) throws IOException;
 
 	/**
 	 * Uploads the (job-unrelated) data from the given input stream to the BLOB server.
@@ -121,7 +121,7 @@ public interface TransientBlobService extends Closeable {
 	 * 		thrown if an I/O error occurs while reading the data from the input stream or uploading the
 	 * 		data to the BLOB server
 	 */
-	BlobKey putTransient(InputStream inputStream) throws IOException;
+	TransientBlobKey putTransient(InputStream inputStream) throws IOException;
 
 	/**
 	 * Uploads the data from the given input stream for the given job to the BLOB server.
@@ -137,7 +137,7 @@ public interface TransientBlobService extends Closeable {
 	 * 		thrown if an I/O error occurs while reading the data from the input stream or uploading the
 	 * 		data to the BLOB server
 	 */
-	BlobKey putTransient(JobID jobId, InputStream inputStream) throws IOException;
+	TransientBlobKey putTransient(JobID jobId, InputStream inputStream) throws IOException;
 
 	// --------------------------------------------------------------------------------------------
 	//  DELETE
@@ -152,7 +152,7 @@ public interface TransientBlobService extends Closeable {
 	 * @return  <tt>true</tt> if the given blob is successfully deleted or non-existing;
 	 *          <tt>false</tt> otherwise
 	 */
-	boolean deleteTransientFromCache(BlobKey key);
+	boolean deleteFromCache(TransientBlobKey key);
 
 	/**
 	 * Deletes the file associated with the provided job ID and blob key from the local cache.
@@ -165,6 +165,6 @@ public interface TransientBlobService extends Closeable {
 	 * @return  <tt>true</tt> if the given blob is successfully deleted or non-existing;
 	 *          <tt>false</tt> otherwise
 	 */
-	boolean deleteTransientFromCache(JobID jobId, BlobKey key);
+	boolean deleteFromCache(JobID jobId, TransientBlobKey key);
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobService.java
@@ -27,15 +27,14 @@ import java.io.InputStream;
 
 /**
  * A service to retrieve transient binary large objects (BLOBs).
- * <p>
- * These include per-job BLOBs that are , e.g. a job's JAR files, parts of an off-loaded {@link
- * org.apache.flink.runtime.deployment.TaskDeploymentDescriptor} or files in the {@link
- * org.apache.flink.api.common.cache.DistributedCache}.
- * <p>
- * Note: None of these BLOBs is highly available (HA). This case is covered by BLOBs in the {@link
- * PermanentBlobService}.
- * <p>
- * TODO: change API to not rely on local files but return {@link InputStream} objects instead and
+ *
+ * <p>These may include per-job BLOBs like files in the {@link
+ * org.apache.flink.api.common.cache.DistributedCache}, for example.
+ *
+ * <p>Note: None of these BLOBs is highly available (HA). This case is covered by BLOBs in the
+ * {@link PermanentBlobService}.
+ *
+ * <p>TODO: change API to not rely on local files but return {@link InputStream} objects instead and
  * change getFile to get-and-delete semantics
  */
 public interface TransientBlobService extends Closeable {
@@ -58,7 +57,7 @@ public interface TransientBlobService extends Closeable {
 	 * @throws IOException
 	 * 		if any other error occurs when retrieving the file
 	 */
-	File getFile(BlobKey key) throws IOException;
+	File getTransientFile(BlobKey key) throws IOException;
 
 	/**
 	 * Returns the path to a local copy of the file associated with the provided job ID and blob
@@ -76,7 +75,7 @@ public interface TransientBlobService extends Closeable {
 	 * @throws IOException
 	 * 		if any other error occurs when retrieving the file
 	 */
-	File getFile(JobID jobId, BlobKey key) throws IOException;
+	File getTransientFile(JobID jobId, BlobKey key) throws IOException;
 
 	// --------------------------------------------------------------------------------------------
 	//  PUT
@@ -93,7 +92,7 @@ public interface TransientBlobService extends Closeable {
 	 * @throws IOException
 	 * 		thrown if an I/O error occurs while uploading the data to the BLOB server
 	 */
-	BlobKey put(byte[] value) throws IOException;
+	BlobKey putTransient(byte[] value) throws IOException;
 
 	/**
 	 * Uploads the data of the given byte array for the given job to the BLOB server.
@@ -108,7 +107,7 @@ public interface TransientBlobService extends Closeable {
 	 * @throws IOException
 	 * 		thrown if an I/O error occurs while uploading the data to the BLOB server
 	 */
-	BlobKey put(JobID jobId, byte[] value) throws IOException;
+	BlobKey putTransient(JobID jobId, byte[] value) throws IOException;
 
 	/**
 	 * Uploads the (job-unrelated) data from the given input stream to the BLOB server.
@@ -122,7 +121,7 @@ public interface TransientBlobService extends Closeable {
 	 * 		thrown if an I/O error occurs while reading the data from the input stream or uploading the
 	 * 		data to the BLOB server
 	 */
-	BlobKey put(InputStream inputStream) throws IOException;
+	BlobKey putTransient(InputStream inputStream) throws IOException;
 
 	/**
 	 * Uploads the data from the given input stream for the given job to the BLOB server.
@@ -138,7 +137,7 @@ public interface TransientBlobService extends Closeable {
 	 * 		thrown if an I/O error occurs while reading the data from the input stream or uploading the
 	 * 		data to the BLOB server
 	 */
-	BlobKey put(JobID jobId, InputStream inputStream) throws IOException;
+	BlobKey putTransient(JobID jobId, InputStream inputStream) throws IOException;
 
 	// --------------------------------------------------------------------------------------------
 	//  DELETE
@@ -153,7 +152,7 @@ public interface TransientBlobService extends Closeable {
 	 * @return  <tt>true</tt> if the given blob is successfully deleted or non-existing;
 	 *          <tt>false</tt> otherwise
 	 */
-	boolean delete(BlobKey key);
+	boolean deleteTransient(BlobKey key);
 
 	/**
 	 * Deletes the file associated with the provided job ID and blob key.
@@ -166,6 +165,6 @@ public interface TransientBlobService extends Closeable {
 	 * @return  <tt>true</tt> if the given blob is successfully deleted or non-existing;
 	 *          <tt>false</tt> otherwise
 	 */
-	boolean delete(JobID jobId, BlobKey key);
+	boolean deleteTransient(JobID jobId, BlobKey key);
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobService.java
@@ -26,7 +26,8 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * A service to retrieve transient binary large objects (BLOBs).
+ * A service to retrieve transient binary large objects (BLOBs) which are deleted on the
+ * {@link BlobServer} when they are retrieved.
  *
  * <p>These may include per-job BLOBs like files in the {@link
  * org.apache.flink.api.common.cache.DistributedCache}, for example.
@@ -34,8 +35,7 @@ import java.io.InputStream;
  * <p>Note: None of these BLOBs is highly available (HA). This case is covered by BLOBs in the
  * {@link PermanentBlobService}.
  *
- * <p>TODO: change API to not rely on local files but return {@link InputStream} objects instead and
- * change getFile to get-and-delete semantics
+ * <p>TODO: change API to not rely on local files but return {@link InputStream} objects
  */
 public interface TransientBlobService extends Closeable {
 
@@ -144,7 +144,7 @@ public interface TransientBlobService extends Closeable {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Deletes the (job-unrelated) file associated with the provided blob key.
+	 * Deletes the (job-unrelated) file associated with the provided blob key from the local cache.
 	 *
 	 * @param key
 	 * 		associated with the file to be deleted
@@ -152,10 +152,10 @@ public interface TransientBlobService extends Closeable {
 	 * @return  <tt>true</tt> if the given blob is successfully deleted or non-existing;
 	 *          <tt>false</tt> otherwise
 	 */
-	boolean deleteTransient(BlobKey key);
+	boolean deleteTransientFromCache(BlobKey key);
 
 	/**
-	 * Deletes the file associated with the provided job ID and blob key.
+	 * Deletes the file associated with the provided job ID and blob key from the local cache.
 	 *
 	 * @param jobId
 	 * 		ID of the job this blob belongs to
@@ -165,6 +165,6 @@ public interface TransientBlobService extends Closeable {
 	 * @return  <tt>true</tt> if the given blob is successfully deleted or non-existing;
 	 *          <tt>false</tt> otherwise
 	 */
-	boolean deleteTransient(JobID jobId, BlobKey key);
+	boolean deleteTransientFromCache(JobID jobId, BlobKey key);
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobService.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * A service to retrieve transient binary large objects (BLOBs).
+ * <p>
+ * These include per-job BLOBs that are , e.g. a job's JAR files, parts of an off-loaded {@link
+ * org.apache.flink.runtime.deployment.TaskDeploymentDescriptor} or files in the {@link
+ * org.apache.flink.api.common.cache.DistributedCache}.
+ * <p>
+ * Note: None of these BLOBs is highly available (HA). This case is covered by BLOBs in the {@link
+ * PermanentBlobService}.
+ * <p>
+ * TODO: change API to not rely on local files but return {@link InputStream} objects instead and
+ * change getFile to get-and-delete semantics
+ */
+public interface TransientBlobService extends Closeable {
+
+	// --------------------------------------------------------------------------------------------
+	//  GET
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Returns the path to a local copy of the (job-unrelated) file associated with the provided
+	 * blob key.
+	 *
+	 * @param key
+	 * 		blob key associated with the requested file
+	 *
+	 * @return The path to the file.
+	 *
+	 * @throws java.io.FileNotFoundException
+	 * 		when the path does not exist;
+	 * @throws IOException
+	 * 		if any other error occurs when retrieving the file
+	 */
+	File getFile(BlobKey key) throws IOException;
+
+	/**
+	 * Returns the path to a local copy of the file associated with the provided job ID and blob
+	 * key.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to
+	 * @param key
+	 * 		blob key associated with the requested file
+	 *
+	 * @return The path to the file.
+	 *
+	 * @throws java.io.FileNotFoundException
+	 * 		when the path does not exist;
+	 * @throws IOException
+	 * 		if any other error occurs when retrieving the file
+	 */
+	File getFile(JobID jobId, BlobKey key) throws IOException;
+
+	// --------------------------------------------------------------------------------------------
+	//  PUT
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Uploads the (job-unrelated) data of the given byte array to the BLOB server.
+	 *
+	 * @param value
+	 * 		the buffer to upload
+	 *
+	 * @return the computed BLOB key identifying the BLOB on the server
+	 *
+	 * @throws IOException
+	 * 		thrown if an I/O error occurs while uploading the data to the BLOB server
+	 */
+	BlobKey put(byte[] value) throws IOException;
+
+	/**
+	 * Uploads the data of the given byte array for the given job to the BLOB server.
+	 *
+	 * @param jobId
+	 * 		the ID of the job the BLOB belongs to
+	 * @param value
+	 * 		the buffer to upload
+	 *
+	 * @return the computed BLOB key identifying the BLOB on the server
+	 *
+	 * @throws IOException
+	 * 		thrown if an I/O error occurs while uploading the data to the BLOB server
+	 */
+	BlobKey put(JobID jobId, byte[] value) throws IOException;
+
+	/**
+	 * Uploads the (job-unrelated) data from the given input stream to the BLOB server.
+	 *
+	 * @param inputStream
+	 * 		the input stream to read the data from
+	 *
+	 * @return the computed BLOB key identifying the BLOB on the server
+	 *
+	 * @throws IOException
+	 * 		thrown if an I/O error occurs while reading the data from the input stream or uploading the
+	 * 		data to the BLOB server
+	 */
+	BlobKey put(InputStream inputStream) throws IOException;
+
+	/**
+	 * Uploads the data from the given input stream for the given job to the BLOB server.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to
+	 * @param inputStream
+	 * 		the input stream to read the data from
+	 *
+	 * @return the computed BLOB key identifying the BLOB on the server
+	 *
+	 * @throws IOException
+	 * 		thrown if an I/O error occurs while reading the data from the input stream or uploading the
+	 * 		data to the BLOB server
+	 */
+	BlobKey put(JobID jobId, InputStream inputStream) throws IOException;
+
+	// --------------------------------------------------------------------------------------------
+	//  DELETE
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Deletes the (job-unrelated) file associated with the provided blob key.
+	 *
+	 * @param key
+	 * 		associated with the file to be deleted
+	 *
+	 * @return  <tt>true</tt> if the given blob is successfully deleted or non-existing;
+	 *          <tt>false</tt> otherwise
+	 */
+	boolean delete(BlobKey key);
+
+	/**
+	 * Deletes the file associated with the provided job ID and blob key.
+	 *
+	 * @param jobId
+	 * 		ID of the job this blob belongs to
+	 * @param key
+	 * 		associated with the file to be deleted
+	 *
+	 * @return  <tt>true</tt> if the given blob is successfully deleted or non-existing;
+	 *          <tt>false</tt> otherwise
+	 */
+	boolean delete(JobID jobId, BlobKey key);
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/VoidBlobStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/VoidBlobStore.java
@@ -29,11 +29,13 @@ import java.io.IOException;
 public class VoidBlobStore implements BlobStoreService {
 
 	@Override
-	public void put(File localFile, JobID jobId, BlobKey blobKey) throws IOException {
+	public boolean put(File localFile, JobID jobId, BlobKey blobKey) throws IOException {
+		return false;
 	}
 
 	@Override
-	public void get(JobID jobId, BlobKey blobKey, File localFile) throws IOException {
+	public boolean get(JobID jobId, BlobKey blobKey, File localFile) throws IOException {
+		return false;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
@@ -215,10 +215,10 @@ public class JobClient {
 			JobManagerMessages.ClassloadingProps props = optProps.get();
 
 			InetSocketAddress serverAddress = new InetSocketAddress(jobManager.getHostname(), props.blobManagerPort());
-			final PermanentBlobCache blobClient;
+			final PermanentBlobCache permanentBlobCache;
 			try {
 				// TODO: Fix lifecycle of PermanentBlobCache to properly close it upon usage
-				blobClient = new PermanentBlobCache(serverAddress, config, highAvailabilityServices.createBlobStore());
+				permanentBlobCache = new PermanentBlobCache(serverAddress, config, highAvailabilityServices.createBlobStore());
 			} catch (IOException e) {
 				throw new JobRetrievalException(
 					jobID,
@@ -234,10 +234,10 @@ public class JobClient {
 			int pos = 0;
 			for (BlobKey blobKey : props.requiredJarFiles()) {
 				try {
-					allURLs[pos++] = blobClient.getHAFile(jobID, blobKey).toURI().toURL();
+					allURLs[pos++] = permanentBlobCache.getPermanentFile(jobID, blobKey).toURI().toURL();
 				} catch (Exception e) {
 					try {
-						blobClient.close();
+						permanentBlobCache.close();
 					} catch (IOException ioe) {
 						LOG.warn("Could not properly close the BlobClient.", ioe);
 					}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
@@ -32,8 +32,8 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.ListeningBehaviour;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -226,15 +226,15 @@ public class JobClient {
 					e);
 			}
 
-			final Collection<BlobKey> requiredJarFiles = props.requiredJarFiles();
+			final Collection<PermanentBlobKey> requiredJarFiles = props.requiredJarFiles();
 			final Collection<URL> requiredClasspaths = props.requiredClasspaths();
 
 			final URL[] allURLs = new URL[requiredJarFiles.size() + requiredClasspaths.size()];
 
 			int pos = 0;
-			for (BlobKey blobKey : props.requiredJarFiles()) {
+			for (PermanentBlobKey blobKey : props.requiredJarFiles()) {
 				try {
-					allURLs[pos++] = permanentBlobCache.getPermanentFile(jobID, blobKey).toURI().toURL();
+					allURLs[pos++] = permanentBlobCache.getFile(jobID, blobKey).toURI().toURL();
 				} catch (Exception e) {
 					try {
 						permanentBlobCache.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
@@ -32,8 +32,8 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.ListeningBehaviour;
-import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -215,10 +215,10 @@ public class JobClient {
 			JobManagerMessages.ClassloadingProps props = optProps.get();
 
 			InetSocketAddress serverAddress = new InetSocketAddress(jobManager.getHostname(), props.blobManagerPort());
-			final BlobCache blobClient;
+			final PermanentBlobCache blobClient;
 			try {
-				// TODO: Fix lifecycle of BlobCache to properly close it upon usage
-				blobClient = new BlobCache(serverAddress, config, highAvailabilityServices.createBlobStore());
+				// TODO: Fix lifecycle of PermanentBlobCache to properly close it upon usage
+				blobClient = new PermanentBlobCache(serverAddress, config, highAvailabilityServices.createBlobStore());
 			} catch (IOException e) {
 				throw new JobRetrievalException(
 					jobID,
@@ -234,7 +234,7 @@ public class JobClient {
 			int pos = 0;
 			for (BlobKey blobKey : props.requiredJarFiles()) {
 				try {
-					allURLs[pos++] = blobClient.getFile(jobID, blobKey).toURI().toURL();
+					allURLs[pos++] = blobClient.getHAFile(jobID, blobKey).toURI().toURL();
 				} catch (Exception e) {
 					try {
 						blobClient.close();
@@ -450,7 +450,7 @@ public class JobClient {
 				"JobManager did not respond within " + timeout, e);
 		} catch (Throwable throwable) {
 			Throwable stripped = ExceptionUtils.stripExecutionException(throwable);
-			
+
 			try {
 				ExceptionUtils.tryDeserializeAndThrow(stripped, classLoader);
 			} catch (JobExecutionException jee) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -177,6 +177,7 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 		commonRpcService = createRpcService(configuration, bindAddress, portRange);
 		haServices = createHaServices(configuration, commonRpcService.getExecutor());
 		blobServer = new BlobServer(configuration, haServices.createBlobStore());
+		blobServer.start();
 		heartbeatServices = createHeartbeatServices(configuration);
 		metricRegistry = createMetricRegistry(configuration);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.execution.librarycache;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.blob.BlobKey;
-import org.apache.flink.runtime.blob.BlobService;
+import org.apache.flink.runtime.blob.PermanentBlobService;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.util.ExceptionUtils;
 
@@ -45,7 +45,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Provides facilities to download a set of libraries (typically JAR files) for a job from a
- * {@link BlobService} and create a class loader with references to them.
+ * {@link PermanentBlobService} and create a class loader with references to them.
  */
 public class BlobLibraryCacheManager implements LibraryCacheManager {
 
@@ -62,15 +62,14 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 	private final Map<JobID, LibraryCacheEntry> cacheEntries = new HashMap<>();
 
 	/** The blob service to download libraries */
-	private final BlobService blobService;
+	private final PermanentBlobService blobService;
 
 	/** The resolve order to use when creating a {@link ClassLoader}. */
 	private final FlinkUserCodeClassLoaders.ResolveOrder classLoaderResolveOrder;
 
 	// --------------------------------------------------------------------------------------------
 
-	public BlobLibraryCacheManager(
-			BlobService blobService,
+	public BlobLibraryCacheManager(PermanentBlobService blobService,
 			FlinkUserCodeClassLoaders.ResolveOrder classLoaderResolveOrder) {
 		this.blobService = checkNotNull(blobService);
 		this.classLoaderResolveOrder = checkNotNull(classLoaderResolveOrder);
@@ -108,7 +107,7 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 				try {
 					// add URLs to locally cached JAR files
 					for (BlobKey key : requiredJarFiles) {
-						urls[count] = blobService.getFile(jobId, key).toURI().toURL();
+						urls[count] = blobService.getHAFile(jobId, key).toURI().toURL();
 						++count;
 					}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.execution.librarycache;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobService;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.util.ExceptionUtils;
@@ -76,7 +76,7 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 	}
 
 	@Override
-	public void registerJob(JobID id, Collection<BlobKey> requiredJarFiles, Collection<URL> requiredClasspaths)
+	public void registerJob(JobID id, Collection<PermanentBlobKey> requiredJarFiles, Collection<URL> requiredClasspaths)
 		throws IOException {
 		registerTask(id, JOB_ATTEMPT_ID, requiredJarFiles, requiredClasspaths);
 	}
@@ -85,7 +85,7 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 	public void registerTask(
 		JobID jobId,
 		ExecutionAttemptID task,
-		@Nullable Collection<BlobKey> requiredJarFiles,
+		@Nullable Collection<PermanentBlobKey> requiredJarFiles,
 		@Nullable Collection<URL> requiredClasspaths) throws IOException {
 
 		checkNotNull(jobId, "The JobId must not be null.");
@@ -106,8 +106,8 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 				int count = 0;
 				try {
 					// add URLs to locally cached JAR files
-					for (BlobKey key : requiredJarFiles) {
-						urls[count] = blobService.getPermanentFile(jobId, key).toURI().toURL();
+					for (PermanentBlobKey key : requiredJarFiles) {
+						urls[count] = blobService.getFile(jobId, key).toURI().toURL();
 						++count;
 					}
 
@@ -219,7 +219,7 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 		 * <p>The purpose of this is to make sure, future registrations do not differ in content as
 		 * this is a contract of the {@link BlobLibraryCacheManager}.
 		 */
-		private final Set<BlobKey> libraries;
+		private final Set<PermanentBlobKey> libraries;
 
 		/**
 		 * Set of class path URLs used for a previous job/task registration.
@@ -245,7 +245,7 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 		 * 		reference holder ID
 		 */
 		LibraryCacheEntry(
-				Collection<BlobKey> requiredLibraries,
+				Collection<PermanentBlobKey> requiredLibraries,
 				Collection<URL> requiredClasspaths,
 				URL[] libraryURLs,
 				ExecutionAttemptID initialReference,
@@ -273,12 +273,12 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 			return classLoader;
 		}
 
-		public Set<BlobKey> getLibraries() {
+		public Set<PermanentBlobKey> getLibraries() {
 			return libraries;
 		}
 
 		public void register(
-				ExecutionAttemptID task, Collection<BlobKey> requiredLibraries,
+				ExecutionAttemptID task, Collection<PermanentBlobKey> requiredLibraries,
 				Collection<URL> requiredClasspaths) {
 
 			// Make sure the previous registration referred to the same libraries and class paths.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -107,7 +107,7 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 				try {
 					// add URLs to locally cached JAR files
 					for (BlobKey key : requiredJarFiles) {
-						urls[count] = blobService.getHAFile(jobId, key).toURI().toURL();
+						urls[count] = blobService.getPermanentFile(jobId, key).toURI().toURL();
 						++count;
 					}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FallbackLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FallbackLibraryCacheManager.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.execution.librarycache;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,12 +37,12 @@ public class FallbackLibraryCacheManager implements LibraryCacheManager {
 	}
 
 	@Override
-	public void registerJob(JobID id, Collection<BlobKey> requiredJarFiles, Collection<URL> requiredClasspaths) {
+	public void registerJob(JobID id, Collection<PermanentBlobKey> requiredJarFiles, Collection<URL> requiredClasspaths) {
 		LOG.warn("FallbackLibraryCacheManager cannot download files associated with blob keys.");
 	}
 
 	@Override
-	public void registerTask(JobID id, ExecutionAttemptID execution, Collection<BlobKey> requiredJarFiles,
+	public void registerTask(JobID id, ExecutionAttemptID execution, Collection<PermanentBlobKey> requiredJarFiles,
 		Collection<URL> requiredClasspaths) {
 		LOG.warn("FallbackLibraryCacheManager cannot download files associated with blob keys.");
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.runtime.execution.librarycache;
 
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 
 import java.io.IOException;
@@ -48,7 +48,7 @@ public interface LibraryCacheManager {
 	 *
 	 * @see #unregisterJob(JobID) counterpart of this method
 	 */
-	void registerJob(JobID id, Collection<BlobKey> requiredJarFiles, Collection<URL> requiredClasspaths)
+	void registerJob(JobID id, Collection<PermanentBlobKey> requiredJarFiles, Collection<URL> requiredClasspaths)
 		throws IOException;
 
 	/**
@@ -63,7 +63,7 @@ public interface LibraryCacheManager {
 	 *
 	 * @see #unregisterTask(JobID, ExecutionAttemptID) counterpart of this method
 	 */
-	void registerTask(JobID id, ExecutionAttemptID execution, Collection<BlobKey> requiredJarFiles,
+	void registerTask(JobID id, ExecutionAttemptID execution, Collection<PermanentBlobKey> requiredJarFiles,
 		Collection<URL> requiredClasspaths) throws IOException;
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -31,7 +31,7 @@ import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.StoppingException;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
-import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
@@ -304,8 +304,8 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 			timeout,
 			restartStrategy,
 			new RestartAllStrategy.Factory(),
-			Collections.<BlobKey>emptyList(),
-			Collections.<URL>emptyList(),
+			Collections.emptyList(),
+			Collections.emptyList(),
 			slotProvider,
 			ExecutionGraph.class.getClassLoader());
 	}
@@ -320,7 +320,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 			Time timeout,
 			RestartStrategy restartStrategy,
 			FailoverStrategy.Factory failoverStrategyFactory,
-			List<BlobKey> requiredJarFiles,
+			List<PermanentBlobKey> requiredJarFiles,
 			List<URL> requiredClasspaths,
 			SlotProvider slotProvider,
 			ClassLoader userClassLoader) {
@@ -536,7 +536,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	 * Returns a list of BLOB keys referring to the JAR files required to run this job
 	 * @return list of BLOB keys referring to the JAR files required to run this job
 	 */
-	public Collection<BlobKey> getRequiredJarFiles() {
+	public Collection<PermanentBlobKey> getRequiredJarFiles() {
 		return jobInformation.getRequiredJarFileBlobKeys();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobInformation.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.executiongraph;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
 
@@ -49,7 +49,7 @@ public class JobInformation implements Serializable {
 	private final Configuration jobConfiguration;
 
 	/** Blob keys for the required jar files */
-	private final Collection<BlobKey> requiredJarFileBlobKeys;
+	private final Collection<PermanentBlobKey> requiredJarFileBlobKeys;
 
 	/** URLs specifying the classpath to add to the class loader */
 	private final Collection<URL> requiredClasspathURLs;
@@ -60,7 +60,7 @@ public class JobInformation implements Serializable {
 			String jobName,
 			SerializedValue<ExecutionConfig> serializedExecutionConfig,
 			Configuration jobConfiguration,
-			Collection<BlobKey> requiredJarFileBlobKeys,
+			Collection<PermanentBlobKey> requiredJarFileBlobKeys,
 			Collection<URL> requiredClasspathURLs) {
 		this.jobId = Preconditions.checkNotNull(jobId);
 		this.jobName = Preconditions.checkNotNull(jobName);
@@ -86,7 +86,7 @@ public class JobInformation implements Serializable {
 		return jobConfiguration;
 	}
 
-	public Collection<BlobKey> getRequiredJarFileBlobKeys() {
+	public Collection<PermanentBlobKey> getRequiredJarFileBlobKeys() {
 		return requiredJarFileBlobKeys;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -535,7 +535,6 @@ public class JobGraph implements Serializable {
 			InetSocketAddress blobServerAddress,
 			Configuration blobClientConfig) throws IOException {
 		if (!userJars.isEmpty()) {
-			// TODO: make use of job-related BLOBs after adapting the BlobLibraryCacheManager
 			List<BlobKey> blobKeys = BlobClient.uploadJarFiles(blobServerAddress, blobClientConfig, jobID, userJars);
 
 			for (BlobKey blobKey : blobKeys) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.blob.BlobClient;
-import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.util.SerializedValue;
 
@@ -99,7 +99,7 @@ public class JobGraph implements Serializable {
 	private final List<Path> userJars = new ArrayList<Path>();
 
 	/** Set of blob keys identifying the JAR files required to run this job. */
-	private final List<BlobKey> userJarBlobKeys = new ArrayList<BlobKey>();
+	private final List<PermanentBlobKey> userJarBlobKeys = new ArrayList<>();
 
 	/** List of classpaths required to run this job. */
 	private List<URL> classpaths = Collections.emptyList();
@@ -494,7 +494,7 @@ public class JobGraph implements Serializable {
 	 * @param key
 	 *        path of the JAR file required to run the job on a task manager
 	 */
-	public void addBlob(BlobKey key) {
+	public void addBlob(PermanentBlobKey key) {
 		if (key == null) {
 			throw new IllegalArgumentException();
 		}
@@ -518,7 +518,7 @@ public class JobGraph implements Serializable {
 	 *
 	 * @return set of BLOB keys referring to the JAR files required to run this job
 	 */
-	public List<BlobKey> getUserJarBlobKeys() {
+	public List<PermanentBlobKey> getUserJarBlobKeys() {
 		return this.userJarBlobKeys;
 	}
 
@@ -535,9 +535,10 @@ public class JobGraph implements Serializable {
 			InetSocketAddress blobServerAddress,
 			Configuration blobClientConfig) throws IOException {
 		if (!userJars.isEmpty()) {
-			List<BlobKey> blobKeys = BlobClient.uploadJarFiles(blobServerAddress, blobClientConfig, jobID, userJars);
+			List<PermanentBlobKey> blobKeys = BlobClient.uploadJarFiles(
+				blobServerAddress, blobClientConfig, jobID, userJars);
 
-			for (BlobKey blobKey : blobKeys) {
+			for (PermanentBlobKey blobKey : blobKeys) {
 				if (!userJarBlobKeys.contains(blobKey)) {
 					userJarBlobKeys.add(blobKey);
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/ActorTaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/ActorTaskManagerGateway.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.jobmanager.slots;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.messages.StopCluster;
@@ -209,24 +209,24 @@ public class ActorTaskManagerGateway implements TaskManagerGateway {
 	}
 
 	@Override
-	public CompletableFuture<BlobKey> requestTaskManagerLog(Time timeout) {
+	public CompletableFuture<TransientBlobKey> requestTaskManagerLog(Time timeout) {
 		return requestTaskManagerLog((TaskManagerMessages.RequestTaskManagerLog) TaskManagerMessages.getRequestTaskManagerLog(), timeout);
 	}
 
 	@Override
-	public CompletableFuture<BlobKey> requestTaskManagerStdout(Time timeout) {
+	public CompletableFuture<TransientBlobKey> requestTaskManagerStdout(Time timeout) {
 		return requestTaskManagerLog((TaskManagerMessages.RequestTaskManagerLog) TaskManagerMessages.getRequestTaskManagerStdout(), timeout);
 	}
 
-	private CompletableFuture<BlobKey> requestTaskManagerLog(TaskManagerMessages.RequestTaskManagerLog request, Time timeout) {
+	private CompletableFuture<TransientBlobKey> requestTaskManagerLog(TaskManagerMessages.RequestTaskManagerLog request, Time timeout) {
 		Preconditions.checkNotNull(request);
 		Preconditions.checkNotNull(timeout);
 
-		scala.concurrent.Future<BlobKey> blobKeyFuture = actorGateway
+		scala.concurrent.Future<TransientBlobKey> blobKeyFuture = actorGateway
 			.ask(
 				request,
 				new FiniteDuration(timeout.getSize(), timeout.getUnit()))
-			.mapTo(ClassTag$.MODULE$.<BlobKey>apply(BlobKey.class));
+			.mapTo(ClassTag$.MODULE$.<TransientBlobKey>apply(TransientBlobKey.class));
 
 		return FutureUtils.toJava(blobKeyFuture);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.jobmanager.slots;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
@@ -177,7 +177,7 @@ public interface TaskManagerGateway {
 	 * @param timeout for the request
 	 * @return Future blob key under which the task manager log has been stored
 	 */
-	CompletableFuture<BlobKey> requestTaskManagerLog(final Time timeout);
+	CompletableFuture<TransientBlobKey> requestTaskManagerLog(final Time timeout);
 
 	/**
 	 * Request the task manager stdout from the task manager.
@@ -185,5 +185,5 @@ public interface TaskManagerGateway {
 	 * @param timeout for the request
 	 * @return Future blob key under which the task manager stdout file has been stored
 	 */
-	CompletableFuture<BlobKey> requestTaskManagerStdout(final Time timeout);
+	CompletableFuture<TransientBlobKey> requestTaskManagerStdout(final Time timeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
@@ -19,7 +19,7 @@ package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
@@ -122,13 +122,13 @@ public class RpcTaskManagerGateway implements TaskManagerGateway {
 	}
 
 	@Override
-	public CompletableFuture<BlobKey> requestTaskManagerLog(Time timeout) {
+	public CompletableFuture<TransientBlobKey> requestTaskManagerLog(Time timeout) {
 //		return taskExecutorGateway.requestTaskManagerLog(timeout);
 		throw new UnsupportedOperationException("Operation is not yet supported.");
 	}
 
 	@Override
-	public CompletableFuture<BlobKey> requestTaskManagerStdout(Time timeout) {
+	public CompletableFuture<TransientBlobKey> requestTaskManagerStdout(Time timeout) {
 //		return taskExecutorGateway.requestTaskManagerStdout(timeout);
 		throw new UnsupportedOperationException("Operation is not yet supported.");
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/message/ClassloadingProps.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/message/ClassloadingProps.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.jobmaster.message;
 
-import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 
 import java.io.Serializable;
 import java.net.URL;
@@ -33,7 +33,7 @@ public class ClassloadingProps implements Serializable {
 
 	private final int blobManagerPort;
 
-	private final Collection<BlobKey> requiredJarFiles;
+	private final Collection<PermanentBlobKey> requiredJarFiles;
 
 	private final Collection<URL> requiredClasspaths;
 
@@ -46,7 +46,7 @@ public class ClassloadingProps implements Serializable {
 	 */
 	public ClassloadingProps(
 		final int blobManagerPort,
-		final Collection<BlobKey> requiredJarFiles,
+		final Collection<PermanentBlobKey> requiredJarFiles,
 		final Collection<URL> requiredClasspaths)
 	{
 		this.blobManagerPort = blobManagerPort;
@@ -58,7 +58,7 @@ public class ClassloadingProps implements Serializable {
 		return blobManagerPort;
 	}
 
-	public Collection<BlobKey> getRequiredJarFiles() {
+	public Collection<PermanentBlobKey> getRequiredJarFiles() {
 		return requiredJarFiles;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -247,6 +247,7 @@ public class MiniCluster {
 					commonRpcService.getExecutor());
 
 				blobServer = new BlobServer(configuration, haServices.createBlobStore());
+				blobServer.start();
 
 				heartbeatServices = HeartbeatServices.fromConfiguration(configuration);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/TaskManagerLogHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/TaskManagerLogHandler.java
@@ -29,9 +29,8 @@ package org.apache.flink.runtime.rest.handler.legacy;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
-import org.apache.flink.runtime.blob.BlobView;
+import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.jobmaster.JobManagerGateway;
@@ -39,7 +38,6 @@ import org.apache.flink.runtime.rest.handler.RedirectHandler;
 import org.apache.flink.runtime.rest.handler.WebHandler;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
@@ -106,14 +104,12 @@ public class TaskManagerLogHandler extends RedirectHandler<JobManagerGateway> im
 	private final Configuration config;
 
 	/** Future of the blob cache. */
-	private CompletableFuture<BlobCache> cache;
+	private CompletableFuture<TransientBlobCache> cache;
 
 	/** Indicates which log file should be displayed. */
 	private FileMode fileMode;
 
 	private final Executor executor;
-
-	private final BlobView blobView;
 
 	/** Used to control whether this handler serves the .log or .out file. */
 	public enum FileMode {
@@ -127,15 +123,12 @@ public class TaskManagerLogHandler extends RedirectHandler<JobManagerGateway> im
 		CompletableFuture<String> localJobManagerAddressPromise,
 		Time timeout,
 		FileMode fileMode,
-		Configuration config,
-		BlobView blobView) {
+		Configuration config) {
 		super(localJobManagerAddressPromise, retriever, timeout);
 
 		this.executor = checkNotNull(executor);
 		this.config = config;
 		this.fileMode = fileMode;
-
-		this.blobView = Preconditions.checkNotNull(blobView, "blobView");
 	}
 
 	@Override
@@ -159,7 +152,7 @@ public class TaskManagerLogHandler extends RedirectHandler<JobManagerGateway> im
 			cache = blobPortFuture.thenApplyAsync(
 				(Integer port) -> {
 					try {
-						return new BlobCache(new InetSocketAddress(jobManagerGateway.getHostname(), port), config, blobView);
+						return new TransientBlobCache(new InetSocketAddress(jobManagerGateway.getHostname(), port), config);
 					} catch (IOException e) {
 						throw new CompletionException(new FlinkException("Could not create BlobCache.", e));
 					}
@@ -198,10 +191,8 @@ public class TaskManagerLogHandler extends RedirectHandler<JobManagerGateway> im
 							HashMap<String, BlobKey> lastSubmittedFile = fileMode == FileMode.LOG ? lastSubmittedLog : lastSubmittedStdout;
 							if (lastSubmittedFile.containsKey(taskManagerID)) {
 								if (!Objects.equals(blobKey, lastSubmittedFile.get(taskManagerID))) {
-									try {
-										blobCache.deleteGlobal(lastSubmittedFile.get(taskManagerID));
-									} catch (IOException e) {
-										throw new CompletionException(new FlinkException("Could not delete file for " + taskManagerID + '.', e));
+									if (!blobCache.delete(lastSubmittedFile.get(taskManagerID))) {
+										throw new CompletionException(new FlinkException("Could not delete file for " + taskManagerID + '.'));
 									}
 									lastSubmittedFile.put(taskManagerID, blobKey);
 								}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/TaskManagerLogHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/TaskManagerLogHandler.java
@@ -154,7 +154,7 @@ public class TaskManagerLogHandler extends RedirectHandler<JobManagerGateway> im
 					try {
 						return new TransientBlobCache(new InetSocketAddress(jobManagerGateway.getHostname(), port), config);
 					} catch (IOException e) {
-						throw new CompletionException(new FlinkException("Could not create BlobCache.", e));
+						throw new CompletionException(new FlinkException("Could not create TransientBlobCache.", e));
 					}
 				},
 				executor);
@@ -191,7 +191,7 @@ public class TaskManagerLogHandler extends RedirectHandler<JobManagerGateway> im
 							HashMap<String, BlobKey> lastSubmittedFile = fileMode == FileMode.LOG ? lastSubmittedLog : lastSubmittedStdout;
 							if (lastSubmittedFile.containsKey(taskManagerID)) {
 								if (!Objects.equals(blobKey, lastSubmittedFile.get(taskManagerID))) {
-									if (!blobCache.delete(lastSubmittedFile.get(taskManagerID))) {
+									if (!blobCache.deleteTransient(lastSubmittedFile.get(taskManagerID))) {
 										throw new CompletionException(new FlinkException("Could not delete file for " + taskManagerID + '.'));
 									}
 									lastSubmittedFile.put(taskManagerID, blobKey);
@@ -200,7 +200,7 @@ public class TaskManagerLogHandler extends RedirectHandler<JobManagerGateway> im
 								lastSubmittedFile.put(taskManagerID, blobKey);
 							}
 							try {
-								return blobCache.getFile(blobKey).getAbsolutePath();
+								return blobCache.getTransientFile(blobKey).getAbsolutePath();
 							} catch (IOException e) {
 								throw new CompletionException(new FlinkException("Could not retrieve blob for " + blobKey + '.', e));
 							}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/TaskManagerLogHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/TaskManagerLogHandler.java
@@ -191,7 +191,7 @@ public class TaskManagerLogHandler extends RedirectHandler<JobManagerGateway> im
 							HashMap<String, BlobKey> lastSubmittedFile = fileMode == FileMode.LOG ? lastSubmittedLog : lastSubmittedStdout;
 							if (lastSubmittedFile.containsKey(taskManagerID)) {
 								if (!Objects.equals(blobKey, lastSubmittedFile.get(taskManagerID))) {
-									if (!blobCache.deleteTransient(lastSubmittedFile.get(taskManagerID))) {
+									if (!blobCache.deleteTransientFromCache(lastSubmittedFile.get(taskManagerID))) {
 										throw new CompletionException(new FlinkException("Could not delete file for " + taskManagerID + '.'));
 									}
 									lastSubmittedFile.put(taskManagerID, blobKey);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobManagerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobManagerConnection.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.blob.BlobCache;
+import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.io.network.netty.PartitionProducerStateChecker;
@@ -51,7 +51,7 @@ public class JobManagerConnection {
 	private final CheckpointResponder checkpointResponder;
 
 	// BLOB cache connected to the BLOB server at the specific job manager
-	private final BlobCache blobCache;
+	private final BlobCacheService blobService;
 
 	// Library cache manager connected to the specific job manager
 	private final LibraryCacheManager libraryCacheManager;
@@ -68,7 +68,7 @@ public class JobManagerConnection {
 				JobMasterGateway jobMasterGateway,
 				TaskManagerActions taskManagerActions,
 				CheckpointResponder checkpointResponder,
-				BlobCache blobCache, LibraryCacheManager libraryCacheManager,
+				BlobCacheService blobService, LibraryCacheManager libraryCacheManager,
 				ResultPartitionConsumableNotifier resultPartitionConsumableNotifier,
 				PartitionProducerStateChecker partitionStateChecker) {
 		this.jobID = Preconditions.checkNotNull(jobID);
@@ -76,7 +76,7 @@ public class JobManagerConnection {
 		this.jobMasterGateway = Preconditions.checkNotNull(jobMasterGateway);
 		this.taskManagerActions = Preconditions.checkNotNull(taskManagerActions);
 		this.checkpointResponder = Preconditions.checkNotNull(checkpointResponder);
-		this.blobCache = Preconditions.checkNotNull(blobCache);
+		this.blobService = Preconditions.checkNotNull(blobService);
 		this.libraryCacheManager = Preconditions.checkNotNull(libraryCacheManager);
 		this.resultPartitionConsumableNotifier = Preconditions.checkNotNull(resultPartitionConsumableNotifier);
 		this.partitionStateChecker = Preconditions.checkNotNull(partitionStateChecker);
@@ -115,8 +115,8 @@ public class JobManagerConnection {
 	 *
 	 * @return BLOB cache
 	 */
-	public BlobCache getBlobCache() {
-		return blobCache;
+	public BlobCacheService getBlobService() {
+		return blobService;
 	}
 
 	public ResultPartitionConsumableNotifier getResultPartitionConsumableNotifier() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
-import org.apache.flink.runtime.blob.BlobCache;
+import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -361,7 +361,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 			TaskManagerActions taskManagerActions = jobManagerConnection.getTaskManagerActions();
 			CheckpointResponder checkpointResponder = jobManagerConnection.getCheckpointResponder();
-			BlobCache blobCache = jobManagerConnection.getBlobCache();
+			BlobCacheService blobService = jobManagerConnection.getBlobService();
 			LibraryCacheManager libraryCache = jobManagerConnection.getLibraryCacheManager();
 			ResultPartitionConsumableNotifier resultPartitionConsumableNotifier = jobManagerConnection.getResultPartitionConsumableNotifier();
 			PartitionProducerStateChecker partitionStateChecker = jobManagerConnection.getPartitionStateChecker();
@@ -384,7 +384,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 				taskManagerActions,
 				inputSplitProvider,
 				checkpointResponder,
-				blobCache,
+				blobService,
 				libraryCache,
 				fileCache,
 				taskManagerConfiguration,
@@ -935,14 +935,14 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		InetSocketAddress blobServerAddress = new InetSocketAddress(jobMasterGateway.getHostname(), blobPort);
 
 		final LibraryCacheManager libraryCacheManager;
-		final BlobCache blobCache;
+		final BlobCacheService blobService;
 		try {
-			blobCache = new BlobCache(
+			blobService = new BlobCacheService(
 				blobServerAddress,
 				taskManagerConfiguration.getConfiguration(),
 				haServices.createBlobStore());
 			libraryCacheManager = new BlobLibraryCacheManager(
-				blobCache.getPermanentBlobService(), taskManagerConfiguration.getClassLoaderResolveOrder());
+				blobService.getPermanentBlobService(), taskManagerConfiguration.getClassLoaderResolveOrder());
 		} catch (IOException e) {
 			// Can't pass the IOException up - we need a RuntimeException anyway
 			// two levels up where this is run asynchronously. Also, we don't
@@ -965,7 +965,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			jobMasterGateway,
 			taskManagerActions,
 			checkpointResponder,
-			blobCache,
+			blobService,
 			libraryCacheManager,
 			resultPartitionConsumableNotifier,
 			partitionStateChecker);
@@ -976,7 +976,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		JobMasterGateway jobManagerGateway = jobManagerConnection.getJobManagerGateway();
 		jobManagerGateway.disconnectTaskManager(getResourceID(), cause);
 		jobManagerConnection.getLibraryCacheManager().shutdown();
-		jobManagerConnection.getBlobCache().close();
+		jobManagerConnection.getBlobService().close();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -942,7 +942,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 				taskManagerConfiguration.getConfiguration(),
 				haServices.createBlobStore());
 			libraryCacheManager = new BlobLibraryCacheManager(
-				blobCache.getPermanentBlobStore(), taskManagerConfiguration.getClassLoaderResolveOrder());
+				blobCache.getPermanentBlobService(), taskManagerConfiguration.getClassLoaderResolveOrder());
 		} catch (IOException e) {
 			// Can't pass the IOException up - we need a RuntimeException anyway
 			// two levels up where this is run asynchronously. Also, we don't

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -941,8 +941,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 				blobServerAddress,
 				taskManagerConfiguration.getConfiguration(),
 				haServices.createBlobStore());
-			libraryCacheManager =
-				new BlobLibraryCacheManager(blobCache, taskManagerConfiguration.getClassLoaderResolveOrder());
+			libraryCacheManager = new BlobLibraryCacheManager(
+				blobCache.getPermanentBlobStore(), taskManagerConfiguration.getClassLoaderResolveOrder());
 		} catch (IOException e) {
 			// Can't pass the IOException up - we need a RuntimeException anyway
 			// two levels up where this is run asynchronously. Also, we don't

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -30,8 +30,8 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.SafetyNetCloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
-import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -205,7 +205,7 @@ public class Task implements Runnable, TaskActions {
 	private final List<TaskExecutionStateListener> taskExecutionStateListeners;
 
 	/** The BLOB cache, from which the task can request BLOB files */
-	private final BlobCache blobCache;
+	private final BlobCacheService blobService;
 
 	/** The library cache, from which the task can request its class loader */
 	private final LibraryCacheManager libraryCache;
@@ -286,7 +286,7 @@ public class Task implements Runnable, TaskActions {
 		TaskManagerActions taskManagerActions,
 		InputSplitProvider inputSplitProvider,
 		CheckpointResponder checkpointResponder,
-		BlobCache blobCache,
+		BlobCacheService blobService,
 		LibraryCacheManager libraryCache,
 		FileCache fileCache,
 		TaskManagerRuntimeInfo taskManagerConfig,
@@ -335,7 +335,7 @@ public class Task implements Runnable, TaskActions {
 		this.checkpointResponder = Preconditions.checkNotNull(checkpointResponder);
 		this.taskManagerActions = checkNotNull(taskManagerActions);
 
-		this.blobCache = Preconditions.checkNotNull(blobCache);
+		this.blobService = Preconditions.checkNotNull(blobService);
 		this.libraryCache = Preconditions.checkNotNull(libraryCache);
 		this.fileCache = Preconditions.checkNotNull(fileCache);
 		this.network = Preconditions.checkNotNull(networkEnvironment);
@@ -574,7 +574,7 @@ public class Task implements Runnable, TaskActions {
 			LOG.info("Creating FileSystem stream leak safety net for task {}", this);
 			FileSystemSafetyNet.initializeSafetyNetForThread();
 
-			blobCache.getPermanentBlobService().registerJob(jobId);
+			blobService.getPermanentBlobService().registerJob(jobId);
 
 			// first of all, get a user-code classloader
 			// this may involve downloading the job's JAR files and/or classes
@@ -835,7 +835,7 @@ public class Task implements Runnable, TaskActions {
 
 				// remove all of the tasks library resources
 				libraryCache.unregisterTask(jobId, executionId);
-				blobCache.getPermanentBlobService().releaseJob(jobId);
+				blobService.getPermanentBlobService().releaseJob(jobId);
 
 				// remove all files in the distributed cache
 				removeCachedFiles(distributedCacheEntries, fileCache);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -574,7 +574,7 @@ public class Task implements Runnable, TaskActions {
 			LOG.info("Creating FileSystem stream leak safety net for task {}", this);
 			FileSystemSafetyNet.initializeSafetyNetForThread();
 
-			blobCache.registerJob(jobId);
+			blobCache.getPermanentBlobStore().registerJob(jobId);
 
 			// first of all, get a user-code classloader
 			// this may involve downloading the job's JAR files and/or classes
@@ -835,7 +835,7 @@ public class Task implements Runnable, TaskActions {
 
 				// remove all of the tasks library resources
 				libraryCache.unregisterTask(jobId, executionId);
-				blobCache.releaseJob(jobId);
+				blobCache.getPermanentBlobStore().releaseJob(jobId);
 
 				// remove all files in the distributed cache
 				removeCachedFiles(distributedCacheEntries, fileCache);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -30,8 +30,8 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.SafetyNetCloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.BlobCacheService;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -161,7 +161,7 @@ public class Task implements Runnable, TaskActions {
 	private final Configuration taskConfiguration;
 
 	/** The jar files used by this task */
-	private final Collection<BlobKey> requiredJarFiles;
+	private final Collection<PermanentBlobKey> requiredJarFiles;
 
 	/** The classpaths used by this task */
 	private final Collection<URL> requiredClasspaths;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -574,7 +574,7 @@ public class Task implements Runnable, TaskActions {
 			LOG.info("Creating FileSystem stream leak safety net for task {}", this);
 			FileSystemSafetyNet.initializeSafetyNetForThread();
 
-			blobCache.getPermanentBlobStore().registerJob(jobId);
+			blobCache.getPermanentBlobService().registerJob(jobId);
 
 			// first of all, get a user-code classloader
 			// this may involve downloading the job's JAR files and/or classes
@@ -835,7 +835,7 @@ public class Task implements Runnable, TaskActions {
 
 				// remove all of the tasks library resources
 				libraryCache.unregisterTask(jobId, executionId);
-				blobCache.getPermanentBlobStore().releaseJob(jobId);
+				blobCache.getPermanentBlobService().releaseJob(jobId);
 
 				// remove all files in the distributed cache
 				removeCachedFiles(distributedCacheEntries, fileCache);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorUtils.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.blob.BlobView;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
@@ -148,7 +147,6 @@ public final class WebMonitorUtils {
 			Constructor<? extends WebMonitor> constructor = clazz.getConstructor(
 				Configuration.class,
 				LeaderRetrievalService.class,
-				BlobView.class,
 				LeaderGatewayRetriever.class,
 				MetricQueryServiceRetriever.class,
 				Time.class,
@@ -156,7 +154,6 @@ public final class WebMonitorUtils {
 			return constructor.newInstance(
 				config,
 				highAvailabilityServices.getJobManagerLeaderRetriever(HighAvailabilityServices.DEFAULT_JOB_ID),
-				highAvailabilityServices.createBlobStore(),
 				jobManagerRetriever,
 				queryServiceRetriever,
 				timeout,

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -461,7 +461,7 @@ class JobManager(
           taskManagerGateway match {
             case x: ActorTaskManagerGateway =>
               handleTaskManagerTerminated(x.getActorGateway().actor(), instance.getId)
-            case _ => log.debug(s"Cannot remove resource ${resourceID}, because there is " +
+            case _ => log.debug(s"Cannot remove reosurce ${resourceID}, because there is " +
                                   s"no ActorRef registered.")
           }
 
@@ -2500,6 +2500,7 @@ object JobManager {
 
     try {
       blobServer = new BlobServer(configuration, blobStore)
+      blobServer.start()
       instanceManager = new InstanceManager()
       scheduler = new FlinkScheduler(ExecutionContext.fromExecutor(futureExecutor))
       libraryCacheManager =

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -461,7 +461,7 @@ class JobManager(
           taskManagerGateway match {
             case x: ActorTaskManagerGateway =>
               handleTaskManagerTerminated(x.getActorGateway().actor(), instance.getId)
-            case _ => log.debug(s"Cannot remove reosurce ${resourceID}, because there is " +
+            case _ => log.debug(s"Cannot remove resource ${resourceID}, because there is " +
                                   s"no ActorRef registered.")
           }
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
@@ -24,7 +24,7 @@ import java.util.UUID
 import akka.actor.ActorRef
 import org.apache.flink.api.common.JobID
 import org.apache.flink.runtime.akka.ListeningBehaviour
-import org.apache.flink.runtime.blob.BlobKey
+import org.apache.flink.runtime.blob.{PermanentBlobKey}
 import org.apache.flink.runtime.client.{JobStatusMessage, SerializedJobExecutionResult}
 import org.apache.flink.runtime.executiongraph.{AccessExecutionGraph, ExecutionAttemptID, ExecutionGraph}
 import org.apache.flink.runtime.instance.{Instance, InstanceID}
@@ -235,7 +235,7 @@ object JobManagerMessages {
     * @param requiredClasspaths The urls of the required classpaths
     */
   case class ClassloadingProps(blobManagerPort: Integer,
-                               requiredJarFiles: java.util.Collection[BlobKey],
+                               requiredJarFiles: java.util.Collection[PermanentBlobKey],
                                requiredClasspaths: java.util.Collection[URL])
 
   /**

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -35,7 +35,7 @@ import org.apache.flink.configuration._
 import org.apache.flink.core.fs.FileSystem
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot
 import org.apache.flink.runtime.akka.{AkkaUtils, DefaultQuarantineHandler, QuarantineMonitor}
-import org.apache.flink.runtime.blob.{BlobCache, BlobClient}
+import org.apache.flink.runtime.blob.{BlobClient, BlobService, BlobCacheService}
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager
 import org.apache.flink.runtime.clusterframework.messages.StopCluster
 import org.apache.flink.runtime.clusterframework.types.ResourceID
@@ -159,7 +159,7 @@ class TaskManager(
     * registered at the job manager */
   private val waitForRegistration = scala.collection.mutable.Set[ActorRef]()
 
-  private var blobCache: Option[BlobCache] = None
+  private var blobCache: Option[BlobCacheService] = None
   private var libraryCacheManager: Option[LibraryCacheManager] = None
 
   /* The current leading JobManager Actor associated with */
@@ -962,7 +962,7 @@ class TaskManager(
       log.info(s"Determined BLOB server address to be $address. Starting BLOB cache.")
 
       try {
-        val blobcache = new BlobCache(
+        val blobcache = new BlobCacheService(
           address,
           config.getConfiguration(),
           highAvailabilityServices.createBlobStore())

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -839,7 +839,7 @@ class TaskManager(
         if (file.exists()) {
           val fis = new FileInputStream(file);
           Future {
-            blobCache.get.getTransientBlobStore.put(fis)
+            blobCache.get.getTransientBlobService.putTransient(fis)
           }(context.dispatcher)
             .onComplete {
               case scala.util.Success(value) =>
@@ -969,7 +969,7 @@ class TaskManager(
         blobCache = Option(blobcache)
         libraryCacheManager = Some(
           new BlobLibraryCacheManager(
-            blobcache.getPermanentBlobStore, config.getClassLoaderResolveOrder()))
+            blobcache.getPermanentBlobService, config.getClassLoaderResolveOrder()))
       }
       catch {
         case e: Exception =>

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -839,8 +839,7 @@ class TaskManager(
         if (file.exists()) {
           val fis = new FileInputStream(file);
           Future {
-            val client: BlobClient = blobCache.get.createClient()
-            client.put(fis);
+            blobCache.get.getTransientBlobStore.put(fis)
           }(context.dispatcher)
             .onComplete {
               case scala.util.Success(value) =>
@@ -969,7 +968,8 @@ class TaskManager(
           highAvailabilityServices.createBlobStore())
         blobCache = Option(blobcache)
         libraryCacheManager = Some(
-          new BlobLibraryCacheManager(blobcache, config.getClassLoaderResolveOrder()))
+          new BlobLibraryCacheManager(
+            blobcache.getPermanentBlobStore, config.getClassLoaderResolveOrder()))
       }
       catch {
         case e: Exception =>

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCleanupTest.java
@@ -128,8 +128,8 @@ public class BlobCacheCleanupTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that {@link BlobCache} sets the expected reference counts and cleanup timeouts when
-	 * registering, releasing, and re-registering jobs.
+	 * Tests that {@link PermanentBlobCache} sets the expected reference counts and cleanup timeouts
+	 * when registering, releasing, and re-registering jobs.
 	 */
 	@Test
 	public void testJobReferences() throws IOException, InterruptedException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCleanupTest.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -73,9 +74,9 @@ public class BlobCacheCleanupTest extends TestLogger {
 			cache = new PermanentBlobCache(serverAddress, config, new VoidBlobStore());
 
 			// upload blobs
-			keys.add(server.putHA(jobId, buf));
+			keys.add(server.putPermanent(jobId, buf));
 			buf[0] += 1;
-			keys.add(server.putHA(jobId, buf));
+			keys.add(server.putPermanent(jobId, buf));
 
 			checkFileCountForJob(2, jobId, server);
 			checkFileCountForJob(0, jobId, cache);
@@ -87,13 +88,13 @@ public class BlobCacheCleanupTest extends TestLogger {
 			checkFileCountForJob(0, jobId, cache);
 
 			for (BlobKey key : keys) {
-				cache.getHAFile(jobId, key);
+				cache.getPermanentFile(jobId, key);
 			}
 
 			// register again (let's say, from another thread or so)
 			cache.registerJob(jobId);
 			for (BlobKey key : keys) {
-				cache.getHAFile(jobId, key);
+				cache.getPermanentFile(jobId, key);
 			}
 
 			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
@@ -226,9 +227,9 @@ public class BlobCacheCleanupTest extends TestLogger {
 			cache = new PermanentBlobCache(serverAddress, config, new VoidBlobStore());
 
 			// upload blobs
-			keys.add(server.putHA(jobId, buf));
+			keys.add(server.putPermanent(jobId, buf));
 			buf[0] += 1;
-			keys.add(server.putHA(jobId, buf));
+			keys.add(server.putPermanent(jobId, buf));
 
 			checkFileCountForJob(2, jobId, server);
 			checkFileCountForJob(0, jobId, cache);
@@ -240,13 +241,13 @@ public class BlobCacheCleanupTest extends TestLogger {
 			checkFileCountForJob(0, jobId, cache);
 
 			for (BlobKey key : keys) {
-				cache.getHAFile(jobId, key);
+				cache.getPermanentFile(jobId, key);
 			}
 
 			// register again (let's say, from another thread or so)
 			cache.registerJob(jobId);
 			for (BlobKey key : keys) {
-				cache.getHAFile(jobId, key);
+				cache.getPermanentFile(jobId, key);
 			}
 
 			assertEquals(2, checkFilesExist(jobId, keys, cache, true));
@@ -317,7 +318,7 @@ public class BlobCacheCleanupTest extends TestLogger {
 	 * @param doThrow
 	 * 		whether exceptions should be ignored (<tt>false</tt>), or thrown (<tt>true</tt>)
 	 *
-	 * @return number of files we were able to retrieve via {@link PermanentBlobService#getHAFile}
+	 * @return number of files we were able to retrieve via {@link PermanentBlobService#getPermanentFile}
 	 */
 	public static int checkFilesExist(
 		JobID jobId, Collection<BlobKey> keys, PermanentBlobService blobService, boolean doThrow)
@@ -361,10 +362,10 @@ public class BlobCacheCleanupTest extends TestLogger {
 		final File jobDir;
 		if (blobService instanceof BlobServer) {
 			BlobServer server = (BlobServer) blobService;
-			jobDir = server.getStorageLocation(jobId, new BlobKey()).getParentFile();
+			jobDir = server.getStorageLocation(jobId, new BlobKey(PERMANENT_BLOB)).getParentFile();
 		} else {
 			PermanentBlobCache cache = (PermanentBlobCache) blobService;
-			jobDir = cache.getStorageLocation(jobId, new BlobKey()).getParentFile();
+			jobDir = cache.getStorageLocation(jobId, new BlobKey(PERMANENT_BLOB)).getParentFile();
 		}
 		File[] blobsForJob = jobDir.listFiles();
 		if (blobsForJob == null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCorruptionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCorruptionTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Tests how GET requests react to corrupt files when downloaded via a {@link BlobCache}.
+ * Tests how GET requests react to corrupt files when downloaded via a {@link BlobCacheService}.
  *
  * <p>Successful GET requests are tested in conjunction wit the PUT requests.
  */
@@ -147,7 +147,7 @@ public class BlobCacheCorruptionTest extends TestLogger {
 
 		try (
 			BlobServer server = new BlobServer(config, blobStore);
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, corruptOnHAStore ? blobStore : new VoidBlobStore())) {
 
 			server.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCorruptionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCorruptionTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.commons.io.FileUtils;
+import org.hamcrest.CoreMatchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.apache.flink.runtime.blob.BlobServerGetTest.get;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests how GET requests react to corrupt files when downloaded via a {@link BlobCache}.
+ *
+ * <p>Successful GET requests are tested in conjunction wit the PUT requests.
+ */
+public class BlobCacheCorruptionTest extends TestLogger {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void testGetFailsFromCorruptFile1() throws IOException {
+		testGetFailsFromCorruptFile(null, false, false);
+	}
+
+	@Test
+	public void testGetFailsFromCorruptFile2() throws IOException {
+		testGetFailsFromCorruptFile(new JobID(), false, false);
+	}
+
+	@Test
+	public void testGetFailsFromCorruptFile3() throws IOException {
+		testGetFailsFromCorruptFile(new JobID(), true, false);
+	}
+
+	@Test
+	public void testGetFailsFromCorruptFile4() throws IOException {
+		testGetFailsFromCorruptFile(new JobID(), true, true);
+	}
+
+	/**
+	 * Checks the GET operation fails when the downloaded file (from {@link BlobServer} or HA store)
+	 * is corrupt, i.e. its content's hash does not match the {@link BlobKey}'s hash.
+	 *
+	 * @param jobId
+	 * 		job ID or <tt>null</tt> if job-unrelated
+	 * @param highAvailability
+	 * 		whether to use HA mode accessors
+	 * @param corruptOnHAStore
+	 * 		whether the file should be corrupt in the HA store (<tt>true</tt>, required
+	 * 		<tt>highAvailability</tt> to be set) or on the {@link BlobServer}'s local store
+	 * 		(<tt>false</tt>)
+	 */
+	private void testGetFailsFromCorruptFile(final JobID jobId, boolean highAvailability,
+			boolean corruptOnHAStore) throws IOException {
+
+		final Configuration config = new Configuration();
+		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+		config.setString(CoreOptions.STATE_BACKEND, "FILESYSTEM");
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getPath());
+
+		BlobStoreService blobStoreService = null;
+
+		try {
+			blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
+
+			testGetFailsFromCorruptFile(jobId, highAvailability, corruptOnHAStore, config,
+				blobStoreService, exception);
+		} finally {
+			if (blobStoreService != null) {
+				blobStoreService.closeAndCleanupAllData();
+			}
+		}
+	}
+
+	/**
+	 * Checks the GET operation fails when the downloaded file (from {@link BlobServer} or HA store)
+	 * is corrupt, i.e. its content's hash does not match the {@link BlobKey}'s hash.
+	 *
+	 * @param jobId
+	 * 		job ID or <tt>null</tt> if job-unrelated
+	 * @param highAvailability
+	 * 		whether to use HA mode accessors
+	 * @param corruptOnHAStore
+	 * 		whether the file should be corrupt in the HA store (<tt>true</tt>, required
+	 * 		<tt>highAvailability</tt> to be set) or on the {@link BlobServer}'s local store
+	 * 		(<tt>false</tt>)
+	 * @param config
+	 * 		blob server configuration (including HA settings like {@link HighAvailabilityOptions#HA_STORAGE_PATH}
+	 * 		and {@link HighAvailabilityOptions#HA_CLUSTER_ID}) used to set up <tt>blobStore</tt>
+	 * @param blobStore
+	 * 		shared HA blob store to use
+	 * @param expectedException
+	 * 		expected exception rule to use
+	 */
+	public static void testGetFailsFromCorruptFile(
+			JobID jobId, boolean highAvailability, boolean corruptOnHAStore, Configuration config,
+			BlobStore blobStore, ExpectedException expectedException) throws IOException {
+
+		assertTrue("corrupt HA file requires a HA setup", !corruptOnHAStore || highAvailability);
+
+		Random rnd = new Random();
+
+		try (
+			BlobServer server = new BlobServer(config, blobStore);
+			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, corruptOnHAStore ? blobStore : new VoidBlobStore())) {
+
+			server.start();
+
+			byte[] data = new byte[2000000];
+			rnd.nextBytes(data);
+
+			// put content addressable (like libraries)
+			BlobKey key = put(server, jobId, data, highAvailability);
+			assertNotNull(key);
+
+			// change server/HA store file contents to make sure that GET requests fail
+			byte[] data2 = Arrays.copyOf(data, data.length);
+			data2[0] ^= 1;
+			if (corruptOnHAStore) {
+				File tmpFile = Files.createTempFile("blob", ".jar").toFile();
+				try {
+					FileUtils.writeByteArrayToFile(tmpFile, data2);
+					blobStore.put(tmpFile, jobId, key);
+				} finally {
+					//noinspection ResultOfMethodCallIgnored
+					tmpFile.delete();
+				}
+
+				// delete local (correct) file on server to make sure that the GET request does not
+				// fall back to downloading the file from the BlobServer's local store
+				File blobFile = server.getStorageLocation(jobId, key);
+				assertTrue(blobFile.delete());
+			} else {
+				File blobFile = server.getStorageLocation(jobId, key);
+				assertTrue(blobFile.exists());
+				FileUtils.writeByteArrayToFile(blobFile, data2);
+			}
+
+			// issue a GET request that fails
+			expectedException.expect(IOException.class);
+			expectedException.expectCause(CoreMatchers.allOf(instanceOf(IOException.class),
+				hasProperty("message", containsString("data corruption"))));
+
+			get(cache, jobId, key, highAvailability);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheDeleteTest.java
@@ -94,7 +94,7 @@ public class BlobCacheDeleteTest extends TestLogger {
 
 	/**
 	 * Uploads a (different) byte array for each of the given jobs and verifies that deleting one of
-	 * them (via the {@link BlobCache}) does not influence the other.
+	 * them (via the {@link BlobCacheService}) does not influence the other.
 	 *
 	 * @param jobId1
 	 * 		first job id
@@ -112,7 +112,7 @@ public class BlobCacheDeleteTest extends TestLogger {
 
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -178,7 +178,7 @@ public class BlobCacheDeleteTest extends TestLogger {
 
 	/**
 	 * Uploads a byte array for the given job and verifies that deleting it (via the {@link
-	 * BlobCache}) does not fail independent of whether the file exists.
+	 * BlobCacheService}) does not fail independent of whether the file exists.
 	 *
 	 * @param jobId
 	 * 		job id
@@ -190,7 +190,7 @@ public class BlobCacheDeleteTest extends TestLogger {
 
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -227,8 +227,8 @@ public class BlobCacheDeleteTest extends TestLogger {
 
 	/**
 	 * Uploads a byte array for the given job and verifies that a delete operation (via the {@link
-	 * BlobCache}) does not fail even if the file is not deletable locally, e.g. via restricting
-	 * the permissions.
+	 * BlobCacheService}) does not fail even if the file is not deletable locally, e.g. via
+	 * restricting the permissions.
 	 *
 	 * @param jobId
 	 * 		job id
@@ -243,7 +243,7 @@ public class BlobCacheDeleteTest extends TestLogger {
 		File directory = null;
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -328,7 +328,7 @@ public class BlobCacheDeleteTest extends TestLogger {
 
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
@@ -55,6 +55,8 @@ import static org.apache.flink.runtime.blob.BlobClientTest.validateGetAndClose;
 import static org.apache.flink.runtime.blob.BlobServerGetTest.get;
 import static org.apache.flink.runtime.blob.BlobServerGetTest.verifyDeleted;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
+import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
+import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
 import static org.apache.flink.runtime.blob.BlobUtils.JOB_DIR_PREFIX;
 import static org.apache.flink.runtime.blob.BlobUtils.NO_JOB_DIR_PREFIX;
 import static org.junit.Assert.assertArrayEquals;
@@ -82,22 +84,22 @@ public class BlobCacheGetTest extends TestLogger {
 
 	@Test
 	public void testGetFailsDuringLookup1() throws IOException {
-		testGetFailsDuringLookup(null, new JobID(), false);
+		testGetFailsDuringLookup(null, new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testGetFailsDuringLookup2() throws IOException {
-		testGetFailsDuringLookup(new JobID(), new JobID(), false);
+		testGetFailsDuringLookup(new JobID(), new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testGetFailsDuringLookup3() throws IOException {
-		testGetFailsDuringLookup(new JobID(), null, false);
+		testGetFailsDuringLookup(new JobID(), null, TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testGetFailsDuringLookupHa() throws IOException {
-		testGetFailsDuringLookup(new JobID(), new JobID(), true);
+		testGetFailsDuringLookup(new JobID(), new JobID(), PERMANENT_BLOB);
 	}
 
 	/**
@@ -105,8 +107,10 @@ public class BlobCacheGetTest extends TestLogger {
 	 *
 	 * @param jobId1 first job ID or <tt>null</tt> if job-unrelated
 	 * @param jobId2 second job ID different to <tt>jobId1</tt>
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 */
-	private void testGetFailsDuringLookup(final JobID jobId1, final JobID jobId2, boolean highAvailability)
+	private void testGetFailsDuringLookup(final JobID jobId1, final JobID jobId2, BlobType blobType)
 		throws IOException {
 		final Configuration config = new Configuration();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
@@ -122,7 +126,7 @@ public class BlobCacheGetTest extends TestLogger {
 			rnd.nextBytes(data);
 
 			// put content addressable (like libraries)
-			BlobKey key = put(server, jobId1, data, highAvailability);
+			BlobKey key = put(server, jobId1, data, blobType);
 			assertNotNull(key);
 
 			// delete file to make sure that GET requests fail
@@ -130,53 +134,53 @@ public class BlobCacheGetTest extends TestLogger {
 			assertTrue(blobFile.delete());
 
 			// issue a GET request that fails
-			verifyDeleted(cache, jobId1, key, highAvailability);
+			verifyDeleted(cache, jobId1, key);
 
 			// add the same data under a second jobId
-			BlobKey key2 = put(server, jobId2, data, highAvailability);
+			BlobKey key2 = put(server, jobId2, data, blobType);
 			assertNotNull(key);
 			assertEquals(key, key2);
 
 			// request for jobId2 should succeed
-			get(cache, jobId2, key, highAvailability);
+			get(cache, jobId2, key);
 			// request for jobId1 should still fail
-			verifyDeleted(cache, jobId1, key, highAvailability);
+			verifyDeleted(cache, jobId1, key);
 
 			// delete on cache, try to retrieve again
-			if (highAvailability) {
-				blobFile = cache.getPermanentBlobStore().getStorageLocation(jobId2, key);
+			if (blobType == PERMANENT_BLOB) {
+				blobFile = cache.getPermanentBlobService().getStorageLocation(jobId2, key);
 			} else {
-				blobFile = cache.getTransientBlobStore().getStorageLocation(jobId2, key);
+				blobFile = cache.getTransientBlobService().getStorageLocation(jobId2, key);
 			}
 			assertTrue(blobFile.delete());
-			get(cache, jobId2, key, highAvailability);
+			get(cache, jobId2, key);
 
 			// delete on cache and server, verify that it is not accessible anymore
-			if (highAvailability) {
-				blobFile = cache.getPermanentBlobStore().getStorageLocation(jobId2, key);
+			if (blobType == PERMANENT_BLOB) {
+				blobFile = cache.getPermanentBlobService().getStorageLocation(jobId2, key);
 			} else {
-				blobFile = cache.getTransientBlobStore().getStorageLocation(jobId2, key);
+				blobFile = cache.getTransientBlobService().getStorageLocation(jobId2, key);
 			}
 			assertTrue(blobFile.delete());
 			blobFile = server.getStorageLocation(jobId2, key);
 			assertTrue(blobFile.delete());
-			verifyDeleted(cache, jobId2, key, highAvailability);
+			verifyDeleted(cache, jobId2, key);
 		}
 	}
 
 	@Test
 	public void testGetFailsIncomingNoJob() throws IOException {
-		testGetFailsIncoming(null, false);
+		testGetFailsIncoming(null, TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testGetFailsIncomingForJob() throws IOException {
-		testGetFailsIncoming(new JobID(), false);
+		testGetFailsIncoming(new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testGetFailsIncomingForJobHa() throws IOException {
-		testGetFailsIncoming(new JobID(), true);
+		testGetFailsIncoming(new JobID(), PERMANENT_BLOB);
 	}
 
 	/**
@@ -185,12 +189,10 @@ public class BlobCacheGetTest extends TestLogger {
 	 *
 	 * @param jobId
 	 * 		job id
-	 * @param highAvailability
-	 * 		whether to retrieve a permanent blob (<tt>true</tt>, via {@link
-	 * 		PermanentBlobCache#getHAFile(JobID, BlobKey)}) or not (<tt>false</tt>, via {@link
-	 * 		TransientBlobCache#getFile(JobID, BlobKey)})
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 */
-	private void testGetFailsIncoming(@Nullable final JobID jobId, boolean highAvailability)
+	private void testGetFailsIncoming(@Nullable final JobID jobId, BlobType blobType)
 			throws IOException {
 		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
 
@@ -208,15 +210,15 @@ public class BlobCacheGetTest extends TestLogger {
 			// store the data on the server
 			byte[] data = new byte[2000000];
 			rnd.nextBytes(data);
-			BlobKey blobKey = put(server, jobId, data, highAvailability);
+			BlobKey blobKey = put(server, jobId, data, blobType);
 
 			// make sure the blob cache cannot create any files in its storage dir
-			if (highAvailability) {
+			if (blobType == PERMANENT_BLOB) {
 				tempFileDir =
-					cache.getPermanentBlobStore().createTemporaryFilename().getParentFile();
+					cache.getPermanentBlobService().createTemporaryFilename().getParentFile();
 			} else {
 				tempFileDir =
-					cache.getTransientBlobStore().createTemporaryFilename().getParentFile();
+					cache.getTransientBlobService().createTemporaryFilename().getParentFile();
 			}
 			assertTrue(tempFileDir.setExecutable(true, false));
 			assertTrue(tempFileDir.setReadable(true, false));
@@ -227,7 +229,7 @@ public class BlobCacheGetTest extends TestLogger {
 			exception.expectMessage("Failed to fetch BLOB ");
 
 			try {
-				get(cache, jobId, blobKey, highAvailability);
+				get(cache, jobId, blobKey);
 			} finally {
 				HashSet<String> expectedDirs = new HashSet<>();
 				expectedDirs.add("incoming");
@@ -266,17 +268,17 @@ public class BlobCacheGetTest extends TestLogger {
 
 	@Test
 	public void testGetFailsStoreNoJob() throws IOException {
-		testGetFailsStore(null, false);
+		testGetFailsStore(null, TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testGetFailsStoreForJob() throws IOException {
-		testGetFailsStore(new JobID(), false);
+		testGetFailsStore(new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testGetFailsStoreForJobHa() throws IOException {
-		testGetFailsStore(new JobID(), true);
+		testGetFailsStore(new JobID(), PERMANENT_BLOB);
 	}
 
 	/**
@@ -285,12 +287,10 @@ public class BlobCacheGetTest extends TestLogger {
 	 *
 	 * @param jobId
 	 * 		job id
-	 * @param highAvailability
-	 * 		whether to retrieve a permanent blob (<tt>true</tt>, via {@link
-	 * 		PermanentBlobCache#getHAFile(JobID, BlobKey)}) or not (<tt>false</tt>, via {@link
-	 * 		TransientBlobCache#getFile(JobID, BlobKey)})
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 */
-	private void testGetFailsStore(@Nullable final JobID jobId, boolean highAvailability)
+	private void testGetFailsStore(@Nullable final JobID jobId, BlobType blobType)
 			throws IOException {
 		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
 
@@ -308,14 +308,16 @@ public class BlobCacheGetTest extends TestLogger {
 			// store the data on the server
 			byte[] data = new byte[2000000];
 			rnd.nextBytes(data);
-			BlobKey blobKey = put(server, jobId, data, highAvailability);
+			BlobKey blobKey = put(server, jobId, data, blobType);
 
 			// make sure the blob cache cannot create any files in its storage dir
-			if (highAvailability) {
-				jobStoreDir = cache.getPermanentBlobStore().getStorageLocation(jobId, new BlobKey())
+			if (blobType == PERMANENT_BLOB) {
+				jobStoreDir = cache.getPermanentBlobService()
+					.getStorageLocation(jobId, new BlobKey(PERMANENT_BLOB))
 					.getParentFile();
 			} else {
-				jobStoreDir = cache.getTransientBlobStore().getStorageLocation(jobId, new BlobKey())
+				jobStoreDir = cache.getTransientBlobService()
+					.getStorageLocation(jobId, new BlobKey(TRANSIENT_BLOB))
 					.getParentFile();
 			}
 			assertTrue(jobStoreDir.setExecutable(true, false));
@@ -326,7 +328,7 @@ public class BlobCacheGetTest extends TestLogger {
 			exception.expect(AccessDeniedException.class);
 
 			try {
-				get(cache, jobId, blobKey, highAvailability);
+				get(cache, jobId, blobKey);
 			} finally {
 				// there should be no remaining incoming files
 				File incomingFileDir = new File(jobStoreDir.getParent(), "incoming");
@@ -365,7 +367,7 @@ public class BlobCacheGetTest extends TestLogger {
 			// store the data on the server (and blobStore), remove from local server store
 			byte[] data = new byte[2000000];
 			rnd.nextBytes(data);
-			BlobKey blobKey = put(server, jobId, data, true);
+			BlobKey blobKey = put(server, jobId, data, PERMANENT_BLOB);
 			assertTrue(server.getStorageLocation(jobId, blobKey).delete());
 
 			File tempFileDir = server.createTemporaryFilename().getParentFile();
@@ -375,7 +377,7 @@ public class BlobCacheGetTest extends TestLogger {
 			exception.expectMessage("Failed to fetch BLOB ");
 
 			try {
-				get(cache, jobId, blobKey, true);
+				get(cache, jobId, blobKey);
 			} finally {
 				HashSet<String> expectedDirs = new HashSet<>();
 				expectedDirs.add("incoming");
@@ -400,22 +402,22 @@ public class BlobCacheGetTest extends TestLogger {
 	 */
 	@Test
 	public void testConcurrentGetOperationsNoJob() throws IOException, ExecutionException, InterruptedException {
-		testConcurrentGetOperations(null, false, false);
+		testConcurrentGetOperations(null, TRANSIENT_BLOB, false);
 	}
 
 	@Test
 	public void testConcurrentGetOperationsForJob() throws IOException, ExecutionException, InterruptedException {
-		testConcurrentGetOperations(new JobID(), false, false);
+		testConcurrentGetOperations(new JobID(), TRANSIENT_BLOB, false);
 	}
 
 	@Test
 	public void testConcurrentGetOperationsForJobHa() throws IOException, ExecutionException, InterruptedException {
-		testConcurrentGetOperations(new JobID(), true, false);
+		testConcurrentGetOperations(new JobID(), PERMANENT_BLOB, false);
 	}
 
 	@Test
 	public void testConcurrentGetOperationsForJobHa2() throws IOException, ExecutionException, InterruptedException {
-		testConcurrentGetOperations(new JobID(), true, true);
+		testConcurrentGetOperations(new JobID(), PERMANENT_BLOB, true);
 	}
 
 	/**
@@ -424,12 +426,12 @@ public class BlobCacheGetTest extends TestLogger {
 	 *
 	 * @param jobId
 	 * 		job ID to use (or <tt>null</tt> if job-unrelated)
-	 * @param highAvailability
-	 * 		whether to use permanent (<tt>true</tt>) or transient BLOBs (<tt>false</tt>)
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 * @param cacheAccessesHAStore
 	 * 		whether the cache has access to the {@link BlobServer}'s HA store or not
 	 */
-	private void testConcurrentGetOperations(final JobID jobId, final boolean highAvailability,
+	private void testConcurrentGetOperations(final JobID jobId, final BlobType blobType,
 			final boolean cacheAccessesHAStore)
 			throws IOException, InterruptedException, ExecutionException {
 		final Configuration config = new Configuration();
@@ -446,7 +448,7 @@ public class BlobCacheGetTest extends TestLogger {
 		MessageDigest md = BlobUtils.createMessageDigest();
 
 		// create the correct blob key by hashing our input data
-		final BlobKey blobKey = new BlobKey(md.digest(data));
+		final BlobKey blobKey = new BlobKey(blobType, md.digest(data));
 
 		final ExecutorService executor = Executors.newFixedThreadPool(numberConcurrentGetOperations);
 
@@ -458,7 +460,7 @@ public class BlobCacheGetTest extends TestLogger {
 			server.start();
 
 			// upload data first
-			assertEquals(blobKey, put(server, jobId, data, highAvailability));
+			assertEquals(blobKey, put(server, jobId, data, blobType));
 
 			// now try accessing it concurrently (only HA mode will be able to retrieve it from HA store!)
 			for (int i = 0; i < numberConcurrentGetOperations; i++) {
@@ -466,7 +468,7 @@ public class BlobCacheGetTest extends TestLogger {
 					.supplyAsync(
 						() -> {
 							try {
-								File file = get(cache, jobId, blobKey, highAvailability);
+								File file = get(cache, jobId, blobKey);
 								// check that we have read the right data
 								validateGetAndClose(new FileInputStream(file), data);
 								return file;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
@@ -1,0 +1,490 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.AccessDeniedException;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.apache.flink.runtime.blob.BlobClientTest.validateGetAndClose;
+import static org.apache.flink.runtime.blob.BlobServerGetTest.get;
+import static org.apache.flink.runtime.blob.BlobServerGetTest.verifyDeleted;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
+import static org.apache.flink.runtime.blob.BlobUtils.JOB_DIR_PREFIX;
+import static org.apache.flink.runtime.blob.BlobUtils.NO_JOB_DIR_PREFIX;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests how failing GET requests behave in the presence of failures when used with a {@link
+ * BlobCache}.
+ *
+ * <p>Successful GET requests are tested in conjunction wit the PUT requests.
+ */
+public class BlobCacheGetTest extends TestLogger {
+
+	private final Random rnd = new Random();
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void testGetFailsDuringLookup1() throws IOException {
+		testGetFailsDuringLookup(null, new JobID(), false);
+	}
+
+	@Test
+	public void testGetFailsDuringLookup2() throws IOException {
+		testGetFailsDuringLookup(new JobID(), new JobID(), false);
+	}
+
+	@Test
+	public void testGetFailsDuringLookup3() throws IOException {
+		testGetFailsDuringLookup(new JobID(), null, false);
+	}
+
+	@Test
+	public void testGetFailsDuringLookupHa() throws IOException {
+		testGetFailsDuringLookup(new JobID(), new JobID(), true);
+	}
+
+	/**
+	 * Checks the correct result if a GET operation fails during the lookup of the file.
+	 *
+	 * @param jobId1 first job ID or <tt>null</tt> if job-unrelated
+	 * @param jobId2 second job ID different to <tt>jobId1</tt>
+	 */
+	private void testGetFailsDuringLookup(final JobID jobId1, final JobID jobId2, boolean highAvailability)
+		throws IOException {
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
+		try (
+			BlobServer server = new BlobServer(config, new VoidBlobStore());
+			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, new VoidBlobStore())) {
+
+			server.start();
+
+			byte[] data = new byte[2000000];
+			rnd.nextBytes(data);
+
+			// put content addressable (like libraries)
+			BlobKey key = put(server, jobId1, data, highAvailability);
+			assertNotNull(key);
+
+			// delete file to make sure that GET requests fail
+			File blobFile = server.getStorageLocation(jobId1, key);
+			assertTrue(blobFile.delete());
+
+			// issue a GET request that fails
+			verifyDeleted(cache, jobId1, key, highAvailability);
+
+			// add the same data under a second jobId
+			BlobKey key2 = put(server, jobId2, data, highAvailability);
+			assertNotNull(key);
+			assertEquals(key, key2);
+
+			// request for jobId2 should succeed
+			get(cache, jobId2, key, highAvailability);
+			// request for jobId1 should still fail
+			verifyDeleted(cache, jobId1, key, highAvailability);
+
+			// delete on cache, try to retrieve again
+			if (highAvailability) {
+				blobFile = cache.getPermanentBlobStore().getStorageLocation(jobId2, key);
+			} else {
+				blobFile = cache.getTransientBlobStore().getStorageLocation(jobId2, key);
+			}
+			assertTrue(blobFile.delete());
+			get(cache, jobId2, key, highAvailability);
+
+			// delete on cache and server, verify that it is not accessible anymore
+			if (highAvailability) {
+				blobFile = cache.getPermanentBlobStore().getStorageLocation(jobId2, key);
+			} else {
+				blobFile = cache.getTransientBlobStore().getStorageLocation(jobId2, key);
+			}
+			assertTrue(blobFile.delete());
+			blobFile = server.getStorageLocation(jobId2, key);
+			assertTrue(blobFile.delete());
+			verifyDeleted(cache, jobId2, key, highAvailability);
+		}
+	}
+
+	@Test
+	public void testGetFailsIncomingNoJob() throws IOException {
+		testGetFailsIncoming(null, false);
+	}
+
+	@Test
+	public void testGetFailsIncomingForJob() throws IOException {
+		testGetFailsIncoming(new JobID(), false);
+	}
+
+	@Test
+	public void testGetFailsIncomingForJobHa() throws IOException {
+		testGetFailsIncoming(new JobID(), true);
+	}
+
+	/**
+	 * Retrieves a BLOB via a {@link BlobCache} which cannot create incoming files. File transfers
+	 * should fail.
+	 *
+	 * @param jobId
+	 * 		job id
+	 * @param highAvailability
+	 * 		whether to retrieve a permanent blob (<tt>true</tt>, via {@link
+	 * 		PermanentBlobCache#getHAFile(JobID, BlobKey)}) or not (<tt>false</tt>, via {@link
+	 * 		TransientBlobCache#getFile(JobID, BlobKey)})
+	 */
+	private void testGetFailsIncoming(@Nullable final JobID jobId, boolean highAvailability)
+			throws IOException {
+		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
+
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
+		File tempFileDir = null;
+		try (
+			BlobServer server = new BlobServer(config, new VoidBlobStore());
+			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, new VoidBlobStore())) {
+
+			server.start();
+
+			// store the data on the server
+			byte[] data = new byte[2000000];
+			rnd.nextBytes(data);
+			BlobKey blobKey = put(server, jobId, data, highAvailability);
+
+			// make sure the blob cache cannot create any files in its storage dir
+			if (highAvailability) {
+				tempFileDir =
+					cache.getPermanentBlobStore().createTemporaryFilename().getParentFile();
+			} else {
+				tempFileDir =
+					cache.getTransientBlobStore().createTemporaryFilename().getParentFile();
+			}
+			assertTrue(tempFileDir.setExecutable(true, false));
+			assertTrue(tempFileDir.setReadable(true, false));
+			assertTrue(tempFileDir.setWritable(false, false));
+
+			// request the file from the server via the cache
+			exception.expect(IOException.class);
+			exception.expectMessage("Failed to fetch BLOB ");
+
+			try {
+				get(cache, jobId, blobKey, highAvailability);
+			} finally {
+				HashSet<String> expectedDirs = new HashSet<>();
+				expectedDirs.add("incoming");
+				if (jobId != null) {
+					// only the incoming and job directory should exist (no job directory!)
+					expectedDirs.add(JOB_DIR_PREFIX + jobId);
+					File storageDir = tempFileDir.getParentFile();
+					String[] actualDirs = storageDir.list();
+					assertNotNull(actualDirs);
+					assertEquals(expectedDirs, new HashSet<>(Arrays.asList(actualDirs)));
+
+					// job directory should be empty
+					File jobDir = new File(tempFileDir.getParentFile(), JOB_DIR_PREFIX + jobId);
+					assertArrayEquals(new String[] {}, jobDir.list());
+				} else {
+					// only the incoming and no_job directory should exist (no job directory!)
+					expectedDirs.add(NO_JOB_DIR_PREFIX);
+					File storageDir = tempFileDir.getParentFile();
+					String[] actualDirs = storageDir.list();
+					assertNotNull(actualDirs);
+					assertEquals(expectedDirs, new HashSet<>(Arrays.asList(actualDirs)));
+
+					// no_job directory should be empty
+					File noJobDir = new File(tempFileDir.getParentFile(), NO_JOB_DIR_PREFIX);
+					assertArrayEquals(new String[] {}, noJobDir.list());
+				}
+			}
+		} finally {
+			// set writable again to make sure we can remove the directory
+			if (tempFileDir != null) {
+				//noinspection ResultOfMethodCallIgnored
+				tempFileDir.setWritable(true, false);
+			}
+		}
+	}
+
+	@Test
+	public void testGetFailsStoreNoJob() throws IOException {
+		testGetFailsStore(null, false);
+	}
+
+	@Test
+	public void testGetFailsStoreForJob() throws IOException {
+		testGetFailsStore(new JobID(), false);
+	}
+
+	@Test
+	public void testGetFailsStoreForJobHa() throws IOException {
+		testGetFailsStore(new JobID(), true);
+	}
+
+	/**
+	 * Retrieves a BLOB via a {@link BlobCache} which cannot create the final storage file. File
+	 * transfers should fail.
+	 *
+	 * @param jobId
+	 * 		job id
+	 * @param highAvailability
+	 * 		whether to retrieve a permanent blob (<tt>true</tt>, via {@link
+	 * 		PermanentBlobCache#getHAFile(JobID, BlobKey)}) or not (<tt>false</tt>, via {@link
+	 * 		TransientBlobCache#getFile(JobID, BlobKey)})
+	 */
+	private void testGetFailsStore(@Nullable final JobID jobId, boolean highAvailability)
+			throws IOException {
+		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
+
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
+		File jobStoreDir = null;
+		try (
+			BlobServer server = new BlobServer(config, new VoidBlobStore());
+			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, new VoidBlobStore())) {
+
+			server.start();
+
+			// store the data on the server
+			byte[] data = new byte[2000000];
+			rnd.nextBytes(data);
+			BlobKey blobKey = put(server, jobId, data, highAvailability);
+
+			// make sure the blob cache cannot create any files in its storage dir
+			if (highAvailability) {
+				jobStoreDir = cache.getPermanentBlobStore().getStorageLocation(jobId, new BlobKey())
+					.getParentFile();
+			} else {
+				jobStoreDir = cache.getTransientBlobStore().getStorageLocation(jobId, new BlobKey())
+					.getParentFile();
+			}
+			assertTrue(jobStoreDir.setExecutable(true, false));
+			assertTrue(jobStoreDir.setReadable(true, false));
+			assertTrue(jobStoreDir.setWritable(false, false));
+
+			// request the file from the server via the cache
+			exception.expect(AccessDeniedException.class);
+
+			try {
+				get(cache, jobId, blobKey, highAvailability);
+			} finally {
+				// there should be no remaining incoming files
+				File incomingFileDir = new File(jobStoreDir.getParent(), "incoming");
+				assertArrayEquals(new String[] {}, incomingFileDir.list());
+
+				// there should be no files in the job directory
+				assertArrayEquals(new String[] {}, jobStoreDir.list());
+			}
+		} finally {
+			// set writable again to make sure we can remove the directory
+			if (jobStoreDir != null) {
+				//noinspection ResultOfMethodCallIgnored
+				jobStoreDir.setWritable(true, false);
+			}
+		}
+	}
+
+	/**
+	 * Retrieves a BLOB from the HA store to a {@link BlobServer} whose HA store does not contain
+	 * the file. File transfers should fail.
+	 */
+	@Test
+	public void testGetFailsHaStoreForJobHa() throws IOException {
+		final JobID jobId = new JobID();
+
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
+		try (
+			BlobServer server = new BlobServer(config, new VoidBlobStore());
+			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, new VoidBlobStore())) {
+
+			server.start();
+
+			// store the data on the server (and blobStore), remove from local server store
+			byte[] data = new byte[2000000];
+			rnd.nextBytes(data);
+			BlobKey blobKey = put(server, jobId, data, true);
+			assertTrue(server.getStorageLocation(jobId, blobKey).delete());
+
+			File tempFileDir = server.createTemporaryFilename().getParentFile();
+
+			// request the file from the server via the cache
+			exception.expect(IOException.class);
+			exception.expectMessage("Failed to fetch BLOB ");
+
+			try {
+				get(cache, jobId, blobKey, true);
+			} finally {
+				HashSet<String> expectedDirs = new HashSet<>();
+				expectedDirs.add("incoming");
+				expectedDirs.add(JOB_DIR_PREFIX + jobId);
+				// only the incoming and job directory should exist (no job directory!)
+				File storageDir = tempFileDir.getParentFile();
+				String[] actualDirs = storageDir.list();
+				assertNotNull(actualDirs);
+				assertEquals(expectedDirs, new HashSet<>(Arrays.asList(actualDirs)));
+
+				// job directory should be empty
+				File jobDir = new File(tempFileDir.getParentFile(), JOB_DIR_PREFIX + jobId);
+				assertArrayEquals(new String[] {}, jobDir.list());
+			}
+		}
+	}
+
+	/**
+	 * FLINK-6020
+	 *
+	 * <p>Tests that concurrent get operations don't concurrently access the BlobStore to download a blob.
+	 */
+	@Test
+	public void testConcurrentGetOperationsNoJob() throws IOException, ExecutionException, InterruptedException {
+		testConcurrentGetOperations(null, false, false);
+	}
+
+	@Test
+	public void testConcurrentGetOperationsForJob() throws IOException, ExecutionException, InterruptedException {
+		testConcurrentGetOperations(new JobID(), false, false);
+	}
+
+	@Test
+	public void testConcurrentGetOperationsForJobHa() throws IOException, ExecutionException, InterruptedException {
+		testConcurrentGetOperations(new JobID(), true, false);
+	}
+
+	@Test
+	public void testConcurrentGetOperationsForJobHa2() throws IOException, ExecutionException, InterruptedException {
+		testConcurrentGetOperations(new JobID(), true, true);
+	}
+
+	/**
+	 * [FLINK-6020] Tests that concurrent get operations don't concurrently access the BlobStore to
+	 * download a blob.
+	 *
+	 * @param jobId
+	 * 		job ID to use (or <tt>null</tt> if job-unrelated)
+	 * @param highAvailability
+	 * 		whether to use permanent (<tt>true</tt>) or transient BLOBs (<tt>false</tt>)
+	 * @param cacheAccessesHAStore
+	 * 		whether the cache has access to the {@link BlobServer}'s HA store or not
+	 */
+	private void testConcurrentGetOperations(final JobID jobId, final boolean highAvailability,
+			final boolean cacheAccessesHAStore)
+			throws IOException, InterruptedException, ExecutionException {
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
+		final BlobStore blobStoreServer = mock(BlobStore.class);
+		final BlobStore blobStoreCache = mock(BlobStore.class);
+
+		final int numberConcurrentGetOperations = 3;
+		final List<CompletableFuture<File>> getOperations = new ArrayList<>(numberConcurrentGetOperations);
+
+		final byte[] data = {1, 2, 3, 4, 99, 42};
+
+		MessageDigest md = BlobUtils.createMessageDigest();
+
+		// create the correct blob key by hashing our input data
+		final BlobKey blobKey = new BlobKey(md.digest(data));
+
+		final ExecutorService executor = Executors.newFixedThreadPool(numberConcurrentGetOperations);
+
+		try (
+			final BlobServer server = new BlobServer(config, blobStoreServer);
+			final BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, cacheAccessesHAStore ? blobStoreServer : blobStoreCache)) {
+
+			server.start();
+
+			// upload data first
+			assertEquals(blobKey, put(server, jobId, data, highAvailability));
+
+			// now try accessing it concurrently (only HA mode will be able to retrieve it from HA store!)
+			for (int i = 0; i < numberConcurrentGetOperations; i++) {
+				CompletableFuture<File> getOperation = CompletableFuture
+					.supplyAsync(
+						() -> {
+							try {
+								File file = get(cache, jobId, blobKey, highAvailability);
+								// check that we have read the right data
+								validateGetAndClose(new FileInputStream(file), data);
+								return file;
+							} catch (IOException e) {
+								throw new CompletionException(new FlinkException(
+									"Could not upload blob.", e));
+							}
+						}, executor);
+
+				getOperations.add(getOperation);
+			}
+
+			FutureUtils.ConjunctFuture<Collection<File>> filesFuture = FutureUtils.combineAll(getOperations);
+
+			// wait until all operations have completed and check that no exception was thrown
+			filesFuture.get();
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
@@ -77,11 +77,11 @@ import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 
 /**
- * Tests for GET-specific parts of the {@link BlobCache}.
+ * Tests for GET-specific parts of the {@link BlobCacheService}.
  *
  * This includes access of transient BLOBs from the {@link PermanentBlobCache}, permanent BLOBS from
  * the {@link TransientBlobCache}, and how failing GET requests behave in the presence of failures
- * when used with a {@link BlobCache}.
+ * when used with a {@link BlobCacheService}.
  *
  * <p>Most successful GET requests are tested in conjunction wit the PUT requests by {@link
  * BlobCachePutTest}.
@@ -109,7 +109,7 @@ public class BlobCacheGetTest extends TestLogger {
 
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -149,7 +149,7 @@ public class BlobCacheGetTest extends TestLogger {
 
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -182,7 +182,7 @@ public class BlobCacheGetTest extends TestLogger {
 
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -244,7 +244,7 @@ public class BlobCacheGetTest extends TestLogger {
 
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -317,8 +317,8 @@ public class BlobCacheGetTest extends TestLogger {
 	}
 
 	/**
-	 * Retrieves a BLOB via a {@link BlobCache} which cannot create incoming files. File transfers
-	 * should fail.
+	 * Retrieves a BLOB via a {@link BlobCacheService} which cannot create incoming files. File
+	 * transfers should fail.
 	 *
 	 * @param jobId
 	 * 		job id
@@ -335,7 +335,7 @@ public class BlobCacheGetTest extends TestLogger {
 		File tempFileDir = null;
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -419,8 +419,8 @@ public class BlobCacheGetTest extends TestLogger {
 	}
 
 	/**
-	 * Retrieves a BLOB via a {@link BlobCache} which cannot create the final storage file. File
-	 * transfers should fail.
+	 * Retrieves a BLOB via a {@link BlobCacheService} which cannot create the final storage file.
+	 * File transfers should fail.
 	 *
 	 * @param jobId
 	 * 		job id
@@ -437,7 +437,7 @@ public class BlobCacheGetTest extends TestLogger {
 		File jobStoreDir = null;
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -505,7 +505,7 @@ public class BlobCacheGetTest extends TestLogger {
 
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -554,8 +554,8 @@ public class BlobCacheGetTest extends TestLogger {
 
 	/**
 	 * Uploads a byte array for the given job and verifies that a get operation of a transient BLOB
-	 * (via the {@link BlobCache}; also deletes the file on the {@link BlobServer}) does not fail
-	 * even if the file is not deletable on the {@link BlobServer}, e.g. via restricting the
+	 * (via the {@link BlobCacheService}; also deletes the file on the {@link BlobServer}) does not
+	 * fail even if the file is not deletable on the {@link BlobServer}, e.g. via restricting the
 	 * permissions.
 	 *
 	 * @param jobId
@@ -572,7 +572,7 @@ public class BlobCacheGetTest extends TestLogger {
 
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -673,7 +673,7 @@ public class BlobCacheGetTest extends TestLogger {
 
 		try (
 			final BlobServer server = new BlobServer(config, blobStoreServer);
-			final BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			final BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, cacheAccessesHAStore ? blobStoreServer : blobStoreCache)) {
 
 			server.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheGetTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -35,6 +36,7 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.file.AccessDeniedException;
@@ -42,6 +44,7 @@ import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -51,26 +54,37 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.apache.flink.runtime.blob.BlobCacheCleanupTest.verifyJobCleanup;
+import static org.apache.flink.runtime.blob.BlobCachePutTest.verifyDeletedEventually;
 import static org.apache.flink.runtime.blob.BlobClientTest.validateGetAndClose;
+import static org.apache.flink.runtime.blob.BlobServerDeleteTest.delete;
 import static org.apache.flink.runtime.blob.BlobServerGetTest.get;
 import static org.apache.flink.runtime.blob.BlobServerGetTest.verifyDeleted;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
 import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
 import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
 import static org.apache.flink.runtime.blob.BlobUtils.JOB_DIR_PREFIX;
 import static org.apache.flink.runtime.blob.BlobUtils.NO_JOB_DIR_PREFIX;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 
 /**
- * Tests how failing GET requests behave in the presence of failures when used with a {@link
- * BlobCache}.
+ * Tests for GET-specific parts of the {@link BlobCache}.
  *
- * <p>Successful GET requests are tested in conjunction wit the PUT requests.
+ * This includes access of transient BLOBs from the {@link PermanentBlobCache}, permanent BLOBS from
+ * the {@link TransientBlobCache}, and how failing GET requests behave in the presence of failures
+ * when used with a {@link BlobCache}.
+ *
+ * <p>Most successful GET requests are tested in conjunction wit the PUT requests by {@link
+ * BlobCachePutTest}.
  */
 public class BlobCacheGetTest extends TestLogger {
 
@@ -82,23 +96,136 @@ public class BlobCacheGetTest extends TestLogger {
 	@Rule
 	public final ExpectedException exception = ExpectedException.none();
 
+	/**
+	 * Checks the correct handling when retrieving transient BLOBs from the {@link
+	 * PermanentBlobCache}.
+	 */
 	@Test
-	public void testGetFailsDuringLookup1() throws IOException {
+	public void testGetTransientBlobForJobFromPermanentCache() throws IOException, InterruptedException {
+		final JobID jobId = new JobID();
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+		config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1L);
+
+		try (
+			BlobServer server = new BlobServer(config, new VoidBlobStore());
+			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, new VoidBlobStore())) {
+
+			server.start();
+
+			byte[] data = new byte[2000000];
+			rnd.nextBytes(data);
+
+			// put content addressable (like libraries)
+			BlobKey key = put(server, jobId, data, TRANSIENT_BLOB);
+			assertNotNull(key);
+			assertEquals(TRANSIENT_BLOB, key.getType());
+
+			// retrieve the transient BLOB from the PermanentBlobService
+			PermanentBlobCache permanentBlobService = cache.getPermanentBlobService();
+			permanentBlobService.registerJob(jobId);
+			File file = permanentBlobService.getPermanentFile(jobId, key);
+			validateGetAndClose(new FileInputStream(file), data);
+
+			// irrespective of the BlobCache, transient BLOBs should be deleted from the server, eventually
+			verifyDeletedEventually(server, jobId, key);
+
+			permanentBlobService.releaseJob(jobId);
+			verifyJobCleanup(permanentBlobService, jobId, Collections.singletonList(key));
+		}
+	}
+
+	/**
+	 * Checks the correct handling when retrieving transient BLOBs from the {@link
+	 * PermanentBlobCache}.
+	 */
+	@Test(expected = NullPointerException.class)
+	public void testGetTransientBlobNoJobFromPermanentCache() throws IOException, InterruptedException {
+		final JobID jobId = null;
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+		config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1L);
+
+		try (
+			BlobServer server = new BlobServer(config, new VoidBlobStore());
+			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, new VoidBlobStore())) {
+
+			server.start();
+
+			byte[] data = new byte[2000000];
+			rnd.nextBytes(data);
+
+			// put content addressable (like libraries)
+			BlobKey key = put(server, jobId, data, TRANSIENT_BLOB);
+			assertNotNull(key);
+			assertEquals(TRANSIENT_BLOB, key.getType());
+
+			// retrieve the transient BLOB from the PermanentBlobService
+			PermanentBlobCache permanentBlobService = cache.getPermanentBlobService();
+			// should crash due to jobId being null
+			permanentBlobService.getPermanentFile(jobId, key);
+		}
+	}
+
+	/**
+	 * Checks the correct handling when retrieving permanent BLOBs from the {@link
+	 * TransientBlobCache}.
+	 */
+	@Test
+	public void testGetPermanentBlobFromTransientCache() throws IOException, InterruptedException {
+		final JobID jobId = new JobID();
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+		config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1L);
+
+		try (
+			BlobServer server = new BlobServer(config, new VoidBlobStore());
+			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, new VoidBlobStore())) {
+
+			server.start();
+
+			byte[] data = new byte[2000000];
+			rnd.nextBytes(data);
+
+			// put content addressable (like libraries)
+			BlobKey key = put(server, jobId, data, PERMANENT_BLOB);
+			assertNotNull(key);
+			assertEquals(PERMANENT_BLOB, key.getType());
+
+			// retrieve the transient BLOB from the PermanentBlobService
+			TransientBlobCache transientBlobService = cache.getTransientBlobService();
+			File file = transientBlobService.getTransientFile(jobId, key);
+			validateGetAndClose(new FileInputStream(file), data);
+
+			// wait a bit and ensure that the BLOB is still available on the server
+			// (we don't know when the delete happens as it may be delayed - this makes it more
+			// probable that it already has, if executed at all)
+			Thread.sleep(100);
+			verifyContents(server, jobId, key, data);
+			verifyContents(cache, jobId, key, data); // accessed via permanent cache
+		}
+	}
+
+	@Test
+	public void testGetTransientFailsDuringLookup1() throws IOException, InterruptedException {
 		testGetFailsDuringLookup(null, new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
-	public void testGetFailsDuringLookup2() throws IOException {
+	public void testGetTransientFailsDuringLookup2() throws IOException, InterruptedException {
 		testGetFailsDuringLookup(new JobID(), new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
-	public void testGetFailsDuringLookup3() throws IOException {
+	public void testGetTransientFailsDuringLookup3() throws IOException, InterruptedException {
 		testGetFailsDuringLookup(new JobID(), null, TRANSIENT_BLOB);
 	}
 
 	@Test
-	public void testGetFailsDuringLookupHa() throws IOException {
+	public void testGetFailsDuringLookupHa() throws IOException, InterruptedException {
 		testGetFailsDuringLookup(new JobID(), new JobID(), PERMANENT_BLOB);
 	}
 
@@ -111,7 +238,7 @@ public class BlobCacheGetTest extends TestLogger {
 	 * 		whether the BLOB should become permanent or transient
 	 */
 	private void testGetFailsDuringLookup(final JobID jobId1, final JobID jobId2, BlobType blobType)
-		throws IOException {
+			throws IOException, InterruptedException {
 		final Configuration config = new Configuration();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
@@ -128,6 +255,7 @@ public class BlobCacheGetTest extends TestLogger {
 			// put content addressable (like libraries)
 			BlobKey key = put(server, jobId1, data, blobType);
 			assertNotNull(key);
+			assertEquals(blobType, key.getType());
 
 			// delete file to make sure that GET requests fail
 			File blobFile = server.getStorageLocation(jobId1, key);
@@ -146,25 +274,30 @@ public class BlobCacheGetTest extends TestLogger {
 			// request for jobId1 should still fail
 			verifyDeleted(cache, jobId1, key);
 
-			// delete on cache, try to retrieve again
 			if (blobType == PERMANENT_BLOB) {
+				// still existing on server
+				assertTrue(server.getStorageLocation(jobId2, key).exists());
+				// delete jobId2 on cache
 				blobFile = cache.getPermanentBlobService().getStorageLocation(jobId2, key);
-			} else {
-				blobFile = cache.getTransientBlobService().getStorageLocation(jobId2, key);
-			}
-			assertTrue(blobFile.delete());
-			get(cache, jobId2, key);
+				assertTrue(blobFile.delete());
+				// try to retrieve again
+				get(cache, jobId2, key);
 
-			// delete on cache and server, verify that it is not accessible anymore
-			if (blobType == PERMANENT_BLOB) {
+				// delete on cache and server, verify that it is not accessible anymore
 				blobFile = cache.getPermanentBlobService().getStorageLocation(jobId2, key);
+				assertTrue(blobFile.delete());
+				blobFile = server.getStorageLocation(jobId2, key);
+				assertTrue(blobFile.delete());
+				verifyDeleted(cache, jobId2, key);
 			} else {
+				// deleted eventually on the server by the GET request above
+				verifyDeletedEventually(server, jobId2, key);
+				// delete jobId2 on cache
 				blobFile = cache.getTransientBlobService().getStorageLocation(jobId2, key);
+				assertTrue(blobFile.delete());
+				// verify that it is not accessible anymore
+				verifyDeleted(cache, jobId2, key);
 			}
-			assertTrue(blobFile.delete());
-			blobFile = server.getStorageLocation(jobId2, key);
-			assertTrue(blobFile.delete());
-			verifyDeleted(cache, jobId2, key);
 		}
 	}
 
@@ -211,6 +344,7 @@ public class BlobCacheGetTest extends TestLogger {
 			byte[] data = new byte[2000000];
 			rnd.nextBytes(data);
 			BlobKey blobKey = put(server, jobId, data, blobType);
+			assertEquals(blobType, blobKey.getType());
 
 			// make sure the blob cache cannot create any files in its storage dir
 			if (blobType == PERMANENT_BLOB) {
@@ -256,6 +390,9 @@ public class BlobCacheGetTest extends TestLogger {
 					File noJobDir = new File(tempFileDir.getParentFile(), NO_JOB_DIR_PREFIX);
 					assertArrayEquals(new String[] {}, noJobDir.list());
 				}
+
+				// file should still be there on the server (even if transient)
+				assertTrue(server.getStorageLocation(jobId, blobKey).exists());
 			}
 		} finally {
 			// set writable again to make sure we can remove the directory
@@ -267,17 +404,17 @@ public class BlobCacheGetTest extends TestLogger {
 	}
 
 	@Test
-	public void testGetFailsStoreNoJob() throws IOException {
+	public void testGetTransientFailsStoreNoJob() throws IOException, InterruptedException {
 		testGetFailsStore(null, TRANSIENT_BLOB);
 	}
 
 	@Test
-	public void testGetFailsStoreForJob() throws IOException {
+	public void testGetTransientFailsStoreForJob() throws IOException, InterruptedException {
 		testGetFailsStore(new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
-	public void testGetFailsStoreForJobHa() throws IOException {
+	public void testGetPermanentFailsStoreForJob() throws IOException, InterruptedException {
 		testGetFailsStore(new JobID(), PERMANENT_BLOB);
 	}
 
@@ -291,7 +428,7 @@ public class BlobCacheGetTest extends TestLogger {
 	 * 		whether the BLOB should become permanent or transient
 	 */
 	private void testGetFailsStore(@Nullable final JobID jobId, BlobType blobType)
-			throws IOException {
+			throws IOException, InterruptedException {
 		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
 
 		final Configuration config = new Configuration();
@@ -309,6 +446,7 @@ public class BlobCacheGetTest extends TestLogger {
 			byte[] data = new byte[2000000];
 			rnd.nextBytes(data);
 			BlobKey blobKey = put(server, jobId, data, blobType);
+			assertEquals(blobType, blobKey.getType());
 
 			// make sure the blob cache cannot create any files in its storage dir
 			if (blobType == PERMANENT_BLOB) {
@@ -336,6 +474,14 @@ public class BlobCacheGetTest extends TestLogger {
 
 				// there should be no files in the job directory
 				assertArrayEquals(new String[] {}, jobStoreDir.list());
+
+				// if transient, the get will fail but since the download was successful, the file
+				// will not be on the server anymore
+				if (blobType == TRANSIENT_BLOB) {
+					verifyDeletedEventually(server, jobId, blobKey);
+				} else {
+					assertTrue(server.getStorageLocation(jobId, blobKey).exists());
+				}
 			}
 		} finally {
 			// set writable again to make sure we can remove the directory
@@ -368,6 +514,7 @@ public class BlobCacheGetTest extends TestLogger {
 			byte[] data = new byte[2000000];
 			rnd.nextBytes(data);
 			BlobKey blobKey = put(server, jobId, data, PERMANENT_BLOB);
+			assertEquals(PERMANENT_BLOB, blobKey.getType());
 			assertTrue(server.getStorageLocation(jobId, blobKey).delete());
 
 			File tempFileDir = server.createTemporaryFilename().getParentFile();
@@ -391,6 +538,78 @@ public class BlobCacheGetTest extends TestLogger {
 				// job directory should be empty
 				File jobDir = new File(tempFileDir.getParentFile(), JOB_DIR_PREFIX + jobId);
 				assertArrayEquals(new String[] {}, jobDir.list());
+			}
+		}
+	}
+
+	@Test
+	public void testGetTransientRemoteDeleteFailsNoJob() throws IOException {
+		testGetTransientRemoteDeleteFails(null);
+	}
+
+	@Test
+	public void testGetTransientRemoteDeleteFailsForJob() throws IOException {
+		testGetTransientRemoteDeleteFails(new JobID());
+	}
+
+	/**
+	 * Uploads a byte array for the given job and verifies that a get operation of a transient BLOB
+	 * (via the {@link BlobCache}; also deletes the file on the {@link BlobServer}) does not fail
+	 * even if the file is not deletable on the {@link BlobServer}, e.g. via restricting the
+	 * permissions.
+	 *
+	 * @param jobId
+	 * 		job id
+	 */
+	private void testGetTransientRemoteDeleteFails(@Nullable final JobID jobId) throws IOException {
+		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
+
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
+		File blobFile = null;
+		File directory = null;
+
+		try (
+			BlobServer server = new BlobServer(config, new VoidBlobStore());
+			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, new VoidBlobStore())) {
+
+			server.start();
+
+			try {
+				byte[] data = new byte[2000000];
+				rnd.nextBytes(data);
+
+				// put BLOB
+				BlobKey key = put(server, jobId, data, TRANSIENT_BLOB);
+				assertNotNull(key);
+				assertEquals(TRANSIENT_BLOB, key.getType());
+
+				blobFile = server.getStorageLocation(jobId, key);
+				directory = blobFile.getParentFile();
+
+				assertTrue(blobFile.setWritable(false, false));
+				assertTrue(directory.setWritable(false, false));
+
+				// access from cache once which also deletes the file on the server
+				verifyContents(cache, jobId, key, data);
+				// delete locally (should not be affected by the server)
+				assertTrue(delete(cache, jobId, key));
+				File blobFileAtCache = cache.getTransientBlobService().getStorageLocation(jobId, key);
+				assertFalse(blobFileAtCache.exists());
+
+				// the file should still be there on the server
+				verifyContents(server, jobId, key, data);
+				// ... and may be retrieved by the cache
+				verifyContents(cache, jobId, key, data);
+			} finally {
+				if (blobFile != null && directory != null) {
+					//noinspection ResultOfMethodCallIgnored
+					blobFile.setWritable(true, false);
+					//noinspection ResultOfMethodCallIgnored
+					directory.setWritable(true, false);
+				}
 			}
 		}
 	}
@@ -474,7 +693,7 @@ public class BlobCacheGetTest extends TestLogger {
 								return file;
 							} catch (IOException e) {
 								throw new CompletionException(new FlinkException(
-									"Could not upload blob.", e));
+									"Could not read blob for key " + blobKey + '.', e));
 							}
 						}, executor);
 
@@ -483,8 +702,29 @@ public class BlobCacheGetTest extends TestLogger {
 
 			FutureUtils.ConjunctFuture<Collection<File>> filesFuture = FutureUtils.combineAll(getOperations);
 
-			// wait until all operations have completed and check that no exception was thrown
-			filesFuture.get();
+			if (blobType == PERMANENT_BLOB) {
+				// wait until all operations have completed and check that no exception was thrown
+				filesFuture.get();
+			} else {
+				// wait for all futures to complete (do not abort on expected exceptions) and check
+				// that at least one succeeded
+				int completedSuccessfully = 0;
+				for (CompletableFuture<File> op : getOperations) {
+					try {
+						op.get();
+						++completedSuccessfully;
+					} catch (Throwable t) {
+						// transient BLOBs get deleted upon first access and only one request will be successful while all others will have an IOException caused by a FileNotFoundException
+						if (!(ExceptionUtils.getRootCause(t) instanceof FileNotFoundException)) {
+							// ignore
+							org.apache.flink.util.ExceptionUtils.rethrowIOException(t);
+						}
+					}
+				}
+				// multiple clients may have accessed the BLOB successfully before it was
+				// deleted, but always at least one:
+				assertThat(completedSuccessfully, greaterThanOrEqualTo(1));
+			}
 		} finally {
 			executor.shutdownNow();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCachePutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCachePutTest.java
@@ -242,8 +242,8 @@ public class BlobCachePutTest extends TestLogger {
 	}
 
 	/**
-	 * Uploads two byte arrays for different jobs into the server via the {@link BlobCache}. File
-	 * transfers should be successful.
+	 * Uploads two byte arrays for different jobs into the server via the {@link BlobCacheService}.
+	 * File transfers should be successful.
 	 *
 	 * @param jobId1
 	 * 		first job id
@@ -261,7 +261,7 @@ public class BlobCachePutTest extends TestLogger {
 
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -349,8 +349,8 @@ public class BlobCachePutTest extends TestLogger {
 	}
 
 	/**
-	 * Uploads two file streams for different jobs into the server via the {@link BlobCache}. File
-	 * transfers should be successful.
+	 * Uploads two file streams for different jobs into the server via the {@link BlobCacheService}.
+	 * File transfers should be successful.
 	 *
 	 * <p>Note that high-availability uploads of streams is currently only possible at the {@link
 	 * BlobServer}.
@@ -368,7 +368,7 @@ public class BlobCachePutTest extends TestLogger {
 
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -453,7 +453,7 @@ public class BlobCachePutTest extends TestLogger {
 
 	/**
 	 * Uploads two chunked file streams for different jobs into the server via the {@link
-	 * BlobCache}. File transfers should be successful.
+	 * BlobCacheService}. File transfers should be successful.
 	 *
 	 * <p>Note that high-availability uploads of streams is currently only possible at the {@link
 	 * BlobServer}.
@@ -472,7 +472,7 @@ public class BlobCachePutTest extends TestLogger {
 
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -547,8 +547,8 @@ public class BlobCachePutTest extends TestLogger {
 	}
 
 	/**
-	 * Uploads a byte array to a server which cannot create any files via the {@link BlobCache}.
-	 * File transfers should fail.
+	 * Uploads a byte array to a server which cannot create any files via the {@link
+	 * BlobCacheService}. File transfers should fail.
 	 *
 	 * @param jobId
 	 * 		job id
@@ -565,7 +565,7 @@ public class BlobCachePutTest extends TestLogger {
 		File tempFileDir = null;
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -611,7 +611,7 @@ public class BlobCachePutTest extends TestLogger {
 
 	/**
 	 * Uploads a byte array to a server which cannot create incoming files via the {@link
-	 * BlobCache}. File transfers should fail.
+	 * BlobCacheService}. File transfers should fail.
 	 *
 	 * @param jobId
 	 * 		job id
@@ -628,7 +628,7 @@ public class BlobCachePutTest extends TestLogger {
 		File tempFileDir = null;
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -678,8 +678,8 @@ public class BlobCachePutTest extends TestLogger {
 	}
 
 	/**
-	 * Uploads a byte array to a server which cannot create files via the {@link BlobCache}. File
-	 * transfers should fail.
+	 * Uploads a byte array to a server which cannot create files via the {@link BlobCacheService}.
+	 * File transfers should fail.
 	 *
 	 * @param jobId
 	 * 		job id
@@ -696,7 +696,7 @@ public class BlobCachePutTest extends TestLogger {
 		File jobStoreDir = null;
 		try (
 			BlobServer server = new BlobServer(config, new VoidBlobStore());
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -790,7 +790,7 @@ public class BlobCachePutTest extends TestLogger {
 
 		try (
 			final BlobServer server = new BlobServer(config, blobStoreServer);
-			final BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			final BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, blobStoreCache)) {
 
 			server.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCachePutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCachePutTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OperatingSystem;
-import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.commons.io.FileUtils;
@@ -39,12 +38,8 @@ import javax.annotation.Nullable;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetSocketAddress;
-import java.nio.file.AccessDeniedException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -58,9 +53,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Supplier;
 
-import static org.apache.flink.runtime.blob.BlobClientTest.validateGetAndClose;
-import static org.apache.flink.runtime.blob.BlobServerGetTest.get;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.BlockingInputStream;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.ChunkedInputStream;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -76,7 +74,7 @@ import static org.mockito.Mockito.verify;
  * Tests for successful and failing PUT operations against the BLOB server,
  * and successful GET operations.
  */
-public class BlobServerPutTest extends TestLogger {
+public class BlobCachePutTest extends TestLogger {
 
 	private final Random rnd = new Random();
 
@@ -89,56 +87,104 @@ public class BlobServerPutTest extends TestLogger {
 	// --- concurrency tests for utility methods which could fail during the put operation ---
 
 	/**
-	 * Checked thread that calls {@link BlobServer#getStorageLocation(JobID, BlobKey)}.
+	 * Checked thread that calls {@link TransientBlobCache#getStorageLocation(JobID, BlobKey)}.
 	 */
-	public static class ContentAddressableGetStorageLocation extends CheckedThread {
-		private final BlobServer server;
+	public static class TransientBlobCacheGetStorageLocation extends CheckedThread {
+		private final TransientBlobCache cache;
 		private final JobID jobId;
 		private final BlobKey key;
 
-		ContentAddressableGetStorageLocation(
-				BlobServer server, @Nullable JobID jobId, BlobKey key) {
-			this.server = server;
+		TransientBlobCacheGetStorageLocation(
+				TransientBlobCache cache, @Nullable JobID jobId, BlobKey key) {
+			this.cache = cache;
 			this.jobId = jobId;
 			this.key = key;
 		}
 
 		@Override
 		public void go() throws Exception {
-			server.getStorageLocation(jobId, key);
+			cache.getStorageLocation(jobId, key);
 		}
 	}
 
 	/**
-	 * Tests concurrent calls to {@link BlobServer#getStorageLocation(JobID, BlobKey)}.
+	 * Checked thread that calls {@link PermanentBlobCache#getStorageLocation(JobID, BlobKey)}.
 	 */
-	@Test
-	public void testServerContentAddressableGetStorageLocationConcurrentNoJob() throws Exception {
-		testServerContentAddressableGetStorageLocationConcurrent(null);
+	public static class PermanentBlobCacheGetStorageLocation extends CheckedThread {
+		private final PermanentBlobCache cache;
+		private final JobID jobId;
+		private final BlobKey key;
+
+		PermanentBlobCacheGetStorageLocation(PermanentBlobCache cache, JobID jobId, BlobKey key) {
+			this.cache = cache;
+			this.jobId = jobId;
+			this.key = key;
+		}
+
+		@Override
+		public void go() throws Exception {
+			cache.getStorageLocation(jobId, key);
+		}
 	}
 
 	/**
-	 * Tests concurrent calls to {@link BlobServer#getStorageLocation(JobID, BlobKey)}.
+	 * Tests concurrent calls to {@link TransientBlobCache#getStorageLocation(JobID, BlobKey)}.
 	 */
 	@Test
-	public void testServerContentAddressableGetStorageLocationConcurrentForJob() throws Exception {
-		testServerContentAddressableGetStorageLocationConcurrent(new JobID());
+	public void testTransientBlobCacheGetStorageLocationConcurrentNoJob() throws Exception {
+		testTransientBlobCacheGetStorageLocationConcurrent(null);
 	}
 
-	private void testServerContentAddressableGetStorageLocationConcurrent(
+	/**
+	 * Tests concurrent calls to {@link TransientBlobCache#getStorageLocation(JobID, BlobKey)}.
+	 */
+	@Test
+	public void testTransientBlobCacheGetStorageLocationConcurrentForJob() throws Exception {
+		testTransientBlobCacheGetStorageLocationConcurrent(new JobID());
+	}
+
+	private void testTransientBlobCacheGetStorageLocationConcurrent(
 			@Nullable final JobID jobId) throws Exception {
 		final Configuration config = new Configuration();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
-		try (BlobServer server = new BlobServer(config, new VoidBlobStore())) {
+		try (BlobServer server = new BlobServer(config, new VoidBlobStore());
+			final TransientBlobCache cache = new TransientBlobCache(
+				new InetSocketAddress("localhost", server.getPort()), config)) {
 
 			server.start();
 
 			BlobKey key = new BlobKey();
 			CheckedThread[] threads = new CheckedThread[] {
-				new ContentAddressableGetStorageLocation(server, jobId, key),
-				new ContentAddressableGetStorageLocation(server, jobId, key),
-				new ContentAddressableGetStorageLocation(server, jobId, key)
+				new TransientBlobCacheGetStorageLocation(cache, jobId, key),
+				new TransientBlobCacheGetStorageLocation(cache, jobId, key),
+				new TransientBlobCacheGetStorageLocation(cache, jobId, key)
+			};
+			checkedThreadSimpleTest(threads);
+		}
+	}
+
+	/**
+	 * Tests concurrent calls to {@link PermanentBlobCache#getStorageLocation(JobID, BlobKey)}.
+	 */
+	@Test
+	public void testPermanentBlobCacheGetStorageLocationConcurrentForJob() throws Exception {
+		final JobID jobId = new JobID();
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
+		try (BlobServer server = new BlobServer(config, new VoidBlobStore());
+			final PermanentBlobCache cache = new PermanentBlobCache(
+				new InetSocketAddress("localhost", server.getPort()), config,
+				new VoidBlobStore())) {
+
+			server.start();
+
+			BlobKey key = new BlobKey();
+			CheckedThread[] threads = new CheckedThread[] {
+				new PermanentBlobCacheGetStorageLocation(cache, jobId, key),
+				new PermanentBlobCacheGetStorageLocation(cache, jobId, key),
+				new PermanentBlobCacheGetStorageLocation(cache, jobId, key)
 			};
 			checkedThreadSimpleTest(threads);
 		}
@@ -192,7 +238,7 @@ public class BlobServerPutTest extends TestLogger {
 	}
 
 	/**
-	 * Uploads two byte arrays for different jobs into the server via the {@link BlobServer}. File
+	 * Uploads two byte arrays for different jobs into the server via the {@link BlobCache}. File
 	 * transfers should be successful.
 	 *
 	 * @param jobId1
@@ -200,7 +246,9 @@ public class BlobServerPutTest extends TestLogger {
 	 * @param jobId2
 	 * 		second job id
 	 * @param highAvailability
-	 * 		whether to upload a permanent blob (<tt>true</tt>) or not
+	 * 		whether to upload a permanent blob (<tt>true</tt>, via {@link
+	 * 		BlobClient#uploadJarFiles(InetSocketAddress, Configuration, JobID, List)}) or not
+	 * 		(<tt>false</tt>, via {@link TransientBlobCache#put(JobID, byte[])}
 	 */
 	private void testPutBufferSuccessfulGet(
 			@Nullable JobID jobId1, @Nullable JobID jobId2, boolean highAvailability)
@@ -209,7 +257,10 @@ public class BlobServerPutTest extends TestLogger {
 		final Configuration config = new Configuration();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
-		try (BlobServer server = new BlobServer(config, new VoidBlobStore())) {
+		try (
+			BlobServer server = new BlobServer(config, new VoidBlobStore());
+			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, new VoidBlobStore())) {
 
 			server.start();
 
@@ -218,21 +269,22 @@ public class BlobServerPutTest extends TestLogger {
 			byte[] data2 = Arrays.copyOfRange(data, 10, 54);
 
 			// put data for jobId1 and verify
-			BlobKey key1a = put(server, jobId1, data, highAvailability);
+			BlobKey key1a = put(cache, jobId1, data, highAvailability);
 			assertNotNull(key1a);
 
-			BlobKey key1b = put(server, jobId1, data2, highAvailability);
+			BlobKey key1b = put(cache, jobId1, data2, highAvailability);
 			assertNotNull(key1b);
 
+			// files should be available on the server
 			verifyContents(server, jobId1, key1a, data, highAvailability);
 			verifyContents(server, jobId1, key1b, data2, highAvailability);
 
 			// now put data for jobId2 and verify that both are ok
-			BlobKey key2a = put(server, jobId2, data, highAvailability);
+			BlobKey key2a = put(cache, jobId2, data, highAvailability);
 			assertNotNull(key2a);
 			assertEquals(key1a, key2a);
 
-			BlobKey key2b = put(server, jobId2, data2, highAvailability);
+			BlobKey key2b = put(cache, jobId2, data2, highAvailability);
 			assertNotNull(key2b);
 			assertEquals(key1b, key2b);
 
@@ -248,48 +300,46 @@ public class BlobServerPutTest extends TestLogger {
 
 	@Test
 	public void testPutStreamSuccessfulGet1() throws IOException {
-		testPutStreamSuccessfulGet(null, null, false);
+		testPutStreamSuccessfulGet(null, null);
 	}
 
 	@Test
 	public void testPutStreamSuccessfulGet2() throws IOException {
-		testPutStreamSuccessfulGet(null, new JobID(), false);
+		testPutStreamSuccessfulGet(null, new JobID());
 	}
 
 	@Test
 	public void testPutStreamSuccessfulGet3() throws IOException {
-		testPutStreamSuccessfulGet(new JobID(), new JobID(), false);
+		testPutStreamSuccessfulGet(new JobID(), new JobID());
 	}
 
 	@Test
 	public void testPutStreamSuccessfulGet4() throws IOException {
-		testPutStreamSuccessfulGet(new JobID(), null, false);
-	}
-
-	@Test
-	public void testPutStreamSuccessfulGetHa() throws IOException {
-		testPutStreamSuccessfulGet(new JobID(), new JobID(), true);
+		testPutStreamSuccessfulGet(new JobID(), null);
 	}
 
 	/**
-	 * Uploads two file streams for different jobs into the server via the {@link BlobServer}. File
+	 * Uploads two file streams for different jobs into the server via the {@link BlobCache}. File
 	 * transfers should be successful.
+	 *
+	 * <p>Note that high-availability uploads of streams is currently only possible at the {@link
+	 * BlobServer}.
 	 *
 	 * @param jobId1
 	 * 		first job id
 	 * @param jobId2
 	 * 		second job id
-	 * @param highAvailability
-	 * 		whether to upload a permanent blob (<tt>true</tt>) or not
 	 */
-	private void testPutStreamSuccessfulGet(
-			@Nullable JobID jobId1, @Nullable JobID jobId2, boolean highAvailability)
+	private void testPutStreamSuccessfulGet(@Nullable JobID jobId1, @Nullable JobID jobId2)
 			throws IOException {
 
 		final Configuration config = new Configuration();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
-		try (BlobServer server = new BlobServer(config, new VoidBlobStore())) {
+		try (
+			BlobServer server = new BlobServer(config, new VoidBlobStore());
+			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, new VoidBlobStore())) {
 
 			server.start();
 
@@ -298,29 +348,30 @@ public class BlobServerPutTest extends TestLogger {
 			byte[] data2 = Arrays.copyOfRange(data, 10, 54);
 
 			// put data for jobId1 and verify
-			BlobKey key1a = put(server, jobId1, new ByteArrayInputStream(data), highAvailability);
+			BlobKey key1a = put(cache, jobId1, new ByteArrayInputStream(data), false);
 			assertNotNull(key1a);
 
-			BlobKey key1b = put(server, jobId1, new ByteArrayInputStream(data2), highAvailability);
+			BlobKey key1b = put(cache, jobId1, new ByteArrayInputStream(data2), false);
 			assertNotNull(key1b);
 
-			verifyContents(server, jobId1, key1a, data, highAvailability);
-			verifyContents(server, jobId1, key1b, data2, highAvailability);
+			// files should be available on the server
+			verifyContents(server, jobId1, key1a, data, false);
+			verifyContents(server, jobId1, key1b, data2, false);
 
 			// now put data for jobId2 and verify that both are ok
-			BlobKey key2a = put(server, jobId2, new ByteArrayInputStream(data), highAvailability);
+			BlobKey key2a = put(cache, jobId2, new ByteArrayInputStream(data), false);
 			assertNotNull(key2a);
 			assertEquals(key1a, key2a);
 
-			BlobKey key2b = put(server, jobId2, new ByteArrayInputStream(data2), highAvailability);
+			BlobKey key2b = put(cache, jobId2, new ByteArrayInputStream(data2), false);
 			assertNotNull(key2b);
 			assertEquals(key1b, key2b);
 
 			// verify the accessibility and the BLOB contents
-			verifyContents(server, jobId1, key1a, data, highAvailability);
-			verifyContents(server, jobId1, key1b, data2, highAvailability);
-			verifyContents(server, jobId2, key2a, data, highAvailability);
-			verifyContents(server, jobId2, key2b, data2, highAvailability);
+			verifyContents(server, jobId1, key1a, data, false);
+			verifyContents(server, jobId1, key1b, data2, false);
+			verifyContents(server, jobId2, key2a, data, false);
+			verifyContents(server, jobId2, key2b, data2, false);
 		}
 	}
 
@@ -328,48 +379,46 @@ public class BlobServerPutTest extends TestLogger {
 
 	@Test
 	public void testPutChunkedStreamSuccessfulGet1() throws IOException {
-		testPutChunkedStreamSuccessfulGet(null, null, false);
+		testPutChunkedStreamSuccessfulGet(null, null);
 	}
 
 	@Test
 	public void testPutChunkedStreamSuccessfulGet2() throws IOException {
-		testPutChunkedStreamSuccessfulGet(null, new JobID(), false);
+		testPutChunkedStreamSuccessfulGet(null, new JobID());
 	}
 
 	@Test
 	public void testPutChunkedStreamSuccessfulGet3() throws IOException {
-		testPutChunkedStreamSuccessfulGet(new JobID(), new JobID(), false);
+		testPutChunkedStreamSuccessfulGet(new JobID(), new JobID());
 	}
 
 	@Test
 	public void testPutChunkedStreamSuccessfulGet4() throws IOException {
-		testPutChunkedStreamSuccessfulGet(new JobID(), null, false);
-	}
-
-	@Test
-	public void testPutChunkedStreamSuccessfulGetHa() throws IOException {
-		testPutChunkedStreamSuccessfulGet(new JobID(), new JobID(), true);
+		testPutChunkedStreamSuccessfulGet(new JobID(), null);
 	}
 
 	/**
 	 * Uploads two chunked file streams for different jobs into the server via the {@link
-	 * BlobServer}. File transfers should be successful.
+	 * BlobCache}. File transfers should be successful.
+	 *
+	 * <p>Note that high-availability uploads of streams is currently only possible at the {@link
+	 * BlobServer}.
 	 *
 	 * @param jobId1
 	 * 		first job id
 	 * @param jobId2
 	 * 		second job id
-	 * @param highAvailability
-	 * 		whether to upload a permanent blob (<tt>true</tt>) or not
 	 */
 	private void testPutChunkedStreamSuccessfulGet(
-			@Nullable JobID jobId1, @Nullable JobID jobId2, boolean highAvailability)
-			throws IOException {
+			@Nullable JobID jobId1, @Nullable JobID jobId2) throws IOException {
 
 		final Configuration config = new Configuration();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
-		try (BlobServer server = new BlobServer(config, new VoidBlobStore())) {
+		try (
+			BlobServer server = new BlobServer(config, new VoidBlobStore());
+			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, new VoidBlobStore())) {
 
 			server.start();
 
@@ -378,29 +427,30 @@ public class BlobServerPutTest extends TestLogger {
 			byte[] data2 = Arrays.copyOfRange(data, 10, 54);
 
 			// put data for jobId1 and verify
-			BlobKey key1a = put(server, jobId1, new ChunkedInputStream(data, 19), highAvailability);
+			BlobKey key1a = put(cache, jobId1, new ChunkedInputStream(data, 19), false);
 			assertNotNull(key1a);
 
-			BlobKey key1b = put(server, jobId1, new ChunkedInputStream(data2, 19), highAvailability);
+			BlobKey key1b = put(cache, jobId1, new ChunkedInputStream(data2, 19), false);
 			assertNotNull(key1b);
 
-			verifyContents(server, jobId1, key1a, data, highAvailability);
-			verifyContents(server, jobId1, key1b, data2, highAvailability);
+			// files should be available on the server
+			verifyContents(server, jobId1, key1a, data, false);
+			verifyContents(server, jobId1, key1b, data2, false);
 
 			// now put data for jobId2 and verify that both are ok
-			BlobKey key2a = put(server, jobId2, new ChunkedInputStream(data, 19), highAvailability);
+			BlobKey key2a = put(cache, jobId2, new ChunkedInputStream(data, 19), false);
 			assertNotNull(key2a);
 			assertEquals(key1a, key2a);
 
-			BlobKey key2b = put(server, jobId2, new ChunkedInputStream(data2, 19), highAvailability);
+			BlobKey key2b = put(cache, jobId2, new ChunkedInputStream(data2, 19), false);
 			assertNotNull(key2b);
 			assertEquals(key1b, key2b);
 
 			// verify the accessibility and the BLOB contents
-			verifyContents(server, jobId1, key1a, data, highAvailability);
-			verifyContents(server, jobId1, key1b, data2, highAvailability);
-			verifyContents(server, jobId2, key2a, data, highAvailability);
-			verifyContents(server, jobId2, key2b, data2, highAvailability);
+			verifyContents(server, jobId1, key1a, data, false);
+			verifyContents(server, jobId1, key1b, data2, false);
+			verifyContents(server, jobId2, key2a, data, false);
+			verifyContents(server, jobId2, key2b, data2, false);
 		}
 	}
 
@@ -422,13 +472,15 @@ public class BlobServerPutTest extends TestLogger {
 	}
 
 	/**
-	 * Uploads a byte array to a server which cannot create any files via the {@link BlobServer}.
+	 * Uploads a byte array to a server which cannot create any files via the {@link BlobCache}.
 	 * File transfers should fail.
 	 *
 	 * @param jobId
 	 * 		job id
 	 * @param highAvailability
-	 * 		whether to upload a permanent blob (<tt>true</tt>) or not
+	 * 		whether to upload a permanent blob (<tt>true</tt>, via {@link
+	 * 		BlobClient#uploadJarFiles(InetSocketAddress, Configuration, JobID, List)}) or not
+	 * 		(<tt>false</tt>, via {@link TransientBlobCache#put(JobID, byte[])}
 	 */
 	private void testPutBufferFails(@Nullable final JobID jobId, boolean highAvailability)
 			throws IOException {
@@ -438,7 +490,10 @@ public class BlobServerPutTest extends TestLogger {
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
 		File tempFileDir = null;
-		try (BlobServer server = new BlobServer(config, new VoidBlobStore())) {
+		try (
+			BlobServer server = new BlobServer(config, new VoidBlobStore());
+			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, new VoidBlobStore())) {
 
 			server.start();
 
@@ -451,11 +506,11 @@ public class BlobServerPutTest extends TestLogger {
 			byte[] data = new byte[2000000];
 			rnd.nextBytes(data);
 
-			// upload the file to the server directly
+			// upload the file to the server via the cache
 			exception.expect(IOException.class);
-			exception.expectMessage("Cannot create directory ");
+			exception.expectMessage("PUT operation failed: ");
 
-			put(server, jobId, data, highAvailability);
+			put(cache, jobId, data, highAvailability);
 
 		} finally {
 			// set writable again to make sure we can remove the directory
@@ -483,12 +538,14 @@ public class BlobServerPutTest extends TestLogger {
 
 	/**
 	 * Uploads a byte array to a server which cannot create incoming files via the {@link
-	 * BlobServer}. File transfers should fail.
+	 * BlobCache}. File transfers should fail.
 	 *
 	 * @param jobId
 	 * 		job id
 	 * @param highAvailability
-	 * 		whether to upload a permanent blob (<tt>true</tt>) or not
+	 * 		whether to upload a permanent blob (<tt>true</tt>, via {@link
+	 * 		BlobClient#uploadJarFiles(InetSocketAddress, Configuration, JobID, List)}) or not
+	 * 		(<tt>false</tt>, via {@link TransientBlobCache#put(JobID, byte[])}
 	 */
 	private void testPutBufferFailsIncoming(@Nullable final JobID jobId, boolean highAvailability)
 			throws IOException {
@@ -498,7 +555,10 @@ public class BlobServerPutTest extends TestLogger {
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
 		File tempFileDir = null;
-		try (BlobServer server = new BlobServer(config, new VoidBlobStore())) {
+		try (
+			BlobServer server = new BlobServer(config, new VoidBlobStore());
+			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, new VoidBlobStore())) {
 
 			server.start();
 
@@ -511,12 +571,12 @@ public class BlobServerPutTest extends TestLogger {
 			byte[] data = new byte[2000000];
 			rnd.nextBytes(data);
 
-			// upload the file to the server directly
+			// upload the file to the server via the cache
 			exception.expect(IOException.class);
-			exception.expectMessage(" (Permission denied)");
+			exception.expectMessage("PUT operation failed: ");
 
 			try {
-				put(server, jobId, data, highAvailability);
+				put(cache, jobId, data, highAvailability);
 			} finally {
 				File storageDir = tempFileDir.getParentFile();
 				// only the incoming directory should exist (no job directory!)
@@ -547,13 +607,15 @@ public class BlobServerPutTest extends TestLogger {
 	}
 
 	/**
-	 * Uploads a byte array to a server which cannot move incoming files to the final blob store via
-	 * the {@link BlobServer}. File transfers should fail.
+	 * Uploads a byte array to a server which cannot create files via the {@link BlobCache}. File
+	 * transfers should fail.
 	 *
 	 * @param jobId
 	 * 		job id
 	 * @param highAvailability
-	 * 		whether to upload a permanent blob (<tt>true</tt>) or not
+	 * 		whether to upload a permanent blob (<tt>true</tt>, via {@link
+	 * 		BlobClient#uploadJarFiles(InetSocketAddress, Configuration, JobID, List)}) or not
+	 * 		(<tt>false</tt>, via {@link TransientBlobCache#put(JobID, byte[])}
 	 */
 	private void testPutBufferFailsStore(@Nullable final JobID jobId, boolean highAvailability)
 			throws IOException {
@@ -563,7 +625,10 @@ public class BlobServerPutTest extends TestLogger {
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
 		File jobStoreDir = null;
-		try (BlobServer server = new BlobServer(config, new VoidBlobStore())) {
+		try (
+			BlobServer server = new BlobServer(config, new VoidBlobStore());
+			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, new VoidBlobStore())) {
 
 			server.start();
 
@@ -576,11 +641,12 @@ public class BlobServerPutTest extends TestLogger {
 			byte[] data = new byte[2000000];
 			rnd.nextBytes(data);
 
-			// upload the file to the server directly
-			exception.expect(AccessDeniedException.class);
+			// upload the file to the server via the cache
+			exception.expect(IOException.class);
+			exception.expectMessage("PUT operation failed: ");
 
 			try {
-				put(server, jobId, data, highAvailability);
+				put(cache, jobId, data, highAvailability);
 			} finally {
 				// there should be no remaining incoming files
 				File incomingFileDir = new File(jobStoreDir.getParent(), "incoming");
@@ -629,38 +695,79 @@ public class BlobServerPutTest extends TestLogger {
 		final Configuration config = new Configuration();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
-		BlobStore blobStore = mock(BlobStore.class);
+		final BlobStore blobStoreServer = mock(BlobStore.class);
+		final BlobStore blobStoreCache = mock(BlobStore.class);
+
 		int concurrentPutOperations = 2;
 		int dataSize = 1024;
 
 		final CountDownLatch countDownLatch = new CountDownLatch(concurrentPutOperations);
 		final byte[] data = new byte[dataSize];
 
-		ArrayList<CompletableFuture<BlobKey>> allFutures = new ArrayList<>(concurrentPutOperations);
+		final List<Path> jars;
+		if (highAvailability) {
+			// implement via JAR file upload instead:
+			File tmpFile = temporaryFolder.newFile();
+			FileUtils.writeByteArrayToFile(tmpFile, data);
+			jars = Collections.singletonList(new Path(tmpFile.getAbsolutePath()));
+		} else {
+			jars = null;
+		}
+
+		Collection<CompletableFuture<BlobKey>> allFutures = new ArrayList<>(concurrentPutOperations);
 
 		ExecutorService executor = Executors.newFixedThreadPool(concurrentPutOperations);
 
-		try (final BlobServer server = new BlobServer(config, blobStore)) {
+		try (
+			final BlobServer server = new BlobServer(config, blobStoreServer);
+			final BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				config, blobStoreCache)) {
 
 			server.start();
 
+			// for highAvailability
+			final InetSocketAddress serverAddress =
+				new InetSocketAddress("localhost", server.getPort());
+			// uploading HA BLOBs works on BlobServer only (and, for now, via the BlobClient)
+
 			for (int i = 0; i < concurrentPutOperations; i++) {
-				CompletableFuture<BlobKey> putFuture = CompletableFuture
-					.supplyAsync(
+				final Supplier<BlobKey> callable;
+				if (highAvailability) {
+					// cannot use a blocking stream here (upload only possible via files)
+					callable =
 						() -> {
 							try {
-								BlockingInputStream inputStream =
-									new BlockingInputStream(countDownLatch, data);
-								BlobKey uploadedKey = put(server, jobId, inputStream, highAvailability);
+								List<BlobKey> keys =
+									BlobClient.uploadJarFiles(serverAddress, config, jobId, jars);
+								assertEquals(1, keys.size());
+								BlobKey uploadedKey = keys.get(0);
 								// check the uploaded file's contents (concurrently)
-								verifyContents(server, jobId, uploadedKey, data, highAvailability);
+								verifyContents(server, jobId, uploadedKey, data, true);
 								return uploadedKey;
 							} catch (IOException e) {
 								throw new CompletionException(new FlinkException(
 									"Could not upload blob.", e));
 							}
-						},
-						executor);
+						};
+
+				} else {
+					callable =
+						() -> {
+							try {
+								BlockingInputStream inputStream =
+									new BlockingInputStream(countDownLatch, data);
+								BlobKey uploadedKey = put(cache, jobId, inputStream, false);
+								// check the uploaded file's contents (concurrently)
+								verifyContents(server, jobId, uploadedKey, data, false);
+								return uploadedKey;
+							} catch (IOException e) {
+								throw new CompletionException(new FlinkException(
+									"Could not upload blob.", e));
+							}
+					};
+				}
+				CompletableFuture<BlobKey> putFuture = CompletableFuture
+					.supplyAsync(callable, executor);
 
 				allFutures.add(putFuture);
 			}
@@ -686,212 +793,16 @@ public class BlobServerPutTest extends TestLogger {
 
 			// check that we only uploaded the file once to the blob store
 			if (highAvailability) {
-				verify(blobStore, times(1)).put(any(File.class), eq(jobId), eq(blobKey));
+				verify(blobStoreServer, times(1)).put(any(File.class), eq(jobId), eq(blobKey));
 			} else {
 				// can't really verify much in the other cases other than that the put operations should
 				// work and not corrupt files
-				verify(blobStore, times(0)).put(any(File.class), eq(jobId), eq(blobKey));
+				verify(blobStoreServer, times(0)).put(any(File.class), eq(jobId), eq(blobKey));
 			}
+			// caches must not access the blob store (they are not allowed to write there)
+			verify(blobStoreCache, times(0)).put(any(File.class), eq(jobId), eq(blobKey));
 		} finally {
 			executor.shutdownNow();
-		}
-	}
-
-	// --------------------------------------------------------------------------------------------
-
-	/**
-	 * Helper to choose the right {@link BlobServer#put} method.
-	 *
-	 * @return blob key for the uploaded data
-	 */
-	static BlobKey put(BlobService service, @Nullable JobID jobId, InputStream data, boolean highAvailability)
-			throws IOException {
-		if (highAvailability) {
-			if (service instanceof BlobServer) {
-				return ((BlobServer) service).putHA(jobId, data);
-			} else {
-				throw new UnsupportedOperationException("uploading streams is only possible at the BlobServer");
-			}
-		} else if (jobId == null) {
-			return service.getTransientBlobStore().put(data);
-		} else {
-			return service.getTransientBlobStore().put(jobId, data);
-		}
-	}
-
-	/**
-	 * Helper to choose the right {@link BlobServer#put} method.
-	 *
-	 * @return blob key for the uploaded data
-	 */
-	static BlobKey put(BlobService service, @Nullable JobID jobId, byte[] data, boolean highAvailability)
-			throws IOException {
-		if (highAvailability) {
-			if (service instanceof BlobServer) {
-				return ((BlobServer) service).putHA(jobId, data);
-			} else {
-				// implement via JAR file upload instead:
-				File tmpFile = Files.createTempFile("blob", ".jar").toFile();
-				try {
-					FileUtils.writeByteArrayToFile(tmpFile, data);
-					InetSocketAddress serverAddress = new InetSocketAddress("localhost", service.getPort());
-					// uploading HA BLOBs works on BlobServer only (and, for now, via the BlobClient)
-					Configuration clientConfig = new Configuration();
-					List<Path> jars = Collections.singletonList(new Path(tmpFile.getAbsolutePath()));
-					List<BlobKey> keys = BlobClient.uploadJarFiles(serverAddress, clientConfig, jobId, jars);
-					assertEquals(1, keys.size());
-					return keys.get(0);
-				} finally {
-					//noinspection ResultOfMethodCallIgnored
-					tmpFile.delete();
-				}
-			}
-		} else if (jobId == null) {
-			return service.getTransientBlobStore().put(data);
-		} else {
-			return service.getTransientBlobStore().put(jobId, data);
-		}
-	}
-
-	/**
-	 * GET the data stored at the two keys and check that it is equal to <tt>data</tt>.
-	 *
-	 * @param blobService
-	 * 		BlobServer to use
-	 * @param jobId
-	 * 		job ID or <tt>null</tt> if job-unrelated
-	 * @param key
-	 * 		blob key
-	 * @param data
-	 * 		expected data
-	 * @param highAvailability
-	 * 		whether to use HA mode accessors
-	 */
-	static void verifyContents(
-			BlobService blobService, @Nullable JobID jobId, BlobKey key, byte[] data, boolean highAvailability)
-			throws IOException {
-
-		File file = get(blobService, jobId, key, highAvailability);
-		validateGetAndClose(new FileInputStream(file), data);
-	}
-
-	/**
-	 * GET the data stored at the two keys and check that it is equal to <tt>data</tt>.
-	 *
-	 * @param blobService
-	 * 		BlobServer to use
-	 * @param jobId
-	 * 		job ID or <tt>null</tt> if job-unrelated
-	 * @param key
-	 * 		blob key
-	 * @param data
-	 * 		expected data
-	 * @param highAvailability
-	 * 		whether to use HA mode accessors
-	 */
-	static void verifyContents(
-			BlobService blobService, @Nullable JobID jobId, BlobKey key, InputStream data,
-			boolean highAvailability) throws IOException {
-
-		File file = get(blobService, jobId, key, highAvailability);
-		validateGetAndClose(new FileInputStream(file), data);
-	}
-
-	// --------------------------------------------------------------------------------------------
-
-	static final class BlockingInputStream extends InputStream {
-
-		private final CountDownLatch countDownLatch;
-		private final byte[] data;
-		private int index = 0;
-
-		BlockingInputStream(CountDownLatch countDownLatch, byte[] data) {
-			this.countDownLatch = Preconditions.checkNotNull(countDownLatch);
-			this.data = Preconditions.checkNotNull(data);
-		}
-
-		@Override
-		public int read() throws IOException {
-
-			countDownLatch.countDown();
-
-			try {
-				countDownLatch.await();
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-				throw new IOException("Blocking operation was interrupted.", e);
-			}
-
-			if (index >= data.length) {
-				return -1;
-			} else {
-				return data[index++];
-			}
-		}
-	}
-
-	// --------------------------------------------------------------------------------------------
-
-	static final class ChunkedInputStream extends InputStream {
-
-		private final byte[][] data;
-
-		private int x = 0, y = 0;
-
-		ChunkedInputStream(byte[] data, int numChunks) {
-			this.data = new byte[numChunks][];
-
-			int bytesPerChunk = data.length / numChunks;
-			int bytesTaken = 0;
-			for (int i = 0; i < numChunks - 1; i++, bytesTaken += bytesPerChunk) {
-				this.data[i] = new byte[bytesPerChunk];
-				System.arraycopy(data, bytesTaken, this.data[i], 0, bytesPerChunk);
-			}
-
-			this.data[numChunks -  1] = new byte[data.length - bytesTaken];
-			System.arraycopy(data, bytesTaken, this.data[numChunks -  1], 0, this.data[numChunks -  1].length);
-		}
-
-		@Override
-		public int read() {
-			if (x < data.length) {
-				byte[] curr = data[x];
-				if (y < curr.length) {
-					byte next = curr[y];
-					y++;
-					return next;
-				}
-				else {
-					y = 0;
-					x++;
-					return read();
-				}
-			} else {
-				return -1;
-			}
-		}
-
-		@Override
-		public int read(byte[] b, int off, int len) throws IOException {
-			if (len == 0) {
-				return 0;
-			}
-			if (x < data.length) {
-				byte[] curr = data[x];
-				if (y < curr.length) {
-					int toCopy = Math.min(len, curr.length - y);
-					System.arraycopy(curr, y, b, off, toCopy);
-					y += toCopy;
-					return toCopy;
-				} else {
-					y = 0;
-					x++;
-					return read(b, off, len);
-				}
-			}
-			else {
-				return -1;
-			}
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRecoveryTest.java
@@ -36,11 +36,11 @@ import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Random;
 
+import static org.apache.flink.runtime.blob.BlobKey.BlobType.PERMANENT_BLOB;
+import static org.apache.flink.runtime.blob.BlobKey.BlobType.TRANSIENT_BLOB;
 import static org.apache.flink.runtime.blob.BlobServerGetTest.verifyDeleted;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
-import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
-import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRecoveryTest.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Tests for the recovery of files of a {@link BlobCache} from a HA store.
+ * Tests for the recovery of files of a {@link BlobCacheService} from a HA store.
  */
 public class BlobCacheRecoveryTest extends TestLogger {
 
@@ -82,9 +82,9 @@ public class BlobCacheRecoveryTest extends TestLogger {
 	/**
 	 * Helper to test that the {@link BlobServer} recovery from its HA store works.
 	 *
-	 * <p>Uploads two BLOBs to one {@link BlobServer} via a {@link BlobCache} and expects a second
-	 * {@link BlobCache} to be able to retrieve them from a second {@link BlobServer} that is
-	 * configured with the same HA store.
+	 * <p>Uploads two BLOBs to one {@link BlobServer} via a {@link BlobCacheService} and expects a
+	 * second {@link BlobCacheService} to be able to retrieve them from a second {@link BlobServer}
+	 * that is configured with the same HA store.
 	 *
 	 * @param config
 	 * 		blob server configuration (including HA settings like {@link HighAvailabilityOptions#HA_STORAGE_PATH}
@@ -106,10 +106,10 @@ public class BlobCacheRecoveryTest extends TestLogger {
 			BlobServer server0 = new BlobServer(config, blobStore);
 			BlobServer server1 = new BlobServer(config, blobStore);
 			// use VoidBlobStore as the HA store to force download from each server's HA store
-			BlobCache cache0 = new BlobCache(
+			BlobCacheService cache0 = new BlobCacheService(
 				new InetSocketAddress("localhost", server0.getPort()), config,
 				new VoidBlobStore());
-			BlobCache cache1 = new BlobCache(
+			BlobCacheService cache1 = new BlobCacheService(
 				new InetSocketAddress("localhost", server1.getPort()), config,
 				new VoidBlobStore())) {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRecoveryTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
@@ -40,7 +39,11 @@ import java.util.Random;
 import static org.apache.flink.runtime.blob.BlobServerGetTest.verifyDeleted;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
-import static org.junit.Assert.assertEquals;
+import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
+import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -60,7 +63,6 @@ public class BlobCacheRecoveryTest extends TestLogger {
 	public void testBlobCacheRecovery() throws Exception {
 		Configuration config = new Configuration();
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-		config.setString(CoreOptions.STATE_BACKEND, "FILESYSTEM");
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getPath());
 
@@ -124,13 +126,15 @@ public class BlobCacheRecoveryTest extends TestLogger {
 
 			// Put job-related HA data
 			JobID[] jobId = new JobID[] { new JobID(), new JobID() };
-			keys[0] = put(cache0, jobId[0], expected, true); // Request 1
-			keys[1] = put(cache0, jobId[1], expected2, true); // Request 2
+			keys[0] = put(cache0, jobId[0], expected, PERMANENT_BLOB); // Request 1
+			keys[1] = put(cache0, jobId[1], expected2, PERMANENT_BLOB); // Request 2
 
 			// put non-HA data
-			nonHAKey = put(cache0, jobId[0], expected2, false);
+			nonHAKey = put(cache0, jobId[0], expected2, TRANSIENT_BLOB);
 			assertNotEquals(keys[0], nonHAKey);
-			assertEquals(keys[1], nonHAKey);
+			assertThat(keys[0].getHash(), not(equalTo(nonHAKey.getHash())));
+			assertNotEquals(keys[1], nonHAKey);
+			assertThat(keys[1].getHash(), equalTo(nonHAKey.getHash()));
 
 			// check that the storage directory exists
 			final Path blobServerPath = new Path(storagePath, "blob");
@@ -138,11 +142,11 @@ public class BlobCacheRecoveryTest extends TestLogger {
 			assertTrue("Unknown storage dir: " + blobServerPath, fs.exists(blobServerPath));
 
 			// Verify HA requests from cache1 (connected to server1) with no immediate access to the file
-			verifyContents(cache1, jobId[0], keys[0], expected, true);
-			verifyContents(cache1, jobId[1], keys[1], expected2, true);
+			verifyContents(cache1, jobId[0], keys[0], expected);
+			verifyContents(cache1, jobId[1], keys[1], expected2);
 
 			// Verify non-HA file is not accessible from server1
-			verifyDeleted(cache1, jobId[0], nonHAKey, true);
+			verifyDeleted(cache1, jobId[0], nonHAKey);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRecoveryTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.apache.flink.runtime.blob.BlobServerGetTest.verifyDeleted;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the recovery of files of a {@link BlobCache} from a HA store.
+ */
+public class BlobCacheRecoveryTest extends TestLogger {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	/**
+	 * Tests that with {@link HighAvailabilityMode#ZOOKEEPER} distributed JARs are recoverable from any
+	 * participating BlobServer.
+	 */
+	@Test
+	public void testBlobCacheRecovery() throws Exception {
+		Configuration config = new Configuration();
+		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+		config.setString(CoreOptions.STATE_BACKEND, "FILESYSTEM");
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getPath());
+
+		BlobStoreService blobStoreService = null;
+
+		try {
+			blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
+
+			testBlobCacheRecovery(config, blobStoreService);
+		} finally {
+			if (blobStoreService != null) {
+				blobStoreService.closeAndCleanupAllData();
+			}
+		}
+	}
+
+	/**
+	 * Helper to test that the {@link BlobServer} recovery from its HA store works.
+	 *
+	 * <p>Uploads two BLOBs to one {@link BlobServer} via a {@link BlobCache} and expects a second
+	 * {@link BlobCache} to be able to retrieve them from a second {@link BlobServer} that is
+	 * configured with the same HA store.
+	 *
+	 * @param config
+	 * 		blob server configuration (including HA settings like {@link HighAvailabilityOptions#HA_STORAGE_PATH}
+	 * 		and {@link HighAvailabilityOptions#HA_CLUSTER_ID}) used to set up <tt>blobStore</tt>
+	 * @param blobStore
+	 * 		shared HA blob store to use
+	 *
+	 * @throws IOException
+	 * 		in case of failures
+	 */
+	public static void testBlobCacheRecovery(
+			final Configuration config, final BlobStore blobStore) throws IOException {
+
+		final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
+		String storagePath = config.getString(HighAvailabilityOptions.HA_STORAGE_PATH) + "/" + clusterId;
+		Random rand = new Random();
+
+		try (
+			BlobServer server0 = new BlobServer(config, blobStore);
+			BlobServer server1 = new BlobServer(config, blobStore);
+			// use VoidBlobStore as the HA store to force download from each server's HA store
+			BlobCache cache0 = new BlobCache(
+				new InetSocketAddress("localhost", server0.getPort()), config,
+				new VoidBlobStore());
+			BlobCache cache1 = new BlobCache(
+				new InetSocketAddress("localhost", server1.getPort()), config,
+				new VoidBlobStore())) {
+
+			server0.start();
+			server1.start();
+
+			// Random data
+			byte[] expected = new byte[1024];
+			rand.nextBytes(expected);
+			byte[] expected2 = Arrays.copyOfRange(expected, 32, 288);
+
+			BlobKey[] keys = new BlobKey[2];
+			BlobKey nonHAKey;
+
+			// Put job-related HA data
+			JobID[] jobId = new JobID[] { new JobID(), new JobID() };
+			keys[0] = put(cache0, jobId[0], expected, true); // Request 1
+			keys[1] = put(cache0, jobId[1], expected2, true); // Request 2
+
+			// put non-HA data
+			nonHAKey = put(cache0, jobId[0], expected2, false);
+			assertNotEquals(keys[0], nonHAKey);
+			assertEquals(keys[1], nonHAKey);
+
+			// check that the storage directory exists
+			final Path blobServerPath = new Path(storagePath, "blob");
+			FileSystem fs = blobServerPath.getFileSystem();
+			assertTrue("Unknown storage dir: " + blobServerPath, fs.exists(blobServerPath));
+
+			// Verify HA requests from cache1 (connected to server1) with no immediate access to the file
+			verifyContents(cache1, jobId[0], keys[0], expected, true);
+			verifyContents(cache1, jobId[1], keys[1], expected2, true);
+
+			// Verify non-HA file is not accessible from server1
+			verifyDeleted(cache1, jobId[0], nonHAKey, true);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
@@ -33,10 +33,10 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
+import static org.apache.flink.runtime.blob.BlobKey.BlobType.PERMANENT_BLOB;
+import static org.apache.flink.runtime.blob.BlobKey.BlobType.TRANSIENT_BLOB;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
-import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
-import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
 import static org.junit.Assert.fail;
 
 /**
@@ -111,7 +111,7 @@ public class BlobCacheRetriesTest extends TestLogger {
 	 */
 	private static void testBlobFetchRetries(
 			final Configuration config, final BlobStore blobStore, @Nullable final JobID jobId,
-			BlobType blobType) throws IOException {
+			BlobKey.BlobType blobType) throws IOException {
 
 		final byte[] data = new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
 
@@ -194,7 +194,7 @@ public class BlobCacheRetriesTest extends TestLogger {
 	 */
 	private static void testBlobFetchWithTooManyFailures(
 			final Configuration config, final BlobStore blobStore, @Nullable final JobID jobId,
-			BlobType blobType) throws IOException {
+			BlobKey.BlobType blobType) throws IOException {
 
 		final byte[] data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 };
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
@@ -117,7 +117,7 @@ public class BlobCacheRetriesTest extends TestLogger {
 
 		try (
 			BlobServer server = new TestingFailingBlobServer(config, blobStore, 2);
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();
@@ -200,7 +200,7 @@ public class BlobCacheRetriesTest extends TestLogger {
 
 		try (
 			BlobServer server = new TestingFailingBlobServer(config, blobStore, 0, 10);
-			BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+			BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 				config, new VoidBlobStore())) {
 
 			server.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
@@ -34,10 +34,10 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 
+import static org.apache.flink.runtime.blob.BlobKey.BlobType.PERMANENT_BLOB;
+import static org.apache.flink.runtime.blob.BlobKey.BlobType.TRANSIENT_BLOB;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
-import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
-import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
 
 /**
  * This class contains unit tests for the {@link BlobCacheService}.
@@ -140,7 +140,7 @@ public class BlobCacheSuccessTest extends TestLogger {
 	 */
 	private void uploadFileGetTest(
 			final Configuration config, @Nullable JobID jobId, boolean shutdownServerAfterUpload,
-			boolean cacheHasAccessToFs, BlobType blobType) throws IOException {
+			boolean cacheHasAccessToFs, BlobKey.BlobType blobType) throws IOException {
 
 		final Configuration cacheConfig = new Configuration(config);
 		cacheConfig.setString(BlobServerOptions.STORAGE_DIRECTORY,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
@@ -22,22 +22,20 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
-import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
 
 /**
  * This class contains unit tests for the {@link BlobCache}.
@@ -57,7 +55,7 @@ public class BlobCacheSuccessTest extends TestLogger {
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
 			temporaryFolder.newFolder().getAbsolutePath());
 
-		uploadFileGetTest(config, null, false, false);
+		uploadFileGetTest(config, null, false, false, false);
 	}
 
 	/**
@@ -70,76 +68,40 @@ public class BlobCacheSuccessTest extends TestLogger {
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
 			temporaryFolder.newFolder().getAbsolutePath());
 
-		uploadFileGetTest(config, new JobID(), false, false);
+		uploadFileGetTest(config, new JobID(), false, false, false);
 	}
 
 	/**
 	 * BlobCache is configured in HA mode and the cache can download files from
 	 * the file system directly and does not need to download BLOBs from the
-	 * BlobServer. Using job-unrelated BLOBs.
-	 */
-	@Test
-	public void testBlobNoJobCacheHa() throws IOException {
-		testBlobCacheHa(null);
-	}
-
-	/**
-	 * BlobCache is configured in HA mode and the cache can download files from
-	 * the file system directly and does not need to download BLOBs from the
-	 * BlobServer. Using job-related BLOBs.
+	 * BlobServer which remains active after the BLOB upload. Using job-related BLOBs.
 	 */
 	@Test
 	public void testBlobForJobCacheHa() throws IOException {
-		testBlobCacheHa(new JobID());
-	}
-
-	private void testBlobCacheHa(final JobID jobId) throws IOException {
 		Configuration config = new Configuration();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
 			temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
 			temporaryFolder.newFolder().getPath());
-		uploadFileGetTest(config, jobId, true, true);
+
+		uploadFileGetTest(config, new JobID(), true, true, true);
 	}
 
 	/**
 	 * BlobCache is configured in HA mode and the cache can download files from
 	 * the file system directly and does not need to download BLOBs from the
-	 * BlobServer. Using job-unrelated BLOBs.
-	 */
-	@Test
-	public void testBlobNoJobCacheHa2() throws IOException {
-		testBlobCacheHa2(null);
-	}
-
-	/**
-	 * BlobCache is configured in HA mode and the cache can download files from
-	 * the file system directly and does not need to download BLOBs from the
-	 * BlobServer. Using job-related BLOBs.
+	 * BlobServer which is shut down after the BLOB upload. Using job-related BLOBs.
 	 */
 	@Test
 	public void testBlobForJobCacheHa2() throws IOException {
-		testBlobCacheHa2(new JobID());
-	}
-
-	private void testBlobCacheHa2(JobID jobId) throws IOException {
 		Configuration config = new Configuration();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
 			temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
 			temporaryFolder.newFolder().getPath());
-		uploadFileGetTest(config, jobId, false, true);
-	}
-
-	/**
-	 * BlobCache is configured in HA mode but the cache itself cannot access the
-	 * file system and thus needs to download BLOBs from the BlobServer. Using job-unrelated BLOBs.
-	 */
-	@Test
-	public void testBlobNoJobCacheHaFallback() throws IOException {
-		testBlobCacheHaFallback(null);
+		uploadFileGetTest(config, new JobID(), false, true, true);
 	}
 
 	/**
@@ -148,17 +110,14 @@ public class BlobCacheSuccessTest extends TestLogger {
 	 */
 	@Test
 	public void testBlobForJobCacheHaFallback() throws IOException {
-		testBlobCacheHaFallback(new JobID());
-	}
-
-	private void testBlobCacheHaFallback(final JobID jobId) throws IOException {
 		Configuration config = new Configuration();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
 			temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
 			temporaryFolder.newFolder().getPath());
-		uploadFileGetTest(config, jobId, false, false);
+
+		uploadFileGetTest(config, new JobID(), false, false, true);
 	}
 
 	/**
@@ -174,101 +133,61 @@ public class BlobCacheSuccessTest extends TestLogger {
 	 * @param cacheHasAccessToFs
 	 * 		whether the cache should have access to a shared <tt>HA_STORAGE_PATH</tt> (only useful with
 	 * 		HA mode)
+	 * @param highAvailability
+	 * 		whether to use HA BLOB upload and download methods
 	 */
-	private void uploadFileGetTest(final Configuration config, JobID jobId, boolean shutdownServerAfterUpload,
-			boolean cacheHasAccessToFs) throws IOException {
-		Preconditions.checkArgument(!shutdownServerAfterUpload || cacheHasAccessToFs);
+	private void uploadFileGetTest(
+			final Configuration config, @Nullable JobID jobId, boolean shutdownServerAfterUpload,
+			boolean cacheHasAccessToFs, boolean highAvailability) throws IOException {
 
-		// First create two BLOBs and upload them to BLOB server
-		final byte[] buf = new byte[128];
-		final List<BlobKey> blobKeys = new ArrayList<BlobKey>(2);
-
-		BlobServer blobServer = null;
-		BlobCache blobCache = null;
-		BlobStoreService blobStoreService = null;
-		try {
-			final Configuration cacheConfig = new Configuration(config);
+		final Configuration cacheConfig = new Configuration(config);
+		cacheConfig.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			temporaryFolder.newFolder().getAbsolutePath());
+		if (!cacheHasAccessToFs) {
+			// make sure the cache cannot access the HA store directly
 			cacheConfig.setString(BlobServerOptions.STORAGE_DIRECTORY,
 				temporaryFolder.newFolder().getAbsolutePath());
-			if (!cacheHasAccessToFs) {
-				// make sure the cache cannot access the HA store directly
-				cacheConfig.setString(BlobServerOptions.STORAGE_DIRECTORY,
-					temporaryFolder.newFolder().getAbsolutePath());
-				cacheConfig.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
-					temporaryFolder.newFolder().getPath() + "/does-not-exist");
-			}
+			cacheConfig.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
+				temporaryFolder.newFolder().getPath() + "/does-not-exist");
+		}
 
+		// First create two BLOBs and upload them to BLOB server
+		final byte[] data = new byte[128];
+		byte[] data2 = Arrays.copyOf(data, data.length);
+		data2[0] ^= 1;
+
+		BlobStoreService blobStoreService = null;
+
+		try {
 			blobStoreService = BlobUtils.createBlobStoreFromConfig(cacheConfig);
+			try (
+				BlobServer server = new BlobServer(config, blobStoreService);
+				BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+					cacheConfig, blobStoreService)) {
 
-			// Start the BLOB server
-			blobServer = new BlobServer(config, blobStoreService);
-			final InetSocketAddress serverAddress = new InetSocketAddress(blobServer.getPort());
+				server.start();
 
-			// Upload BLOBs
-			BlobClient blobClient = null;
-			try {
+				// Upload BLOBs
+				BlobKey key1 = put(server, jobId, data, highAvailability);
+				BlobKey key2 = put(server, jobId, data2, highAvailability);
 
-				blobClient = new BlobClient(serverAddress, config);
-
-				blobKeys.add(blobClient.put(jobId, buf));
-				buf[0] = 1; // Make sure the BLOB key changes
-				blobKeys.add(blobClient.put(jobId, buf));
-			} finally {
-				if (blobClient != null) {
-					blobClient.close();
+				if (shutdownServerAfterUpload) {
+					// Now, shut down the BLOB server, the BLOBs must still be accessible through the cache.
+					server.close();
 				}
-			}
 
-			if (shutdownServerAfterUpload) {
-				// Now, shut down the BLOB server, the BLOBs must still be accessible through the cache.
-				blobServer.close();
-				blobServer = null;
-			}
+				verifyContents(cache, jobId, key1, data, highAvailability);
+				verifyContents(cache, jobId, key2, data2, highAvailability);
 
-			blobCache = new BlobCache(serverAddress, cacheConfig, blobStoreService);
+				if (shutdownServerAfterUpload) {
+					// Now, shut down the BLOB server, the BLOBs must still be accessible through the cache.
+					server.close();
 
-			for (BlobKey blobKey : blobKeys) {
-				if (jobId == null) {
-					blobCache.getFile(blobKey);
-				} else {
-					blobCache.getFile(jobId, blobKey);
+					verifyContents(cache, jobId, key1, data, highAvailability);
+					verifyContents(cache, jobId, key2, data2, highAvailability);
 				}
-			}
-
-			if (blobServer != null) {
-				// Now, shut down the BLOB server, the BLOBs must still be accessible through the cache.
-				blobServer.close();
-				blobServer = null;
-			}
-
-			final File[] files = new File[blobKeys.size()];
-
-			for(int i = 0; i < blobKeys.size(); i++){
-				if (jobId == null) {
-					files[i] = blobCache.getFile(blobKeys.get(i));
-				} else {
-					files[i] = blobCache.getFile(jobId, blobKeys.get(i));
-				}
-			}
-
-			// Verify the result
-			assertEquals(blobKeys.size(), files.length);
-
-			for (final File file : files) {
-				assertNotNull(file);
-
-				assertTrue(file.exists());
-				assertEquals(buf.length, file.length());
 			}
 		} finally {
-			if (blobServer != null) {
-				blobServer.close();
-			}
-
-			if(blobCache != null){
-				blobCache.close();
-			}
-
 			if (blobStoreService != null) {
 				blobStoreService.closeAndCleanupAllData();
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
@@ -40,7 +40,7 @@ import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
 import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
 
 /**
- * This class contains unit tests for the {@link BlobCache}.
+ * This class contains unit tests for the {@link BlobCacheService}.
  */
 public class BlobCacheSuccessTest extends TestLogger {
 
@@ -124,7 +124,7 @@ public class BlobCacheSuccessTest extends TestLogger {
 
 	/**
 	 * Uploads two different BLOBs to the {@link BlobServer} via a {@link BlobClient} and verifies
-	 * we can access the files from a {@link BlobCache}.
+	 * we can access the files from a {@link BlobCacheService}.
 	 *
 	 * @param config
 	 * 		configuration to use for the server and cache (the final cache's configuration will
@@ -164,7 +164,7 @@ public class BlobCacheSuccessTest extends TestLogger {
 			blobStoreService = BlobUtils.createBlobStoreFromConfig(cacheConfig);
 			try (
 				BlobServer server = new BlobServer(config, blobStoreService);
-				BlobCache cache = new BlobCache(new InetSocketAddress("localhost", server.getPort()),
+				BlobCacheService cache = new BlobCacheService(new InetSocketAddress("localhost", server.getPort()),
 					cacheConfig, blobStoreService)) {
 
 				server.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
@@ -113,7 +113,7 @@ public class BlobClientSslTest extends BlobClientTest {
 	}
 
 	/**
-	 * Verify ssl client to ssl server upload
+	 * Verify ssl client to ssl server upload.
 	 */
 	@Test
 	public void testUploadJarFilesHelper() throws Exception {
@@ -121,7 +121,7 @@ public class BlobClientSslTest extends BlobClientTest {
 	}
 
 	/**
-	 * Verify ssl client to non-ssl server failure
+	 * Verify ssl client to non-ssl server failure.
 	 */
 	@Test(expected = IOException.class)
 	public void testSSLClientFailure() throws Exception {
@@ -130,7 +130,7 @@ public class BlobClientSslTest extends BlobClientTest {
 	}
 
 	/**
-	 * Verify ssl client to non-ssl server failure
+	 * Verify ssl client to non-ssl server failure.
 	 */
 	@Test(expected = IOException.class)
 	public void testSSLClientFailure2() throws Exception {
@@ -139,7 +139,7 @@ public class BlobClientSslTest extends BlobClientTest {
 	}
 
 	/**
-	 * Verify non-ssl client to ssl server failure
+	 * Verify non-ssl client to ssl server failure.
 	 */
 	@Test(expected = IOException.class)
 	public void testSSLServerFailure() throws Exception {
@@ -148,7 +148,7 @@ public class BlobClientSslTest extends BlobClientTest {
 	}
 
 	/**
-	 * Verify non-ssl client to ssl server failure
+	 * Verify non-ssl client to ssl server failure.
 	 */
 	@Test(expected = IOException.class)
 	public void testSSLServerFailure2() throws Exception {
@@ -157,7 +157,7 @@ public class BlobClientSslTest extends BlobClientTest {
 	}
 
 	/**
-	 * Verify non-ssl connection sanity
+	 * Verify non-ssl connection sanity.
 	 */
 	@Test
 	public void testNonSSLConnection() throws Exception {
@@ -165,7 +165,7 @@ public class BlobClientSslTest extends BlobClientTest {
 	}
 
 	/**
-	 * Verify non-ssl connection sanity
+	 * Verify non-ssl connection sanity.
 	 */
 	@Test
 	public void testNonSSLConnection2() throws Exception {
@@ -173,7 +173,7 @@ public class BlobClientSslTest extends BlobClientTest {
 	}
 
 	/**
-	 * Verify non-ssl connection sanity
+	 * Verify non-ssl connection sanity.
 	 */
 	@Test
 	public void testNonSSLConnection3() throws Exception {
@@ -181,7 +181,7 @@ public class BlobClientSslTest extends BlobClientTest {
 	}
 
 	/**
-	 * Verify non-ssl connection sanity
+	 * Verify non-ssl connection sanity.
 	 */
 	@Test
 	public void testNonSSLConnection4() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SecurityOptions;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -62,6 +63,7 @@ public class BlobClientSslTest extends BlobClientTest {
 		config.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
 		config.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
 		BLOB_SSL_SERVER = new BlobServer(config, new VoidBlobStore());
+		BLOB_SSL_SERVER.start();
 
 		sslClientConfig = new Configuration();
 		sslClientConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
@@ -80,6 +82,7 @@ public class BlobClientSslTest extends BlobClientTest {
 		config.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
 		config.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
 		BLOB_NON_SSL_SERVER = new BlobServer(config, new VoidBlobStore());
+		BLOB_NON_SSL_SERVER.start();
 
 		nonSslClientConfig = new Configuration();
 		nonSslClientConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -44,6 +44,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
+import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
+import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -105,16 +107,20 @@ public class BlobClientTest extends TestLogger {
 	}
 
 	/**
-	 * Prepares a test file for the unit tests, i.e. the methods fills the file with a particular byte patterns and
-	 * computes the file's BLOB key.
+	 * Prepares a test file for the unit tests, i.e. the methods fills the file with a particular
+	 * byte patterns and computes the file's BLOB key.
 	 *
 	 * @param file
-	 *        the file to prepare for the unit tests
+	 * 		the file to prepare for the unit tests
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
+	 *
 	 * @return the BLOB key of the prepared file
+	 *
 	 * @throws IOException
-	 *         thrown if an I/O error occurs while writing to the test file
+	 * 		thrown if an I/O error occurs while writing to the test file
 	 */
-	private static BlobKey prepareTestFile(File file) throws IOException {
+	private static BlobKey prepareTestFile(File file, BlobType blobType) throws IOException {
 
 		MessageDigest md = BlobUtils.createMessageDigest();
 
@@ -138,7 +144,7 @@ public class BlobClientTest extends TestLogger {
 			}
 		}
 
-		return new BlobKey(md.digest());
+		return new BlobKey(blobType, md.digest());
 	}
 
 	/**
@@ -225,28 +231,28 @@ public class BlobClientTest extends TestLogger {
 
 	@Test
 	public void testContentAddressableBufferTransientBlob() throws IOException {
-		testContentAddressableBuffer(false);
+		testContentAddressableBuffer(TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testContentAddressableBufferPermantBlob() throws IOException {
-		testContentAddressableBuffer(true);
+		testContentAddressableBuffer(PERMANENT_BLOB);
 	}
 
 	/**
 	 * Tests the PUT/GET operations for content-addressable buffers.
 	 *
-	 * @param permanentBlob
-	 * 		whether the BLOB is permanent (<tt>true</tt>) or transient (<tt>false</tt>)
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 */
-	private void testContentAddressableBuffer(boolean permanentBlob) throws IOException {
+	private void testContentAddressableBuffer(BlobType blobType) throws IOException {
 		BlobClient client = null;
 
 		try {
 			byte[] testBuffer = createTestBuffer();
 			MessageDigest md = BlobUtils.createMessageDigest();
 			md.update(testBuffer);
-			BlobKey origKey = new BlobKey(md.digest());
+			BlobKey origKey = new BlobKey(blobType, md.digest());
 
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", getBlobServer().getPort());
 			client = new BlobClient(serverAddress, getBlobClientConfig());
@@ -255,24 +261,24 @@ public class BlobClientTest extends TestLogger {
 			BlobKey receivedKey;
 
 			// Store the data (job-unrelated)
-			if (!permanentBlob) {
-				receivedKey = client.putBuffer(null, testBuffer, 0, testBuffer.length, false);
+			if (blobType == TRANSIENT_BLOB) {
+				receivedKey = client.putBuffer(null, testBuffer, 0, testBuffer.length, blobType);
 				assertEquals(origKey, receivedKey);
 			}
 
 			// try again with a job-related BLOB:
-			receivedKey = client.putBuffer(jobId, testBuffer, 0, testBuffer.length, permanentBlob);
+			receivedKey = client.putBuffer(jobId, testBuffer, 0, testBuffer.length, blobType);
 			assertEquals(origKey, receivedKey);
 
 			// Retrieve the data (job-unrelated)
-			if (!permanentBlob) {
-				validateGetAndClose(client.getInternal(null, receivedKey, false), testBuffer);
+			if (blobType == TRANSIENT_BLOB) {
+				validateGetAndClose(client.getInternal(null, receivedKey), testBuffer);
 			}
 			// job-related
-			validateGetAndClose(client.getInternal(jobId, receivedKey, permanentBlob), testBuffer);
+			validateGetAndClose(client.getInternal(jobId, receivedKey), testBuffer);
 
 			// Check reaction to invalid keys for job-unrelated blobs
-			try (InputStream ignored = client.getInternal(null, new BlobKey(), permanentBlob)) {
+			try (InputStream ignored = client.getInternal(null, new BlobKey(blobType))) {
 				fail("Expected IOException did not occur");
 			}
 			catch (IOException fnfe) {
@@ -282,7 +288,7 @@ public class BlobClientTest extends TestLogger {
 			// Check reaction to invalid keys for job-related blobs
 			// new client needed (closed from failure above)
 			client = new BlobClient(serverAddress, getBlobClientConfig());
-			try (InputStream ignored = client.getInternal(jobId, new BlobKey(), permanentBlob)) {
+			try (InputStream ignored = client.getInternal(jobId, new BlobKey(blobType))) {
 				fail("Expected IOException did not occur");
 			}
 			catch (IOException fnfe) {
@@ -308,24 +314,24 @@ public class BlobClientTest extends TestLogger {
 
 	@Test
 	public void testContentAddressableStreamTransientBlob() throws IOException {
-		testContentAddressableStream(false);
+		testContentAddressableStream(TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testContentAddressableStreamPermanentBlob() throws IOException {
-		testContentAddressableStream(true);
+		testContentAddressableStream(PERMANENT_BLOB);
 	}
 
 	/**
 	 * Tests the PUT/GET operations for content-addressable streams.
 	 *
-	 * @param permanentBlob
-	 * 		whether the BLOB is permanent (<tt>true</tt>) or transient (<tt>false</tt>)
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 */
-	private void testContentAddressableStream(boolean permanentBlob) throws IOException {
+	private void testContentAddressableStream(BlobType blobType) throws IOException {
 
 		File testFile = temporaryFolder.newFile();
-		BlobKey origKey = prepareTestFile(testFile);
+		BlobKey origKey = prepareTestFile(testFile, blobType);
 
 		InputStream is = null;
 
@@ -335,26 +341,26 @@ public class BlobClientTest extends TestLogger {
 			BlobKey receivedKey;
 
 			// Store the data (job-unrelated)
-			if (!permanentBlob) {
+			if (blobType == TRANSIENT_BLOB) {
 				is = new FileInputStream(testFile);
-				receivedKey = client.putInputStream(null, is, false);
+				receivedKey = client.putInputStream(null, is, blobType);
 				assertEquals(origKey, receivedKey);
 			}
 
 			// try again with a job-related BLOB:
 			is = new FileInputStream(testFile);
-			receivedKey = client.putInputStream(jobId, is, permanentBlob);
+			receivedKey = client.putInputStream(jobId, is, blobType);
 			assertEquals(origKey, receivedKey);
 
 			is.close();
 			is = null;
 
 			// Retrieve the data (job-unrelated)
-			if (!permanentBlob) {
-				validateGetAndClose(client.getInternal(null, receivedKey, false), testFile);
+			if (blobType == TRANSIENT_BLOB) {
+				validateGetAndClose(client.getInternal(null, receivedKey), testFile);
 			}
 			// job-related
-			validateGetAndClose(client.getInternal(jobId, receivedKey, permanentBlob), testFile);
+			validateGetAndClose(client.getInternal(jobId, receivedKey), testFile);
 		} finally {
 			if (is != null) {
 				try {
@@ -366,17 +372,17 @@ public class BlobClientTest extends TestLogger {
 
 	@Test
 	public void testGetFailsDuringStreamingNoJobTransientBlob() throws IOException {
-		testGetFailsDuringStreaming(null, false);
+		testGetFailsDuringStreaming(null, TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testGetFailsDuringStreamingForJobTransientBlob() throws IOException {
-		testGetFailsDuringStreaming(new JobID(), false);
+		testGetFailsDuringStreaming(new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testGetFailsDuringStreamingForJobPermanentBlob() throws IOException {
-		testGetFailsDuringStreaming(new JobID(), true);
+		testGetFailsDuringStreaming(new JobID(), PERMANENT_BLOB);
 	}
 
 	/**
@@ -384,10 +390,10 @@ public class BlobClientTest extends TestLogger {
 	 *
 	 * @param jobId
 	 * 		job ID or <tt>null</tt> if job-unrelated
-	 * @param permanentBlob
-	 * 		whether the BLOB is permanent (<tt>true</tt>) or transient (<tt>false</tt>)
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 */
-	private void testGetFailsDuringStreaming(@Nullable final JobID jobId, boolean permanentBlob)
+	private void testGetFailsDuringStreaming(@Nullable final JobID jobId, BlobType blobType)
 			throws IOException {
 
 		try (BlobClient client = new BlobClient(
@@ -398,11 +404,11 @@ public class BlobClientTest extends TestLogger {
 			rnd.nextBytes(data);
 
 			// put content addressable (like libraries)
-			BlobKey key = client.putBuffer(jobId, data, 0, data.length, permanentBlob);
+			BlobKey key = client.putBuffer(jobId, data, 0, data.length, blobType);
 			assertNotNull(key);
 
 			// issue a GET request that succeeds
-			InputStream is = client.getInternal(jobId, key, permanentBlob);
+			InputStream is = client.getInternal(jobId, key);
 
 			byte[] receiveBuffer = new byte[data.length];
 			int firstChunkLen = 50000;
@@ -440,7 +446,7 @@ public class BlobClientTest extends TestLogger {
 	static void uploadJarFile(BlobServer blobServer, Configuration blobClientConfig) throws Exception {
 		final File testFile = File.createTempFile("testfile", ".dat");
 		testFile.deleteOnExit();
-		prepareTestFile(testFile);
+		prepareTestFile(testFile, PERMANENT_BLOB);
 
 		InetSocketAddress serverAddress = new InetSocketAddress("localhost", blobServer.getPort());
 
@@ -458,7 +464,7 @@ public class BlobClientTest extends TestLogger {
 		assertEquals(1, blobKeys.size());
 
 		try (BlobClient blobClient = new BlobClient(serverAddress, blobClientConfig)) {
-			validateGetAndClose(blobClient.getInternal(jobId, blobKeys.get(0), true), testFile);
+			validateGetAndClose(blobClient.getInternal(jobId, blobKeys.get(0)), testFile);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -18,14 +18,19 @@
 
 package org.apache.flink.runtime.blob;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.TestLogger;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import javax.annotation.Nullable;
 
 import java.io.EOFException;
 import java.io.File;
@@ -37,12 +42,11 @@ import java.net.InetSocketAddress;
 import java.security.MessageDigest;
 import java.util.Collections;
 import java.util.List;
-
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.util.TestLogger;
+import java.util.Random;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 /**
@@ -56,7 +60,7 @@ public class BlobClientTest extends TestLogger {
 	/** The instance of the (non-ssl) BLOB server used during the tests. */
 	static BlobServer BLOB_SERVER;
 
-	/** The blob service (non-ssl) client configuration */
+	/** The blob service (non-ssl) client configuration. */
 	static Configuration clientConfig;
 
 	@ClassRule
@@ -72,6 +76,7 @@ public class BlobClientTest extends TestLogger {
 			temporaryFolder.newFolder().getAbsolutePath());
 
 		BLOB_SERVER = new BlobServer(config, new VoidBlobStore());
+		BLOB_SERVER.start();
 
 		clientConfig = new Configuration();
 	}
@@ -88,7 +93,7 @@ public class BlobClientTest extends TestLogger {
 
 	/**
 	 * Creates a test buffer and fills it with a specific byte pattern.
-	 * 
+	 *
 	 * @return a test buffer filled with a specific byte pattern
 	 */
 	private static byte[] createTestBuffer() {
@@ -102,7 +107,7 @@ public class BlobClientTest extends TestLogger {
 	/**
 	 * Prepares a test file for the unit tests, i.e. the methods fills the file with a particular byte patterns and
 	 * computes the file's BLOB key.
-	 * 
+	 *
 	 * @param file
 	 *        the file to prepare for the unit tests
 	 * @return the BLOB key of the prepared file
@@ -139,62 +144,56 @@ public class BlobClientTest extends TestLogger {
 	/**
 	 * Validates the result of a GET operation by comparing the data from the retrieved input stream to the content of
 	 * the specified buffer.
-	 * 
-	 * @param inputStream
+	 *
+	 * @param actualInputStream
 	 *        the input stream returned from the GET operation (will be closed by this method)
-	 * @param buf
+	 * @param expectedBuf
 	 *        the buffer to compare the input stream's data to
 	 * @throws IOException
 	 *         thrown if an I/O error occurs while reading the input stream
 	 */
-	static void validateGetAndClose(final InputStream inputStream, final byte[] buf) throws IOException {
+	static void validateGetAndClose(final InputStream actualInputStream, final byte[] expectedBuf) throws IOException {
 		try {
-			byte[] receivedBuffer = new byte[buf.length];
+			byte[] receivedBuffer = new byte[expectedBuf.length];
 
 			int bytesReceived = 0;
 
 			while (true) {
 
-				final int read = inputStream
-					.read(receivedBuffer, bytesReceived, receivedBuffer.length - bytesReceived);
+				final int read = actualInputStream.read(receivedBuffer, bytesReceived, receivedBuffer.length - bytesReceived);
 				if (read < 0) {
 					throw new EOFException();
 				}
 				bytesReceived += read;
 
 				if (bytesReceived == receivedBuffer.length) {
-					assertEquals(-1, inputStream.read());
-					assertArrayEquals(buf, receivedBuffer);
+					assertEquals(-1, actualInputStream.read());
+					assertArrayEquals(expectedBuf, receivedBuffer);
 					return;
 				}
 			}
 		} finally {
-			inputStream.close();
+			actualInputStream.close();
 		}
 	}
 
 	/**
 	 * Validates the result of a GET operation by comparing the data from the retrieved input stream to the content of
-	 * the specified file.
-	 * 
-	 * @param inputStream
+	 * the expected input stream.
+	 *
+	 * @param actualInputStream
 	 *        the input stream returned from the GET operation (will be closed by this method)
-	 * @param file
-	 *        the file to compare the input stream's data to
+	 * @param expectedInputStream
+	 *        the input stream to compare the input stream's data to
 	 * @throws IOException
-	 *         thrown if an I/O error occurs while reading the input stream or the file
+	 *         thrown if an I/O error occurs while reading any input stream
 	 */
-	private static void validateGetAndClose(final InputStream inputStream, final File file) throws IOException {
-
-		InputStream inputStream2 = null;
+	static void validateGetAndClose(InputStream actualInputStream, InputStream expectedInputStream)
+			throws IOException {
 		try {
-
-			inputStream2 = new FileInputStream(file);
-
 			while (true) {
-
-				final int r1 = inputStream.read();
-				final int r2 = inputStream2.read();
+				final int r1 = actualInputStream.read();
+				final int r2 = expectedInputStream.read();
 
 				assertEquals(r2, r1);
 
@@ -202,22 +201,45 @@ public class BlobClientTest extends TestLogger {
 					break;
 				}
 			}
-
 		} finally {
-			if (inputStream2 != null) {
-				inputStream2.close();
-			}
-			inputStream.close();
+			actualInputStream.close();
+			expectedInputStream.close();
 		}
+	}
 
+	/**
+	 * Validates the result of a GET operation by comparing the data from the retrieved input stream to the content of
+	 * the specified file.
+	 *
+	 * @param actualInputStream
+	 *        the input stream returned from the GET operation
+	 * @param expectedFile
+	 *        the file to compare the input stream's data to
+	 * @throws IOException
+	 *         thrown if an I/O error occurs while reading the input stream or the file
+	 */
+	@SuppressWarnings("WeakerAccess")
+	static void validateGetAndClose(final InputStream actualInputStream, final File expectedFile) throws IOException {
+		validateGetAndClose(actualInputStream, new FileInputStream(expectedFile));
+	}
+
+	@Test
+	public void testContentAddressableBufferTransientBlob() throws IOException {
+		testContentAddressableBuffer(false);
+	}
+
+	@Test
+	public void testContentAddressableBufferPermantBlob() throws IOException {
+		testContentAddressableBuffer(true);
 	}
 
 	/**
 	 * Tests the PUT/GET operations for content-addressable buffers.
+	 *
+	 * @param permanentBlob
+	 * 		whether the BLOB is permanent (<tt>true</tt>) or transient (<tt>false</tt>)
 	 */
-	@Test
-	public void testContentAddressableBuffer() throws IOException {
-
+	private void testContentAddressableBuffer(boolean permanentBlob) throws IOException {
 		BlobClient client = null;
 
 		try {
@@ -230,28 +252,37 @@ public class BlobClientTest extends TestLogger {
 			client = new BlobClient(serverAddress, getBlobClientConfig());
 
 			JobID jobId = new JobID();
+			BlobKey receivedKey;
 
-			// Store the data
-			BlobKey receivedKey = client.put(null, testBuffer);
-			assertEquals(origKey, receivedKey);
+			// Store the data (job-unrelated)
+			if (!permanentBlob) {
+				receivedKey = client.putBuffer(null, testBuffer, 0, testBuffer.length, false);
+				assertEquals(origKey, receivedKey);
+			}
+
 			// try again with a job-related BLOB:
-			receivedKey = client.put(jobId, testBuffer);
+			receivedKey = client.putBuffer(jobId, testBuffer, 0, testBuffer.length, permanentBlob);
 			assertEquals(origKey, receivedKey);
 
-			// Retrieve the data
-			validateGetAndClose(client.get(receivedKey), testBuffer);
-			validateGetAndClose(client.get(jobId, receivedKey), testBuffer);
+			// Retrieve the data (job-unrelated)
+			if (!permanentBlob) {
+				validateGetAndClose(client.getInternal(null, receivedKey, false), testBuffer);
+			}
+			// job-related
+			validateGetAndClose(client.getInternal(jobId, receivedKey, permanentBlob), testBuffer);
 
-			// Check reaction to invalid keys
-			try (InputStream ignored = client.get(new BlobKey())) {
+			// Check reaction to invalid keys for job-unrelated blobs
+			try (InputStream ignored = client.getInternal(null, new BlobKey(), permanentBlob)) {
 				fail("Expected IOException did not occur");
 			}
 			catch (IOException fnfe) {
 				// expected
 			}
+
+			// Check reaction to invalid keys for job-related blobs
 			// new client needed (closed from failure above)
 			client = new BlobClient(serverAddress, getBlobClientConfig());
-			try (InputStream ignored = client.get(jobId, new BlobKey())) {
+			try (InputStream ignored = client.getInternal(jobId, new BlobKey(), permanentBlob)) {
 				fail("Expected IOException did not occur");
 			}
 			catch (IOException fnfe) {
@@ -275,52 +306,122 @@ public class BlobClientTest extends TestLogger {
 		return BLOB_SERVER;
 	}
 
+	@Test
+	public void testContentAddressableStreamTransientBlob() throws IOException {
+		testContentAddressableStream(false);
+	}
+
+	@Test
+	public void testContentAddressableStreamPermanentBlob() throws IOException {
+		testContentAddressableStream(true);
+	}
+
 	/**
 	 * Tests the PUT/GET operations for content-addressable streams.
+	 *
+	 * @param permanentBlob
+	 * 		whether the BLOB is permanent (<tt>true</tt>) or transient (<tt>false</tt>)
 	 */
-	@Test
-	public void testContentAddressableStream() throws IOException {
+	private void testContentAddressableStream(boolean permanentBlob) throws IOException {
 
-		BlobClient client = null;
+		File testFile = temporaryFolder.newFile();
+		BlobKey origKey = prepareTestFile(testFile);
+
 		InputStream is = null;
 
-		try {
-			File testFile = File.createTempFile("testfile", ".dat");
-			testFile.deleteOnExit();
-
-			BlobKey origKey = prepareTestFile(testFile);
-
-			InetSocketAddress serverAddress = new InetSocketAddress("localhost", getBlobServer().getPort());
-			client = new BlobClient(serverAddress, getBlobClientConfig());
+		try (BlobClient client = new BlobClient(new InetSocketAddress("localhost", getBlobServer().getPort()), getBlobClientConfig())) {
 
 			JobID jobId = new JobID();
+			BlobKey receivedKey;
 
-			// Store the data
-			is = new FileInputStream(testFile);
-			BlobKey receivedKey = client.put(is);
-			assertEquals(origKey, receivedKey);
+			// Store the data (job-unrelated)
+			if (!permanentBlob) {
+				is = new FileInputStream(testFile);
+				receivedKey = client.putInputStream(null, is, false);
+				assertEquals(origKey, receivedKey);
+			}
+
 			// try again with a job-related BLOB:
 			is = new FileInputStream(testFile);
-			receivedKey = client.put(jobId, is);
+			receivedKey = client.putInputStream(jobId, is, permanentBlob);
 			assertEquals(origKey, receivedKey);
 
 			is.close();
 			is = null;
 
-			// Retrieve the data
-			validateGetAndClose(client.get(receivedKey), testFile);
-			validateGetAndClose(client.get(jobId, receivedKey), testFile);
-		}
-		finally {
+			// Retrieve the data (job-unrelated)
+			if (!permanentBlob) {
+				validateGetAndClose(client.getInternal(null, receivedKey, false), testFile);
+			}
+			// job-related
+			validateGetAndClose(client.getInternal(jobId, receivedKey, permanentBlob), testFile);
+		} finally {
 			if (is != null) {
 				try {
 					is.close();
 				} catch (Throwable ignored) {}
 			}
-			if (client != null) {
-				try {
-					client.close();
-				} catch (Throwable ignored) {}
+		}
+	}
+
+	@Test
+	public void testGetFailsDuringStreamingNoJobTransientBlob() throws IOException {
+		testGetFailsDuringStreaming(null, false);
+	}
+
+	@Test
+	public void testGetFailsDuringStreamingForJobTransientBlob() throws IOException {
+		testGetFailsDuringStreaming(new JobID(), false);
+	}
+
+	@Test
+	public void testGetFailsDuringStreamingForJobPermanentBlob() throws IOException {
+		testGetFailsDuringStreaming(new JobID(), true);
+	}
+
+	/**
+	 * Checks the correct result if a GET operation fails during the file download.
+	 *
+	 * @param jobId
+	 * 		job ID or <tt>null</tt> if job-unrelated
+	 * @param permanentBlob
+	 * 		whether the BLOB is permanent (<tt>true</tt>) or transient (<tt>false</tt>)
+	 */
+	private void testGetFailsDuringStreaming(@Nullable final JobID jobId, boolean permanentBlob)
+			throws IOException {
+
+		try (BlobClient client = new BlobClient(
+			new InetSocketAddress("localhost", getBlobServer().getPort()), getBlobClientConfig())) {
+
+			byte[] data = new byte[5000000];
+			Random rnd = new Random();
+			rnd.nextBytes(data);
+
+			// put content addressable (like libraries)
+			BlobKey key = client.putBuffer(jobId, data, 0, data.length, permanentBlob);
+			assertNotNull(key);
+
+			// issue a GET request that succeeds
+			InputStream is = client.getInternal(jobId, key, permanentBlob);
+
+			byte[] receiveBuffer = new byte[data.length];
+			int firstChunkLen = 50000;
+			BlobUtils.readFully(is, receiveBuffer, 0, firstChunkLen, null);
+			BlobUtils.readFully(is, receiveBuffer, firstChunkLen, firstChunkLen, null);
+
+			// shut down the server
+			for (BlobServerConnection conn : getBlobServer().getCurrentActiveConnections()) {
+				conn.close();
+			}
+
+			try {
+				BlobUtils.readFully(is, receiveBuffer, 2 * firstChunkLen, data.length - 2 * firstChunkLen, null);
+				// we tolerate that this succeeds, as the receiver socket may have buffered
+				// everything already, but in this case, also verify the contents
+				assertArrayEquals(data, receiveBuffer);
+			}
+			catch (IOException e) {
+				// expected
 			}
 		}
 	}
@@ -357,7 +458,7 @@ public class BlobClientTest extends TestLogger {
 		assertEquals(1, blobKeys.size());
 
 		try (BlobClient blobClient = new BlobClient(serverAddress, blobClientConfig)) {
-			validateGetAndClose(blobClient.get(jobId, blobKeys.get(0)), testFile);
+			validateGetAndClose(blobClient.getInternal(jobId, blobKeys.get(0), true), testFile);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobKeyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobKeyTest.java
@@ -18,20 +18,17 @@
 
 package org.apache.flink.runtime.blob;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-
 import org.apache.flink.core.testutils.CommonTestUtils;
-import org.apache.flink.util.StringUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This class contains unit tests for the {@link BlobKey} class.
@@ -46,7 +43,8 @@ public final class BlobKeyTest extends TestLogger {
 	 * The second key array to be used during the unit tests.
 	 */
 	private static final byte[] KEY_ARRAY_2 = new byte[20];
-	/**
+
+	/*
 	 * Initialize the key array.
 	 */
 	static {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobKeyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobKeyTest.java
@@ -27,12 +27,14 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
-import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
+import static org.apache.flink.runtime.blob.BlobKey.BlobType.PERMANENT_BLOB;
+import static org.apache.flink.runtime.blob.BlobKey.BlobType.TRANSIENT_BLOB;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -62,6 +64,18 @@ public final class BlobKeyTest extends TestLogger {
 	}
 
 	@Test
+	public void testCreateKey() {
+		BlobKey key = BlobKey.createKey(PERMANENT_BLOB, KEY_ARRAY_1);
+		verifyType(PERMANENT_BLOB, key);
+		assertArrayEquals(KEY_ARRAY_1, key.getHash());
+
+		key = BlobKey.createKey(TRANSIENT_BLOB, KEY_ARRAY_1);
+		verifyType(TRANSIENT_BLOB, key);
+		assertArrayEquals(KEY_ARRAY_1, key.getHash());
+
+	}
+
+	@Test
 	public void testSerializationTransient() throws Exception {
 		testSerialization(TRANSIENT_BLOB);
 	}
@@ -74,8 +88,8 @@ public final class BlobKeyTest extends TestLogger {
 	/**
 	 * Tests the serialization/deserialization of BLOB keys.
 	 */
-	private void testSerialization(BlobType blobType) throws Exception {
-		final BlobKey k1 = new BlobKey(blobType, KEY_ARRAY_1);
+	private void testSerialization(BlobKey.BlobType blobType) throws Exception {
+		final BlobKey k1 = BlobKey.createKey(blobType, KEY_ARRAY_1);
 		final BlobKey k2 = CommonTestUtils.createCopySerializable(k1);
 		assertEquals(k1, k2);
 		assertEquals(k1.hashCode(), k2.hashCode());
@@ -95,10 +109,10 @@ public final class BlobKeyTest extends TestLogger {
 	/**
 	 * Tests the equals method.
 	 */
-	private void testEquals(BlobType blobType) {
-		final BlobKey k1 = new BlobKey(blobType, KEY_ARRAY_1);
-		final BlobKey k2 = new BlobKey(blobType, KEY_ARRAY_1);
-		final BlobKey k3 = new BlobKey(blobType, KEY_ARRAY_2);
+	private void testEquals(BlobKey.BlobType blobType) {
+		final BlobKey k1 = BlobKey.createKey(blobType, KEY_ARRAY_1);
+		final BlobKey k2 = BlobKey.createKey(blobType, KEY_ARRAY_1);
+		final BlobKey k3 = BlobKey.createKey(blobType, KEY_ARRAY_2);
 		assertTrue(k1.equals(k2));
 		assertTrue(k2.equals(k1));
 		assertFalse(k1.equals(k3));
@@ -110,8 +124,8 @@ public final class BlobKeyTest extends TestLogger {
 	 */
 	@Test
 	public void testEqualsDifferentBlobType() {
-		final BlobKey k1 = new BlobKey(TRANSIENT_BLOB, KEY_ARRAY_1);
-		final BlobKey k2 = new BlobKey(PERMANENT_BLOB, KEY_ARRAY_1);
+		final BlobKey k1 = BlobKey.createKey(TRANSIENT_BLOB, KEY_ARRAY_1);
+		final BlobKey k2 = BlobKey.createKey(PERMANENT_BLOB, KEY_ARRAY_1);
 		assertFalse(k1.equals(k2));
 		assertFalse(k2.equals(k1));
 	}
@@ -129,10 +143,10 @@ public final class BlobKeyTest extends TestLogger {
 	/**
 	 * Tests the compares method.
 	 */
-	private void testCompares(BlobType blobType) {
-		final BlobKey k1 = new BlobKey(blobType, KEY_ARRAY_1);
-		final BlobKey k2 = new BlobKey(blobType, KEY_ARRAY_1);
-		final BlobKey k3 = new BlobKey(blobType, KEY_ARRAY_2);
+	private void testCompares(BlobKey.BlobType blobType) {
+		final BlobKey k1 = BlobKey.createKey(blobType, KEY_ARRAY_1);
+		final BlobKey k2 = BlobKey.createKey(blobType, KEY_ARRAY_1);
+		final BlobKey k3 = BlobKey.createKey(blobType, KEY_ARRAY_2);
 		assertThat(k1.compareTo(k2), is(0));
 		assertThat(k2.compareTo(k1), is(0));
 		assertThat(k1.compareTo(k3), lessThan(0));
@@ -141,8 +155,8 @@ public final class BlobKeyTest extends TestLogger {
 
 	@Test
 	public void testComparesDifferentBlobType() {
-		final BlobKey k1 = new BlobKey(TRANSIENT_BLOB, KEY_ARRAY_1);
-		final BlobKey k2 = new BlobKey(PERMANENT_BLOB, KEY_ARRAY_1);
+		final BlobKey k1 = BlobKey.createKey(TRANSIENT_BLOB, KEY_ARRAY_1);
+		final BlobKey k2 = BlobKey.createKey(PERMANENT_BLOB, KEY_ARRAY_1);
 		assertThat(k1.compareTo(k2), greaterThan(0));
 		assertThat(k2.compareTo(k1), lessThan(0));
 	}
@@ -160,8 +174,8 @@ public final class BlobKeyTest extends TestLogger {
 	/**
 	 * Test the serialization/deserialization using input/output streams.
 	 */
-	private void testStreams(BlobType blobType) throws IOException {
-		final BlobKey k1 = new BlobKey(blobType, KEY_ARRAY_1);
+	private void testStreams(BlobKey.BlobType blobType) throws IOException {
+		final BlobKey k1 = BlobKey.createKey(blobType, KEY_ARRAY_1);
 		final ByteArrayOutputStream baos = new ByteArrayOutputStream(20);
 
 		k1.writeToOutputStream(baos);
@@ -171,5 +185,19 @@ public final class BlobKeyTest extends TestLogger {
 		final BlobKey k2 = BlobKey.readFromInputStream(bais);
 
 		assertEquals(k1, k2);
+	}
+
+	/**
+	 * Verifies that the given <tt>key</tt> is of an expected type.
+	 *
+	 * @param expected the type the key should have
+	 * @param key      the key to verify
+	 */
+	static void verifyType(BlobKey.BlobType expected, BlobKey key) {
+		if (expected == PERMANENT_BLOB) {
+			assertThat(key, is(instanceOf(PermanentBlobKey.class)));
+		} else {
+			assertThat(key, is(instanceOf(TransientBlobKey.class)));
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobKeyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobKeyTest.java
@@ -55,7 +55,7 @@ public final class BlobKeyTest extends TestLogger {
 	}
 
 	/**
-	 * Tests the serialization/deserialization of BLOB keys
+	 * Tests the serialization/deserialization of BLOB keys.
 	 */
 	@Test
 	public void testSerialization() throws Exception {
@@ -97,10 +97,10 @@ public final class BlobKeyTest extends TestLogger {
 	public void testStreams() throws Exception {
 		final BlobKey k1 = new BlobKey(KEY_ARRAY_1);
 		final ByteArrayOutputStream baos = new ByteArrayOutputStream(20);
-		
+
 		k1.writeToOutputStream(baos);
 		baos.close();
-		
+
 		final ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
 		final BlobKey k2 = BlobKey.readFromInputStream(bais);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCorruptionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCorruptionTest.java
@@ -36,9 +36,9 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Random;
 
+import static org.apache.flink.runtime.blob.BlobKey.BlobType.PERMANENT_BLOB;
 import static org.apache.flink.runtime.blob.BlobServerGetTest.get;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
-import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCorruptionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCorruptionTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.apache.flink.runtime.blob.BlobServerGetTest.get;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests how GET requests react to corrupt files when downloaded via a {@link BlobServer}.
+ *
+ * <p>Successful GET requests are tested in conjunction wit the PUT requests.
+ */
+public class BlobServerCorruptionTest extends TestLogger {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	/**
+	 * Checks the GET operation fails when the downloaded file (from {@link BlobServer} or HA store)
+	 * is corrupt, i.e. its content's hash does not match the {@link BlobKey}'s hash.
+	 */
+	@Test
+	public void testGetFailsFromCorruptFile() throws IOException {
+
+		final Configuration config = new Configuration();
+		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+		config.setString(CoreOptions.STATE_BACKEND, "FILESYSTEM");
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getPath());
+
+		BlobStoreService blobStoreService = null;
+
+		try {
+			blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
+
+			testGetFailsFromCorruptFile(config, blobStoreService, exception);
+		} finally {
+			if (blobStoreService != null) {
+				blobStoreService.closeAndCleanupAllData();
+			}
+		}
+	}
+
+	/**
+	 * Checks the GET operation fails when the downloaded file (from HA store)
+	 * is corrupt, i.e. its content's hash does not match the {@link BlobKey}'s hash.
+	 *
+	 * @param config
+	 * 		blob server configuration (including HA settings like {@link HighAvailabilityOptions#HA_STORAGE_PATH}
+	 * 		and {@link HighAvailabilityOptions#HA_CLUSTER_ID}) used to set up <tt>blobStore</tt>
+	 * @param blobStore
+	 * 		shared HA blob store to use
+	 * @param expectedException
+	 * 		expected exception rule to use
+	 */
+	public static void testGetFailsFromCorruptFile(
+			Configuration config, BlobStore blobStore, ExpectedException expectedException)
+			throws IOException {
+
+		Random rnd = new Random();
+		JobID jobId = new JobID();
+
+		try (BlobServer server = new BlobServer(config, blobStore)) {
+
+			server.start();
+
+			byte[] data = new byte[2000000];
+			rnd.nextBytes(data);
+
+			// put content addressable (like libraries)
+			BlobKey key = put(server, jobId, data, true);
+			assertNotNull(key);
+
+			// delete local file to make sure that the GET requests downloads from HA
+			File blobFile = server.getStorageLocation(jobId, key);
+			assertTrue(blobFile.delete());
+
+			// change HA store file contents to make sure that GET requests fail
+			byte[] data2 = Arrays.copyOf(data, data.length);
+			data2[0] ^= 1;
+			File tmpFile = Files.createTempFile("blob", ".jar").toFile();
+			try {
+				FileUtils.writeByteArrayToFile(tmpFile, data2);
+				blobStore.put(tmpFile, jobId, key);
+			} finally {
+				//noinspection ResultOfMethodCallIgnored
+				tmpFile.delete();
+			}
+
+			// issue a GET request that fails
+			expectedException.expect(IOException.class);
+			expectedException.expectMessage("data corruption");
+
+			get(server, jobId, key, true);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCorruptionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCorruptionTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.util.TestLogger;
 
@@ -39,6 +38,7 @@ import java.util.Random;
 
 import static org.apache.flink.runtime.blob.BlobServerGetTest.get;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
+import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -64,7 +64,6 @@ public class BlobServerCorruptionTest extends TestLogger {
 
 		final Configuration config = new Configuration();
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-		config.setString(CoreOptions.STATE_BACKEND, "FILESYSTEM");
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getPath());
 
@@ -108,7 +107,7 @@ public class BlobServerCorruptionTest extends TestLogger {
 			rnd.nextBytes(data);
 
 			// put content addressable (like libraries)
-			BlobKey key = put(server, jobId, data, true);
+			BlobKey key = put(server, jobId, data, PERMANENT_BLOB);
 			assertNotNull(key);
 
 			// delete local file to make sure that the GET requests downloads from HA
@@ -131,7 +130,7 @@ public class BlobServerCorruptionTest extends TestLogger {
 			expectedException.expect(IOException.class);
 			expectedException.expectMessage("data corruption");
 
-			get(server, jobId, key, true);
+			get(server, jobId, key);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -21,27 +21,33 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
+import javax.annotation.Nullable;
+
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.InetSocketAddress;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.NoSuchFileException;
 import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
@@ -51,22 +57,23 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.apache.flink.runtime.blob.BlobClientTest.validateGetAndClose;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
+import static org.apache.flink.runtime.blob.BlobUtils.JOB_DIR_PREFIX;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
- * Tests how failing GET requests behave in the presence of failures.
- * Successful GET requests are tested in conjunction wit the PUT
- * requests.
+ * Tests how failing GET requests behave in the presence of failures when used with a {@link
+ * BlobServer}.
+ *
+ * <p>Successful GET requests are tested in conjunction wit the PUT requests.
  */
 public class BlobServerGetTest extends TestLogger {
 
@@ -75,19 +82,27 @@ public class BlobServerGetTest extends TestLogger {
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
 	@Test
 	public void testGetFailsDuringLookup1() throws IOException {
-		testGetFailsDuringLookup(null, new JobID());
+		testGetFailsDuringLookup(null, new JobID(), false);
 	}
 
 	@Test
 	public void testGetFailsDuringLookup2() throws IOException {
-		testGetFailsDuringLookup(new JobID(), new JobID());
+		testGetFailsDuringLookup(new JobID(), new JobID(), false);
 	}
 
 	@Test
 	public void testGetFailsDuringLookup3() throws IOException {
-		testGetFailsDuringLookup(new JobID(), null);
+		testGetFailsDuringLookup(new JobID(), null, false);
+	}
+
+	@Test
+	public void testGetFailsDuringLookupHa() throws IOException {
+		testGetFailsDuringLookup(new JobID(), new JobID(), true);
 	}
 
 	/**
@@ -96,25 +111,21 @@ public class BlobServerGetTest extends TestLogger {
 	 * @param jobId1 first job ID or <tt>null</tt> if job-unrelated
 	 * @param jobId2 second job ID different to <tt>jobId1</tt>
 	 */
-	private void testGetFailsDuringLookup(final JobID jobId1, final JobID jobId2)
-		throws IOException {
-		BlobServer server = null;
-		BlobClient client = null;
+	private void testGetFailsDuringLookup(
+			@Nullable final JobID jobId1, @Nullable final JobID jobId2, boolean highAvailability)
+			throws IOException {
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
-		try {
-			final Configuration config = new Configuration();
-			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+		try (BlobServer server = new BlobServer(config, new VoidBlobStore())) {
 
-			server = new BlobServer(config, new VoidBlobStore());
-
-			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
-			client = new BlobClient(serverAddress, config);
+			server.start();
 
 			byte[] data = new byte[2000000];
 			rnd.nextBytes(data);
 
 			// put content addressable (like libraries)
-			BlobKey key = client.put(jobId1, data);
+			BlobKey key = put(server, jobId1, data, highAvailability);
 			assertNotNull(key);
 
 			// delete file to make sure that GET requests fail
@@ -122,148 +133,233 @@ public class BlobServerGetTest extends TestLogger {
 			assertTrue(blobFile.delete());
 
 			// issue a GET request that fails
-			client = verifyDeleted(client, jobId1, key, serverAddress, config);
+			verifyDeleted(server, jobId1, key, highAvailability);
 
-			BlobKey key2 = client.put(jobId2, data);
+			// add the same data under a second jobId
+			BlobKey key2 = put(server, jobId2, data, highAvailability);
 			assertNotNull(key);
 			assertEquals(key, key2);
+
 			// request for jobId2 should succeed
-			validateGetAndClose(getFileHelper(client, jobId2, key), data);
+			get(server, jobId2, key, highAvailability);
 			// request for jobId1 should still fail
-			client = verifyDeleted(client, jobId1, key, serverAddress, config);
+			verifyDeleted(server, jobId1, key, highAvailability);
 
 			// same checks as for jobId1 but for jobId2 should also work:
 			blobFile = server.getStorageLocation(jobId2, key);
 			assertTrue(blobFile.delete());
-			client = verifyDeleted(client, jobId2, key, serverAddress, config);
-
-		} finally {
-			if (client != null) {
-				client.close();
-			}
-			if (server != null) {
-				server.close();
-			}
+			verifyDeleted(server, jobId2, key, highAvailability);
 		}
 	}
 
 	/**
-	 * Checks that the given blob does not exist anymore.
-	 *
-	 * @param client
-	 * 		BLOB client to use for connecting to the BLOB server
-	 * @param jobId
-	 * 		job ID or <tt>null</tt> if job-unrelated
-	 * @param key
-	 * 		key identifying the BLOB to request
-	 * @param serverAddress
-	 * 		BLOB server address
-	 * @param config
-	 * 		client config
-	 *
-	 * @return a new client (since the old one is being closed on failure)
+	 * Retrieves a BLOB from the HA store to a {@link BlobServer} which cannot create incoming
+	 * files. File transfers should fail.
 	 */
-	private static BlobClient verifyDeleted(
-			BlobClient client, JobID jobId, BlobKey key,
-			InetSocketAddress serverAddress, Configuration config) throws IOException {
-		try (InputStream ignored = getFileHelper(client, jobId, key)) {
-			fail("This should not succeed.");
-		} catch (IOException e) {
-			// expected
-		}
-		// need a new client (old ony closed due to failure
-		return new BlobClient(serverAddress, config);
-	}
-
 	@Test
-	public void testGetFailsDuringStreamingNoJob() throws IOException {
-		testGetFailsDuringStreaming(null);
-	}
+	public void testGetFailsIncomingForJobHa() throws IOException {
+		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
 
-	@Test
-	public void testGetFailsDuringStreamingForJob() throws IOException {
-		testGetFailsDuringStreaming(new JobID());
-	}
+		final JobID jobId = new JobID();
 
-	/**
-	 * Checks the correct result if a GET operation fails during the file download.
-	 *
-	 * @param jobId job ID or <tt>null</tt> if job-unrelated
-	 */
-	private void testGetFailsDuringStreaming(final JobID jobId) throws IOException {
-		BlobServer server = null;
-		BlobClient client = null;
+		final Configuration config = new Configuration();
+		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+		config.setString(CoreOptions.STATE_BACKEND, "FILESYSTEM");
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getPath());
+
+		BlobStoreService blobStore = null;
 
 		try {
-			final Configuration config = new Configuration();
-			config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+			blobStore = BlobUtils.createBlobStoreFromConfig(config);
 
-			server = new BlobServer(config, new VoidBlobStore());
+			File tempFileDir = null;
+			try (BlobServer server = new BlobServer(config, blobStore)) {
 
-			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
-			client = new BlobClient(serverAddress, config);
+				server.start();
 
-			byte[] data = new byte[5000000];
-			rnd.nextBytes(data);
+				// store the data on the server (and blobStore), remove from local store
+				byte[] data = new byte[2000000];
+				rnd.nextBytes(data);
+				BlobKey blobKey = put(server, jobId, data, true);
+				assertTrue(server.getStorageLocation(jobId, blobKey).delete());
 
-			// put content addressable (like libraries)
-			BlobKey key = client.put(jobId, data);
-			assertNotNull(key);
+				// make sure the blob server cannot create any files in its storage dir
+				tempFileDir = server.createTemporaryFilename().getParentFile();
+				assertTrue(tempFileDir.setExecutable(true, false));
+				assertTrue(tempFileDir.setReadable(true, false));
+				assertTrue(tempFileDir.setWritable(false, false));
 
-			// issue a GET request that succeeds
-			InputStream is = getFileHelper(client, jobId, key);
+				// request the file from the BlobStore
+				exception.expect(IOException.class);
+				exception.expectMessage("Permission denied");
 
-			byte[] receiveBuffer = new byte[data.length];
-			int firstChunkLen = 50000;
-			BlobUtils.readFully(is, receiveBuffer, 0, firstChunkLen, null);
-			BlobUtils.readFully(is, receiveBuffer, firstChunkLen, firstChunkLen, null);
+				try {
+					get(server, jobId, blobKey, true);
+				} finally {
+					HashSet<String> expectedDirs = new HashSet<>();
+					expectedDirs.add("incoming");
+					expectedDirs.add(JOB_DIR_PREFIX + jobId);
+					// only the incoming and job directory should exist (no job directory!)
+					File storageDir = tempFileDir.getParentFile();
+					String[] actualDirs = storageDir.list();
+					assertNotNull(actualDirs);
+					assertEquals(expectedDirs, new HashSet<>(Arrays.asList(actualDirs)));
 
-			// shut down the server
-			for (BlobServerConnection conn : server.getCurrentActiveConnections()) {
-				conn.close();
+					// job directory should be empty
+					File jobDir = new File(tempFileDir.getParentFile(), JOB_DIR_PREFIX + jobId);
+					assertArrayEquals(new String[] {}, jobDir.list());
+				}
+			} finally {
+				// set writable again to make sure we can remove the directory
+				if (tempFileDir != null) {
+					//noinspection ResultOfMethodCallIgnored
+					tempFileDir.setWritable(true, false);
+				}
 			}
-
-			try {
-				BlobUtils.readFully(is, receiveBuffer, 2 * firstChunkLen, data.length - 2 * firstChunkLen, null);
-				// we tolerate that this succeeds, as the receiver socket may have buffered
-				// everything already, but in this case, also verify the contents
-				assertArrayEquals(data, receiveBuffer);
-			}
-			catch (IOException e) {
-				// expected
-			}
-			is.close();
 		} finally {
-			if (client != null) {
-				client.close();
-			}
-			if (server != null) {
-				server.close();
+			if (blobStore != null) {
+				blobStore.closeAndCleanupAllData();
 			}
 		}
 	}
 
 	/**
-	 * FLINK-6020
-	 *
-	 * Tests that concurrent get operations don't concurrently access the BlobStore to download a blob.
+	 * Retrieves a BLOB from the HA store to a {@link BlobServer} which cannot create the final
+	 * storage file. File transfers should fail.
 	 */
 	@Test
-	public void testConcurrentGetOperationsNoJob() throws IOException, ExecutionException, InterruptedException {
-		testConcurrentGetOperations(null);
+	public void testGetFailsStoreForJobHa() throws IOException {
+		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
+
+		final JobID jobId = new JobID();
+
+		final Configuration config = new Configuration();
+		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+		config.setString(CoreOptions.STATE_BACKEND, "FILESYSTEM");
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getPath());
+
+		BlobStoreService blobStore = null;
+
+		try {
+			blobStore = BlobUtils.createBlobStoreFromConfig(config);
+
+			File jobStoreDir = null;
+			try (BlobServer server = new BlobServer(config, blobStore)) {
+
+				server.start();
+
+				// store the data on the server (and blobStore), remove from local store
+				byte[] data = new byte[2000000];
+				rnd.nextBytes(data);
+				BlobKey blobKey = put(server, jobId, data, true);
+				assertTrue(server.getStorageLocation(jobId, blobKey).delete());
+
+				// make sure the blob cache cannot create any files in its storage dir
+				jobStoreDir = server.getStorageLocation(jobId, blobKey).getParentFile();
+				assertTrue(jobStoreDir.setExecutable(true, false));
+				assertTrue(jobStoreDir.setReadable(true, false));
+				assertTrue(jobStoreDir.setWritable(false, false));
+
+				// request the file from the BlobStore
+				exception.expect(AccessDeniedException.class);
+
+				try {
+					get(server, jobId, blobKey, true);
+				} finally {
+					// there should be no remaining incoming files
+					File incomingFileDir = new File(jobStoreDir.getParent(), "incoming");
+					assertArrayEquals(new String[] {}, incomingFileDir.list());
+
+					// there should be no files in the job directory
+					assertArrayEquals(new String[] {}, jobStoreDir.list());
+				}
+			} finally {
+				// set writable again to make sure we can remove the directory
+				if (jobStoreDir != null) {
+					//noinspection ResultOfMethodCallIgnored
+					jobStoreDir.setWritable(true, false);
+				}
+			}
+		} finally {
+			if (blobStore != null) {
+				blobStore.closeAndCleanupAllData();
+			}
+		}
 	}
 
 	/**
-	 * FLINK-6020
-	 *
-	 * Tests that concurrent get operations don't concurrently access the BlobStore to download a blob.
+	 * Retrieves a BLOB from the HA store to a {@link BlobServer} whose HA store does not contain
+	 * the file. File transfers should fail.
 	 */
 	@Test
-	public void testConcurrentGetOperationsForJob() throws IOException, ExecutionException, InterruptedException {
-		testConcurrentGetOperations(new JobID());
+	public void testGetFailsHaStoreForJobHa() throws IOException {
+		final JobID jobId = new JobID();
+
+		final Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
+		try (BlobServer server = new BlobServer(config, new VoidBlobStore())) {
+
+			server.start();
+
+			// store the data on the server (and blobStore), remove from local store
+			byte[] data = new byte[2000000];
+			rnd.nextBytes(data);
+			BlobKey blobKey = put(server, jobId, data, true);
+			assertTrue(server.getStorageLocation(jobId, blobKey).delete());
+
+			File tempFileDir = server.createTemporaryFilename().getParentFile();
+
+			// request the file from the BlobStore
+			exception.expect(NoSuchFileException.class);
+
+			try {
+				get(server, jobId, blobKey, true);
+			} finally {
+				HashSet<String> expectedDirs = new HashSet<>();
+				expectedDirs.add("incoming");
+				expectedDirs.add(JOB_DIR_PREFIX + jobId);
+				// only the incoming and job directory should exist (no job directory!)
+				File storageDir = tempFileDir.getParentFile();
+				String[] actualDirs = storageDir.list();
+				assertNotNull(actualDirs);
+				assertEquals(expectedDirs, new HashSet<>(Arrays.asList(actualDirs)));
+
+				// job directory should be empty
+				File jobDir = new File(tempFileDir.getParentFile(), JOB_DIR_PREFIX + jobId);
+				assertArrayEquals(new String[] {}, jobDir.list());
+			}
+		}
 	}
 
-	private void testConcurrentGetOperations(final JobID jobId)
+	@Test
+	public void testConcurrentGetOperationsNoJob() throws IOException, ExecutionException, InterruptedException {
+		testConcurrentGetOperations(null, false);
+	}
+
+	@Test
+	public void testConcurrentGetOperationsForJob() throws IOException, ExecutionException, InterruptedException {
+		testConcurrentGetOperations(new JobID(), false);
+	}
+
+	@Test
+	public void testConcurrentGetOperationsForJobHa() throws IOException, ExecutionException, InterruptedException {
+		testConcurrentGetOperations(new JobID(), true);
+	}
+
+	/**
+	 * [FLINK-6020] Tests that concurrent get operations don't concurrently access the BlobStore to
+	 * download a blob.
+	 *
+	 * @param jobId
+	 * 		job ID to use (or <tt>null</tt> if job-unrelated)
+	 * @param highAvailability
+	 * 		whether to use permanent (<tt>true</tt>) or transient BLOBs (<tt>false</tt>)
+	 */
+	private void testConcurrentGetOperations(
+			@Nullable final JobID jobId, final boolean highAvailability)
 			throws IOException, InterruptedException, ExecutionException {
 		final Configuration config = new Configuration();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
@@ -271,10 +367,9 @@ public class BlobServerGetTest extends TestLogger {
 		final BlobStore blobStore = mock(BlobStore.class);
 
 		final int numberConcurrentGetOperations = 3;
-		final List<CompletableFuture<InputStream>> getOperations = new ArrayList<>(numberConcurrentGetOperations);
+		final List<CompletableFuture<File>> getOperations = new ArrayList<>(numberConcurrentGetOperations);
 
 		final byte[] data = {1, 2, 3, 4, 99, 42};
-		final ByteArrayInputStream bais = new ByteArrayInputStream(data);
 
 		MessageDigest md = BlobUtils.createMessageDigest();
 
@@ -287,7 +382,7 @@ public class BlobServerGetTest extends TestLogger {
 				public Object answer(InvocationOnMock invocation) throws Throwable {
 					File targetFile = (File) invocation.getArguments()[2];
 
-					FileUtils.copyInputStreamToFile(bais, targetFile);
+					FileUtils.writeByteArrayToFile(targetFile, data);
 
 					return null;
 				}
@@ -296,19 +391,29 @@ public class BlobServerGetTest extends TestLogger {
 
 		final ExecutorService executor = Executors.newFixedThreadPool(numberConcurrentGetOperations);
 
-		try (final BlobServer blobServer = new BlobServer(config, blobStore)) {
+		try (final BlobServer server = new BlobServer(config, blobStore)) {
+
+			server.start();
+
+			// upload data first
+			assertEquals(blobKey, put(server, jobId, data, highAvailability));
+
+			// now try accessing it concurrently (only HA mode will be able to retrieve it from HA store!)
+			if (highAvailability) {
+				// remove local copy so that a transfer from HA store takes place
+				assertTrue(server.getStorageLocation(jobId, blobKey).delete());
+			}
 			for (int i = 0; i < numberConcurrentGetOperations; i++) {
-				CompletableFuture<InputStream> getOperation = CompletableFuture.supplyAsync(
+				CompletableFuture<File> getOperation = CompletableFuture.supplyAsync(
 					() -> {
-						try (BlobClient blobClient = blobServer.createClient();
-							InputStream inputStream = getFileHelper(blobClient, jobId, blobKey)) {
-							byte[] buffer = new byte[data.length];
-
-							IOUtils.readFully(inputStream, buffer);
-
-							return new ByteArrayInputStream(buffer);
+						try {
+							File file = get(server, jobId, blobKey, highAvailability);
+							// check that we have read the right data
+							validateGetAndClose(new FileInputStream(file), data);
+							return file;
 						} catch (IOException e) {
-							throw new CompletionException(new FlinkException("Could not read blob for key " + blobKey + '.', e));
+							throw new CompletionException(new FlinkException(
+								"Could not read blob for key " + blobKey + '.', e));
 						}
 					},
 					executor);
@@ -316,37 +421,63 @@ public class BlobServerGetTest extends TestLogger {
 				getOperations.add(getOperation);
 			}
 
-			CompletableFuture<Collection<InputStream>> inputStreamsFuture = FutureUtils.combineAll(getOperations);
-
-			Collection<InputStream> inputStreams = inputStreamsFuture.get();
-
-			// check that we have read the right data
-			for (InputStream inputStream : inputStreams) {
-				ByteArrayOutputStream baos = new ByteArrayOutputStream(data.length);
-
-				IOUtils.copy(inputStream, baos);
-
-				baos.close();
-				byte[] input = baos.toByteArray();
-
-				assertArrayEquals(data, input);
-
-				inputStream.close();
-			}
-
-			// verify that we downloaded the requested blob exactly once from the BlobStore
-			verify(blobStore, times(1)).get(eq(jobId), eq(blobKey), any(File.class));
+			CompletableFuture<Collection<File>> filesFuture = FutureUtils.combineAll(getOperations);
+			filesFuture.get();
 		} finally {
 			executor.shutdownNow();
 		}
 	}
 
-	static InputStream getFileHelper(BlobClient blobClient, JobID jobId, BlobKey blobKey)
-		throws IOException {
-		if (jobId == null) {
-			return blobClient.get(blobKey);
+	/**
+	 * Retrieves the given blob.
+	 *
+	 * <p>Note that if a {@link BlobCache} is used, it may try to access the {@link BlobServer} to
+	 * retrieve the blob.
+	 *
+	 * @param service
+	 * 		BLOB client to use for connecting to the BLOB service
+	 * @param jobId
+	 * 		job ID or <tt>null</tt> if job-unrelated
+	 * @param key
+	 * 		key identifying the BLOB to request
+	 * @param highAvailability
+	 * 		whether to check HA mode accessors
+	 */
+	static File get(
+			BlobService service, @Nullable JobID jobId, BlobKey key, boolean highAvailability)
+			throws IOException {
+		if (highAvailability) {
+			return service.getPermanentBlobStore().getHAFile(jobId, key);
+		} else if (jobId == null) {
+			return service.getTransientBlobStore().getFile(key);
 		} else {
-			return blobClient.get(jobId, blobKey);
+			return service.getTransientBlobStore().getFile(jobId, key);
+		}
+	}
+
+	/**
+	 * Checks that the given blob does not exist anymore by trying to access it.
+	 *
+	 * <p>Note that if a {@link BlobCache} is used, it may try to access the {@link BlobServer} to
+	 * retrieve the blob.
+	 *
+	 * @param service
+	 * 		BLOB client to use for connecting to the BLOB service
+	 * @param jobId
+	 * 		job ID or <tt>null</tt> if job-unrelated
+	 * @param key
+	 * 		key identifying the BLOB to request
+	 * @param highAvailability
+	 * 		whether to check HA mode accessors
+	 */
+	static void verifyDeleted(
+			BlobService service, @Nullable JobID jobId, BlobKey key, boolean highAvailability)
+			throws IOException {
+		try {
+			get(service, jobId, key, highAvailability);
+			fail("File " + jobId + "/" + key + " should have been deleted.");
+		} catch (IOException e) {
+			// expected
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -74,7 +74,8 @@ import static org.mockito.Mockito.mock;
  * Tests how failing GET requests behave in the presence of failures when used with a {@link
  * BlobServer}.
  *
- * <p>Successful GET requests are tested in conjunction wit the PUT requests.
+ * <p>Successful GET requests are tested in conjunction wit the PUT requests by {@link
+ * BlobServerPutTest}.
  */
 public class BlobServerGetTest extends TestLogger {
 
@@ -87,22 +88,22 @@ public class BlobServerGetTest extends TestLogger {
 	public final ExpectedException exception = ExpectedException.none();
 
 	@Test
-	public void testGetFailsDuringLookup1() throws IOException {
+	public void testGetTransientFailsDuringLookup1() throws IOException {
 		testGetFailsDuringLookup(null, new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
-	public void testGetFailsDuringLookup2() throws IOException {
+	public void testGetTransientFailsDuringLookup2() throws IOException {
 		testGetFailsDuringLookup(new JobID(), new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
-	public void testGetFailsDuringLookup3() throws IOException {
+	public void testGetTransientFailsDuringLookup3() throws IOException {
 		testGetFailsDuringLookup(new JobID(), null, TRANSIENT_BLOB);
 	}
 
 	@Test
-	public void testGetFailsDuringLookupHa() throws IOException {
+	public void testGetPermanentFailsDuringLookup() throws IOException {
 		testGetFailsDuringLookup(new JobID(), new JobID(), PERMANENT_BLOB);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -433,8 +433,8 @@ public class BlobServerGetTest extends TestLogger {
 	/**
 	 * Retrieves the given blob.
 	 *
-	 * <p>Note that if a {@link BlobCache} is used, it may try to access the {@link BlobServer} to
-	 * retrieve the blob.
+	 * <p>Note that if a {@link BlobCacheService} is used, it may try to access the {@link
+	 * BlobServer} to retrieve the blob.
 	 *
 	 * @param service
 	 * 		BLOB client to use for connecting to the BLOB service
@@ -456,8 +456,8 @@ public class BlobServerGetTest extends TestLogger {
 	/**
 	 * Checks that the given blob does not exist anymore by trying to access it.
 	 *
-	 * <p>Note that if a {@link BlobCache} is used, it may try to access the {@link BlobServer} to
-	 * retrieve the blob.
+	 * <p>Note that if a {@link BlobCacheService} is used, it may try to access the {@link
+	 * BlobServer} to retrieve the blob.
 	 *
 	 * @param service
 	 * 		BLOB client to use for connecting to the BLOB service

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -243,6 +243,11 @@ public class BlobServerPutTest extends TestLogger {
 			assertEquals(key1b, key2b);
 
 			// verify the accessibility and the BLOB contents
+			verifyContents(server, jobId2, key2a, data);
+			verifyContents(server, jobId2, key2b, data2);
+
+			// verify the accessibility and the BLOB contents one more time (transient BLOBs should
+			// not be deleted here)
 			verifyContents(server, jobId1, key1a, data);
 			verifyContents(server, jobId1, key1b, data2);
 			verifyContents(server, jobId2, key2a, data);
@@ -323,6 +328,11 @@ public class BlobServerPutTest extends TestLogger {
 			assertEquals(key1b, key2b);
 
 			// verify the accessibility and the BLOB contents
+			verifyContents(server, jobId2, key2a, data);
+			verifyContents(server, jobId2, key2b, data2);
+
+			// verify the accessibility and the BLOB contents one more time (transient BLOBs should
+			// not be deleted here)
 			verifyContents(server, jobId1, key1a, data);
 			verifyContents(server, jobId1, key1b, data2);
 			verifyContents(server, jobId2, key2a, data);
@@ -403,6 +413,11 @@ public class BlobServerPutTest extends TestLogger {
 			assertEquals(key1b, key2b);
 
 			// verify the accessibility and the BLOB contents
+			verifyContents(server, jobId2, key2a, data);
+			verifyContents(server, jobId2, key2b, data2);
+
+			// verify the accessibility and the BLOB contents one more time (transient BLOBs should
+			// not be deleted here)
 			verifyContents(server, jobId1, key1a, data);
 			verifyContents(server, jobId1, key1b, data2);
 			verifyContents(server, jobId2, key2a, data);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -61,6 +61,8 @@ import java.util.concurrent.Executors;
 
 import static org.apache.flink.runtime.blob.BlobClientTest.validateGetAndClose;
 import static org.apache.flink.runtime.blob.BlobServerGetTest.get;
+import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
+import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -134,11 +136,15 @@ public class BlobServerPutTest extends TestLogger {
 
 			server.start();
 
-			BlobKey key = new BlobKey();
+			BlobKey key1 = new BlobKey(TRANSIENT_BLOB);
+			BlobKey key2 = new BlobKey(PERMANENT_BLOB);
 			CheckedThread[] threads = new CheckedThread[] {
-				new ContentAddressableGetStorageLocation(server, jobId, key),
-				new ContentAddressableGetStorageLocation(server, jobId, key),
-				new ContentAddressableGetStorageLocation(server, jobId, key)
+				new ContentAddressableGetStorageLocation(server, jobId, key1),
+				new ContentAddressableGetStorageLocation(server, jobId, key1),
+				new ContentAddressableGetStorageLocation(server, jobId, key1),
+				new ContentAddressableGetStorageLocation(server, jobId, key2),
+				new ContentAddressableGetStorageLocation(server, jobId, key2),
+				new ContentAddressableGetStorageLocation(server, jobId, key2)
 			};
 			checkedThreadSimpleTest(threads);
 		}
@@ -168,27 +174,27 @@ public class BlobServerPutTest extends TestLogger {
 
 	@Test
 	public void testPutBufferSuccessfulGet1() throws IOException {
-		testPutBufferSuccessfulGet(null, null, false);
+		testPutBufferSuccessfulGet(null, null, TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutBufferSuccessfulGet2() throws IOException {
-		testPutBufferSuccessfulGet(null, new JobID(), false);
+		testPutBufferSuccessfulGet(null, new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutBufferSuccessfulGet3() throws IOException {
-		testPutBufferSuccessfulGet(new JobID(), new JobID(), false);
+		testPutBufferSuccessfulGet(new JobID(), new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutBufferSuccessfulGet4() throws IOException {
-		testPutBufferSuccessfulGet(new JobID(), null, false);
+		testPutBufferSuccessfulGet(new JobID(), null, TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutBufferSuccessfulGetHa() throws IOException {
-		testPutBufferSuccessfulGet(new JobID(), new JobID(), true);
+		testPutBufferSuccessfulGet(new JobID(), new JobID(), PERMANENT_BLOB);
 	}
 
 	/**
@@ -199,11 +205,11 @@ public class BlobServerPutTest extends TestLogger {
 	 * 		first job id
 	 * @param jobId2
 	 * 		second job id
-	 * @param highAvailability
-	 * 		whether to upload a permanent blob (<tt>true</tt>) or not
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 */
 	private void testPutBufferSuccessfulGet(
-			@Nullable JobID jobId1, @Nullable JobID jobId2, boolean highAvailability)
+			@Nullable JobID jobId1, @Nullable JobID jobId2, BlobType blobType)
 			throws IOException {
 
 		final Configuration config = new Configuration();
@@ -218,29 +224,29 @@ public class BlobServerPutTest extends TestLogger {
 			byte[] data2 = Arrays.copyOfRange(data, 10, 54);
 
 			// put data for jobId1 and verify
-			BlobKey key1a = put(server, jobId1, data, highAvailability);
+			BlobKey key1a = put(server, jobId1, data, blobType);
 			assertNotNull(key1a);
 
-			BlobKey key1b = put(server, jobId1, data2, highAvailability);
+			BlobKey key1b = put(server, jobId1, data2, blobType);
 			assertNotNull(key1b);
 
-			verifyContents(server, jobId1, key1a, data, highAvailability);
-			verifyContents(server, jobId1, key1b, data2, highAvailability);
+			verifyContents(server, jobId1, key1a, data);
+			verifyContents(server, jobId1, key1b, data2);
 
 			// now put data for jobId2 and verify that both are ok
-			BlobKey key2a = put(server, jobId2, data, highAvailability);
+			BlobKey key2a = put(server, jobId2, data, blobType);
 			assertNotNull(key2a);
 			assertEquals(key1a, key2a);
 
-			BlobKey key2b = put(server, jobId2, data2, highAvailability);
+			BlobKey key2b = put(server, jobId2, data2, blobType);
 			assertNotNull(key2b);
 			assertEquals(key1b, key2b);
 
 			// verify the accessibility and the BLOB contents
-			verifyContents(server, jobId1, key1a, data, highAvailability);
-			verifyContents(server, jobId1, key1b, data2, highAvailability);
-			verifyContents(server, jobId2, key2a, data, highAvailability);
-			verifyContents(server, jobId2, key2b, data2, highAvailability);
+			verifyContents(server, jobId1, key1a, data);
+			verifyContents(server, jobId1, key1b, data2);
+			verifyContents(server, jobId2, key2a, data);
+			verifyContents(server, jobId2, key2b, data2);
 		}
 	}
 
@@ -248,27 +254,27 @@ public class BlobServerPutTest extends TestLogger {
 
 	@Test
 	public void testPutStreamSuccessfulGet1() throws IOException {
-		testPutStreamSuccessfulGet(null, null, false);
+		testPutStreamSuccessfulGet(null, null, TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutStreamSuccessfulGet2() throws IOException {
-		testPutStreamSuccessfulGet(null, new JobID(), false);
+		testPutStreamSuccessfulGet(null, new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutStreamSuccessfulGet3() throws IOException {
-		testPutStreamSuccessfulGet(new JobID(), new JobID(), false);
+		testPutStreamSuccessfulGet(new JobID(), new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutStreamSuccessfulGet4() throws IOException {
-		testPutStreamSuccessfulGet(new JobID(), null, false);
+		testPutStreamSuccessfulGet(new JobID(), null, TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutStreamSuccessfulGetHa() throws IOException {
-		testPutStreamSuccessfulGet(new JobID(), new JobID(), true);
+		testPutStreamSuccessfulGet(new JobID(), new JobID(), PERMANENT_BLOB);
 	}
 
 	/**
@@ -279,11 +285,11 @@ public class BlobServerPutTest extends TestLogger {
 	 * 		first job id
 	 * @param jobId2
 	 * 		second job id
-	 * @param highAvailability
-	 * 		whether to upload a permanent blob (<tt>true</tt>) or not
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 */
 	private void testPutStreamSuccessfulGet(
-			@Nullable JobID jobId1, @Nullable JobID jobId2, boolean highAvailability)
+			@Nullable JobID jobId1, @Nullable JobID jobId2, BlobType blobType)
 			throws IOException {
 
 		final Configuration config = new Configuration();
@@ -298,29 +304,29 @@ public class BlobServerPutTest extends TestLogger {
 			byte[] data2 = Arrays.copyOfRange(data, 10, 54);
 
 			// put data for jobId1 and verify
-			BlobKey key1a = put(server, jobId1, new ByteArrayInputStream(data), highAvailability);
+			BlobKey key1a = put(server, jobId1, new ByteArrayInputStream(data), blobType);
 			assertNotNull(key1a);
 
-			BlobKey key1b = put(server, jobId1, new ByteArrayInputStream(data2), highAvailability);
+			BlobKey key1b = put(server, jobId1, new ByteArrayInputStream(data2), blobType);
 			assertNotNull(key1b);
 
-			verifyContents(server, jobId1, key1a, data, highAvailability);
-			verifyContents(server, jobId1, key1b, data2, highAvailability);
+			verifyContents(server, jobId1, key1a, data);
+			verifyContents(server, jobId1, key1b, data2);
 
 			// now put data for jobId2 and verify that both are ok
-			BlobKey key2a = put(server, jobId2, new ByteArrayInputStream(data), highAvailability);
+			BlobKey key2a = put(server, jobId2, new ByteArrayInputStream(data), blobType);
 			assertNotNull(key2a);
 			assertEquals(key1a, key2a);
 
-			BlobKey key2b = put(server, jobId2, new ByteArrayInputStream(data2), highAvailability);
+			BlobKey key2b = put(server, jobId2, new ByteArrayInputStream(data2), blobType);
 			assertNotNull(key2b);
 			assertEquals(key1b, key2b);
 
 			// verify the accessibility and the BLOB contents
-			verifyContents(server, jobId1, key1a, data, highAvailability);
-			verifyContents(server, jobId1, key1b, data2, highAvailability);
-			verifyContents(server, jobId2, key2a, data, highAvailability);
-			verifyContents(server, jobId2, key2b, data2, highAvailability);
+			verifyContents(server, jobId1, key1a, data);
+			verifyContents(server, jobId1, key1b, data2);
+			verifyContents(server, jobId2, key2a, data);
+			verifyContents(server, jobId2, key2b, data2);
 		}
 	}
 
@@ -328,27 +334,27 @@ public class BlobServerPutTest extends TestLogger {
 
 	@Test
 	public void testPutChunkedStreamSuccessfulGet1() throws IOException {
-		testPutChunkedStreamSuccessfulGet(null, null, false);
+		testPutChunkedStreamSuccessfulGet(null, null, TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutChunkedStreamSuccessfulGet2() throws IOException {
-		testPutChunkedStreamSuccessfulGet(null, new JobID(), false);
+		testPutChunkedStreamSuccessfulGet(null, new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutChunkedStreamSuccessfulGet3() throws IOException {
-		testPutChunkedStreamSuccessfulGet(new JobID(), new JobID(), false);
+		testPutChunkedStreamSuccessfulGet(new JobID(), new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutChunkedStreamSuccessfulGet4() throws IOException {
-		testPutChunkedStreamSuccessfulGet(new JobID(), null, false);
+		testPutChunkedStreamSuccessfulGet(new JobID(), null, TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutChunkedStreamSuccessfulGetHa() throws IOException {
-		testPutChunkedStreamSuccessfulGet(new JobID(), new JobID(), true);
+		testPutChunkedStreamSuccessfulGet(new JobID(), new JobID(), PERMANENT_BLOB);
 	}
 
 	/**
@@ -359,11 +365,11 @@ public class BlobServerPutTest extends TestLogger {
 	 * 		first job id
 	 * @param jobId2
 	 * 		second job id
-	 * @param highAvailability
-	 * 		whether to upload a permanent blob (<tt>true</tt>) or not
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 */
 	private void testPutChunkedStreamSuccessfulGet(
-			@Nullable JobID jobId1, @Nullable JobID jobId2, boolean highAvailability)
+			@Nullable JobID jobId1, @Nullable JobID jobId2, BlobType blobType)
 			throws IOException {
 
 		final Configuration config = new Configuration();
@@ -378,29 +384,29 @@ public class BlobServerPutTest extends TestLogger {
 			byte[] data2 = Arrays.copyOfRange(data, 10, 54);
 
 			// put data for jobId1 and verify
-			BlobKey key1a = put(server, jobId1, new ChunkedInputStream(data, 19), highAvailability);
+			BlobKey key1a = put(server, jobId1, new ChunkedInputStream(data, 19), blobType);
 			assertNotNull(key1a);
 
-			BlobKey key1b = put(server, jobId1, new ChunkedInputStream(data2, 19), highAvailability);
+			BlobKey key1b = put(server, jobId1, new ChunkedInputStream(data2, 19), blobType);
 			assertNotNull(key1b);
 
-			verifyContents(server, jobId1, key1a, data, highAvailability);
-			verifyContents(server, jobId1, key1b, data2, highAvailability);
+			verifyContents(server, jobId1, key1a, data);
+			verifyContents(server, jobId1, key1b, data2);
 
 			// now put data for jobId2 and verify that both are ok
-			BlobKey key2a = put(server, jobId2, new ChunkedInputStream(data, 19), highAvailability);
+			BlobKey key2a = put(server, jobId2, new ChunkedInputStream(data, 19), blobType);
 			assertNotNull(key2a);
 			assertEquals(key1a, key2a);
 
-			BlobKey key2b = put(server, jobId2, new ChunkedInputStream(data2, 19), highAvailability);
+			BlobKey key2b = put(server, jobId2, new ChunkedInputStream(data2, 19), blobType);
 			assertNotNull(key2b);
 			assertEquals(key1b, key2b);
 
 			// verify the accessibility and the BLOB contents
-			verifyContents(server, jobId1, key1a, data, highAvailability);
-			verifyContents(server, jobId1, key1b, data2, highAvailability);
-			verifyContents(server, jobId2, key2a, data, highAvailability);
-			verifyContents(server, jobId2, key2b, data2, highAvailability);
+			verifyContents(server, jobId1, key1a, data);
+			verifyContents(server, jobId1, key1b, data2);
+			verifyContents(server, jobId2, key2a, data);
+			verifyContents(server, jobId2, key2b, data2);
 		}
 	}
 
@@ -408,17 +414,17 @@ public class BlobServerPutTest extends TestLogger {
 
 	@Test
 	public void testPutBufferFailsNoJob() throws IOException {
-		testPutBufferFails(null, false);
+		testPutBufferFails(null, TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutBufferFailsForJob() throws IOException {
-		testPutBufferFails(new JobID(), false);
+		testPutBufferFails(new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutBufferFailsForJobHa() throws IOException {
-		testPutBufferFails(new JobID(), true);
+		testPutBufferFails(new JobID(), PERMANENT_BLOB);
 	}
 
 	/**
@@ -427,10 +433,10 @@ public class BlobServerPutTest extends TestLogger {
 	 *
 	 * @param jobId
 	 * 		job id
-	 * @param highAvailability
-	 * 		whether to upload a permanent blob (<tt>true</tt>) or not
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 */
-	private void testPutBufferFails(@Nullable final JobID jobId, boolean highAvailability)
+	private void testPutBufferFails(@Nullable final JobID jobId, BlobType blobType)
 			throws IOException {
 		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
 
@@ -455,7 +461,7 @@ public class BlobServerPutTest extends TestLogger {
 			exception.expect(IOException.class);
 			exception.expectMessage("Cannot create directory ");
 
-			put(server, jobId, data, highAvailability);
+			put(server, jobId, data, blobType);
 
 		} finally {
 			// set writable again to make sure we can remove the directory
@@ -468,17 +474,17 @@ public class BlobServerPutTest extends TestLogger {
 
 	@Test
 	public void testPutBufferFailsIncomingNoJob() throws IOException {
-		testPutBufferFailsIncoming(null, false);
+		testPutBufferFailsIncoming(null, TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutBufferFailsIncomingForJob() throws IOException {
-		testPutBufferFailsIncoming(new JobID(), false);
+		testPutBufferFailsIncoming(new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutBufferFailsIncomingForJobHa() throws IOException {
-		testPutBufferFailsIncoming(new JobID(), true);
+		testPutBufferFailsIncoming(new JobID(), PERMANENT_BLOB);
 	}
 
 	/**
@@ -487,10 +493,10 @@ public class BlobServerPutTest extends TestLogger {
 	 *
 	 * @param jobId
 	 * 		job id
-	 * @param highAvailability
-	 * 		whether to upload a permanent blob (<tt>true</tt>) or not
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 */
-	private void testPutBufferFailsIncoming(@Nullable final JobID jobId, boolean highAvailability)
+	private void testPutBufferFailsIncoming(@Nullable final JobID jobId, BlobType blobType)
 			throws IOException {
 		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
 
@@ -516,7 +522,7 @@ public class BlobServerPutTest extends TestLogger {
 			exception.expectMessage(" (Permission denied)");
 
 			try {
-				put(server, jobId, data, highAvailability);
+				put(server, jobId, data, blobType);
 			} finally {
 				File storageDir = tempFileDir.getParentFile();
 				// only the incoming directory should exist (no job directory!)
@@ -533,17 +539,17 @@ public class BlobServerPutTest extends TestLogger {
 
 	@Test
 	public void testPutBufferFailsStoreNoJob() throws IOException {
-		testPutBufferFailsStore(null, false);
+		testPutBufferFailsStore(null, TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutBufferFailsStoreForJob() throws IOException {
-		testPutBufferFailsStore(new JobID(), false);
+		testPutBufferFailsStore(new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testPutBufferFailsStoreForJobHa() throws IOException {
-		testPutBufferFailsStore(new JobID(), true);
+		testPutBufferFailsStore(new JobID(), PERMANENT_BLOB);
 	}
 
 	/**
@@ -552,10 +558,10 @@ public class BlobServerPutTest extends TestLogger {
 	 *
 	 * @param jobId
 	 * 		job id
-	 * @param highAvailability
-	 * 		whether to upload a permanent blob (<tt>true</tt>) or not
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 */
-	private void testPutBufferFailsStore(@Nullable final JobID jobId, boolean highAvailability)
+	private void testPutBufferFailsStore(@Nullable final JobID jobId, BlobType blobType)
 			throws IOException {
 		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
 
@@ -568,7 +574,8 @@ public class BlobServerPutTest extends TestLogger {
 			server.start();
 
 			// make sure the blob server cannot create any files in its storage dir
-			jobStoreDir = server.getStorageLocation(jobId, new BlobKey()).getParentFile();
+			jobStoreDir = server.getStorageLocation(jobId,
+				new BlobKey(blobType)).getParentFile();
 			assertTrue(jobStoreDir.setExecutable(true, false));
 			assertTrue(jobStoreDir.setReadable(true, false));
 			assertTrue(jobStoreDir.setWritable(false, false));
@@ -580,7 +587,7 @@ public class BlobServerPutTest extends TestLogger {
 			exception.expect(AccessDeniedException.class);
 
 			try {
-				put(server, jobId, data, highAvailability);
+				put(server, jobId, data, blobType);
 			} finally {
 				// there should be no remaining incoming files
 				File incomingFileDir = new File(jobStoreDir.getParent(), "incoming");
@@ -600,17 +607,17 @@ public class BlobServerPutTest extends TestLogger {
 
 	@Test
 	public void testConcurrentPutOperationsNoJob() throws IOException, ExecutionException, InterruptedException {
-		testConcurrentPutOperations(null, false);
+		testConcurrentPutOperations(null, TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testConcurrentPutOperationsForJob() throws IOException, ExecutionException, InterruptedException {
-		testConcurrentPutOperations(new JobID(), false);
+		testConcurrentPutOperations(new JobID(), TRANSIENT_BLOB);
 	}
 
 	@Test
 	public void testConcurrentPutOperationsForJobHa() throws IOException, ExecutionException, InterruptedException {
-		testConcurrentPutOperations(new JobID(), true);
+		testConcurrentPutOperations(new JobID(), PERMANENT_BLOB);
 	}
 
 	/**
@@ -620,11 +627,11 @@ public class BlobServerPutTest extends TestLogger {
 	 *
 	 * @param jobId
 	 * 		job ID to use (or <tt>null</tt> if job-unrelated)
-	 * @param highAvailability
-	 * 		whether to use permanent (<tt>true</tt>) or transient BLOBs (<tt>false</tt>)
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 */
 	private void testConcurrentPutOperations(
-			@Nullable final JobID jobId, final boolean highAvailability)
+			@Nullable final JobID jobId, final BlobType blobType)
 			throws IOException, InterruptedException, ExecutionException {
 		final Configuration config = new Configuration();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
@@ -651,9 +658,9 @@ public class BlobServerPutTest extends TestLogger {
 							try {
 								BlockingInputStream inputStream =
 									new BlockingInputStream(countDownLatch, data);
-								BlobKey uploadedKey = put(server, jobId, inputStream, highAvailability);
+								BlobKey uploadedKey = put(server, jobId, inputStream, blobType);
 								// check the uploaded file's contents (concurrently)
-								verifyContents(server, jobId, uploadedKey, data, highAvailability);
+								verifyContents(server, jobId, uploadedKey, data);
 								return uploadedKey;
 							} catch (IOException e) {
 								throw new CompletionException(new FlinkException(
@@ -682,10 +689,10 @@ public class BlobServerPutTest extends TestLogger {
 			}
 
 			// check the uploaded file's contents
-			verifyContents(server, jobId, blobKey, data, highAvailability);
+			verifyContents(server, jobId, blobKey, data);
 
 			// check that we only uploaded the file once to the blob store
-			if (highAvailability) {
+			if (blobType == PERMANENT_BLOB) {
 				verify(blobStore, times(1)).put(any(File.class), eq(jobId), eq(blobKey));
 			} else {
 				// can't really verify much in the other cases other than that the put operations should
@@ -700,35 +707,41 @@ public class BlobServerPutTest extends TestLogger {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Helper to choose the right {@link BlobServer#put} method.
+	 * Helper to choose the right {@link BlobServer#putTransient} method.
+	 *
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 *
 	 * @return blob key for the uploaded data
 	 */
-	static BlobKey put(BlobService service, @Nullable JobID jobId, InputStream data, boolean highAvailability)
+	static BlobKey put(BlobService service, @Nullable JobID jobId, InputStream data, BlobType blobType)
 			throws IOException {
-		if (highAvailability) {
+		if (blobType == PERMANENT_BLOB) {
 			if (service instanceof BlobServer) {
-				return ((BlobServer) service).putHA(jobId, data);
+				return ((BlobServer) service).putPermanent(jobId, data);
 			} else {
 				throw new UnsupportedOperationException("uploading streams is only possible at the BlobServer");
 			}
 		} else if (jobId == null) {
-			return service.getTransientBlobStore().put(data);
+			return service.getTransientBlobService().putTransient(data);
 		} else {
-			return service.getTransientBlobStore().put(jobId, data);
+			return service.getTransientBlobService().putTransient(jobId, data);
 		}
 	}
 
 	/**
-	 * Helper to choose the right {@link BlobServer#put} method.
+	 * Helper to choose the right {@link BlobServer#putTransient} method.
+	 *
+	 * @param blobType
+	 * 		whether the BLOB should become permanent or transient
 	 *
 	 * @return blob key for the uploaded data
 	 */
-	static BlobKey put(BlobService service, @Nullable JobID jobId, byte[] data, boolean highAvailability)
+	static BlobKey put(BlobService service, @Nullable JobID jobId, byte[] data, BlobType blobType)
 			throws IOException {
-		if (highAvailability) {
+		if (blobType == PERMANENT_BLOB) {
 			if (service instanceof BlobServer) {
-				return ((BlobServer) service).putHA(jobId, data);
+				return ((BlobServer) service).putPermanent(jobId, data);
 			} else {
 				// implement via JAR file upload instead:
 				File tmpFile = Files.createTempFile("blob", ".jar").toFile();
@@ -747,9 +760,9 @@ public class BlobServerPutTest extends TestLogger {
 				}
 			}
 		} else if (jobId == null) {
-			return service.getTransientBlobStore().put(data);
+			return service.getTransientBlobService().putTransient(data);
 		} else {
-			return service.getTransientBlobStore().put(jobId, data);
+			return service.getTransientBlobService().putTransient(jobId, data);
 		}
 	}
 
@@ -764,14 +777,12 @@ public class BlobServerPutTest extends TestLogger {
 	 * 		blob key
 	 * @param data
 	 * 		expected data
-	 * @param highAvailability
-	 * 		whether to use HA mode accessors
 	 */
 	static void verifyContents(
-			BlobService blobService, @Nullable JobID jobId, BlobKey key, byte[] data, boolean highAvailability)
+			BlobService blobService, @Nullable JobID jobId, BlobKey key, byte[] data)
 			throws IOException {
 
-		File file = get(blobService, jobId, key, highAvailability);
+		File file = get(blobService, jobId, key);
 		validateGetAndClose(new FileInputStream(file), data);
 	}
 
@@ -786,14 +797,12 @@ public class BlobServerPutTest extends TestLogger {
 	 * 		blob key
 	 * @param data
 	 * 		expected data
-	 * @param highAvailability
-	 * 		whether to use HA mode accessors
 	 */
 	static void verifyContents(
-			BlobService blobService, @Nullable JobID jobId, BlobKey key, InputStream data,
-			boolean highAvailability) throws IOException {
+			BlobService blobService, @Nullable JobID jobId, BlobKey key, InputStream data)
+			throws IOException {
 
-		File file = get(blobService, jobId, key, highAvailability);
+		File file = get(blobService, jobId, key);
 		validateGetAndClose(new FileInputStream(file), data);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRangeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRangeTest.java
@@ -40,7 +40,7 @@ public class BlobServerRangeTest extends TestLogger {
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	/**
-	 * Start blob server on 0 = pick an ephemeral port
+	 * Start blob server on 0 = pick an ephemeral port.
 	 */
 	@Test
 	public void testOnEphemeralPort() throws IOException {
@@ -82,13 +82,13 @@ public class BlobServerRangeTest extends TestLogger {
 
 	/**
 	 * Give the BlobServer a choice of three ports, where two of them
-	 * are allocated
+	 * are allocated.
 	 */
 	@Test
 	public void testOnePortAvailable() throws IOException {
 		int numAllocated = 2;
 		ServerSocket[] sockets = new ServerSocket[numAllocated];
-		for(int i = 0; i < numAllocated; i++) {
+		for (int i = 0; i < numAllocated; i++) {
 			try {
 				sockets[i] = new ServerSocket(0);
 			} catch (IOException e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRangeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRangeTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.TestLogger;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,13 +48,13 @@ public class BlobServerRangeTest extends TestLogger {
 		conf.setString(BlobServerOptions.PORT, "0");
 		conf.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
 
-		BlobServer srv = new BlobServer(conf, new VoidBlobStore());
-		srv.close();
+		BlobServer server = new BlobServer(conf, new VoidBlobStore());
+		server.start();
+		server.close();
 	}
 
 	/**
-	 * Try allocating on an unavailable port
-	 * @throws IOException
+	 * Try allocating on an unavailable port.
 	 */
 	@Test(expected = IOException.class)
 	public void testPortUnavailable() throws IOException {
@@ -72,7 +73,8 @@ public class BlobServerRangeTest extends TestLogger {
 
 		// this thing is going to throw an exception
 		try {
-			BlobServer srv = new BlobServer(conf, new VoidBlobStore());
+			BlobServer server = new BlobServer(conf, new VoidBlobStore());
+			server.start();
 		} finally {
 			socket.close();
 		}
@@ -87,7 +89,6 @@ public class BlobServerRangeTest extends TestLogger {
 		int numAllocated = 2;
 		ServerSocket[] sockets = new ServerSocket[numAllocated];
 		for(int i = 0; i < numAllocated; i++) {
-			ServerSocket socket = null;
 			try {
 				sockets[i] = new ServerSocket(0);
 			} catch (IOException e) {
@@ -102,12 +103,14 @@ public class BlobServerRangeTest extends TestLogger {
 
 		// this thing is going to throw an exception
 		try {
-			BlobServer srv = new BlobServer(conf, new VoidBlobStore());
-			Assert.assertEquals(availablePort, srv.getPort());
-			srv.close();
+			BlobServer server = new BlobServer(conf, new VoidBlobStore());
+			server.start();
+			Assert.assertEquals(availablePort, server.getPort());
+			server.close();
 		} finally {
-			sockets[0].close();
-			sockets[1].close();
+			for (int i = 0; i < numAllocated; ++i) {
+				sockets[i].close();
+			}
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRecoveryTest.java
@@ -37,11 +37,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Random;
 
+import static org.apache.flink.runtime.blob.BlobKey.BlobType.PERMANENT_BLOB;
+import static org.apache.flink.runtime.blob.BlobKey.BlobType.TRANSIENT_BLOB;
 import static org.apache.flink.runtime.blob.BlobServerGetTest.verifyDeleted;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
 import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
-import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
-import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNotEquals;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRecoveryTest.java
@@ -84,7 +84,7 @@ public class BlobServerRecoveryTest extends TestLogger {
 	 * Helper to test that the {@link BlobServer} recovery from its HA store works.
 	 *
 	 * <p>Uploads two BLOBs to one {@link BlobServer} and expects a second one to be able to retrieve
-	 * them via a shared HA store upon request of a {@link BlobCache}.
+	 * them via a shared HA store upon request of a {@link BlobCacheService}.
 	 *
 	 * @param config
 	 * 		blob server configuration (including HA settings like {@link HighAvailabilityOptions#HA_STORAGE_PATH}
@@ -104,7 +104,7 @@ public class BlobServerRecoveryTest extends TestLogger {
 			BlobServer server0 = new BlobServer(config, blobStore);
 			BlobServer server1 = new BlobServer(config, blobStore);
 			// use VoidBlobStore as the HA store to force download from server[1]'s HA store
-			BlobCache cache1 = new BlobCache(
+			BlobCacheService cache1 = new BlobCacheService(
 				new InetSocketAddress("localhost", server1.getPort()), config,
 				new VoidBlobStore())) {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRecoveryTest.java
@@ -80,9 +80,9 @@ public class BlobServerRecoveryTest extends TestLogger {
 
 	/**
 	 * Helper to test that the {@link BlobServer} recovery from its HA store works.
-	 * <p>
-	 * Uploads two BLOBs to one {@link BlobServer} and expects a second one to be able to retrieve
-	 * them via a shared HA store.
+	 *
+	 * <p>Uploads two BLOBs to one {@link BlobServer} and expects a second one to be able to retrieve
+	 * them via a shared HA store upon request of a {@link BlobCache}.
 	 *
 	 * @param config
 	 * 		blob server configuration (including HA settings like {@link HighAvailabilityOptions#HA_STORAGE_PATH}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRecoveryTest.java
@@ -27,21 +27,28 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.util.TestLogger;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Random;
 
+import static org.apache.flink.runtime.blob.BlobServerGetTest.verifyDeleted;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.put;
+import static org.apache.flink.runtime.blob.BlobServerPutTest.verifyContents;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class BlobRecoveryITCase extends TestLogger {
+/**
+ * Tests for the recovery of files of a {@link BlobServer} from a HA store.
+ */
+public class BlobServerRecoveryTest extends TestLogger {
 
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -71,118 +78,80 @@ public class BlobRecoveryITCase extends TestLogger {
 		}
 	}
 
+	/**
+	 * Helper to test that the {@link BlobServer} recovery from its HA store works.
+	 * <p>
+	 * Uploads two BLOBs to one {@link BlobServer} and expects a second one to be able to retrieve
+	 * them via a shared HA store.
+	 *
+	 * @param config
+	 * 		blob server configuration (including HA settings like {@link HighAvailabilityOptions#HA_STORAGE_PATH}
+	 * 		and {@link HighAvailabilityOptions#HA_CLUSTER_ID}) used to set up <tt>blobStore</tt>
+	 * @param blobStore
+	 * 		shared HA blob store to use
+	 *
+	 * @throws IOException
+	 * 		in case of failures
+	 */
 	public static void testBlobServerRecovery(final Configuration config, final BlobStore blobStore) throws IOException {
 		final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
 		String storagePath = config.getString(HighAvailabilityOptions.HA_STORAGE_PATH) + "/" + clusterId;
 		Random rand = new Random();
 
-		BlobServer[] server = new BlobServer[2];
-		InetSocketAddress[] serverAddress = new InetSocketAddress[2];
-		BlobClient client = null;
+		try (
+			BlobServer server0 = new BlobServer(config, blobStore);
+			BlobServer server1 = new BlobServer(config, blobStore);
+			// use VoidBlobStore as the HA store to force download from server[1]'s HA store
+			BlobCache cache1 = new BlobCache(
+				new InetSocketAddress("localhost", server1.getPort()), config,
+				new VoidBlobStore())) {
 
-		try {
-			for (int i = 0; i < server.length; i++) {
-				server[i] = new BlobServer(config, blobStore);
-				serverAddress[i] = new InetSocketAddress("localhost", server[i].getPort());
-			}
-
-			client = new BlobClient(serverAddress[0], config);
+			server0.start();
+			server1.start();
 
 			// Random data
 			byte[] expected = new byte[1024];
 			rand.nextBytes(expected);
+			byte[] expected2 = Arrays.copyOfRange(expected, 32, 288);
 
 			BlobKey[] keys = new BlobKey[2];
+			BlobKey nonHAKey;
 
-			// Put job-unrelated data
-			keys[0] = client.put(null, expected); // Request 1
-			keys[1] = client.put(null, expected, 32, 256); // Request 2
-
-			// Put job-related data, verify that the checksums match
+			// Put job-related HA data
 			JobID[] jobId = new JobID[] { new JobID(), new JobID() };
-			BlobKey key;
-			key = client.put(jobId[0], expected); // Request 3
-			assertEquals(keys[0], key);
-			key = client.put(jobId[1], expected, 32, 256); // Request 4
-			assertEquals(keys[1], key);
+			keys[0] = put(server0, jobId[0], expected, true); // Request 1
+			keys[1] = put(server0, jobId[1], expected2, true); // Request 2
+
+			// put non-HA data
+			nonHAKey = put(server0, jobId[0], expected2, false);
+			assertEquals(keys[1], nonHAKey);
 
 			// check that the storage directory exists
 			final Path blobServerPath = new Path(storagePath, "blob");
 			FileSystem fs = blobServerPath.getFileSystem();
 			assertTrue("Unknown storage dir: " + blobServerPath, fs.exists(blobServerPath));
 
-			// Close the client and connect to the other server
-			client.close();
-			client = new BlobClient(serverAddress[1], config);
+			// Verify HA requests from cache1 (connected to server1) with no immediate access to the file
+			verifyContents(cache1, jobId[0], keys[0], expected, true);
+			verifyContents(cache1, jobId[1], keys[1], expected2, true);
 
-			// Verify request 1
-			try (InputStream is = client.get(keys[0])) {
-				byte[] actual = new byte[expected.length];
-
-				BlobUtils.readFully(is, actual, 0, expected.length, null);
-
-				for (int i = 0; i < expected.length; i++) {
-					assertEquals(expected[i], actual[i]);
-				}
-			}
-
-			// Verify request 2
-			try (InputStream is = client.get(keys[1])) {
-				byte[] actual = new byte[256];
-				BlobUtils.readFully(is, actual, 0, 256, null);
-
-				for (int i = 32, j = 0; i < 256; i++, j++) {
-					assertEquals(expected[i], actual[j]);
-				}
-			}
-
-			// Verify request 3
-			try (InputStream is = client.get(jobId[0], keys[0])) {
-				byte[] actual = new byte[expected.length];
-				BlobUtils.readFully(is, actual, 0, expected.length, null);
-
-				for (int i = 0; i < expected.length; i++) {
-					assertEquals(expected[i], actual[i]);
-				}
-			}
-
-			// Verify request 4
-			try (InputStream is = client.get(jobId[1], keys[1])) {
-				byte[] actual = new byte[256];
-				BlobUtils.readFully(is, actual, 0, 256, null);
-
-				for (int i = 32, j = 0; i < 256; i++, j++) {
-					assertEquals(expected[i], actual[j]);
-				}
-			}
+			// Verify non-HA file is not accessible from server1
+			verifyDeleted(cache1, jobId[0], nonHAKey, true);
 
 			// Remove again
-			client.delete(keys[0]);
-			client.delete(keys[1]);
-			client.delete(jobId[0], keys[0]);
-			client.delete(jobId[1], keys[1]);
+			server1.cleanupJob(jobId[0]);
+			server1.cleanupJob(jobId[1]);
 
 			// Verify everything is clean
 			assertTrue("HA storage directory does not exist", fs.exists(new Path(storagePath)));
 			if (fs.exists(blobServerPath)) {
 				final org.apache.flink.core.fs.FileStatus[] recoveryFiles =
 					fs.listStatus(blobServerPath);
-				ArrayList<String> filenames = new ArrayList<String>(recoveryFiles.length);
+				ArrayList<String> filenames = new ArrayList<>(recoveryFiles.length);
 				for (org.apache.flink.core.fs.FileStatus file: recoveryFiles) {
 					filenames.add(file.toString());
 				}
 				fail("Unclean state backend: " + filenames);
-			}
-		}
-		finally {
-			for (BlobServer s : server) {
-				if (s != null) {
-					s.close();
-				}
-			}
-
-			if (client != null) {
-				client.close();
 			}
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assume.assumeTrue;
  */
 public class BlobUtilsTest extends TestLogger {
 
-	private final static String CANNOT_CREATE_THIS = "cannot-create-this";
+	private static final String CANNOT_CREATE_THIS = "cannot-create-this";
 
 	private File blobUtilsTestDirectory;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -31,6 +31,8 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 
+import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
+import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
@@ -73,12 +75,18 @@ public class BlobUtilsTest extends TestLogger {
 	@Test(expected = IOException.class)
 	public void testExceptionOnCreateCacheDirectoryFailureNoJob() throws IOException {
 		// Should throw an Exception
-		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), null, new BlobKey());
+		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), null, new BlobKey(TRANSIENT_BLOB));
 	}
 
 	@Test(expected = IOException.class)
-	public void testExceptionOnCreateCacheDirectoryFailureForJob() throws IOException {
+	public void testExceptionOnCreateCacheDirectoryFailureForJobTransient() throws IOException {
 		// Should throw an Exception
-		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), new JobID(), new BlobKey());
+		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), new JobID(), new BlobKey(TRANSIENT_BLOB));
+	}
+
+	@Test(expected = IOException.class)
+	public void testExceptionOnCreateCacheDirectoryFailureForJobPermanent() throws IOException {
+		// Should throw an Exception
+		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), new JobID(), new BlobKey(PERMANENT_BLOB));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -33,8 +33,10 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
-import static org.mockito.Mockito.mock;
 
+/**
+ * Tests for {@link BlobUtils}.
+ */
 public class BlobUtilsTest extends TestLogger {
 
 	private final static String CANNOT_CREATE_THIS = "cannot-create-this";
@@ -68,15 +70,15 @@ public class BlobUtilsTest extends TestLogger {
 		BlobUtils.initLocalStorageDirectory(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS).getAbsolutePath());
 	}
 
-	@Test(expected = Exception.class)
-	public void testExceptionOnCreateCacheDirectoryFailureNoJob() {
+	@Test(expected = IOException.class)
+	public void testExceptionOnCreateCacheDirectoryFailureNoJob() throws IOException {
 		// Should throw an Exception
-		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), null, mock(BlobKey.class));
+		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), null, new BlobKey());
 	}
 
-	@Test(expected = Exception.class)
-	public void testExceptionOnCreateCacheDirectoryFailureForJob() {
+	@Test(expected = IOException.class)
+	public void testExceptionOnCreateCacheDirectoryFailureForJob() throws IOException {
 		// Should throw an Exception
-		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), new JobID(), mock(BlobKey.class));
+		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), new JobID(), new BlobKey());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -31,8 +31,6 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 
-import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
-import static org.apache.flink.runtime.blob.BlobType.TRANSIENT_BLOB;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
@@ -75,18 +73,18 @@ public class BlobUtilsTest extends TestLogger {
 	@Test(expected = IOException.class)
 	public void testExceptionOnCreateCacheDirectoryFailureNoJob() throws IOException {
 		// Should throw an Exception
-		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), null, new BlobKey(TRANSIENT_BLOB));
+		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), null, new TransientBlobKey());
 	}
 
 	@Test(expected = IOException.class)
 	public void testExceptionOnCreateCacheDirectoryFailureForJobTransient() throws IOException {
 		// Should throw an Exception
-		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), new JobID(), new BlobKey(TRANSIENT_BLOB));
+		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), new JobID(), new TransientBlobKey());
 	}
 
 	@Test(expected = IOException.class)
 	public void testExceptionOnCreateCacheDirectoryFailureForJobPermanent() throws IOException {
 		// Should throw an Exception
-		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), new JobID(), new BlobKey(PERMANENT_BLOB));
+		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), new JobID(), new PermanentBlobKey());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingFailingBlobServer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingFailingBlobServer.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.runtime.blob;
 
 import org.apache.flink.configuration.Configuration;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingFailingBlobServer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingFailingBlobServer.java
@@ -24,12 +24,24 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
 
+/**
+ * Implements a {@link BlobServer} that, after some initial normal operation, closes incoming
+ * connections for a given number of times and continues normally again.
+ */
 public class TestingFailingBlobServer extends BlobServer {
 
-	private int numFailures;
+	private final int numAccept;
+	private final int numFailures;
 
-	public TestingFailingBlobServer(Configuration config, BlobStore blobStore, int numFailures) throws IOException {
+	public TestingFailingBlobServer(Configuration config, BlobStore blobStore, int numFailures)
+			throws IOException {
+		this(config, blobStore, 1, numFailures);
+	}
+
+	public TestingFailingBlobServer(Configuration config, BlobStore blobStore, int numAccept, int numFailures)
+			throws IOException {
 		super(config, blobStore);
+		this.numAccept = numAccept;
 		this.numFailures = numFailures;
 	}
 
@@ -38,7 +50,9 @@ public class TestingFailingBlobServer extends BlobServer {
 
 		// we do properly the first operation (PUT)
 		try {
-			new BlobServerConnection(getServerSocket().accept(), this).start();
+			for (int num = 0; num < numAccept && !isShutdown(); num++) {
+				new BlobServerConnection(getServerSocket().accept(), this).start();
+			}
 		}
 		catch (Throwable t) {
 			t.printStackTrace();
@@ -57,13 +71,13 @@ public class TestingFailingBlobServer extends BlobServer {
 				os.close();
 				socket.close();
 			}
-			catch (IOException e) {
+			catch (IOException ignored) {
 			}
 			finally {
 				if (socket != null) {
 					try {
 						socket.close();
-					} catch(Throwable t) {}
+					} catch(Throwable ignored) {}
 				}
 			}
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.failover.RestartAllStrategy;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
@@ -36,7 +35,6 @@ import org.apache.flink.util.SerializedValue;
 
 import org.junit.Test;
 
-import java.net.URL;
 import java.util.Collections;
 
 import static org.mockito.Matchers.eq;
@@ -92,8 +90,8 @@ public class ExecutionGraphCheckpointCoordinatorTest {
 			Time.days(1L),
 			new NoRestartStrategy(),
 			new RestartAllStrategy.Factory(),
-			Collections.<BlobKey>emptyList(),
-			Collections.<URL>emptyList(),
+			Collections.emptyList(),
+			Collections.emptyList(),
 			new Scheduler(TestingUtils.defaultExecutionContext()),
 			ClassLoader.getSystemClassLoader());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.CommonTestUtils;
-import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -65,8 +65,8 @@ public class TaskDeploymentDescriptorTest {
 			final Class<? extends AbstractInvokable> invokableClass = BatchTask.class;
 			final List<ResultPartitionDeploymentDescriptor> producedResults = new ArrayList<ResultPartitionDeploymentDescriptor>(0);
 			final List<InputGateDeploymentDescriptor> inputGates = new ArrayList<InputGateDeploymentDescriptor>(0);
-			final List<BlobKey> requiredJars = new ArrayList<BlobKey>(0);
-			final List<URL> requiredClasspaths = new ArrayList<URL>(0);
+			final List<PermanentBlobKey> requiredJars = new ArrayList<>(0);
+			final List<URL> requiredClasspaths = new ArrayList<>(0);
 			final SerializedValue<ExecutionConfig> executionConfig = new SerializedValue<>(new ExecutionConfig());
 			final SerializedValue<JobInformation> serializedJobInformation = new SerializedValue<>(new JobInformation(
 				jobID, jobName, executionConfig, jobConfiguration, requiredJars, requiredClasspaths));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -21,9 +21,9 @@ package org.apache.flink.runtime.execution.librarycache;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.util.OperatingSystem;
@@ -44,7 +44,6 @@ import java.util.List;
 
 import static org.apache.flink.runtime.blob.BlobCacheCleanupTest.checkFileCountForJob;
 import static org.apache.flink.runtime.blob.BlobCacheCleanupTest.checkFilesExist;
-import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -69,8 +68,8 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 
 		JobID jobId1 = new JobID();
 		JobID jobId2 = new JobID();
-		List<BlobKey> keys1 = new ArrayList<>();
-		List<BlobKey> keys2 = new ArrayList<>();
+		List<PermanentBlobKey> keys1 = new ArrayList<>();
+		List<PermanentBlobKey> keys2 = new ArrayList<>();
 		BlobServer server = null;
 		PermanentBlobCache cache = null;
 		BlobLibraryCacheManager libCache = null;
@@ -201,7 +200,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 		JobID jobId = new JobID();
 		ExecutionAttemptID attempt1 = new ExecutionAttemptID();
 		ExecutionAttemptID attempt2 = new ExecutionAttemptID();
-		List<BlobKey> keys = new ArrayList<>();
+		List<PermanentBlobKey> keys = new ArrayList<>();
 		BlobServer server = null;
 		PermanentBlobCache cache = null;
 		BlobLibraryCacheManager libCache = null;
@@ -246,8 +245,8 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 
 			try {
 				libCache.registerTask(
-					jobId, new ExecutionAttemptID(), Collections.<BlobKey>emptyList(),
-					Collections.<URL>emptyList());
+					jobId, new ExecutionAttemptID(), Collections.emptyList(),
+					Collections.emptyList());
 				fail("Should fail with an IllegalStateException");
 			}
 			catch (IllegalStateException e) {
@@ -313,7 +312,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 
 		JobID jobId = new JobID();
 		ExecutionAttemptID attempt1 = new ExecutionAttemptID();
-		List<BlobKey> keys = new ArrayList<>();
+		List<PermanentBlobKey> keys = new ArrayList<>();
 		BlobServer server = null;
 		PermanentBlobCache cache = null;
 		BlobLibraryCacheManager libCache = null;
@@ -358,8 +357,8 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 
 			try {
 				libCache.registerTask(
-					jobId, new ExecutionAttemptID(), Collections.<BlobKey>emptyList(),
-					Collections.<URL>emptyList());
+					jobId, new ExecutionAttemptID(), Collections.emptyList(),
+					Collections.emptyList());
 				fail("Should fail with an IllegalStateException");
 			}
 			catch (IllegalStateException e) {
@@ -438,8 +437,8 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 			cache = new PermanentBlobCache(serverAddress, config, new VoidBlobStore());
 
 			// upload some meaningless data to the server
-			BlobKey dataKey1 = server.putPermanent(jobId, new byte[]{1, 2, 3, 4, 5, 6, 7, 8});
-			BlobKey dataKey2 = server.putPermanent(jobId, new byte[]{11, 12, 13, 14, 15, 16, 17, 18});
+			PermanentBlobKey dataKey1 = server.putPermanent(jobId, new byte[]{1, 2, 3, 4, 5, 6, 7, 8});
+			PermanentBlobKey dataKey2 = server.putPermanent(jobId, new byte[]{11, 12, 13, 14, 15, 16, 17, 18});
 
 			libCache = new BlobLibraryCacheManager(cache, FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST);
 			assertEquals(0, libCache.getNumberOfManagedJobs());
@@ -458,7 +457,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 
 			// register some BLOBs as libraries
 			{
-				Collection<BlobKey> keys = Collections.singleton(dataKey1);
+				Collection<PermanentBlobKey> keys = Collections.singleton(dataKey1);
 
 				cache.registerJob(jobId);
 				ExecutionAttemptID executionId = new ExecutionAttemptID();
@@ -515,7 +514,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 			}
 
 			// see BlobUtils for the directory layout
-			cacheDir = cache.getStorageLocation(jobId, new BlobKey(PERMANENT_BLOB)).getParentFile();
+			cacheDir = cache.getStorageLocation(jobId, new PermanentBlobKey()).getParentFile();
 			assertTrue(cacheDir.exists());
 
 			// make sure no further blobs can be downloaded by removing the write

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -44,6 +44,7 @@ import java.util.List;
 
 import static org.apache.flink.runtime.blob.BlobCacheCleanupTest.checkFileCountForJob;
 import static org.apache.flink.runtime.blob.BlobCacheCleanupTest.checkFilesExist;
+import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -87,10 +88,10 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
 			cache = new PermanentBlobCache(serverAddress, config, new VoidBlobStore());
 
-			keys1.add(server.putHA(jobId1, buf));
+			keys1.add(server.putPermanent(jobId1, buf));
 			buf[0] += 1;
-			keys1.add(server.putHA(jobId1, buf));
-			keys2.add(server.putHA(jobId2, buf));
+			keys1.add(server.putPermanent(jobId1, buf));
+			keys2.add(server.putPermanent(jobId2, buf));
 
 			libCache = new BlobLibraryCacheManager(cache, FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST);
 			cache.registerJob(jobId1);
@@ -218,9 +219,9 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
 			cache = new PermanentBlobCache(serverAddress, config, new VoidBlobStore());
 
-			keys.add(server.putHA(jobId, buf));
+			keys.add(server.putPermanent(jobId, buf));
 			buf[0] += 1;
-			keys.add(server.putHA(jobId, buf));
+			keys.add(server.putPermanent(jobId, buf));
 
 			libCache = new BlobLibraryCacheManager(cache, FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST);
 			cache.registerJob(jobId);
@@ -330,9 +331,9 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 			InetSocketAddress serverAddress = new InetSocketAddress("localhost", server.getPort());
 			cache = new PermanentBlobCache(serverAddress, config, new VoidBlobStore());
 
-			keys.add(server.putHA(jobId, buf));
+			keys.add(server.putPermanent(jobId, buf));
 			buf[0] += 1;
-			keys.add(server.putHA(jobId, buf));
+			keys.add(server.putPermanent(jobId, buf));
 
 			libCache = new BlobLibraryCacheManager(cache, FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST);
 			cache.registerJob(jobId);
@@ -437,8 +438,8 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 			cache = new PermanentBlobCache(serverAddress, config, new VoidBlobStore());
 
 			// upload some meaningless data to the server
-			BlobKey dataKey1 = server.putHA(jobId, new byte[]{1, 2, 3, 4, 5, 6, 7, 8});
-			BlobKey dataKey2 = server.putHA(jobId, new byte[]{11, 12, 13, 14, 15, 16, 17, 18});
+			BlobKey dataKey1 = server.putPermanent(jobId, new byte[]{1, 2, 3, 4, 5, 6, 7, 8});
+			BlobKey dataKey2 = server.putPermanent(jobId, new byte[]{11, 12, 13, 14, 15, 16, 17, 18});
 
 			libCache = new BlobLibraryCacheManager(cache, FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST);
 			assertEquals(0, libCache.getNumberOfManagedJobs());
@@ -514,7 +515,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 			}
 
 			// see BlobUtils for the directory layout
-			cacheDir = cache.getStorageLocation(jobId, new BlobKey()).getParentFile();
+			cacheDir = cache.getStorageLocation(jobId, new BlobKey(PERMANENT_BLOB)).getParentFile();
 			assertTrue(cacheDir.exists());
 
 			// make sure no further blobs can be downloaded by removing the write

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.execution.librarycache;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.BlobServer;
@@ -72,7 +71,6 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 
 		Configuration config = new Configuration();
 		config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-		config.setString(CoreOptions.STATE_BACKEND, "FILESYSTEM");
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
 			temporaryFolder.newFolder().getAbsolutePath());
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH,
@@ -98,9 +96,9 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			JobID jobId = new JobID();
 
 			// Upload some data (libraries)
-			keys.add(server[0].putHA(jobId, expected)); // Request 1
+			keys.add(server[0].putPermanent(jobId, expected)); // Request 1
 			byte[] expected2 = Arrays.copyOfRange(expected, 32, 288);
-			keys.add(server[0].putHA(jobId, expected2)); // Request 2
+			keys.add(server[0].putPermanent(jobId, expected2)); // Request 2
 
 			// The cache
 			cache = new PermanentBlobCache(serverAddress[0], config, blobStoreService);
@@ -110,7 +108,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			libServer[0].registerTask(jobId, executionId, keys, Collections.<URL>emptyList());
 
 			// Verify key 1
-			File f = cache.getHAFile(jobId, keys.get(0));
+			File f = cache.getPermanentFile(jobId, keys.get(0));
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -127,7 +125,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			cache = new PermanentBlobCache(serverAddress[1], config, blobStoreService);
 
 			// Verify key 1
-			f = cache.getHAFile(jobId, keys.get(0));
+			f = cache.getPermanentFile(jobId, keys.get(0));
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -139,7 +137,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			}
 
 			// Verify key 2
-			f = cache.getHAFile(jobId, keys.get(1));
+			f = cache.getPermanentFile(jobId, keys.get(1));
 			assertEquals(expected2.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -22,11 +22,11 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.BlobStoreService;
 import org.apache.flink.runtime.blob.BlobUtils;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.util.TestLogger;
@@ -42,7 +42,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
@@ -91,7 +90,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			byte[] expected = new byte[1024];
 			rand.nextBytes(expected);
 
-			List<BlobKey> keys = new ArrayList<>(2);
+			ArrayList<PermanentBlobKey> keys = new ArrayList<>(2);
 
 			JobID jobId = new JobID();
 
@@ -108,7 +107,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			libServer[0].registerTask(jobId, executionId, keys, Collections.<URL>emptyList());
 
 			// Verify key 1
-			File f = cache.getPermanentFile(jobId, keys.get(0));
+			File f = cache.getFile(jobId, keys.get(0));
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -125,7 +124,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			cache = new PermanentBlobCache(serverAddress[1], config, blobStoreService);
 
 			// Verify key 1
-			f = cache.getPermanentFile(jobId, keys.get(0));
+			f = cache.getFile(jobId, keys.get(0));
 			assertEquals(expected.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {
@@ -137,7 +136,7 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
 			}
 
 			// Verify key 2
-			f = cache.getPermanentFile(jobId, keys.get(1));
+			f = cache.getFile(jobId, keys.get(1));
 			assertEquals(expected2.length, f.length());
 
 			try (FileInputStream fis = new FileInputStream(f)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FailoverRegionTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.JobException;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
@@ -50,7 +49,6 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -140,8 +138,8 @@ public class FailoverRegionTest extends TestLogger {
 				AkkaUtils.getDefaultTimeout(),
 				new InfiniteDelayRestartStrategy(10),
 				new FailoverPipelinedRegionWithDirectExecutor(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
+				Collections.emptyList(),
+				Collections.emptyList(),
 				slotProvider,
 				ExecutionGraph.class.getClassLoader());
 
@@ -267,8 +265,8 @@ public class FailoverRegionTest extends TestLogger {
 				AkkaUtils.getDefaultTimeout(),
 				new InfiniteDelayRestartStrategy(10),
 				new RestartPipelinedRegionStrategy.Factory(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
+				Collections.emptyList(),
+				Collections.emptyList(),
 				scheduler,
 				ExecutionGraph.class.getClassLoader());
 		try {
@@ -344,8 +342,8 @@ public class FailoverRegionTest extends TestLogger {
 				AkkaUtils.getDefaultTimeout(),
 				new InfiniteDelayRestartStrategy(10),
 				new FailoverPipelinedRegionWithDirectExecutor(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
+				Collections.emptyList(),
+				Collections.emptyList(),
 				scheduler,
 				ExecutionGraph.class.getClassLoader());
 		try {
@@ -457,8 +455,8 @@ public class FailoverRegionTest extends TestLogger {
 				AkkaUtils.getDefaultTimeout(),
 				restartStrategy,
 				new FailoverPipelinedRegionWithDirectExecutor(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
+				Collections.emptyList(),
+				Collections.emptyList(),
 				scheduler,
 				ExecutionGraph.class.getClassLoader());
 		try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy.Factory;
@@ -37,7 +36,6 @@ import org.apache.flink.util.SerializedValue;
 
 import org.junit.Test;
 
-import java.net.URL;
 import java.util.Collections;
 import java.util.Random;
 
@@ -174,8 +172,8 @@ public class GlobalModVersionTest {
 				Time.seconds(10),
 				new InfiniteDelayRestartStrategy(),
 				new CustomStrategy(failoverStrategy),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
+				Collections.emptyList(),
+				Collections.emptyList(),
 				slotProvider,
 				getClass().getClassLoader());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/IndividualRestartsConcurrencyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/IndividualRestartsConcurrencyTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.ManuallyTriggeredDirectExecutor;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy.Factory;
@@ -42,7 +41,6 @@ import org.apache.flink.util.SerializedValue;
 
 import org.junit.Test;
 
-import java.net.URL;
 import java.util.Collections;
 import java.util.concurrent.Executor;
 
@@ -298,8 +296,8 @@ public class IndividualRestartsConcurrencyTest {
 				Time.seconds(10),
 				restartStrategy,
 				failoverStrategy,
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
+				Collections.emptyList(),
+				Collections.emptyList(),
 				slotProvider,
 				getClass().getClassLoader());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PipelinedRegionFailoverConcurrencyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PipelinedRegionFailoverConcurrencyTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.ManuallyTriggeredDirectExecutor;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.SuppressRestartsException;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
@@ -42,7 +41,6 @@ import org.apache.flink.util.SerializedValue;
 
 import org.junit.Test;
 
-import java.net.URL;
 import java.util.Collections;
 import java.util.concurrent.Executor;
 
@@ -320,8 +318,8 @@ public class PipelinedRegionFailoverConcurrencyTest {
 				Time.seconds(10),
 				restartStrategy,
 				failoverStrategy,
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
+				Collections.emptyList(),
+				Collections.emptyList(),
 				slotProvider,
 				getClass().getClassLoader());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RestartPipelinedRegionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RestartPipelinedRegionStrategyTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.JobException;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.executiongraph.failover.FailoverRegion;
 import org.apache.flink.runtime.executiongraph.failover.RestartPipelinedRegionStrategy;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
@@ -36,7 +35,6 @@ import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
 import org.junit.Test;
 
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -105,8 +103,8 @@ public class RestartPipelinedRegionStrategyTest {
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
             new RestartPipelinedRegionStrategy.Factory(),
-            Collections.<BlobKey>emptyList(),
-            Collections.<URL>emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
             scheduler,
             ExecutionGraph.class.getClassLoader());
 		try {
@@ -190,8 +188,8 @@ public class RestartPipelinedRegionStrategyTest {
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
             new RestartPipelinedRegionStrategy.Factory(),
-            Collections.<BlobKey>emptyList(),
-            Collections.<URL>emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
             scheduler,
             ExecutionGraph.class.getClassLoader());
 		try {
@@ -280,8 +278,8 @@ public class RestartPipelinedRegionStrategyTest {
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
             new RestartPipelinedRegionStrategy.Factory(),
-            Collections.<BlobKey>emptyList(),
-            Collections.<URL>emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
             scheduler,
             ExecutionGraph.class.getClassLoader());
 		try {
@@ -361,8 +359,8 @@ public class RestartPipelinedRegionStrategyTest {
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
             new RestartPipelinedRegionStrategy.Factory(),
-            Collections.<BlobKey>emptyList(),
-            Collections.<URL>emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
             scheduler,
             ExecutionGraph.class.getClassLoader());
 		try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.executiongraph.utils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -123,12 +123,12 @@ public class SimpleAckingTaskManagerGateway implements TaskManagerGateway {
 			CheckpointOptions checkpointOptions) {}
 
 	@Override
-	public CompletableFuture<BlobKey> requestTaskManagerLog(Time timeout) {
+	public CompletableFuture<TransientBlobKey> requestTaskManagerLog(Time timeout) {
 		return FutureUtils.completedExceptionally(new UnsupportedOperationException());
 	}
 
 	@Override
-	public CompletableFuture<BlobKey> requestTaskManagerStdout(Time timeout) {
+	public CompletableFuture<TransientBlobKey> requestTaskManagerStdout(Time timeout) {
 		return FutureUtils.completedExceptionally(new UnsupportedOperationException());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerCleanupITCase.java
@@ -59,6 +59,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
 import static org.apache.flink.runtime.testingUtils.TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -197,7 +198,7 @@ public class JobManagerCleanupITCase extends TestLogger {
 
 						if (testCase == TestCase.JOB_SUBMISSION_FAILS) {
 							// add an invalid key so that the submission fails
-							jobGraph.addBlob(new BlobKey());
+							jobGraph.addBlob(new BlobKey(PERMANENT_BLOB));
 						}
 
 						// Submit the job and wait for all vertices to be running

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerCleanupITCase.java
@@ -276,7 +276,7 @@ public class JobManagerCleanupITCase extends TestLogger {
 	 *
 	 * @param blobDir
 	 * 		directory of a {@link org.apache.flink.runtime.blob.BlobServer} or {@link
-	 * 		org.apache.flink.runtime.blob.BlobCache}
+	 * 		org.apache.flink.runtime.blob.BlobCacheService}
 	 * @param remaining
 	 * 		remaining time for this test
 	 *

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerCleanupITCase.java
@@ -29,7 +29,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.ListeningBehaviour;
 import org.apache.flink.runtime.blob.BlobClient;
-import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
@@ -59,7 +59,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
 import static org.apache.flink.runtime.testingUtils.TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -189,7 +188,7 @@ public class JobManagerCleanupITCase extends TestLogger {
 
 						// upload a blob
 						tempBlob = File.createTempFile("Required", ".jar");
-						List<BlobKey> keys =
+						List<PermanentBlobKey> keys =
 							BlobClient.uploadJarFiles(new InetSocketAddress("localhost", blobPort),
 								config, jid,
 								Collections.singletonList(new Path(tempBlob.getAbsolutePath())));
@@ -198,7 +197,7 @@ public class JobManagerCleanupITCase extends TestLogger {
 
 						if (testCase == TestCase.JOB_SUBMISSION_FAILS) {
 							// add an invalid key so that the submission fails
-							jobGraph.addBlob(new BlobKey(PERMANENT_BLOB));
+							jobGraph.addBlob(new PermanentBlobKey());
 						}
 
 						// Submit the job and wait for all vertices to be running

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -189,6 +189,7 @@ public class JobManagerHARecoveryTest extends TestLogger {
 			BlobServer blobServer = new BlobServer(
 				flinkConfiguration,
 				testingHighAvailabilityServices.createBlobStore());
+			blobServer.start();
 			Props jobManagerProps = Props.create(
 				TestingJobManager.class,
 				flinkConfiguration,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
@@ -19,12 +19,10 @@
 package org.apache.flink.runtime.jobmanager;
 
 import akka.actor.ActorSystem;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.ListeningBehaviour;
-import org.apache.flink.runtime.blob.BlobClient;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -54,7 +52,6 @@ import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -134,27 +131,8 @@ public class JobSubmitTest {
 			jobVertex.setInvokableClass(NoOpInvokable.class);
 			JobGraph jg = new JobGraph("test job", jobVertex);
 
-			// request the blob port from the job manager
-			Future<Object> future = jmGateway.ask(JobManagerMessages.getRequestBlobManagerPort(), timeout);
-			int blobPort = (Integer) Await.result(future, timeout);
-
-			// upload two dummy bytes and add their keys to the job graph as dependencies
-			BlobKey key1, key2;
-			BlobClient bc = new BlobClient(new InetSocketAddress("localhost", blobPort), jmConfig);
-			JobID jobId = jg.getJobID();
-			try {
-				key1 = bc.put(jobId, new byte[10]);
-				key2 = bc.put(jobId, new byte[10]);
-
-				// delete one of the blobs to make sure that the startup failed
-				bc.delete(jobId, key2);
-			}
-			finally {
-				bc.close();
-			}
-
-			jg.addBlob(key1);
-			jg.addBlob(key2);
+			// add a reference to some non-existing BLOB to the job graph as a dependency
+			jg.addBlob(new BlobKey());
 
 			// submit the job
 			Future<Object> submitFuture = jmGateway.ask(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
@@ -56,6 +56,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -132,7 +133,7 @@ public class JobSubmitTest {
 			JobGraph jg = new JobGraph("test job", jobVertex);
 
 			// add a reference to some non-existing BLOB to the job graph as a dependency
-			jg.addBlob(new BlobKey());
+			jg.addBlob(new BlobKey(PERMANENT_BLOB));
 
 			// submit the job
 			Future<Object> submitFuture = jmGateway.ask(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobSubmitTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.ListeningBehaviour;
-import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServices;
@@ -56,7 +56,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.flink.runtime.blob.BlobType.PERMANENT_BLOB;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -133,7 +132,7 @@ public class JobSubmitTest {
 			JobGraph jg = new JobGraph("test job", jobVertex);
 
 			// add a reference to some non-existing BLOB to the job graph as a dependency
-			jg.addBlob(new BlobKey(PERMANENT_BLOB));
+			jg.addBlob(new PermanentBlobKey());
 
 			// submit the job
 			Future<Object> submitFuture = jmGateway.ask(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/JobManagerLeaderElectionTest.java
@@ -182,6 +182,7 @@ public class JobManagerLeaderElectionTest extends TestLogger {
 		configuration.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1L);
 
 		BlobServer blobServer = new BlobServer(configuration, new VoidBlobStore());
+		blobServer.start();
 		return Props.create(
 			TestingJobManager.class,
 			configuration,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/TaskManagerLogHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/TaskManagerLogHandlerTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobKey;
-import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.instance.Instance;
@@ -68,8 +67,7 @@ public class TaskManagerLogHandlerTest {
 			CompletableFuture.completedFuture("/jm/address"),
 			TestingUtils.TIMEOUT(),
 			TaskManagerLogHandler.FileMode.LOG,
-			new Configuration(),
-			new VoidBlobStore());
+			new Configuration());
 		String[] pathsLog = handlerLog.getPaths();
 		Assert.assertEquals(1, pathsLog.length);
 		Assert.assertEquals("/taskmanagers/:taskmanagerid/log", pathsLog[0]);
@@ -80,8 +78,7 @@ public class TaskManagerLogHandlerTest {
 			CompletableFuture.completedFuture("/jm/address"),
 			TestingUtils.TIMEOUT(),
 			TaskManagerLogHandler.FileMode.STDOUT,
-			new Configuration(),
-			new VoidBlobStore());
+			new Configuration());
 		String[] pathsOut = handlerOut.getPaths();
 		Assert.assertEquals(1, pathsOut.length);
 		Assert.assertEquals("/taskmanagers/:taskmanagerid/stdout", pathsOut[0]);
@@ -121,8 +118,7 @@ public class TaskManagerLogHandlerTest {
 			CompletableFuture.completedFuture("/jm/address"),
 			TestingUtils.TIMEOUT(),
 			TaskManagerLogHandler.FileMode.LOG,
-			new Configuration(),
-			new VoidBlobStore());
+			new Configuration());
 
 		final AtomicReference<String> exception = new AtomicReference<>();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/TaskManagerLogHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/TaskManagerLogHandlerTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.rest.handler.legacy;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.instance.Instance;
@@ -96,7 +96,7 @@ public class TaskManagerLogHandlerTest {
 		when(taskManager.getId()).thenReturn(tmID);
 		when(taskManager.getTaskManagerID()).thenReturn(tmRID);
 		when(taskManager.getTaskManagerGateway()).thenReturn(taskManagerGateway);
-		CompletableFuture<BlobKey> future = new CompletableFuture<>();
+		CompletableFuture<TransientBlobKey> future = new CompletableFuture<>();
 		future.completeExceptionally(new IOException("failure"));
 		when(taskManagerGateway.requestTaskManagerLog(any(Time.class))).thenReturn(future);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -703,8 +703,8 @@ public class TaskExecutorTest extends TestLogger {
 		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
 		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
 
-		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
 
 		final JobManagerConnection jobManagerConnection = new JobManagerConnection(
 			jobId,
@@ -1216,8 +1216,8 @@ public class TaskExecutorTest extends TestLogger {
 		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
 		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
 
-		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
 
 		final JobManagerConnection jobManagerConnection = new JobManagerConnection(
 			jobId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
@@ -99,7 +98,6 @@ import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 
 import java.net.InetAddress;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -667,8 +665,8 @@ public class TaskExecutorTest extends TestLogger {
 				name.getMethodName(),
 				new SerializedValue<>(new ExecutionConfig()),
 				new Configuration(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList());
+				Collections.emptyList(),
+				Collections.emptyList());
 
 		TaskInformation taskInformation = new TaskInformation(
 				jobVertexId,
@@ -1266,8 +1264,8 @@ public class TaskExecutorTest extends TestLogger {
 				name.getMethodName(),
 				new SerializedValue<>(new ExecutionConfig()),
 				new Configuration(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList());
+				Collections.emptyList(),
+				Collections.emptyList());
 
 			TaskInformation taskInformation = new TaskInformation(
 				jobVertexId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
@@ -699,12 +699,8 @@ public class TaskExecutorTest extends TestLogger {
 		final JobMasterGateway jobMasterGateway = mock(JobMasterGateway.class);
 		when(jobMasterGateway.getFencingToken()).thenReturn(jobMasterId);
 
-		BlobCache blobCache = mock(BlobCache.class);
-		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
-		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
-
-		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
+		BlobCacheService blobService =
+			new BlobCacheService(mock(PermanentBlobCache.class), mock(TransientBlobCache.class));
 
 		final JobManagerConnection jobManagerConnection = new JobManagerConnection(
 			jobId,
@@ -712,7 +708,7 @@ public class TaskExecutorTest extends TestLogger {
 			jobMasterGateway,
 			mock(TaskManagerActions.class),
 			mock(CheckpointResponder.class),
-			blobCache,
+			blobService,
 			libraryCacheManager,
 			mock(ResultPartitionConsumableNotifier.class),
 			mock(PartitionProducerStateChecker.class));
@@ -1212,12 +1208,8 @@ public class TaskExecutorTest extends TestLogger {
 		final LibraryCacheManager libraryCacheManager = mock(LibraryCacheManager.class);
 		when(libraryCacheManager.getClassLoader(eq(jobId))).thenReturn(getClass().getClassLoader());
 
-		BlobCache blobCache = mock(BlobCache.class);
-		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
-		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
-
-		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
+		BlobCacheService blobService =
+			new BlobCacheService(mock(PermanentBlobCache.class), mock(TransientBlobCache.class));
 
 		final JobManagerConnection jobManagerConnection = new JobManagerConnection(
 			jobId,
@@ -1225,7 +1217,7 @@ public class TaskExecutorTest extends TestLogger {
 			jobMasterGateway,
 			mock(TaskManagerActions.class),
 			mock(CheckpointResponder.class),
-			blobCache,
+			blobService,
 			libraryCacheManager,
 			mock(ResultPartitionConsumableNotifier.class),
 			mock(PartitionProducerStateChecker.class));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -24,6 +24,8 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobCache;
+import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -697,13 +699,20 @@ public class TaskExecutorTest extends TestLogger {
 		final JobMasterGateway jobMasterGateway = mock(JobMasterGateway.class);
 		when(jobMasterGateway.getFencingToken()).thenReturn(jobMasterId);
 
+		BlobCache blobCache = mock(BlobCache.class);
+		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
+		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
+
+		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+
 		final JobManagerConnection jobManagerConnection = new JobManagerConnection(
 			jobId,
 			ResourceID.generate(),
 			jobMasterGateway,
 			mock(TaskManagerActions.class),
 			mock(CheckpointResponder.class),
-			mock(BlobCache.class),
+			blobCache,
 			libraryCacheManager,
 			mock(ResultPartitionConsumableNotifier.class),
 			mock(PartitionProducerStateChecker.class));
@@ -1203,13 +1212,20 @@ public class TaskExecutorTest extends TestLogger {
 		final LibraryCacheManager libraryCacheManager = mock(LibraryCacheManager.class);
 		when(libraryCacheManager.getClassLoader(eq(jobId))).thenReturn(getClass().getClassLoader());
 
+		BlobCache blobCache = mock(BlobCache.class);
+		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
+		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
+
+		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+
 		final JobManagerConnection jobManagerConnection = new JobManagerConnection(
 			jobId,
 			jmResourceId,
 			jobMasterGateway,
 			mock(TaskManagerActions.class),
 			mock(CheckpointResponder.class),
-			mock(BlobCache.class),
+			blobCache,
 			libraryCacheManager,
 			mock(ResultPartitionConsumableNotifier.class),
 			mock(PartitionProducerStateChecker.class));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
@@ -148,12 +148,8 @@ public class TaskAsyncCallTest {
 	}
 	
 	private static Task createTask() throws Exception {
-		BlobCache blobCache = mock(BlobCache.class);
-		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
-		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
-
-		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
+		BlobCacheService blobService =
+			new BlobCacheService(mock(PermanentBlobCache.class), mock(TransientBlobCache.class));
 
 		LibraryCacheManager libCache = mock(LibraryCacheManager.class);
 		when(libCache.getClassLoader(any(JobID.class))).thenReturn(ClassLoader.getSystemClassLoader());
@@ -205,7 +201,7 @@ public class TaskAsyncCallTest {
 			mock(TaskManagerActions.class),
 			mock(InputSplitProvider.class),
 			mock(CheckpointResponder.class),
-			blobCache,
+			blobService,
 			libCache,
 			mock(FileCache.class),
 			new TestingTaskManagerRuntimeInfo(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -152,8 +152,8 @@ public class TaskAsyncCallTest {
 		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
 		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
 
-		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
 
 		LibraryCacheManager libCache = mock(LibraryCacheManager.class);
 		when(libCache.getClassLoader(any(JobID.class))).thenReturn(ClassLoader.getSystemClassLoader());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
@@ -59,7 +58,6 @@ import org.apache.flink.util.SerializedValue;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.net.URL;
 import java.util.Collections;
 import java.util.concurrent.Executor;
 
@@ -172,8 +170,8 @@ public class TaskAsyncCallTest {
 			"Job Name",
 			new SerializedValue<>(new ExecutionConfig()),
 			new Configuration(),
-			Collections.<BlobKey>emptyList(),
-			Collections.<URL>emptyList());
+			Collections.emptyList(),
+			Collections.emptyList());
 
 		TaskInformation taskInformation = new TaskInformation(
 			new JobVertexID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -24,6 +24,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobCache;
+import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
@@ -147,6 +149,12 @@ public class TaskAsyncCallTest {
 	
 	private static Task createTask() throws Exception {
 		BlobCache blobCache = mock(BlobCache.class);
+		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
+		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
+
+		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+
 		LibraryCacheManager libCache = mock(LibraryCacheManager.class);
 		when(libCache.getClassLoader(any(JobID.class))).thenReturn(ClassLoader.getSystemClassLoader());
 		

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -33,7 +33,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.FlinkUntypedActor;
-import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -210,7 +210,7 @@ public class TaskManagerTest extends TestLogger {
 					TestInvokableCorrect.class.getName(),
 					Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 					Collections.<InputGateDeploymentDescriptor>emptyList(),
-					new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+					new ArrayList<PermanentBlobKey>(), Collections.emptyList(), 0);
 
 
 				new Within(d) {
@@ -313,7 +313,7 @@ public class TaskManagerTest extends TestLogger {
 						new Configuration(), new Configuration(), TestInvokableBlockingCancelable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+						new ArrayList<>(), Collections.<URL>emptyList(), 0);
 
 				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid2, "TestJob2", vid2, eid2,
@@ -322,7 +322,7 @@ public class TaskManagerTest extends TestLogger {
 						new Configuration(), new Configuration(), TestInvokableBlockingCancelable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0);
 
 				final ActorGateway tm = taskManager;
 
@@ -453,13 +453,13 @@ public class TaskManagerTest extends TestLogger {
 						"TestTask1", 5, 1, 5, 0, new Configuration(), new Configuration(), StoppableInvokable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0);
 
 				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(jid2, "TestJob", vid2, eid2, executionConfig,
 						"TestTask2", 7, 2, 7, 0, new Configuration(), new Configuration(), TestInvokableBlockingCancelable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0);
 
 				final ActorGateway tm = taskManager;
 
@@ -585,7 +585,7 @@ public class TaskManagerTest extends TestLogger {
 						new Configuration(), new Configuration(), Tasks.Sender.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0);
 
 				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid2, eid2,
@@ -594,7 +594,7 @@ public class TaskManagerTest extends TestLogger {
 						new Configuration(), new Configuration(), Tasks.Receiver.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0);
 
 				new Within(d){
 
@@ -692,8 +692,8 @@ public class TaskManagerTest extends TestLogger {
 						new SerializedValue<>(new ExecutionConfig()),
 						"Sender", 1, 0, 1, 0,
 						new Configuration(), new Configuration(), Tasks.Sender.class.getName(),
-						irpdd, Collections.<InputGateDeploymentDescriptor>emptyList(), new ArrayList<BlobKey>(),
-						Collections.<URL>emptyList(), 0);
+						irpdd, Collections.<InputGateDeploymentDescriptor>emptyList(), new ArrayList<>(),
+						Collections.emptyList(), 0);
 
 				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid2, eid2,
@@ -702,7 +702,7 @@ public class TaskManagerTest extends TestLogger {
 						new Configuration(), new Configuration(), Tasks.Receiver.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.singletonList(ircdd),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0);
 
 				new Within(d) {
 
@@ -842,7 +842,7 @@ public class TaskManagerTest extends TestLogger {
 						"Sender", 1, 0, 1, 0,
 						new Configuration(), new Configuration(), Tasks.Sender.class.getName(),
 						irpdd, Collections.<InputGateDeploymentDescriptor>emptyList(),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0);
 
 				final TaskDeploymentDescriptor tdd2 = createTaskDeploymentDescriptor(
 						jid, "TestJob", vid2, eid2,
@@ -851,7 +851,7 @@ public class TaskManagerTest extends TestLogger {
 						new Configuration(), new Configuration(), Tasks.BlockingReceiver.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.singletonList(ircdd),
-						new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+						new ArrayList<>(), Collections.emptyList(), 0);
 
 				new Within(d){
 
@@ -998,8 +998,8 @@ public class TaskManagerTest extends TestLogger {
 						Tasks.AgnosticReceiver.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.singletonList(igdd),
-						Collections.<BlobKey>emptyList(),
-						Collections.<URL>emptyList(), 0);
+						Collections.emptyList(),
+						Collections.emptyList(), 0);
 
 				new Within(d) {
 					@Override
@@ -1116,8 +1116,8 @@ public class TaskManagerTest extends TestLogger {
 						Tasks.AgnosticReceiver.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.singletonList(igdd),
-						Collections.<BlobKey>emptyList(),
-						Collections.<URL>emptyList(), 0);
+						Collections.emptyList(),
+						Collections.emptyList(), 0);
 
 				new Within(new FiniteDuration(120, TimeUnit.SECONDS)) {
 					@Override
@@ -1266,8 +1266,8 @@ public class TaskManagerTest extends TestLogger {
 						BlockingNoOpInvokable.class.getName(),
 						Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 						Collections.<InputGateDeploymentDescriptor>emptyList(),
-						Collections.<BlobKey>emptyList(),
-						Collections.<URL>emptyList(),
+						Collections.emptyList(),
+						Collections.emptyList(),
 						0);
 
 				// Submit the task
@@ -1587,7 +1587,7 @@ public class TaskManagerTest extends TestLogger {
 				TestInvokableRecordCancel.class.getName(),
 				Collections.singletonList(resultPartitionDeploymentDescriptor),
 				Collections.<InputGateDeploymentDescriptor>emptyList(),
-				new ArrayList<BlobKey>(), Collections.<URL>emptyList(), 0);
+				new ArrayList<>(), Collections.emptyList(), 0);
 
 
 			ActorRef jmActorRef = system.actorOf(Props.create(FailingScheduleOrUpdateConsumersJobManager.class, leaderSessionID), "jobmanager");
@@ -1662,8 +1662,8 @@ public class TaskManagerTest extends TestLogger {
 				"Foobar",
 				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 				Collections.<InputGateDeploymentDescriptor>emptyList(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
+				Collections.emptyList(),
+				Collections.emptyList(),
 				0);
 
 			Future<Object> submitResponse = taskManager.ask(new SubmitTask(tdd), timeout);
@@ -1723,8 +1723,8 @@ public class TaskManagerTest extends TestLogger {
 				BlockingNoOpInvokable.class.getName(),
 				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 				Collections.<InputGateDeploymentDescriptor>emptyList(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
+				Collections.emptyList(),
+				Collections.emptyList(),
 				0);
 
 			Future<Object> submitResponse = taskManager.ask(new SubmitTask(tdd), timeout);
@@ -1836,8 +1836,8 @@ public class TaskManagerTest extends TestLogger {
 				BlockingNoOpInvokable.class.getName(),
 				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 				Collections.<InputGateDeploymentDescriptor>emptyList(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList(),
+				Collections.emptyList(),
+				Collections.emptyList(),
 				0);
 
 			Future<Object> submitResponse = taskManager.ask(new SubmitTask(tdd), timeout);
@@ -2125,7 +2125,7 @@ public class TaskManagerTest extends TestLogger {
 		String invokableClassName,
 		Collection<ResultPartitionDeploymentDescriptor> producedPartitions,
 		Collection<InputGateDeploymentDescriptor> inputGates,
-		Collection<BlobKey> requiredJarFiles,
+		Collection<PermanentBlobKey> requiredJarFiles,
 		Collection<URL> requiredClasspaths,
 		int targetSlotNumber) throws IOException {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
@@ -81,8 +81,8 @@ public class TaskStopTest {
 		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
 		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
 
-		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
 
 		task = new Task(
 			mock(JobInformation.class),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.taskmanager;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobCache;
+import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
@@ -77,12 +77,8 @@ public class TaskStopTest {
 		TaskMetricGroup taskMetricGroup = mock(TaskMetricGroup.class);
 		when(taskMetricGroup.getIOMetricGroup()).thenReturn(mock(TaskIOMetricGroup.class));
 
-		BlobCache blobCache = mock(BlobCache.class);
-		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
-		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
-
-		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
+		BlobCacheService blobService =
+			new BlobCacheService(mock(PermanentBlobCache.class), mock(TransientBlobCache.class));
 
 		task = new Task(
 			mock(JobInformation.class),
@@ -108,7 +104,7 @@ public class TaskStopTest {
 			mock(TaskManagerActions.class),
 			mock(InputSplitProvider.class),
 			mock(CheckpointResponder.class),
-			blobCache,
+			blobService,
 			mock(LibraryCacheManager.class),
 			mock(FileCache.class),
 			tmRuntimeInfo,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskStopTest.java
@@ -21,6 +21,8 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobCache;
+import org.apache.flink.runtime.blob.PermanentBlobCache;
+import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -75,6 +77,13 @@ public class TaskStopTest {
 		TaskMetricGroup taskMetricGroup = mock(TaskMetricGroup.class);
 		when(taskMetricGroup.getIOMetricGroup()).thenReturn(mock(TaskIOMetricGroup.class));
 
+		BlobCache blobCache = mock(BlobCache.class);
+		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
+		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
+
+		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+
 		task = new Task(
 			mock(JobInformation.class),
 			new TaskInformation(
@@ -99,7 +108,7 @@ public class TaskStopTest {
 			mock(TaskManagerActions.class),
 			mock(InputSplitProvider.class),
 			mock(CheckpointResponder.class),
-			mock(BlobCache.class),
+			blobCache,
 			mock(LibraryCacheManager.class),
 			mock(FileCache.class),
 			tmRuntimeInfo,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.blob.BlobCache;
+import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
@@ -230,8 +230,8 @@ public class TaskTest extends TestLogger {
 	@Test
 	public void testLibraryCacheRegistrationFailed() {
 		try {
-			BlobCache blobCache = createBlobCache();
-			Task task = createTask(TestInvokableCorrect.class, blobCache,
+			BlobCacheService blobService = createBlobCache();
+			Task task = createTask(TestInvokableCorrect.class, blobService,
 				mock(LibraryCacheManager.class));
 
 			// task should be new and perfect
@@ -266,7 +266,7 @@ public class TaskTest extends TestLogger {
 	@Test
 	public void testExecutionFailsInNetworkRegistration() {
 		try {
-			BlobCache blobCache = createBlobCache();
+			BlobCacheService blobService = createBlobCache();
 			// mock a working library cache
 			LibraryCacheManager libCache = mock(LibraryCacheManager.class);
 			when(libCache.getClassLoader(any(JobID.class))).thenReturn(getClass().getClassLoader());
@@ -281,7 +281,7 @@ public class TaskTest extends TestLogger {
 			when(network.getDefaultIOMode()).thenReturn(IOManager.IOMode.SYNC);
 			doThrow(new RuntimeException("buffers")).when(network).registerTask(any(Task.class));
 
-			Task task = createTask(TestInvokableCorrect.class, blobCache, libCache, network, consumableNotifier, partitionProducerStateChecker, executor);
+			Task task = createTask(TestInvokableCorrect.class, blobService, libCache, network, consumableNotifier, partitionProducerStateChecker, executor);
 
 			task.registerExecutionListener(listener);
 
@@ -626,7 +626,7 @@ public class TaskTest extends TestLogger {
 		IntermediateDataSetID resultId = new IntermediateDataSetID();
 		ResultPartitionID partitionId = new ResultPartitionID();
 
-		BlobCache blobCache = createBlobCache();
+		BlobCacheService blobService = createBlobCache();
 		LibraryCacheManager libCache = mock(LibraryCacheManager.class);
 		when(libCache.getClassLoader(any(JobID.class))).thenReturn(getClass().getClassLoader());
 
@@ -639,7 +639,7 @@ public class TaskTest extends TestLogger {
 		when(network.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class)))
 			.thenReturn(mock(TaskKvStateRegistry.class));
 
-		createTask(InvokableBlockingInInvoke.class, blobCache, libCache, network, consumableNotifier, partitionChecker, Executors.directExecutor());
+		createTask(InvokableBlockingInInvoke.class, blobService, libCache, network, consumableNotifier, partitionChecker, Executors.directExecutor());
 
 		// Test all branches of trigger partition state check
 
@@ -648,7 +648,7 @@ public class TaskTest extends TestLogger {
 			createQueuesAndActors();
 
 			// PartitionProducerDisposedException
-			Task task = createTask(InvokableBlockingInInvoke.class, blobCache, libCache, network, consumableNotifier, partitionChecker, Executors.directExecutor());
+			Task task = createTask(InvokableBlockingInInvoke.class, blobService, libCache, network, consumableNotifier, partitionChecker, Executors.directExecutor());
 
 			CompletableFuture<ExecutionState> promise = new CompletableFuture<>();
 			when(partitionChecker.requestPartitionProducerState(eq(task.getJobID()), eq(resultId), eq(partitionId))).thenReturn(promise);
@@ -664,7 +664,7 @@ public class TaskTest extends TestLogger {
 			createQueuesAndActors();
 
 			// Any other exception
-			Task task = createTask(InvokableBlockingInInvoke.class, blobCache, libCache, network, consumableNotifier, partitionChecker, Executors.directExecutor());
+			Task task = createTask(InvokableBlockingInInvoke.class, blobService, libCache, network, consumableNotifier, partitionChecker, Executors.directExecutor());
 
 			CompletableFuture<ExecutionState> promise = new CompletableFuture<>();
 			when(partitionChecker.requestPartitionProducerState(eq(task.getJobID()), eq(resultId), eq(partitionId))).thenReturn(promise);
@@ -681,7 +681,7 @@ public class TaskTest extends TestLogger {
 			createQueuesAndActors();
 
 			// TimeoutException handled special => retry
-			Task task = createTask(InvokableBlockingInInvoke.class, blobCache, libCache, network, consumableNotifier, partitionChecker, Executors.directExecutor());
+			Task task = createTask(InvokableBlockingInInvoke.class, blobService, libCache, network, consumableNotifier, partitionChecker, Executors.directExecutor());
 			SingleInputGate inputGate = mock(SingleInputGate.class);
 			when(inputGate.getConsumedResultId()).thenReturn(resultId);
 
@@ -712,7 +712,7 @@ public class TaskTest extends TestLogger {
 			createQueuesAndActors();
 
 			// Success
-			Task task = createTask(InvokableBlockingInInvoke.class, blobCache, libCache, network, consumableNotifier, partitionChecker, Executors.directExecutor());
+			Task task = createTask(InvokableBlockingInInvoke.class, blobService, libCache, network, consumableNotifier, partitionChecker, Executors.directExecutor());
 			SingleInputGate inputGate = mock(SingleInputGate.class);
 			when(inputGate.getConsumedResultId()).thenReturn(resultId);
 
@@ -888,19 +888,15 @@ public class TaskTest extends TestLogger {
 	}
 
 	/**
-	 * Creates a {@link BlobCache} mock that is suitable to be used in the tests above.
+	 * Creates a {@link BlobCacheService} mock that is suitable to be used in the tests above.
 	 *
 	 * @return BlobCache mock with the bare minimum of implemented functions that work
 	 */
-	private BlobCache createBlobCache() {
-		BlobCache blobCache = mock(BlobCache.class);
-		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
-		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
+	private BlobCacheService createBlobCache() {
+		BlobCacheService blobService =
+			new BlobCacheService(mock(PermanentBlobCache.class), mock(TransientBlobCache.class));
 
-		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
-
-		return blobCache;
+		return blobService;
 	}
 
 	private Task createTask(Class<? extends AbstractInvokable> invokable) throws IOException {
@@ -908,30 +904,30 @@ public class TaskTest extends TestLogger {
 	}
 
 	private Task createTask(Class<? extends AbstractInvokable> invokable, Configuration config) throws IOException {
-		BlobCache blobCache = createBlobCache();
+		BlobCacheService blobService = createBlobCache();
 		LibraryCacheManager libCache = mock(LibraryCacheManager.class);
 		when(libCache.getClassLoader(any(JobID.class))).thenReturn(getClass().getClassLoader());
-		return createTask(invokable, blobCache,libCache, config, new ExecutionConfig());
+		return createTask(invokable, blobService,libCache, config, new ExecutionConfig());
 	}
 
 	private Task createTask(Class<? extends AbstractInvokable> invokable, Configuration config, ExecutionConfig execConfig) throws IOException {
-		BlobCache blobCache = createBlobCache();
+		BlobCacheService blobService = createBlobCache();
 		LibraryCacheManager libCache = mock(LibraryCacheManager.class);
 		when(libCache.getClassLoader(any(JobID.class))).thenReturn(getClass().getClassLoader());
-		return createTask(invokable, blobCache,libCache, config, execConfig);
+		return createTask(invokable, blobService,libCache, config, execConfig);
 	}
 
 	private Task createTask(
 			Class<? extends AbstractInvokable> invokable,
-			BlobCache blobCache,
+			BlobCacheService blobService,
 			LibraryCacheManager libCache) throws IOException {
 
-		return createTask(invokable, blobCache,libCache, new Configuration(), new ExecutionConfig());
+		return createTask(invokable, blobService,libCache, new Configuration(), new ExecutionConfig());
 	}
 
 	private Task createTask(
 			Class<? extends AbstractInvokable> invokable,
-			BlobCache blobCache,
+			BlobCacheService blobService,
 			LibraryCacheManager libCache,
 			Configuration config,
 			ExecutionConfig execConfig) throws IOException {
@@ -946,23 +942,23 @@ public class TaskTest extends TestLogger {
 		when(network.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class)))
 				.thenReturn(mock(TaskKvStateRegistry.class));
 
-		return createTask(invokable, blobCache, libCache, network, consumableNotifier, partitionProducerStateChecker, executor, config, execConfig);
+		return createTask(invokable, blobService, libCache, network, consumableNotifier, partitionProducerStateChecker, executor, config, execConfig);
 	}
 
 	private Task createTask(
 			Class<? extends AbstractInvokable> invokable,
-			BlobCache blobCache,
+			BlobCacheService blobService,
 			LibraryCacheManager libCache,
 			NetworkEnvironment networkEnvironment,
 			ResultPartitionConsumableNotifier consumableNotifier,
 			PartitionProducerStateChecker partitionProducerStateChecker,
 			Executor executor) throws IOException {
-		return createTask(invokable, blobCache, libCache, networkEnvironment, consumableNotifier, partitionProducerStateChecker, executor, new Configuration(), new ExecutionConfig());
+		return createTask(invokable, blobService, libCache, networkEnvironment, consumableNotifier, partitionProducerStateChecker, executor, new Configuration(), new ExecutionConfig());
 	}
 	
 	private Task createTask(
 		Class<? extends AbstractInvokable> invokable,
-		BlobCache blobCache,
+		BlobCacheService blobService,
 		LibraryCacheManager libCache,
 		NetworkEnvironment networkEnvironment,
 		ResultPartitionConsumableNotifier consumableNotifier,
@@ -1023,7 +1019,7 @@ public class TaskTest extends TestLogger {
 			taskManagerConnection,
 			inputSplitProvider,
 			checkpointResponder,
-			blobCache,
+			blobService,
 			libCache,
 			mock(FileCache.class),
 			new TestingTaskManagerRuntimeInfo(taskManagerConfig),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -897,8 +897,8 @@ public class TaskTest extends TestLogger {
 		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
 		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
 
-		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
 
 		return blobCache;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCacheService;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
@@ -70,7 +69,6 @@ import scala.concurrent.duration.FiniteDuration;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -987,8 +985,8 @@ public class TaskTest extends TestLogger {
 			"Test Job",
 			serializedExecutionConfig,
 			new Configuration(),
-			Collections.<BlobKey>emptyList(),
-			Collections.<URL>emptyList());
+			Collections.emptyList(),
+			Collections.emptyList());
 
 		TaskInformation taskInformation = new TaskInformation(
 			jobVertexId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.blob.BlobCacheService;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
@@ -66,7 +65,6 @@ import org.apache.flink.util.SerializedValue;
 
 import org.junit.Test;
 
-import java.net.URL;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -148,7 +146,7 @@ public class JvmExitOnFatalErrorTest {
 
 				final JobInformation jobInformation = new JobInformation(
 						jid, "Test Job", execConfig, new Configuration(),
-						Collections.<BlobKey>emptyList(), Collections.<URL>emptyList());
+						Collections.emptyList(), Collections.emptyList());
 
 				final TaskInformation taskInformation = new TaskInformation(
 						jobVertexId, "Test Task", 1, 1, OomInvokable.class.getName(), new Configuration());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -26,6 +26,8 @@ import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobCache;
+import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
@@ -161,6 +163,13 @@ public class JvmExitOnFatalErrorTest {
 
 				final Executor executor = Executors.newCachedThreadPool();
 
+				BlobCache blobCache = mock(BlobCache.class);
+				PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
+				TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
+
+				when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
+				when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+
 				Task task = new Task(
 						jobInformation,
 						taskInformation,
@@ -179,7 +188,7 @@ public class JvmExitOnFatalErrorTest {
 						new NoOpTaskManagerActions(),
 						new NoOpInputSplitProvider(),
 						new NoOpCheckpointResponder(),
-						mock(BlobCache.class),
+						blobCache,
 						new FallbackLibraryCacheManager(),
 						new FileCache(tmInfo.getTmpDirectories()),
 						tmInfo,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -167,8 +167,8 @@ public class JvmExitOnFatalErrorTest {
 				PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
 				TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
 
-				when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
-				when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+				when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
+				when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
 
 				Task task = new Task(
 						jobInformation,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.testutils.CommonTestUtils;
-import org.apache.flink.runtime.blob.BlobCache;
+import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
@@ -163,12 +163,8 @@ public class JvmExitOnFatalErrorTest {
 
 				final Executor executor = Executors.newCachedThreadPool();
 
-				BlobCache blobCache = mock(BlobCache.class);
-				PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
-				TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
-
-				when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
-				when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
+				BlobCacheService blobService =
+					new BlobCacheService(mock(PermanentBlobCache.class), mock(TransientBlobCache.class));
 
 				Task task = new Task(
 						jobInformation,
@@ -188,7 +184,7 @@ public class JvmExitOnFatalErrorTest {
 						new NoOpTaskManagerActions(),
 						new NoOpInputSplitProvider(),
 						new NoOpCheckpointResponder(),
-						blobCache,
+					blobService,
 						new FallbackLibraryCacheManager(),
 						new FileCache(tmInfo.getTmpDirectories()),
 						tmInfo,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.executiongraph.ExecutionEdge;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
@@ -48,7 +47,6 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -154,8 +152,8 @@ public class RescalePartitionerTest extends TestLogger {
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
 			new RestartAllStrategy.Factory(),
-			new ArrayList<BlobKey>(),
-			new ArrayList<URL>(),
+			new ArrayList<>(),
+			new ArrayList<>(),
 			new Scheduler(TestingUtils.defaultExecutionContext()),
 			ExecutionGraph.class.getClassLoader());
 		try {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.blob.BlobCache;
+import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
@@ -141,12 +141,8 @@ public class BlockingCheckpointsTest {
 		NetworkEnvironment network = mock(NetworkEnvironment.class);
 		when(network.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class))).thenReturn(mockKvRegistry);
 
-		BlobCache blobCache = mock(BlobCache.class);
-		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
-		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
-
-		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
+		BlobCacheService blobService =
+			new BlobCacheService(mock(PermanentBlobCache.class), mock(TransientBlobCache.class));
 
 		return new Task(
 				jobInformation,
@@ -166,7 +162,7 @@ public class BlockingCheckpointsTest {
 				mock(TaskManagerActions.class),
 				mock(InputSplitProvider.class),
 				mock(CheckpointResponder.class),
-				blobCache,
+			blobService,
 				new FallbackLibraryCacheManager(),
 				new FileCache(new String[] { EnvironmentInformation.getTemporaryFileDirectory() }),
 				new TestingTaskManagerRuntimeInfo(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCacheService;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
@@ -75,7 +74,6 @@ import org.apache.flink.util.SerializedValue;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
@@ -126,8 +124,8 @@ public class BlockingCheckpointsTest {
 				"test job name",
 				new SerializedValue<>(new ExecutionConfig()),
 				new Configuration(),
-				Collections.<BlobKey>emptyList(),
-				Collections.<URL>emptyList());
+				Collections.emptyList(),
+				Collections.emptyList());
 
 		TaskInformation taskInformation = new TaskInformation(
 				new JobVertexID(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
@@ -26,6 +26,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobCache;
+import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
@@ -139,6 +141,13 @@ public class BlockingCheckpointsTest {
 		NetworkEnvironment network = mock(NetworkEnvironment.class);
 		when(network.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class))).thenReturn(mockKvRegistry);
 
+		BlobCache blobCache = mock(BlobCache.class);
+		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
+		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
+
+		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+
 		return new Task(
 				jobInformation,
 				taskInformation,
@@ -157,7 +166,7 @@ public class BlockingCheckpointsTest {
 				mock(TaskManagerActions.class),
 				mock(InputSplitProvider.class),
 				mock(CheckpointResponder.class),
-				mock(BlobCache.class),
+				blobCache,
 				new FallbackLibraryCacheManager(),
 				new FileCache(new String[] { EnvironmentInformation.getTemporaryFileDirectory() }),
 				new TestingTaskManagerRuntimeInfo(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
@@ -145,8 +145,8 @@ public class BlockingCheckpointsTest {
 		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
 		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
 
-		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
 
 		return new Task(
 				jobInformation,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -246,8 +246,8 @@ public class InterruptSensitiveRestoreTest {
 		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
 		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
 
-		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
 
 		return new Task(
 			jobInformation,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.blob.BlobCache;
+import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
@@ -242,12 +242,8 @@ public class InterruptSensitiveRestoreTest {
 			SourceStreamTask.class.getName(),
 			taskConfig);
 
-		BlobCache blobCache = mock(BlobCache.class);
-		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
-		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
-
-		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
+		BlobCacheService blobService =
+			new BlobCacheService(mock(PermanentBlobCache.class), mock(TransientBlobCache.class));
 
 		return new Task(
 			jobInformation,
@@ -267,7 +263,7 @@ public class InterruptSensitiveRestoreTest {
 			mock(TaskManagerActions.class),
 			mock(InputSplitProvider.class),
 			mock(CheckpointResponder.class),
-			blobCache,
+			blobService,
 			new FallbackLibraryCacheManager(),
 			new FileCache(new String[] { EnvironmentInformation.getTemporaryFileDirectory() }),
 			new TestingTaskManagerRuntimeInfo(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCacheService;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
@@ -76,7 +75,6 @@ import org.junit.Test;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -231,8 +229,8 @@ public class InterruptSensitiveRestoreTest {
 			"test job name",
 			new SerializedValue<>(new ExecutionConfig()),
 			new Configuration(),
-			Collections.<BlobKey>emptyList(),
-			Collections.<URL>emptyList());
+			Collections.emptyList(),
+			Collections.emptyList());
 
 		TaskInformation taskInformation = new TaskInformation(
 			jobVertexID,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -26,6 +26,8 @@ import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobCache;
+import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
@@ -240,6 +242,13 @@ public class InterruptSensitiveRestoreTest {
 			SourceStreamTask.class.getName(),
 			taskConfig);
 
+		BlobCache blobCache = mock(BlobCache.class);
+		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
+		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
+
+		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+
 		return new Task(
 			jobInformation,
 			taskInformation,
@@ -258,7 +267,7 @@ public class InterruptSensitiveRestoreTest {
 			mock(TaskManagerActions.class),
 			mock(InputSplitProvider.class),
 			mock(CheckpointResponder.class),
-			mock(BlobCache.class),
+			blobCache,
 			new FallbackLibraryCacheManager(),
 			new FileCache(new String[] { EnvironmentInformation.getTemporaryFileDirectory() }),
 			new TestingTaskManagerRuntimeInfo(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCacheService;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
@@ -74,7 +73,6 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.Collections;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -122,8 +120,8 @@ public class StreamTaskTerminationTest extends TestLogger {
 			"Test Job",
 			new SerializedValue<>(new ExecutionConfig()),
 			new Configuration(),
-			Collections.<BlobKey>emptyList(),
-			Collections.<URL>emptyList());
+			Collections.emptyList(),
+			Collections.emptyList());
 
 		final TaskInformation taskInformation = new TaskInformation(
 			new JobVertexID(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -142,8 +142,8 @@ public class StreamTaskTerminationTest extends TestLogger {
 		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
 		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
 
-		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
 
 		final Task task = new Task(
 			jobInformation,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -25,6 +25,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobCache;
+import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -136,6 +138,13 @@ public class StreamTaskTerminationTest extends TestLogger {
 		final NetworkEnvironment networkEnv = mock(NetworkEnvironment.class);
 		when(networkEnv.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class))).thenReturn(mock(TaskKvStateRegistry.class));
 
+		BlobCache blobCache = mock(BlobCache.class);
+		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
+		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
+
+		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+
 		final Task task = new Task(
 			jobInformation,
 			taskInformation,
@@ -154,7 +163,7 @@ public class StreamTaskTerminationTest extends TestLogger {
 			mock(TaskManagerActions.class),
 			mock(InputSplitProvider.class),
 			mock(CheckpointResponder.class),
-			mock(BlobCache.class),
+			blobCache,
 			new FallbackLibraryCacheManager(),
 			mock(FileCache.class),
 			taskManagerRuntimeInfo,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.blob.BlobCache;
+import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
@@ -138,12 +138,8 @@ public class StreamTaskTerminationTest extends TestLogger {
 		final NetworkEnvironment networkEnv = mock(NetworkEnvironment.class);
 		when(networkEnv.createKvStateTaskRegistry(any(JobID.class), any(JobVertexID.class))).thenReturn(mock(TaskKvStateRegistry.class));
 
-		BlobCache blobCache = mock(BlobCache.class);
-		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
-		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
-
-		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
+		BlobCacheService blobService =
+			new BlobCacheService(mock(PermanentBlobCache.class), mock(TransientBlobCache.class));
 
 		final Task task = new Task(
 			jobInformation,
@@ -163,7 +159,7 @@ public class StreamTaskTerminationTest extends TestLogger {
 			mock(TaskManagerActions.class),
 			mock(InputSplitProvider.class),
 			mock(CheckpointResponder.class),
-			blobCache,
+			blobService,
 			new FallbackLibraryCacheManager(),
 			mock(FileCache.class),
 			taskManagerRuntimeInfo,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCacheService;
-import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
@@ -110,7 +109,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -882,8 +880,8 @@ public class StreamTaskTest extends TestLogger {
 			"Job Name",
 			new SerializedValue<>(new ExecutionConfig()),
 			new Configuration(),
-			Collections.<BlobKey>emptyList(),
-			Collections.<URL>emptyList());
+			Collections.emptyList(),
+			Collections.emptyList());
 
 		TaskInformation taskInformation = new TaskInformation(
 			new JobVertexID(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -864,8 +864,8 @@ public class StreamTaskTest extends TestLogger {
 		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
 		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
 
-		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
 
 		LibraryCacheManager libCache = mock(LibraryCacheManager.class);
 		when(libCache.getClassLoader(any(JobID.class))).thenReturn(StreamTaskTest.class.getClassLoader());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -27,7 +27,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.blob.BlobCache;
+import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
@@ -860,12 +860,8 @@ public class StreamTaskTest extends TestLogger {
 			StreamConfig taskConfig,
 			Configuration taskManagerConfig) throws Exception {
 
-		BlobCache blobCache = mock(BlobCache.class);
-		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
-		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
-
-		when(blobCache.getPermanentBlobService()).thenReturn(permanentBlobCache);
-		when(blobCache.getTransientBlobService()).thenReturn(transientBlobCache);
+		BlobCacheService blobService =
+			new BlobCacheService(mock(PermanentBlobCache.class), mock(TransientBlobCache.class));
 
 		LibraryCacheManager libCache = mock(LibraryCacheManager.class);
 		when(libCache.getClassLoader(any(JobID.class))).thenReturn(StreamTaskTest.class.getClassLoader());
@@ -915,7 +911,7 @@ public class StreamTaskTest extends TestLogger {
 			mock(TaskManagerActions.class),
 			mock(InputSplitProvider.class),
 			mock(CheckpointResponder.class),
-			blobCache,
+			blobService,
 			libCache,
 			mock(FileCache.class),
 			new TestingTaskManagerRuntimeInfo(taskManagerConfig, new String[] {System.getProperty("java.io.tmpdir")}),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -29,6 +29,8 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.blob.PermanentBlobCache;
+import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
@@ -859,6 +861,12 @@ public class StreamTaskTest extends TestLogger {
 			Configuration taskManagerConfig) throws Exception {
 
 		BlobCache blobCache = mock(BlobCache.class);
+		PermanentBlobCache permanentBlobCache = mock(PermanentBlobCache.class);
+		TransientBlobCache transientBlobCache = mock(TransientBlobCache.class);
+
+		when(blobCache.getPermanentBlobStore()).thenReturn(permanentBlobCache);
+		when(blobCache.getTransientBlobStore()).thenReturn(transientBlobCache);
+
 		LibraryCacheManager libCache = mock(LibraryCacheManager.class);
 		when(libCache.getClassLoader(any(JobID.class))).thenReturn(StreamTaskTest.class.getClassLoader());
 


### PR DESCRIPTION
This splits up the BLOB store classes into two different use cases which is the biggest change of FLIP-19:
* a `PermanentBlobStore` should resemble use cases for BLOBs that are permanently stored for a job's life time (HA and non-HA).
* a `TransientBlobStore` should reflect BLOB offloading for logs, RPC, etc. which even does not have to be reflected by files.

The `BlobServer` implements both while the `BlobCache` provides access to individual implementations of the two. HA files may only be uploaded by the `BlobServer` (and the (now) only publicly useful method of `BlobClient` to upload jar files). All other accesses should go through the two BLOB store classes.

This PR is based upon #4238 in a series to implement FLINK-6916. It contains some development history and should be squashed.

- [X] General
  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
  - The pull request addresses only one issue
  - Each commit in the PR has a meaningful commit message (including the JIRA id)

- [X] Documentation
  - Documentation has been added for new functionality
  - Old documentation affected by the pull request has been updated
  - JavaDoc for public methods has been added

- [X] Tests & Build
  - Functionality added by the pull request is covered by tests
  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
