### PR TITLE
[FLINK-7323] [futures] Replace Flink's futures with Java 8's CompletableFuture in MasterHooks

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.java
@@ -19,9 +19,10 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.runtime.concurrent.Future;
 
 import javax.annotation.Nullable;
+
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 /**
@@ -90,7 +91,7 @@ public interface MasterTriggerRestoreHook<T> {
 	 * @throws Exception Exceptions encountered when calling the hook will cause the checkpoint to abort.
 	 */
 	@Nullable
-	Future<T> triggerCheckpoint(long checkpointId, long timestamp, Executor executor) throws Exception;
+	CompletableFuture<T> triggerCheckpoint(long checkpointId, long timestamp, Executor executor) throws Exception;
 
 	/**
 	 * This method is called by the checkpoint coordinator prior to restoring the state of a checkpoint.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/hooks/MasterHooks.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/hooks/MasterHooks.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.checkpoint.MasterState;
 import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 
@@ -36,6 +35,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
@@ -98,7 +98,7 @@ public class MasterHooks {
 		final SimpleVersionedSerializer<T> serializer = typedHook.createCheckpointDataSerializer();
 
 		// call the hook!
-		final Future<T> resultFuture;
+		final CompletableFuture<T> resultFuture;
 		try {
 			resultFuture = typedHook.triggerCheckpoint(checkpointId, timestamp, executor);
 		}
@@ -307,7 +307,7 @@ public class MasterHooks {
 
 		@Nullable
 		@Override
-		public Future<T> triggerCheckpoint(long checkpointId, long timestamp, final Executor executor) throws Exception {
+		public CompletableFuture<T> triggerCheckpoint(long checkpointId, long timestamp, final Executor executor) throws Exception {
 			Executor wrappedExecutor = new Executor() {
 				@Override
 				public void execute(Runnable command) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.Future;
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
@@ -44,6 +43,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTest.mockExecutionVertex;
@@ -140,13 +140,13 @@ public class CheckpointCoordinatorMasterHooksTest {
 		when(statefulHook1.getIdentifier()).thenReturn(id1);
 		when(statefulHook1.createCheckpointDataSerializer()).thenReturn(new StringSerializer());
 		when(statefulHook1.triggerCheckpoint(anyLong(), anyLong(), any(Executor.class)))
-				.thenReturn(FlinkCompletableFuture.completed(state1));
+				.thenReturn(CompletableFuture.completedFuture(state1));
 
 		final MasterTriggerRestoreHook<Long> statefulHook2 = mockGeneric(MasterTriggerRestoreHook.class);
 		when(statefulHook2.getIdentifier()).thenReturn(id2);
 		when(statefulHook2.createCheckpointDataSerializer()).thenReturn(new LongSerializer());
 		when(statefulHook2.triggerCheckpoint(anyLong(), anyLong(), any(Executor.class)))
-				.thenReturn(FlinkCompletableFuture.completed(state2));
+				.thenReturn(CompletableFuture.completedFuture(state2));
 
 		final MasterTriggerRestoreHook<Void> statelessHook = mockGeneric(MasterTriggerRestoreHook.class);
 		when(statelessHook.getIdentifier()).thenReturn("some-id");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/hooks/MasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/hooks/MasterHooksTest.java
@@ -20,13 +20,13 @@ package org.apache.flink.runtime.checkpoint.hooks;
 
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import static org.junit.Assert.assertEquals;
@@ -69,7 +69,7 @@ public class MasterHooksTest extends TestLogger {
 
 			@Nullable
 			@Override
-			public Future<String> triggerCheckpoint(long checkpointId, long timestamp, Executor executor) throws Exception {
+			public CompletableFuture<String> triggerCheckpoint(long checkpointId, long timestamp, Executor executor) throws Exception {
 				assertEquals(userClassLoader, Thread.currentThread().getContextClassLoader());
 				executor.execute(command);
 				return null;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/WithMasterCheckpointHookConfigTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/WithMasterCheckpointHookConfigTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
 import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook.Factory;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.streaming.api.checkpoint.WithMasterCheckpointHook;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -36,6 +35,7 @@ import javax.annotation.Nullable;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import static java.util.Arrays.asList;
@@ -115,7 +115,7 @@ public class WithMasterCheckpointHookConfigTest {
 		}
 
 		@Override
-		public Future<String> triggerCheckpoint(long checkpointId, long timestamp, Executor executor) {
+		public CompletableFuture<String> triggerCheckpoint(long checkpointId, long timestamp, Executor executor) {
 			throw new UnsupportedOperationException();
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

Replace Flink's futures with Java 8's CompletableFuture in MasterHooks.

This PR is based on #4429.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes)

