### PR TITLE
[FLINK-7318] [futures] Replace Flink's futures in StackTraceSampleCoordinator with Java 8 CompletableFuture

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTracker.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTracker.java
@@ -19,8 +19,6 @@
 package org.apache.flink.runtime.webmonitor;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.concurrent.BiFunction;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
@@ -38,8 +36,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 
 import scala.Option;
 
@@ -177,7 +177,7 @@ public class BackPressureStatsTracker {
 						LOG.debug("Triggering stack trace sample for tasks: " + Arrays.toString(vertex.getTaskVertices()));
 					}
 
-					Future<StackTraceSample> sample = coordinator.triggerStackTraceSample(
+					CompletableFuture<StackTraceSample> sample = coordinator.triggerStackTraceSample(
 							vertex.getTaskVertices(),
 							numSamples,
 							delayBetweenSamples,

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerTest.java
@@ -20,8 +20,6 @@ package org.apache.flink.runtime.webmonitor;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.concurrent.CompletableFuture;
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
@@ -29,6 +27,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
@@ -36,6 +35,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import static org.junit.Assert.assertEquals;
@@ -51,13 +51,13 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for the BackPressureStatsTracker.
  */
-public class BackPressureStatsTrackerTest {
+public class BackPressureStatsTrackerTest extends TestLogger {
 
 	/** Tests simple statistics with fake stack traces. */
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testTriggerStackTraceSample() throws Exception {
-		CompletableFuture<StackTraceSample> sampleFuture = new FlinkCompletableFuture<>();
+		CompletableFuture<StackTraceSample> sampleFuture = new CompletableFuture<>();
 
 		StackTraceSampleCoordinator sampleCoordinator = mock(StackTraceSampleCoordinator.class);
 		when(sampleCoordinator.triggerStackTraceSample(

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorITCase.java
@@ -23,7 +23,6 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.client.JobClient;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -44,9 +43,11 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import scala.concurrent.Await;
+import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
 
 import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.AllVerticesRunning;
@@ -150,7 +151,7 @@ public class StackTraceSampleCoordinatorITCase extends TestLogger {
 								StackTraceSampleCoordinator coordinator = new StackTraceSampleCoordinator(
 										testActorSystem.dispatcher(), 60000);
 
-								Future<StackTraceSample> sampleFuture = coordinator.triggerStackTraceSample(
+								CompletableFuture<StackTraceSample> sampleFuture = coordinator.triggerStackTraceSample(
 									vertex.getTaskVertices(),
 									// Do this often so we have a good
 									// chance of removing the job during
@@ -164,7 +165,7 @@ public class StackTraceSampleCoordinatorITCase extends TestLogger {
 								Thread.sleep(sleepTime);
 
 								// Cancel job
-								scala.concurrent.Future<?> removeFuture = jm.ask(
+								Future<?> removeFuture = jm.ask(
 										new TestingJobManagerMessages.NotifyWhenJobRemoved(jobGraph.getJobID()),
 										remaining());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
@@ -26,6 +26,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import scala.concurrent.ExecutionContext;
+
 /**
  * Collection of {@link Executor} implementations
  */
@@ -55,6 +57,41 @@ public class Executors {
 		@Override
 		public void execute(@Nonnull Runnable command) {
 			command.run();
+		}
+	}
+
+	/**
+	 * Return a direct execution context. The direct execution context executes the runnable directly
+	 * in the calling thread.
+	 *
+	 * @return Direct execution context.
+	 */
+	public static ExecutionContext directExecutionContext() {
+		return DirectExecutionContext.INSTANCE;
+	}
+
+	/**
+	 * Direct execution context.
+	 */
+	private static class DirectExecutionContext implements ExecutionContext {
+
+		static final DirectExecutionContext INSTANCE = new DirectExecutionContext();
+
+		private DirectExecutionContext() {}
+
+		@Override
+		public void execute(Runnable runnable) {
+			runnable.run();
+		}
+
+		@Override
+		public void reportFailure(Throwable cause) {
+			throw new IllegalStateException("Error in direct execution context.", cause);
+		}
+
+		@Override
+		public ExecutionContext prepare() {
+			return this;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FlinkFutureException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FlinkFutureException.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Base class for exceptions which are thrown in {@link CompletionStage}.
+ *
+ * <p>The exception has to extend {@link FlinkRuntimeException} because only
+ * unchecked exceptions can be thrown in a future's stage. Additionally we let
+ * it extend the Flink runtime exception because it designates the exception to
+ * come from a Flink stage.
+ */
+public class FlinkFutureException extends FlinkRuntimeException {
+	private static final long serialVersionUID = -8878194471694178210L;
+
+	public FlinkFutureException(String message) {
+		super(message);
+	}
+
+	public FlinkFutureException(Throwable cause) {
+		super(cause);
+	}
+
+	public FlinkFutureException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.concurrent;
 import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.util.Preconditions;
 
+import akka.dispatch.OnComplete;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -285,5 +287,61 @@ public class FutureUtils {
 		public int getNumFuturesCompleted() {
 			return numCompleted.get();
 		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Converting futures
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Converts a Scala {@link scala.concurrent.Future} to a {@link java.util.concurrent.CompletableFuture}.
+	 *
+	 * @param scalaFuture to convert to a Java 8 CompletableFuture
+	 * @param <T> type of the future value
+	 * @return Java 8 CompletableFuture
+	 */
+	public static <T> java.util.concurrent.CompletableFuture<T> toJava(scala.concurrent.Future<T> scalaFuture) {
+		final java.util.concurrent.CompletableFuture<T> result = new java.util.concurrent.CompletableFuture<>();
+
+		scalaFuture.onComplete(new OnComplete<T>() {
+			@Override
+			public void onComplete(Throwable failure, T success) throws Throwable {
+				if (failure != null) {
+					result.completeExceptionally(failure);
+				} else {
+					result.complete(success);
+				}
+			}
+		}, Executors.directExecutionContext());
+
+		return result;
+	}
+
+	/**
+	 * Converts a Flink {@link Future} into a {@link CompletableFuture}.
+	 *
+	 * @param flinkFuture to convert to a Java 8 CompletableFuture
+	 * @param <T> type of the future value
+	 * @return Java 8 CompletableFuture
+	 *
+	 * @deprecated Will be removed once we completely remove Flink's futures
+	 */
+	@Deprecated
+	public static <T> java.util.concurrent.CompletableFuture<T> toJava(Future<T> flinkFuture) {
+		final java.util.concurrent.CompletableFuture<T> result = new java.util.concurrent.CompletableFuture<>();
+
+		flinkFuture.handle(
+			(t, throwable) -> {
+				if (throwable != null) {
+					result.completeExceptionally(throwable);
+				} else {
+					result.complete(t);
+				}
+
+				return null;
+			}
+		);
+
+		return result;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Replace Flink's futures in `StackTraceSampleCoordinator` and `BackPressureStatsTracker` with Java 8 `CompletableFuture`.

This PR is based on #4429.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

