### PR TITLE
[FLINK-7320] [futures] Replace Flink's futures with Java 8's CompletableFuture in Scheduler

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinator.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.webmonitor;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -125,18 +126,14 @@ public class StackTraceSampleCoordinator {
 				executions[i] = execution;
 				triggerIds[i] = execution.getAttemptId();
 			} else {
-				CompletableFuture<StackTraceSample> result = new CompletableFuture();
-				result.completeExceptionally(new IllegalStateException("Task " + tasksToSample[i]
+				return FutureUtils.completedExceptionally(new IllegalStateException("Task " + tasksToSample[i]
 					.getTaskNameWithSubtaskIndex() + " is not running."));
-				return result;
 			}
 		}
 
 		synchronized (lock) {
 			if (isShutDown) {
-				CompletableFuture<StackTraceSample> result = new CompletableFuture();
-				result.completeExceptionally(new IllegalStateException("Shut down"));
-				return result;
+				return FutureUtils.completedExceptionally(new IllegalStateException("Shut down"));
 			}
 
 			final int sampleId = sampleIdCounter++;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.runtime.checkpoint.hooks.MasterHooks;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointLoader;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointStore;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -381,9 +382,7 @@ public class CheckpointCoordinator {
 			result = triggerResult.getPendingCheckpoint().getCompletionFuture();
 		} else {
 			Throwable cause = new Exception("Failed to trigger savepoint: " + triggerResult.getFailureReason().message());
-			result = new CompletableFuture<>();
-			result.completeExceptionally(cause);
-			return result;
+			return FutureUtils.completedExceptionally(cause);
 		}
 
 		// Make sure to remove the created base directory on Exceptions
@@ -439,9 +438,7 @@ public class CheckpointCoordinator {
 					return triggerResult.getPendingCheckpoint().getCompletionFuture();
 				} else {
 					Throwable cause = new Exception("Failed to trigger checkpoint: " + triggerResult.getFailureReason().message());
-					CompletableFuture<CompletedCheckpoint> failedResult = new CompletableFuture<>();
-					failedResult.completeExceptionally(cause);
-					return failedResult;
+					return FutureUtils.completedExceptionally(cause);
 				}
 
 			default:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -60,9 +60,7 @@ public class FutureUtils {
 		try {
 			operationResultFuture = operation.call();
 		} catch (Exception e) {
-			java.util.concurrent.CompletableFuture<T> exceptionResult = new java.util.concurrent.CompletableFuture<>();
-			exceptionResult.completeExceptionally(new RetryException("Could not execute the provided operation.", e));
-			return exceptionResult;
+			return FutureUtils.completedExceptionally(new RetryException("Could not execute the provided operation.", e));
 		}
 
 		return operationResultFuture.handleAsync(
@@ -71,10 +69,8 @@ public class FutureUtils {
 					if (retries > 0) {
 						return retry(operation, retries - 1, executor);
 					} else {
-						java.util.concurrent.CompletableFuture<T> exceptionResult = new java.util.concurrent.CompletableFuture<>();
-						exceptionResult.completeExceptionally(new RetryException("Could not complete the operation. Number of retries " +
+						return FutureUtils.<T>completedExceptionally(new RetryException("Could not complete the operation. Number of retries " +
 							"has been exhausted.", throwable));
-						return exceptionResult;
 					}
 				} else {
 					return java.util.concurrent.CompletableFuture.completedFuture(t);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -688,10 +688,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 					maxStrackTraceDepth,
 					timeout));
 		} else {
-			CompletableFuture<StackTraceSampleResponse> result = new CompletableFuture<>();
-			result.completeExceptionally(new Exception("The execution has no slot assigned."));
-
-			return result;
+			return FutureUtils.completedExceptionally(new Exception("The execution has no slot assigned."));
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -359,7 +359,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 					new ScheduledUnit(this, sharingGroup) :
 					new ScheduledUnit(this, sharingGroup, locationConstraint);
 
-			return FutureUtils.toJava(slotProvider.allocateSlot(toSchedule, queued));
+			return slotProvider.allocateSlot(toSchedule, queued);
 		}
 		else {
 			// call race, already deployed, or already done

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotPool.java
@@ -980,11 +980,11 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 		}
 
 		@Override
-		public Future<SimpleSlot> allocateSlot(ScheduledUnit task, boolean allowQueued) {
+		public CompletableFuture<SimpleSlot> allocateSlot(ScheduledUnit task, boolean allowQueued) {
 			Iterable<TaskManagerLocation> locationPreferences = 
 					task.getTaskToExecute().getVertex().getPreferredLocations();
 
-			return gateway.allocateSlot(task, ResourceProfile.UNKNOWN, locationPreferences, timeout);
+			return FutureUtils.toJava(gateway.allocateSlot(task, ResourceProfile.UNKNOWN, locationPreferences, timeout));
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotProvider.java
@@ -18,8 +18,9 @@
 
 package org.apache.flink.runtime.instance;
 
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * The slot provider is responsible for preparing slots for ready-to-run tasks.
@@ -27,7 +28,7 @@ import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
  * <p>It supports two allocating modes:
  * <ul>
  *     <li>Immediate allocating: A request for a task slot immediately gets satisfied, we can call
- *         {@link Future#getNow(Object)} to get the allocated slot.</li>
+ *         {@link CompletableFuture#getNow(Object)} to get the allocated slot.</li>
  *     <li>Queued allocating: A request for a task slot is queued and returns a future that will be
  *         fulfilled as soon as a slot becomes available.</li>
  * </ul>
@@ -41,5 +42,5 @@ public interface SlotProvider {
 	 * @param allowQueued  Whether allow the task be queued if we do not have enough resource
 	 * @return The future of the allocation
 	 */
-	Future<SimpleSlot> allocateSlot(ScheduledUnit task, boolean allowQueued);
+	CompletableFuture<SimpleSlot> allocateSlot(ScheduledUnit task, boolean allowQueued);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.instance.SlotProvider;
 import org.apache.flink.runtime.instance.SlotSharingGroupAssignment;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -150,9 +151,7 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener, Sl
 			}
 		}
 		catch (NoResourceAvailableException e) {
-			CompletableFuture<SimpleSlot> notEnoughResources = new CompletableFuture<>();
-			notEnoughResources.completeExceptionally(e);
-			return notEnoughResources;
+			return FutureUtils.completedExceptionally(e);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -37,9 +38,6 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.concurrent.CompletableFuture;
-import org.apache.flink.runtime.concurrent.Future;
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.instance.SlotProvider;
 import org.apache.flink.runtime.instance.SlotSharingGroupAssignment;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -134,16 +132,16 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener, Sl
 
 
 	@Override
-	public Future<SimpleSlot> allocateSlot(ScheduledUnit task, boolean allowQueued) {
+	public CompletableFuture<SimpleSlot> allocateSlot(ScheduledUnit task, boolean allowQueued) {
 		try {
 			final Object ret = scheduleTask(task, allowQueued);
 
 			if (ret instanceof SimpleSlot) {
-				return FlinkCompletableFuture.completed((SimpleSlot) ret);
+				return CompletableFuture.completedFuture((SimpleSlot) ret);
 			}
-			else if (ret instanceof Future) {
+			else if (ret instanceof CompletableFuture) {
 				@SuppressWarnings("unchecked")
-				Future<SimpleSlot> typed = (Future<SimpleSlot>) ret;
+				CompletableFuture<SimpleSlot> typed = (CompletableFuture<SimpleSlot>) ret;
 				return typed;
 			}
 			else {
@@ -152,12 +150,14 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener, Sl
 			}
 		}
 		catch (NoResourceAvailableException e) {
-			return FlinkCompletableFuture.completedExceptionally(e);
+			CompletableFuture<SimpleSlot> notEnoughResources = new CompletableFuture<>();
+			notEnoughResources.completeExceptionally(e);
+			return notEnoughResources;
 		}
 	}
 
 	/**
-	 * Returns either a {@link SimpleSlot}, or a {@link Future}.
+	 * Returns either a {@link SimpleSlot}, or a {@link CompletableFuture}.
 	 */
 	private Object scheduleTask(ScheduledUnit task, boolean queueIfNoResource) throws NoResourceAvailableException {
 		if (task == null) {
@@ -320,7 +320,7 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener, Sl
 				else {
 					// no resource available now, so queue the request
 					if (queueIfNoResource) {
-						CompletableFuture<SimpleSlot> future = new FlinkCompletableFuture<>();
+						CompletableFuture<SimpleSlot> future = new CompletableFuture<>();
 						this.taskQueue.add(new QueuedTask(task, future));
 						return future;
 					}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphMetricsTest.java
@@ -55,6 +55,7 @@ import org.mockito.Matchers;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -113,7 +114,7 @@ public class ExecutionGraphMetricsTest extends TestLogger {
 			when(simpleSlot.getRoot()).thenReturn(rootSlot);
 			when(simpleSlot.getAllocatedSlot()).thenReturn(mockAllocatedSlot);
 
-			FlinkCompletableFuture<SimpleSlot> future = new FlinkCompletableFuture<>();
+			CompletableFuture<SimpleSlot> future = new CompletableFuture<>();
 			future.complete(simpleSlot);
 			when(scheduler.allocateSlot(any(ScheduledUnit.class), anyBoolean())).thenReturn(future);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
@@ -59,6 +59,7 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -110,8 +111,8 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		final JobID jobId = new JobID();
 		final JobGraph jobGraph = new JobGraph(jobId, "test", sourceVertex, targetVertex);
 
-		final FlinkCompletableFuture<SimpleSlot> sourceFuture = new FlinkCompletableFuture<>();
-		final FlinkCompletableFuture<SimpleSlot> targetFuture = new FlinkCompletableFuture<>();
+		final CompletableFuture<SimpleSlot> sourceFuture = new CompletableFuture<>();
+		final CompletableFuture<SimpleSlot> targetFuture = new CompletableFuture<>();
 
 		ProgrammedSlotProvider slotProvider = new ProgrammedSlotProvider(parallelism);
 		slotProvider.addSlot(sourceVertex.getID(), 0, sourceFuture);
@@ -178,9 +179,9 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		final JobGraph jobGraph = new JobGraph(jobId, "test", sourceVertex, targetVertex);
 
 		@SuppressWarnings({"unchecked", "rawtypes"})
-		final FlinkCompletableFuture<SimpleSlot>[] sourceFutures = new FlinkCompletableFuture[parallelism];
+		final CompletableFuture<SimpleSlot>[] sourceFutures = new CompletableFuture[parallelism];
 		@SuppressWarnings({"unchecked", "rawtypes"})
-		final FlinkCompletableFuture<SimpleSlot>[] targetFutures = new FlinkCompletableFuture[parallelism];
+		final CompletableFuture<SimpleSlot>[] targetFutures = new CompletableFuture[parallelism];
 
 		//
 		//  Create the slots, futures, and the slot provider
@@ -198,8 +199,8 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 			sourceSlots[i] = createSlot(sourceTaskManagers[i], jobId);
 			targetSlots[i] = createSlot(targetTaskManagers[i], jobId);
 
-			sourceFutures[i] = new FlinkCompletableFuture<>();
-			targetFutures[i] = new FlinkCompletableFuture<>();
+			sourceFutures[i] = new CompletableFuture<>();
+			targetFutures[i] = new CompletableFuture<>();
 		}
 
 		ProgrammedSlotProvider slotProvider = new ProgrammedSlotProvider(parallelism);
@@ -284,16 +285,16 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		final SimpleSlot[] targetSlots = new SimpleSlot[parallelism];
 
 		@SuppressWarnings({"unchecked", "rawtypes"})
-		final FlinkCompletableFuture<SimpleSlot>[] sourceFutures = new FlinkCompletableFuture[parallelism];
+		final CompletableFuture<SimpleSlot>[] sourceFutures = new CompletableFuture[parallelism];
 		@SuppressWarnings({"unchecked", "rawtypes"})
-		final FlinkCompletableFuture<SimpleSlot>[] targetFutures = new FlinkCompletableFuture[parallelism];
+		final CompletableFuture<SimpleSlot>[] targetFutures = new CompletableFuture[parallelism];
 
 		for (int i = 0; i < parallelism; i++) {
 			sourceSlots[i] = createSlot(taskManager, jobId, slotOwner);
 			targetSlots[i] = createSlot(taskManager, jobId, slotOwner);
 
-			sourceFutures[i] = new FlinkCompletableFuture<>();
-			targetFutures[i] = new FlinkCompletableFuture<>();
+			sourceFutures[i] = new CompletableFuture<>();
+			targetFutures[i] = new CompletableFuture<>();
 		}
 
 		ProgrammedSlotProvider slotProvider = new ProgrammedSlotProvider(parallelism);
@@ -359,11 +360,11 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		final TaskManagerGateway taskManager = mock(TaskManagerGateway.class);
 		final SimpleSlot[] slots = new SimpleSlot[parallelism];
 		@SuppressWarnings({"unchecked", "rawtypes"})
-		final FlinkCompletableFuture<SimpleSlot>[] slotFutures = new FlinkCompletableFuture[parallelism];
+		final CompletableFuture<SimpleSlot>[] slotFutures = new CompletableFuture[parallelism];
 
 		for (int i = 0; i < parallelism; i++) {
 			slots[i] = createSlot(taskManager, jobId, slotOwner);
-			slotFutures[i] = new FlinkCompletableFuture<>();
+			slotFutures[i] = new CompletableFuture<>();
 		}
 
 		ProgrammedSlotProvider slotProvider = new ProgrammedSlotProvider(parallelism);
@@ -393,7 +394,7 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		//  verify that no deployments have happened
 		verify(taskManager, times(0)).submitTask(any(TaskDeploymentDescriptor.class), any(Time.class));
 
-		for (Future<SimpleSlot> future : slotFutures) {
+		for (CompletableFuture<SimpleSlot> future : slotFutures) {
 			if (future.isDone()) {
 				assertTrue(future.get().isCanceled());
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSchedulingTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
@@ -52,7 +51,6 @@ import org.junit.After;
 import org.junit.Test;
 
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.mockito.verification.Timeout;
 
 import java.net.InetAddress;
@@ -436,17 +434,13 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 			createSlot(taskManager, jobId, recycler)));
 
 		when(slotProvider.allocateSlot(any(ScheduledUnit.class), anyBoolean())).then(
-			new Answer<Future<SimpleSlot>>() {
-
-				@Override
-				public Future<SimpleSlot> answer(InvocationOnMock invocation) {
+			(InvocationOnMock invocation) -> {
 					if (availableSlots.isEmpty()) {
 						throw new TestRuntimeException();
 					} else {
-						return FlinkCompletableFuture.completed(availableSlots.remove(0));
+						return CompletableFuture.completedFuture(availableSlots.remove(0));
 					}
-				}
-			});
+				});
 
 		final ExecutionGraph eg = createExecutionGraph(jobGraph, slotProvider);
 		final ExecutionJobVertex ejv = eg.getJobVertex(vertex.getID());
@@ -514,17 +508,13 @@ public class ExecutionGraphSchedulingTest extends TestLogger {
 		final SlotProvider slotProvider = mock(SlotProvider.class);
 
 		when(slotProvider.allocateSlot(any(ScheduledUnit.class), anyBoolean())).then(
-			new Answer<Future<SimpleSlot>>() {
-
-				@Override
-				public Future<SimpleSlot> answer(InvocationOnMock invocation) {
+			(InvocationOnMock invocation) -> {
 					if (availableSlots.isEmpty()) {
 						throw new TestRuntimeException();
 					} else {
-						return FlinkCompletableFuture.completed(availableSlots.remove(0));
+						return CompletableFuture.completedFuture(availableSlots.remove(0));
 					}
-				}
-			});
+				});
 
 		final ExecutionGraph eg = createExecutionGraph(jobGraph, slotProvider);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.instance.DummyActorGateway;
 import org.apache.flink.runtime.instance.Instance;
@@ -32,6 +31,8 @@ import org.apache.flink.runtime.testingUtils.TestingUtils;
 
 import org.junit.Test;
 import org.mockito.Matchers;
+
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.getExecutionVertex;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.getInstance;
@@ -59,7 +60,7 @@ public class ExecutionVertexSchedulingTest {
 			assertTrue(slot.isReleased());
 
 			Scheduler scheduler = mock(Scheduler.class);
-			FlinkCompletableFuture<SimpleSlot> future = new FlinkCompletableFuture<>();
+			CompletableFuture<SimpleSlot> future = new CompletableFuture<>();
 			future.complete(slot);
 			when(scheduler.allocateSlot(Matchers.any(ScheduledUnit.class), anyBoolean())).thenReturn(future);
 
@@ -90,7 +91,7 @@ public class ExecutionVertexSchedulingTest {
 			slot.releaseSlot();
 			assertTrue(slot.isReleased());
 
-			final FlinkCompletableFuture<SimpleSlot> future = new FlinkCompletableFuture<>();
+			final CompletableFuture<SimpleSlot> future = new CompletableFuture<>();
 
 			Scheduler scheduler = mock(Scheduler.class);
 			when(scheduler.allocateSlot(Matchers.any(ScheduledUnit.class), anyBoolean())).thenReturn(future);
@@ -125,7 +126,7 @@ public class ExecutionVertexSchedulingTest {
 			final SimpleSlot slot = instance.allocateSimpleSlot(ejv.getJobId());
 
 			Scheduler scheduler = mock(Scheduler.class);
-			FlinkCompletableFuture<SimpleSlot> future = new FlinkCompletableFuture<>();
+			CompletableFuture<SimpleSlot> future = new CompletableFuture<>();
 			future.complete(slot);
 			when(scheduler.allocateSlot(Matchers.any(ScheduledUnit.class), anyBoolean())).thenReturn(future);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleSlotProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleSlotProvider.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.instance.Slot;
 import org.apache.flink.runtime.instance.SlotProvider;
@@ -85,9 +86,7 @@ public class SimpleSlotProvider implements SlotProvider, SlotOwner {
 			return CompletableFuture.completedFuture(result);
 		}
 		else {
-			CompletableFuture<SimpleSlot> failed = new CompletableFuture<>();
-			failed.completeExceptionally(new NoResourceAvailableException());
-			return failed;
+			return FutureUtils.completedExceptionally(new NoResourceAvailableException());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleSlotProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleSlotProvider.java
@@ -22,8 +22,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.concurrent.Future;
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.instance.Slot;
 import org.apache.flink.runtime.instance.SlotProvider;
@@ -36,6 +34,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 import java.net.InetAddress;
 import java.util.ArrayDeque;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -70,7 +69,7 @@ public class SimpleSlotProvider implements SlotProvider, SlotOwner {
 	}
 
 	@Override
-	public Future<SimpleSlot> allocateSlot(ScheduledUnit task, boolean allowQueued) {
+	public CompletableFuture<SimpleSlot> allocateSlot(ScheduledUnit task, boolean allowQueued) {
 		final AllocatedSlot slot;
 
 		synchronized (slots) {
@@ -83,10 +82,12 @@ public class SimpleSlotProvider implements SlotProvider, SlotOwner {
 
 		if (slot != null) {
 			SimpleSlot result = new SimpleSlot(slot, this, 0);
-			return FlinkCompletableFuture.completed(result);
+			return CompletableFuture.completedFuture(result);
 		}
 		else {
-			return FlinkCompletableFuture.completedExceptionally(new NoResourceAvailableException());
+			CompletableFuture<SimpleSlot> failed = new CompletableFuture<>();
+			failed.completeExceptionally(new NoResourceAvailableException());
+			return failed;
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Replace Flink's futures with Java 8's CompletableFuture in Scheduler.

This PR is based on #4433.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)

