### PR TITLE
[FLINK-7317] [futures] Replace Flink's futures with Java 8's CompletableFuture in ExecutionGraph

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinator.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinator.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.webmonitor;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -159,13 +158,12 @@ public class StackTraceSampleCoordinator {
 
 			// Trigger all samples
 			for (Execution execution: executions) {
-				final CompletableFuture<StackTraceSampleResponse> stackTraceSampleFuture = FutureUtils.toJava(
-					execution.requestStackTraceSample(
-						sampleId,
-						numSamples,
-						delayBetweenSamples,
-						maxStackTraceDepth,
-						timeout));
+				final CompletableFuture<StackTraceSampleResponse> stackTraceSampleFuture = execution.requestStackTraceSample(
+					sampleId,
+					numSamples,
+					delayBetweenSamples,
+					maxStackTraceDepth,
+					timeout);
 
 				stackTraceSampleFuture.handleAsync(
 					(StackTraceSampleResponse stackTraceSampleResponse, Throwable throwable) -> {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.webmonitor;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -394,13 +393,16 @@ public class StackTraceSampleCoordinatorTest extends TestLogger {
 			boolean sendSuccess) {
 
 		Execution exec = mock(Execution.class);
+		CompletableFuture<StackTraceSampleResponse> failedFuture = new CompletableFuture<>();
+		failedFuture.completeExceptionally(new Exception("Send failed."));
+
 		when(exec.getAttemptId()).thenReturn(executionId);
 		when(exec.getState()).thenReturn(state);
 		when(exec.requestStackTraceSample(anyInt(), anyInt(), any(Time.class), anyInt(), any(Time.class)))
 			.thenReturn(
 				sendSuccess ?
-					FlinkCompletableFuture.completed(mock(StackTraceSampleResponse.class)) :
-					FlinkCompletableFuture.completedExceptionally(new Exception("Send failed")));
+					CompletableFuture.completedFuture(mock(StackTraceSampleResponse.class)) :
+					failedFuture);
 
 		ExecutionVertex vertex = mock(ExecutionVertex.class);
 		when(vertex.getJobvertexId()).thenReturn(new JobVertexID());
@@ -415,7 +417,7 @@ public class StackTraceSampleCoordinatorTest extends TestLogger {
 		ScheduledExecutorService scheduledExecutorService,
 		int timeout) {
 
-		final FlinkCompletableFuture<StackTraceSampleResponse> future = new FlinkCompletableFuture<>();
+		final CompletableFuture<StackTraceSampleResponse> future = new CompletableFuture<>();
 
 		Execution exec = mock(Execution.class);
 		when(exec.getAttemptId()).thenReturn(executionId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -25,12 +25,7 @@ import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.concurrent.ApplyFunction;
-import org.apache.flink.runtime.concurrent.BiFunction;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.concurrent.FutureUtils;
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
-import org.apache.flink.runtime.concurrent.impl.FlinkFuture;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.PartialInputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionLocation;
@@ -56,7 +51,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
@@ -129,7 +124,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	private final ConcurrentLinkedQueue<PartialInputChannelDeploymentDescriptor> partialInputChannelDeploymentDescriptors;
 
 	/** A future that completes once the Execution reaches a terminal ExecutionState */
-	private final FlinkCompletableFuture<ExecutionState> terminationFuture;
+	private final CompletableFuture<ExecutionState> terminationFuture;
 
 	private volatile ExecutionState state = CREATED;
 
@@ -189,7 +184,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		markTimestamp(ExecutionState.CREATED, startTimestamp);
 
 		this.partialInputChannelDeploymentDescriptors = new ConcurrentLinkedQueue<>();
-		this.terminationFuture = new FlinkCompletableFuture<>();
+		this.terminationFuture = new CompletableFuture<>();
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -279,7 +274,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 *
 	 * @return A future for the execution's termination
 	 */
-	public Future<ExecutionState> getTerminationFuture() {
+	public CompletableFuture<ExecutionState> getTerminationFuture() {
 		return terminationFuture;
 	}
 
@@ -306,14 +301,13 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 */
 	public boolean scheduleForExecution(SlotProvider slotProvider, boolean queued) {
 		try {
-			final Future<SimpleSlot> slotAllocationFuture = allocateSlotForExecution(slotProvider, queued);
+			final CompletableFuture<SimpleSlot> slotAllocationFuture = allocateSlotForExecution(slotProvider, queued);
 
 			// IMPORTANT: We have to use the synchronous handle operation (direct executor) here so
 			// that we directly deploy the tasks if the slot allocation future is completed. This is
 			// necessary for immediate deployment.
-			final Future<Void> deploymentFuture = slotAllocationFuture.handle(new BiFunction<SimpleSlot, Throwable, Void>() {
-				@Override
-				public Void apply(SimpleSlot simpleSlot, Throwable throwable) {
+			final CompletableFuture<Void> deploymentFuture = slotAllocationFuture.handle(
+				(simpleSlot, throwable) ->  {
 					if (simpleSlot != null) {
 						try {
 							deployToSlot(simpleSlot);
@@ -330,7 +324,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 					}
 					return null;
 				}
-			});
+			);
 
 			// if tasks have to scheduled immediately check that the task has been deployed
 			if (!queued && !deploymentFuture.isDone()) {
@@ -344,7 +338,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		}
 	}
 
-	public Future<SimpleSlot> allocateSlotForExecution(SlotProvider slotProvider, boolean queued) 
+	public CompletableFuture<SimpleSlot> allocateSlotForExecution(SlotProvider slotProvider, boolean queued)
 			throws IllegalExecutionStateException {
 
 		checkNotNull(slotProvider);
@@ -365,7 +359,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 					new ScheduledUnit(this, sharingGroup) :
 					new ScheduledUnit(this, sharingGroup, locationConstraint);
 
-			return slotProvider.allocateSlot(toSchedule, queued);
+			return FutureUtils.toJava(slotProvider.allocateSlot(toSchedule, queued));
 		}
 		else {
 			// call race, already deployed, or already done
@@ -424,24 +418,25 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 			final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
 
-			final Future<Acknowledge> submitResultFuture = taskManagerGateway.submitTask(deployment, timeout);
+			final CompletableFuture<Acknowledge> submitResultFuture = FutureUtils.toJava(
+				taskManagerGateway.submitTask(deployment, timeout));
 
-			submitResultFuture.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
-				@Override
-				public Void apply(Throwable failure) {
-					if (failure instanceof TimeoutException) {
-						String taskname = vertex.getTaskNameWithSubtaskIndex()+ " (" + attemptId + ')';
+			submitResultFuture.whenCompleteAsync(
+				(ack, failure) -> {
+					// only respond to the failure case
+					if (failure != null) {
+						if (failure instanceof TimeoutException) {
+							String taskname = vertex.getTaskNameWithSubtaskIndex() + " (" + attemptId + ')';
 
-						markFailed(new Exception(
-							"Cannot deploy task " + taskname + " - TaskManager (" + getAssignedResourceLocation()
-								+ ") not responding after a timeout of " + timeout, failure));
+							markFailed(new Exception(
+								"Cannot deploy task " + taskname + " - TaskManager (" + getAssignedResourceLocation()
+									+ ") not responding after a timeout of " + timeout, failure));
+						} else {
+							markFailed(failure);
+						}
 					}
-					else {
-						markFailed(failure);
-					}
-					return null;
-				}
-			}, executor);
+				},
+				executor);
 		}
 		catch (Throwable t) {
 			markFailed(t);
@@ -458,24 +453,16 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		if (slot != null) {
 			final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
 
-			Future<Acknowledge> stopResultFuture = FutureUtils.retry(
-				new Callable<Future<Acknowledge>>() {
-
-					@Override
-					public Future<Acknowledge> call() throws Exception {
-						return taskManagerGateway.stopTask(attemptId, timeout);
-					}
-				},
+			CompletableFuture<Acknowledge> stopResultFuture = FutureUtils.retry(
+				() -> FutureUtils.toJava(taskManagerGateway.stopTask(attemptId, timeout)),
 				NUM_STOP_CALL_TRIES,
 				executor);
 
-			stopResultFuture.exceptionally(new ApplyFunction<Throwable, Void>() {
-				@Override
-				public Void apply(Throwable failure) {
+			stopResultFuture.exceptionally(
+				failure -> {
 					LOG.info("Stopping task was not successful.", failure);
 					return null;
-				}
-			});
+				});
 		}
 	}
 
@@ -575,9 +562,8 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 				// TODO The current approach may send many update messages even though the consuming
 				// task has already been deployed with all necessary information. We have to check
 				// whether this is a problem and fix it, if it is.
-				FlinkFuture.supplyAsync(new Callable<Void>(){
-					@Override
-					public Void call() throws Exception {
+				CompletableFuture.supplyAsync(
+					() -> {
 						try {
 							consumerVertex.scheduleForExecution(
 									consumerVertex.getExecutionGraph().getSlotProvider(),
@@ -588,8 +574,8 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 						}
 
 						return null;
-					}
-				}, executor);
+					},
+					executor);
 
 				// double check to resolve race conditions
 				if(consumerVertex.getExecutionState() == RUNNING){
@@ -681,7 +667,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 * @param timeout until the request times out
 	 * @return Future stack trace sample response
 	 */
-	public Future<StackTraceSampleResponse> requestStackTraceSample(
+	public CompletableFuture<StackTraceSampleResponse> requestStackTraceSample(
 			int sampleId,
 			int numSamples,
 			Time delayBetweenSamples,
@@ -693,15 +679,19 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		if (slot != null) {
 			final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
 
-			return taskManagerGateway.requestStackTraceSample(
-				attemptId,
-				sampleId,
-				numSamples,
-				delayBetweenSamples,
-				maxStrackTraceDepth,
-				timeout);
+			return FutureUtils.toJava(
+				taskManagerGateway.requestStackTraceSample(
+					attemptId,
+					sampleId,
+					numSamples,
+					delayBetweenSamples,
+					maxStrackTraceDepth,
+					timeout));
 		} else {
-			return FlinkCompletableFuture.completedExceptionally(new Exception("The execution has no slot assigned."));
+			CompletableFuture<StackTraceSampleResponse> result = new CompletableFuture<>();
+			result.completeExceptionally(new Exception("The execution has no slot assigned."));
+
+			return result;
 		}
 	}
 
@@ -1023,23 +1013,18 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 		if (slot != null) {
 			final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
 
-			Future<Acknowledge> cancelResultFuture = FutureUtils.retry(
-				new Callable<Future<Acknowledge>>() {
-					@Override
-					public Future<Acknowledge> call() throws Exception {
-						return taskManagerGateway.cancelTask(attemptId, timeout);
-					}
-				},
+			CompletableFuture<Acknowledge> cancelResultFuture = FutureUtils.retry(
+				() -> FutureUtils.toJava(taskManagerGateway.cancelTask(attemptId, timeout)),
 				NUM_CANCEL_CALL_TRIES,
 				executor);
 
-			cancelResultFuture.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
-				@Override
-				public Void apply(Throwable failure) {
-					fail(new Exception("Task could not be canceled.", failure));
-					return null;
-				}
-			}, executor);
+			cancelResultFuture.whenCompleteAsync(
+				(ack, failure) -> {
+					if (failure != null) {
+						fail(new Exception("Task could not be canceled.", failure));
+					}
+				},
+				executor);
 		}
 	}
 
@@ -1068,16 +1053,17 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 			final TaskManagerGateway taskManagerGateway = slot.getTaskManagerGateway();
 			final TaskManagerLocation taskManagerLocation = slot.getTaskManagerLocation();
 
-			Future<Acknowledge> updatePartitionsResultFuture = taskManagerGateway.updatePartitions(attemptId, partitionInfos, timeout);
+			CompletableFuture<Acknowledge> updatePartitionsResultFuture = FutureUtils.toJava(
+				taskManagerGateway.updatePartitions(attemptId, partitionInfos, timeout));
 
-			updatePartitionsResultFuture.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
-				@Override
-				public Void apply(Throwable failure) {
-					fail(new IllegalStateException("Update task on TaskManager " + taskManagerLocation +
-						" failed due to:", failure));
-					return null;
-				}
-			}, executor);
+			updatePartitionsResultFuture.whenCompleteAsync(
+				(ack, failure) -> {
+					// fail if there was a failure
+					if (failure != null) {
+						fail(new IllegalStateException("Update task on TaskManager " + taskManagerLocation +
+							" failed due to:", failure));
+					}
+				}, executor);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionAndSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionAndSlot.java
@@ -18,8 +18,9 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.instance.SimpleSlot;
+
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -30,9 +31,9 @@ public class ExecutionAndSlot {
 
 	public final Execution executionAttempt;
 
-	public final Future<SimpleSlot> slotFuture;
+	public final CompletableFuture<SimpleSlot> slotFuture;
 
-	public ExecutionAndSlot(Execution executionAttempt, Future<SimpleSlot> slotFuture) {
+	public ExecutionAndSlot(Execution executionAttempt, CompletableFuture<SimpleSlot> slotFuture) {
 		this.executionAttempt = checkNotNull(executionAttempt);
 		this.slotFuture = checkNotNull(slotFuture);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -38,14 +38,9 @@ import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsTracker;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
-import org.apache.flink.runtime.concurrent.AcceptFunction;
-import org.apache.flink.runtime.concurrent.BiFunction;
-import org.apache.flink.runtime.concurrent.CompletableFuture;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.FutureUtils.ConjunctFuture;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.SuppressRestartsException;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
@@ -91,6 +86,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
@@ -793,7 +790,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 			newExecJobVertices.add(ejv);
 		}
 
-		terminationFuture = new FlinkCompletableFuture<>();
+		terminationFuture = new CompletableFuture<>();
 		failoverStrategy.notifyNewVertices(newExecJobVertices);
 	}
 
@@ -852,7 +849,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 
 		try {
 			// collecting all the slots may resize and fail in that operation without slots getting lost
-			final ArrayList<Future<SimpleSlot>> slotFutures = new ArrayList<>(getNumberOfExecutionJobVertices());
+			final ArrayList<CompletableFuture<SimpleSlot>> slotFutures = new ArrayList<>(getNumberOfExecutionJobVertices());
 
 			// allocate the slots (obtain all their futures
 			for (ExecutionJobVertex ejv : getVerticesTopologically()) {
@@ -887,10 +884,8 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 			}, timeout.getSize(), timeout.getUnit());
 
 
-			allAllocationsComplete.handleAsync(new BiFunction<Void, Throwable, Void>() {
-
-				@Override
-				public Void apply(Void slots, Throwable throwable) {
+			allAllocationsComplete.handleAsync(
+				(Void slots, Throwable throwable) -> {
 					try {
 						// we do not need the cancellation timeout any more
 						timeoutCancelHandle.cancel(false);
@@ -907,9 +902,9 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 										slot = execAndSlot.slotFuture.getNow(null);
 										checkNotNull(slot);
 									}
-									catch (ExecutionException | NullPointerException e) {
+									catch (CompletionException | NullPointerException e) {
 										throw new IllegalStateException("SlotFuture is incomplete " +
-												"or erroneous even though all futures completed");
+												"or erroneous even though all futures completed", e);
 									}
 
 									// actual deployment
@@ -938,8 +933,8 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 					// Wouldn't it be nice if we could return an actual Void object?
 					// return (Void) Unsafe.getUnsafe().allocateInstance(Void.class);
 					return null; 
-				}
-			}, futureExecutor);
+				},
+				futureExecutor);
 
 			// from now on, slots will be rescued by the the futures and their completion, or by the timeout
 			successful = true;
@@ -964,7 +959,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 					// make sure no concurrent local actions interfere with the cancellation
 					final long globalVersionForRestart = incrementGlobalModVersion();
 
-					final ArrayList<Future<?>> futures = new ArrayList<>(verticesInCreationOrder.size());
+					final ArrayList<CompletableFuture<?>> futures = new ArrayList<>(verticesInCreationOrder.size());
 
 					// cancel all tasks (that still need cancelling)
 					for (ExecutionJobVertex ejv : verticesInCreationOrder) {
@@ -973,14 +968,13 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 
 					// we build a future that is complete once all vertices have reached a terminal state
 					final ConjunctFuture<Void> allTerminal = FutureUtils.waitForAll(futures);
-					allTerminal.thenAccept(new AcceptFunction<Void>() {
-						@Override
-						public void accept(Void value) {
+					allTerminal.thenAccept(
+						(Void value) -> {
 							// cancellations may currently be overridden by failures which trigger
 							// restarts, so we need to pass a proper restart global version here
 							allVerticesInTerminalState(globalVersionForRestart);
 						}
-					});
+					);
 
 					return;
 				}
@@ -1126,7 +1120,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 				final long globalVersionForRestart = incrementGlobalModVersion();
 
 				// we build a future that is complete once all vertices have reached a terminal state
-				final ArrayList<Future<?>> futures = new ArrayList<>(verticesInCreationOrder.size());
+				final ArrayList<CompletableFuture<?>> futures = new ArrayList<>(verticesInCreationOrder.size());
 
 				// cancel all tasks (that still need cancelling)
 				for (ExecutionJobVertex ejv : verticesInCreationOrder) {
@@ -1134,12 +1128,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 				}
 
 				final ConjunctFuture<Void> allTerminal = FutureUtils.waitForAll(futures);
-				allTerminal.thenAccept(new AcceptFunction<Void>() {
-					@Override
-					public void accept(Void value) {
-						allVerticesInTerminalState(globalVersionForRestart);
-					}
-				});
+				allTerminal.thenAccept((Void value) -> allVerticesInTerminalState(globalVersionForRestart));
 
 				return;
 			}
@@ -1250,7 +1239,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	}
 
 	@VisibleForTesting
-	public Future<JobStatus> getTerminationFuture() {
+	public CompletableFuture<JobStatus> getTerminationFuture() {
 		return terminationFuture;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphUtils.java
@@ -19,11 +19,11 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.runtime.concurrent.BiFunction;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.util.ExceptionUtils;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Utilities for dealing with the execution graphs and scheduling.
@@ -40,8 +40,8 @@ public class ExecutionGraphUtils {
 	 * 
 	 * @param slotFuture The future for the slot to release.
 	 */
-	public static void releaseSlotFuture(Future<SimpleSlot> slotFuture) {
-		slotFuture.handle(ReleaseSlotFunction.INSTANCE);
+	public static void releaseSlotFuture(CompletableFuture<SimpleSlot> slotFuture) {
+		slotFuture.handle(ReleaseSlotFunction.INSTANCE::apply);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.Archiveable;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.JobException;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.PartialInputChannelDeploymentDescriptor;
@@ -61,6 +60,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.runtime.execution.ExecutionState.FINISHED;
 
@@ -604,7 +604,7 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	 *  
 	 * @return A future that completes once the execution has reached its final state.
 	 */
-	public Future<ExecutionState> cancel() {
+	public CompletableFuture<ExecutionState> cancel() {
 		// to avoid any case of mixup in the presence of concurrent calls,
 		// we copy a reference to the stack to make sure both calls go to the same Execution 
 		final Execution exec = this.currentExecution;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/RestartIndividualStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/RestartIndividualStrategy.java
@@ -20,8 +20,6 @@ package org.apache.flink.runtime.executiongraph.failover;
 
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
-import org.apache.flink.runtime.concurrent.AcceptFunction;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
@@ -36,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -107,14 +106,13 @@ public class RestartIndividualStrategy extends FailoverStrategy {
 		// Note: currently all tasks passed here are already in their terminal state,
 		//       so we could actually avoid the future. We use it anyways because it is cheap and
 		//       it helps to support better testing
-		final Future<ExecutionState> terminationFuture = taskExecution.getTerminationFuture();
+		final CompletableFuture<ExecutionState> terminationFuture = taskExecution.getTerminationFuture();
 
 		final ExecutionVertex vertexToRecover = taskExecution.getVertex(); 
 		final long globalModVersion = taskExecution.getGlobalModVersion();
 
-		terminationFuture.thenAcceptAsync(new AcceptFunction<ExecutionState>() {
-			@Override
-			public void accept(ExecutionState value) {
+		terminationFuture.thenAcceptAsync(
+			(ExecutionState value) -> {
 				try {
 					long createTimestamp = System.currentTimeMillis();
 					Execution newExecution = vertexToRecover.resetForNewExecution(createTimestamp, globalModVersion);
@@ -127,8 +125,8 @@ public class RestartIndividualStrategy extends FailoverStrategy {
 					executionGraph.failGlobal(
 							new Exception("Error during fine grained recovery - triggering full recovery", e));
 				}
-			}
-		}, callbackExecutor);
+			},
+			callbackExecutor);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.concurrent;
 
 import org.apache.flink.runtime.concurrent.FutureUtils.ConjunctFuture;
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 
 import org.apache.flink.util.TestLogger;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
@@ -31,6 +30,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.*;
@@ -58,9 +58,9 @@ public class FutureUtilsTest extends TestLogger{
 
 		try {
 			futureFactory.createFuture(Arrays.asList(
-					new FlinkCompletableFuture<Object>(),
+					new CompletableFuture<>(),
 					null,
-					new FlinkCompletableFuture<Object>()));
+					new CompletableFuture<>()));
 			fail();
 		} catch (NullPointerException ignored) {}
 	}
@@ -68,10 +68,10 @@ public class FutureUtilsTest extends TestLogger{
 	@Test
 	public void testConjunctFutureCompletion() throws Exception {
 		// some futures that we combine
-		CompletableFuture<Object> future1 = new FlinkCompletableFuture<>();
-		CompletableFuture<Object> future2 = new FlinkCompletableFuture<>();
-		CompletableFuture<Object> future3 = new FlinkCompletableFuture<>();
-		CompletableFuture<Object> future4 = new FlinkCompletableFuture<>();
+		java.util.concurrent.CompletableFuture<Object> future1 = new java.util.concurrent.CompletableFuture<>();
+		java.util.concurrent.CompletableFuture<Object> future2 = new java.util.concurrent.CompletableFuture<>();
+		java.util.concurrent.CompletableFuture<Object> future3 = new java.util.concurrent.CompletableFuture<>();
+		java.util.concurrent.CompletableFuture<Object> future4 = new java.util.concurrent.CompletableFuture<>();
 
 		// some future is initially completed
 		future2.complete(new Object());
@@ -79,10 +79,7 @@ public class FutureUtilsTest extends TestLogger{
 		// build the conjunct future
 		ConjunctFuture<?> result = futureFactory.createFuture(Arrays.asList(future1, future2, future3, future4));
 
-		Future<?> resultMapped = result.thenAccept(new AcceptFunction<Object>() {
-			@Override
-			public void accept(Object value) {}
-		});
+		CompletableFuture<?> resultMapped = result.thenAccept(value -> {});
 
 		assertEquals(4, result.getNumFuturesTotal());
 		assertEquals(1, result.getNumFuturesCompleted());
@@ -116,18 +113,15 @@ public class FutureUtilsTest extends TestLogger{
 	@Test
 	public void testConjunctFutureFailureOnFirst() throws Exception {
 
-		CompletableFuture<Object> future1 = new FlinkCompletableFuture<>();
-		CompletableFuture<Object> future2 = new FlinkCompletableFuture<>();
-		CompletableFuture<Object> future3 = new FlinkCompletableFuture<>();
-		CompletableFuture<Object> future4 = new FlinkCompletableFuture<>();
+		java.util.concurrent.CompletableFuture<Object> future1 = new java.util.concurrent.CompletableFuture<>();
+		java.util.concurrent.CompletableFuture<Object> future2 = new java.util.concurrent.CompletableFuture<>();
+		java.util.concurrent.CompletableFuture<Object> future3 = new java.util.concurrent.CompletableFuture<>();
+		java.util.concurrent.CompletableFuture<Object> future4 = new java.util.concurrent.CompletableFuture<>();
 
 		// build the conjunct future
 		ConjunctFuture<?> result = futureFactory.createFuture(Arrays.asList(future1, future2, future3, future4));
 
-		Future<?> resultMapped = result.thenAccept(new AcceptFunction<Object>() {
-			@Override
-			public void accept(Object value) {}
-		});
+		CompletableFuture<?> resultMapped = result.thenAccept(value -> {});
 
 		assertEquals(4, result.getNumFuturesTotal());
 		assertEquals(0, result.getNumFuturesCompleted());
@@ -158,19 +152,16 @@ public class FutureUtilsTest extends TestLogger{
 	@Test
 	public void testConjunctFutureFailureOnSuccessive() throws Exception {
 
-		CompletableFuture<Object> future1 = new FlinkCompletableFuture<>();
-		CompletableFuture<Object> future2 = new FlinkCompletableFuture<>();
-		CompletableFuture<Object> future3 = new FlinkCompletableFuture<>();
-		CompletableFuture<Object> future4 = new FlinkCompletableFuture<>();
+		java.util.concurrent.CompletableFuture<Object> future1 = new java.util.concurrent.CompletableFuture<>();
+		java.util.concurrent.CompletableFuture<Object> future2 = new java.util.concurrent.CompletableFuture<>();
+		java.util.concurrent.CompletableFuture<Object> future3 = new java.util.concurrent.CompletableFuture<>();
+		java.util.concurrent.CompletableFuture<Object> future4 = new java.util.concurrent.CompletableFuture<>();
 
 		// build the conjunct future
 		ConjunctFuture<?> result = futureFactory.createFuture(Arrays.asList(future1, future2, future3, future4));
 		assertEquals(4, result.getNumFuturesTotal());
 
-		Future<?> resultMapped = result.thenAccept(new AcceptFunction<Object>() {
-			@Override
-			public void accept(Object value) {}
-		});
+		java.util.concurrent.CompletableFuture<?> resultMapped = result.thenAccept(value -> {});
 
 		future1.complete(new Object());
 		future3.complete(new Object());
@@ -202,11 +193,11 @@ public class FutureUtilsTest extends TestLogger{
 	 */
 	@Test
 	public void testConjunctFutureValue() throws ExecutionException, InterruptedException {
-		CompletableFuture<Integer> future1 = FlinkCompletableFuture.completed(1);
-		CompletableFuture<Long> future2 = FlinkCompletableFuture.completed(2L);
-		CompletableFuture<Double> future3 = new FlinkCompletableFuture<>();
+		java.util.concurrent.CompletableFuture<Integer> future1 = java.util.concurrent.CompletableFuture.completedFuture(1);
+		java.util.concurrent.CompletableFuture<Long> future2 = java.util.concurrent.CompletableFuture.completedFuture(2L);
+		java.util.concurrent.CompletableFuture<Double> future3 = new java.util.concurrent.CompletableFuture<>();
 
-		ConjunctFuture<Collection<Number>> result = FutureUtils.<Number>combineAll(Arrays.asList(future1, future2, future3));
+		ConjunctFuture<Collection<Number>> result = FutureUtils.combineAll(Arrays.asList(future1, future2, future3));
 
 		assertFalse(result.isDone());
 
@@ -219,7 +210,7 @@ public class FutureUtilsTest extends TestLogger{
 
 	@Test
 	public void testConjunctOfNone() throws Exception {
-		final ConjunctFuture<?> result = futureFactory.createFuture(Collections.<Future<Object>>emptyList());
+		final ConjunctFuture<?> result = futureFactory.createFuture(Collections.<java.util.concurrent.CompletableFuture<Object>>emptyList());
 
 		assertEquals(0, result.getNumFuturesTotal());
 		assertEquals(0, result.getNumFuturesCompleted());
@@ -230,13 +221,13 @@ public class FutureUtilsTest extends TestLogger{
 	 * Factory to create {@link ConjunctFuture} for testing.
 	 */
 	private interface FutureFactory {
-		ConjunctFuture<?> createFuture(Collection<? extends Future<?>> futures);
+		ConjunctFuture<?> createFuture(Collection<? extends java.util.concurrent.CompletableFuture<?>> futures);
 	}
 
 	private static class ConjunctFutureFactory implements FutureFactory {
 
 		@Override
-		public ConjunctFuture<?> createFuture(Collection<? extends Future<?>> futures) {
+		public ConjunctFuture<?> createFuture(Collection<? extends java.util.concurrent.CompletableFuture<?>> futures) {
 			return FutureUtils.combineAll(futures);
 		}
 	}
@@ -244,7 +235,7 @@ public class FutureUtilsTest extends TestLogger{
 	private static class WaitingFutureFactory implements FutureFactory {
 
 		@Override
-		public ConjunctFuture<?> createFuture(Collection<? extends Future<?>> futures) {
+		public ConjunctFuture<?> createFuture(Collection<? extends java.util.concurrent.CompletableFuture<?>> futures) {
 			return FutureUtils.waitForAll(futures);
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphUtilsTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.jobmanager.slots.AllocatedSlot;
 import org.apache.flink.runtime.jobmanager.slots.SlotOwner;
@@ -34,6 +33,7 @@ import org.junit.Test;
 import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.Mockito.*;
 
@@ -51,12 +51,12 @@ public class ExecutionGraphUtilsTest {
 		final SimpleSlot slot2 = new SimpleSlot(createAllocatedSlot(jid, 1), owner, 1);
 		final SimpleSlot slot3 = new SimpleSlot(createAllocatedSlot(jid, 2), owner, 2);
 
-		final FlinkCompletableFuture<SimpleSlot> incompleteFuture = new FlinkCompletableFuture<>();
+		final CompletableFuture<SimpleSlot> incompleteFuture = new CompletableFuture<>();
 
-		final FlinkCompletableFuture<SimpleSlot> completeFuture = new FlinkCompletableFuture<>();
+		final CompletableFuture<SimpleSlot> completeFuture = new CompletableFuture<>();
 		completeFuture.complete(slot2);
 
-		final FlinkCompletableFuture<SimpleSlot> disposedSlotFuture = new FlinkCompletableFuture<>();
+		final CompletableFuture<SimpleSlot> disposedSlotFuture = new CompletableFuture<>();
 		slot3.releaseSlot();
 		disposedSlotFuture.complete(slot3);
 
@@ -89,16 +89,16 @@ public class ExecutionGraphUtilsTest {
 
 		ExecutionAndSlot[] slots1 = new ExecutionAndSlot[] {
 				null,
-				new ExecutionAndSlot(mockExecution, FlinkCompletableFuture.completed(slot1)),
+				new ExecutionAndSlot(mockExecution, CompletableFuture.completedFuture(slot1)),
 				null,
-				new ExecutionAndSlot(mockExecution, FlinkCompletableFuture.completed(slot2)),
+				new ExecutionAndSlot(mockExecution, CompletableFuture.completedFuture(slot2)),
 				null
 		};
 
 		ExecutionAndSlot[] slots2 = new ExecutionAndSlot[] {
-				new ExecutionAndSlot(mockExecution, FlinkCompletableFuture.completed(slot3)),
-				new ExecutionAndSlot(mockExecution, FlinkCompletableFuture.completed(slot4)),
-				new ExecutionAndSlot(mockExecution, FlinkCompletableFuture.completed(slot5))
+				new ExecutionAndSlot(mockExecution, CompletableFuture.completedFuture(slot3)),
+				new ExecutionAndSlot(mockExecution, CompletableFuture.completedFuture(slot4)),
+				new ExecutionAndSlot(mockExecution, CompletableFuture.completedFuture(slot5))
 		};
 
 		List<ExecutionAndSlot[]> resources = Arrays.asList(null, slots1, new ExecutionAndSlot[0], null, slots2);


### PR DESCRIPTION
## What is the purpose of the change

Replace Flink's `Futures` with Java 8's `CompletableFuture` in `ExecutionGraph`

This PR is based #4429, #4431, #4432, #4430.

## Brief change log

  - Use `CompletableFuture` in `ExecutionGraph`
  - Change `FutureUtils#retry` to work with `CompletableFuture`
  - Let `ConjunctFuture` extend from `CompletableFuture`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)

