### PR TITLE
[FLINK-7303] [build] Build elasticsearch5 by default

### DIFF
--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -48,6 +48,7 @@ under the License.
 		<module>flink-connector-elasticsearch-base</module>
 		<module>flink-connector-elasticsearch</module>
 		<module>flink-connector-elasticsearch2</module>
+		<module>flink-connector-elasticsearch5</module>
 		<module>flink-connector-rabbitmq</module>
 		<module>flink-connector-twitter</module>
 		<module>flink-connector-nifi</module>
@@ -84,20 +85,6 @@ under the License.
 			<id>include-kinesis</id>
 			<modules>
 				<module>flink-connector-kinesis</module>
-			</modules>
-		</profile>
-
-		<!--
-			Since Elasticsearch 5.x requires Java 8 at a minimum, we use this profile
-			to include it as part of Java 8 builds only.
-		-->
-		<profile>
-			<id>include-elasticsearch5</id>
-			<activation>
-				<jdk>1.8</jdk>
-			</activation>
-			<modules>
-				<module>flink-connector-elasticsearch5</module>
 			</modules>
 		</profile>
 	</profiles>

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -79,6 +79,7 @@ flink-connectors/flink-jdbc,\
 flink-connectors/flink-connector-cassandra,\
 flink-connectors/flink-connector-elasticsearch,\
 flink-connectors/flink-connector-elasticsearch2,\
+flink-connectors/flink-connector-elasticsearch5,\
 flink-connectors/flink-connector-elasticsearch-base,\
 flink-connectors/flink-connector-filesystem,\
 flink-connectors/flink-connector-kafka-0.8,\
@@ -91,14 +92,6 @@ flink-connectors/flink-connector-twitter"
 
 MODULES_TESTS="\
 flink-tests"
-
-if [[ $PROFILE == *"jdk8"* ]]; then
-	case $TEST in
-		(connectors)
-			MODULES_CONNECTORS="$MODULES_CONNECTORS,flink-connectors/flink-connector-elasticsearch5"
-		;;
-	esac
-fi
 
 if [[ $PROFILE == *"include-kinesis"* ]]; then
 	case $TEST in


### PR DESCRIPTION
## What is the purpose of the change

Remove unnecessary include-elasticsearch5 profile since its activation condition (usage of jdk8) is always true.

## Verifying this change

Run any mvn command in `flink` or `flink-connectors` and check that the reactor includes ES5.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (~~yes~~ /  no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ~~(yes~~ / no)
  - The serializers: (~~yes~~ / no / ~~don't know~~)
  - The runtime per-record code paths (performance sensitive): (~~yes~~ / no / ~~don't know~~)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (~~yes~~ / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (~~yes~~ / no)
  - If yes, how is the feature documented? (not applicable ~~/ docs / JavaDocs / not documented~~)

