### PR TITLE
[FLINK-7312][checkstyle] activate checkstyle for flink/core/memory/*

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataInputView.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataInputView.java
@@ -40,7 +40,7 @@ public interface DataInputView extends DataInput {
 	 * @throws IOException Thrown, if any I/O related problem occurred such that the input could not
 	 *                     be advanced to the desired position.
 	 */
-	public void skipBytesToRead(int numBytes) throws IOException;
+	void skipBytesToRead(int numBytes) throws IOException;
 
 	/**
 	 * Reads up to {@code len} bytes of memory and stores it into {@code b} starting at offset {@code off}.
@@ -52,7 +52,7 @@ public interface DataInputView extends DataInput {
 	 * @return the number of actually read bytes of -1 if there is no more data left
 	 * @throws IOException
 	 */
-	public int read(byte[] b, int off, int len) throws IOException;
+	int read(byte[] b, int off, int len) throws IOException;
 
 	/**
 	 * Tries to fill the given byte array {@code b}. Returns the actually number of read bytes or -1 if there is no
@@ -62,5 +62,5 @@ public interface DataInputView extends DataInput {
 	 * @return the number of read bytes or -1 if there is no more data left
 	 * @throws IOException
 	 */
-	public int read(byte[] b) throws IOException;
+	int read(byte[] b) throws IOException;
 }

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataInputView.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataInputView.java
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 
-
 package org.apache.flink.core.memory;
-
 
 import org.apache.flink.annotation.Public;
 
