### PR TITLE
[FLINK-7273] [gelly] Gelly tests with empty graphs

### DIFF
--- a/docs/dev/libs/gelly/library_methods.md
+++ b/docs/dev/libs/gelly/library_methods.md
@@ -330,6 +330,7 @@ The algorithm takes a simple directed graph as input and outputs a `DataSet` of 
 hub score, and authority score. Termination is configured by the number of iterations and/or a convergence threshold on
 the iteration sum of the change in scores over all vertices.
 
+* `setIncludeZeroDegreeVertices`: whether to include zero-degree vertices in the iterative computation
 * `setParallelism`: override the operator parallelism
 
 ### PageRank

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/PageRank.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/PageRank.java
@@ -20,13 +20,14 @@ package org.apache.flink.graph.drivers;
 
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.drivers.parameter.BooleanParameter;
 import org.apache.flink.graph.drivers.parameter.DoubleParameter;
 import org.apache.flink.graph.drivers.parameter.IterationConvergence;
 
 import org.apache.commons.lang3.text.StrBuilder;
 
 /**
- * @see org.apache.flink.graph.library.linkanalysis.PageRank
+ * Driver for {@link org.apache.flink.graph.library.linkanalysis.PageRank}.
  */
 public class PageRank<K, VV, EV>
 extends DriverBase<K, VV, EV> {
@@ -39,6 +40,8 @@ extends DriverBase<K, VV, EV> {
 		.setMaximumValue(1.0, false);
 
 	private IterationConvergence iterationConvergence = new IterationConvergence(this, DEFAULT_ITERATIONS);
+
+	private BooleanParameter includeZeroDegreeVertices = new BooleanParameter(this, "__include_zero_degree_vertices");
 
 	@Override
 	public String getShortDescription() {
@@ -63,6 +66,7 @@ extends DriverBase<K, VV, EV> {
 					dampingFactor.getValue(),
 					iterationConvergence.getValue().iterations,
 					iterationConvergence.getValue().convergenceThreshold)
+				.setIncludeZeroDegreeVertices(includeZeroDegreeVertices.getValue())
 				.setParallelism(parallelism.getValue().intValue()));
 	}
 }

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/EmptyGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/EmptyGraph.java
@@ -18,12 +18,11 @@
 
 package org.apache.flink.graph.generator;
 
