### PR TITLE
[FLINK-7325] [futures] Replace Flink's futures by Java 8's CompletableFuture in MiniCluster

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
@@ -53,6 +52,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.ExceptionUtils.firstOrSuppressed;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -404,7 +404,7 @@ public class MiniCluster {
 
 	public void waitUntilTaskManagerRegistrationsComplete() throws Exception {
 		LeaderRetrievalService rmMasterListener = null;
-		Future<LeaderAddressAndId> addressAndIdFuture;
+		CompletableFuture<LeaderAddressAndId> addressAndIdFuture;
 
 		try {
 			synchronized (lock) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/OneTimeLeaderListenerFuture.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/OneTimeLeaderListenerFuture.java
@@ -18,12 +18,11 @@
 
 package org.apache.flink.runtime.minicluster;
 
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
-import org.apache.flink.runtime.concurrent.impl.FlinkFuture;
 import org.apache.flink.runtime.leaderelection.LeaderAddressAndId;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * A leader listener that exposes a future for the first leader notification.  
@@ -32,17 +31,17 @@ import java.util.UUID;
  */
 public class OneTimeLeaderListenerFuture implements LeaderRetrievalListener {
 
-	private final FlinkCompletableFuture<LeaderAddressAndId> future;
+	private final CompletableFuture<LeaderAddressAndId> future;
 
 	public OneTimeLeaderListenerFuture() {
-		this.future = new FlinkCompletableFuture<>();
+		this.future = new CompletableFuture<>();
 	}
 
 	/**
 	 * Gets the future that is completed with the leader address and ID. 
 	 * @return The future.
 	 */
-	public FlinkFuture<LeaderAddressAndId> future() {
+	public CompletableFuture<LeaderAddressAndId> future() {
 		return future;
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Replace Flink's futures by Java 8's CompletableFuture in MiniCluster.

This PR is based on #4429.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