@@ -32,13 +30,13 @@ import java.io.IOException;
  */
 @Public
 public interface DataInputView extends DataInput {
-	
+
 	/**
 	 * Skips {@code numBytes} bytes of memory. In contrast to the {@link #skipBytes(int)} method,
 	 * this method always skips the desired number of bytes or throws an {@link java.io.EOFException}.
-	 * 
+	 *
 	 * @param numBytes The number of bytes to skip.
-	 * 
+	 *
 	 * @throws IOException Thrown, if any I/O related problem occurred such that the input could not
 	 *                     be advanced to the desired position.
 	 */

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataInputViewStreamWrapper.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataInputViewStreamWrapper.java
@@ -34,7 +34,7 @@ public class DataInputViewStreamWrapper extends DataInputStream implements DataI
 	public DataInputViewStreamWrapper(InputStream in) {
 		super(in);
 	}
-	
+
 	@Override
 	public void skipBytesToRead(int numBytes) throws IOException {
 		if (skipBytes(numBytes) != numBytes){

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputView.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputView.java
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 
-
 package org.apache.flink.core.memory;
-
 
 import org.apache.flink.annotation.Public;
 
@@ -32,24 +30,24 @@ import java.io.IOException;
  */
 @Public
 public interface DataOutputView extends DataOutput {
-	
+
 	/**
 	 * Skips {@code numBytes} bytes memory. If some program reads the memory that was skipped over, the
-	 * results are undefined. 
-	 * 
+	 * results are undefined.
+	 *
 	 * @param numBytes The number of bytes to skip.
-	 * 
+	 *
 	 * @throws IOException Thrown, if any I/O related problem occurred such that the view could not
 	 *                     be advanced to the desired position.
 	 */
 	public void skipBytesToWrite(int numBytes) throws IOException;
-	
+
 	/**
 	 * Copies {@code numBytes} bytes from the source to this view.
-	 * 
+	 *
 	 * @param source The source to copy the bytes from.
 	 * @param numBytes The number of bytes to copy.
-	 * 
+	 *
 	 * @throws IOException Thrown, if any I/O related problem occurred, such that either the input view
 	 *                     could not be read, or the output could not be written.
 	 */

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputView.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputView.java
@@ -40,7 +40,7 @@ public interface DataOutputView extends DataOutput {
 	 * @throws IOException Thrown, if any I/O related problem occurred such that the view could not
 	 *                     be advanced to the desired position.
 	 */
-	public void skipBytesToWrite(int numBytes) throws IOException;
+	void skipBytesToWrite(int numBytes) throws IOException;
 
 	/**
 	 * Copies {@code numBytes} bytes from the source to this view.
@@ -51,5 +51,5 @@ public interface DataOutputView extends DataOutput {
 	 * @throws IOException Thrown, if any I/O related problem occurred, such that either the input view
 	 *                     could not be read, or the output could not be written.
 	 */
-	public void write(DataInputView source, int numBytes) throws IOException;
+	void write(DataInputView source, int numBytes) throws IOException;
 }

--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputViewStreamWrapper.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataOutputViewStreamWrapper.java
@@ -31,7 +31,7 @@ import java.io.OutputStream;
 public class DataOutputViewStreamWrapper extends DataOutputStream implements DataOutputView {
 
 	private byte[] tempBuffer;
-	
+
 	public DataOutputViewStreamWrapper(OutputStream out) {
 		super(out);
 	}
@@ -54,7 +54,7 @@ public class DataOutputViewStreamWrapper extends DataOutputStream implements Dat
 		if (tempBuffer == null) {
 			tempBuffer = new byte[4096];
 		}
-		
+
 		while (numBytes > 0) {
 			int toCopy = Math.min(numBytes, tempBuffer.length);
 			source.readFully(tempBuffer, 0, toCopy);

--- a/flink-core/src/main/java/org/apache/flink/core/memory/HeapMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HeapMemorySegment.java
@@ -30,18 +30,20 @@ import java.util.Objects;
  * This class represents a piece of heap memory managed by Flink.
  * The segment is backed by a byte array and features random put and get methods for the basic types,
  * as well as compare and swap methods.
- * <p>
- * This class specialized byte access and byte copy calls for heap memory, while reusing the
+ *
+ * <p>This class specializes byte access and byte copy calls for heap memory, while reusing the
  * multi-byte type accesses and cross-segment operations from the MemorySegment.
- * <p>
- * Note that memory segments should usually not be allocated manually, but rather through the
+ *
+ * <p>Note that memory segments should usually not be allocated manually, but rather through the
  * {@link MemorySegmentFactory}.
  */
 @Internal
 public final class HeapMemorySegment extends MemorySegment {
 
-	/** An extra reference to the heap memory, so we can let byte array checks fail 
-	 *  by the built-in checks automatically without extra checks */
+	/**
+	 * An extra reference to the heap memory, so we can let byte array checks fail by the built-in
+	 * checks automatically without extra checks.
+	 */
 	private byte[] memory;
 
 	/**
@@ -198,7 +200,9 @@ public final class HeapMemorySegment extends MemorySegment {
 					"The MemorySegment factory was not initialized for off-heap memory.");
 		}
 
-		/** prevent external instantiation */
+		/**
+		 * Prevent external instantiation.
+		 */
 		HeapMemorySegmentFactory() {}
 	};
 

--- a/flink-core/src/main/java/org/apache/flink/core/memory/HeapMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HeapMemorySegment.java
@@ -204,7 +204,7 @@ public final class HeapMemorySegment extends MemorySegment {
 		 * Prevent external instantiation.
 		 */
 		HeapMemorySegmentFactory() {}
-	};
+	}
 
 	public static final HeapMemorySegmentFactory FACTORY = new HeapMemorySegmentFactory();
 }

--- a/flink-core/src/main/java/org/apache/flink/core/memory/HeapMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HeapMemorySegment.java
@@ -53,7 +53,7 @@ public final class HeapMemorySegment extends MemorySegment {
 	HeapMemorySegment(byte[] memory) {
 		this(memory, null);
 	}
-	
+
 	/**
 	 * Creates a new memory segment that represents the data in the given byte array.
 	 * The memory segment references the given owner.
@@ -65,7 +65,7 @@ public final class HeapMemorySegment extends MemorySegment {
 		super(Objects.requireNonNull(memory), owner);
 		this.memory = memory;
 	}
-	
+
 	// -------------------------------------------------------------------------
 	//  MemorySegment operations
 	// -------------------------------------------------------------------------
@@ -94,11 +94,11 @@ public final class HeapMemorySegment extends MemorySegment {
 	public byte[] getArray() {
 		return this.heapMemory;
 	}
-	
+
 	// ------------------------------------------------------------------------
 	//                    Random Access get() and put() methods
 	// ------------------------------------------------------------------------
-	
+
 	@Override
 	public final byte get(int index) {
 		return this.memory[index];

--- a/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
@@ -32,7 +32,7 @@ import java.nio.ByteBuffer;
  * This class represents a piece of memory managed by Flink. The memory can be on-heap or off-heap,
  * this is transparently handled by this class.
  * <p>
- * This class specialized byte access and byte copy calls for heap memory, while reusing the
+ * This class specializes byte access and byte copy calls for heap memory, while reusing the
  * multi-byte type accesses and cross-segment operations from the MemorySegment.
  * <p>
  * This class subsumes the functionality of the {@link org.apache.flink.core.memory.HeapMemorySegment}, 

--- a/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
@@ -43,7 +43,7 @@ import java.nio.ByteBuffer;
  */
 @Internal
 public final class HybridMemorySegment extends MemorySegment {
-	
+
 	/** The direct byte buffer that allocated the off-heap memory. This memory segment holds a reference
 	 * to that buffer, so as long as this memory segment lives, the memory will not be released. */
 	private final ByteBuffer offHeapBuffer;
@@ -61,7 +61,7 @@ public final class HybridMemorySegment extends MemorySegment {
 	HybridMemorySegment(ByteBuffer buffer) {
 		this(buffer, null);
 	}
-	
+
 	/**
 	 * Creates a new memory segment that represents the memory backing the given direct byte buffer.
 	 * Note that the given ByteBuffer must be direct {@link java.nio.ByteBuffer#allocateDirect(int)},
@@ -105,7 +105,7 @@ public final class HybridMemorySegment extends MemorySegment {
 	// -------------------------------------------------------------------------
 	//  MemorySegment operations
 	// -------------------------------------------------------------------------
-	
+
 	public byte[] getArray() {
 		if (heapMemory != null) {
 			return heapMemory;
@@ -153,7 +153,7 @@ public final class HybridMemorySegment extends MemorySegment {
 	// ------------------------------------------------------------------------
 	//  Random Access get() and put() methods
 	// ------------------------------------------------------------------------
-	
+
 	@Override
 	public byte get(int index) {
 		final long pos = address + index;
@@ -221,7 +221,7 @@ public final class HybridMemorySegment extends MemorySegment {
 		if ((offset | length | (offset + length) | (src.length - (offset + length))) < 0) {
 			throw new IndexOutOfBoundsException();
 		}
-		
+
 		final long pos = address + index;
 
 		if (index >= 0 && pos <= addressLimit - length) {
@@ -263,7 +263,7 @@ public final class HybridMemorySegment extends MemorySegment {
 					offset += 8;
 					length -= 8;
 				}
-		
+
 				while (length > 0) {
 					out.writeByte(get(offset));
 					offset++;
@@ -421,7 +421,7 @@ public final class HybridMemorySegment extends MemorySegment {
 			throw new RuntimeException("Could not access direct byte buffer address.", t);
 		}
 	}
-	
+
 	private static long checkBufferAndGetAddress(ByteBuffer buffer) {
 		if (buffer == null) {
 			throw new NullPointerException("buffer is null");
@@ -440,7 +440,7 @@ public final class HybridMemorySegment extends MemorySegment {
 	 * Base factory for hybrid memory segments.
 	 */
 	public static final class HybridMemorySegmentFactory implements MemorySegmentFactory.Factory {
-		
+
 		@Override
 		public HybridMemorySegment wrap(byte[] memory) {
 			return new HybridMemorySegment(memory);

--- a/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
@@ -31,29 +31,32 @@ import java.nio.ByteBuffer;
 /**
  * This class represents a piece of memory managed by Flink. The memory can be on-heap or off-heap,
  * this is transparently handled by this class.
- * <p>
- * This class specializes byte access and byte copy calls for heap memory, while reusing the
+ *
+ * <p>This class specializes byte access and byte copy calls for heap memory, while reusing the
  * multi-byte type accesses and cross-segment operations from the MemorySegment.
- * <p>
- * This class subsumes the functionality of the {@link org.apache.flink.core.memory.HeapMemorySegment}, 
+ *
+ * <p>This class subsumes the functionality of the {@link org.apache.flink.core.memory.HeapMemorySegment},
  * but is a bit less efficient for operations on individual bytes.
- * <p>
- * Note that memory segments should usually not be allocated manually, but rather through the
+ *
+ * <p>Note that memory segments should usually not be allocated manually, but rather through the
  * {@link MemorySegmentFactory}.
  */
 @Internal
 public final class HybridMemorySegment extends MemorySegment {
 
-	/** The direct byte buffer that allocated the off-heap memory. This memory segment holds a reference
-	 * to that buffer, so as long as this memory segment lives, the memory will not be released. */
+	/**
+	 * The direct byte buffer that allocated the off-heap memory. This memory segment holds a
+	 * reference to that buffer, so as long as this memory segment lives, the memory will not be
+	 * released.
+	 */
 	private final ByteBuffer offHeapBuffer;
 
 	/**
 	 * Creates a new memory segment that represents the memory backing the given direct byte buffer.
 	 * Note that the given ByteBuffer must be direct {@link java.nio.ByteBuffer#allocateDirect(int)},
 	 * otherwise this method with throw an IllegalArgumentException.
-	 * <p>
-	 * The owner referenced by this memory segment is null.
+	 *
+	 * <p>The owner referenced by this memory segment is null.
 	 *
 	 * @param buffer The byte buffer whose memory is represented by this memory segment.
 	 * @throws IllegalArgumentException Thrown, if the given ByteBuffer is not direct.
@@ -66,8 +69,8 @@ public final class HybridMemorySegment extends MemorySegment {
 	 * Creates a new memory segment that represents the memory backing the given direct byte buffer.
 	 * Note that the given ByteBuffer must be direct {@link java.nio.ByteBuffer#allocateDirect(int)},
 	 * otherwise this method with throw an IllegalArgumentException.
-	 * <p>
-	 * The memory segment references the given owner.
+	 *
+	 * <p>The memory segment references the given owner.
 	 *
 	 * @param buffer The byte buffer whose memory is represented by this memory segment.
 	 * @param owner The owner references by this memory segment.
@@ -80,8 +83,8 @@ public final class HybridMemorySegment extends MemorySegment {
 
 	/**
 	 * Creates a new memory segment that represents the memory of the byte array.
-	 * <p>
-	 * The owner referenced by this memory segment is null.
+	 *
+	 * <p>The owner referenced by this memory segment is null.
 	 *
 	 * @param buffer The byte array whose memory is represented by this memory segment.
 	 */
@@ -91,8 +94,8 @@ public final class HybridMemorySegment extends MemorySegment {
 
 	/**
 	 * Creates a new memory segment that represents the memory of the byte array.
-	 * <p>
-	 * The memory segment references the given owner.
+	 *
+	 * <p>The memory segment references the given owner.
 	 *
 	 * @param buffer The byte array whose memory is represented by this memory segment.
 	 * @param owner The owner references by this memory segment.
@@ -396,7 +399,9 @@ public final class HybridMemorySegment extends MemorySegment {
 	//  Utilities for native memory accesses and checks
 	// --------------------------------------------------------------------------------------------
 
-	/** The reflection fields with which we access the off-heap pointer from direct ByteBuffers */
+	/**
+	 * The reflection fields with which we access the off-heap pointer from direct ByteBuffers.
+	 */
 	private static final Field ADDRESS_FIELD;
 
 	static {
@@ -461,7 +466,9 @@ public final class HybridMemorySegment extends MemorySegment {
 			return new HybridMemorySegment(memory, owner);
 		}
 
-		/** prevent external instantiation */
+		/**
+		 * Prevent external instantiation.
+		 */
 		HybridMemorySegmentFactory() {}
 	};
 

--- a/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
@@ -200,7 +200,7 @@ public final class HybridMemorySegment extends MemorySegment {
 	@Override
 	public void get(int index, byte[] dst, int offset, int length) {
 		// check the byte array offset and length and the status
-		if ( (offset | length | (offset + length) | (dst.length - (offset + length))) < 0) {
+		if ((offset | length | (offset + length) | (dst.length - (offset + length))) < 0) {
 			throw new IndexOutOfBoundsException();
 		}
 
@@ -470,7 +470,7 @@ public final class HybridMemorySegment extends MemorySegment {
 		 * Prevent external instantiation.
 		 */
 		HybridMemorySegmentFactory() {}
-	};
+	}
 
 	public static final HybridMemorySegmentFactory FACTORY = new HybridMemorySegmentFactory();
 }

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
@@ -47,7 +47,7 @@ import java.nio.ByteOrder;
  *         a byte order.</li>
  *     <li>It transparently and efficiently moves data between on-heap and off-heap variants.</li>
  * </ul>
- * 
+ *
  * <i>Comments on the implementation</i>:
  * We make heavy use of operations that are supported by native
  * instructions, to achieve a high efficiency. Multi byte types (int, long, float, double, ...)
@@ -86,7 +86,7 @@ import java.nio.ByteOrder;
  * subclass is loaded, or that the methods that are abstract in this class are used only from one of the
  * subclasses (either the {@link org.apache.flink.core.memory.HeapMemorySegment}, or the 
  * {@link org.apache.flink.core.memory.HybridMemorySegment}).
- * 
+ *
  * That way, all the abstract methods in the MemorySegment base class have only one loaded
  * actual implementation. This is easy for the JIT to recognize through class hierarchy analysis,
  * or by identifying that the invocations are monomorphic (all go to the same concrete
@@ -102,11 +102,11 @@ public abstract class MemorySegment {
 	/** The beginning of the byte array contents, relative to the byte array object */
 	@SuppressWarnings("restriction")
 	protected static final long BYTE_ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
-	
+
 	/** Constant that flags the byte order. Because this is a boolean constant,
 	 * the JIT compiler can use this well to aggressively eliminate the non-applicable code paths */
 	private static final boolean LITTLE_ENDIAN = (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN);
-	
+
 	// ------------------------------------------------------------------------
 
 	/** The heap byte array object relative to which we access the memory. Is non-null if the
@@ -122,10 +122,10 @@ public abstract class MemorySegment {
 	/** The address one byte after the last addressable byte.
 	 *  This is address + size while the segment is not disposed */
 	protected final long addressLimit;
-	
+
 	/** The size in bytes of the memory segment */
 	protected final int size;
-	
+
 	/** Optional owner of the memory segment */
 	private final Object owner;
 
@@ -140,7 +140,7 @@ public abstract class MemorySegment {
 		if (buffer == null) {
 			throw new NullPointerException("buffer");
 		}
-		
+
 		this.heapMemory = buffer;
 		this.address = BYTE_ARRAY_BASE_OFFSET;
 		this.size = buffer.length;
@@ -164,14 +164,14 @@ public abstract class MemorySegment {
 			throw new IllegalArgumentException("Segment initialized with too large address: " + offHeapAddress
 					+ " ; Max allowed address is " + (Long.MAX_VALUE - Integer.MAX_VALUE - 1));
 		}
-		
+
 		this.heapMemory = null;
 		this.address = offHeapAddress;
 		this.addressLimit = this.address + size;
 		this.size = size;
 		this.owner = owner;
 	}
-	
+
 	// ------------------------------------------------------------------------
 	// Memory Segment Operations
 	// ------------------------------------------------------------------------
@@ -231,8 +231,8 @@ public abstract class MemorySegment {
 	public Object getOwner() {
 		return owner;
 	}
-	
-	
+
+
 	// ------------------------------------------------------------------------
 	//                    Random Access get() and put() methods
 	// ------------------------------------------------------------------------
@@ -241,13 +241,13 @@ public abstract class MemorySegment {
 	// Notes on the implementation: We try to collapse as many checks as
 	// possible. We need to obey the following rules to make this safe
 	// against segfaults:
-	// 
+	//
 	//  - Grab mutable fields onto the stack before checking and using. This
 	//    guards us against concurrent modifications which invalidate the
 	//    pointers
-	//  - Use subtrations for range checks, as they are tolerant 
+	//  - Use subtrations for range checks, as they are tolerant
 	//------------------------------------------------------------------------
-	
+
 	/**
 	 * Reads the byte at the given position.
 	 *
@@ -277,7 +277,7 @@ public abstract class MemorySegment {
 	 * @param index The position at which the first byte will be read.
 	 * @param dst The memory into which the memory will be copied.
 	 *
-	 * @throws IndexOutOfBoundsException Thrown, if the index is negative, or too large that the data between the 
+	 * @throws IndexOutOfBoundsException Thrown, if the index is negative, or too large that the data between the
 	 *                                   index and the memory segment end is not enough to fill the destination array.
 	 */
 	public abstract void get(int index, byte[] dst);
@@ -289,7 +289,7 @@ public abstract class MemorySegment {
 	 * @param index The index in the memory segment array, where the data is put.
 	 * @param src The source array to copy the data from.
 	 *
-	 * @throws IndexOutOfBoundsException Thrown, if the index is negative, or too large such that the array 
+	 * @throws IndexOutOfBoundsException Thrown, if the index is negative, or too large such that the array
 	 *                                   size exceed the amount of memory between the index and the memory
 	 *                                   segment's end. 
 	 */
@@ -304,7 +304,7 @@ public abstract class MemorySegment {
 	 * @param offset The copying offset in the destination memory.
 	 * @param length The number of bytes to be copied.
 	 *
-	 * @throws IndexOutOfBoundsException Thrown, if the index is negative, or too large that the requested number of 
+	 * @throws IndexOutOfBoundsException Thrown, if the index is negative, or too large that the requested number of
 	 *                                   bytes exceed the amount of memory between the index and the memory
 	 *                                   segment's end.
 	 */
@@ -320,7 +320,7 @@ public abstract class MemorySegment {
 	 * @param offset The offset in the source array where the copying is started.
 	 * @param length The number of bytes to copy.
 	 *
-	 * @throws IndexOutOfBoundsException Thrown, if the index is negative, or too large such that the array 
+	 * @throws IndexOutOfBoundsException Thrown, if the index is negative, or too large such that the array
 	 *                                   portion to copy exceed the amount of memory between the index and the memory
 	 *                                   segment's end.
 	 */
@@ -377,7 +377,7 @@ public abstract class MemorySegment {
 	/**
 	 * Reads an character value (16 bit, 2 bytes) from the given position, in little-endian byte order.
 	 * This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #getChar(int)}. For most cases (such as 
+	 * is possibly slower than {@link #getChar(int)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #getChar(int)} is the preferable choice.
@@ -398,7 +398,7 @@ public abstract class MemorySegment {
 	/**
 	 * Reads an character value (16 bit, 2 bytes) from the given position, in big-endian byte order.
 	 * This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #getChar(int)}. For most cases (such as 
+	 * is possibly slower than {@link #getChar(int)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #getChar(int)} is the preferable choice.
@@ -443,7 +443,7 @@ public abstract class MemorySegment {
 	/**
 	 * Writes the given character (16 bit, 2 bytes) to the given position in little-endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #putChar(int, char)}. For most cases (such as 
+	 * is possibly slower than {@link #putChar(int, char)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #putChar(int, char)} is the preferable choice.
@@ -464,7 +464,7 @@ public abstract class MemorySegment {
 	/**
 	 * Writes the given character (16 bit, 2 bytes) to the given position in big-endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #putChar(int, char)}. For most cases (such as 
+	 * is possibly slower than {@link #putChar(int, char)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #putChar(int, char)} is the preferable choice.
@@ -509,7 +509,7 @@ public abstract class MemorySegment {
 	/**
 	 * Reads an short integer value (16 bit, 2 bytes) from the given position, in little-endian byte order.
 	 * This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #getShort(int)}. For most cases (such as 
+	 * is possibly slower than {@link #getShort(int)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #getShort(int)} is the preferable choice.
@@ -530,7 +530,7 @@ public abstract class MemorySegment {
 	/**
 	 * Reads an short integer value (16 bit, 2 bytes) from the given position, in big-endian byte order.
 	 * This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #getShort(int)}. For most cases (such as 
+	 * is possibly slower than {@link #getShort(int)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #getShort(int)} is the preferable choice.
@@ -575,7 +575,7 @@ public abstract class MemorySegment {
 	/**
 	 * Writes the given short integer value (16 bit, 2 bytes) to the given position in little-endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #putShort(int, short)}. For most cases (such as 
+	 * is possibly slower than {@link #putShort(int, short)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #putShort(int, short)} is the preferable choice.
@@ -596,7 +596,7 @@ public abstract class MemorySegment {
 	/**
 	 * Writes the given short integer value (16 bit, 2 bytes) to the given position in big-endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #putShort(int, short)}. For most cases (such as 
+	 * is possibly slower than {@link #putShort(int, short)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #putShort(int, short)} is the preferable choice.
@@ -618,7 +618,7 @@ public abstract class MemorySegment {
 	 * Reads an int value (32bit, 4 bytes) from the given position, in the system's native byte order.
 	 * This method offers the best speed for integer reading and should be used
 	 * unless a specific byte order is required. In most cases, it suffices to know that the
-	 * byte order in which the value is written is the same as the one in which it is read 
+	 * byte order in which the value is written is the same as the one in which it is read
 	 * (such as transient storage in memory, or serialization for I/O and network), making this
 	 * method the preferable choice.
 	 *
@@ -645,7 +645,7 @@ public abstract class MemorySegment {
 	/**
 	 * Reads an int value (32bit, 4 bytes) from the given position, in little-endian byte order.
 	 * This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #getInt(int)}. For most cases (such as 
+	 * is possibly slower than {@link #getInt(int)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #getInt(int)} is the preferable choice.
@@ -667,7 +667,7 @@ public abstract class MemorySegment {
 	/**
 	 * Reads an int value (32bit, 4 bytes) from the given position, in big-endian byte order.
 	 * This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #getInt(int)}. For most cases (such as 
+	 * is possibly slower than {@link #getInt(int)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #getInt(int)} is the preferable choice.
@@ -690,7 +690,7 @@ public abstract class MemorySegment {
 	 * Writes the given int value (32bit, 4 bytes) to the given position in the system's native
 	 * byte order. This method offers the best speed for integer writing and should be used
 	 * unless a specific byte order is required. In most cases, it suffices to know that the
-	 * byte order in which the value is written is the same as the one in which it is read 
+	 * byte order in which the value is written is the same as the one in which it is read
 	 * (such as transient storage in memory, or serialization for I/O and network), making this
 	 * method the preferable choice.
 	 *
@@ -717,7 +717,7 @@ public abstract class MemorySegment {
 	/**
 	 * Writes the given int value (32bit, 4 bytes) to the given position in little endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #putInt(int, int)}. For most cases (such as 
+	 * is possibly slower than {@link #putInt(int, int)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #putInt(int, int)} is the preferable choice.
@@ -739,7 +739,7 @@ public abstract class MemorySegment {
 	/**
 	 * Writes the given int value (32bit, 4 bytes) to the given position in big endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #putInt(int, int)}. For most cases (such as 
+	 * is possibly slower than {@link #putInt(int, int)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #putInt(int, int)} is the preferable choice.
@@ -762,7 +762,7 @@ public abstract class MemorySegment {
 	 * Reads a long value (64bit, 8 bytes) from the given position, in the system's native byte order.
 	 * This method offers the best speed for long integer reading and should be used
 	 * unless a specific byte order is required. In most cases, it suffices to know that the
-	 * byte order in which the value is written is the same as the one in which it is read 
+	 * byte order in which the value is written is the same as the one in which it is read
 	 * (such as transient storage in memory, or serialization for I/O and network), making this
 	 * method the preferable choice.
 	 *
@@ -789,7 +789,7 @@ public abstract class MemorySegment {
 	/**
 	 * Reads a long integer value (64bit, 8 bytes) from the given position, in little endian byte order.
 	 * This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #getLong(int)}. For most cases (such as 
+	 * is possibly slower than {@link #getLong(int)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #getLong(int)} is the preferable choice.
@@ -811,7 +811,7 @@ public abstract class MemorySegment {
 	/**
 	 * Reads a long integer value (64bit, 8 bytes) from the given position, in big endian byte order.
 	 * This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #getLong(int)}. For most cases (such as 
+	 * is possibly slower than {@link #getLong(int)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #getLong(int)} is the preferable choice.
@@ -834,7 +834,7 @@ public abstract class MemorySegment {
 	 * Writes the given long value (64bit, 8 bytes) to the given position in the system's native
 	 * byte order. This method offers the best speed for long integer writing and should be used
 	 * unless a specific byte order is required. In most cases, it suffices to know that the
-	 * byte order in which the value is written is the same as the one in which it is read 
+	 * byte order in which the value is written is the same as the one in which it is read
 	 * (such as transient storage in memory, or serialization for I/O and network), making this
 	 * method the preferable choice.
 	 *
@@ -861,7 +861,7 @@ public abstract class MemorySegment {
 	/**
 	 * Writes the given long value (64bit, 8 bytes) to the given position in little endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #putLong(int, long)}. For most cases (such as 
+	 * is possibly slower than {@link #putLong(int, long)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #putLong(int, long)} is the preferable choice.
@@ -883,7 +883,7 @@ public abstract class MemorySegment {
 	/**
 	 * Writes the given long value (64bit, 8 bytes) to the given position in big endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #putLong(int, long)}. For most cases (such as 
+	 * is possibly slower than {@link #putLong(int, long)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #putLong(int, long)} is the preferable choice.
@@ -906,7 +906,7 @@ public abstract class MemorySegment {
 	 * Reads a single-precision floating point value (32bit, 4 bytes) from the given position, in the system's
 	 * native byte order. This method offers the best speed for float reading and should be used
 	 * unless a specific byte order is required. In most cases, it suffices to know that the
-	 * byte order in which the value is written is the same as the one in which it is read 
+	 * byte order in which the value is written is the same as the one in which it is read
 	 * (such as transient storage in memory, or serialization for I/O and network), making this
 	 * method the preferable choice.
 	 *
@@ -923,7 +923,7 @@ public abstract class MemorySegment {
 	/**
 	 * Reads a single-precision floating point value (32bit, 4 bytes) from the given position, in little endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #getFloat(int)}. For most cases (such as 
+	 * is possibly slower than {@link #getFloat(int)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #getFloat(int)} is the preferable choice.
@@ -941,7 +941,7 @@ public abstract class MemorySegment {
 	/**
 	 * Reads a single-precision floating point value (32bit, 4 bytes) from the given position, in big endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #getFloat(int)}. For most cases (such as 
+	 * is possibly slower than {@link #getFloat(int)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #getFloat(int)} is the preferable choice.
@@ -960,7 +960,7 @@ public abstract class MemorySegment {
 	 * Writes the given single-precision float value (32bit, 4 bytes) to the given position in the system's native
 	 * byte order. This method offers the best speed for float writing and should be used
 	 * unless a specific byte order is required. In most cases, it suffices to know that the
-	 * byte order in which the value is written is the same as the one in which it is read 
+	 * byte order in which the value is written is the same as the one in which it is read
 	 * (such as transient storage in memory, or serialization for I/O and network), making this
 	 * method the preferable choice.
 	 *
@@ -977,7 +977,7 @@ public abstract class MemorySegment {
 	/**
 	 * Writes the given single-precision float value (32bit, 4 bytes) to the given position in little endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #putFloat(int, float)}. For most cases (such as 
+	 * is possibly slower than {@link #putFloat(int, float)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #putFloat(int, float)} is the preferable choice.
@@ -995,7 +995,7 @@ public abstract class MemorySegment {
 	/**
 	 * Writes the given single-precision float value (32bit, 4 bytes) to the given position in big endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #putFloat(int, float)}. For most cases (such as 
+	 * is possibly slower than {@link #putFloat(int, float)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #putFloat(int, float)} is the preferable choice.
@@ -1014,7 +1014,7 @@ public abstract class MemorySegment {
 	 * Reads a double-precision floating point value (64bit, 8 bytes) from the given position, in the system's
 	 * native byte order. This method offers the best speed for double reading and should be used
 	 * unless a specific byte order is required. In most cases, it suffices to know that the
-	 * byte order in which the value is written is the same as the one in which it is read 
+	 * byte order in which the value is written is the same as the one in which it is read
 	 * (such as transient storage in memory, or serialization for I/O and network), making this
 	 * method the preferable choice.
 	 *
@@ -1031,7 +1031,7 @@ public abstract class MemorySegment {
 	/**
 	 * Reads a double-precision floating point value (64bit, 8 bytes) from the given position, in little endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #getDouble(int)}. For most cases (such as 
+	 * is possibly slower than {@link #getDouble(int)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #getDouble(int)} is the preferable choice.
@@ -1049,7 +1049,7 @@ public abstract class MemorySegment {
 	/**
 	 * Reads a double-precision floating point value (64bit, 8 bytes) from the given position, in big endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #getDouble(int)}. For most cases (such as 
+	 * is possibly slower than {@link #getDouble(int)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #getDouble(int)} is the preferable choice.
@@ -1068,7 +1068,7 @@ public abstract class MemorySegment {
 	 * Writes the given double-precision floating-point value (64bit, 8 bytes) to the given position in the
 	 * system's native byte order. This method offers the best speed for double writing and should be used
 	 * unless a specific byte order is required. In most cases, it suffices to know that the
-	 * byte order in which the value is written is the same as the one in which it is read 
+	 * byte order in which the value is written is the same as the one in which it is read
 	 * (such as transient storage in memory, or serialization for I/O and network), making this
 	 * method the preferable choice.
 	 *
@@ -1085,7 +1085,7 @@ public abstract class MemorySegment {
 	/**
 	 * Writes the given double-precision floating-point value (64bit, 8 bytes) to the given position in little endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #putDouble(int, double)}. For most cases (such as 
+	 * is possibly slower than {@link #putDouble(int, double)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #putDouble(int, double)} is the preferable choice.
@@ -1103,7 +1103,7 @@ public abstract class MemorySegment {
 	/**
 	 * Writes the given double-precision floating-point value (64bit, 8 bytes) to the given position in big endian
 	 * byte order. This method's speed depends on the system's native byte order, and it
-	 * is possibly slower than {@link #putDouble(int, double)}. For most cases (such as 
+	 * is possibly slower than {@link #putDouble(int, double)}. For most cases (such as
 	 * transient storage in memory or serialization for I/O and network),
 	 * it suffices to know that the byte order in which the value is written is the same as the
 	 * one in which it is read, and {@link #putDouble(int, double)} is the preferable choice.
@@ -1130,7 +1130,7 @@ public abstract class MemorySegment {
 	 *
 	 * @param in The DataInput to get the data from.
 	 * @param offset The position in the memory segment to copy the chunk to.
-	 * @param length The number of bytes to get. 
+	 * @param length The number of bytes to get.
 	 *
 	 * @throws IOException Thrown, if the DataInput encountered a problem upon reading,
 	 *                     such as an End-Of-File.
@@ -1265,14 +1265,14 @@ public abstract class MemorySegment {
 		if ( (offset1 | offset2 | len | (tempBuffer.length - len) ) >= 0) {
 			final long thisPos = this.address + offset1;
 			final long otherPos = seg2.address + offset2;
-			
+
 			if (thisPos <= this.addressLimit - len && otherPos <= seg2.addressLimit - len) {
 				// this -> temp buffer
 				UNSAFE.copyMemory(this.heapMemory, thisPos, tempBuffer, BYTE_ARRAY_BASE_OFFSET, len);
-	
+
 				// other -> this
 				UNSAFE.copyMemory(seg2.heapMemory, otherPos, this.heapMemory, thisPos, len);
-	
+
 				// temp buffer -> other
 				UNSAFE.copyMemory(tempBuffer, BYTE_ARRAY_BASE_OFFSET, seg2.heapMemory, otherPos, len);
 				return;
@@ -1284,7 +1284,7 @@ public abstract class MemorySegment {
 				throw new IllegalStateException("other memory segment has been freed.");
 			}
 		}
-		
+
 		// index is in fact invalid
 		throw new IndexOutOfBoundsException(
 					String.format("offset1=%d, offset2=%d, len=%d, bufferSize=%d, address1=%d, address2=%d",

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
@@ -1219,9 +1219,8 @@ public abstract class MemorySegment {
 		final long thisPointer = this.address + offset;
 		final long otherPointer = target.address + targetOffset;
 
-		if ( (numBytes | offset | targetOffset) >= 0 &&
-				thisPointer <= this.addressLimit - numBytes && otherPointer <= target.addressLimit - numBytes)
-		{
+		if ((numBytes | offset | targetOffset) >= 0 &&
+				thisPointer <= this.addressLimit - numBytes && otherPointer <= target.addressLimit - numBytes) {
 			UNSAFE.copyMemory(thisHeapRef, thisPointer, otherHeapRef, otherPointer, numBytes);
 		}
 		else if (this.address > this.addressLimit) {
@@ -1288,7 +1287,7 @@ public abstract class MemorySegment {
 	 * @param len Length of the swapped memory region
 	 */
 	public final void swapBytes(byte[] tempBuffer, MemorySegment seg2, int offset1, int offset2, int len) {
-		if ( (offset1 | offset2 | len | (tempBuffer.length - len) ) >= 0) {
+		if ((offset1 | offset2 | len | (tempBuffer.length - len)) >= 0) {
 			final long thisPos = this.address + offset1;
 			final long otherPos = seg2.address + offset2;
 

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
@@ -157,7 +157,7 @@ public class MemorySegmentFactory {
 	}
 
 	/**
-	 * Sets the factory to the {@link HeapMemorySegment#FACTORY} is no factory has been initialized, yet.
+	 * Sets the factory to the {@link HeapMemorySegment#FACTORY} if no factory has been initialized, yet.
 	 */
 	private static void ensureInitialized() {
 		if (factory == null) {

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
@@ -36,7 +36,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class MemorySegmentFactory {
 
-	/** The factory to use */
+	/**
+	 * The factory to use.
+	 */
 	private static volatile Factory factory;
 
 	/**
@@ -54,8 +56,8 @@ public class MemorySegmentFactory {
 	/**
 	 * Allocates some unpooled memory and creates a new memory segment that represents
 	 * that memory.
-	 * <p>
-	 * This method is similar to {@link #allocateUnpooledSegment(int, Object)}, but the
+	 *
+	 * <p>This method is similar to {@link #allocateUnpooledSegment(int, Object)}, but the
 	 * memory segment will have null as the owner.
 	 *
 	 * @param size The size of the memory segment to allocate.
@@ -68,8 +70,8 @@ public class MemorySegmentFactory {
 	/**
 	 * Allocates some unpooled memory and creates a new memory segment that represents
 	 * that memory.
-	 * <p>
-	 * This method is similar to {@link #allocateUnpooledSegment(int)}, but additionally sets
+	 *
+	 * <p>This method is similar to {@link #allocateUnpooledSegment(int)}, but additionally sets
 	 * the owner of the memory segment.
 	 *
 	 * @param size The size of the memory segment to allocate.
@@ -83,10 +85,10 @@ public class MemorySegmentFactory {
 
 	/**
 	 * Creates a memory segment that wraps the given byte array.
-	 * <p>
-	 * This method is intended to be used for components which pool memory and create
+	 *
+	 * <p>This method is intended to be used for components which pool memory and create
 	 * memory segments around long-lived memory regions.
-	 * *
+	 *
 	 * @param memory The heap memory to be represented by the memory segment.
 	 * @param owner The owner to associate with the memory segment.
 	 * @return A new memory segment representing the given heap memory.
@@ -99,8 +101,8 @@ public class MemorySegmentFactory {
 	/**
 	 * Creates a memory segment that wraps the off-heap memory backing the given ByteBuffer.
 	 * Note that the ByteBuffer needs to be a <i>direct ByteBuffer</i>.
-	 * <p>
-	 * This method is intended to be used for components which pool memory and create
+	 *
+	 * <p>This method is intended to be used for components which pool memory and create
 	 * memory segments around long-lived memory regions.
 	 *
 	 * @param memory The byte buffer with the off-heap memory to be represented by the memory segment.
@@ -197,8 +199,8 @@ public class MemorySegmentFactory {
 
 		/**
 		 * Creates a memory segment that wraps the given byte array.
-		 * <p>
-		 * This method is intended to be used for components which pool memory and create
+		 *
+		 * <p>This method is intended to be used for components which pool memory and create
 		 * memory segments around long-lived memory regions.
 		 *
 		 *
@@ -211,8 +213,8 @@ public class MemorySegmentFactory {
 		/**
 		 * Creates a memory segment that wraps the off-heap memory backing the given ByteBuffer.
 		 * Note that the ByteBuffer needs to be a <i>direct ByteBuffer</i>.
-		 * <p>
-		 * This method is intended to be used for components which pool memory and create
+		 *
+		 * <p>This method is intended to be used for components which pool memory and create
 		 * memory segments around long-lived memory regions.
 		 *
 		 * @param memory The byte buffer with the off-heap memory to be represented by the memory segment.

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
@@ -29,7 +29,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * for heap data are of the same type. That way, the runtime does not mix the various specializations
  * of the {@link org.apache.flink.core.memory.MemorySegment}. Not mixing them has shown to be beneficial
  * to method specialization by the JIT and to overall performance.
- * 
+ *
  * <p>Note that this factory auto-initialized to use {@link org.apache.flink.core.memory.HeapMemorySegment},
  * if a request to create a segment comes before the initialization.
  */
@@ -71,7 +71,7 @@ public class MemorySegmentFactory {
 	 * <p>
 	 * This method is similar to {@link #allocateUnpooledSegment(int)}, but additionally sets
 	 * the owner of the memory segment.
-	 * 
+	 *
 	 * @param size The size of the memory segment to allocate.
 	 * @param owner The owner to associate with the memory segment.
 	 * @return A new memory segment, backed by unpooled heap memory.
@@ -86,8 +86,7 @@ public class MemorySegmentFactory {
 	 * <p>
 	 * This method is intended to be used for components which pool memory and create
 	 * memory segments around long-lived memory regions.
-	 *
-	 * 
+	 * *
 	 * @param memory The heap memory to be represented by the memory segment.
 	 * @param owner The owner to associate with the memory segment.
 	 * @return A new memory segment representing the given heap memory.
@@ -99,7 +98,7 @@ public class MemorySegmentFactory {
 
 	/**
 	 * Creates a memory segment that wraps the off-heap memory backing the given ByteBuffer.
-	 * Note that the ByteBuffer needs to be a <i>direct ByteBuffer</i>. 
+	 * Note that the ByteBuffer needs to be a <i>direct ByteBuffer</i>.
 	 * <p>
 	 * This method is intended to be used for components which pool memory and create
 	 * memory segments around long-lived memory regions.
@@ -140,7 +139,7 @@ public class MemorySegmentFactory {
 
 	/**
 	 * Checks whether this memory segment factory has been initialized (with a type to produce).
-	 * 
+	 *
 	 * @return True, if the factory has been initialized, false otherwise.
 	 */
 	public static boolean isInitialized() {
@@ -149,7 +148,7 @@ public class MemorySegmentFactory {
 
 	/**
 	 * Gets the factory. May return null, if the factory has not been initialized.
-	 * 
+	 *
 	 * @return The factory, or null, if the factory has not been initialized.
 	 */
 	public static Factory getFactory() {
@@ -172,7 +171,7 @@ public class MemorySegmentFactory {
 	// ------------------------------------------------------------------------
 	//  Internal factory
 	// ------------------------------------------------------------------------
-	
+
 	/**
 	 * A concrete factory for memory segments.
 	 */
@@ -211,7 +210,7 @@ public class MemorySegmentFactory {
 
 		/**
 		 * Creates a memory segment that wraps the off-heap memory backing the given ByteBuffer.
-		 * Note that the ByteBuffer needs to be a <i>direct ByteBuffer</i>. 
+		 * Note that the ByteBuffer needs to be a <i>direct ByteBuffer</i>.
 		 * <p>
 		 * This method is intended to be used for components which pool memory and create
 		 * memory segments around long-lived memory regions.

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentSource.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentSource.java
@@ -31,5 +31,5 @@ public interface MemorySegmentSource {
 	 *
 	 * @return The next memory segment, or null, if none is available.
 	 */
-	public MemorySegment nextSegment();
+	MemorySegment nextSegment();
 }

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentSource.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentSource.java
@@ -25,10 +25,10 @@ import org.apache.flink.annotation.Internal;
  */
 @Internal
 public interface MemorySegmentSource {
-	
+
 	/**
 	 * Gets the next memory segment. If no more segments are available, it returns null.
-	 * 
+	 *
 	 * @return The next memory segment, or null, if none is available.
 	 */
 	public MemorySegment nextSegment();

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
@@ -55,6 +55,6 @@ public class MemoryUtils {
 		}
 	}
 
-	/** Should not be instantiated */
+	/** Should not be instantiated. */
 	private MemoryUtils() {}
 }

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
@@ -28,11 +28,11 @@ import java.nio.ByteOrder;
  */
 @Internal
 public class MemoryUtils {
-	
+
 	/** The "unsafe", which can be used to perform native memory accesses. */
 	@SuppressWarnings("restriction")
 	public static final sun.misc.Unsafe UNSAFE = getUnsafe();
-	
+
 	/** The native byte order of the platform on which the system currently runs. */
 	public static final ByteOrder NATIVE_BYTE_ORDER = ByteOrder.nativeOrder();
 

--- a/flink-core/src/main/java/org/apache/flink/core/memory/SeekableDataInputView.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/SeekableDataInputView.java
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.flink.core.memory;
 
 import org.apache.flink.annotation.PublicEvolving;
@@ -27,10 +26,10 @@ import org.apache.flink.annotation.PublicEvolving;
  */
 @PublicEvolving
 public interface SeekableDataInputView extends DataInputView {
-	
+
 	/**
 	 * Sets the read pointer to the given position.
-	 * 
+	 *
 	 * @param position The new read position.
 	 */
 	public void setReadPosition(long position);

--- a/flink-core/src/main/java/org/apache/flink/core/memory/SeekableDataInputView.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/SeekableDataInputView.java
@@ -32,5 +32,5 @@ public interface SeekableDataInputView extends DataInputView {
 	 *
 	 * @param position The new read position.
 	 */
-	public void setReadPosition(long position);
+	void setReadPosition(long position);
 }

--- a/flink-core/src/main/java/org/apache/flink/core/memory/SeekableDataOutputView.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/SeekableDataOutputView.java
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.flink.core.memory;
 
 import org.apache.flink.annotation.PublicEvolving;
@@ -27,10 +26,10 @@ import org.apache.flink.annotation.PublicEvolving;
  */
 @PublicEvolving
 public interface SeekableDataOutputView extends DataOutputView {
-	
+
 	/**
 	 * Sets the write pointer to the given position.
-	 * 
+	 *
 	 * @param position The new write position.
 	 */
 	public void setWritePosition(long position);

--- a/flink-core/src/main/java/org/apache/flink/core/memory/SeekableDataOutputView.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/SeekableDataOutputView.java
@@ -32,5 +32,5 @@ public interface SeekableDataOutputView extends DataOutputView {
 	 *
 	 * @param position The new write position.
 	 */
-	public void setWritePosition(long position);
+	void setWritePosition(long position);
 }

--- a/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayInputStreamWithPosTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayInputStreamWithPosTest.java
@@ -24,6 +24,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+/**
+ * Tests for {@link ByteArrayInputStreamWithPos}.
+ */
 public class ByteArrayInputStreamWithPosTest {
 
 	@Rule
@@ -39,7 +42,7 @@ public class ByteArrayInputStreamWithPosTest {
 	}
 
 	/**
-	 *  Test setting position on a {@link ByteArrayInputStreamWithPos}
+	 * Test setting position on a {@link ByteArrayInputStreamWithPos}.
 	 */
 	@Test
 	public void testSetPosition() throws Exception {
@@ -60,7 +63,7 @@ public class ByteArrayInputStreamWithPosTest {
 	}
 
 	/**
-	 * Test that the expected position exceeds the capacity of the byte array
+	 * Test that the expected position exceeds the capacity of the byte array.
 	 */
 	@Test
 	public void testSetTooLargePosition() throws Exception {
@@ -70,7 +73,7 @@ public class ByteArrayInputStreamWithPosTest {
 	}
 
 	/**
-	 * Test setting a negative position
+	 * Test setting a negative position.
 	 */
 	@Test
 	public void testSetNegativePosition() throws Exception {

--- a/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayInputStreamWithPosTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayInputStreamWithPosTest.java
@@ -32,7 +32,7 @@ public class ByteArrayInputStreamWithPosTest {
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
 
-	private byte[] data = new byte[] {'0','1','2','3','4','5','6','7','8','9'};
+	private byte[] data = new byte[] {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
 
 	private ByteArrayInputStreamWithPos stream;
 

--- a/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
@@ -104,7 +104,7 @@ public class ByteArrayOutputStreamWithPosTest {
 		stream.write(data);
 		Assert.assertArrayEquals(data, stream.toString().getBytes(ConfigConstants.DEFAULT_CHARSET));
 
-		for (int i = 0 ; i < data.length ; i++) {
+		for (int i = 0; i < data.length; i++) {
 			stream.setPosition(i);
 			Assert.assertArrayEquals(Arrays.copyOf(data, i), stream.toString().getBytes(ConfigConstants.DEFAULT_CHARSET));
 		}

--- a/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.core.memory;
 
 import org.apache.flink.configuration.ConfigConstants;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;

--- a/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPosTest.java
@@ -29,6 +29,9 @@ import org.junit.rules.ExpectedException;
 import java.io.IOException;
 import java.util.Arrays;
 
+/**
+ * Tests for {@link ByteArrayOutputStreamWithPos}.
+ */
 public class ByteArrayOutputStreamWithPosTest {
 
 	private static final int BUFFER_SIZE = 32;
@@ -44,7 +47,7 @@ public class ByteArrayOutputStreamWithPosTest {
 	}
 
 	/**
-	 * Test setting position which is exactly the same with the buffer size
+	 * Test setting position which is exactly the same with the buffer size.
 	 */
 	@Test
 	public void testSetPositionWhenBufferIsFull() throws Exception {
@@ -63,7 +66,7 @@ public class ByteArrayOutputStreamWithPosTest {
 	}
 
 	/**
-	 * Test setting negative position
+	 * Test setting negative position.
 	 */
 	@Test
 	public void testSetNegativePosition() throws Exception {
@@ -75,7 +78,7 @@ public class ByteArrayOutputStreamWithPosTest {
 	}
 
 	/**
-	 * Test setting position larger than buffer size
+	 * Test setting position larger than buffer size.
 	 */
 	@Test
 	public void testSetPositionLargerThanBufferSize() throws Exception {
@@ -90,7 +93,7 @@ public class ByteArrayOutputStreamWithPosTest {
 	}
 
 	/**
-	 * Test that toString returns a substring of the buffer with range(0, position)
+	 * Test that toString returns a substring of the buffer with range(0, position).
 	 */
 	@Test
 	public void testToString() throws IOException {

--- a/flink-core/src/test/java/org/apache/flink/core/memory/CrossSegmentTypeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/CrossSegmentTypeTest.java
@@ -29,6 +29,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+/**
+ * Verifies interoperability between {@link HeapMemorySegment} and {@link HybridMemorySegment} (in
+ * both heap and off-heap modes).
+ */
 public class CrossSegmentTypeTest {
 
 	private final int pageSize = 32*1024;

--- a/flink-core/src/test/java/org/apache/flink/core/memory/CrossSegmentTypeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/CrossSegmentTypeTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.fail;
  */
 public class CrossSegmentTypeTest {
 
-	private final int pageSize = 32*1024;
+	private final int pageSize = 32 * 1024;
 
 	// ------------------------------------------------------------------------
 
@@ -89,7 +89,7 @@ public class CrossSegmentTypeTest {
 			int pos2 = random.nextInt(bytes2.length);
 
 			int len = Math.min(Math.min(bytes1.length - pos1, bytes2.length - pos2),
-					random.nextInt(pageSize / 50 ));
+					random.nextInt(pageSize / 50));
 
 			int cmp = seg1.compare(seg2, pos1, pos2, len);
 
@@ -104,7 +104,7 @@ public class CrossSegmentTypeTest {
 
 	@Test
 	public void testSwapBytesMixedSegments() {
-		final int HALF_SIZE = pageSize / 2;
+		final int halfPageSize = pageSize / 2;
 
 		MemorySegment[] segs1 = {
 				new HeapMemorySegment(new byte[pageSize]),
@@ -113,16 +113,16 @@ public class CrossSegmentTypeTest {
 		};
 
 		MemorySegment[] segs2 = {
-				new HeapMemorySegment(new byte[HALF_SIZE]),
-				new HybridMemorySegment(new byte[HALF_SIZE]),
-				new HybridMemorySegment(ByteBuffer.allocateDirect(HALF_SIZE))
+				new HeapMemorySegment(new byte[halfPageSize]),
+				new HybridMemorySegment(new byte[halfPageSize]),
+				new HybridMemorySegment(ByteBuffer.allocateDirect(halfPageSize))
 		};
 
 		Random rnd = new Random();
 
 		for (MemorySegment seg1 : segs1) {
 			for (MemorySegment seg2 : segs2) {
-				testSwap(seg1, seg2, rnd, HALF_SIZE);
+				testSwap(seg1, seg2, rnd, halfPageSize);
 			}
 		}
 	}

--- a/flink-core/src/test/java/org/apache/flink/core/memory/CrossSegmentTypeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/CrossSegmentTypeTest.java
@@ -32,9 +32,9 @@ import static org.junit.Assert.fail;
 public class CrossSegmentTypeTest {
 
 	private final int pageSize = 32*1024;
-	
+
 	// ------------------------------------------------------------------------
-	
+
 	@Test
 	public void testCompareBytesMixedSegments() {
 		MemorySegment[] segs1 = {
@@ -57,11 +57,11 @@ public class CrossSegmentTypeTest {
 			}
 		}
 	}
-	
+
 	private void testCompare(MemorySegment seg1, MemorySegment seg2, Random random) {
 		assertEquals(pageSize, seg1.size());
 		assertEquals(pageSize, seg2.size());
-		
+
 		final byte[] bytes1 = new byte[pageSize];
 		final byte[] bytes2 = new byte[pageSize];
 
@@ -76,7 +76,7 @@ public class CrossSegmentTypeTest {
 				bytes2[i + shift] = val;
 			}
 		}
-		
+
 		seg1.put(0, bytes1);
 		seg2.put(0, bytes2);
 
@@ -97,7 +97,6 @@ public class CrossSegmentTypeTest {
 			}
 		}
 	}
-
 
 	@Test
 	public void testSwapBytesMixedSegments() {
@@ -123,7 +122,7 @@ public class CrossSegmentTypeTest {
 			}
 		}
 	}
-	
+
 	private void testSwap(MemorySegment seg1, MemorySegment seg2, Random random, int smallerSize) {
 		assertEquals(pageSize, seg1.size());
 		assertEquals(smallerSize, seg2.size());
@@ -132,7 +131,7 @@ public class CrossSegmentTypeTest {
 		final byte[] bytes2 = new byte[smallerSize];
 
 		Arrays.fill(bytes2, (byte) 1);
-		
+
 		seg1.put(0, bytes1);
 		seg2.put(0, bytes2);
 
@@ -184,29 +183,29 @@ public class CrossSegmentTypeTest {
 
 		byte[] expected = new byte[pageSize];
 		byte[] actual = new byte[pageSize];
-		
+
 		// zero out the memory
 		seg1.put(0, expected);
 		seg2.put(0, expected);
-		
+
 		for (int i = 0; i < 40; i++) {
 			int numBytes = random.nextInt(pageSize / 20);
 			byte[] bytes = new byte[numBytes];
 			random.nextBytes(bytes);
-			
+
 			int thisPos = random.nextInt(pageSize - numBytes);
 			int otherPos = random.nextInt(pageSize - numBytes);
-			
+
 			// track what we expect
 			System.arraycopy(bytes, 0, expected, otherPos, numBytes);
-			
+
 			seg1.put(thisPos, bytes);
 			seg1.copyTo(thisPos, seg2, otherPos, numBytes);
 		}
-		
+
 		seg2.get(0, actual);
 		assertArrayEquals(expected, actual);
-		
+
 		// test out of bound conditions
 
 		final int[] validOffsets = { 0, 1, pageSize / 10 * 9 };
@@ -229,7 +228,7 @@ public class CrossSegmentTypeTest {
 						fail("should fail with an IndexOutOfBoundsException");
 					}
 					catch (IndexOutOfBoundsException ignored) {}
-					
+
 					try {
 						seg2.copyTo(off1, seg1, off2, len);
 						fail("should fail with an IndexOutOfBoundsException");

--- a/flink-core/src/test/java/org/apache/flink/core/memory/EndiannessAccessChecks.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/EndiannessAccessChecks.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class EndiannessAccessChecks {
-	
+
 	@Test
 	public void testHeapSegment() {
 		testBigAndLittleEndianAccessUnaligned(new HeapMemorySegment(new byte[11111]));
@@ -40,19 +40,19 @@ public class EndiannessAccessChecks {
 	public void testHybridOffHeapSegment() {
 		testBigAndLittleEndianAccessUnaligned(new HybridMemorySegment(ByteBuffer.allocateDirect(11111)));
 	}
-	
+
 	private void testBigAndLittleEndianAccessUnaligned(MemorySegment segment) {
 		final Random rnd = new Random();
-		
+
 		// longs
 		{
 			final long seed = rnd.nextLong();
-			
+
 			rnd.setSeed(seed);
 			for (int i = 0; i < 10000; i++) {
 				long val = rnd.nextLong();
 				int pos = rnd.nextInt(segment.size - 7);
-				
+
 				segment.putLongLittleEndian(pos, val);
 				long r = segment.getLongBigEndian(pos);
 				assertEquals(val, Long.reverseBytes(r));

--- a/flink-core/src/test/java/org/apache/flink/core/memory/EndiannessAccessChecks.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/EndiannessAccessChecks.java
@@ -25,6 +25,10 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Verifies correct accesses with regards to endianness in {@link HeapMemorySegment} and {@link
+ * HybridMemorySegment} (in both heap and off-heap modes).
+ */
 public class EndiannessAccessChecks {
 
 	@Test

--- a/flink-core/src/test/java/org/apache/flink/core/memory/EndiannessAccessChecks.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/EndiannessAccessChecks.java
@@ -18,11 +18,12 @@
 
 package org.apache.flink.core.memory;
 
-import java.nio.ByteBuffer;
-import java.util.Random;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
 
 public class EndiannessAccessChecks {
 

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HeapMemorySegmentTest.java
@@ -24,7 +24,9 @@ import org.junit.runners.Parameterized;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class HeapMemorySegmentTest extends MemorySegmentTestBase {

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HeapMemorySegmentTest.java
@@ -28,6 +28,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Tests for the {@link HeapMemorySegment} in off-heap mode.
+ */
 @RunWith(Parameterized.class)
 public class HeapMemorySegmentTest extends MemorySegmentTestBase {
 

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HeapMemorySegmentTest.java
@@ -42,7 +42,7 @@ public class HeapMemorySegmentTest extends MemorySegmentTestBase {
 	MemorySegment createSegment(int size, Object owner) {
 		return new HeapMemorySegment(new byte[size], owner);
 	}
-	
+
 	@Test
 	public void testHeapSegmentSpecifics() {
 		final byte[] buffer = new byte[411];

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HybridOffHeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HybridOffHeapMemorySegmentTest.java
@@ -29,6 +29,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+/**
+ * Tests for the {@link HybridMemorySegment} in off-heap mode.
+ */
 @RunWith(Parameterized.class)
 public class HybridOffHeapMemorySegmentTest extends MemorySegmentTestBase {
 

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HybridOffHeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HybridOffHeapMemorySegmentTest.java
@@ -60,6 +60,7 @@ public class HybridOffHeapMemorySegmentTest extends MemorySegmentTestBase {
 		assertTrue(buffer == seg.getOffHeapBuffer());
 
 		try {
+			//noinspection ResultOfMethodCallIgnored
 			seg.getArray();
 			fail("should throw an exception");
 		}

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
@@ -60,6 +60,7 @@ public class HybridOnHeapMemorySegmentTest extends MemorySegmentTestBase {
 		assertTrue(buffer == seg.getArray());
 
 		try {
+			//noinspection ResultOfMethodCallIgnored
 			seg.getOffHeapBuffer();
 			fail("should throw an exception");
 		}

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
@@ -45,7 +45,7 @@ public class HybridOnHeapMemorySegmentTest extends MemorySegmentTestBase {
 	MemorySegment createSegment(int size, Object owner) {
 		return new HybridMemorySegment(new byte[size], owner);
 	}
-	
+
 	@Test
 	public void testHybridHeapSegmentSpecifics() {
 		final byte[] buffer = new byte[411];

--- a/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/HybridOnHeapMemorySegmentTest.java
@@ -29,6 +29,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+/**
+ * Tests for the {@link HybridMemorySegment} in on-heap mode.
+ */
 @RunWith(Parameterized.class)
 public class HybridOnHeapMemorySegmentTest extends MemorySegmentTestBase {
 

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentChecksTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentChecksTest.java
@@ -66,17 +66,17 @@ public class MemorySegmentChecksTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testZeroAddress(){
-		new MockSegment(0L, 4*1024, null);
+		new MockSegment(0L, 4 * 1024, null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testNegativeAddress(){
-		new MockSegment(-1L, 4*1024, null);
+		new MockSegment(-1L, 4 * 1024, null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testTooLargeAddress(){
-		new MockSegment(Long.MAX_VALUE - 8*1024, 4*1024, null);
+		new MockSegment(Long.MAX_VALUE - 8 * 1024, 4 * 1024, null);
 	}
 
 	// ------------------------------------------------------------------------
@@ -131,5 +131,5 @@ public class MemorySegmentChecksTest {
 
 		@Override
 		public void put(int offset, ByteBuffer source, int numBytes) {}
-	};
+	}
 }

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentChecksTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentChecksTest.java
@@ -28,7 +28,7 @@ import java.nio.ByteBuffer;
  * Tests for the sanity checks of the memory segments.
  */
 public class MemorySegmentChecksTest {
-	
+
 	@Test(expected = NullPointerException.class)
 	public void testHeapNullBuffer1() {
 		new HeapMemorySegment(null);
@@ -78,9 +78,9 @@ public class MemorySegmentChecksTest {
 	public void testTooLargeAddress(){
 		new MockSegment(Long.MAX_VALUE - 8*1024, 4*1024, null);
 	}
-	
+
 	// ------------------------------------------------------------------------
-	
+
 	final class MockSegment extends MemorySegment {
 
 		MockSegment(long offHeapAddress, int size, Object owner) {

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentFactoryTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentFactoryTest.java
@@ -22,7 +22,9 @@ import org.junit.Test;
 
 import java.lang.reflect.Field;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the {@link MemorySegmentFactory} in on/off-heap modes.

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentFactoryTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentFactoryTest.java
@@ -24,6 +24,9 @@ import java.lang.reflect.Field;
 
 import static org.junit.Assert.*;
 
+/**
+ * Tests for the {@link MemorySegmentFactory} in on/off-heap modes.
+ */
 public class MemorySegmentFactoryTest {
 
 	@Test

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
@@ -63,7 +63,7 @@ public abstract class MemorySegmentTestBase {
 
 	abstract MemorySegment createSegment(int size);
 
-	abstract MemorySegment createSegment(int size, Object owner);
+	abstract MemorySegment createSegment(@SuppressWarnings("SameParameterValue") int size, Object owner);
 
 	// ------------------------------------------------------------------------
 	//  Access to primitives

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
@@ -42,12 +42,11 @@ import static org.junit.Assert.*;
  * Tests for the access and transfer methods of the HeapMemorySegment.
  */
 public abstract class MemorySegmentTestBase {
-	
+
 	private final Random random = new Random();
-	
+
 	private final int pageSize;
-	
-	
+
 	public MemorySegmentTestBase(int pageSize) {
 		this.pageSize = pageSize;
 	}
@@ -59,7 +58,7 @@ public abstract class MemorySegmentTestBase {
 	abstract MemorySegment createSegment(int size);
 
 	abstract MemorySegment createSegment(int size, Object owner);
-	
+
 	// ------------------------------------------------------------------------
 	//  Access to primitives
 	// ------------------------------------------------------------------------
@@ -1884,7 +1883,7 @@ public abstract class MemorySegmentTestBase {
 		testByteBufferGet(false);
 		testByteBufferGet(true);
 	}
-	
+
 	private void testByteBufferGet(boolean directBuffer) {
 		MemorySegment seg = createSegment(pageSize);
 		byte[] bytes = new byte[pageSize];
@@ -1926,7 +1925,7 @@ public abstract class MemorySegmentTestBase {
 		ByteBuffer source = directBuffer ?
 			ByteBuffer.allocateDirect(pageSize) :
 			ByteBuffer.allocate(pageSize);
-		
+
 		source.put(bytes);
 		source.clear();
 
@@ -1969,9 +1968,9 @@ public abstract class MemorySegmentTestBase {
 		ByteBuffer target = directBuffer ?
 				ByteBuffer.allocateDirect(pageSize + 49) :
 				ByteBuffer.allocate(pageSize + 49);
-		
+
 		target.position(19).limit(19 + pageSize);
-		
+
 		ByteBuffer slicedTarget = target.slice();
 
 		// transfer the segment in chunks into the byte buffer
@@ -2004,7 +2003,7 @@ public abstract class MemorySegmentTestBase {
 		ByteBuffer source = directBuffer ?
 				ByteBuffer.allocateDirect(pageSize + 49) :
 				ByteBuffer.allocate(pageSize + 49);
-		
+
 		source.put(bytes);
 		source.position(19).limit(19 + pageSize);
 		ByteBuffer slicedSource = source.slice();
@@ -2141,7 +2140,6 @@ public abstract class MemorySegmentTestBase {
 		assertEquals(0, bb.position());
 		assertEquals(bb.capacity(), bb.limit());
 
-
 		int pos = bb.capacity() / 3;
 		int limit = 2 * bb.capacity() / 3;
 		bb.limit(limit);
@@ -2167,7 +2165,7 @@ public abstract class MemorySegmentTestBase {
 		assertEquals(pos, bb.position());
 		assertEquals(limit, bb.limit());
 	}
-	
+
 	// ------------------------------------------------------------------------
 	//  Comparing and swapping
 	// ------------------------------------------------------------------------
@@ -2300,9 +2298,9 @@ public abstract class MemorySegmentTestBase {
 			assertTrue(e instanceof IllegalStateException || e instanceof NullPointerException);
 		}
 	}
-	
+
 	// ------------------------------------------------------------------------
-	//  Miscellaneous 
+	//  Miscellaneous
 	// ------------------------------------------------------------------------
 
 	@Test
@@ -2399,11 +2397,11 @@ public abstract class MemorySegmentTestBase {
 		assertTrue(seg.isFreed());
 		assertEquals(SIZE, seg.size());
 	}
-	
+
 	// ------------------------------------------------------------------------
 	//  Parametrization to run with different segment sizes
 	// ------------------------------------------------------------------------
-	
+
 	@Parameterized.Parameters(name = "segment-size = {0}")
 	public static Collection<Object[]> executionModes(){
 		return Arrays.asList(

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
@@ -36,7 +36,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Random;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the access and transfer methods of the HeapMemorySegment.

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
@@ -53,7 +53,7 @@ public abstract class MemorySegmentTestBase {
 
 	private final int pageSize;
 
-	public MemorySegmentTestBase(int pageSize) {
+	MemorySegmentTestBase(int pageSize) {
 		this.pageSize = pageSize;
 	}
 
@@ -414,7 +414,7 @@ public abstract class MemorySegmentTestBase {
 				continue;
 			} else {
 				occupied[pos] = true;
-				occupied[pos+1] = true;
+				occupied[pos + 1] = true;
 			}
 
 			segment.putChar(pos, (char) (random.nextInt(Character.MAX_VALUE)));
@@ -430,7 +430,7 @@ public abstract class MemorySegmentTestBase {
 				continue;
 			} else {
 				occupied[pos] = true;
-				occupied[pos+1] = true;
+				occupied[pos + 1] = true;
 			}
 
 			assertEquals((char) (random.nextInt(Character.MAX_VALUE)), segment.getChar(pos));
@@ -549,7 +549,7 @@ public abstract class MemorySegmentTestBase {
 				continue;
 			} else {
 				occupied[pos] = true;
-				occupied[pos+1] = true;
+				occupied[pos + 1] = true;
 			}
 
 			segment.putShort(pos, (short) random.nextInt());
@@ -565,7 +565,7 @@ public abstract class MemorySegmentTestBase {
 				continue;
 			} else {
 				occupied[pos] = true;
-				occupied[pos+1] = true;
+				occupied[pos + 1] = true;
 			}
 
 			assertEquals((short) random.nextInt(), segment.getShort(pos));
@@ -700,9 +700,9 @@ public abstract class MemorySegmentTestBase {
 				continue;
 			} else {
 				occupied[pos] = true;
-				occupied[pos+1] = true;
-				occupied[pos+2] = true;
-				occupied[pos+3] = true;
+				occupied[pos + 1] = true;
+				occupied[pos + 2] = true;
+				occupied[pos + 3] = true;
 			}
 
 			segment.putInt(pos, random.nextInt());
@@ -718,9 +718,9 @@ public abstract class MemorySegmentTestBase {
 				continue;
 			} else {
 				occupied[pos] = true;
-				occupied[pos+1] = true;
-				occupied[pos+2] = true;
-				occupied[pos+3] = true;
+				occupied[pos + 1] = true;
+				occupied[pos + 2] = true;
+				occupied[pos + 3] = true;
 			}
 
 			assertEquals(random.nextInt(), segment.getInt(pos));
@@ -852,19 +852,18 @@ public abstract class MemorySegmentTestBase {
 			int pos = random.nextInt(pageSize - 7);
 
 			if (occupied[pos] || occupied[pos + 1] || occupied[pos + 2] || occupied[pos + 3] ||
-					occupied[pos + 4] || occupied[pos + 5] || occupied[pos + 6] || occupied[pos + 7])
-			{
+					occupied[pos + 4] || occupied[pos + 5] || occupied[pos + 6] || occupied[pos + 7]) {
 				continue;
 			}
 			else {
 				occupied[pos] = true;
-				occupied[pos+1] = true;
-				occupied[pos+2] = true;
-				occupied[pos+3] = true;
-				occupied[pos+4] = true;
-				occupied[pos+5] = true;
-				occupied[pos+6] = true;
-				occupied[pos+7] = true;
+				occupied[pos + 1] = true;
+				occupied[pos + 2] = true;
+				occupied[pos + 3] = true;
+				occupied[pos + 4] = true;
+				occupied[pos + 5] = true;
+				occupied[pos + 6] = true;
+				occupied[pos + 7] = true;
 			}
 
 			segment.putLong(pos, random.nextLong());
@@ -877,19 +876,18 @@ public abstract class MemorySegmentTestBase {
 			int pos = random.nextInt(pageSize - 7);
 
 			if (occupied[pos] || occupied[pos + 1] || occupied[pos + 2] || occupied[pos + 3] ||
-					occupied[pos + 4] || occupied[pos + 5] || occupied[pos + 6] || occupied[pos + 7])
-			{
+					occupied[pos + 4] || occupied[pos + 5] || occupied[pos + 6] || occupied[pos + 7]) {
 				continue;
 			}
 			else {
 				occupied[pos] = true;
-				occupied[pos+1] = true;
-				occupied[pos+2] = true;
-				occupied[pos+3] = true;
-				occupied[pos+4] = true;
-				occupied[pos+5] = true;
-				occupied[pos+6] = true;
-				occupied[pos+7] = true;
+				occupied[pos + 1] = true;
+				occupied[pos + 2] = true;
+				occupied[pos + 3] = true;
+				occupied[pos + 4] = true;
+				occupied[pos + 5] = true;
+				occupied[pos + 6] = true;
+				occupied[pos + 7] = true;
 			}
 
 			assertEquals(random.nextLong(), segment.getLong(pos));
@@ -1024,9 +1022,9 @@ public abstract class MemorySegmentTestBase {
 				continue;
 			} else {
 				occupied[pos] = true;
-				occupied[pos+1] = true;
-				occupied[pos+2] = true;
-				occupied[pos+3] = true;
+				occupied[pos + 1] = true;
+				occupied[pos + 2] = true;
+				occupied[pos + 3] = true;
 			}
 
 			segment.putFloat(pos, random.nextFloat());
@@ -1042,9 +1040,9 @@ public abstract class MemorySegmentTestBase {
 				continue;
 			} else {
 				occupied[pos] = true;
-				occupied[pos+1] = true;
-				occupied[pos+2] = true;
-				occupied[pos+3] = true;
+				occupied[pos + 1] = true;
+				occupied[pos + 2] = true;
+				occupied[pos + 3] = true;
 			}
 
 			assertEquals(random.nextFloat(), segment.getFloat(pos), 0.0);
@@ -1175,19 +1173,18 @@ public abstract class MemorySegmentTestBase {
 			int pos = random.nextInt(pageSize - 7);
 
 			if (occupied[pos] || occupied[pos + 1] || occupied[pos + 2] || occupied[pos + 3] ||
-					occupied[pos + 4] || occupied[pos + 5] || occupied[pos + 6] || occupied[pos + 7])
-			{
+					occupied[pos + 4] || occupied[pos + 5] || occupied[pos + 6] || occupied[pos + 7]) {
 				continue;
 			}
 			else {
 				occupied[pos] = true;
-				occupied[pos+1] = true;
-				occupied[pos+2] = true;
-				occupied[pos+3] = true;
-				occupied[pos+4] = true;
-				occupied[pos+5] = true;
-				occupied[pos+6] = true;
-				occupied[pos+7] = true;
+				occupied[pos + 1] = true;
+				occupied[pos + 2] = true;
+				occupied[pos + 3] = true;
+				occupied[pos + 4] = true;
+				occupied[pos + 5] = true;
+				occupied[pos + 6] = true;
+				occupied[pos + 7] = true;
 			}
 
 			segment.putDouble(pos, random.nextDouble());
@@ -1200,19 +1197,18 @@ public abstract class MemorySegmentTestBase {
 			int pos = random.nextInt(pageSize - 7);
 
 			if (occupied[pos] || occupied[pos + 1] || occupied[pos + 2] || occupied[pos + 3] ||
-					occupied[pos + 4] || occupied[pos + 5] || occupied[pos + 6] || occupied[pos + 7])
-			{
+					occupied[pos + 4] || occupied[pos + 5] || occupied[pos + 6] || occupied[pos + 7]) {
 				continue;
 			}
 			else {
 				occupied[pos] = true;
-				occupied[pos+1] = true;
-				occupied[pos+2] = true;
-				occupied[pos+3] = true;
-				occupied[pos+4] = true;
-				occupied[pos+5] = true;
-				occupied[pos+6] = true;
-				occupied[pos+7] = true;
+				occupied[pos + 1] = true;
+				occupied[pos + 2] = true;
+				occupied[pos + 3] = true;
+				occupied[pos + 4] = true;
+				occupied[pos + 5] = true;
+				occupied[pos + 6] = true;
+				occupied[pos + 7] = true;
 			}
 
 			assertEquals(random.nextDouble(), segment.getDouble(pos), 0.0);
@@ -1227,7 +1223,7 @@ public abstract class MemorySegmentTestBase {
 	public void testBulkBytePutExceptions() {
 		final MemorySegment segment = createSegment(pageSize);
 
-		byte[] bytes = new byte[pageSize / 4 + (pageSize%4)];
+		byte[] bytes = new byte[pageSize / 4 + (pageSize % 4)];
 		random.nextBytes(bytes);
 
 		// wrong positions into memory segment
@@ -2053,8 +2049,7 @@ public abstract class MemorySegmentTestBase {
 
 		for (ByteBuffer bb : new ByteBuffer[] {
 						ByteBuffer.allocate(bbCapacity),
-						ByteBuffer.allocateDirect(bbCapacity) } )
-		{
+						ByteBuffer.allocateDirect(bbCapacity) }) {
 			for (int off : validOffsets) {
 				for (int len : invalidLengths) {
 					try {
@@ -2203,7 +2198,7 @@ public abstract class MemorySegmentTestBase {
 			int pos2 = random.nextInt(bytes2.length);
 
 			int len = Math.min(Math.min(bytes1.length - pos1, bytes2.length - pos2),
-					random.nextInt(pageSize / 50 ));
+					random.nextInt(pageSize / 50));
 
 			int cmp = seg1.compare(seg2, pos1, pos2, len);
 
@@ -2218,34 +2213,34 @@ public abstract class MemorySegmentTestBase {
 
 	@Test
 	public void testSwapBytes() {
-		final int HALF_SIZE = pageSize / 2;
+		final int halfPageSize = pageSize / 2;
 
 		final byte[] bytes1 = new byte[pageSize];
-		final byte[] bytes2 = new byte[HALF_SIZE];
+		final byte[] bytes2 = new byte[halfPageSize];
 
 		Arrays.fill(bytes2, (byte) 1);
 
 		MemorySegment seg1 = createSegment(pageSize);
-		MemorySegment seg2 = createSegment(HALF_SIZE);
+		MemorySegment seg2 = createSegment(halfPageSize);
 		seg1.put(0, bytes1);
 		seg2.put(0, bytes2);
 
 		// wap the second half of the first segment with the second segment
 
 		int pos = 0;
-		while (pos < HALF_SIZE) {
+		while (pos < halfPageSize) {
 			int len = random.nextInt(pageSize / 40);
-			len = Math.min(len, HALF_SIZE - pos);
-			seg1.swapBytes(new byte[len], seg2, pos + HALF_SIZE, pos, len);
+			len = Math.min(len, halfPageSize - pos);
+			seg1.swapBytes(new byte[len], seg2, pos + halfPageSize, pos, len);
 			pos += len;
 		}
 
 		// the second segment should now be all zeros, the first segment should have one in its second half
 
-		for (int i = 0; i < HALF_SIZE; i++) {
+		for (int i = 0; i < halfPageSize; i++) {
 			assertEquals((byte) 0, seg1.get(i));
 			assertEquals((byte) 0, seg2.get(i));
-			assertEquals((byte) 1, seg1.get(i + HALF_SIZE));
+			assertEquals((byte) 1, seg1.get(i + halfPageSize));
 		}
 	}
 
@@ -2393,15 +2388,15 @@ public abstract class MemorySegmentTestBase {
 	@Test
 	public void testSizeAndFreeing() {
 		// a segment without an owner has a null owner
-		final int SIZE = 651;
-		MemorySegment seg = createSegment(SIZE);
+		final int segmentSize = 651;
+		MemorySegment seg = createSegment(segmentSize);
 
-		assertEquals(SIZE, seg.size());
+		assertEquals(segmentSize, seg.size());
 		assertFalse(seg.isFreed());
 
 		seg.free();
 		assertTrue(seg.isFreed());
-		assertEquals(SIZE, seg.size());
+		assertEquals(segmentSize, seg.size());
 	}
 
 	// ------------------------------------------------------------------------
@@ -2411,8 +2406,8 @@ public abstract class MemorySegmentTestBase {
 	@Parameterized.Parameters(name = "segment-size = {0}")
 	public static Collection<Object[]> executionModes(){
 		return Arrays.asList(
-				new Object[] { 32*1024 },
-				new Object[] { 4*1024 },
-				new Object[] { 512*1024 } );
+				new Object[] { 32 * 1024 },
+				new Object[] { 4 * 1024 },
+				new Object[] { 512 * 1024 });
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentUndersizedTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentUndersizedTest.java
@@ -1101,7 +1101,7 @@ public class MemorySegmentUndersizedTest {
 		// ------ ByteBuffer ------
 
 		final ByteBuffer buf = ByteBuffer.allocate(7);
-		final int numBytes = 3; 
+		final int numBytes = 3;
 
 		try {
 			segment.put(0, buf, numBytes);

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentUndersizedTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentUndersizedTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class MemorySegmentUndersizedTest {
-	
+
 	@Test
 	public void testZeroSizeHeapSegment() {
 		MemorySegment segment = new HeapMemorySegment(new byte[0]);
@@ -109,7 +109,7 @@ public class MemorySegmentUndersizedTest {
 			assertTrue(e instanceof IndexOutOfBoundsException);
 		}
 	}
-	
+
 	private static void testSegmentWithSizeLargerZero(MemorySegment segment) {
 
 		// ------ bytes ------
@@ -145,7 +145,7 @@ public class MemorySegmentUndersizedTest {
 		catch (Exception e) {
 			assertTrue(e instanceof IndexOutOfBoundsException);
 		}
-		
+
 		try {
 			segment.put(Integer.MAX_VALUE, (byte) 0);
 			fail("IndexOutOfBoundsException expected");
@@ -161,7 +161,7 @@ public class MemorySegmentUndersizedTest {
 		catch (Exception e) {
 			assertTrue(e instanceof IndexOutOfBoundsException);
 		}
-		
+
 		try {
 			segment.get(1);
 			fail("IndexOutOfBoundsException expected");
@@ -169,7 +169,7 @@ public class MemorySegmentUndersizedTest {
 		catch (Exception e) {
 			assertTrue(e instanceof IndexOutOfBoundsException);
 		}
-		
+
 		try {
 			segment.get(-1);
 			fail("IndexOutOfBoundsException expected");
@@ -193,7 +193,7 @@ public class MemorySegmentUndersizedTest {
 		catch (Exception e) {
 			assertTrue(e instanceof IndexOutOfBoundsException);
 		}
-		
+
 		try {
 			segment.get(Integer.MAX_VALUE);
 			fail("IndexOutOfBoundsException expected");
@@ -243,7 +243,7 @@ public class MemorySegmentUndersizedTest {
 		catch (Exception e) {
 			assertTrue(e instanceof IndexOutOfBoundsException);
 		}
-		
+
 		try {
 			segment.putBoolean(Integer.MAX_VALUE, true);
 			fail("IndexOutOfBoundsException expected");
@@ -259,7 +259,7 @@ public class MemorySegmentUndersizedTest {
 		catch (Exception e) {
 			assertTrue(e instanceof IndexOutOfBoundsException);
 		}
-		
+
 		try {
 			segment.getBoolean(1);
 			fail("IndexOutOfBoundsException expected");
@@ -373,7 +373,7 @@ public class MemorySegmentUndersizedTest {
 		catch (Exception e) {
 			assertTrue(e instanceof IndexOutOfBoundsException);
 		}
-		
+
 		try {
 			segment.getChar(1);
 			fail("IndexOutOfBoundsException expected");
@@ -487,7 +487,7 @@ public class MemorySegmentUndersizedTest {
 		catch (Exception e) {
 			assertTrue(e instanceof IndexOutOfBoundsException);
 		}
-		
+
 		try {
 			segment.getShort(1);
 			fail("IndexOutOfBoundsException expected");
@@ -971,7 +971,7 @@ public class MemorySegmentUndersizedTest {
 		catch (Exception e) {
 			assertTrue(e instanceof IndexOutOfBoundsException);
 		}
-		
+
 		try {
 			segment.getDouble(Integer.MIN_VALUE);
 			fail("IndexOutOfBoundsException expected");
@@ -979,7 +979,6 @@ public class MemorySegmentUndersizedTest {
 		catch (Exception e) {
 			assertTrue(e instanceof IndexOutOfBoundsException);
 		}
-		
 
 		// ------ byte[] ------
 
@@ -1046,7 +1045,7 @@ public class MemorySegmentUndersizedTest {
 		catch (Exception e) {
 			assertTrue(e instanceof IndexOutOfBoundsException);
 		}
-		
+
 		try {
 			segment.get(1, new byte[7]);
 			fail("IndexOutOfBoundsException expected");
@@ -1099,7 +1098,7 @@ public class MemorySegmentUndersizedTest {
 
 		final ByteBuffer buf = ByteBuffer.allocate(7);
 		final int numBytes = 3; 
-		
+
 		try {
 			segment.put(0, buf, numBytes);
 			fail("IndexOutOfBoundsException expected");
@@ -1139,7 +1138,7 @@ public class MemorySegmentUndersizedTest {
 		catch (Exception e) {
 			assertTrue(e instanceof IndexOutOfBoundsException);
 		}
-		
+
 		try {
 			segment.put(Integer.MAX_VALUE, buf, numBytes);
 			fail("IndexOutOfBoundsException expected");
@@ -1215,7 +1214,7 @@ public class MemorySegmentUndersizedTest {
 
 		final DataInput dataInput = new DataInputStream(new ByteArrayInputStream(new byte[20]));
 		final DataOutput dataOutput = new DataOutputStream(new ByteArrayOutputStream());
-		
+
 		try {
 			segment.put(dataInput, 0, numBytes);
 			fail("IndexOutOfBoundsException expected");

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentUndersizedTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentUndersizedTest.java
@@ -31,6 +31,10 @@ import java.nio.ByteBuffer;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+/**
+ * Tests for undersized {@link HeapMemorySegment} and {@link HybridMemorySegment} (in both heap and
+ * off-heap modes).
+ */
 public class MemorySegmentUndersizedTest {
 
 	@Test

--- a/flink-core/src/test/java/org/apache/flink/core/memory/OperationsOnFreedSegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/OperationsOnFreedSegmentTest.java
@@ -944,8 +944,8 @@ public class OperationsOnFreedSegmentTest {
 
 		for (ByteBuffer bbuf : new ByteBuffer[] {
 				ByteBuffer.allocate(55),
-				ByteBuffer.allocateDirect(55) } )
-		{
+				ByteBuffer.allocateDirect(55) }) {
+
 			try {
 				segment.get(0, bbuf, 17);
 				fail("Should fail with an exception");
@@ -1019,7 +1019,7 @@ public class OperationsOnFreedSegmentTest {
 			catch (IllegalStateException | NullPointerException | IndexOutOfBoundsException ignored) {}
 
 			try {
-				segment.put(Integer.MAX_VALUE,bbuf, 17);
+				segment.put(Integer.MAX_VALUE, bbuf, 17);
 				fail("Should fail with an exception");
 			}
 			catch (IllegalStateException | NullPointerException | IndexOutOfBoundsException ignored) {}

--- a/flink-core/src/test/java/org/apache/flink/core/memory/OperationsOnFreedSegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/OperationsOnFreedSegmentTest.java
@@ -31,6 +31,10 @@ import java.nio.ByteBuffer;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+/**
+ * Various tests with freed memory segments for {@link HeapMemorySegment} and {@link
+ * HybridMemorySegment} (in both heap and off-heap modes).
+ */
 public class OperationsOnFreedSegmentTest {
 
 	private static final int PAGE_SIZE = (int) ((Math.random() * 10000) + 1000);

--- a/flink-core/src/test/java/org/apache/flink/core/memory/OperationsOnFreedSegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/OperationsOnFreedSegmentTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.*;
 public class OperationsOnFreedSegmentTest {
 
 	private static final int PAGE_SIZE = (int) ((Math.random() * 10000) + 1000);
-	
+
 	@Test
 	public void testSingleSegmentOperationsHeapSegment() throws Exception {
 		testOpsOnFreedSegment(new HeapMemorySegment(new byte[PAGE_SIZE]));
@@ -78,7 +78,7 @@ public class OperationsOnFreedSegmentTest {
 			}
 		}
 	}
-	
+
 	@Test
 	public void testCopyTo() {
 		MemorySegment aliveHeap = new HeapMemorySegment(new byte[PAGE_SIZE]);
@@ -154,13 +154,13 @@ public class OperationsOnFreedSegmentTest {
 			}
 		}
 	}
-	
+
 	private void testOpsOnFreedSegment(MemorySegment segment) throws Exception {
 		segment.free();
 		assertTrue(segment.isFreed());
-		
-		// --------- bytes ----------- 
-		
+
+		// --------- bytes -----------
+
 		try {
 			segment.get(0);
 			fail("Should fail with an exception");
@@ -190,7 +190,7 @@ public class OperationsOnFreedSegmentTest {
 			fail("Should fail with an exception");
 		}
 		catch (IllegalStateException | NullPointerException | IndexOutOfBoundsException ignored) {}
-		
+
 		try {
 			segment.get(Integer.MAX_VALUE);
 			fail("Should fail with an exception");
@@ -245,7 +245,7 @@ public class OperationsOnFreedSegmentTest {
 		}
 		catch (IllegalStateException | NullPointerException ignored) {}
 
-		// --------- booleans ----------- 
+		// --------- booleans -----------
 
 		try {
 			segment.getBoolean(0);
@@ -330,8 +330,8 @@ public class OperationsOnFreedSegmentTest {
 			fail("Should fail with an exception");
 		}
 		catch (IllegalStateException | NullPointerException ignored) {}
-		
-		// --------- char ----------- 
+
+		// --------- char -----------
 
 		try {
 			segment.getChar(0);
@@ -417,7 +417,7 @@ public class OperationsOnFreedSegmentTest {
 		}
 		catch (IllegalStateException ignored) {}
 
-		// --------- short ----------- 
+		// --------- short -----------
 
 		try {
 			segment.getShort(0);
@@ -503,7 +503,7 @@ public class OperationsOnFreedSegmentTest {
 		}
 		catch (IllegalStateException ignored) {}
 
-		// --------- integer ----------- 
+		// --------- integer -----------
 
 		try {
 			segment.getInt(0);
@@ -589,7 +589,7 @@ public class OperationsOnFreedSegmentTest {
 		}
 		catch (IllegalStateException ignored) {}
 
-		// --------- longs ----------- 
+		// --------- longs -----------
 
 		try {
 			segment.getLong(0);
@@ -675,7 +675,7 @@ public class OperationsOnFreedSegmentTest {
 		}
 		catch (IllegalStateException ignored) {}
 
-		// --------- floats ----------- 
+		// --------- floats -----------
 
 		try {
 			segment.getFloat(0);
@@ -761,7 +761,7 @@ public class OperationsOnFreedSegmentTest {
 		}
 		catch (IllegalStateException ignored) {}
 
-		// --------- doubles ----------- 
+		// --------- doubles -----------
 
 		try {
 			segment.getDouble(0);
@@ -847,10 +847,10 @@ public class OperationsOnFreedSegmentTest {
 		}
 		catch (IllegalStateException ignored) {}
 
-		// --------- byte[] ----------- 
+		// --------- byte[] -----------
 
 		final byte[] array = new byte[55];
-		
+
 		try {
 			segment.get(0, array, 3, 17);
 			fail("Should fail with an exception");
@@ -935,7 +935,7 @@ public class OperationsOnFreedSegmentTest {
 		}
 		catch (IllegalStateException | NullPointerException ignored) {}
 
-		// --------- ByteBuffer ----------- 
+		// --------- ByteBuffer -----------
 
 		for (ByteBuffer bbuf : new ByteBuffer[] {
 				ByteBuffer.allocate(55),
@@ -946,79 +946,79 @@ public class OperationsOnFreedSegmentTest {
 				fail("Should fail with an exception");
 			}
 			catch (IllegalStateException | NullPointerException ignored) {}
-	
+
 			try {
 				segment.get(-1, bbuf, 17);
 				fail("Should fail with an exception");
 			}
 			catch (IllegalStateException | NullPointerException | IndexOutOfBoundsException ignored) {}
-	
+
 			try {
 				segment.get(1, bbuf, 17);
 				fail("Should fail with an exception");
 			}
 			catch (IllegalStateException | NullPointerException ignored) {}
-	
+
 			try {
 				segment.get(segment.size(), bbuf, 17);
 				fail("Should fail with an exception");
 			}
 			catch (IllegalStateException | NullPointerException ignored) {}
-	
+
 			try {
 				segment.get(-segment.size(), bbuf, 17);
 				fail("Should fail with an exception");
 			}
 			catch (IllegalStateException | NullPointerException | IndexOutOfBoundsException ignored) {}
-	
+
 			try {
 				segment.get(Integer.MAX_VALUE, bbuf, 17);
 				fail("Should fail with an exception");
 			}
 			catch (IllegalStateException | NullPointerException | IndexOutOfBoundsException ignored) {}
-	
+
 			try {
 				segment.get(Integer.MIN_VALUE, bbuf, 17);
 				fail("Should fail with an exception");
 			}
 			catch (IllegalStateException | NullPointerException | IndexOutOfBoundsException ignored) {}
-	
+
 			try {
 				segment.put(0, bbuf, 17);
 				fail("Should fail with an exception");
 			}
 			catch (IllegalStateException | NullPointerException | IndexOutOfBoundsException ignored) {}
-	
+
 			try {
 				segment.put(-1, bbuf, 17);
 				fail("Should fail with an exception");
 			}
 			catch (IllegalStateException | NullPointerException | IndexOutOfBoundsException ignored) {}
-	
+
 			try {
 				segment.put(1, bbuf, 17);
 				fail("Should fail with an exception");
 			}
 			catch (IllegalStateException | NullPointerException ignored) {}
-	
+
 			try {
 				segment.put(segment.size(), bbuf, 17);
 				fail("Should fail with an exception");
 			}
 			catch (IllegalStateException | NullPointerException ignored) {}
-	
+
 			try {
 				segment.put(-segment.size(), bbuf, 17);
 				fail("Should fail with an exception");
 			}
 			catch (IllegalStateException | NullPointerException | IndexOutOfBoundsException ignored) {}
-	
+
 			try {
 				segment.put(Integer.MAX_VALUE,bbuf, 17);
 				fail("Should fail with an exception");
 			}
 			catch (IllegalStateException | NullPointerException | IndexOutOfBoundsException ignored) {}
-	
+
 			try {
 				segment.put(Integer.MIN_VALUE, bbuf, 17);
 				fail("Should fail with an exception");
@@ -1026,7 +1026,7 @@ public class OperationsOnFreedSegmentTest {
 			catch (IllegalStateException | NullPointerException | IndexOutOfBoundsException ignored) {}
 		}
 
-		// --------- Data Input / Output ----------- 
+		// --------- Data Input / Output -----------
 
 		final DataInput din = new DataInputStream(new ByteArrayInputStream(new byte[100]));
 		final DataOutput dout = new DataOutputStream(new ByteArrayOutputStream());
@@ -1115,12 +1115,11 @@ public class OperationsOnFreedSegmentTest {
 		}
 		catch (IllegalStateException | NullPointerException | IndexOutOfBoundsException ignored) {}
 	}
-	
-	
+
 	private void testCompare(MemorySegment seg1, MemorySegment seg2) {
 		int[] offsetsToTest = { 0, 1, -1, seg1.size(), -seg1.size(), Integer.MAX_VALUE, Integer.MIN_VALUE };
 		int[] lengthsToTest = { 1, seg1.size(), Integer.MAX_VALUE };
-		
+
 		for (int off1 : offsetsToTest) {
 			for (int off2 : offsetsToTest) {
 				for (int len : lengthsToTest) {
@@ -1155,7 +1154,7 @@ public class OperationsOnFreedSegmentTest {
 		int[] offsetsToTest = { 0, 1, -1, seg1.size(), -seg1.size(), Integer.MAX_VALUE, Integer.MIN_VALUE };
 		int[] lengthsToTest = { 0, 1, -1, seg1.size(), -seg1.size(), Integer.MAX_VALUE, Integer.MIN_VALUE };
 		byte[] swapBuffer = new byte[seg1.size()];
-		
+
 		for (int off1 : offsetsToTest) {
 			for (int off2 : offsetsToTest) {
 				for (int len : lengthsToTest) {

--- a/flink-core/src/test/java/org/apache/flink/core/memory/OperationsOnFreedSegmentTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/OperationsOnFreedSegmentTest.java
@@ -28,7 +28,8 @@ import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class OperationsOnFreedSegmentTest {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -685,7 +685,7 @@ public class MemoryManager {
 				hybridSegment.free();
 			}
 			else {
-				throw new IllegalArgumentException("Memory segment is not a " + HeapMemorySegment.class.getSimpleName());
+				throw new IllegalArgumentException("Memory segment is not a " + HybridMemorySegment.class.getSimpleName());
 			}
 		}
 

--- a/tools/maven/suppressions-core.xml
+++ b/tools/maven/suppressions-core.xml
@@ -128,14 +128,6 @@ under the License.
 		checks="AvoidStarImport"/>
 
 	<suppress
-		files="(.*)core[/\\]memory[/\\](.*)"
-		checks="NewlineAtEndOfFile|RegexpSingleline|TodoComment|RedundantImport|ImportOrder|RedundantModifier|JavadocMethod|JavadocParagraph|JavadocType|JavadocStyle|PackageName|TypeNameCheck|ConstantNameCheck|StaticVariableNameCheck|MemberNameCheck|MethodNameCheck|ParameterName|LocalFinalVariableName|LocalVariableName|LeftCurly|UpperEll|FallThrough|reliefPattern|SimplifyBooleanExpression|EmptyStatement|ModifierOrder|EmptyLineSeparator|WhitespaceAround|WhitespaceAfter|NoWhitespaceAfter|NoWhitespaceBefore|OperatorWrap|ParenPad"/>
-	<!--Only additional checks for test sources. Those checks were present in the "pre-strict" checkstyle but were not applied to test sources. We do not want to suppress them for sources directory-->
-	<suppress
-		files="(.*)test[/\\](.*)core[/\\]memory[/\\](.*)"
-		checks="AvoidStarImport"/>
-
-	<suppress
 		files="(.*)migration[/\\](.*)"
 		checks="NewlineAtEndOfFile|RegexpSingleline|TodoComment|RedundantImport|ImportOrder|RedundantModifier|JavadocMethod|JavadocParagraph|JavadocType|JavadocStyle|PackageName|TypeNameCheck|ConstantNameCheck|StaticVariableNameCheck|MemberNameCheck|MethodNameCheck|ParameterName|LocalFinalVariableName|LocalVariableName|LeftCurly|UpperEll|FallThrough|reliefPattern|SimplifyBooleanExpression|EmptyStatement|ModifierOrder|EmptyLineSeparator|WhitespaceAround|WhitespaceAfter|NoWhitespaceAfter|NoWhitespaceBefore|OperatorWrap|ParenPad"/>
 


### PR DESCRIPTION
## What is the purpose of the change

Activate checkstyle for `flink/core/memory/*`.

~This PR is based on #4446.~

## Brief change log

  - adapt the code to the checkstyle rules
  - remove the checkstyle suppression for `"(.*)core[/\\]memory[/\\](.*)"`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

