### PR TITLE
[FLINK-7220] [checkpoints] Update RocksDB dependency to 5.6.1

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/pom.xml
+++ b/flink-contrib/flink-statebackend-rocksdb/pom.xml
@@ -55,9 +55,9 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>frocksdbjni</artifactId>
-			<version>4.11.2-artisans</version>
+			<groupId>org.rocksdb</groupId>
+			<artifactId>rocksdbjni</artifactId>
+			<version>5.5.5</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-contrib/flink-statebackend-rocksdb/pom.xml
+++ b/flink-contrib/flink-statebackend-rocksdb/pom.xml
@@ -57,7 +57,7 @@ under the License.
 		<dependency>
 			<groupId>org.rocksdb</groupId>
 			<artifactId>rocksdbjni</artifactId>
-			<version>5.5.5</version>
+			<version>5.6.1</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
@@ -19,10 +19,10 @@
 package org.apache.flink.contrib.streaming.state;
 
 import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.BloomFilter;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.CompactionStyle;
 import org.rocksdb.DBOptions;
-import org.rocksdb.StringAppendOperator;
 
 /**
  * The {@code PredefinedOptions} are configuration settings for the {@link RocksDBStateBackend}.
@@ -46,14 +46,13 @@ public enum PredefinedOptions {
 		@Override
 		public DBOptions createDBOptions() {
 			return new DBOptions()
-					.setUseFsync(false)
-					.setDisableDataSync(true);
+					.setUseFsync(false);
 		}
 
 		@Override
 		public ColumnFamilyOptions createColumnOptions() {
 			return new ColumnFamilyOptions()
-					.setMergeOperator(new StringAppendOperator());
+					.setMergeOperatorName(MERGE_OPERATOR_NAME);
 		}
 
 	},
@@ -86,14 +85,13 @@ public enum PredefinedOptions {
 			return new DBOptions()
 					.setIncreaseParallelism(4)
 					.setUseFsync(false)
-					.setDisableDataSync(true)
 					.setMaxOpenFiles(-1);
 		}
 
 		@Override
 		public ColumnFamilyOptions createColumnOptions() {
 			return new ColumnFamilyOptions()
-					.setMergeOperator(new StringAppendOperator())
+					.setMergeOperatorName(MERGE_OPERATOR_NAME)
 					.setCompactionStyle(CompactionStyle.LEVEL)
 					.setLevelCompactionDynamicLevelBytes(true);
 		}
@@ -133,7 +131,6 @@ public enum PredefinedOptions {
 			return new DBOptions()
 					.setIncreaseParallelism(4)
 					.setUseFsync(false)
-					.setDisableDataSync(true)
 					.setMaxOpenFiles(-1);
 		}
 
@@ -146,7 +143,7 @@ public enum PredefinedOptions {
 			final long writeBufferSize = 64 * 1024 * 1024;
 
 			return new ColumnFamilyOptions()
-					.setMergeOperator(new StringAppendOperator())
+					.setMergeOperatorName(MERGE_OPERATOR_NAME)
 					.setCompactionStyle(CompactionStyle.LEVEL)
 					.setLevelCompactionDynamicLevelBytes(true)
 					.setTargetFileSizeBase(targetFileSize)
@@ -158,6 +155,7 @@ public enum PredefinedOptions {
 							new BlockBasedTableConfig()
 									.setBlockCacheSize(blockCacheSize)
 									.setBlockSize(blockSize)
+									.setFilter(new BloomFilter())
 					);
 		}
 	},
@@ -186,18 +184,20 @@ public enum PredefinedOptions {
 			return new DBOptions()
 					.setIncreaseParallelism(4)
 					.setUseFsync(false)
-					.setDisableDataSync(true)
 					.setMaxOpenFiles(-1);
 		}
 
 		@Override
 		public ColumnFamilyOptions createColumnOptions() {
 			return new ColumnFamilyOptions()
-					.setMergeOperator(new StringAppendOperator());
+					.setMergeOperatorName(MERGE_OPERATOR_NAME);
 		}
 	};
 
 	// ------------------------------------------------------------------------
+
+	// The name of the merge operator in RocksDB. Do not change except you know exactly what you do.
+	public static final String MERGE_OPERATOR_NAME = "stringappendtest";
 
 	/**
 	 * Creates the {@link DBOptions}for this pre-defined setting.

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
@@ -51,8 +51,7 @@ public enum PredefinedOptions {
 
 		@Override
 		public ColumnFamilyOptions createColumnOptions() {
-			return new ColumnFamilyOptions()
-					.setMergeOperatorName(MERGE_OPERATOR_NAME);
+			return new ColumnFamilyOptions();
 		}
 
 	},
@@ -91,7 +90,6 @@ public enum PredefinedOptions {
 		@Override
 		public ColumnFamilyOptions createColumnOptions() {
 			return new ColumnFamilyOptions()
-					.setMergeOperatorName(MERGE_OPERATOR_NAME)
 					.setCompactionStyle(CompactionStyle.LEVEL)
 					.setLevelCompactionDynamicLevelBytes(true);
 		}
@@ -143,7 +141,6 @@ public enum PredefinedOptions {
 			final long writeBufferSize = 64 * 1024 * 1024;
 
 			return new ColumnFamilyOptions()
-					.setMergeOperatorName(MERGE_OPERATOR_NAME)
 					.setCompactionStyle(CompactionStyle.LEVEL)
 					.setLevelCompactionDynamicLevelBytes(true)
 					.setTargetFileSizeBase(targetFileSize)
@@ -189,15 +186,11 @@ public enum PredefinedOptions {
 
 		@Override
 		public ColumnFamilyOptions createColumnOptions() {
-			return new ColumnFamilyOptions()
-					.setMergeOperatorName(MERGE_OPERATOR_NAME);
+			return new ColumnFamilyOptions();
 		}
 	};
 
 	// ------------------------------------------------------------------------
-
-	// The name of the merge operator in RocksDB. Do not change except you know exactly what you do.
-	public static final String MERGE_OPERATOR_NAME = "stringappendtest";
 
 	/**
 	 * Creates the {@link DBOptions}for this pre-defined setting.

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -135,6 +135,9 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(RocksDBKeyedStateBackend.class);
 
+	/** The name of the merge operator in RocksDB. Do not change except you know exactly what you do. */
+	public static final String MERGE_OPERATOR_NAME = "stringappendtest";
+
 	private final String operatorIdentifier;
 
 	/** The column family options from the options factory. */
