### PR TITLE
[FLINK-7226] [webUI] Properly include UTF-8 in content-type header

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/RuntimeMonitorHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/RuntimeMonitorHandler.java
@@ -112,7 +112,7 @@ public class RuntimeMonitorHandler extends RuntimeMonitorHandlerBase {
 			ByteBuf message = e.getMessage() == null ? Unpooled.buffer(0)
 					: Unpooled.wrappedBuffer(e.getMessage().getBytes(ENCODING));
 			response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND, message);
-			response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/plain");
+			response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/plain; charset=" + ENCODING.name());
 			response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, response.content().readableBytes());
 			LOG.debug("Error while handling request", e);
 		}
@@ -120,15 +120,13 @@ public class RuntimeMonitorHandler extends RuntimeMonitorHandlerBase {
 			byte[] bytes = ExceptionUtils.stringifyException(e).getBytes(ENCODING);
 			response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
 					HttpResponseStatus.INTERNAL_SERVER_ERROR, Unpooled.wrappedBuffer(bytes));
-			response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/plain");
+			response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "text/plain; charset=" + ENCODING.name());
 			response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, response.content().readableBytes());
 
 			LOG.debug("Error while handling request", e);
 		}
 
 		response.headers().set(HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN, allowOrigin);
-		// Content-Encoding:utf-8
-		response.headers().set(HttpHeaders.Names.CONTENT_ENCODING, ENCODING.name());
 
 		KeepAliveWrite.flush(ctx, routed.request(), response);
 	}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/AbstractJsonRequestHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/AbstractJsonRequestHandler.java
@@ -45,7 +45,7 @@ public abstract class AbstractJsonRequestHandler implements RequestHandler {
 		DefaultFullHttpResponse response = new DefaultFullHttpResponse(
 				HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.wrappedBuffer(bytes));
 
-		response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "application/json");
+		response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "application/json; charset=" + ENCODING.name());
 		response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, response.content().readableBytes());
 
 		return response;

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobCancellationWithSavepointHandlers.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JobCancellationWithSavepointHandlers.java
@@ -266,7 +266,7 @@ public class JobCancellationWithSavepointHandlers {
 
 			response.headers().set(HttpHeaders.Names.LOCATION, location);
 
-			response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "application/json");
+			response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "application/json; charset=UTF-8");
 			response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, response.content().readableBytes());
 
 			FullHttpResponse accepted = response;
@@ -377,7 +377,7 @@ public class JobCancellationWithSavepointHandlers {
 					HttpResponseStatus.CREATED,
 					Unpooled.wrappedBuffer(bytes));
 
-			response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "application/json");
+			response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "application/json; charset=" + ENCODING.name());
 			response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, response.content().readableBytes());
 
 			return response;
@@ -402,7 +402,7 @@ public class JobCancellationWithSavepointHandlers {
 					HttpResponseStatus.ACCEPTED,
 					Unpooled.wrappedBuffer(bytes));
 
-			response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "application/json");
+			response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "application/json; charset=" + ENCODING.name());
 			response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, response.content().readableBytes());
 
 			return response;
@@ -428,7 +428,7 @@ public class JobCancellationWithSavepointHandlers {
 					code,
 					Unpooled.wrappedBuffer(bytes));
 
-			response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "application/json");
+			response.headers().set(HttpHeaders.Names.CONTENT_TYPE, "application/json; charset=" + ENCODING.name());
 			response.headers().set(HttpHeaders.Names.CONTENT_LENGTH, response.content().readableBytes());
 
 			return response;

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.apache.flink.runtime.testutils.StoppableInvokable;
-import org.apache.flink.runtime.webmonitor.files.MimeTypes;
 import org.apache.flink.runtime.webmonitor.testutils.HttpTestClient;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.util.TestLogger;
