### PR TITLE
[FLINK-7321] [futures] Replace Flink's futures with Java 8's CompletableFuture in HeartbeatManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatListener.java
@@ -19,7 +19,8 @@
 package org.apache.flink.runtime.heartbeat;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.concurrent.Future;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Interface for the interaction with the {@link HeartbeatManager}. The heartbeat listener is used
@@ -58,5 +59,5 @@ public interface HeartbeatListener<I, O> {
 	 *
 	 * @return Future containing the next payload for heartbeats
 	 */
-	Future<O> retrievePayload();
+	CompletableFuture<O> retrievePayload();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
@@ -19,13 +19,11 @@
 package org.apache.flink.runtime.heartbeat;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.concurrent.AcceptFunction;
-import org.apache.flink.runtime.concurrent.ApplyFunction;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 
 import org.slf4j.Logger;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -65,25 +63,20 @@ public class HeartbeatManagerSenderImpl<I, O> extends HeartbeatManagerImpl<I, O>
 		if (!stopped) {
 			log.debug("Trigger heartbeat request.");
 			for (HeartbeatMonitor<O> heartbeatMonitor : getHeartbeatTargets()) {
-				Future<O> futurePayload = getHeartbeatListener().retrievePayload();
+				CompletableFuture<O> futurePayload = getHeartbeatListener().retrievePayload();
 				final HeartbeatTarget<O> heartbeatTarget = heartbeatMonitor.getHeartbeatTarget();
 
 				if (futurePayload != null) {
-					Future<Void> requestHeartbeatFuture = futurePayload.thenAcceptAsync(new AcceptFunction<O>() {
-						@Override
-						public void accept(O payload) {
-							heartbeatTarget.requestHeartbeat(getOwnResourceID(), payload);
-						}
-					}, getExecutor());
+					CompletableFuture<Void> requestHeartbeatFuture = futurePayload.thenAcceptAsync(
+						payload -> heartbeatTarget.requestHeartbeat(getOwnResourceID(), payload),
+						getExecutor());
 
-					requestHeartbeatFuture.exceptionally(new ApplyFunction<Throwable, Void>() {
-						@Override
-						public Void apply(Throwable failure) {
+					requestHeartbeatFuture.exceptionally(
+						(Throwable failure) -> {
 							log.warn("Could not request the heartbeat from target {}.", heartbeatTarget, failure);
 
 							return null;
-						}
-					});
+						});
 				} else {
 					heartbeatTarget.requestHeartbeat(getOwnResourceID(), null);
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -106,6 +106,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
@@ -1123,8 +1124,8 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 		}
 
 		@Override
-		public Future<Void> retrievePayload() {
-			return FlinkCompletableFuture.completed(null);
+		public CompletableFuture<Void> retrievePayload() {
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 
@@ -1150,8 +1151,8 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 		}
 
 		@Override
-		public Future<Void> retrievePayload() {
-			return FlinkCompletableFuture.completed(null);
+		public CompletableFuture<Void> retrievePayload() {
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -67,6 +67,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeoutException;
@@ -999,8 +1000,8 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 		}
 
 		@Override
-		public Future<Void> retrievePayload() {
-			return FlinkCompletableFuture.completed(null);
+		public CompletableFuture<Void> retrievePayload() {
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 
@@ -1032,8 +1033,8 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 		}
 
 		@Override
-		public Future<Void> retrievePayload() {
-			return FlinkCompletableFuture.completed(null);
+		public CompletableFuture<Void> retrievePayload() {
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
@@ -19,11 +19,8 @@
 package org.apache.flink.runtime.heartbeat;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.concurrent.CompletableFuture;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.util.DirectExecutorService;
 import org.apache.flink.util.TestLogger;
 
@@ -31,6 +28,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -72,7 +70,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 		Object expectedObject = new Object();
 
-		when(heartbeatListener.retrievePayload()).thenReturn(FlinkCompletableFuture.completed(expectedObject));
+		when(heartbeatListener.retrievePayload()).thenReturn(CompletableFuture.completedFuture(expectedObject));
 
 		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
@@ -113,7 +111,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 		Object expectedObject = new Object();
 
-		when(heartbeatListener.retrievePayload()).thenReturn(FlinkCompletableFuture.completed(expectedObject));
+		when(heartbeatListener.retrievePayload()).thenReturn(CompletableFuture.completedFuture(expectedObject));
 
 		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
@@ -165,7 +163,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 		HeartbeatTarget<Object> heartbeatTarget = mock(HeartbeatTarget.class);
 
-		Future<ResourceID> timeoutFuture = heartbeatListener.getTimeoutFuture();
+		CompletableFuture<ResourceID> timeoutFuture = heartbeatListener.getTimeoutFuture();
 
 		heartbeatManager.monitorTarget(targetResourceID, heartbeatTarget);
 
@@ -199,11 +197,11 @@ public class HeartbeatManagerTest extends TestLogger {
 		ResourceID resourceID2 = new ResourceID("barfoo");
 		HeartbeatListener<Object, Object> heartbeatListener = mock(HeartbeatListener.class);
 
-		when(heartbeatListener.retrievePayload()).thenReturn(FlinkCompletableFuture.completed(object));
+		when(heartbeatListener.retrievePayload()).thenReturn(CompletableFuture.completedFuture(object));
 
 		TestingHeartbeatListener heartbeatListener2 = new TestingHeartbeatListener(object2);
 
-		Future<ResourceID> futureTimeout = heartbeatListener2.getTimeoutFuture();
+		CompletableFuture<ResourceID> futureTimeout = heartbeatListener2.getTimeoutFuture();
 
 		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
@@ -266,7 +264,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 		heartbeatManager.unmonitorTarget(targetID);
 
-		Future<ResourceID> timeout = heartbeatListener.getTimeoutFuture();
+		CompletableFuture<ResourceID> timeout = heartbeatListener.getTimeoutFuture();
 
 		try {
 			timeout.get(2 * heartbeatTimeout, TimeUnit.MILLISECONDS);
@@ -278,7 +276,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 	static class TestingHeartbeatListener implements HeartbeatListener<Object, Object> {
 
-		private final CompletableFuture<ResourceID> future = new FlinkCompletableFuture<>();
+		private final CompletableFuture<ResourceID> future = new CompletableFuture<>();
 
 		private final Object payload;
 
@@ -288,7 +286,11 @@ public class HeartbeatManagerTest extends TestLogger {
 			this.payload = payload;
 		}
 
-		public Future<ResourceID> getTimeoutFuture() {
+		public CompletableFuture<ResourceID> getFuture() {
+			return future;
+		}
+
+		CompletableFuture<ResourceID> getTimeoutFuture() {
 			return future;
 		}
 
@@ -307,8 +309,8 @@ public class HeartbeatManagerTest extends TestLogger {
 		}
 
 		@Override
-		public Future<Object> retrievePayload() {
-			return FlinkCompletableFuture.completed(payload);
+		public CompletableFuture<Object> retrievePayload() {
+			return CompletableFuture.completedFuture(payload);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
@@ -286,10 +286,6 @@ public class HeartbeatManagerTest extends TestLogger {
 			this.payload = payload;
 		}
 
-		public CompletableFuture<ResourceID> getFuture() {
-			return future;
-		}
-
 		CompletableFuture<ResourceID> getTimeoutFuture() {
 			return future;
 		}


### PR DESCRIPTION
## What is the purpose of the change

Replace Flink's futures with Java 8's CompletableFuture in HeartbeatManager.

This PR is based on #4429.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

