### PR TITLE
[FLINK-7332] [futures] Replace Flink's futures with Java 8's CompletableFuture in TaskExecutor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
@@ -26,6 +26,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import scala.concurrent.ExecutionContext;
+
 /**
  * Collection of {@link Executor} implementations
  */
@@ -55,6 +57,41 @@ public class Executors {
 		@Override
 		public void execute(@Nonnull Runnable command) {
 			command.run();
+		}
+	}
+
+	/**
+	 * Return a direct execution context. The direct execution context executes the runnable directly
+	 * in the calling thread.
+	 *
+	 * @return Direct execution context.
+	 */
+	public static ExecutionContext directExecutionContext() {
+		return DirectExecutionContext.INSTANCE;
+	}
+
+	/**
+	 * Direct execution context.
+	 */
+	private static class DirectExecutionContext implements ExecutionContext {
+
+		static final DirectExecutionContext INSTANCE = new DirectExecutionContext();
+
+		private DirectExecutionContext() {}
+
+		@Override
+		public void execute(Runnable runnable) {
+			runnable.run();
+		}
+
+		@Override
+		public void reportFailure(Throwable cause) {
+			throw new IllegalStateException("Error in direct execution context.", cause);
+		}
+
+		@Override
+		public ExecutionContext prepare() {
+			return this;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FlinkFutureException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FlinkFutureException.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Base class for exceptions which are thrown in {@link CompletionStage}.
+ *
+ * <p>The exception has to extend {@link FlinkRuntimeException} because only
+ * unchecked exceptions can be thrown in a future's stage. Additionally we let
+ * it extend the Flink runtime exception because it designates the exception to
+ * come from a Flink stage.
+ */
+public class FlinkFutureException extends FlinkRuntimeException {
+	private static final long serialVersionUID = -8878194471694178210L;
+
+	public FlinkFutureException(String message) {
+		super(message);
+	}
+
+	public FlinkFutureException(Throwable cause) {
+		super(cause);
+	}
+
+	public FlinkFutureException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -344,4 +344,26 @@ public class FutureUtils {
 
 		return result;
 	}
+
+	/**
+	 * Converts a Java 8 {@link java.util.concurrent.CompletableFuture} into a Flink {@link Future}.
+	 *
+	 * @param javaFuture to convert to a Flink future
+	 * @param <T> type of the future value
+	 * @return Flink future
+	 */
+	public static <T> Future<T> toFlinkFuture(java.util.concurrent.CompletableFuture<T> javaFuture) {
+		FlinkCompletableFuture<T> result = new FlinkCompletableFuture<>();
+
+		javaFuture.whenComplete(
+			(value, throwable) -> {
+				if (throwable == null) {
+					result.complete(value);
+				} else {
+					result.completeExceptionally(throwable);
+				}
+			});
+
+		return result;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.concurrent;
 import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.util.Preconditions;
 
+import akka.dispatch.OnComplete;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -285,5 +287,61 @@ public class FutureUtils {
 		public int getNumFuturesCompleted() {
 			return numCompleted.get();
 		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Converting futures
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Converts a Scala {@link scala.concurrent.Future} to a {@link java.util.concurrent.CompletableFuture}.
+	 *
+	 * @param scalaFuture to convert to a Java 8 CompletableFuture
+	 * @param <T> type of the future value
+	 * @return Java 8 CompletableFuture
+	 */
+	public static <T> java.util.concurrent.CompletableFuture<T> toJava(scala.concurrent.Future<T> scalaFuture) {
+		final java.util.concurrent.CompletableFuture<T> result = new java.util.concurrent.CompletableFuture<>();
+
+		scalaFuture.onComplete(new OnComplete<T>() {
+			@Override
+			public void onComplete(Throwable failure, T success) throws Throwable {
+				if (failure != null) {
+					result.completeExceptionally(failure);
+				} else {
+					result.complete(success);
+				}
+			}
+		}, Executors.directExecutionContext());
+
+		return result;
+	}
+
+	/**
+	 * Converts a Flink {@link Future} into a {@link CompletableFuture}.
+	 *
+	 * @param flinkFuture to convert to a Java 8 CompletableFuture
+	 * @param <T> type of the future value
+	 * @return Java 8 CompletableFuture
+	 *
+	 * @deprecated Will be removed once we completely remove Flink's futures
+	 */
+	@Deprecated
+	public static <T> java.util.concurrent.CompletableFuture<T> toJava(Future<T> flinkFuture) {
+		final java.util.concurrent.CompletableFuture<T> result = new java.util.concurrent.CompletableFuture<>();
+
+		flinkFuture.handle(
+			(t, throwable) -> {
+				if (throwable != null) {
+					result.completeExceptionally(throwable);
+				} else {
+					result.complete(t);
+				}
+
+				return null;
+			}
+		);
+
+		return result;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatListener.java
@@ -19,7 +19,8 @@
 package org.apache.flink.runtime.heartbeat;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.concurrent.Future;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Interface for the interaction with the {@link HeartbeatManager}. The heartbeat listener is used
@@ -58,5 +59,5 @@ public interface HeartbeatListener<I, O> {
 	 *
 	 * @return Future containing the next payload for heartbeats
 	 */
-	Future<O> retrievePayload();
+	CompletableFuture<O> retrievePayload();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
@@ -19,13 +19,11 @@
 package org.apache.flink.runtime.heartbeat;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.concurrent.AcceptFunction;
-import org.apache.flink.runtime.concurrent.ApplyFunction;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 
 import org.slf4j.Logger;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -65,25 +63,20 @@ public class HeartbeatManagerSenderImpl<I, O> extends HeartbeatManagerImpl<I, O>
 		if (!stopped) {
 			log.debug("Trigger heartbeat request.");
 			for (HeartbeatMonitor<O> heartbeatMonitor : getHeartbeatTargets()) {
-				Future<O> futurePayload = getHeartbeatListener().retrievePayload();
+				CompletableFuture<O> futurePayload = getHeartbeatListener().retrievePayload();
 				final HeartbeatTarget<O> heartbeatTarget = heartbeatMonitor.getHeartbeatTarget();
 
 				if (futurePayload != null) {
-					Future<Void> requestHeartbeatFuture = futurePayload.thenAcceptAsync(new AcceptFunction<O>() {
-						@Override
-						public void accept(O payload) {
-							heartbeatTarget.requestHeartbeat(getOwnResourceID(), payload);
-						}
-					}, getExecutor());
+					CompletableFuture<Void> requestHeartbeatFuture = futurePayload.thenAcceptAsync(
+						payload -> heartbeatTarget.requestHeartbeat(getOwnResourceID(), payload),
+						getExecutor());
 
-					requestHeartbeatFuture.exceptionally(new ApplyFunction<Throwable, Void>() {
-						@Override
-						public Void apply(Throwable failure) {
+					requestHeartbeatFuture.exceptionally(
+						(Throwable failure) -> {
 							log.warn("Could not request the heartbeat from target {}.", heartbeatTarget, failure);
 
 							return null;
-						}
-					});
+						});
 				} else {
 					heartbeatTarget.requestHeartbeat(getOwnResourceID(), null);
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotPool.java
@@ -25,10 +25,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.concurrent.AcceptFunction;
-import org.apache.flink.runtime.concurrent.ApplyFunction;
 import org.apache.flink.runtime.concurrent.Future;
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
@@ -57,6 +55,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -246,7 +245,7 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 
 		// work on all slots waiting for this connection
 		for (PendingRequest pending : waitingForResourceManager.values()) {
-			requestSlotFromResourceManager(pending.allocationID(), pending.future(), pending.resourceProfile());
+			requestSlotFromResourceManager(pending.allocationID(), pending.getFuture(), pending.resourceProfile());
 		}
 
 		// all sent off
@@ -269,7 +268,7 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 			ResourceProfile resources,
 			Iterable<TaskManagerLocation> locationPreferences) {
 
-		return internalAllocateSlot(task, resources, locationPreferences);
+		return FutureUtils.toFlinkFuture(internalAllocateSlot(task, resources, locationPreferences));
 	}
 
 	@RpcMethod
@@ -278,7 +277,7 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 	}
 
 
-	Future<SimpleSlot> internalAllocateSlot(
+	CompletableFuture<SimpleSlot> internalAllocateSlot(
 			ScheduledUnit task,
 			ResourceProfile resources,
 			Iterable<TaskManagerLocation> locationPreferences) {
@@ -288,12 +287,12 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 		if (slotFromPool != null) {
 			SimpleSlot slot = createSimpleSlot(slotFromPool.slot(), slotFromPool.locality());
 			allocatedSlots.add(slot);
-			return FlinkCompletableFuture.completed(slot);
+			return CompletableFuture.completedFuture(slot);
 		}
 
 		// the request will be completed by a future
 		final AllocationID allocationID = new AllocationID();
-		final FlinkCompletableFuture<SimpleSlot> future = new FlinkCompletableFuture<>();
+		final CompletableFuture<SimpleSlot> future = new CompletableFuture<>();
 
 		// (2) need to request a slot
 
@@ -310,34 +309,33 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 
 	private void requestSlotFromResourceManager(
 			final AllocationID allocationID,
-			final FlinkCompletableFuture<SimpleSlot> future,
+			final CompletableFuture<SimpleSlot> future,
 			final ResourceProfile resources) {
 
 		LOG.info("Requesting slot with profile {} from resource manager (request = {}).", resources, allocationID);
 
 		pendingRequests.put(allocationID, new PendingRequest(allocationID, future, resources));
 
-		Future<Acknowledge> rmResponse = resourceManagerGateway.requestSlot(
+		CompletableFuture<Acknowledge> rmResponse = FutureUtils.toJava(
+			resourceManagerGateway.requestSlot(
 				jobManagerLeaderId, resourceManagerLeaderId,
 				new SlotRequest(jobId, allocationID, resources, jobManagerAddress),
-				resourceManagerRequestsTimeout);
+				resourceManagerRequestsTimeout));
 
-		Future<Void> slotRequestProcessingFuture = rmResponse.thenAcceptAsync(new AcceptFunction<Acknowledge>() {
-			@Override
-			public void accept(Acknowledge value) {
+		CompletableFuture<Void> slotRequestProcessingFuture = rmResponse.thenAcceptAsync(
+			(Acknowledge value) -> {
 				slotRequestToResourceManagerSuccess(allocationID);
-			}
-		}, getMainThreadExecutor());
+			},
+			getMainThreadExecutor());
 
 		// on failure, fail the request future
-		slotRequestProcessingFuture.exceptionallyAsync(new ApplyFunction<Throwable, Void>() {
-
-			@Override
-			public Void apply(Throwable failure) {
-				slotRequestToResourceManagerFailed(allocationID, failure);
-				return null;
-			}
-		}, getMainThreadExecutor());
+		slotRequestProcessingFuture.whenCompleteAsync(
+			(Void v, Throwable failure) -> {
+				if (failure != null) {
+					slotRequestToResourceManagerFailed(allocationID, failure);
+				}
+			},
+			getMainThreadExecutor());
 	}
 
 	private void slotRequestToResourceManagerSuccess(final AllocationID allocationID) {
@@ -354,7 +352,7 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 	private void slotRequestToResourceManagerFailed(AllocationID allocationID, Throwable failure) {
 		PendingRequest request = pendingRequests.remove(allocationID);
 		if (request != null) {
-			request.future().completeExceptionally(new NoResourceAvailableException(
+			request.getFuture().completeExceptionally(new NoResourceAvailableException(
 					"No pooled slot available and request to ResourceManager for new slot failed", failure));
 		} else {
 			if (LOG.isDebugEnabled()) {
@@ -365,15 +363,15 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 
 	private void checkTimeoutSlotAllocation(AllocationID allocationID) {
 		PendingRequest request = pendingRequests.remove(allocationID);
-		if (request != null && !request.future().isDone()) {
-			request.future().completeExceptionally(new TimeoutException("Slot allocation request timed out"));
+		if (request != null && !request.getFuture().isDone()) {
+			request.getFuture().completeExceptionally(new TimeoutException("Slot allocation request timed out"));
 		}
 	}
 
 	private void stashRequestWaitingForResourceManager(
 			final AllocationID allocationID,
 			final ResourceProfile resources,
-			final FlinkCompletableFuture<SimpleSlot> future) {
+			final CompletableFuture<SimpleSlot> future) {
 
 		LOG.info("Cannot serve slot request, no ResourceManager connected. " +
 				"Adding as pending request {}",  allocationID);
@@ -390,8 +388,8 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 
 	private void checkTimeoutRequestWaitingForResourceManager(AllocationID allocationID) {
 		PendingRequest request = waitingForResourceManager.remove(allocationID);
-		if (request != null && !request.future().isDone()) {
-			request.future().completeExceptionally(new NoResourceAvailableException(
+		if (request != null && !request.getFuture().isDone()) {
+			request.getFuture().completeExceptionally(new NoResourceAvailableException(
 					"No slot available and no connection to Resource Manager established."));
 		}
 	}
@@ -426,7 +424,7 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 
 					SimpleSlot newSlot = createSimpleSlot(taskManagerSlot, Locality.UNKNOWN);
 					allocatedSlots.add(newSlot);
-					pendingRequest.future().complete(newSlot);
+					pendingRequest.getFuture().complete(newSlot);
 				}
 				else {
 					LOG.debug("Adding returned slot [{}] to available slots", taskManagerSlot.getSlotAllocationId());
@@ -513,7 +511,7 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 		if (pendingRequest != null) {
 			// we were waiting for this!
 			SimpleSlot resultSlot = createSimpleSlot(slot, Locality.UNKNOWN);
-			pendingRequest.future().complete(resultSlot);
+			pendingRequest.getFuture().complete(resultSlot);
 			allocatedSlots.add(resultSlot);
 		}
 		else {
@@ -552,7 +550,7 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 		if (pendingRequest != null) {
 			// request was still pending
 			LOG.debug("Failed pending request [{}] with ", allocationID, cause);
-			pendingRequest.future().completeExceptionally(cause);
+			pendingRequest.getFuture().completeExceptionally(cause);
 		}
 		else if (availableSlots.tryRemove(allocationID)) {
 			LOG.debug("Failed available slot [{}] with ", allocationID, cause);
@@ -999,13 +997,13 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 
 		private final AllocationID allocationID;
 
-		private final FlinkCompletableFuture<SimpleSlot> future;
+		private final CompletableFuture<SimpleSlot> future;
 
 		private final ResourceProfile resourceProfile;
 
 		PendingRequest(
 				AllocationID allocationID,
-				FlinkCompletableFuture<SimpleSlot> future,
+				CompletableFuture<SimpleSlot> future,
 				ResourceProfile resourceProfile) {
 			this.allocationID = allocationID;
 			this.future = future;
@@ -1016,7 +1014,7 @@ public class SlotPool extends RpcEndpoint<SlotPoolGateway> {
 			return allocationID;
 		}
 
-		public FlinkCompletableFuture<SimpleSlot> future() {
+		public CompletableFuture<SimpleSlot> getFuture() {
 			return future;
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -106,6 +106,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
@@ -1123,8 +1124,8 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 		}
 
 		@Override
-		public Future<Void> retrievePayload() {
-			return FlinkCompletableFuture.completed(null);
+		public CompletableFuture<Void> retrievePayload() {
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 
@@ -1150,8 +1151,8 @@ public class JobMaster extends RpcEndpoint<JobMasterGateway> {
 		}
 
 		@Override
-		public Future<Void> retrievePayload() {
-			return FlinkCompletableFuture.completed(null);
+		public CompletableFuture<Void> retrievePayload() {
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -67,6 +67,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeoutException;
@@ -999,8 +1000,8 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 		}
 
 		@Override
-		public Future<Void> retrievePayload() {
-			return FlinkCompletableFuture.completed(null);
+		public CompletableFuture<Void> retrievePayload() {
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 
@@ -1032,8 +1033,8 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 		}
 
 		@Override
-		public Future<Void> retrievePayload() {
-			return FlinkCompletableFuture.completed(null);
+		public CompletableFuture<Void> retrievePayload() {
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
@@ -19,11 +19,8 @@
 package org.apache.flink.runtime.heartbeat;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.concurrent.CompletableFuture;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.util.DirectExecutorService;
 import org.apache.flink.util.TestLogger;
 
@@ -31,6 +28,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -72,7 +70,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 		Object expectedObject = new Object();
 
-		when(heartbeatListener.retrievePayload()).thenReturn(FlinkCompletableFuture.completed(expectedObject));
+		when(heartbeatListener.retrievePayload()).thenReturn(CompletableFuture.completedFuture(expectedObject));
 
 		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
@@ -113,7 +111,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 		Object expectedObject = new Object();
 
-		when(heartbeatListener.retrievePayload()).thenReturn(FlinkCompletableFuture.completed(expectedObject));
+		when(heartbeatListener.retrievePayload()).thenReturn(CompletableFuture.completedFuture(expectedObject));
 
 		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
@@ -165,7 +163,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 		HeartbeatTarget<Object> heartbeatTarget = mock(HeartbeatTarget.class);
 
-		Future<ResourceID> timeoutFuture = heartbeatListener.getTimeoutFuture();
+		CompletableFuture<ResourceID> timeoutFuture = heartbeatListener.getTimeoutFuture();
 
 		heartbeatManager.monitorTarget(targetResourceID, heartbeatTarget);
 
@@ -199,11 +197,11 @@ public class HeartbeatManagerTest extends TestLogger {
 		ResourceID resourceID2 = new ResourceID("barfoo");
 		HeartbeatListener<Object, Object> heartbeatListener = mock(HeartbeatListener.class);
 
-		when(heartbeatListener.retrievePayload()).thenReturn(FlinkCompletableFuture.completed(object));
+		when(heartbeatListener.retrievePayload()).thenReturn(CompletableFuture.completedFuture(object));
 
 		TestingHeartbeatListener heartbeatListener2 = new TestingHeartbeatListener(object2);
 
-		Future<ResourceID> futureTimeout = heartbeatListener2.getTimeoutFuture();
+		CompletableFuture<ResourceID> futureTimeout = heartbeatListener2.getTimeoutFuture();
 
 		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
@@ -266,7 +264,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 		heartbeatManager.unmonitorTarget(targetID);
 
-		Future<ResourceID> timeout = heartbeatListener.getTimeoutFuture();
+		CompletableFuture<ResourceID> timeout = heartbeatListener.getTimeoutFuture();
 
 		try {
 			timeout.get(2 * heartbeatTimeout, TimeUnit.MILLISECONDS);
@@ -278,7 +276,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 	static class TestingHeartbeatListener implements HeartbeatListener<Object, Object> {
 
-		private final CompletableFuture<ResourceID> future = new FlinkCompletableFuture<>();
+		private final CompletableFuture<ResourceID> future = new CompletableFuture<>();
 
 		private final Object payload;
 
@@ -288,7 +286,11 @@ public class HeartbeatManagerTest extends TestLogger {
 			this.payload = payload;
 		}
 
-		public Future<ResourceID> getTimeoutFuture() {
+		public CompletableFuture<ResourceID> getFuture() {
+			return future;
+		}
+
+		CompletableFuture<ResourceID> getTimeoutFuture() {
 			return future;
 		}
 
@@ -307,8 +309,8 @@ public class HeartbeatManagerTest extends TestLogger {
 		}
 
 		@Override
-		public Future<Object> retrievePayload() {
-			return FlinkCompletableFuture.completed(payload);
+		public CompletableFuture<Object> retrievePayload() {
+			return CompletableFuture.completedFuture(payload);
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Replace Flink's futures with Java 8's CompletableFuture in TaskExecutor.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