+import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.operators.DataSource;
-import org.apache.flink.api.java.typeutils.TupleTypeInfo;
-import org.apache.flink.api.java.typeutils.ValueTypeInfo;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
@@ -39,7 +38,7 @@ import java.util.Collections;
 public class EmptyGraph
 extends GraphGeneratorBase<LongValue, NullValue, NullValue> {
 
-	public static final int MINIMUM_VERTEX_COUNT = 1;
+	public static final int MINIMUM_VERTEX_COUNT = 0;
 
 	// Required to create the DataSource
 	private final ExecutionEnvironment env;
@@ -64,14 +63,20 @@ extends GraphGeneratorBase<LongValue, NullValue, NullValue> {
 	@Override
 	public Graph<LongValue, NullValue, NullValue> generate() {
 		// Vertices
-		DataSet<Vertex<LongValue, NullValue>> vertices = GraphGeneratorUtils.vertexSequence(env, parallelism, vertexCount);
+		DataSet<Vertex<LongValue, NullValue>> vertices;
+
+		if (vertexCount > 0) {
+			vertices = GraphGeneratorUtils.vertexSequence(env, parallelism, vertexCount);
+		} else {
+			vertices = env
+				.fromCollection(Collections.<Vertex<LongValue, NullValue>>emptyList(), TypeInformation.of(new TypeHint<Vertex<LongValue, NullValue>>(){}))
+					.setParallelism(parallelism)
+					.name("Empty vertex set");
+		}
 
 		// Edges
-		TypeInformation<Edge<LongValue, NullValue>> typeInformation = new TupleTypeInfo<>(
-			ValueTypeInfo.LONG_VALUE_TYPE_INFO, ValueTypeInfo.LONG_VALUE_TYPE_INFO, ValueTypeInfo.NULL_VALUE_TYPE_INFO);
-
 		DataSource<Edge<LongValue, NullValue>> edges = env
-			.fromCollection(Collections.<Edge<LongValue, NullValue>>emptyList(), typeInformation)
+			.fromCollection(Collections.<Edge<LongValue, NullValue>>emptyList(), TypeInformation.of(new TypeHint<Edge<LongValue, NullValue>>(){}))
 				.setParallelism(parallelism)
 				.name("Empty edge set");
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/GraphGeneratorUtils.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/GraphGeneratorUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.graph.generator;
 
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.operators.base.ReduceOperatorBase.CombineHint;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.functions.FunctionAnnotation.ForwardedFields;
@@ -97,6 +98,7 @@ public class GraphGeneratorUtils {
 
 		return vertexSet
 			.distinct()
+			.setCombineHint(CombineHint.HASH)
 				.setParallelism(parallelism)
 				.name("Emit vertex labels");
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/AverageClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/AverageClusteringCoefficient.java
@@ -150,6 +150,11 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 		}
 
 		@Override
+		public String toString() {
+			return toPrintableString();
+		}
+
+		@Override
 		public String toPrintableString() {
 			return "vertex count: " + vertexCount
 				+ ", average clustering coefficient: " + averageLocalClusteringCoefficient;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/GlobalClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/GlobalClusteringCoefficient.java
@@ -137,6 +137,11 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 		}
 
 		@Override
+		public String toString() {
+			return toPrintableString();
+		}
+
+		@Override
 		public String toPrintableString() {
 			return "triplet count: " + tripletCount
 				+ ", triangle count: " + triangleCount

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/TriadicCensus.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/TriadicCensus.java
@@ -504,6 +504,11 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 		}
 
 		@Override
+		public String toString() {
+			return toPrintableString();
+		}
+
+		@Override
 		public String toPrintableString() {
 			NumberFormat nf = NumberFormat.getInstance();
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/AverageClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/AverageClusteringCoefficient.java
@@ -150,6 +150,11 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 		}
 
 		@Override
+		public String toString() {
+			return toPrintableString();
+		}
+
+		@Override
 		public String toPrintableString() {
 			return "vertex count: " + vertexCount
 				+ ", average clustering coefficient: " + averageLocalClusteringCoefficient;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/GlobalClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/GlobalClusteringCoefficient.java
@@ -136,6 +136,11 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 		}
 
 		@Override
+		public String toString() {
+			return toPrintableString();
+		}
+
+		@Override
 		public String toPrintableString() {
 			return "triplet count: " + tripletCount
 				+ ", triangle count: " + triangleCount

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/TriadicCensus.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/TriadicCensus.java
@@ -198,6 +198,11 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 		}
 
 		@Override
+		public String toString() {
+			return toPrintableString();
+		}
+
+		@Override
 		public String toPrintableString() {
 			NumberFormat nf = NumberFormat.getInstance();
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/HITS.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/HITS.java
@@ -48,6 +48,7 @@ import org.apache.flink.util.Collector;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collection;
+import java.util.Iterator;
 
 /**
  * Hyperlink-Induced Topic Search computes two interdependent scores for every
@@ -387,12 +388,13 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		public void open(Configuration parameters) throws Exception {
 			super.open(parameters);
 
-			Collection<DoubleValue> var;
-			var = getRuntimeContext().getBroadcastVariable(HUBBINESS_SUM_SQUARED);
-			hubbinessRootSumSquared = Math.sqrt(var.iterator().next().getValue());
+			Collection<DoubleValue> hubbinessSumSquared = getRuntimeContext().getBroadcastVariable(HUBBINESS_SUM_SQUARED);
+			Iterator<DoubleValue> hubbinessSumSquaredIterator = hubbinessSumSquared.iterator();
+			this.hubbinessRootSumSquared = hubbinessSumSquaredIterator.hasNext() ? Math.sqrt(hubbinessSumSquaredIterator.next().getValue()) : Double.NaN;
 
-			var = getRuntimeContext().getBroadcastVariable(AUTHORITY_SUM_SQUARED);
-			authorityRootSumSquared = Math.sqrt(var.iterator().next().getValue());
+			Collection<DoubleValue> authoritySumSquared = getRuntimeContext().getBroadcastVariable(AUTHORITY_SUM_SQUARED);
+			Iterator<DoubleValue> authoritySumSquaredIterator = authoritySumSquared.iterator();
+			this.authorityRootSumSquared = authoritySumSquaredIterator.hasNext() ? Math.sqrt(authoritySumSquaredIterator.next().getValue()) : Double.NaN;
 		}
 
 		@Override

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/PageRank.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/PageRank.java
@@ -84,6 +84,9 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 
 	private double convergenceThreshold;
 
+	// Optional configuration
+	private boolean includeZeroDegreeVertices = false;
+
 	/**
 	 * PageRank with a fixed number of iterations.
 	 *
@@ -126,6 +129,42 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		this.convergenceThreshold = convergenceThreshold;
 	}
 
+	/**
+	 * This PageRank implementation properly handles both source and sink
+	 * vertices which have, respectively, only outgoing and incoming edges.
+	 *
+	 * <p>Setting this flag includes "zero-degree" vertices in the PageRank
+	 * computation and result. These vertices are handled the same as other
+	 * "source" vertices (with a consistent score of
+	 * <code>(1 - damping factor) / number of vertices</code>) but only
+	 * affect the scores of other vertices indirectly through the taking of
+	 * this proportional portion of the "random jump" score.
+	 *
+	 * <p>The cost to include zero-degree vertices is a reduce for uniqueness
+	 * on the vertex set followed by an outer join on the vertex degree
+	 * DataSet.
+	 *
+	 * @param includeZeroDegreeVertices whether to include zero-degree vertices in the iterative computation
+	 * @return this
+	 */
+	public PageRank<K, VV, EV> setIncludeZeroDegreeVertices(boolean includeZeroDegreeVertices) {
+		this.includeZeroDegreeVertices = includeZeroDegreeVertices;
+
+		return this;
+	}
+
+	@Override
+	protected boolean canMergeConfigurationWith(GraphAlgorithmWrappingBase other) {
+		if (!super.canMergeConfigurationWith(other)) {
+			return false;
+		}
+
+		PageRank rhs = (PageRank) other;
+
+		return dampingFactor == rhs.dampingFactor &&
+			includeZeroDegreeVertices == rhs.includeZeroDegreeVertices;
+	}
+
 	@Override
 	protected void mergeConfiguration(GraphAlgorithmWrappingBase other) {
 		super.mergeConfiguration(other);
@@ -142,6 +181,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		// vertex degree
 		DataSet<Vertex<K, Degrees>> vertexDegree = input
 			.run(new VertexDegrees<K, VV, EV>()
+				.setIncludeZeroDegreeVertices(includeZeroDegreeVertices)
 				.setParallelism(parallelism));
 
 		// vertex count
@@ -158,7 +198,6 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		// vertices with zero in-edges
 		DataSet<Tuple2<K, DoubleValue>> sourceVertices = vertexDegree
 			.flatMap(new InitializeSourceVertices<K>())
-			.withBroadcastSet(vertexCount, VERTEX_COUNT)
 				.setParallelism(parallelism)
 				.name("Initialize source vertex scores");
 
@@ -285,7 +324,8 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 			super.open(parameters);
 
 			Collection<LongValue> vertexCount = getRuntimeContext().getBroadcastVariable(VERTEX_COUNT);
-			output.f1 = new DoubleValue(1.0 / vertexCount.iterator().next().getValue());
+			Iterator<LongValue> vertexCountIterator = vertexCount.iterator();
+			output.f1 = new DoubleValue(vertexCountIterator.hasNext() ? 1.0 / vertexCountIterator.next().getValue() : Double.NaN);
 		}
 
 		@Override
@@ -376,11 +416,13 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 			super.open(parameters);
 
 			Collection<Tuple2<T, DoubleValue>> sumOfScores = getRuntimeContext().getBroadcastVariable(SUM_OF_SCORES);
+			Iterator<Tuple2<T, DoubleValue>> sumOfScoresIterator = sumOfScores.iterator();
 			// floating point precision error is also included in sumOfSinks
-			double sumOfSinks = 1 - sumOfScores.iterator().next().f1.getValue();
+			double sumOfSinks = 1 - (sumOfScoresIterator.hasNext() ? sumOfScoresIterator.next().f1.getValue() : 0);
 
 			Collection<LongValue> vertexCount = getRuntimeContext().getBroadcastVariable(VERTEX_COUNT);
-			this.vertexCount = vertexCount.iterator().next().getValue();
+			Iterator<LongValue> vertexCountIterator = vertexCount.iterator();
+			this.vertexCount = vertexCountIterator.hasNext() ? vertexCountIterator.next().getValue() : 0;
 
 			this.uniformlyDistributedScore = ((1 - dampingFactor) + dampingFactor * sumOfSinks) / this.vertexCount;
 		}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/AsmTestBase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/AsmTestBase.java
@@ -24,6 +24,7 @@ import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.generator.CompleteGraph;
 import org.apache.flink.graph.generator.EmptyGraph;
 import org.apache.flink.graph.generator.RMatGraph;
+import org.apache.flink.graph.generator.StarGraph;
 import org.apache.flink.graph.generator.random.JDKRandomGeneratorFactory;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
@@ -56,11 +57,17 @@ public class AsmTestBase {
 	// empty graph
 	protected final long emptyGraphVertexCount = 3;
 
-	protected Graph<LongValue, NullValue, NullValue> emptyGraph;
+	protected Graph<LongValue, NullValue, NullValue> emptyGraphWithVertices;
+
+	protected Graph<LongValue, NullValue, NullValue> emptyGraphWithoutVertices;
+
+	// star graph
+	protected final long starGraphVertexCount = 29;
+
+	protected Graph<LongValue, NullValue, NullValue> starGraph;
 
 	@Before
-	public void setup()
-			throws Exception {
+	public void setup() throws Exception {
 		env = ExecutionEnvironment.createCollectionsEnvironment();
 		env.getConfig().enableObjectReuse();
 
@@ -89,8 +96,16 @@ public class AsmTestBase {
 		completeGraph = new CompleteGraph(env, completeGraphVertexCount)
 			.generate();
 
-		// empty graph
-		emptyGraph = new EmptyGraph(env, emptyGraphVertexCount)
+		// empty graph with vertices but no edges
+		emptyGraphWithVertices = new EmptyGraph(env, emptyGraphVertexCount)
+			.generate();
+
+		// empty graph with no vertices or edges
+		emptyGraphWithoutVertices = new EmptyGraph(env, 0)
+			.generate();
+
+		// star graph
+		starGraph = new StarGraph(env, starGraphVertexCount)
 			.generate();
 	}
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/dataset/ChecksumHashCodeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/dataset/ChecksumHashCodeTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.graph.asm.dataset;
 
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.graph.asm.dataset.ChecksumHashCode.Checksum;
@@ -27,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -39,15 +42,13 @@ public class ChecksumHashCodeTest {
 	private ExecutionEnvironment env;
 
 	@Before
-	public void setup()
-			throws Exception {
+	public void setup() throws Exception {
 		env = ExecutionEnvironment.createCollectionsEnvironment();
 		env.getConfig().enableObjectReuse();
 	}
 
 	@Test
-	public void testChecksumHashCode()
-			throws Exception {
+	public void testList() throws Exception {
 		List<Long> list = Arrays.asList(ArrayUtils.toObject(
 			new long[]{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }));
 
@@ -57,5 +58,15 @@ public class ChecksumHashCodeTest {
 
 		assertEquals(list.size(), checksum.getCount());
 		assertEquals(list.size() * (list.size() - 1) / 2, checksum.getChecksum());
+	}
+
+	@Test
+	public void testEmptyList() throws Exception {
+		DataSet<Long> dataset = env.fromCollection(Collections.<Long>emptyList(), TypeInformation.of(new TypeHint<Long>(){}));
+
+		Checksum checksum = new ChecksumHashCode<Long>().run(dataset).execute();
+
+		assertEquals(0, checksum.getCount());
+		assertEquals(0, checksum.getChecksum());
 	}
 }

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/dataset/CollectTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/dataset/CollectTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.graph.asm.dataset;
 
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 
@@ -26,9 +28,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for {@link Collect}.
@@ -38,15 +42,13 @@ public class CollectTest {
 	private ExecutionEnvironment env;
 
 	@Before
-	public void setup()
-			throws Exception {
+	public void setup() throws Exception {
 		env = ExecutionEnvironment.createCollectionsEnvironment();
 		env.getConfig().enableObjectReuse();
 	}
 
 	@Test
-	public void testCollect()
-			throws Exception {
+	public void testList() throws Exception {
 		List<Long> list = Arrays.asList(ArrayUtils.toObject(
 			new long[]{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }));
 
@@ -55,5 +57,14 @@ public class CollectTest {
 		List<Long> collected = new Collect<Long>().run(dataset).execute();
 
 		assertArrayEquals(list.toArray(), collected.toArray());
+	}
+
+	@Test
+	public void testEmptyList() throws Exception {
+		DataSet<Long> dataset = env.fromCollection(Collections.<Long>emptyList(), TypeInformation.of(new TypeHint<Long>(){}));
+
+		List<Long> collected = new Collect<Long>().run(dataset).execute();
+
+		assertEquals(0, collected.size());
 	}
 }

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/dataset/CountTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/dataset/CountTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.graph.asm.dataset;
 
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 
@@ -26,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -38,15 +41,13 @@ public class CountTest {
 	private ExecutionEnvironment env;
 
 	@Before
-	public void setup()
-			throws Exception {
+	public void setup() throws Exception {
 		env = ExecutionEnvironment.createCollectionsEnvironment();
 		env.getConfig().enableObjectReuse();
 	}
 
 	@Test
-	public void testCount()
-			throws Exception {
+	public void testList() throws Exception {
 		List<Long> list = Arrays.asList(ArrayUtils.toObject(
 			new long[]{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }));
 
@@ -55,5 +56,14 @@ public class CountTest {
 		long count = new Count<Long>().run(dataset).execute();
 
 		assertEquals(list.size(), count);
+	}
+
+	@Test
+	public void testEmptyList() throws Exception {
+		DataSet<Long> dataset = env.fromCollection(Collections.<Long>emptyList(), TypeInformation.of(new TypeHint<Long>(){}));
+
+		long count = new Count<Long>().run(dataset).execute();
+
+		assertEquals(0, count);
 	}
 }

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeDegreesPairTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeDegreesPairTest.java
@@ -37,8 +37,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link EdgeDegreesPair}.
  */
-public class EdgeDegreesPairTest
-extends AsmTestBase {
+public class EdgeDegreesPairTest extends AsmTestBase {
 
 	@Test
 	public void testWithSimpleGraph()
@@ -59,8 +58,23 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		DataSet<Edge<LongValue, Tuple3<NullValue, Degrees, Degrees>>> degreesPair = emptyGraphWithVertices
+			.run(new EdgeDegreesPair<LongValue, NullValue, NullValue>());
+
+		assertEquals(0, degreesPair.collect().size());
+	}
+
+	@Test
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		DataSet<Edge<LongValue, Tuple3<NullValue, Degrees, Degrees>>> degreesPair = emptyGraphWithoutVertices
+			.run(new EdgeDegreesPair<LongValue, NullValue, NullValue>());
+
+		assertEquals(0, degreesPair.collect().size());
+	}
+
+	@Test
+	public void testWithRMatGraph() throws Exception {
 		DataSet<Edge<LongValue, Tuple3<NullValue, Degrees, Degrees>>> degreesPair = directedRMatGraph(10, 16)
 			.run(new EdgeDegreesPair<LongValue, NullValue, NullValue>());
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeSourceDegreesTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeSourceDegreesTest.java
@@ -37,12 +37,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link EdgeSourceDegrees}.
  */
-public class EdgeSourceDegreesTest
-extends AsmTestBase {
+public class EdgeSourceDegreesTest extends AsmTestBase {
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		String expectedResult =
 			"(0,1,((null),(2,2,0)))\n" +
 			"(0,2,((null),(2,2,0)))\n" +
@@ -59,8 +57,23 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		DataSet<Edge<LongValue, Tuple2<NullValue, Degrees>>> sourceDegrees = emptyGraphWithVertices
+			.run(new EdgeSourceDegrees<LongValue, NullValue, NullValue>());
+
+		assertEquals(0, sourceDegrees.collect().size());
+	}
+
+	@Test
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		DataSet<Edge<LongValue, Tuple2<NullValue, Degrees>>> sourceDegrees = emptyGraphWithoutVertices
+			.run(new EdgeSourceDegrees<LongValue, NullValue, NullValue>());
+
+		assertEquals(0, sourceDegrees.collect().size());
+	}
+
+	@Test
+	public void testWithRMatGraph() throws Exception {
 		DataSet<Edge<LongValue, Tuple2<NullValue, Degrees>>> sourceDegrees = directedRMatGraph(10, 16)
 			.run(new EdgeSourceDegrees<LongValue, NullValue, NullValue>());
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeTargetDegreesTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeTargetDegreesTest.java
@@ -37,12 +37,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link EdgeTargetDegrees}.
  */
-public class EdgeTargetDegreesTest
-extends AsmTestBase {
+public class EdgeTargetDegreesTest extends AsmTestBase {
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		String expectedResult =
 			"(0,1,((null),(3,0,3)))\n" +
 			"(0,2,((null),(3,2,1)))\n" +
@@ -59,8 +57,23 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		DataSet<Edge<LongValue, Tuple2<NullValue, Degrees>>> targetDegrees = emptyGraphWithVertices
+			.run(new EdgeTargetDegrees<LongValue, NullValue, NullValue>());
+
+		assertEquals(0, targetDegrees.collect().size());
+	}
+
+	@Test
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		DataSet<Edge<LongValue, Tuple2<NullValue, Degrees>>> targetDegrees = emptyGraphWithoutVertices
+			.run(new EdgeTargetDegrees<LongValue, NullValue, NullValue>());
+
+		assertEquals(0, targetDegrees.collect().size());
+	}
+
+	@Test
+	public void testWithRMatGraph() throws Exception {
 		DataSet<Edge<LongValue, Tuple2<NullValue, Degrees>>> targetDegrees = directedRMatGraph(10, 16)
 			.run(new EdgeTargetDegrees<LongValue, NullValue, NullValue>());
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexDegreesTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexDegreesTest.java
@@ -36,12 +36,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link VertexDegrees}.
  */
-public class VertexDegreesTest
-extends AsmTestBase {
+public class VertexDegreesTest extends AsmTestBase {
 
 	@Test
-	public void testWithSimpleDirectedGraph()
-			throws Exception {
+	public void testWithSimpleDirectedGraph() throws Exception {
 		DataSet<Vertex<IntValue, Degrees>> degrees = directedSimpleGraph
 			.run(new VertexDegrees<IntValue, NullValue, NullValue>());
 
@@ -57,8 +55,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithSimpleUndirectedGraph()
-			throws Exception {
+	public void testWithSimpleUndirectedGraph() throws Exception {
 		DataSet<Vertex<IntValue, Degrees>> degrees = undirectedSimpleGraph
 			.run(new VertexDegrees<IntValue, NullValue, NullValue>());
 
@@ -74,17 +71,14 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithEmptyGraph()
-			throws Exception {
-		DataSet<Vertex<LongValue, Degrees>> degrees;
-
-		degrees = emptyGraph
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		DataSet<Vertex<LongValue, Degrees>> degreesWithoutZeroDegreeVertices = emptyGraphWithVertices
 			.run(new VertexDegrees<LongValue, NullValue, NullValue>()
 				.setIncludeZeroDegreeVertices(false));
 
-		assertEquals(0, degrees.collect().size());
+		assertEquals(0, degreesWithoutZeroDegreeVertices.collect().size());
 
-		degrees = emptyGraph
+		DataSet<Vertex<LongValue, Degrees>> degreesWithZeroDegreeVertices = emptyGraphWithVertices
 			.run(new VertexDegrees<LongValue, NullValue, NullValue>()
 				.setIncludeZeroDegreeVertices(true));
 
@@ -93,12 +87,26 @@ extends AsmTestBase {
 			"(1,(0,0,0))\n" +
 			"(2,(0,0,0))";
 
-		TestBaseUtils.compareResultAsText(degrees.collect(), expectedResult);
+		TestBaseUtils.compareResultAsText(degreesWithZeroDegreeVertices.collect(), expectedResult);
 	}
 
 	@Test
-	public void testWithRMatGraph()
-	throws Exception {
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		DataSet<Vertex<LongValue, Degrees>> degreesWithoutZeroDegreeVertices = emptyGraphWithoutVertices
+			.run(new VertexDegrees<LongValue, NullValue, NullValue>()
+				.setIncludeZeroDegreeVertices(false));
+
+		assertEquals(0, degreesWithoutZeroDegreeVertices.collect().size());
+
+		DataSet<Vertex<LongValue, Degrees>> degreesWithZeroDegreeVertices = emptyGraphWithoutVertices
+			.run(new VertexDegrees<LongValue, NullValue, NullValue>()
+				.setIncludeZeroDegreeVertices(true));
+
+		assertEquals(0, degreesWithZeroDegreeVertices.collect().size());
+	}
+
+	@Test
+	public void testWithRMatGraph() throws Exception {
 		DataSet<Vertex<LongValue, Degrees>> degrees = directedRMatGraph(10, 16)
 			.run(new VertexDegrees<LongValue, NullValue, NullValue>());
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexInDegreeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexInDegreeTest.java
@@ -35,12 +35,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link VertexInDegree}.
  */
-public class VertexInDegreeTest
-extends AsmTestBase {
+public class VertexInDegreeTest extends AsmTestBase {
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		DataSet<Vertex<IntValue, LongValue>> inDegree = directedSimpleGraph
 			.run(new VertexInDegree<IntValue, NullValue, NullValue>()
 				.setIncludeZeroDegreeVertices(true));
@@ -57,17 +55,14 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithEmptyGraph()
-			throws Exception {
-		DataSet<Vertex<LongValue, LongValue>> inDegree;
-
-		inDegree = emptyGraph
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		DataSet<Vertex<LongValue, LongValue>> inDegreeWithoutZeroDegreeVertices = emptyGraphWithVertices
 			.run(new VertexInDegree<LongValue, NullValue, NullValue>()
 				.setIncludeZeroDegreeVertices(false));
 
-		assertEquals(0, inDegree.collect().size());
+		assertEquals(0, inDegreeWithoutZeroDegreeVertices.collect().size());
 
-		inDegree = emptyGraph
+		DataSet<Vertex<LongValue, LongValue>> inDegreeWithZeroDegreeVertices = emptyGraphWithVertices
 			.run(new VertexInDegree<LongValue, NullValue, NullValue>()
 				.setIncludeZeroDegreeVertices(true));
 
@@ -76,12 +71,26 @@ extends AsmTestBase {
 			"(1,0)\n" +
 			"(2,0)";
 
-		TestBaseUtils.compareResultAsText(inDegree.collect(), expectedResult);
+		TestBaseUtils.compareResultAsText(inDegreeWithZeroDegreeVertices.collect(), expectedResult);
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		DataSet<Vertex<LongValue, LongValue>> inDegreeWithoutZeroDegreeVertices = emptyGraphWithoutVertices
+			.run(new VertexInDegree<LongValue, NullValue, NullValue>()
+				.setIncludeZeroDegreeVertices(false));
+
+		assertEquals(0, inDegreeWithoutZeroDegreeVertices.collect().size());
+
+		DataSet<Vertex<LongValue, LongValue>> inDegreeWithZeroDegreeVertices = emptyGraphWithoutVertices
+			.run(new VertexInDegree<LongValue, NullValue, NullValue>()
+				.setIncludeZeroDegreeVertices(true));
+
+		assertEquals(0, inDegreeWithZeroDegreeVertices.collect().size());
+	}
+
+	@Test
+	public void testWithRMatGraph() throws Exception {
 		DataSet<Vertex<LongValue, LongValue>> inDegree = directedRMatGraph(10, 16)
 			.run(new VertexInDegree<LongValue, NullValue, NullValue>()
 				.setIncludeZeroDegreeVertices(true));

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexOutDegreeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexOutDegreeTest.java
@@ -35,12 +35,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link VertexOutDegree}.
  */
-public class VertexOutDegreeTest
-extends AsmTestBase {
+public class VertexOutDegreeTest extends AsmTestBase {
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		DataSet<Vertex<IntValue, LongValue>> outDegree = directedSimpleGraph
 			.run(new VertexOutDegree<IntValue, NullValue, NullValue>()
 				.setIncludeZeroDegreeVertices(true));
@@ -57,17 +55,14 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithEmptyGraph()
-			throws Exception {
-		DataSet<Vertex<LongValue, LongValue>> outDegree;
-
-		outDegree = emptyGraph
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		DataSet<Vertex<LongValue, LongValue>> outDegreeWithoutZeroDegreeVertices = emptyGraphWithVertices
 			.run(new VertexOutDegree<LongValue, NullValue, NullValue>()
 				.setIncludeZeroDegreeVertices(false));
 
-		assertEquals(0, outDegree.collect().size());
+		assertEquals(0, outDegreeWithoutZeroDegreeVertices.collect().size());
 
-		outDegree = emptyGraph
+		DataSet<Vertex<LongValue, LongValue>> outDegreeWithZeroDegreeVertices = emptyGraphWithVertices
 			.run(new VertexOutDegree<LongValue, NullValue, NullValue>()
 				.setIncludeZeroDegreeVertices(true));
 
@@ -76,12 +71,26 @@ extends AsmTestBase {
 			"(1,0)\n" +
 			"(2,0)";
 
-		TestBaseUtils.compareResultAsText(outDegree.collect(), expectedResult);
+		TestBaseUtils.compareResultAsText(outDegreeWithZeroDegreeVertices.collect(), expectedResult);
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		DataSet<Vertex<LongValue, LongValue>> outDegreeWithoutZeroDegreeVertices = emptyGraphWithoutVertices
+			.run(new VertexOutDegree<LongValue, NullValue, NullValue>()
+				.setIncludeZeroDegreeVertices(false));
+
+		assertEquals(0, outDegreeWithoutZeroDegreeVertices.collect().size());
+
+		DataSet<Vertex<LongValue, LongValue>> outDegreeWithZeroDegreeVertices = emptyGraphWithoutVertices
+			.run(new VertexOutDegree<LongValue, NullValue, NullValue>()
+				.setIncludeZeroDegreeVertices(true));
+
+		assertEquals(0, outDegreeWithZeroDegreeVertices.collect().size());
+	}
+
+	@Test
+	public void testWithRMatGraph() throws Exception {
 		DataSet<Vertex<LongValue, LongValue>> outDegree = directedRMatGraph(10, 16)
 			.run(new VertexOutDegree<LongValue, NullValue, NullValue>()
 				.setIncludeZeroDegreeVertices(true));

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeDegreePairTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeDegreePairTest.java
@@ -36,12 +36,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link EdgeDegreePair}.
  */
-public class EdgeDegreePairTest
-extends AsmTestBase {
+public class EdgeDegreePairTest extends AsmTestBase {
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		String expectedResult =
 			"(0,1,((null),2,3))\n" +
 			"(0,2,((null),2,3))\n" +
@@ -59,7 +57,8 @@ extends AsmTestBase {
 			"(5,3,((null),1,4))";
 
 		DataSet<Edge<IntValue, Tuple3<NullValue, LongValue, LongValue>>> degreePairOnSourceId = undirectedSimpleGraph
-			.run(new EdgeDegreePair<IntValue, NullValue, NullValue>());
+			.run(new EdgeDegreePair<IntValue, NullValue, NullValue>()
+				.setReduceOnTargetId(false));
 
 		TestBaseUtils.compareResultAsText(degreePairOnSourceId.collect(), expectedResult);
 
@@ -71,10 +70,40 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		DataSet<Edge<LongValue, Tuple3<NullValue, LongValue, LongValue>>> degreePairOnSourceId = emptyGraphWithVertices
+			.run(new EdgeDegreePair<LongValue, NullValue, NullValue>()
+				.setReduceOnTargetId(false));
+
+		assertEquals(0, degreePairOnSourceId.collect().size());
+
+		DataSet<Edge<LongValue, Tuple3<NullValue, LongValue, LongValue>>> degreePairOnTargetId = emptyGraphWithVertices
+			.run(new EdgeDegreePair<LongValue, NullValue, NullValue>()
+				.setReduceOnTargetId(true));
+
+		assertEquals(0, degreePairOnTargetId.collect().size());
+	}
+
+	@Test
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		DataSet<Edge<LongValue, Tuple3<NullValue, LongValue, LongValue>>> degreePairOnSourceId = emptyGraphWithoutVertices
+			.run(new EdgeDegreePair<LongValue, NullValue, NullValue>()
+				.setReduceOnTargetId(false));
+
+		assertEquals(0, degreePairOnSourceId.collect().size());
+
+		DataSet<Edge<LongValue, Tuple3<NullValue, LongValue, LongValue>>> degreePairOnTargetId = emptyGraphWithoutVertices
+			.run(new EdgeDegreePair<LongValue, NullValue, NullValue>()
+				.setReduceOnTargetId(true));
+
+		assertEquals(0, degreePairOnTargetId.collect().size());
+	}
+
+	@Test
+	public void testWithRMatGraph() throws Exception {
 		DataSet<Edge<LongValue, Tuple3<NullValue, LongValue, LongValue>>> degreePairOnSourceId = undirectedRMatGraph(10, 16)
-			.run(new EdgeDegreePair<LongValue, NullValue, NullValue>());
+			.run(new EdgeDegreePair<LongValue, NullValue, NullValue>()
+				.setReduceOnTargetId(false));
 
 		Checksum checksumOnSourceId = new ChecksumHashCode<Edge<LongValue, Tuple3<NullValue, LongValue, LongValue>>>()
 			.run(degreePairOnSourceId)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeSourceDegreeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeSourceDegreeTest.java
@@ -36,12 +36,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link EdgeSourceDegree}.
  */
-public class EdgeSourceDegreeTest
-extends AsmTestBase {
+public class EdgeSourceDegreeTest extends AsmTestBase {
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		String expectedResult =
 			"(0,1,((null),2))\n" +
 			"(0,2,((null),2))\n" +
@@ -59,7 +57,8 @@ extends AsmTestBase {
 			"(5,3,((null),1))";
 
 		DataSet<Edge<IntValue, Tuple2<NullValue, LongValue>>> sourceDegreeOnSourceId = undirectedSimpleGraph
-			.run(new EdgeSourceDegree<IntValue, NullValue, NullValue>());
+			.run(new EdgeSourceDegree<IntValue, NullValue, NullValue>()
+				.setReduceOnTargetId(false));
 
 		TestBaseUtils.compareResultAsText(sourceDegreeOnSourceId.collect(), expectedResult);
 
@@ -71,10 +70,40 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		DataSet<Edge<LongValue, Tuple2<NullValue, LongValue>>> sourceDegreeOnSourceId = emptyGraphWithVertices
+			.run(new EdgeSourceDegree<LongValue, NullValue, NullValue>()
+				.setReduceOnTargetId(false));
+
+		assertEquals(0, sourceDegreeOnSourceId.collect().size());
+
+		DataSet<Edge<LongValue, Tuple2<NullValue, LongValue>>> sourceDegreeOnTargetId = emptyGraphWithVertices
+			.run(new EdgeSourceDegree<LongValue, NullValue, NullValue>()
+				.setReduceOnTargetId(true));
+
+		assertEquals(0, sourceDegreeOnTargetId.collect().size());
+	}
+
+	@Test
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		DataSet<Edge<LongValue, Tuple2<NullValue, LongValue>>> sourceDegreeOnSourceId = emptyGraphWithoutVertices
+			.run(new EdgeSourceDegree<LongValue, NullValue, NullValue>()
+				.setReduceOnTargetId(false));
+
+		assertEquals(0, sourceDegreeOnSourceId.collect().size());
+
+		DataSet<Edge<LongValue, Tuple2<NullValue, LongValue>>> sourceDegreeOnTargetId = emptyGraphWithoutVertices
+			.run(new EdgeSourceDegree<LongValue, NullValue, NullValue>()
+				.setReduceOnTargetId(true));
+
+		assertEquals(0, sourceDegreeOnTargetId.collect().size());
+	}
+
+	@Test
+	public void testWithRMatGraph() throws Exception {
 		DataSet<Edge<LongValue, Tuple2<NullValue, LongValue>>> sourceDegreeOnSourceId = undirectedRMatGraph(10, 16)
-			.run(new EdgeSourceDegree<LongValue, NullValue, NullValue>());
+			.run(new EdgeSourceDegree<LongValue, NullValue, NullValue>()
+				.setReduceOnTargetId(false));
 
 		Checksum checksumOnSourceId = new ChecksumHashCode<Edge<LongValue, Tuple2<NullValue, LongValue>>>()
 			.run(sourceDegreeOnSourceId)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeTargetDegreeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeTargetDegreeTest.java
@@ -36,12 +36,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link EdgeTargetDegree}.
  */
-public class EdgeTargetDegreeTest
-extends AsmTestBase {
+public class EdgeTargetDegreeTest extends AsmTestBase {
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		String expectedResult =
 			"(0,1,((null),3))\n" +
 			"(0,2,((null),3))\n" +
@@ -59,7 +57,8 @@ extends AsmTestBase {
 			"(5,3,((null),4))";
 
 		DataSet<Edge<IntValue, Tuple2<NullValue, LongValue>>> targetDegreeOnTargetId = undirectedSimpleGraph
-				.run(new EdgeTargetDegree<IntValue, NullValue, NullValue>());
+				.run(new EdgeTargetDegree<IntValue, NullValue, NullValue>()
+					.setReduceOnSourceId(false));
 
 		TestBaseUtils.compareResultAsText(targetDegreeOnTargetId.collect(), expectedResult);
 
@@ -71,10 +70,40 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		DataSet<Edge<LongValue, Tuple2<NullValue, LongValue>>> targetDegreeOnTargetId = emptyGraphWithVertices
+			.run(new EdgeTargetDegree<LongValue, NullValue, NullValue>()
+				.setReduceOnSourceId(false));
+
+		assertEquals(0, targetDegreeOnTargetId.collect().size());
+
+		DataSet<Edge<LongValue, Tuple2<NullValue, LongValue>>> targetDegreeOnSourceId = emptyGraphWithVertices
+			.run(new EdgeTargetDegree<LongValue, NullValue, NullValue>()
+				.setReduceOnSourceId(true));
+
+		assertEquals(0, targetDegreeOnSourceId.collect().size());
+	}
+
+	@Test
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		DataSet<Edge<LongValue, Tuple2<NullValue, LongValue>>> targetDegreeOnTargetId = emptyGraphWithoutVertices
+			.run(new EdgeTargetDegree<LongValue, NullValue, NullValue>()
+				.setReduceOnSourceId(false));
+
+		assertEquals(0, targetDegreeOnTargetId.collect().size());
+
+		DataSet<Edge<LongValue, Tuple2<NullValue, LongValue>>> targetDegreeOnSourceId = emptyGraphWithoutVertices
+			.run(new EdgeTargetDegree<LongValue, NullValue, NullValue>()
+				.setReduceOnSourceId(true));
+
+		assertEquals(0, targetDegreeOnSourceId.collect().size());
+	}
+
+	@Test
+	public void testWithRMatGraph() throws Exception {
 		DataSet<Edge<LongValue, Tuple2<NullValue, LongValue>>> targetDegreeOnTargetId = undirectedRMatGraph(10, 16)
-			.run(new EdgeSourceDegree<LongValue, NullValue, NullValue>());
+			.run(new EdgeTargetDegree<LongValue, NullValue, NullValue>()
+				.setReduceOnSourceId(false));
 
 		Checksum checksumOnTargetId = new ChecksumHashCode<Edge<LongValue, Tuple2<NullValue, LongValue>>>()
 			.run(targetDegreeOnTargetId)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/VertexDegreeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/VertexDegreeTest.java
@@ -35,12 +35,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link VertexDegree}.
  */
-public class VertexDegreeTest
-extends AsmTestBase {
+public class VertexDegreeTest extends AsmTestBase {
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		String expectedResult =
 			"(0,2)\n" +
 			"(1,3)\n" +
@@ -50,7 +48,8 @@ extends AsmTestBase {
 			"(5,1)";
 
 		DataSet<Vertex<IntValue, LongValue>> degreeOnSourceId = undirectedSimpleGraph
-			.run(new VertexDegree<IntValue, NullValue, NullValue>());
+			.run(new VertexDegree<IntValue, NullValue, NullValue>()
+				.setReduceOnTargetId(false));
 
 		TestBaseUtils.compareResultAsText(degreeOnSourceId.collect(), expectedResult);
 
@@ -62,12 +61,12 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithCompleteGraph()
-			throws Exception {
+	public void testWithCompleteGraph() throws Exception {
 		long expectedDegree = completeGraphVertexCount - 1;
 
 		DataSet<Vertex<LongValue, LongValue>> degreeOnSourceId = completeGraph
-			.run(new VertexDegree<LongValue, NullValue, NullValue>());
+			.run(new VertexDegree<LongValue, NullValue, NullValue>()
+				.setReduceOnTargetId(false));
 
 		for (Vertex<LongValue, LongValue> vertex : degreeOnSourceId.collect()) {
 			assertEquals(expectedDegree, vertex.getValue().getValue());
@@ -83,17 +82,16 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithEmptyGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithVertices() throws Exception {
 		DataSet<Vertex<LongValue, LongValue>> degree;
 
-		degree = emptyGraph
+		degree = emptyGraphWithVertices
 			.run(new VertexDegree<LongValue, NullValue, NullValue>()
 				.setIncludeZeroDegreeVertices(false));
 
 		assertEquals(0, degree.collect().size());
 
-		degree = emptyGraph
+		degree = emptyGraphWithVertices
 			.run(new VertexDegree<LongValue, NullValue, NullValue>()
 				.setIncludeZeroDegreeVertices(true));
 
@@ -106,10 +104,27 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		DataSet<Vertex<LongValue, LongValue>> degree;
+
+		degree = emptyGraphWithoutVertices
+			.run(new VertexDegree<LongValue, NullValue, NullValue>()
+				.setIncludeZeroDegreeVertices(false));
+
+		assertEquals(0, degree.collect().size());
+
+		degree = emptyGraphWithoutVertices
+			.run(new VertexDegree<LongValue, NullValue, NullValue>()
+				.setIncludeZeroDegreeVertices(true));
+
+		assertEquals(0, degree.collect().size());
+	}
+
+	@Test
+	public void testWithRMatGraph() throws Exception {
 		DataSet<Vertex<LongValue, LongValue>> degreeOnSourceId = undirectedRMatGraph(10, 16)
-			.run(new VertexDegree<LongValue, NullValue, NullValue>());
+			.run(new VertexDegree<LongValue, NullValue, NullValue>()
+				.setReduceOnTargetId(false));
 
 		Checksum checksumOnSourceId = new ChecksumHashCode<Vertex<LongValue, LongValue>>()
 			.run(degreeOnSourceId)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/filter/undirected/MaximumDegreeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/filter/undirected/MaximumDegreeTest.java
@@ -34,12 +34,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link MaximumDegree}.
  */
-public class MaximumDegreeTest
-extends AsmTestBase {
+public class MaximumDegreeTest extends AsmTestBase {
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		Graph<IntValue, NullValue, NullValue> graph = undirectedSimpleGraph
 			.run(new MaximumDegree<IntValue, NullValue, NullValue>(3));
 
@@ -64,8 +62,25 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		Graph<LongValue, NullValue, NullValue> graph = emptyGraphWithVertices
+			.run(new MaximumDegree<LongValue, NullValue, NullValue>(1));
+
+		assertEquals(emptyGraphVertexCount, graph.getVertices().collect().size());
+		assertEquals(0, graph.getEdges().collect().size());
+	}
+
+	@Test
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		Graph<LongValue, NullValue, NullValue> graph = emptyGraphWithoutVertices
+			.run(new MaximumDegree<LongValue, NullValue, NullValue>(1));
+
+		assertEquals(0, graph.getVertices().collect().size());
+		assertEquals(0, graph.getEdges().collect().size());
+	}
+
+	@Test
+	public void testWithRMatGraph() throws Exception {
 		Checksum checksum = undirectedRMatGraph(10, 16)
 			.run(new MaximumDegree<LongValue, NullValue, NullValue>(16))
 			.run(new ChecksumHashCode<LongValue, NullValue, NullValue>())

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/simple/directed/SimplifyTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/simple/directed/SimplifyTest.java
@@ -62,8 +62,7 @@ public class SimplifyTest {
 	}
 
 	@Test
-	public void test()
-			throws Exception {
+	public void test() throws Exception {
 		String expectedResult =
 			"(0,1,(null))\n" +
 			"(0,2,(null))\n" +

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/simple/undirected/SimplifyTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/simple/undirected/SimplifyTest.java
@@ -62,8 +62,7 @@ public class SimplifyTest {
 	}
 
 	@Test
-	public void testWithFullFlip()
-			throws Exception {
+	public void testWithFullFlip() throws Exception {
 		String expectedResult =
 			"(0,1,(null))\n" +
 			"(0,2,(null))\n" +
@@ -77,8 +76,7 @@ public class SimplifyTest {
 	}
 
 	@Test
-	public void testWithClipAndFlip()
-			throws Exception {
+	public void testWithClipAndFlip() throws Exception {
 		String expectedResult =
 			"(0,1,(null))\n" +
 			"(1,0,(null))";

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/translate/TranslateTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/translate/TranslateTest.java
@@ -88,8 +88,7 @@ public class TranslateTest {
 	}
 
 	@Test
-	public void testTranslateGraphIds()
-			throws Exception {
+	public void testTranslateGraphIds() throws Exception {
 		Graph<StringValue, LongValue, LongValue> stringIdGraph = graph
 			.translateGraphIds(new LongValueToStringValue());
 
@@ -109,8 +108,7 @@ public class TranslateTest {
 	}
 
 	@Test
-	public void testTranslateVertexValues()
-			throws Exception {
+	public void testTranslateVertexValues() throws Exception {
 		DataSet<Vertex<LongValue, StringValue>> vertexSet = graph
 			.translateVertexValues(new LongValueToStringValue())
 			.getVertices();
@@ -124,8 +122,7 @@ public class TranslateTest {
 	}
 
 	@Test
-	public void testTranslateEdgeValues()
-			throws Exception {
+	public void testTranslateEdgeValues() throws Exception {
 		DataSet<Edge<LongValue, StringValue>> edgeSet = graph
 			.translateEdgeValues(new LongValueToStringValue())
 			.getEdges();

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CirculantGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CirculantGraphTest.java
@@ -32,12 +32,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link CirculantGraph}.
  */
-public class CirculantGraphTest
-extends GraphGeneratorTestBase {
+public class CirculantGraphTest extends GraphGeneratorTestBase {
 
 	@Test
-	public void testGraph()
-			throws Exception {
+	public void testGraph() throws Exception {
 		Graph<LongValue, NullValue, NullValue> graph = new CirculantGraph(env, 10)
 			.addRange(4, 3)
 			.generate();
@@ -52,8 +50,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testGraphMetrics()
-			throws Exception {
+	public void testGraphMetrics() throws Exception {
 		int vertexCount = 10;
 		int offset = 4;
 		int length = 2;
@@ -73,8 +70,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testParallelism()
-			throws Exception {
+	public void testParallelism() throws Exception {
 		int parallelism = 2;
 
 		Graph<LongValue, NullValue, NullValue> graph = new CirculantGraph(env, 10)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CompleteGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CompleteGraphTest.java
@@ -32,12 +32,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link CompleteGraph}.
  */
-public class CompleteGraphTest
-extends GraphGeneratorTestBase {
+public class CompleteGraphTest extends GraphGeneratorTestBase {
 
 	@Test
-	public void testGraph()
-			throws Exception {
+	public void testGraph() throws Exception {
 		int vertexCount = 4;
 
 		Graph<LongValue, NullValue, NullValue> graph = new CompleteGraph(env, vertexCount)
@@ -50,8 +48,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testGraphMetrics()
-			throws Exception {
+	public void testGraphMetrics() throws Exception {
 		int vertexCount = 10;
 
 		Graph<LongValue, NullValue, NullValue> graph = new CompleteGraph(env, vertexCount)
@@ -72,8 +69,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testParallelism()
-			throws Exception {
+	public void testParallelism() throws Exception {
 		int parallelism = 2;
 
 		Graph<LongValue, NullValue, NullValue> graph = new CompleteGraph(env, 10)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CycleGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CycleGraphTest.java
@@ -32,12 +32,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link CycleGraph}.
  */
-public class CycleGraphTest
-extends GraphGeneratorTestBase {
+public class CycleGraphTest extends GraphGeneratorTestBase {
 
 	@Test
-	public void testGraph()
-			throws Exception {
+	public void testGraph() throws Exception {
 		Graph<LongValue, NullValue, NullValue> graph = new CycleGraph(env, 10)
 			.generate();
 
@@ -49,8 +47,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testGraphMetrics()
-			throws Exception {
+	public void testGraphMetrics() throws Exception {
 		int vertexCount = 100;
 
 		Graph<LongValue, NullValue, NullValue> graph = new CycleGraph(env, vertexCount)
@@ -71,8 +68,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testParallelism()
-			throws Exception {
+	public void testParallelism() throws Exception {
 		int parallelism = 2;
 
 		Graph<LongValue, NullValue, NullValue> graph = new CycleGraph(env, 100)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/EchoGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/EchoGraphTest.java
@@ -34,15 +34,13 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link EchoGraph}.
  */
-public class EchoGraphTest
-extends GraphGeneratorTestBase {
+public class EchoGraphTest extends GraphGeneratorTestBase {
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
 
 	@Test
-	public void testGraphWithEvenVertexCountWithOddVertexDegree()
-			throws Exception {
+	public void testGraphWithEvenVertexCountWithOddVertexDegree() throws Exception {
 		Graph<LongValue, NullValue, NullValue> graph = new EchoGraph(env, 10, 3)
 			.generate();
 
@@ -56,8 +54,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testGraphWithOddVertexCountWithEvenVertexDegree()
-			throws Exception {
+	public void testGraphWithOddVertexCountWithEvenVertexDegree() throws Exception {
 		Graph<LongValue, NullValue, NullValue> graph = new EchoGraph(env, 9, 2)
 			.generate();
 
@@ -70,8 +67,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testGraphWithOddVertexCountWithOddVertexDegree()
-			throws Exception {
+	public void testGraphWithOddVertexCountWithOddVertexDegree() throws Exception {
 		thrown.expect(IllegalArgumentException.class);
 		thrown.expectMessage("Vertex count or vertex degree must be an even number but not both.");
 
@@ -79,8 +75,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testGraphWithEvenVertexCountWithEvenVertexDegree()
-			throws Exception {
+	public void testGraphWithEvenVertexCountWithEvenVertexDegree() throws Exception {
 		thrown.expect(IllegalArgumentException.class);
 		thrown.expectMessage("Vertex count or vertex degree must be an even number but not both.");
 
@@ -88,8 +83,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testGraphWithVertexDegreeTooLarge()
-			throws Exception {
+	public void testGraphWithVertexDegreeTooLarge() throws Exception {
 		thrown.expect(IllegalArgumentException.class);
 		thrown.expectMessage("Vertex degree must be less than the vertex count.");
 
@@ -97,8 +91,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testGraphMetrics()
-			throws Exception {
+	public void testGraphMetrics() throws Exception {
 		int vertexCount = 10;
 		int vertexDegree = 3;
 
@@ -116,8 +109,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testParallelism()
-			throws Exception {
+	public void testParallelism() throws Exception {
 		int parallelism = 2;
 
 		Graph<LongValue, NullValue, NullValue> graph = new EchoGraph(env, 10, 3)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/EmptyGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/EmptyGraphTest.java
@@ -32,12 +32,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link EmptyGraph}.
  */
-public class EmptyGraphTest
-extends GraphGeneratorTestBase {
+public class EmptyGraphTest extends GraphGeneratorTestBase {
 
 	@Test
-	public void testGraph()
-			throws Exception {
+	public void testGraph() throws Exception {
 		Graph<LongValue, NullValue, NullValue> graph = new EmptyGraph(env, 10)
 			.generate();
 
@@ -48,8 +46,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testGraphMetrics()
-			throws Exception {
+	public void testGraphMetrics() throws Exception {
 		int vertexCount = 100;
 
 		Graph<LongValue, NullValue, NullValue> graph = new EmptyGraph(env, vertexCount)
@@ -66,8 +63,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testParallelism()
-			throws Exception {
+	public void testParallelism() throws Exception {
 		int parallelism = 2;
 
 		Graph<LongValue, NullValue, NullValue> graph = new EmptyGraph(env, 100)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/GridGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/GridGraphTest.java
@@ -32,12 +32,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link GridGraph}.
  */
-public class GridGraphTest
-extends GraphGeneratorTestBase {
+public class GridGraphTest extends GraphGeneratorTestBase {
 
 	@Test
-	public void testGraph()
-			throws Exception {
+	public void testGraph() throws Exception {
 		Graph<LongValue, NullValue, NullValue> graph = new GridGraph(env)
 			.addDimension(2, false)
 			.addDimension(3, false)
@@ -53,8 +51,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testGraphMetrics()
-			throws Exception {
+	public void testGraphMetrics() throws Exception {
 		Graph<LongValue, NullValue, NullValue> graph = new GridGraph(env)
 			.addDimension(2, true)
 			.addDimension(3, true)
@@ -79,8 +76,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testParallelism()
-			throws Exception {
+	public void testParallelism() throws Exception {
 		int parallelism = 2;
 
 		Graph<LongValue, NullValue, NullValue> graph = new GridGraph(env)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/HypercubeGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/HypercubeGraphTest.java
@@ -32,12 +32,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link HypercubeGraph}.
  */
-public class HypercubeGraphTest
-extends GraphGeneratorTestBase {
+public class HypercubeGraphTest extends GraphGeneratorTestBase {
 
 	@Test
-	public void testGraph()
-			throws Exception {
+	public void testGraph() throws Exception {
 		int dimensions = 3;
 
 		Graph<LongValue, NullValue, NullValue> graph = new HypercubeGraph(env, dimensions)
@@ -51,8 +49,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testGraphMetrics()
-			throws Exception {
+	public void testGraphMetrics() throws Exception {
 		int dimensions = 10;
 
 		Graph<LongValue, NullValue, NullValue> graph = new HypercubeGraph(env, dimensions)
@@ -73,8 +70,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testParallelism()
-			throws Exception {
+	public void testParallelism() throws Exception {
 		int parallelism = 2;
 
 		Graph<LongValue, NullValue, NullValue> graph = new HypercubeGraph(env, 4)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/PathGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/PathGraphTest.java
@@ -32,12 +32,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link PathGraph}.
  */
-public class PathGraphTest
-extends GraphGeneratorTestBase {
+public class PathGraphTest extends GraphGeneratorTestBase {
 
 	@Test
-	public void testGraph()
-			throws Exception {
+	public void testGraph() throws Exception {
 		Graph<LongValue, NullValue, NullValue> graph = new PathGraph(env, 10)
 			.generate();
 
@@ -49,8 +47,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testGraphMetrics()
-			throws Exception {
+	public void testGraphMetrics() throws Exception {
 		int vertexCount = 100;
 
 		Graph<LongValue, NullValue, NullValue> graph = new PathGraph(env, vertexCount)
@@ -71,8 +68,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testParallelism()
-			throws Exception {
+	public void testParallelism() throws Exception {
 		int parallelism = 2;
 
 		Graph<LongValue, NullValue, NullValue> graph = new PathGraph(env, 100)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/RMatGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/RMatGraphTest.java
@@ -36,12 +36,10 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests for {@link RMatGraph}.
  */
-public class RMatGraphTest
-extends GraphGeneratorTestBase {
+public class RMatGraphTest extends GraphGeneratorTestBase {
 
 	@Test
-	public void testGraphMetrics()
-			throws Exception {
+	public void testGraphMetrics() throws Exception {
 		long vertexCount = 100;
 
 		long edgeCount = 1000;
@@ -56,8 +54,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testParallelism()
-			throws Exception {
+	public void testParallelism() throws Exception {
 		int parallelism = 2;
 
 		RandomGenerableFactory<JDKRandomGenerator> rnd = new JDKRandomGeneratorFactory();

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/SingletonEdgeGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/SingletonEdgeGraphTest.java
@@ -32,12 +32,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link SingletonEdgeGraph}.
  */
-public class SingletonEdgeGraphTest
-extends GraphGeneratorTestBase {
+public class SingletonEdgeGraphTest extends GraphGeneratorTestBase {
 
 	@Test
-	public void testGraph()
-			throws Exception {
+	public void testGraph() throws Exception {
 		int vertexPairCount = 5;
 
 		Graph<LongValue, NullValue, NullValue> graph = new SingletonEdgeGraph(env, vertexPairCount)
@@ -50,8 +48,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testGraphMetrics()
-			throws Exception {
+	public void testGraphMetrics() throws Exception {
 		int vertexPairCount = 10;
 
 		Graph<LongValue, NullValue, NullValue> graph = new SingletonEdgeGraph(env, vertexPairCount)
@@ -72,8 +69,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testParallelism()
-			throws Exception {
+	public void testParallelism() throws Exception {
 		int parallelism = 2;
 
 		Graph<LongValue, NullValue, NullValue> graph = new SingletonEdgeGraph(env, 10)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/StarGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/StarGraphTest.java
@@ -32,12 +32,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link StarGraph}.
  */
-public class StarGraphTest
-extends GraphGeneratorTestBase {
+public class StarGraphTest extends GraphGeneratorTestBase {
 
 	@Test
-	public void testGraph()
-			throws Exception {
+	public void testGraph() throws Exception {
 		int vertexCount = 10;
 
 		Graph<LongValue, NullValue, NullValue> graph = new StarGraph(env, vertexCount)
@@ -51,8 +49,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testGraphMetrics()
-			throws Exception {
+	public void testGraphMetrics() throws Exception {
 		int vertexCount = 100;
 
 		Graph<LongValue, NullValue, NullValue> graph = new StarGraph(env, vertexCount)
@@ -73,8 +70,7 @@ extends GraphGeneratorTestBase {
 	}
 
 	@Test
-	public void testParallelism()
-			throws Exception {
+	public void testParallelism() throws Exception {
 		int parallelism = 2;
 
 		Graph<LongValue, NullValue, NullValue> graph = new StarGraph(env, 100)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/TestUtils.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/TestUtils.java
@@ -53,14 +53,12 @@ public final class TestUtils {
 	 * @param <EV> the value type for edges
 	 * @throws Exception
 	 */
-	public static <K, VV, EV> void compareGraph(Graph<K, VV, EV> graph, String expectedVertices, String expectedEdges)
-			throws Exception {
+	public static <K, VV, EV> void compareGraph(Graph<K, VV, EV> graph, String expectedVertices, String expectedEdges) throws Exception {
 		compareVertices(graph, expectedVertices);
 		compareEdges(graph, expectedEdges);
 	}
 
-	private static <K, VV, EV> void compareVertices(Graph<K, VV, EV> graph, String expectedVertices)
-			throws Exception {
+	private static <K, VV, EV> void compareVertices(Graph<K, VV, EV> graph, String expectedVertices) throws Exception {
 		if (expectedVertices != null) {
 			List<Vertex<K, VV>> vertices = graph.getVertices().collect();
 			List<String> resultVertices = new ArrayList<>(vertices.size());
@@ -73,8 +71,7 @@ public final class TestUtils {
 		}
 	}
 
-	private static <K, VV, EV> void compareEdges(Graph<K, VV, EV> graph, String expectedEdges)
-			throws Exception {
+	private static <K, VV, EV> void compareEdges(Graph<K, VV, EV> graph, String expectedEdges) throws Exception {
 		if (expectedEdges != null) {
 			List<Edge<K, EV>> edges = graph.getEdges().collect();
 			List<String> resultEdges = new ArrayList<>(edges.size());

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/directed/AverageClusteringCoefficientTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/directed/AverageClusteringCoefficientTest.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.graph.library.clustering.directed;
 
+import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.asm.AsmTestBase;
 import org.apache.flink.graph.library.clustering.directed.AverageClusteringCoefficient.Result;
-import org.apache.flink.types.IntValue;
-import org.apache.flink.types.LongValue;
+import org.apache.flink.types.CopyableValue;
 import org.apache.flink.types.NullValue;
 
 import org.junit.Test;
@@ -31,56 +31,50 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link AverageClusteringCoefficient}.
  */
-public class AverageClusteringCoefficientTest
-extends AsmTestBase {
+public class AverageClusteringCoefficientTest extends AsmTestBase {
+
+	/**
+	 * Validate a test where each result has the same values.
+	 *
+	 * @param graph input graph
+	 * @param vertexCount result vertex count
+	 * @param averageClusteringCoefficient result average clustering coefficient
+	 * @param <T> graph ID type
+	 * @throws Exception on error
+	 */
+	private static <T extends Comparable<T> & CopyableValue<T>> void validate(
+			Graph<T, NullValue, NullValue> graph, long vertexCount, double averageClusteringCoefficient) throws Exception {
+		Result result = new AverageClusteringCoefficient<T, NullValue, NullValue>()
+			.run(graph)
+			.execute();
+
+		assertEquals(vertexCount, result.getNumberOfVertices());
+		assertEquals(averageClusteringCoefficient, result.getAverageClusteringCoefficient(), 0.000001);
+	}
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		// see results in LocalClusteringCoefficientTest.testSimpleGraph
-		Result expectedResult = new Result(6, 1.0 / 2 + 2.0 / 6 + 2.0 / 6 + 1.0 / 12);
-
-		Result averageClusteringCoefficient = new AverageClusteringCoefficient<IntValue, NullValue, NullValue>()
-			.run(directedSimpleGraph)
-			.execute();
-
-		assertEquals(expectedResult, averageClusteringCoefficient);
+		validate(directedSimpleGraph, 6, (1.0 / 2 + 2.0 / 6 + 2.0 / 6 + 1.0 / 12) / 6);
 	}
 
 	@Test
-	public void testWithCompleteGraph()
-			throws Exception {
-		Result expectedResult = new Result(completeGraphVertexCount, completeGraphVertexCount);
-
-		Result averageClusteringCoefficient = new AverageClusteringCoefficient<LongValue, NullValue, NullValue>()
-			.run(completeGraph)
-			.execute();
-
-		assertEquals(expectedResult, averageClusteringCoefficient);
+	public void testWithCompleteGraph() throws Exception {
+		validate(completeGraph, completeGraphVertexCount, 1.0);
 	}
 
 	@Test
-	public void testWithEmptyGraph()
-			throws Exception {
-		Result expectedResult = new Result(emptyGraphVertexCount, 0);
-
-		Result averageClusteringCoefficient = new AverageClusteringCoefficient<LongValue, NullValue, NullValue>()
-			.run(emptyGraph)
-			.execute();
-
-		assertEquals(expectedResult, averageClusteringCoefficient);
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		validate(emptyGraphWithVertices, emptyGraphVertexCount, 0);
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
-		Result expectedResult = new Result(902, 297.152607);
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		validate(emptyGraphWithoutVertices, 0, Double.NaN);
+	}
 
-		Result averageClusteringCoefficient = new AverageClusteringCoefficient<LongValue, NullValue, NullValue>()
-			.run(directedRMatGraph(10, 16))
-			.execute();
-
-		assertEquals(expectedResult.getNumberOfVertices(), averageClusteringCoefficient.getNumberOfVertices());
-		assertEquals(expectedResult.getAverageClusteringCoefficient(), averageClusteringCoefficient.getAverageClusteringCoefficient(), 0.000001);
+	@Test
+	public void testWithRMatGraph() throws Exception {
+		validate(directedRMatGraph(10, 16), 902, 0.329437);
 	}
 }

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/directed/GlobalClusteringCoefficientTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/directed/GlobalClusteringCoefficientTest.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.graph.library.clustering.directed;
 
+import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.asm.AsmTestBase;
 import org.apache.flink.graph.library.clustering.directed.GlobalClusteringCoefficient.Result;
-import org.apache.flink.types.IntValue;
-import org.apache.flink.types.LongValue;
+import org.apache.flink.types.CopyableValue;
 import org.apache.flink.types.NullValue;
 
 import org.apache.commons.math3.util.CombinatoricsUtils;
@@ -32,57 +32,52 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link GlobalClusteringCoefficient}.
  */
-public class GlobalClusteringCoefficientTest
-extends AsmTestBase {
+public class GlobalClusteringCoefficientTest extends AsmTestBase {
 
-	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
-		Result expectedResult = new Result(13, 6);
-
-		Result globalClusteringCoefficient = new GlobalClusteringCoefficient<IntValue, NullValue, NullValue>()
-			.run(directedSimpleGraph)
+	/**
+	 * Validate a test where each result has the same values.
+	 *
+	 * @param graph input graph
+	 * @param tripletCount result triplet count
+	 * @param triangleCount result triangle count
+	 * @param <T> graph ID type
+	 * @throws Exception on error
+	 */
+	private static <T extends Comparable<T> & CopyableValue<T>> void validate(
+			Graph<T, NullValue, NullValue> graph, long tripletCount, long triangleCount) throws Exception {
+		Result result = new GlobalClusteringCoefficient<T, NullValue, NullValue>()
+			.run(graph)
 			.execute();
 
-		assertEquals(expectedResult, globalClusteringCoefficient);
+		assertEquals(tripletCount, result.getNumberOfTriplets());
+		assertEquals(triangleCount, result.getNumberOfTriangles());
 	}
 
 	@Test
-	public void testWithCompleteGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
+		validate(directedSimpleGraph, 13, 6);
+	}
+
+	@Test
+	public void testWithCompleteGraph() throws Exception {
 		long expectedDegree = completeGraphVertexCount - 1;
 		long expectedCount = completeGraphVertexCount * CombinatoricsUtils.binomialCoefficient((int) expectedDegree, 2);
 
-		Result expectedResult = new Result(expectedCount, expectedCount);
-
-		Result globalClusteringCoefficient = new GlobalClusteringCoefficient<LongValue, NullValue, NullValue>()
-			.run(completeGraph)
-			.execute();
-
-		assertEquals(expectedResult, globalClusteringCoefficient);
+		validate(completeGraph, expectedCount, expectedCount);
 	}
 
 	@Test
-	public void testWithEmptyGraph()
-			throws Exception {
-		Result expectedResult = new Result(0, 0);
-
-		Result globalClusteringCoefficient = new GlobalClusteringCoefficient<LongValue, NullValue, NullValue>()
-			.run(emptyGraph)
-			.execute();
-
-		assertEquals(expectedResult, globalClusteringCoefficient);
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		validate(emptyGraphWithVertices, 0, 0);
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
-		Result expectedResult = new Result(1003442, 225147);
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		validate(emptyGraphWithoutVertices, 0, 0);
+	}
 
-		Result globalClusteringCoefficient = new GlobalClusteringCoefficient<LongValue, NullValue, NullValue>()
-			.run(directedRMatGraph(10, 16))
-			.execute();
-
-		assertEquals(expectedResult, globalClusteringCoefficient);
+	@Test
+	public void testWithRMatGraph() throws Exception {
+		validate(directedRMatGraph(10, 16), 1003442, 225147);
 	}
 }

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/directed/TriadicCensusTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/directed/TriadicCensusTest.java
@@ -32,12 +32,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link TriadicCensus}.
  */
-public class TriadicCensusTest
-extends AsmTestBase {
+public class TriadicCensusTest extends AsmTestBase {
 
 	@Test
-	public void testWithUndirectedSimpleGraph()
-			throws Exception {
+	public void testWithUndirectedSimpleGraph() throws Exception {
 		Result expectedResult = new Result(3, 0, 8, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 2);
 
 		Result triadCensus = new TriadicCensus<IntValue, NullValue, NullValue>()
@@ -48,8 +46,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithDirectedSimpleGraph()
-			throws Exception {
+	public void testWithDirectedSimpleGraph() throws Exception {
 		Result expectedResult = new Result(3, 8, 0, 1, 2, 4, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0);
 
 		Result triadCensus = new TriadicCensus<IntValue, NullValue, NullValue>()
@@ -60,8 +57,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithCompleteGraph()
-			throws Exception {
+	public void testWithCompleteGraph() throws Exception {
 		long expectedDegree = completeGraphVertexCount - 1;
 		long expectedCount = completeGraphVertexCount * CombinatoricsUtils.binomialCoefficient((int) expectedDegree, 2) / 3;
 
@@ -75,20 +71,29 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithEmptyGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithVertices() throws Exception {
 		Result expectedResult = new Result(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 
 		Result triadCensus = new TriadicCensus<LongValue, NullValue, NullValue>()
-			.run(emptyGraph)
+			.run(emptyGraphWithVertices)
 			.execute();
 
 		assertEquals(expectedResult, triadCensus);
 	}
 
 	@Test
-	public void testWithUndirectedRMatGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		Result expectedResult = new Result(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+
+		Result triadCensus = new TriadicCensus<LongValue, NullValue, NullValue>()
+			.run(emptyGraphWithoutVertices)
+			.execute();
+
+		assertEquals(expectedResult, triadCensus);
+	}
+
+	@Test
+	public void testWithUndirectedRMatGraph() throws Exception {
 		Result expectedResult = new Result(113_435_893, 0, 7_616_063, 0, 0, 0, 0, 0, 0, 0, 778_295, 0, 0, 0, 0, 75_049);
 
 		Result triadCensus = new TriadicCensus<LongValue, NullValue, NullValue>()
@@ -110,8 +115,7 @@ extends AsmTestBase {
 		print('{}: {}'.format(key, census[key]))
 	 */
 	@Test
-	public void testWithDirectedRMatGraph()
-			throws Exception {
+	public void testWithDirectedRMatGraph() throws Exception {
 		Result expectedResult = new Result(
 			113_435_893, 6_632_528, 983_535, 118_574,
 			118_566, 237_767, 129_773, 130_041,

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/directed/TriangleListingTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/directed/TriangleListingTest.java
@@ -39,12 +39,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link TriangleListing}.
  */
-public class TriangleListingTest
-extends AsmTestBase {
+public class TriangleListingTest extends AsmTestBase {
 
 	@Test
-	public void testSimpleGraphSorted()
-			throws Exception {
+	public void testSimpleGraphSorted() throws Exception {
 		DataSet<Result<IntValue>> tl = directedSimpleGraph
 			.run(new TriangleListing<IntValue, NullValue, NullValue>()
 				.setSortTriangleVertices(true));
@@ -57,8 +55,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testSimpleGraphPermuted()
-			throws Exception {
+	public void testSimpleGraphPermuted() throws Exception {
 		DataSet<Result<IntValue>> tl = directedSimpleGraph
 			.run(new TriangleListing<IntValue, NullValue, NullValue>()
 				.setPermuteResults(true));
@@ -107,8 +104,23 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testRMatGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		DataSet<Result<LongValue>> tl = emptyGraphWithVertices
+			.run(new TriangleListing<LongValue, NullValue, NullValue>());
+
+		assertEquals(0, tl.collect().size());
+	}
+
+	@Test
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		DataSet<Result<LongValue>> tl = emptyGraphWithoutVertices
+			.run(new TriangleListing<LongValue, NullValue, NullValue>());
+
+		assertEquals(0, tl.collect().size());
+	}
+
+	@Test
+	public void testRMatGraph() throws Exception {
 		DataSet<Result<LongValue>> tl = directedRMatGraph(10, 16)
 			.run(new TriangleListing<LongValue, NullValue, NullValue>()
 				.setSortTriangleVertices(true));

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/AverageClusteringCoefficientTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/AverageClusteringCoefficientTest.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.graph.library.clustering.undirected;
 
+import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.asm.AsmTestBase;
 import org.apache.flink.graph.library.clustering.undirected.AverageClusteringCoefficient.Result;
-import org.apache.flink.types.IntValue;
-import org.apache.flink.types.LongValue;
+import org.apache.flink.types.CopyableValue;
 import org.apache.flink.types.NullValue;
 
 import org.junit.Test;
@@ -31,56 +31,50 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link AverageClusteringCoefficient}.
  */
-public class AverageClusteringCoefficientTest
-extends AsmTestBase {
+public class AverageClusteringCoefficientTest extends AsmTestBase {
+
+	/**
+	 * Validate a test where each result has the same values.
+	 *
+	 * @param graph input graph
+	 * @param vertexCount result vertex count
+	 * @param averageClusteringCoefficient result average clustering coefficient
+	 * @param <T> graph ID type
+	 * @throws Exception on error
+	 */
+	private static <T extends Comparable<T> & CopyableValue<T>> void validate(
+			Graph<T, NullValue, NullValue> graph, long vertexCount, double averageClusteringCoefficient) throws Exception {
+		Result result = new AverageClusteringCoefficient<T, NullValue, NullValue>()
+			.run(graph)
+			.execute();
+
+		assertEquals(vertexCount, result.getNumberOfVertices());
+		assertEquals(averageClusteringCoefficient, result.getAverageClusteringCoefficient(), 0.000001);
+	}
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		// see results in LocalClusteringCoefficientTest.testSimpleGraph
-		Result expectedResult = new Result(6, 1.0 / 1 + 2.0 / 3 + 2.0 / 3 + 1.0 / 6);
-
-		Result averageClusteringCoefficient = new AverageClusteringCoefficient<IntValue, NullValue, NullValue>()
-			.run(undirectedSimpleGraph)
-			.execute();
-
-		assertEquals(expectedResult, averageClusteringCoefficient);
+		validate(undirectedSimpleGraph, 6, (1.0 / 1 + 2.0 / 3 + 2.0 / 3 + 1.0 / 6) / 6);
 	}
 
 	@Test
-	public void testWithCompleteGraph()
-			throws Exception {
-		Result expectedResult = new Result(completeGraphVertexCount, completeGraphVertexCount);
-
-		Result averageClusteringCoefficient = new AverageClusteringCoefficient<LongValue, NullValue, NullValue>()
-			.run(completeGraph)
-			.execute();
-
-		assertEquals(expectedResult, averageClusteringCoefficient);
+	public void testWithCompleteGraph() throws Exception {
+		validate(completeGraph, completeGraphVertexCount, 1.0);
 	}
 
 	@Test
-	public void testWithEmptyGraph()
-			throws Exception {
-		Result expectedResult = new Result(emptyGraphVertexCount, 0);
-
-		Result averageClusteringCoefficient = new AverageClusteringCoefficient<LongValue, NullValue, NullValue>()
-			.run(emptyGraph)
-			.execute();
-
-		assertEquals(expectedResult, averageClusteringCoefficient);
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		validate(emptyGraphWithVertices, emptyGraphVertexCount, 0);
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
-		Result expectedResult = new Result(902, 380.40109);
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		validate(emptyGraphWithoutVertices, 0, Double.NaN);
+	}
 
-		Result averageClusteringCoefficient = new AverageClusteringCoefficient<LongValue, NullValue, NullValue>()
-			.run(undirectedRMatGraph(10, 16))
-			.execute();
-
-		assertEquals(expectedResult.getNumberOfVertices(), averageClusteringCoefficient.getNumberOfVertices());
-		assertEquals(expectedResult.getAverageClusteringCoefficient(), averageClusteringCoefficient.getAverageClusteringCoefficient(), 0.000001);
+	@Test
+	public void testWithRMatGraph() throws Exception {
+		validate(undirectedRMatGraph(10, 16), 902, 0.421730);
 	}
 }

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/GlobalClusteringCoefficientTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/GlobalClusteringCoefficientTest.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.graph.library.clustering.undirected;
 
+import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.asm.AsmTestBase;
 import org.apache.flink.graph.library.clustering.undirected.GlobalClusteringCoefficient.Result;
-import org.apache.flink.types.IntValue;
-import org.apache.flink.types.LongValue;
+import org.apache.flink.types.CopyableValue;
 import org.apache.flink.types.NullValue;
 
 import org.apache.commons.math3.util.CombinatoricsUtils;
@@ -32,57 +32,52 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link GlobalClusteringCoefficient}.
  */
-public class GlobalClusteringCoefficientTest
-extends AsmTestBase {
+public class GlobalClusteringCoefficientTest extends AsmTestBase {
 
-	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
-		Result expectedResult = new Result(13, 6);
-
-		Result globalClusteringCoefficient = new GlobalClusteringCoefficient<IntValue, NullValue, NullValue>()
-			.run(undirectedSimpleGraph)
+	/**
+	 * Validate a test where each result has the same values.
+	 *
+	 * @param graph input graph
+	 * @param tripletCount result triplet count
+	 * @param triangleCount result triangle count
+	 * @param <T> graph ID type
+	 * @throws Exception on error
+	 */
+	private static <T extends Comparable<T> & CopyableValue<T>> void validate(
+			Graph<T, NullValue, NullValue> graph, long tripletCount, long triangleCount) throws Exception {
+		Result result = new GlobalClusteringCoefficient<T, NullValue, NullValue>()
+			.run(graph)
 			.execute();
 
-		assertEquals(expectedResult, globalClusteringCoefficient);
+		assertEquals(tripletCount, result.getNumberOfTriplets());
+		assertEquals(triangleCount, result.getNumberOfTriangles());
 	}
 
 	@Test
-	public void testWithCompleteGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
+		validate(undirectedSimpleGraph, 13, 6);
+	}
+
+	@Test
+	public void testWithCompleteGraph() throws Exception {
 		long expectedDegree = completeGraphVertexCount - 1;
 		long expectedCount = completeGraphVertexCount * CombinatoricsUtils.binomialCoefficient((int) expectedDegree, 2);
 
-		Result expectedResult = new Result(expectedCount, expectedCount);
-
-		Result globalClusteringCoefficient = new GlobalClusteringCoefficient<LongValue, NullValue, NullValue>()
-			.run(completeGraph)
-			.execute();
-
-		assertEquals(expectedResult, globalClusteringCoefficient);
+		validate(completeGraph, expectedCount, expectedCount);
 	}
 
 	@Test
-	public void testWithEmptyGraph()
-			throws Exception {
-		Result expectedResult = new Result(0, 0);
-
-		Result globalClusteringCoefficient = new GlobalClusteringCoefficient<LongValue, NullValue, NullValue>()
-			.run(emptyGraph)
-			.execute();
-
-		assertEquals(expectedResult, globalClusteringCoefficient);
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		validate(emptyGraphWithVertices, 0, 0);
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
-		Result expectedResult = new Result(1003442, 225147);
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		validate(emptyGraphWithoutVertices, 0, 0);
+	}
 
-		Result globalClusteringCoefficient = new GlobalClusteringCoefficient<LongValue, NullValue, NullValue>()
-			.run(undirectedRMatGraph(10, 16))
-			.execute();
-
-		assertEquals(expectedResult, globalClusteringCoefficient);
+	@Test
+	public void testWithRMatGraph() throws Exception {
+		validate(undirectedRMatGraph(10, 16), 1003442, 225147);
 	}
 }

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/LocalClusteringCoefficientTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/LocalClusteringCoefficientTest.java
@@ -19,11 +19,13 @@
 package org.apache.flink.graph.library.clustering.undirected;
 
 import org.apache.flink.api.java.DataSet;
+import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.asm.AsmTestBase;
 import org.apache.flink.graph.asm.dataset.ChecksumHashCode;
 import org.apache.flink.graph.asm.dataset.ChecksumHashCode.Checksum;
 import org.apache.flink.graph.library.clustering.undirected.LocalClusteringCoefficient.Result;
 import org.apache.flink.test.util.TestBaseUtils;
+import org.apache.flink.types.CopyableValue;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
@@ -38,12 +40,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link LocalClusteringCoefficient}.
  */
-public class LocalClusteringCoefficientTest
-extends AsmTestBase {
+public class LocalClusteringCoefficientTest extends AsmTestBase {
 
 	@Test
-	public void testSimpleGraph()
-			throws Exception {
+	public void testSimpleGraph() throws Exception {
 		String expectedResult =
 			"(0,2,1)\n" +
 			"(1,3,2)\n" +
@@ -58,28 +58,51 @@ extends AsmTestBase {
 		TestBaseUtils.compareResultAsText(cc.collect(), expectedResult);
 	}
 
-	@Test
-	public void testCompleteGraph()
-			throws Exception {
-		long expectedDegree = completeGraphVertexCount - 1;
-		long expectedTriangleCount = CombinatoricsUtils.binomialCoefficient((int) expectedDegree, 2);
+	/**
+	 * Validate a test where each result has the same values.
+	 *
+	 * @param graph input graph
+	 * @param count number of results
+	 * @param degree result degree
+	 * @param triangleCount result triangle count
+	 * @param <T> graph ID type
+	 * @throws Exception on error
+	 */
+	private static <T extends Comparable<T> & CopyableValue<T>> void validateUniformResult(
+		Graph<T, NullValue, NullValue> graph, long count, long degree, long triangleCount) throws Exception {
+		DataSet<Result<T>> cc = graph
+			.run(new LocalClusteringCoefficient<T, NullValue, NullValue>());
 
-		DataSet<Result<LongValue>> cc = completeGraph
-			.run(new LocalClusteringCoefficient<LongValue, NullValue, NullValue>());
+		List<Result<T>> results = cc.collect();
 
-		List<Result<LongValue>> results = cc.collect();
+		assertEquals(count, results.size());
 
-		assertEquals(completeGraphVertexCount, results.size());
-
-		for (Result<LongValue> result : results) {
-			assertEquals(expectedDegree, result.getDegree().getValue());
-			assertEquals(expectedTriangleCount, result.getTriangleCount().getValue());
+		for (Result<T> result : results) {
+			assertEquals(degree, result.getDegree().getValue());
+			assertEquals(triangleCount, result.getTriangleCount().getValue());
 		}
 	}
 
 	@Test
-	public void testRMatGraph()
-			throws Exception {
+	public void testCompleteGraph() throws Exception {
+		long degree = completeGraphVertexCount - 1;
+		long triangleCount = CombinatoricsUtils.binomialCoefficient((int) degree, 2);
+
+		validateUniformResult(completeGraph, completeGraphVertexCount, degree, triangleCount);
+	}
+
+	@Test
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		validateUniformResult(emptyGraphWithVertices, emptyGraphVertexCount, 0, 0);
+	}
+
+	@Test
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		validateUniformResult(emptyGraphWithoutVertices, 0, 0, 0);
+	}
+
+	@Test
+	public void testRMatGraph() throws Exception {
 		DataSet<Result<LongValue>> cc = undirectedRMatGraph(10, 16)
 			.run(new LocalClusteringCoefficient<LongValue, NullValue, NullValue>());
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/TriadicCensusTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/TriadicCensusTest.java
@@ -32,12 +32,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link TriadicCensus}.
  */
-public class TriadicCensusTest
-extends AsmTestBase {
+public class TriadicCensusTest extends AsmTestBase {
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		Result expectedResult = new Result(3, 8, 7, 2);
 
 		Result triadCensus = new TriadicCensus<IntValue, NullValue, NullValue>()
@@ -48,8 +46,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithCompleteGraph()
-			throws Exception {
+	public void testWithCompleteGraph() throws Exception {
 		long expectedDegree = completeGraphVertexCount - 1;
 		long expectedCount = completeGraphVertexCount * CombinatoricsUtils.binomialCoefficient((int) expectedDegree, 2) / 3;
 
@@ -63,12 +60,22 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithEmptyGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithVertices() throws Exception {
 		Result expectedResult = new Result(0, 0, 0, 0);
 
 		Result triadCensus = new TriadicCensus<LongValue, NullValue, NullValue>()
-			.run(emptyGraph)
+			.run(emptyGraphWithVertices)
+			.execute();
+
+		assertEquals(expectedResult, triadCensus);
+	}
+
+	@Test
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		Result expectedResult = new Result(0, 0, 0, 0);
+
+		Result triadCensus = new TriadicCensus<LongValue, NullValue, NullValue>()
+			.run(emptyGraphWithoutVertices)
 			.execute();
 
 		assertEquals(expectedResult, triadCensus);
@@ -85,8 +92,7 @@ extends AsmTestBase {
 		print('{}: {}'.format(key, census[key]))
 	 */
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
+	public void testWithRMatGraph() throws Exception {
 		Result expectedResult = new Result(113_435_893, 7_616_063, 778_295, 75_049);
 
 		Result triadCensus = new TriadicCensus<LongValue, NullValue, NullValue>()

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/TriangleListingTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/TriangleListingTest.java
@@ -39,12 +39,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link TriangleListing}.
  */
-public class TriangleListingTest
-extends AsmTestBase {
+public class TriangleListingTest extends AsmTestBase {
 
 	@Test
-	public void testSimpleGraphSorted()
-			throws Exception {
+	public void testSimpleGraphSorted() throws Exception {
 		DataSet<Result<IntValue>> tl = undirectedSimpleGraph
 			.run(new TriangleListing<IntValue, NullValue, NullValue>()
 				.setSortTriangleVertices(true));
@@ -57,8 +55,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testSimpleGraphPermuted()
-			throws Exception {
+	public void testSimpleGraphPermuted() throws Exception {
 		DataSet<Result<IntValue>> tl = undirectedSimpleGraph
 			.run(new TriangleListing<IntValue, NullValue, NullValue>()
 				.setPermuteResults(true));
@@ -89,8 +86,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testCompleteGraph()
-			throws Exception {
+	public void testCompleteGraph() throws Exception {
 		long expectedDegree = completeGraphVertexCount - 1;
 		long expectedCount = completeGraphVertexCount * CombinatoricsUtils.binomialCoefficient((int) expectedDegree, 2) / 3;
 
@@ -105,8 +101,23 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testRMatGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		DataSet<Result<LongValue>> tl = emptyGraphWithVertices
+			.run(new TriangleListing<LongValue, NullValue, NullValue>());
+
+		assertEquals(0, tl.collect().size());
+	}
+
+	@Test
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		DataSet<Result<LongValue>> tl = emptyGraphWithoutVertices
+			.run(new TriangleListing<LongValue, NullValue, NullValue>());
+
+		assertEquals(0, tl.collect().size());
+	}
+
+	@Test
+	public void testRMatGraph() throws Exception {
 		DataSet<Result<LongValue>> tl = undirectedRMatGraph(10, 16)
 			.run(new TriangleListing<LongValue, NullValue, NullValue>()
 				.setSortTriangleVertices(true));

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/ChecksumHashCodeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/ChecksumHashCodeTest.java
@@ -22,6 +22,8 @@ import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.asm.AsmTestBase;
 import org.apache.flink.graph.asm.dataset.ChecksumHashCode.Checksum;
 import org.apache.flink.graph.test.TestGraphUtils;
+import org.apache.flink.types.LongValue;
+import org.apache.flink.types.NullValue;
 
 import org.junit.Test;
 
@@ -30,8 +32,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link ChecksumHashCode}.
  */
-public class ChecksumHashCodeTest
-extends AsmTestBase {
+public class ChecksumHashCodeTest extends AsmTestBase {
 
 	@Test
 	public void testSmallGraph() throws Exception {
@@ -44,7 +45,27 @@ extends AsmTestBase {
 			.run(new ChecksumHashCode<Long, Long, Long>())
 			.execute();
 
-		assertEquals(checksum.getCount(), 12L);
-		assertEquals(checksum.getChecksum(), 19665L);
+		assertEquals(12, checksum.getCount());
+		assertEquals(0x4cd1, checksum.getChecksum());
+	}
+
+	@Test
+	public void testEmptyGraphWithVertices() throws Exception {
+		Checksum checksum = emptyGraphWithVertices
+			.run(new ChecksumHashCode<LongValue, NullValue, NullValue>())
+			.execute();
+
+		assertEquals(3, checksum.getCount());
+		assertEquals(0x109b, checksum.getChecksum());
+	}
+
+	@Test
+	public void testEmptyGraphWithoutVertices() throws Exception {
+		Checksum checksum = emptyGraphWithoutVertices
+			.run(new ChecksumHashCode<LongValue, NullValue, NullValue>())
+			.execute();
+
+		assertEquals(0, checksum.getCount());
+		assertEquals(0, checksum.getChecksum());
 	}
 }

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/directed/EdgeMetricsTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/directed/EdgeMetricsTest.java
@@ -32,12 +32,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link EdgeMetrics}.
  */
-public class EdgeMetricsTest
-extends AsmTestBase {
+public class EdgeMetricsTest extends AsmTestBase {
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		Result expectedResult = new Result(2, 6, 1, 3);
 
 		Result edgeMetrics = new EdgeMetrics<IntValue, NullValue, NullValue>()
@@ -48,8 +46,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithCompleteGraph()
-			throws Exception {
+	public void testWithCompleteGraph() throws Exception {
 		long expectedDegree = completeGraphVertexCount - 1;
 		long expectedMaximumTriplets = CombinatoricsUtils.binomialCoefficient((int) expectedDegree, 2);
 		long expectedTriplets = completeGraphVertexCount * expectedMaximumTriplets;
@@ -65,22 +62,33 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithEmptyGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithVertices() throws Exception {
 		Result expectedResult;
 
 		expectedResult = new Result(0, 0, 0, 0);
 
 		Result withoutZeroDegreeVertices = new EdgeMetrics<LongValue, NullValue, NullValue>()
-			.run(emptyGraph)
+			.run(emptyGraphWithVertices)
 			.execute();
 
 		assertEquals(withoutZeroDegreeVertices, expectedResult);
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		Result expectedResult;
+
+		expectedResult = new Result(0, 0, 0, 0);
+
+		Result withoutZeroDegreeVertices = new EdgeMetrics<LongValue, NullValue, NullValue>()
+			.run(emptyGraphWithoutVertices)
+			.execute();
+
+		assertEquals(withoutZeroDegreeVertices, expectedResult);
+	}
+
+	@Test
+	public void testWithRMatGraph() throws Exception {
 		Result expectedResult = new Result(107817, 315537, 820, 3822);
 
 		Result withoutZeroDegreeVertices = new EdgeMetrics<LongValue, NullValue, NullValue>()

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/directed/VertexMetricsTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/directed/VertexMetricsTest.java
@@ -32,12 +32,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link VertexMetrics}.
  */
-public class VertexMetricsTest
-extends AsmTestBase {
+public class VertexMetricsTest extends AsmTestBase {
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		Result expectedResult = new Result(6, 7, 0, 13, 4, 2, 3, 6);
 
 		Result vertexMetrics = new VertexMetrics<IntValue, NullValue, NullValue>()
@@ -48,8 +46,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithCompleteGraph()
-			throws Exception {
+	public void testWithCompleteGraph() throws Exception {
 		long expectedDegree = completeGraphVertexCount - 1;
 		long expectedBidirectionalEdges = completeGraphVertexCount * expectedDegree / 2;
 		long expectedMaximumTriplets = CombinatoricsUtils.binomialCoefficient((int) expectedDegree, 2);
@@ -68,15 +65,14 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithEmptyGraph()
-			throws Exception {
+	public void testWithEmptyGraph() throws Exception {
 		Result expectedResult;
 
 		expectedResult = new Result(0, 0, 0, 0, 0, 0, 0, 0);
 
 		Result withoutZeroDegreeVertices = new VertexMetrics<LongValue, NullValue, NullValue>()
 			.setIncludeZeroDegreeVertices(false)
-			.run(emptyGraph)
+			.run(emptyGraphWithVertices)
 			.execute();
 
 		assertEquals(expectedResult, withoutZeroDegreeVertices);
@@ -87,7 +83,7 @@ extends AsmTestBase {
 
 		Result withZeroDegreeVertices = new VertexMetrics<LongValue, NullValue, NullValue>()
 			.setIncludeZeroDegreeVertices(true)
-			.run(emptyGraph)
+			.run(emptyGraphWithVertices)
 			.execute();
 
 		assertEquals(expectedResult, withZeroDegreeVertices);
@@ -96,8 +92,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
+	public void testWithRMatGraph() throws Exception {
 		Result expectedResult = new Result(902, 8875, 1567, 1003442, 463, 334, 342, 106953);
 
 		Result withoutZeroDegreeVertices = new VertexMetrics<LongValue, NullValue, NullValue>()

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/undirected/EdgeMetricsTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/undirected/EdgeMetricsTest.java
@@ -32,12 +32,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link EdgeMetrics}.
  */
-public class EdgeMetricsTest
-extends AsmTestBase {
+public class EdgeMetricsTest extends AsmTestBase {
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		Result expectedResult = new Result(2, 6, 1, 3);
 
 		Result edgeMetrics = new EdgeMetrics<IntValue, NullValue, NullValue>()
@@ -48,8 +46,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithCompleteGraph()
-			throws Exception {
+	public void testWithCompleteGraph() throws Exception {
 		long expectedDegree = completeGraphVertexCount - 1;
 		long expectedMaximumTriplets = CombinatoricsUtils.binomialCoefficient((int) expectedDegree, 2);
 		long expectedTriplets = completeGraphVertexCount * expectedMaximumTriplets;
@@ -65,22 +62,20 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithEmptyGraph()
-			throws Exception {
+	public void testWithEmptyGraph() throws Exception {
 		Result expectedResult;
 
 		expectedResult = new Result(0, 0, 0, 0);
 
 		Result withoutZeroDegreeVertices = new EdgeMetrics<LongValue, NullValue, NullValue>()
-			.run(emptyGraph)
+			.run(emptyGraphWithVertices)
 			.execute();
 
 		assertEquals(withoutZeroDegreeVertices, expectedResult);
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
+	public void testWithRMatGraph() throws Exception {
 		Result expectedResult = new Result(107817, 315537, 820, 3822);
 
 		Result withoutZeroDegreeVertices = new EdgeMetrics<LongValue, NullValue, NullValue>()

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/undirected/VertexMetricsTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/undirected/VertexMetricsTest.java
@@ -32,12 +32,10 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link VertexMetrics}.
  */
-public class VertexMetricsTest
-extends AsmTestBase {
+public class VertexMetricsTest extends AsmTestBase {
 
 	@Test
-	public void testWithSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		Result expectedResult = new Result(6, 7, 13, 4, 6);
 
 		Result vertexMetrics = new VertexMetrics<IntValue, NullValue, NullValue>()
@@ -48,8 +46,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithCompleteGraph()
-			throws Exception {
+	public void testWithCompleteGraph() throws Exception {
 		long expectedDegree = completeGraphVertexCount - 1;
 		long expectedEdges = completeGraphVertexCount * expectedDegree / 2;
 		long expectedMaximumTriplets = CombinatoricsUtils.binomialCoefficient((int) expectedDegree, 2);
@@ -68,15 +65,14 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithEmptyGraph()
-			throws Exception {
+	public void testWithEmptyGraph() throws Exception {
 		Result expectedResult;
 
 		expectedResult = new Result(0, 0, 0, 0, 0);
 
 		Result withoutZeroDegreeVertices = new VertexMetrics<LongValue, NullValue, NullValue>()
 			.setIncludeZeroDegreeVertices(false)
-			.run(emptyGraph)
+			.run(emptyGraphWithVertices)
 			.execute();
 
 		assertEquals(expectedResult, withoutZeroDegreeVertices);
@@ -87,7 +83,7 @@ extends AsmTestBase {
 
 		Result withZeroDegreeVertices = new VertexMetrics<LongValue, NullValue, NullValue>()
 			.setIncludeZeroDegreeVertices(true)
-			.run(emptyGraph)
+			.run(emptyGraphWithVertices)
 			.execute();
 
 		assertEquals(expectedResult, withZeroDegreeVertices);
@@ -96,8 +92,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testWithRMatGraph()
-			throws Exception {
+	public void testWithRMatGraph() throws Exception {
 		Result expectedResult = new Result(902, 10442, 1003442, 463, 106953);
 
 		Result withoutZeroDegreeVertices = new VertexMetrics<LongValue, NullValue, NullValue>()

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/similarity/AdamicAdarTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/similarity/AdamicAdarTest.java
@@ -19,22 +19,26 @@
 package org.apache.flink.graph.library.similarity;
 
 import org.apache.flink.api.java.DataSet;
+import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.asm.AsmTestBase;
 import org.apache.flink.graph.library.similarity.AdamicAdar.Result;
 import org.apache.flink.test.util.TestBaseUtils;
+import org.apache.flink.types.CopyableValue;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
+import org.apache.commons.math3.util.CombinatoricsUtils;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for {@link AdamicAdar}.
  */
-public class AdamicAdarTest
-extends AsmTestBase {
+public class AdamicAdarTest extends AsmTestBase {
 
 	private float[] ilog = {
 		1.0f / (float) Math.log(2),
@@ -46,8 +50,7 @@ extends AsmTestBase {
 	};
 
 	@Test
-	public void testSimpleGraph()
-			throws Exception {
+	public void testWithSimpleGraph() throws Exception {
 		DataSet<Result<IntValue>> aa = undirectedSimpleGraph
 			.run(new AdamicAdar<IntValue, NullValue, NullValue>());
 
@@ -68,8 +71,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testSimpleGraphWithMinimumScore()
-			throws Exception {
+	public void testWithSimpleGraphWithMinimumScore() throws Exception {
 		DataSet<Result<IntValue>> aa = undirectedSimpleGraph
 			.run(new AdamicAdar<IntValue, NullValue, NullValue>()
 				.setMinimumScore(0.75f));
@@ -86,8 +88,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testSimpleGraphWithMinimumRatio()
-			throws Exception {
+	public void testWithSimpleGraphWithMinimumRatio() throws Exception {
 		DataSet<Result<IntValue>> aa = undirectedSimpleGraph
 			.run(new AdamicAdar<IntValue, NullValue, NullValue>()
 				.setMinimumRatio(1.5f));
@@ -99,22 +100,63 @@ extends AsmTestBase {
 		TestBaseUtils.compareResultAsText(aa.collect(), expectedResult);
 	}
 
-	@Test
-	public void testCompleteGraph()
-			throws Exception {
-		float expectedScore = (completeGraphVertexCount - 2) / (float) Math.log(completeGraphVertexCount - 1);
+	/**
+	 * Validate a test where each result has the same values.
+	 *
+	 * @param graph input graph
+	 * @param count number of results
+	 * @param score result score
+	 * @param <T> graph ID type
+	 * @throws Exception on error
+	 */
+	private static <T extends CopyableValue<T>> void validateUniformResult(
+			Graph<T, NullValue, NullValue> graph, long count, double score) throws Exception {
+		DataSet<Result<T>> aa = graph
+			.run(new AdamicAdar<T, NullValue, NullValue>());
 
-		DataSet<Result<LongValue>> aa = completeGraph
-			.run(new AdamicAdar<LongValue, NullValue, NullValue>());
+		List<Result<T>> results = aa.collect();
 
-		for (Result<LongValue> result : aa.collect()) {
-			assertEquals(expectedScore, result.getAdamicAdarScore().getValue(), 0.00001);
+		assertEquals(count, results.size());
+
+		for (Result<T> result : results) {
+			assertEquals(score, result.getAdamicAdarScore().getValue(), 0.00001);
 		}
 	}
 
 	@Test
-	public void testRMatGraph()
-			throws Exception {
+	public void testWithCompleteGraph() throws Exception {
+		// all vertex pairs are linked
+		long expectedCount = CombinatoricsUtils.binomialCoefficient((int) completeGraphVertexCount, 2);
+
+		float expectedScore = (completeGraphVertexCount - 2) / (float) Math.log(completeGraphVertexCount - 1);
+
+		validateUniformResult(completeGraph, expectedCount, expectedScore);
+	}
+
+	@Test
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		validateUniformResult(emptyGraphWithVertices, 0, Double.NaN);
+	}
+
+	@Test
+	public void testWithStarGraph() throws Exception {
+		// all leaf vertices form a triplet with all other leaf vertices;
+		// only the center vertex is excluded
+		long expectedCount = CombinatoricsUtils.binomialCoefficient((int) starGraphVertexCount - 1, 2);
+
+		// the intersection includes only the center vertex
+		float expectedScore = 1 / (float) Math.log(starGraphVertexCount - 1);
+
+		validateUniformResult(starGraph, expectedCount, expectedScore);
+	}
+
+	@Test
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		validateUniformResult(emptyGraphWithoutVertices, 0, Double.NaN);
+	}
+
+	@Test
+	public void testWithRMatGraph() throws Exception {
 		DataSet<Result<LongValue>> aa = undirectedRMatGraph(8, 8)
 			.run(new AdamicAdar<LongValue, NullValue, NullValue>());
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/similarity/JaccardIndexTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/similarity/JaccardIndexTest.java
@@ -19,28 +19,31 @@
 package org.apache.flink.graph.library.similarity;
 
 import org.apache.flink.api.java.DataSet;
+import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.asm.AsmTestBase;
 import org.apache.flink.graph.asm.dataset.ChecksumHashCode;
 import org.apache.flink.graph.asm.dataset.ChecksumHashCode.Checksum;
 import org.apache.flink.graph.library.similarity.JaccardIndex.Result;
 import org.apache.flink.test.util.TestBaseUtils;
+import org.apache.flink.types.CopyableValue;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
+import org.apache.commons.math3.util.CombinatoricsUtils;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for {@link JaccardIndex}.
  */
-public class JaccardIndexTest
-extends AsmTestBase {
+public class JaccardIndexTest extends AsmTestBase {
 
 	@Test
-	public void testSimpleGraph()
-			throws Exception {
+	public void testSimpleGraph() throws Exception {
 		DataSet<Result<IntValue>> ji = undirectedSimpleGraph
 			.run(new JaccardIndex<IntValue, NullValue, NullValue>());
 
@@ -61,8 +64,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testSimpleGraphWithMinimumScore()
-			throws Exception {
+	public void testWithSimpleGraphWithMinimumScore() throws Exception {
 		DataSet<Result<IntValue>> ji = undirectedSimpleGraph
 			.run(new JaccardIndex<IntValue, NullValue, NullValue>()
 				.setMinimumScore(1, 2));
@@ -76,8 +78,7 @@ extends AsmTestBase {
 	}
 
 	@Test
-	public void testSimpleGraphWithMaximumScore()
-			throws Exception {
+	public void testWithSimpleGraphWithMaximumScore() throws Exception {
 		DataSet<Result<IntValue>> ji = undirectedSimpleGraph
 			.run(new JaccardIndex<IntValue, NullValue, NullValue>()
 				.setMaximumScore(1, 2));
@@ -97,25 +98,73 @@ extends AsmTestBase {
 		TestBaseUtils.compareResultAsText(ji.collect(), expectedResult);
 	}
 
-	@Test
-	public void testCompleteGraph()
-			throws Exception {
-		DataSet<Result<LongValue>> ji = completeGraph
-			.run(new JaccardIndex<LongValue, NullValue, NullValue>()
+	/**
+	 * Validate a test where each result has the same values.
+	 *
+	 * @param graph input graph
+	 * @param count number of results
+	 * @param distinctNeighborCount result distinct neighbor count
+	 * @param sharedNeighborCount result shared neighbor count
+	 * @param <T> graph ID type
+	 * @throws Exception on error
+	 */
+	private static <T extends CopyableValue<T>> void validateUniformResult(
+			Graph<T, NullValue, NullValue> graph, long count, long distinctNeighborCount, long sharedNeighborCount) throws Exception {
+		DataSet<Result<T>> ji = graph
+			.run(new JaccardIndex<T, NullValue, NullValue>()
 				.setGroupSize(4));
 
-		for (Result<LongValue> result : ji.collect()) {
-			// the intersection includes every vertex
-			assertEquals(completeGraphVertexCount, result.getDistinctNeighborCount().getValue());
+		List<Result<T>> results = ji.collect();
 
-			// the union only excludes the two vertices from the similarity score
-			assertEquals(completeGraphVertexCount - 2, result.getSharedNeighborCount().getValue());
+		assertEquals(count, results.size());
+
+		for (Result<T> result : results) {
+			assertEquals(distinctNeighborCount, result.getDistinctNeighborCount().getValue());
+			assertEquals(sharedNeighborCount, result.getSharedNeighborCount().getValue());
 		}
 	}
 
 	@Test
-	public void testRMatGraph()
-			throws Exception {
+	public void testWithCompleteGraph() throws Exception {
+		// all vertex pairs are linked
+		long expectedCount = CombinatoricsUtils.binomialCoefficient((int) completeGraphVertexCount, 2);
+
+		// the intersection includes every vertex
+		long expectedDistinctNeighborCount = completeGraphVertexCount;
+
+		// the union only excludes the two vertices from the similarity score
+		long expectedSharedNeighborCount = completeGraphVertexCount - 2;
+
+		validateUniformResult(completeGraph, expectedCount, expectedDistinctNeighborCount, expectedSharedNeighborCount);
+	}
+
+	@Test
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		validateUniformResult(emptyGraphWithVertices, 0, 0, 0);
+	}
+
+	@Test
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		validateUniformResult(emptyGraphWithoutVertices, 0, 0, 0);
+	}
+
+	@Test
+	public void testWithStarGraph() throws Exception {
+		// all leaf vertices form a triplet with all other leaf vertices;
+		// only the center vertex is excluded
+		long expectedCount = CombinatoricsUtils.binomialCoefficient((int) starGraphVertexCount - 1, 2);
+
+		// the intersection includes only the center vertex
+		long expectedDistinctNeighborCount = 1;
+
+		// the union includes only the center vertex
+		long expectedSharedNeighborCount = 1;
+
+		validateUniformResult(starGraph, expectedCount, expectedDistinctNeighborCount, expectedSharedNeighborCount);
+	}
+
+	@Test
+	public void testWithRMatGraph() throws Exception {
 		DataSet<Result<LongValue>> ji = undirectedRMatGraph(8, 8)
 			.run(new JaccardIndex<LongValue, NullValue, NullValue>()
 				.setGroupSize(4));


### PR DESCRIPTION
## What is the purpose of the change

This was prompted by user feedback comparing Gelly's `PageRank` which noticed that zero-degree vertices (not present in the edge set) were not included in the computation. There existed an `EmptyGraph` generated which was sometimes used. This PR adds missing tests using empty edge and vertex sets for each algorithm.

## Brief change log

There exist some tests with empty graphs but the `EmptyGraph` in `AsmTestBase` contained vertices but no edges. Add a new `EmptyGraph` without vertices and test both empty graphs for each algorithm.

EmptyGraph now generates the proper TypeInformation (for Edge<> not Tuple3) which had prevented adding edges due to a union incompatibility.

GraphGeneratorUtils#vertexSet now uses a hash-combine for distinct.

`PageRank` optionally includes zero-degree vertices in the results (at a performance cost).

## Verifying this change

This change added tests and can be verified as follows: running new unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)