### PR TITLE
 [FLINK-7250] [build] Remove jdk8 profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,52 +24,52 @@ matrix:
     - jdk: "oraclejdk8"
       env:
         - TEST="core"
-        - PROFILE="-Dhadoop.version=2.8.0 -Pjdk8"
+        - PROFILE="-Dhadoop.version=2.8.0"
         - CACHE_NAME=JDK8_H280_CO
     - jdk: "oraclejdk8"
       env:
         - TEST="libraries"
-        - PROFILE="-Dhadoop.version=2.8.0 -Pjdk8"
+        - PROFILE="-Dhadoop.version=2.8.0"
         - CACHE_NAME=JDK8_H280_L
     - jdk: "oraclejdk8"
       env:
         - TEST="connectors"
-        - PROFILE="-Dhadoop.version=2.8.0 -Pjdk8,include-kinesis"
+        - PROFILE="-Dhadoop.version=2.8.0 -Pinclude-kinesis"
         - CACHE_NAME=JDK8_H280_CN
     - jdk: "oraclejdk8"
       env:
         - TEST="tests"
-        - PROFILE="-Dhadoop.version=2.8.0 -Pjdk8"
+        - PROFILE="-Dhadoop.version=2.8.0"
         - CACHE_NAME=JDK8_H280_T
     - jdk: "oraclejdk8"
       env:
         - TEST="misc"
-        - PROFILE="-Dhadoop.version=2.8.0 -Pjdk8"
+        - PROFILE="-Dhadoop.version=2.8.0"
         - CACHE_NAME=JDK8_H280_M
     - jdk: "openjdk8"
       env:
         - TEST="core"
-        - PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.10 -Pjdk8"
+        - PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.10"
         - CACHE_NAME=JDK8_H241_CO
     - jdk: "openjdk8"
       env:
         - TEST="libraries"
-        - PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.10 -Pjdk8"
+        - PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.10"
         - CACHE_NAME=JDK8_H241_L
     - jdk: "openjdk8"
       env:
         - TEST="connectors"
-        - PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.10 -Pjdk8,include-kinesis"
+        - PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.10 -Pinclude-kinesis"
         - CACHE_NAME=JDK8_H241_CN
     - jdk: "openjdk8"
       env:
         - TEST="tests"
-        - PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.10 -Pjdk8"
+        - PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.10"
         - CACHE_NAME=JDK8_H241_T
     - jdk: "openjdk8"
       env:
         - TEST="misc"
-        - PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.10 -Pjdk8"
+        - PROFILE="-Dhadoop.version=2.4.1 -Dscala-2.10"
         - CACHE_NAME=JDK8_H241_M
 
 git:

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -307,8 +307,8 @@ under the License.
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source> <!-- If you want to use Java 8, change this to "1.8" -->
-					<target>1.7</target> <!-- If you want to use Java 8, change this to "1.8" -->
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -307,8 +307,8 @@ under the License.
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@ under the License.
 		<log4j.configuration>log4j-test.properties</log4j.configuration>
 		<guava.version>18.0</guava.version>
 		<akka.version>2.3-custom</akka.version>
-		<java.version>1.7</java.version>
+		<java.version>1.8</java.version>
 		<!-- Overwrite default values from parent pom.
 			 Intellij is (sometimes?) using those values to choose target language level
 			 and thus is changing back to java 1.6 on each maven re-import -->
@@ -748,7 +748,7 @@ under the License.
 		<profile>
 			<id>release</id>
 			<properties>
-				<java.version>1.7</java.version>
+				<java.version>1.8</java.version>
 			</properties>
 			<build>
 				<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@ under the License.
 		<module>flink-shaded-curator</module>
 		<module>flink-core</module>
 		<module>flink-java</module>
+		<module>flink-java8</module>
 		<module>flink-scala</module>
 		<module>flink-runtime</module>
 		<module>flink-runtime-web</module>
@@ -826,40 +827,6 @@ under the License.
 						</plugin>
 					</plugins>
 				</pluginManagement>
-			</build>
-		</profile>
-		<profile>
-			<id>jdk8</id>
-			<!-- do not activate automatically to prevent 1.8 target while Java 7 is the supported -->
-			<properties>
-				<java.version>1.8</java.version>
-			</properties>
-			<modules>
-				<module>flink-java8</module>
-			</modules>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>2.9.1</version><!--$NO-MVN-MAN-VER$-->
-						<configuration>
-							<quiet>true</quiet>
-						</configuration>
-						<executions>
-							<execution>
-								<id>attach-javadocs</id>
-								<goals>
-									<goal>jar</goal>
-								</goals>
-								<configuration>
-									<additionalparam>-Xdoclint:none</additionalparam>
-									<detectOfflineLinks>false</detectOfflineLinks>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
 			</build>
 		</profile>
 	</profiles>


### PR DESCRIPTION
This PR is based on #4398 .

It removes the `jdk8` maven profile, removing uses in the travis.yml, and including the java8 module in the build by default.