### PR TITLE
[FLINK-7302] [table] Fix failed to run CorrelateITCase class under wi…

### DIFF
--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/CorrelateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/CorrelateITCase.scala
@@ -25,11 +25,18 @@ import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.runtime.utils.JavaUserDefinedTableFunctions.JavaTableFunc0
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.expressions.utils.{Func1, Func13, Func18, RichFunc2}
+import org.apache.flink.table.expressions.utils.{Func1, Func18, RichFunc2}
 import org.apache.flink.table.runtime.utils.TableProgramsClusterTestBase
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
 import org.apache.flink.table.runtime.utils._
-import org.apache.flink.table.utils._
+import org.apache.flink.table.utils.TableFunc0
+import org.apache.flink.table.utils.TableFunc1
+import org.apache.flink.table.utils.TableFunc2
+import org.apache.flink.table.utils.TableFunc3
+import org.apache.flink.table.utils.VarArgsFunc0
+import org.apache.flink.table.utils.HierarchyTableFunction
+import org.apache.flink.table.utils.PojoTableFunc
+import org.apache.flink.table.utils.RichTableFunc1
 import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
 import org.apache.flink.test.util.TestBaseUtils
 import org.apache.flink.types.Row

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
@@ -25,7 +25,11 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils.{Func18, RichFunc2}
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData}
 import org.apache.flink.table.runtime.utils._
-import org.apache.flink.table.utils._
+import org.apache.flink.table.utils.TableFunc0
+import org.apache.flink.table.utils.TableFunc3
+import org.apache.flink.table.utils.PojoTableFunc
+import org.apache.flink.table.utils.RichTableFunc1
+import org.apache.flink.table.utils.VarArgsFunc0
 import org.apache.flink.types.Row
 import org.junit.Assert._
 import org.junit.{Before, Test}


### PR DESCRIPTION
With an environment on Windows, Test run failed as reference to UserDefinedFunctionTestUtils is ambiguous;
it is imported twice in the same scope by ```import org.apache.flink.table.utils._``` and ```import org.apache.flink.table.runtime.utils._```

Both happened on stream and batch package.