### PR TITLE
[FLINK-7258] [network] Fix watermark configuration order

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -121,8 +121,8 @@ class NettyServer {
 		}
 
 		// Low and high water marks for flow control
-		bootstrap.childOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, config.getMemorySegmentSize() + 1);
 		bootstrap.childOption(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, 2 * config.getMemorySegmentSize());
+		bootstrap.childOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, config.getMemorySegmentSize() + 1);
 
 		// SSL related configuration
 		try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/netty/KvStateServer.java
@@ -141,8 +141,8 @@ public class KvStateServer {
 				.option(ChannelOption.ALLOCATOR, bufferPool)
 				// Child channel options
 				.childOption(ChannelOption.ALLOCATOR, bufferPool)
-				.childOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, LOW_WATER_MARK)
 				.childOption(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, HIGH_WATER_MARK)
+				.childOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, LOW_WATER_MARK)
 				// See initializer for pipeline details
 				.childHandler(new KvStateServerChannelInitializer(serverHandler));
 	}


### PR DESCRIPTION
## Purpose
This PR changes the order in which low and high watermarks are configured for Netty server child connections (high first). That way we avoid running into an `IllegalArgumentException` when the low watermark is larger than the high watermark (relevant if the configured memory segment size is larger than the default).

This situation surfaced only as a logged warning and the low watermark configuration was ignored.

## Changelog
- Configure high watermark before low watermark in `NettyServer`
- Configure high watermark before low watermark in `KvStateServer`

## Verifying this change
- The change is pretty trivial with an extended `NettyServerLowAndHighWatermarkTest` that now checks the expected watermarks.
- I didn't add a test for `KvStateServer`, because the watermarks can't be configured there manually.
- To verify, you can run `NettyServerLowAndHighWatermarkTest` with logging before and after this change and verify that no warning is logged anymore.

## Does this pull request potentially affect one of the following parts?
- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **no**
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**

## Documentation
- Does this pull request introduce a new feature? **no**
- If yes, how is the feature documented? **not applicable**
