### PR TITLE
 [FLINK-7314] [futures] Replace Flink's futures with CompletableFuture in TaskManagerLogHandler

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagerLogHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/TaskManagerLogHandler.java
@@ -27,18 +27,13 @@ package org.apache.flink.runtime.webmonitor.handlers;
  *****************************************************************************/
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.BlobView;
-import org.apache.flink.runtime.concurrent.AcceptFunction;
-import org.apache.flink.runtime.concurrent.ApplyFunction;
-import org.apache.flink.runtime.concurrent.BiFunction;
-import org.apache.flink.runtime.concurrent.Future;
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
-import org.apache.flink.runtime.concurrent.impl.FlinkFuture;
+import org.apache.flink.runtime.concurrent.FlinkFutureException;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceID;
@@ -65,6 +60,7 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.router.Routed;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedFile;
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,6 +72,8 @@ import java.io.RandomAccessFile;
 import java.net.InetSocketAddress;
 import java.nio.channels.FileChannel;
 import java.util.HashMap;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 import scala.Option;
@@ -111,7 +109,7 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 	private final Configuration config;
 
 	/** Future of the blob cache. */
-	private Future<BlobCache> cache;
+	private CompletableFuture<BlobCache> cache;
 
 	/** Indicates which log file should be displayed. */
 	private FileMode fileMode;
@@ -176,7 +174,7 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 				}
 			}, executor);
 
-			cache = new FlinkFuture<>(cacheFuture);
+			cache = FutureUtils.toJava(cacheFuture);
 		}
 
 		final String taskManagerID = routed.pathParams().get(TaskManagersHandler.TASK_MANAGER_ID_KEY);
@@ -190,47 +188,34 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 					.ask(new JobManagerMessages.RequestTaskManagerInstance(instanceID), timeout)
 					.mapTo(ClassTag$.MODULE$.<JobManagerMessages.TaskManagerInstance>apply(JobManagerMessages.TaskManagerInstance.class));
 
-				Future<JobManagerMessages.TaskManagerInstance> taskManagerFuture = new FlinkFuture<>(scalaTaskManagerFuture);
+				CompletableFuture<JobManagerMessages.TaskManagerInstance> taskManagerFuture = FutureUtils.toJava(scalaTaskManagerFuture);
 