@@ -220,7 +223,10 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		this.enableIncrementalCheckpointing = enableIncrementalCheckpointing;
 
-		this.columnOptions = Preconditions.checkNotNull(columnFamilyOptions);
+		// ensure that we use the right merge operator, because other code relies on this
+		this.columnOptions = Preconditions.checkNotNull(columnFamilyOptions)
+			.setMergeOperatorName(MERGE_OPERATOR_NAME);
+
 		this.dbOptions = Preconditions.checkNotNull(dbOptions);
 
 		this.instanceBasePath = Preconditions.checkNotNull(instanceBasePath);

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -73,7 +73,6 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	/** The number of (re)tries for loading the RocksDB JNI library. */
 	private static final int ROCKSDB_LIB_LOADING_ATTEMPTS = 3;
 
-
 	private static boolean rocksDbInitialized = false;
 
 	// ------------------------------------------------------------------------

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -260,16 +260,7 @@ public class RocksDBStateBackendConfigTest {
 		rocksDbBackend.setPredefinedOptions(PredefinedOptions.SPINNING_DISK_OPTIMIZED);
 		assertEquals(PredefinedOptions.SPINNING_DISK_OPTIMIZED, rocksDbBackend.getPredefinedOptions());
 
-		try (
-				DBOptions optCreated = rocksDbBackend.getDbOptions();
-				DBOptions optReference = new DBOptions();
-				ColumnFamilyOptions colCreated = rocksDbBackend.getColumnOptions()) {
-
-			// check that our instance uses something that we configured
-			assertEquals(true, optCreated.disableDataSync());
-			// just ensure that we pickend an option that actually differs from the reference.
-			assertEquals(false, optReference.disableDataSync());
-
+		try (ColumnFamilyOptions colCreated = rocksDbBackend.getColumnOptions()) {
 			assertEquals(CompactionStyle.LEVEL, colCreated.compactionStyle());
 		}
 	}

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -48,10 +48,13 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksIterator;
@@ -231,6 +234,28 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 			verify(rocksCloseable, times(1)).close();
 		}
 
