### PR TITLE
[FLINK-7298] [table] Records can be cleared all at once when all data in state is invalid

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/ProcTimeWindowInnerJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/ProcTimeWindowInnerJoin.scala
@@ -324,17 +324,18 @@ class ProcTimeWindowInnerJoin(
       }
     }
 
-    // Remove expired records from state
-    var i = removeList.size - 1
-    while (i >= 0) {
-      rowMapState.remove(removeList.get(i))
-      i -= 1
-    }
-    removeList.clear()
-
     // If the state has non-expired timestamps, register a new timer.
     // Otherwise clean the complete state for this input.
     if (validTimestamp) {
+
+      // Remove expired records from state
+      var i = removeList.size - 1
+      while (i >= 0) {
+        rowMapState.remove(removeList.get(i))
+        i -= 1
+      }
+      removeList.clear()
+
       val cleanupTime = curTime + winSize + 1
       ctx.timerService.registerProcessingTimeTimer(cleanupTime)
       timerState.update(cleanupTime)


### PR DESCRIPTION
In `ProcTimeWindowInnerJoin`.`expireOutTimeRow`, we need not to remove records one by one from state when there is no valid records. Instead, we can clear them all at once.