### PR TITLE
[FLINK-7269] Refactor passing of dynamic properties

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -79,7 +79,15 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	}
 	
 	// --------------------------------------------------------------------------------------------
-	
+
+	/**
+	 * Set the process-wide dynamic properties to be merged with the configuration.
+	 * @param dynamicProperties The given dynamic properties
+     */
+	public void setDynamicProperties(Configuration dynamicProperties) {
+		this.addAll(dynamicProperties);
+	}
+
 	/**
 	 * Returns the class associated with the given key as a string.
 	 * 

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -85,7 +85,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 * @param dynamicProperties The given dynamic properties
      */
 	public void setDynamicProperties(Configuration dynamicProperties) {
-		this.addAll(dynamicProperties);
+		addAll(dynamicProperties);
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
@@ -262,6 +262,11 @@ public final class DelegatingConfiguration extends Configuration {
 	}
 
 	@Override
+	public void setDynamicProperties(Configuration dynamicProperties) {
+		this.backingConfig.setDynamicProperties(dynamicProperties);
+	}
+
+	@Override
 	public void addAll(Configuration other) {
 		this.addAll(other, "");
 	}

--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -62,6 +62,17 @@ public final class GlobalConfiguration {
 	}
 
 	/**
+	 * Loads the global configuration with given dynamic properties
+	 * @param dynamicProperties The given dynamic properties
+	 * @return Returns the Configuration
+     */
+	public static Configuration loadConfigurationWithDynamicProperties(Configuration dynamicProperties) {
+		Configuration configuration = loadConfiguration();
+		configuration.setDynamicProperties(dynamicProperties);
+		return configuration;
+	}
+
+	/**
 	 * Loads the configuration files from the specified directory.
 	 * <p>
 	 * YAML files are supported as configuration files.

--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -46,24 +46,6 @@ public final class GlobalConfiguration {
 
 	// --------------------------------------------------------------------------------------------
 
-	private static Configuration dynamicProperties = null;
-
-	/**
-	 * Set the process-wide dynamic properties to be merged with the loaded configuration.
-     */
-	public static void setDynamicProperties(Configuration dynamicProperties) {
-		GlobalConfiguration.dynamicProperties = new Configuration(dynamicProperties);
-	}
-
-	/**
-	 * Get the dynamic properties.
-     */
-	public static Configuration getDynamicProperties() {
-		return GlobalConfiguration.dynamicProperties;
-	}
-
-	// --------------------------------------------------------------------------------------------
-
 	/**
 	 * Loads the global configuration from the environment. Fails if an error occurs during loading. Returns an
 	 * empty configuration object if the environment variable is not set. In production this variable is set but
@@ -109,13 +91,7 @@ public final class GlobalConfiguration {
 					"' (" + confDirFile.getAbsolutePath() + ") does not exist.");
 		}
 
-		Configuration conf = loadYAMLResource(yamlConfigFile);
-
-		if(dynamicProperties != null) {
-			conf.addAll(dynamicProperties);
-		}
-
-		return conf;
+		return loadYAMLResource(yamlConfigFile);
 	}
 
 	/**

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -303,4 +303,28 @@ public class ConfigurationTest extends TestLogger {
 		assertEquals(13, cfg.getInteger(matchesThird));
 		assertEquals(-1, cfg.getInteger(notContained));
 	}
+
+	@Test
+	public void testDynamicProperties() {
+		final Configuration orig = new Configuration();
+		orig.setString("mykey", "myvalue");
+		orig.setInteger("mynumber", 100);
+		orig.setBoolean("shouldbetrue", true);
+
+		assertEquals("myvalue", orig.getString("mykey", null));
+		assertEquals(100, orig.getInteger("mynumber", 0));
+		assertEquals(true, orig.getBoolean("shouldbetrue", false));
+
+		final Configuration dynamicProperties = new Configuration();
+		dynamicProperties.setString("mykey", "myvalue2");
+		dynamicProperties.setInteger("mynumber", 1000);
+		dynamicProperties.setBoolean("shouldbefalse", false);
+		dynamicProperties.setBoolean("shouldbetrue", false);
+		orig.setDynamicProperties(dynamicProperties);
+
+		assertEquals("myvalue2", orig.getString("mykey", null));
+		assertEquals(1000, orig.getInteger("mynumber", 0));
+		assertEquals(false, orig.getBoolean("shouldbefalse", true));
+		assertEquals(false, orig.getBoolean("shouldbetrue", true));
+	}
 }

--- a/flink-core/src/test/java/org/apache/flink/configuration/UnmodifiableConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/UnmodifiableConfigurationTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.configuration;
 
+import org.apache.commons.lang3.StringUtils;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -73,7 +75,7 @@ public class UnmodifiableConfigurationTest extends TestLogger {
 			UnmodifiableConfiguration config = new UnmodifiableConfiguration(new Configuration());
 
 			for (Method m : clazz.getMethods()) {
-				if (m.getName().startsWith("set")) {
+				if (m.getName().startsWith("set") && !StringUtils.equals(m.getName(), "setDynamicProperties")) {
 
 					Class<?> keyClass = m.getParameterTypes()[0];
 					Class<?> parameterClass = m.getParameterTypes()[1];

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
@@ -159,8 +159,8 @@ public class MesosApplicationMasterRunner {
 			CommandLine cmd = parser.parse(ALL_OPTIONS, args);
 
 			final Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
-			GlobalConfiguration.setDynamicProperties(dynamicProperties);
 			final Configuration config = GlobalConfiguration.loadConfiguration();
+			config.setDynamicProperties(dynamicProperties);
 
 			// configure the default filesystem
 			try {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
@@ -159,8 +159,7 @@ public class MesosApplicationMasterRunner {
 			CommandLine cmd = parser.parse(ALL_OPTIONS, args);
 
 			final Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
-			final Configuration config = GlobalConfiguration.loadConfiguration();
-			config.setDynamicProperties(dynamicProperties);
+			final Configuration config = GlobalConfiguration.loadConfigurationWithDynamicProperties(dynamicProperties);
 
 			// configure the default filesystem
 			try {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerRunner.java
@@ -75,8 +75,7 @@ public class MesosTaskManagerRunner {
 			final Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
 			LOG.debug("Mesos dynamic properties: {}", dynamicProperties);
 
-			configuration = GlobalConfiguration.loadConfiguration();
-			configuration.setDynamicProperties(dynamicProperties);
+			configuration = GlobalConfiguration.loadConfigurationWithDynamicProperties(dynamicProperties);
 		}
 		catch (Throwable t) {
 			LOG.error("Failed to load the TaskManager configuration and dynamic properties.", t);

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerRunner.java
@@ -73,10 +73,10 @@ public class MesosTaskManagerRunner {
 		final Configuration configuration;
 		try {
 			final Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
-			GlobalConfiguration.setDynamicProperties(dynamicProperties);
 			LOG.debug("Mesos dynamic properties: {}", dynamicProperties);
 
 			configuration = GlobalConfiguration.loadConfiguration();
+			configuration.setDynamicProperties(dynamicProperties);
 		}
 		catch (Throwable t) {
 			LOG.error("Failed to load the TaskManager configuration and dynamic properties.", t);


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds  the dynamic properties to the loaded Configuration instead of set a static field in GlobalConfiguration which is read whenever we load the Configuration.*


## Brief change log

  - *remove `public static void setDynamicProperties(Configuration dynamicProperties)` method in `GlobalConfiguration`*
  - *add `public void setDynamicProperties(Configuration dynamicProperties)` method in `Configuration`*

## Verifying this change
This change added tests and can be verified as follows:
  - *Add test case `testDynamicProperties` in `ConfigurationTest`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no

## Documentation

  - Does this pull request introduce a new feature? no