+	}
+
+	@Test
+	public void testCorrectMergeOperatorSet() throws IOException {
+		ColumnFamilyOptions columnFamilyOptions = mock(ColumnFamilyOptions.class);
+
+		try (RocksDBKeyedStateBackend<Integer> test = new RocksDBKeyedStateBackend<>(
+			"test",
+			Thread.currentThread().getContextClassLoader(),
+			tempFolder.newFolder(),
+			mock(DBOptions.class),
+			columnFamilyOptions,
+			mock(TaskKvStateRegistry.class),
+			IntSerializer.INSTANCE,
+			1,
+			new KeyGroupRange(0, 0),
+			new ExecutionConfig(),
+			enableIncrementalCheckpointing)) {
+
+			verify(columnFamilyOptions, Mockito.times(1))
+				.setMergeOperatorName(RocksDBKeyedStateBackend.MERGE_OPERATOR_NAME);
+		}
 	}
 
 	@Test

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBPerformanceTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBPerformanceTest.java
@@ -31,13 +31,14 @@ import org.rocksdb.NativeLibraryLoader;
 import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksIterator;
-import org.rocksdb.StringAppendOperator;
 import org.rocksdb.WriteOptions;
 import sun.misc.Unsafe;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+
+import static org.apache.flink.contrib.streaming.state.PredefinedOptions.MERGE_OPERATOR_NAME;
 
 /**
  * Test that validates that the performance of RocksDB is as expected.
@@ -74,9 +75,8 @@ public class RocksDBPerformanceTest extends TestLogger {
 					.setIncreaseParallelism(4)
 					.setUseFsync(false)
 					.setMaxOpenFiles(-1)
-					.setDisableDataSync(true)
 					.setCreateIfMissing(true)
-					.setMergeOperator(new StringAppendOperator());
+					.setMergeOperatorName(MERGE_OPERATOR_NAME);
 
 			final WriteOptions write_options = new WriteOptions()
 					.setSync(false)
@@ -152,9 +152,8 @@ public class RocksDBPerformanceTest extends TestLogger {
 					.setIncreaseParallelism(4)
 					.setUseFsync(false)
 					.setMaxOpenFiles(-1)
-					.setDisableDataSync(true)
 					.setCreateIfMissing(true)
-					.setMergeOperator(new StringAppendOperator());
+					.setMergeOperatorName(MERGE_OPERATOR_NAME);
 
 			final WriteOptions write_options = new WriteOptions()
 					.setSync(false)

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBPerformanceTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBPerformanceTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.contrib.streaming.state.benchmark;
 
+import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend;
 import org.apache.flink.core.memory.MemoryUtils;
 import org.apache.flink.testutils.junit.RetryOnFailure;
 import org.apache.flink.testutils.junit.RetryRule;
@@ -37,8 +38,6 @@ import sun.misc.Unsafe;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-
-import static org.apache.flink.contrib.streaming.state.PredefinedOptions.MERGE_OPERATOR_NAME;
 
 /**
  * Test that validates that the performance of RocksDB is as expected.
@@ -76,7 +75,7 @@ public class RocksDBPerformanceTest extends TestLogger {
 					.setUseFsync(false)
 					.setMaxOpenFiles(-1)
 					.setCreateIfMissing(true)
-					.setMergeOperatorName(MERGE_OPERATOR_NAME);
+					.setMergeOperatorName(RocksDBKeyedStateBackend.MERGE_OPERATOR_NAME);
 
 			final WriteOptions write_options = new WriteOptions()
 					.setSync(false)
@@ -153,7 +152,7 @@ public class RocksDBPerformanceTest extends TestLogger {
 					.setUseFsync(false)
 					.setMaxOpenFiles(-1)
 					.setCreateIfMissing(true)
-					.setMergeOperatorName(MERGE_OPERATOR_NAME);
+					.setMergeOperatorName(RocksDBKeyedStateBackend.MERGE_OPERATOR_NAME);
 
 			final WriteOptions write_options = new WriteOptions()
 					.setSync(false)


### PR DESCRIPTION
This PR updates the RocksDB dependency to 5.6.1. Further changes:

- the more performant merge operator is used via `setMergeOperatorName("stringappendtest")`.
- the option `.setDisableDataSync(...)` was removed from RocksDB. Usage is also removed from Flink.
- Takes care of also close the default column family before closing the RocksDB instance.