@@ -37,10 +36,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.nio.file.Files;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -100,6 +104,38 @@ public class WebFrontendITCase extends TestLogger {
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testResponseHeaders() throws Exception {
+		// check headers for successful json response
+		URL taskManagersUrl = new URL("http://localhost:" + port + "/taskmanagers");
+		HttpURLConnection taskManagerConnection = (HttpURLConnection) taskManagersUrl.openConnection();
+		taskManagerConnection.setConnectTimeout(100000);
+		taskManagerConnection.connect();
+		if (taskManagerConnection.getResponseCode() >= 400) {
+			// error!
+			InputStream is = taskManagerConnection.getErrorStream();
+			String errorMessage = IOUtils.toString(is, ConfigConstants.DEFAULT_CHARSET);
+			throw new RuntimeException(errorMessage);
+		}
+
+		// we don't set the content-encoding header
+		Assert.assertNull(taskManagerConnection.getContentEncoding());
+		Assert.assertEquals("application/json; charset=UTF-8", taskManagerConnection.getContentType());
+
+		// check headers in case of an error
+		URL notFoundJobUrl = new URL("http://localhost:" + port + "/jobs/dontexist");
+		HttpURLConnection notFoundJobConnection = (HttpURLConnection) notFoundJobUrl.openConnection();
+		notFoundJobConnection.setConnectTimeout(100000);
+		notFoundJobConnection.connect();
+		if (notFoundJobConnection.getResponseCode() >= 400) {
+			// we don't set the content-encoding header
+			Assert.assertNull(notFoundJobConnection.getContentEncoding());
+			Assert.assertEquals("text/plain; charset=UTF-8", notFoundJobConnection.getContentType());
+		} else {
+			throw new RuntimeException("Request for non-existing job did not return an error.");
 		}
 	}
 
@@ -227,7 +263,7 @@ public class WebFrontendITCase extends TestLogger {
 				HttpTestClient.SimpleHttpResponse response = client.getNextResponse(deadline.timeLeft());
 
 				assertEquals(HttpResponseStatus.OK, response.getStatus());
-				assertEquals(response.getType(), MimeTypes.getMimeTypeForExtension("json"));
+				assertEquals("application/json; charset=UTF-8", response.getType());
 				assertEquals("{}", response.getContent());
 			}
 
@@ -241,7 +277,7 @@ public class WebFrontendITCase extends TestLogger {
 			HttpTestClient.SimpleHttpResponse response = client.getNextResponse(timeout);
 
 			assertEquals(HttpResponseStatus.OK, response.getStatus());
-			assertEquals(response.getType(), MimeTypes.getMimeTypeForExtension("json"));
+			assertEquals("application/json; charset=UTF-8", response.getType());
 			assertEquals("{\"jid\":\"" + jid + "\",\"name\":\"Stoppable streaming test job\"," +
 				"\"execution-config\":{\"execution-mode\":\"PIPELINED\",\"restart-strategy\":\"default\"," +
 				"\"job-parallelism\":-1,\"object-reuse-mode\":false,\"user-config\":{}}}", response.getContent());
@@ -280,7 +316,7 @@ public class WebFrontendITCase extends TestLogger {
 					.getNextResponse(deadline.timeLeft());
 
 				assertEquals(HttpResponseStatus.OK, response.getStatus());
-				assertEquals(response.getType(), MimeTypes.getMimeTypeForExtension("json"));
+				assertEquals("application/json; charset=UTF-8", response.getType());
 				assertEquals("{}", response.getContent());
 			}
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitorITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitorITCase.java
@@ -108,7 +108,7 @@ public class WebRuntimeMonitorITCase extends TestLogger {
 
 				response = client.getNextResponse(deadline.timeLeft());
 				assertEquals(HttpResponseStatus.OK, response.getStatus());
-				assertEquals(response.getType(), MimeTypes.getMimeTypeForExtension("json"));
+				assertEquals("application/json; charset=UTF-8", response.getType());
 				assertTrue(response.getContent().contains("\"taskmanagers\":1"));
 			}
 		}
@@ -255,7 +255,7 @@ public class WebRuntimeMonitorITCase extends TestLogger {
 
 				response = followingClient.getNextResponse(deadline.timeLeft());
 				assertEquals(HttpResponseStatus.OK, response.getStatus());
-				assertEquals(response.getType(), MimeTypes.getMimeTypeForExtension("json"));
+				assertEquals("application/json; charset=UTF-8", response.getType());
 				assertTrue(response.getContent().contains("\"taskmanagers\":1") ||
 						response.getContent().contains("\"taskmanagers\":0"));
 			} finally {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobCancellationWithSavepointHandlersTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JobCancellationWithSavepointHandlersTest.java
@@ -199,7 +199,7 @@ public class JobCancellationWithSavepointHandlersTest {
 		String location = String.format("/jobs/%s/cancel-with-savepoint/in-progress/1", jobId);
 
 		assertEquals(HttpResponseStatus.ACCEPTED, response.getStatus());
-		assertEquals("application/json", response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
+		assertEquals("application/json; charset=UTF-8", response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
 		assertEquals(Integer.toString(response.content().readableBytes()), response.headers().get(HttpHeaders.Names.CONTENT_LENGTH));
 		assertEquals(location, response.headers().get(HttpHeaders.Names.LOCATION));
 
@@ -213,7 +213,7 @@ public class JobCancellationWithSavepointHandlersTest {
 		// Trigger again
 		response = trigger.handleRequest(params, Collections.<String, String>emptyMap(), jobManager);
 		assertEquals(HttpResponseStatus.ACCEPTED, response.getStatus());
-		assertEquals("application/json", response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
+		assertEquals("application/json; charset=UTF-8", response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
 		assertEquals(Integer.toString(response.content().readableBytes()), response.headers().get(HttpHeaders.Names.CONTENT_LENGTH));
 		assertEquals(location, response.headers().get(HttpHeaders.Names.LOCATION));
 
@@ -232,7 +232,7 @@ public class JobCancellationWithSavepointHandlersTest {
 
 		response = progress.handleRequest(params, Collections.<String, String>emptyMap(), jobManager);
 		assertEquals(HttpResponseStatus.ACCEPTED, response.getStatus());
-		assertEquals("application/json", response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
+		assertEquals("application/json; charset=UTF-8", response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
 		assertEquals(Integer.toString(response.content().readableBytes()), response.headers().get(HttpHeaders.Names.CONTENT_LENGTH));
 
 		json = response.content().toString(Charset.forName("UTF-8"));
@@ -247,7 +247,7 @@ public class JobCancellationWithSavepointHandlersTest {
 		response = progress.handleRequest(params, Collections.<String, String>emptyMap(), jobManager);
 
 		assertEquals(HttpResponseStatus.CREATED, response.getStatus());
-		assertEquals("application/json", response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
+		assertEquals("application/json; charset=UTF-8", response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
 		assertEquals(Integer.toString(response.content().readableBytes()), response.headers().get(HttpHeaders.Names.CONTENT_LENGTH));
 
 		json = response.content().toString(Charset.forName("UTF-8"));
@@ -263,7 +263,7 @@ public class JobCancellationWithSavepointHandlersTest {
 		response = progress.handleRequest(params, Collections.<String, String>emptyMap(), jobManager);
 
 		assertEquals(HttpResponseStatus.CREATED, response.getStatus());
-		assertEquals("application/json", response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
+		assertEquals("application/json; charset=UTF-8", response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
 		assertEquals(Integer.toString(response.content().readableBytes()), response.headers().get(HttpHeaders.Names.CONTENT_LENGTH));
 
 		json = response.content().toString(Charset.forName("UTF-8"));
@@ -279,7 +279,7 @@ public class JobCancellationWithSavepointHandlersTest {
 
 		response = progress.handleRequest(params, Collections.<String, String>emptyMap(), jobManager);
 		assertEquals(HttpResponseStatus.BAD_REQUEST, response.getStatus());
-		assertEquals("application/json", response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
+		assertEquals("application/json; charset=UTF-8", response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
 		assertEquals(Integer.toString(response.content().readableBytes()), response.headers().get(HttpHeaders.Names.CONTENT_LENGTH));
 
 		json = response.content().toString(Charset.forName("UTF-8"));
@@ -326,7 +326,7 @@ public class JobCancellationWithSavepointHandlersTest {
 
 		FullHttpResponse response = progress.handleRequest(params, Collections.<String, String>emptyMap(), jobManager);
 		assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR, response.getStatus());
-		assertEquals("application/json", response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
+		assertEquals("application/json; charset=UTF-8", response.headers().get(HttpHeaders.Names.CONTENT_TYPE));
 		assertEquals(Integer.toString(response.content().readableBytes()), response.headers().get(HttpHeaders.Names.CONTENT_LENGTH));
 
 		String json = response.content().toString(Charset.forName("UTF-8"));

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
@@ -614,7 +614,7 @@ public class TestBaseUtils extends TestLogger {
 			is = connection.getInputStream();
 		}
 
-		return IOUtils.toString(is, connection.getContentEncoding() != null ? connection.getContentEncoding() : "UTF-8");
+		return IOUtils.toString(is, ConfigConstants.DEFAULT_CHARSET);
 	}
 
 	/**


### PR DESCRIPTION
This PR corrects the `content-encoding` header introduced in FLINK-5705. As documented [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding) this header is used to denote how the content is compressed (for example, with gzip or deflate).

That the strings are encoded using `UTF-8` should be documented in the `content-type` header instead, using the `charset` parameter, as documented [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type).

There was also a bug in `TestBaseUtils#getFromHTTP`, where the UTF-8 charset was retrieved from the `content-encoding` header.

I've added tests to make sure we don't break this _again_.