### PR TITLE
[FLINK-7305] [checkstyle] Allow imports from org.apache.flink.shaded and add new import block

### DIFF
--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -198,7 +198,7 @@ This file is based on the checkstyle file of Apache Beam.
       <!-- Checks for out of order import statements. -->
       <property name="severity" value="error"/>
       <!-- Flink imports first, then other imports, then javax, java and scala imports, then static imports. -->
-      <property name="groups" value="org.apache.flink,*,javax,java,scala"/>
+      <property name="groups" value="org.apache.flink,org.apache.flink.shaded,*,javax,java,scala"/>
       <property name="separated" value="true"/>
       <property name="sortStaticImportsAlphabetically" value="true"/>
       <property name="option" value="bottom"/>
@@ -212,7 +212,7 @@ This file is based on the checkstyle file of Apache Beam.
     </module>
 
     <module name="IllegalImport">
-      <property name="illegalPkgs" value="org.apache.flink.shaded, autovalue.shaded, avro.shaded, com.google.api.client.repackaged, com.google.appengine.repackaged, io.netty.util.internal"/>
+      <property name="illegalPkgs" value="autovalue.shaded, avro.shaded, com.google.api.client.repackaged, com.google.appengine.repackaged, io.netty.util.internal"/>
     </module>
 
     <module name="RedundantModifier">


### PR DESCRIPTION
## What is the purpose of the change

This PR allows shaded imports which is hard requirement for the integration of flink-shaded, and adds a separate checkstyle import block to distinguish these from actual flink imports.

## Brief change log

  - allow shaded imports from org.apache.flink.shaded
  - add new import block for shaded imports

## Verifying this change

This change can be verified by
* importing some class from org.apache.flink.shaded (doesn't have to exist)
* run `mvn checkstyle:check`, it should only raise an `UnusedImport` error.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)

