### PR TITLE
[FLINK-7299][AVRO] Write GenericRecord using AvroOutputFormat

### DIFF
--- a/flink-connectors/flink-avro/src/main/java/org/apache/flink/api/java/io/AvroOutputFormat.java
+++ b/flink-connectors/flink-avro/src/main/java/org/apache/flink/api/java/io/AvroOutputFormat.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.avro.Schema;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.avro.reflect.ReflectDatumWriter;
@@ -134,6 +135,12 @@ public class AvroOutputFormat<E> extends FileOutputFormat<E> implements Serializ
 			} catch (InstantiationException | IllegalAccessException e) {
 				throw new RuntimeException(e.getMessage());
 			}
+		} else if (org.apache.avro.generic.GenericRecord.class.isAssignableFrom(avroValueType)) {
+			if (userDefinedSchema == null) {
+				throw new IllegalStateException("Schema must be set when using Generic Record");
+			}
+			datumWriter = new GenericDatumWriter<E>(userDefinedSchema);
+			schema = userDefinedSchema;
 		} else {
 			datumWriter = new ReflectDatumWriter<E>(avroValueType);
 			schema = ReflectData.get().getSchema(avroValueType);


### PR DESCRIPTION
## What is the purpose of the change

Allow writing Avro GenericRecord using AvroOutputFormat. 

## Brief change log

- Added condition in AvroOutputFormat to check if avroValue is an instance of GenericRecord and create a GenericDatumWriter.

## Verifying this change

This change added tests and can be verified as follows:

 -  Added unit tests- testGenericRecord() in AvroOutputFormatTest to write GenericRecords.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no

## Documentation

  - Does this pull request introduce a new feature?: no (not a major feature)
  - If yes, how is the feature documented? not applicable 

