### PR TITLE
[FLINK-7265] [FLINK-7266] Introduce FileSystemKind and ConsistencyLevel for FileSystem

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/ConsistencyLevel.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/ConsistencyLevel.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * An enumeration describing the level of consistency offered by a {@link FileSystem}.
+ * 
+ * <p>The consistency levels described here make statements about the visibility
+ * of file existence and file contents in the presence of <i>new file creation</i>,
+ * <i>file deletion</i>, <i>file renaming</i>, and <i>directory listing</i>.
+ * 
+ * <p>An operation is defined as consistent if the following holds: After the function
+ * call triggering the operation returns, its result is immediately reflected in
+ * in the view presented to any other party calling a file system function.
+ * 
+ * <p>Please note that these levels do not make any statements about the effects or visibility of
+ * file content modification or file appends. In fact, content modification or appending are
+ * not supported in various file systems.
+ * 
+ * <p>Some of these consistency levels indicate that the storage system does not actually
+ * qualify to be called a FileSystem, but rather a blob-/object store.
+ */
+@PublicEvolving
+public enum ConsistencyLevel {
+
+	/**
+	 * This consistency level only guarantees that files are visible with a consistent
+	 * view of their contents after their initial creation, once the writing stream has been closed.
+	 * Any modifications, renames, deletes are not guaranteed to be immediately visible in a
+	 * consistent manner.
+	 * 
+	 * <p>To access a file/object consistently, the full path/key must be provided. Enumeration
+	 * of files/objects is not consistent.
+	 * 
+	 * <p>An example of a storage system with this consistency level is Amazon's S3 object store.
+	 * 
+	 * <p>This is the weakest consistency level with which Flink's checkpointing can work.
+	 * 
+	 * <b>Summary:</b>
+	 * <ul>
+	 *     <li>New file creation: Consistent
+	 *     <li>File deletion: NOT consistent
+	 *     <li>File renaming: NOT consistent
+	 *     <li>Directory listing: NOT consistent
+	 * </ul>
+	 */
+	READ_AFTER_CREATE,
+
+	/**
+	 * This consistency level guarantees that files are visible with a consistent
+	 * view of their contents after their initial creation, and after renaming them.
+	 * The non-existence is consistently visible after delete operations.
+	 *
+	 * <p>To access a file/object consistently, the full path/key must be provided. Enumeration
+	 * of files/objects is not necessarily consistent.
+	 *
+	 * <b>Summary:</b>
+	 * <ul>
+	 *     <li>New file creation: consistent
+	 *     <li>File deletion: consistent
+	 *     <li>File renaming: consistent, but not necessarily atomic
+	 *     <li>Directory listing: NOT consistent
+	 * </ul>
+	 */
+	CONSISTENT_RENAME_DELETE,
+	
+	/**
+	 * This consistency level guarantees that files are visible with a consistent
+	 * view of their contents after their initial creation, as well as after renaming operations.
+	 * File deletion is immediately visible to all parties.
+	 * 
+	 * <p>Directory listings are consistent, meaning after file creation/rename/delete, the file
+	 * existence or non-existence is reflected when enumerating the parent directory's contents.
+	 *
+	 * <p>An example of storage systems and file systems falling under this consistency level are
+	 * HDFS, MapR FS, and the Windows file systems.
+	 * 
+	 * <b>Summary:</b>
+	 * <ul>
+	 *     <li>New file creation: consistent
+	 *     <li>File deletion: consistent
+	 *     <li>File renaming: consistent, but not necessarily atomic
+	 *     <li>Directory listing: consistent
+	 * </ul>
+	 */
+	CONSISTENT_LIST_RENAME_DELETE,
+
+	/**
+	 * This consistency level has all guarantees of {@link ConsistencyLevel#CONSISTENT_LIST_RENAME_DELETE}
+	 * and supports in addition atomic renames of files.
+	 * 
+	 * <b>Summary:</b>
+	 * <ul>
+	 *     <li>New file creation: consistent
+	 *     <li>File deletion: consistent
+	 *     <li>File renaming: consistent and atomic
+	 *     <li>Directory listing: consistent
+	 * </ul>
+	 */
+	POSIX_STYLE_CONSISTENCY
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -659,6 +659,11 @@ public abstract class FileSystem {
 	 */
 	public abstract boolean isDistributedFS();
 
+	/**
+	 * Gets a description of the characteristics of this file system.
+	 */
+	public abstract FileSystemKind getKind();
+
 	// ------------------------------------------------------------------------
 	//  output directory initialization
 	// ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystemKind.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystemKind.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * An enumeration defining the kind and characteristics of a {@link FileSystem}.
+ * 
+ * <p>Note that the categorization here makes statements only about <i>consistency</i> and
+ * <i>directory handling</i>. It explicitly does not look at the ability to modify files,
+ * which we assume for no operation going through Flink's File System abstraction, at the moment.
+ * This might change in the future. 
+ */
+@PublicEvolving
+public enum FileSystemKind {
+
+	/**
+	 * A POSIX compliant file system, as for example found on UNIX / Linux.
+	 * 
+	 * <p>Posix file systems support directories, a consistent view, atomic renames,
+	 * and deletion of open files.
+	 */
+	POSIX_COMPLIANT(ConsistencyLevel.POSIX_STYLE_CONSISTENCY),
+
+	/**
+	 * A file system that gives a consistent view of its contents.
+	 * 
+	 * <p>File systems in this category are for example Windows file systems,
+	 * HDFS, or MapR FS. They support directories, a consistent view, but not
+	 * necessarily atomic file renaming, or deletion of open files.
+	 */
+	CONSISTENT_FILESYSTEM(ConsistencyLevel.CONSISTENT_LIST_RENAME_DELETE),
+
+	/**
+	 * A consistent object store (not an actual file system).
+	 *
+	 * <p>"File systems" of this kind support no real directories, but  and no consistent
+	 * renaming and delete operations.
+	 */
+	CONSISTENT_OBJECT_STORE(ConsistencyLevel.CONSISTENT_RENAME_DELETE),
+
+	/**
+	 * An eventually consistent object store (not an actual file system), like
+	 * Amazon's S3.
+	 * 
+	 * <p>"File systems" of this kind support no real directories and no consistent
+	 * renaming and delete operations.
+	 */
+	EVENTUALLY_CONSISTENT_OBJECT_STORE(ConsistencyLevel.READ_AFTER_CREATE);
+
+	// ------------------------------------------------------------------------
+
+	private final ConsistencyLevel consistencyLevel;
+
+	FileSystemKind(ConsistencyLevel consistencyLevel) {
+		this.consistencyLevel = consistencyLevel;
+	}
+
+	/**
+	 * Gets the consistency level of the file system, which describes how consistently
+	 * visible operations like file creation, deletion, and directory listings are.
+	 */
+	public ConsistencyLevel consistencyLevel() {
+		return consistencyLevel;
+	}
+
+
+	/**
+	 * Checks whether the file system support real directories, or whether it actually only
+	 * encodes a hierarchy into the file names. 
+	 */
+	public boolean supportsRealDirectories() {
+		return this != EVENTUALLY_CONSISTENT_OBJECT_STORE && this != CONSISTENT_OBJECT_STORE;
+	}
+
+	/**
+	 * Checks whether the file system supports efficient recursive directory deletes, or
+	 * whether the
+	 */
+	public boolean supportsEfficientRecursiveDeletes() {
+		return this != EVENTUALLY_CONSISTENT_OBJECT_STORE && this != CONSISTENT_OBJECT_STORE;
+	}
+
+	/**
+	 * Checks whether the file system supports to delete files from a directory, while there
+	 * are still open streams to the file.
+	 *
+	 * <p>File systems that do not support that operation typically throw an exception when trying
+	 * to delete that file.
+	 */
+	public boolean supportsDeleteOfOpenFiles() {
+		return this == POSIX_COMPLIANT;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
@@ -146,6 +146,11 @@ public class SafetyNetWrapperFileSystem extends FileSystem implements WrappingPr
 	}
 
 	@Override
+	public FileSystemKind getKind() {
+		return unsafeFileSystem.getKind();
+	}
+
+	@Override
 	public FileSystem getWrappedDelegate() {
 		return unsafeFileSystem;
 	}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -31,6 +31,7 @@ import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemKind;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.OperatingSystem;
 
@@ -288,5 +289,14 @@ public class LocalFileSystem extends FileSystem {
 	@Override
 	public boolean isDistributedFS() {
 		return false;
+	}
+
+	@Override
+	public FileSystemKind getKind() {
+		return OperatingSystem.isLinux() ||
+				OperatingSystem.isMac() ||
+				OperatingSystem.isSolaris() ||
+				OperatingSystem.isFreeBSD() ? 
+			FileSystemKind.POSIX_COMPLIANT : FileSystemKind.CONSISTENT_FILESYSTEM;
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/core/fs/FileSystemKindTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/FileSystemKindTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FileSystemKindTest {
+
+	@Test
+	public void testPosixFileSystemKind() {
+		final FileSystemKind kind = FileSystemKind.POSIX_COMPLIANT;
+		assertEquals(ConsistencyLevel.POSIX_STYLE_CONSISTENCY, kind.consistencyLevel());
+
+		assertTrue(kind.supportsDeleteOfOpenFiles());
+		assertTrue(kind.supportsRealDirectories());
+		assertTrue(kind.supportsEfficientRecursiveDeletes());
+	}
+
+	@Test
+	public void testConsistentFileSystemKind() {
+		final FileSystemKind kind = FileSystemKind.CONSISTENT_FILESYSTEM;
+
+		assertEquals(ConsistencyLevel.CONSISTENT_LIST_RENAME_DELETE, kind.consistencyLevel());
+		assertFalse(kind.supportsDeleteOfOpenFiles());
+		assertTrue(kind.supportsRealDirectories());
+		assertTrue(kind.supportsEfficientRecursiveDeletes());
+	}
+
+	@Test
+	public void testConsistentObjectStoreKind() {
+		final FileSystemKind kind = FileSystemKind.CONSISTENT_OBJECT_STORE;
+
+		assertEquals(ConsistencyLevel.CONSISTENT_RENAME_DELETE, kind.consistencyLevel());
+		assertFalse(kind.supportsDeleteOfOpenFiles());
+		assertFalse(kind.supportsRealDirectories());
+		assertFalse(kind.supportsEfficientRecursiveDeletes());
+	}
+
+	@Test
+	public void testEventuallyConsistentObjectStoreKind() {
+		final FileSystemKind kind = FileSystemKind.EVENTUALLY_CONSISTENT_OBJECT_STORE;
+
+		assertEquals(ConsistencyLevel.READ_AFTER_CREATE, kind.consistencyLevel());
+		assertFalse(kind.supportsDeleteOfOpenFiles());
+		assertFalse(kind.supportsRealDirectories());
+		assertFalse(kind.supportsEfficientRecursiveDeletes());
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalFileSystemTest.java
@@ -34,10 +34,12 @@ import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemKind;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.util.FileUtils;
 
+import org.apache.flink.util.OperatingSystem;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
@@ -311,5 +313,16 @@ public class LocalFileSystemTest {
 		assertTrue(dstFile.delete());
 		assertTrue(fs.rename(new Path(srcFolder.toURI()), new Path(dstFolder.toURI())));
 		assertTrue(new File(dstFolder, srcFile.getName()).exists());
+	}
+
+	@Test
+	public void testKind() {
+		final FileSystem fs = FileSystem.getLocalFileSystem();
+
+		if (OperatingSystem.isWindows()) {
+			assertEquals(FileSystemKind.CONSISTENT_FILESYSTEM, fs.getKind());
+		} else {
+			assertEquals(FileSystemKind.POSIX_COMPLIANT, fs.getKind());
+		}
 	}
 }

--- a/flink-fs-tests/src/test/java/org/apache/flink/runtime/fs/hdfs/HdfsKindTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/runtime/fs/hdfs/HdfsKindTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.fs.hdfs;
+
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemKind;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for extracting the {@link FileSystemKind} from file systems that Flink
+ * accesses through Hadoop's File System interface.
+ *
+ * <p>This class needs to be in this package, because it accesses package private methods
+ * from the HDFS file system wrapper class.
+ */
+public class HdfsKindTest extends TestLogger {
+
+	@Test
+	public void testHdfsKind() throws IOException {
+		final FileSystem fs = new Path("hdfs://localhost:55445/my/file").getFileSystem();
+		assertEquals(FileSystemKind.CONSISTENT_FILESYSTEM, fs.getKind());
+	}
+
+	@Test
+	public void testS3Kind() throws IOException {
+		try {
+			Class.forName("org.apache.hadoop.fs.s3.S3FileSystem");
+		} catch (ClassNotFoundException ignored) {
+			// not in the classpath, cannot run this test
+			log.info("Skipping test 'testS3Kind()' because the S3 file system is not in the class path");
+			return;
+		}
+
+		final FileSystem s3 = new Path("s3://myId:mySecret@bucket/some/bucket/some/object").getFileSystem();
+		assertEquals(FileSystemKind.EVENTUALLY_CONSISTENT_OBJECT_STORE, s3.getKind());
+	}
+
+	@Test
+	public void testS3nKind() throws IOException {
+		try {
+			Class.forName("org.apache.hadoop.fs.s3native.NativeS3FileSystem");
+		} catch (ClassNotFoundException ignored) {
+			// not in the classpath, cannot run this test
+			log.info("Skipping test 'testS3nKind()' because the Native S3 file system is not in the class path");
+			return;
+		}
+
+		final FileSystem s3n = new Path("s3n://myId:mySecret@bucket/some/bucket/some/object").getFileSystem();
+		assertEquals(FileSystemKind.EVENTUALLY_CONSISTENT_OBJECT_STORE, s3n.getKind());
+	}
+
+	@Test
+	public void testS3aKind() throws IOException {
+		try {
+			Class.forName("org.apache.hadoop.fs.s3a.S3AFileSystem");
+		} catch (ClassNotFoundException ignored) {
+			// not in the classpath, cannot run this test
+			log.info("Skipping test 'testS3aKind()' because the S3AFileSystem is not in the class path");
+			return;
+		}
+
+		final FileSystem s3a = new Path("s3a://myId:mySecret@bucket/some/bucket/some/object").getFileSystem();
+		assertEquals(FileSystemKind.EVENTUALLY_CONSISTENT_OBJECT_STORE, s3a.getKind());
+	}
+
+	@Test
+	public void testS3fileSystemSchemes() {
+		assertEquals(FileSystemKind.EVENTUALLY_CONSISTENT_OBJECT_STORE, HadoopFileSystem.getKindForScheme("s3"));
+		assertEquals(FileSystemKind.EVENTUALLY_CONSISTENT_OBJECT_STORE, HadoopFileSystem.getKindForScheme("s3n"));
+		assertEquals(FileSystemKind.EVENTUALLY_CONSISTENT_OBJECT_STORE, HadoopFileSystem.getKindForScheme("s3a"));
+		assertEquals(FileSystemKind.EVENTUALLY_CONSISTENT_OBJECT_STORE, HadoopFileSystem.getKindForScheme("EMRFS"));
+	}
+
+	@Test
+	public void testViewFs() {
+		assertEquals(FileSystemKind.CONSISTENT_FILESYSTEM, HadoopFileSystem.getKindForScheme("viewfs"));
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
@@ -487,8 +487,8 @@ public final class HadoopFileSystem extends FileSystem implements HadoopFileSyst
 
 	/**
 	 * Gets the kind of the file system from its scheme.
-	 * 
-	 * <p>Implementation node: Initially, especially within the Flink 1.3.x line
+	 *
+	 * <p>Implementation note: Initially, especially within the Flink 1.3.x line
 	 * (in order to not break backwards compatibility), we must only label file systems
 	 * as 'inconsistent' or as 'not proper filesystems' if we are sure about it.
 	 * Otherwise, we cause regression for example in the performance and cleanup handling

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
@@ -23,11 +23,13 @@ import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.core.fs.BlockLocation;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemKind;
 import org.apache.flink.core.fs.HadoopFileSystemWrapper;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.InstantiationUtil;
 
 import org.apache.hadoop.conf.Configuration;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +38,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.util.Locale;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -61,6 +64,8 @@ public final class HadoopFileSystem extends FileSystem implements HadoopFileSyst
 	private final org.apache.hadoop.conf.Configuration conf;
 
 	private final org.apache.hadoop.fs.FileSystem fs;
+
+	private FileSystemKind fsKind;
 
 
 	/**
@@ -457,6 +462,14 @@ public final class HadoopFileSystem extends FileSystem implements HadoopFileSyst
 	}
 
 	@Override
+	public FileSystemKind getKind() {
+		if (fsKind == null) {
+			fsKind = getKindForScheme(this.fs.getUri().getScheme());
+		}
+		return fsKind;
+	}
+
+	@Override
 	public Class<?> getHadoopWrapperClassNameForFileSystem(String scheme) {
 		Configuration hadoopConf = getHadoopConfiguration();
 		Class<? extends org.apache.hadoop.fs.FileSystem> clazz = null;
@@ -471,4 +484,36 @@ public final class HadoopFileSystem extends FileSystem implements HadoopFileSyst
 		}
 		return clazz;
 	}
+
+	/**
+	 * Gets the kind of the file system from its scheme.
+	 * 
+	 * <p>Implementation node: Initially, especially within the Flink 1.3.x line
+	 * (in order to not break backwards compatibility), we must only label file systems
+	 * as 'inconsistent' or as 'not proper filesystems' if we are sure about it.
+	 * Otherwise, we cause regression for example in the performance and cleanup handling
+	 * of checkpoints.
+	 * For that reason, we initially mark some filesystems as 'eventually consistent' or
+	 * as 'object stores', and leave the others as 'consistent file systems'.
+	 */
+	static FileSystemKind getKindForScheme(String scheme) {
+		scheme = scheme.toLowerCase(Locale.US);
+
+		if (scheme.startsWith("s3") || scheme.startsWith("emr")) {
+			// the Amazon S3 storage
+			return FileSystemKind.EVENTUALLY_CONSISTENT_OBJECT_STORE;
+		}
+		else if (scheme.startsWith("http") || scheme.startsWith("ftp")) {
+			// file servers instead of file systems
+			// they might actually be consistent, but we have no hard guarantees
+			// currently to rely on that
+			return FileSystemKind.EVENTUALLY_CONSISTENT_OBJECT_STORE;
+		}
+		else {
+			// the remainder should include hdfs, kosmos, ceph, ...
+			// this also includes federated HDFS (viewfs).
+			return FileSystemKind.CONSISTENT_FILESYSTEM;
+		}
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/fs/maprfs/MapRFileSystem.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/fs/maprfs/MapRFileSystem.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemKind;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.fs.hdfs.HadoopBlockLocation;
 import org.apache.flink.runtime.fs.hdfs.HadoopDataInputStream;
@@ -382,7 +383,11 @@ public final class MapRFileSystem extends FileSystem {
 
 	@Override
 	public boolean isDistributedFS() {
-
 		return true;
+	}
+
+	@Override
+	public FileSystemKind getKind() {
+		return FileSystemKind.CONSISTENT_FILESYSTEM;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileStateHandle.java
@@ -77,14 +77,15 @@ public class FileStateHandle implements StreamStateHandle {
 	 */
 	@Override
 	public void discardState() throws Exception {
-
 		FileSystem fs = getFileSystem();
 
 		fs.delete(filePath, false);
 
-		try {
-			FileUtils.deletePathIfEmpty(fs, filePath.getParent());
-		} catch (Exception ignored) {}
+		if (fs.getKind().supportsRealDirectories()) {
+			try {
+				FileUtils.deletePathIfEmpty(fs, filePath.getParent());
+			} catch (Exception ignored) {}
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

This change lets File Systems exposes more information about their kind and consistency. For example, whether they support real directory structures, efficient recursive deletes, or rename consistency.

This information is used to hotfix the [FLINK-7266] bug where S3 cleanup becomes prohibitively expensive due to excessive and unnecessary bucket contents listing.

## Brief change log

  - Adds `ConsistencyLevel` and `FileSystemKind` enums do describe file systems
  - All `FileSystems` declare their kind and consistency
  - `HadoopFileSystemWrapper` infers the kind and consistency from the scheme
  - `FileStateHandle` only attempts to delete parent directory if the target file system is a proper filesystem.


## Verifying this change

This change is verified by the addition of some unit tests:
  - Checking that the consistency levels and properties relate as expected
  - Check inference of `LocalFileSystem` consistency (Linux / Windows)
  - Check inference of HDFS wrapper file systems consistency

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**

The worst thing that could happen here is that empty checkpoint parent directories are not cleaned up on some file systems identifying themselves as `s3` or so.

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
