### PR TITLE
[FLINK-7263] Improve Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,71 @@
-Thanks for contributing to Apache Flink. Before you open your pull request, please take the following check list into consideration.
-If your changes take all of the items into account, feel free to open your pull request. For more information and/or questions please refer to the [How To Contribute guide](http://flink.apache.org/how-to-contribute.html).
-In addition to going through the list, please provide a meaningful description of your changes.
 
-- [ ] General
-  - The pull request references the related JIRA issue ("[FLINK-XXX] Jira title text")
-  - The pull request addresses only one issue
-  - Each commit in the PR has a meaningful commit message (including the JIRA id)
+*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review you contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*
 
-- [ ] Documentation
-  - Documentation has been added for new functionality
-  - Old documentation affected by the pull request has been updated
-  - JavaDoc for public methods has been added
+*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*
 
-- [ ] Tests & Build
-  - Functionality added by the pull request is covered by tests
-  - `mvn clean verify` has been executed successfully locally or a Travis build has passed
+## Contribution Checklist
+
+  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
+  
+  - Name the pull request in the form "[FLINK-1234] [component] Title of the pull request", where *FLINK-1234* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
+  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.
+
+  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
+  
+  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` 
+
+  - Each pull request should address only one issue, not mix up code from multiple issues.
+  
+  - Each commit in the pull request has a meaningful commit message (including the JIRA id)
+
+  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
+
+
+**(The sections below can be removed for hotfixes of typos)**
+
+## What is the purpose of the change
+
+*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*
+
+
+## Brief change log
+
+*(for example:)*
+  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
+  - *Deployments RPC transmits only the blob storage reference*
+  - *TaskManagers retrieve the TaskInfo from the blob cache*
+
+
+## Verifying this change
+
+*(Please pick either of the following options)*
+
+This change is a trivial rework / code cleanup without any test coverage.
+
+*(or)*
+
+This change is already covered by existing tests, such as *(please describe tests)*.
+
+*(or)*
+
+This change added tests and can be verified as follows:
+
+*(example:)*
+  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
+  - *Extended integration test for recovery after master (JobManager) failure*
+  - *Added test that validates that TaskInfo is transferred only once across recoveries*
+  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and to TaskManagers during the execution, verifying that recovery happens correctly.*
+
+## Does this pull request potentially affect one of the following parts:
+
+  - Dependencies (does it add or upgrade a dependency): **(yes / no)**
+  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **(yes / no)**
+  - The serializers: **(yes / no / don't know)**
+  - The runtime per-record code paths (performance sensitive): **(yes / no / don't know)**
+  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **(yes / no / don't know)**:
+
+## Documentation
+
+  - Does this pull request introduce a new feature? **(yes / no)**
+  - If yes, how is the feature documented? **(not applicable / docs / JavaDocs / not documented)**
+


### PR DESCRIPTION
As discussed on the [mailing list](https://lists.apache.org/thread.html/0a27a9faa6a4895fae74ea2e6795334967b8914af43fa49eec5f060d@%3Cdev.flink.apache.org%3E), here is a suggestion to make extend the pull request template.

## Main goals
  - Communicating more clearly the prerequisites for every contribution to foster high quality pull requests
  - Encouraging more thorough description of change and ways to verify the change to help reviewers.
  - Clearly marking pull requests that tough potentially sensitive parts of the system, to make contributors and reviewers explicitly reflect on potential implications.

# The Template

*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review you contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-1234] [component] Title of the pull request", where *FLINK-1234* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` 

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and to TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **(yes / no)**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **(yes / no)**
  - The serializers: **(yes / no / don't know)**
  - The runtime per-record code paths (performance sensitive): **(yes / no / don't know)**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **(yes / no / don't know)**:

## Documentation

  - Does this pull request introduce a new feature? **(yes / no)**
  - If yes, how is the feature documented? **(not applicable / docs / JavaDocs / not documented)**
