### PR TITLE
[FLINK-7331] [futures] Replace Flink's Future with Java 8's CompletableFuture in ResourceManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -290,6 +290,24 @@ public class FutureUtils {
 	}
 
 	// ------------------------------------------------------------------------
+	//  Helper methods
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Returns an exceptionally completed {@link java.util.concurrent.CompletableFuture}.
+	 *
+	 * @param cause to complete the future with
+	 * @param <T> type of the future
+	 * @return An exceptionally completed CompletableFuture
+	 */
+	public static <T>java.util.concurrent.CompletableFuture<T> completedExceptionally(Throwable cause) {
+		java.util.concurrent.CompletableFuture<T> result = new java.util.concurrent.CompletableFuture<>();
+		result.completeExceptionally(cause);
+
+		return result;
+	}
+
+	// ------------------------------------------------------------------------
 	//  Converting futures
 	// ------------------------------------------------------------------------
 


### PR DESCRIPTION
## What is the purpose of the change

Replace Flink's Future with Java 8's CompletableFuture in ResourceManager.

This PR is based on #4443.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

