### PR TITLE
[FLINK-7255] [docs] Remove default value from ListStateDescriptor con…

### DIFF
--- a/docs/dev/stream/state.md
+++ b/docs/dev/stream/state.md
@@ -373,8 +373,7 @@ public class BufferingSink
         ListStateDescriptor<Tuple2<String, Integer>> descriptor =
             new ListStateDescriptor<>(
                 "buffered-elements",
-                TypeInformation.of(new TypeHint<Tuple2<Long, Long>>() {}),
-                Tuple2.of(0L, 0L));
+                TypeInformation.of(new TypeHint<Tuple2<Long, Long>>() {}));
 
         checkpointedState = context.getOperatorStateStore().getListState(descriptor);
 


### PR DESCRIPTION
This PR corrects the docs regarding the ListStateDescriptor; it no longer passes a default value to the constructor.

This applies to 1.3 and master.