### PR TITLE
[hotfix][tests] fix Invokable subclasses being private

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
@@ -132,7 +132,12 @@ public class JobRetrievalITCase extends TestLogger {
 		}
 	}
 
-	private static class SemaphoreInvokable extends AbstractInvokable {
+	/**
+	 * Invokable that waits on {@link #lock} to be released and finishes afterwards.
+	 *
+	 * <p>NOTE: needs to be <tt>public</tt> so that a task can be run with this!
+	 */
+	public static class SemaphoreInvokable extends AbstractInvokable {
 
 		@Override
 		public void invoke() throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/NetworkStackThroughputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/NetworkStackThroughputITCase.java
@@ -163,7 +163,14 @@ public class NetworkStackThroughputITCase extends TestLogger {
 
 	// ------------------------------------------------------------------------
 
-	private static class SpeedTestProducer extends AbstractInvokable {
+	/**
+	 * Invokable that produces records and allows slowdown via {@link #IS_SLOW_EVERY_NUM_RECORDS}
+	 * and {@link #IS_SLOW_SENDER_CONFIG_KEY} and creates records of different data sizes via {@link
+	 * #DATA_VOLUME_GB_CONFIG_KEY}.
+	 *
+	 * <p>NOTE: needs to be <tt>public</tt> so that a task can be run with this!
+	 */
+	public static class SpeedTestProducer extends AbstractInvokable {
 
 		@Override
 		public void invoke() throws Exception {
@@ -198,7 +205,12 @@ public class NetworkStackThroughputITCase extends TestLogger {
 		}
 	}
 
-	private static class SpeedTestForwarder extends AbstractInvokable {
+	/**
+	 * Invokable that forwards incoming records.
+	 *
+	 * <p>NOTE: needs to be <tt>public</tt> so that a task can be run with this!
+	 */
+	public static class SpeedTestForwarder extends AbstractInvokable {
 
 		@Override
 		public void invoke() throws Exception {
@@ -222,7 +234,13 @@ public class NetworkStackThroughputITCase extends TestLogger {
 		}
 	}
 
-	private static class SpeedTestConsumer extends AbstractInvokable {
+	/**
+	 * Invokable that consumes incoming records and allows slowdown via {@link
+	 * #IS_SLOW_EVERY_NUM_RECORDS}.
+	 *
+	 * <p>NOTE: needs to be <tt>public</tt> so that a task can be run with this!
+	 */
+	public static class SpeedTestConsumer extends AbstractInvokable {
 
 		@Override
 		public void invoke() throws Exception {
@@ -247,7 +265,12 @@ public class NetworkStackThroughputITCase extends TestLogger {
 		}
 	}
 
-	private static class SpeedTestRecord implements IOReadableWritable {
+	/**
+	 * Record type for the speed test.
+	 *
+	 * <p>NOTE: needs to be <tt>public</tt> to allow deserialization!
+	 */
+	public static class SpeedTestRecord implements IOReadableWritable {
 
 		private static final int RECORD_SIZE = 128;
 


### PR DESCRIPTION
## What is the purpose of the change

Recently, some `Invokable` subclasses became `private` and thus failed to be executed at the task managers. This fixes the problem in one `@Ignore`d class (which was not working anymore) and one where the result of the job execution did not matter and only produces an superfluous log entry.

## Brief change log

  - fix `JobRetrievalITCase#testJobRetrieval()` test job not running
  - fix `NetworkStackThroughputITCase` not working anymore

## Verifying this change

This change is already covered by existing tests, such as `JobRetrievalITCase` (where the error only showed as a superfluous exception in the logs) and `NetworkStackThroughputITCase` (which was not working anymore but is a manual test).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)

