### PR TITLE
[FLINK-7304] [scripts] Simplify taskmanager GC configuration

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -42,17 +42,7 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
     # if memory allocation mode is lazy and no other JVM options are set,
     # set the 'Concurrent Mark Sweep GC'
     if [[ $FLINK_TM_MEM_PRE_ALLOCATE == "false" ]] && [ -z "${FLINK_ENV_JAVA_OPTS}" ] && [ -z "${FLINK_ENV_JAVA_OPTS_TM}" ]; then
-
-        JAVA_VERSION=$($JAVA_RUN -version 2>&1 | sed 's/.*version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
-
-        # set the GC to G1 in Java 8 and to CMS in Java 7
-        if [[ ${JAVA_VERSION} =~ ${IS_NUMBER} ]]; then
-            if [ "$JAVA_VERSION" -lt 18 ]; then
-                export JVM_ARGS="$JVM_ARGS -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled"
-            else
-                export JVM_ARGS="$JVM_ARGS -XX:+UseG1GC"
-            fi
-        fi
+        export JVM_ARGS="$JVM_ARGS -XX:+UseG1GC"
     fi
 
     if [[ ! ${FLINK_TM_HEAP} =~ ${IS_NUMBER} ]] || [[ "${FLINK_TM_HEAP}" -lt "0" ]]; then


### PR DESCRIPTION
## What is the purpose of the change

Simplify jdk-version-dependent GC configuration in `taskmanager.sh` since we only use jdk8.

## Verifying this change

Run `taskmanager.sh` and check JVM options.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable~~)

