### PR TITLE
[FLINK-7279][minicluster] fix a deadlock between TM and cluster shutdown

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -649,7 +649,8 @@ public class MiniCluster {
 
 			try {
 				synchronized (lock) {
-					if (taskManagers[index] != null) {
+					// note: if not running (after shutdown) taskManagers may be null!
+					if (running && taskManagers[index] != null) {
 						taskManagers[index].shutDown();
 					}
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1124,9 +1124,15 @@ public class TaskExecutor extends RpcEndpoint<TaskExecutorGateway> {
 	 *
 	 * @param t The exception describing the fatal error
 	 */
-	void onFatalError(Throwable t) {
+	void onFatalError(final Throwable t) {
 		log.error("Fatal error occurred.", t);
-		fatalErrorHandler.onFatalError(t);
+		// this could potentially be a blocking call -> call asynchronously:
+		getRpcService().getExecutor().execute(new Runnable() {
+			@Override
+			public void run() {
+				fatalErrorHandler.onFatalError(t);
+			}
+		});
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

The `MiniCluster` can deadlock if the fatal error handler is called while the `MiniCluster` shuts down. The reason is that the shut down happens under a lock which is required by the fatal error handler as well. If now the `MiniCluster` tries to shut down the underlying RPC service which waits for all actors to terminate, it will never complete because one actor is still waiting for the lock.

## Brief change log

  - ~guard both shutdown methods by a new `ReentrantLock` and ignore the TM shutdown in the `TerminatingFatalErrorHandler` if the cluster is already shut down.~
  - call fatal error handlers in `TaskExecutor` asynchronously so that the RPC service does not get blocked on this (this is more future proof than fixing the locking problem itself which may eventually re-occur)

## Verifying this change

This change is already covered by existing tests, such as `MiniClusterITCase` which was instable because of this bug (also see [FLINK-7115]).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)

