### PR TITLE
[Flink-7218] [JobManager] ExecutionVertex.getPreferredLocationsBasedOnInputs() will always return empty

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -133,6 +133,8 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 	private volatile ExecutionState state = CREATED;
 
+	private volatile Future<SimpleSlot> assignedFutureResource;     // once assigned, never changes until the execution is archived
+
 	private volatile SimpleSlot assignedResource;     // once assigned, never changes until the execution is archived
 
 	private volatile Throwable failureCause;          // once assigned, never changes
@@ -229,11 +231,16 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		return assignedResource;
 	}
 
+	public  Future<SimpleSlot> getAssignedFutureResource() {
+		return assignedFutureResource;
+	}
+
 	@Override
 	public TaskManagerLocation getAssignedResourceLocation() {
 		// returns non-null only when a location is already assigned
 		return assignedResource != null ? assignedResource.getTaskManagerLocation() : null;
 	}
+
 
 	public Throwable getFailureCause() {
 		return failureCause;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -372,7 +372,8 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 					new ScheduledUnit(this, sharingGroup) :
 					new ScheduledUnit(this, sharingGroup, locationConstraint);
 
-			return slotProvider.allocateSlot(toSchedule, queued);
+			assignedFutureResource = slotProvider.allocateSlot(toSchedule, queued);
+			return assignedFutureResource;
 		}
 		else {
 			// call race, already deployed, or already done

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -133,7 +133,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 	private volatile ExecutionState state = CREATED;
 
-	private volatile Future<SimpleSlot> assignedFutureResource;     // once assigned, never changes until the execution is archived
+	private volatile SimpleSlot assignedFutureResource;     // once assigned, never changes until the execution is archived
 
 	private volatile SimpleSlot assignedResource;     // once assigned, never changes until the execution is archived
 
@@ -231,7 +231,11 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		return assignedResource;
 	}
 
-	public  Future<SimpleSlot> getAssignedFutureResource() {
+	public void setAssignedFutureResource(SimpleSlot slot) {
+		assignedFutureResource = slot;
+	}
+
+	public  SimpleSlot getAssignedFutureResource() {
 		return assignedFutureResource;
 	}
 
@@ -372,8 +376,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 					new ScheduledUnit(this, sharingGroup) :
 					new ScheduledUnit(this, sharingGroup, locationConstraint);
 
-			assignedFutureResource = slotProvider.allocateSlot(toSchedule, queued);
-			return assignedFutureResource;
+			return slotProvider.allocateSlot(toSchedule, queued);
 		}
 		else {
 			// call race, already deployed, or already done

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -61,7 +61,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 
 import static org.apache.flink.runtime.execution.ExecutionState.FINISHED;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -495,16 +495,7 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 						SimpleSlot sourceSlot = sources[k].getSource().getProducer().getCurrentAssignedResource();
 						if (sourceSlot == null) {
 							// look-up assigned future slot of input
-							final Future<SimpleSlot> sourceFutureSource = sources[k].getSource().getProducer().getCurrentExecutionAttempt().getAssignedFutureResource();
-							if (sourceFutureSource != null) {
-								try {
-									sourceSlot = sourceFutureSource.get();
-								} catch (InterruptedException e) {
-									LOG.info("get sourceSlot from future failed {}.", e);
-								} catch (ExecutionException e) {
-									LOG.info("get sourceSlot from future failed {}.", e);
-								}
-							}
+							sourceSlot = sources[k].getSource().getProducer().getCurrentExecutionAttempt().getAssignedFutureResource();
 						}
 						if (sourceSlot != null) {
 							// add input location

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -494,7 +494,7 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 						// look-up assigned slot of input source
 						SimpleSlot sourceSlot = sources[k].getSource().getProducer().getCurrentAssignedResource();
 						if (sourceSlot == null) {
-							// look-up assigned slot of input source from assigned future source
+							// look-up assigned future slot of input
 							final Future<SimpleSlot> sourceFutureSource = sources[k].getSource().getProducer().getCurrentExecutionAttempt().getAssignedFutureResource();
 							if (sourceFutureSource != null) {
 								try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
@@ -139,6 +139,8 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener, Sl
 			final Object ret = scheduleTask(task, allowQueued);
 
 			if (ret instanceof SimpleSlot) {
+				//record the slot info in execution as soon as we got one.
+				task.getTaskToExecute().setAssignedFutureResource((SimpleSlot) ret);
 				return FlinkCompletableFuture.completed((SimpleSlot) ret);
 			}
 			else if (ret instanceof Future) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
@@ -139,7 +139,7 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener, Sl
 			final Object ret = scheduleTask(task, allowQueued);
 
 			if (ret instanceof SimpleSlot) {
-				//record the slot info in execution as soon as we got one.
+				//record the slot info as soon as we got one.
 				task.getTaskToExecute().setAssignedFutureResource((SimpleSlot) ret);
 				return FlinkCompletableFuture.completed((SimpleSlot) ret);
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
@@ -53,7 +53,6 @@ import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.TestLogger;
 
-
 import org.junit.After;
 import org.junit.Test;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
@@ -656,7 +656,6 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 			assertTrue(target2VertexPreferredSet.contains(ejvMap.get(source2Id).getTaskVertices()[2].getCurrentExecutionAttempt().getAssignedFutureResource().getTaskManagerLocation()));
 			assertTrue(target2VertexPreferredSet.contains(ejvMap.get(source2Id).getTaskVertices()[3].getCurrentExecutionAttempt().getAssignedFutureResource().getTaskManagerLocation()));
 		} catch (Exception e) {
-			e.printStackTrace();
 			fail(e.getMessage());
 		}
 	}


### PR DESCRIPTION
I really like the new PR template, so i use it instead of the default one on github~

You can view, comment on, or merge this pull request online at:[https://github.com/apache/flink/pull/4369](https://github.com/apache/flink/pull/4369)

## What is the purpose of the change

The ExecutionVertex.getPreferredLocationsBasedOnInputs will always return empty, cause `sourceSlot` always be null until `ExectionVertex` has been deployed via 'Execution.deployToSlot()'. So allocate resource base on preferred location can't work correctly, we need to set the slot info for `Execution` as soon as Scheduler.scheduleTask() called successfully.

## Brief change log
- Once `Scheduler.scheduleTask()` called successfully and return a SimpleSlot, we record the slot info by new field `assignedFutureSlot` in `Execution`. `assignedFutureSlot`  will be used in `ExectionVertex. getPreferredLocationsBasedOnInputs ()` to get ExecutionVertex's preferred locations.

## Verifying this change

This change added tests and can be verified as follows:
- The test case is under ExecutionGraphSchedulingTest. testExecutionVertexGetPreferredLocationsBasedOnInputs(), i have simulated the process of the JobGraph deployment and validated the results in this test case.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **(no)**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **(no)**
  - The serializers: **(don't know)**
  - The runtime per-record code paths (performance sensitive): **(no)**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **(yes)**:

## Documentation
  - Does this pull request introduce a new feature? **(no)**