### PR TITLE
[FLINK-7346][tests] fix IncrementalRocksDbBackendEventTimeWindowCheckpointingITCase taking too long for the TravisCI output check

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
@@ -48,12 +48,14 @@ import org.apache.flink.test.util.SuccessException;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -87,6 +89,9 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 
 	@Rule
 	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@Rule
+	public TestName name = new TestName();
 
 	private StateBackendEnum stateBackendEnum;
 	private AbstractStateBackend stateBackend;
@@ -123,7 +128,13 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 	}
 
 	@Before
-	public void initStateBackend() throws IOException {
+	public void beforeTest() throws IOException {
+		// print a message when starting a test method to avoid Travis' <tt>"Maven produced no
+		// output for xxx seconds."</tt> messages
+		System.out.println(
+			"Starting " + getClass().getCanonicalName() + "#" + name.getMethodName() + ".");
+
+		// init state back-end
 		switch (stateBackendEnum) {
 			case MEM:
 				this.stateBackend = new MemoryStateBackend(MAX_MEM_STATE_SIZE, false);
@@ -164,6 +175,16 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 			}
 
 		}
+	}
+
+	/**
+	 * Prints a message when finishing a test method to avoid Travis' <tt>"Maven produced no output
+	 * for xxx seconds."</tt> messages.
+	 */
+	@After
+	public void afterTest() {
+		System.out.println(
+			"Finished " + getClass().getCanonicalName() + "#" + name.getMethodName() + ".");
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/IncrementalRocksDbBackendEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/IncrementalRocksDbBackendEventTimeWindowCheckpointingITCase.java
@@ -18,13 +18,41 @@
 
 package org.apache.flink.test.checkpointing;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
+
 /**
  * Integration tests for incremental RocksDB backend.
  */
 public class IncrementalRocksDbBackendEventTimeWindowCheckpointingITCase extends AbstractEventTimeWindowCheckpointingITCase {
 
+	@Rule
+	public TestName name = new TestName();
+
 	public IncrementalRocksDbBackendEventTimeWindowCheckpointingITCase() {
 		super(StateBackendEnum.ROCKSDB_INCREMENTAL);
+	}
+
+	/**
+	 * Prints a message when starting a test method to avoid Travis' <tt>"Maven produced no output
+	 * for xxx seconds."</tt> messages.
+	 */
+	@Before
+	public void printMethodStart() {
+		System.out.println(
+			"Starting " + getClass().getCanonicalName() + "#" + name.getMethodName() + ".");
+	}
+
+	/**
+	 * Prints a message when finishing a test method to avoid Travis' <tt>"Maven produced no output
+	 * for xxx seconds."</tt> messages.
+	 */
+	@After
+	public void printProgress() {
+		System.out.println(
+			"Finished " + getClass().getCanonicalName() + "#" + name.getMethodName() + ".");
 	}
 
 	@Override

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/IncrementalRocksDbBackendEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/IncrementalRocksDbBackendEventTimeWindowCheckpointingITCase.java
@@ -18,41 +18,13 @@
 
 package org.apache.flink.test.checkpointing;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TestName;
-
 /**
  * Integration tests for incremental RocksDB backend.
  */
 public class IncrementalRocksDbBackendEventTimeWindowCheckpointingITCase extends AbstractEventTimeWindowCheckpointingITCase {
 
-	@Rule
-	public TestName name = new TestName();
-
 	public IncrementalRocksDbBackendEventTimeWindowCheckpointingITCase() {
 		super(StateBackendEnum.ROCKSDB_INCREMENTAL);
-	}
-
-	/**
-	 * Prints a message when starting a test method to avoid Travis' <tt>"Maven produced no output
-	 * for xxx seconds."</tt> messages.
-	 */
-	@Before
-	public void printMethodStart() {
-		System.out.println(
-			"Starting " + getClass().getCanonicalName() + "#" + name.getMethodName() + ".");
-	}
-
-	/**
-	 * Prints a message when finishing a test method to avoid Travis' <tt>"Maven produced no output
-	 * for xxx seconds."</tt> messages.
-	 */
-	@After
-	public void printProgress() {
-		System.out.println(
-			"Finished " + getClass().getCanonicalName() + "#" + name.getMethodName() + ".");
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Fix test failures due to `IncrementalRocksDbBackendEventTimeWindowCheckpointingITCase` not producing an output for 300s on Travis.

## Brief change log

  - provide output in the form of progress messages regarding the execution of test cases

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)