-				Future<BlobKey> blobKeyFuture = taskManagerFuture.thenCompose(new ApplyFunction<JobManagerMessages.TaskManagerInstance, Future<BlobKey>>() {
-					@Override
-					public Future<BlobKey> apply(JobManagerMessages.TaskManagerInstance value) {
-						Instance taskManager = value.instance().get();
+				CompletableFuture<BlobKey> blobKeyFuture = taskManagerFuture.thenCompose(
+					taskManagerInstance -> {
+						Instance taskManager = taskManagerInstance.instance().get();
 
 						switch (fileMode) {
 							case LOG:
-								return taskManager.getTaskManagerGateway().requestTaskManagerLog(timeTimeout);
+								return FutureUtils.toJava(taskManager.getTaskManagerGateway().requestTaskManagerLog(timeTimeout));
 							case STDOUT:
 							default:
-								return taskManager.getTaskManagerGateway().requestTaskManagerStdout(timeTimeout);
+								return FutureUtils.toJava(taskManager.getTaskManagerGateway().requestTaskManagerStdout(timeTimeout));
 						}
 					}
-				});
+				);
 
-				Future<String> logPathFuture = blobKeyFuture
-					.thenCombine(
+				CompletableFuture<String> logPathFuture = blobKeyFuture
+					.thenCombineAsync(
 						cache,
-						new BiFunction<BlobKey, BlobCache, Tuple2<BlobKey, BlobCache>>() {
-							@Override
-							public Tuple2<BlobKey, BlobCache> apply(BlobKey blobKey, BlobCache blobCache) {
-								return Tuple2.of(blobKey, blobCache);
-							}
-						})
-					.thenComposeAsync(new ApplyFunction<Tuple2<BlobKey, BlobCache>, Future<String>>() {
-						@Override
-						public Future<String> apply(Tuple2<BlobKey, BlobCache> value) {
-							final BlobKey blobKey = value.f0;
-							final BlobCache blobCache = value.f1;
-
+						(blobKey, blobCache) -> {
 							//delete previous log file, if it is different than the current one
 							HashMap<String, BlobKey> lastSubmittedFile = fileMode == FileMode.LOG ? lastSubmittedLog : lastSubmittedStdout;
 							if (lastSubmittedFile.containsKey(taskManagerID)) {
-								if (!blobKey.equals(lastSubmittedFile.get(taskManagerID))) {
+								if (!Objects.equals(blobKey, lastSubmittedFile.get(taskManagerID))) {
 									try {
 										blobCache.deleteGlobal(lastSubmittedFile.get(taskManagerID));
 									} catch (IOException e) {
-										return FlinkCompletableFuture.completedExceptionally(
-											new Exception("Could not delete file for " + taskManagerID + '.', e));
+										throw new FlinkFutureException("Could not delete file for " + taskManagerID + '.', e);
 									}
 									lastSubmittedFile.put(taskManagerID, blobKey);
 								}
@@ -238,28 +223,24 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 								lastSubmittedFile.put(taskManagerID, blobKey);
 							}
 							try {
-								return FlinkCompletableFuture.completed(blobCache.getURL(blobKey).getFile());
+								return blobCache.getURL(blobKey).getFile();
 							} catch (IOException e) {
-								return FlinkCompletableFuture.completedExceptionally(
-									new Exception("Could not retrieve blob for " + blobKey + '.', e));
+								throw new FlinkFutureException("Could not retrieve blob for " + blobKey + '.', e);
 							}
-						}
-					}, executor);
+						},
+						executor);
 
-				logPathFuture.exceptionally(new ApplyFunction<Throwable, Void>() {
-					@Override
-					public Void apply(Throwable failure) {
+				logPathFuture.exceptionally(
+					failure -> {
 						display(ctx, request, "Fetching TaskManager log failed.");
 						LOG.error("Fetching TaskManager log failed.", failure);
 						lastRequestPending.remove(taskManagerID);
 
 						return null;
-					}
-				});
+					});
 
-				logPathFuture.thenAccept(new AcceptFunction<String>() {
-					@Override
-					public void accept(String filePath) {
+				logPathFuture.thenAccept(
+					filePath -> {
 						File file = new File(filePath);
 						final RandomAccessFile raf;
 						try {
@@ -299,15 +280,11 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 
 						// write the content.
 						ChannelFuture lastContentFuture;
-						final GenericFutureListener<io.netty.util.concurrent.Future<? super Void>> completionListener =
-							new GenericFutureListener<io.netty.util.concurrent.Future<? super Void>>() {
-								@Override
-								public void operationComplete(io.netty.util.concurrent.Future<? super Void> future) throws Exception {
-									lastRequestPending.remove(taskManagerID);
-									fc.close();
-									raf.close();
-								}
-							};
+						final GenericFutureListener<Future<? super Void>> completionListener = future -> {
+							lastRequestPending.remove(taskManagerID);
+							fc.close();
+							raf.close();
+						};
 						if (ctx.pipeline().get(SslHandler.class) == null) {
 							ctx.write(
 								new DefaultFileRegion(fc, 0, fileLength), ctx.newProgressivePromise())
@@ -333,8 +310,7 @@ public class TaskManagerLogHandler extends RuntimeMonitorHandlerBase {
 						if (!HttpHeaders.isKeepAlive(request)) {
 							lastContentFuture.addListener(ChannelFutureListener.CLOSE);
 						}
-					}
-				});
+					});
 			} catch (Exception e) {
 				display(ctx, request, "Error: " + e.getMessage());
 				LOG.error("Fetching TaskManager log failed.", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
@@ -26,6 +26,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import scala.concurrent.ExecutionContext;
+
 /**
  * Collection of {@link Executor} implementations
  */
@@ -55,6 +57,41 @@ public class Executors {
 		@Override
 		public void execute(@Nonnull Runnable command) {
 			command.run();
+		}
+	}
+
+	/**
+	 * Return a direct execution context. The direct execution context executes the runnable directly
+	 * in the calling thread.
+	 *
+	 * @return Direct execution context.
+	 */
+	public static ExecutionContext directExecutionContext() {
+		return DirectExecutionContext.INSTANCE;
+	}
+
+	/**
+	 * Direct execution context.
+	 */
+	private static class DirectExecutionContext implements ExecutionContext {
+
+		static final DirectExecutionContext INSTANCE = new DirectExecutionContext();
+
+		private DirectExecutionContext() {}
+
+		@Override
+		public void execute(Runnable runnable) {
+			runnable.run();
+		}
+
+		@Override
+		public void reportFailure(Throwable cause) {
+			throw new IllegalStateException("Error in direct execution context.", cause);
+		}
+
+		@Override
+		public ExecutionContext prepare() {
+			return this;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FlinkFutureException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FlinkFutureException.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Base class for exceptions which are thrown in {@link CompletionStage}.
+ *
+ * <p>The exception has to extend {@link FlinkRuntimeException} because only
+ * unchecked exceptions can be thrown in a future's stage. Additionally we let
+ * it extend the Flink runtime exception because it designates the exception to
+ * come from a Flink stage.
+ */
+public class FlinkFutureException extends FlinkRuntimeException {
+	private static final long serialVersionUID = -8878194471694178210L;
+
+	public FlinkFutureException(String message) {
+		super(message);
+	}
+
+	public FlinkFutureException(Throwable cause) {
+		super(cause);
+	}
+
+	public FlinkFutureException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.concurrent;
 import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.util.Preconditions;
 
+import akka.dispatch.OnComplete;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -285,5 +287,61 @@ public class FutureUtils {
 		public int getNumFuturesCompleted() {
 			return numCompleted.get();
 		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Converting futures
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Converts a Scala {@link scala.concurrent.Future} to a {@link java.util.concurrent.CompletableFuture}.
+	 *
+	 * @param scalaFuture to convert to a Java 8 CompletableFuture
+	 * @param <T> type of the future value
+	 * @return Java 8 CompletableFuture
+	 */
+	public static <T> java.util.concurrent.CompletableFuture<T> toJava(scala.concurrent.Future<T> scalaFuture) {
+		final java.util.concurrent.CompletableFuture<T> result = new java.util.concurrent.CompletableFuture<>();
+
+		scalaFuture.onComplete(new OnComplete<T>() {
+			@Override
+			public void onComplete(Throwable failure, T success) throws Throwable {
+				if (failure != null) {
+					result.completeExceptionally(failure);
+				} else {
+					result.complete(success);
+				}
+			}
+		}, Executors.directExecutionContext());
+
+		return result;
+	}
+
+	/**
+	 * Converts a Flink {@link Future} into a {@link CompletableFuture}.
+	 *
+	 * @param flinkFuture to convert to a Java 8 CompletableFuture
+	 * @param <T> type of the future value
+	 * @return Java 8 CompletableFuture
+	 *
+	 * @deprecated Will be removed once we completely remove Flink's futures
+	 */
+	@Deprecated
+	public static <T> java.util.concurrent.CompletableFuture<T> toJava(Future<T> flinkFuture) {
+		final java.util.concurrent.CompletableFuture<T> result = new java.util.concurrent.CompletableFuture<>();
+
+		flinkFuture.handle(
+			(t, throwable) -> {
+				if (throwable != null) {
+					result.completeExceptionally(throwable);
+				} else {
+					result.complete(t);
+				}
+
+				return null;
+			}
+		);
+
+		return result;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Replaces Flink's `Futures` with `CompletableFuture` in `TaskManagerLogHandler`.

This PR is based onto #4429.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
