### PR TITLE
[FLINK-7333] [futures] Replace Flink's futures with Java 8's CompletableFuture in Task

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
@@ -26,6 +26,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import scala.concurrent.ExecutionContext;
+
 /**
  * Collection of {@link Executor} implementations
  */
@@ -55,6 +57,41 @@ public class Executors {
 		@Override
 		public void execute(@Nonnull Runnable command) {
 			command.run();
+		}
+	}
+
+	/**
+	 * Return a direct execution context. The direct execution context executes the runnable directly
+	 * in the calling thread.
+	 *
+	 * @return Direct execution context.
+	 */
+	public static ExecutionContext directExecutionContext() {
+		return DirectExecutionContext.INSTANCE;
+	}
+
+	/**
+	 * Direct execution context.
+	 */
+	private static class DirectExecutionContext implements ExecutionContext {
+
+		static final DirectExecutionContext INSTANCE = new DirectExecutionContext();
+
+		private DirectExecutionContext() {}
+
+		@Override
+		public void execute(Runnable runnable) {
+			runnable.run();
+		}
+
+		@Override
+		public void reportFailure(Throwable cause) {
+			throw new IllegalStateException("Error in direct execution context.", cause);
+		}
+
+		@Override
+		public ExecutionContext prepare() {
+			return this;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FlinkFutureException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FlinkFutureException.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Base class for exceptions which are thrown in {@link CompletionStage}.
+ *
+ * <p>The exception has to extend {@link FlinkRuntimeException} because only
+ * unchecked exceptions can be thrown in a future's stage. Additionally we let
+ * it extend the Flink runtime exception because it designates the exception to
+ * come from a Flink stage.
+ */
+public class FlinkFutureException extends FlinkRuntimeException {
+	private static final long serialVersionUID = -8878194471694178210L;
+
+	public FlinkFutureException(String message) {
+		super(message);
+	}
+
+	public FlinkFutureException(Throwable cause) {
+		super(cause);
+	}
+
+	public FlinkFutureException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.concurrent;
 import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.util.Preconditions;
 
+import akka.dispatch.OnComplete;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -285,5 +287,61 @@ public class FutureUtils {
 		public int getNumFuturesCompleted() {
 			return numCompleted.get();
 		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Converting futures
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Converts a Scala {@link scala.concurrent.Future} to a {@link java.util.concurrent.CompletableFuture}.
+	 *
+	 * @param scalaFuture to convert to a Java 8 CompletableFuture
+	 * @param <T> type of the future value
+	 * @return Java 8 CompletableFuture
+	 */
+	public static <T> java.util.concurrent.CompletableFuture<T> toJava(scala.concurrent.Future<T> scalaFuture) {
+		final java.util.concurrent.CompletableFuture<T> result = new java.util.concurrent.CompletableFuture<>();
+
+		scalaFuture.onComplete(new OnComplete<T>() {
+			@Override
+			public void onComplete(Throwable failure, T success) throws Throwable {
+				if (failure != null) {
+					result.completeExceptionally(failure);
+				} else {
+					result.complete(success);
+				}
+			}
+		}, Executors.directExecutionContext());
+
+		return result;
+	}
+
+	/**
+	 * Converts a Flink {@link Future} into a {@link CompletableFuture}.
+	 *
+	 * @param flinkFuture to convert to a Java 8 CompletableFuture
+	 * @param <T> type of the future value
+	 * @return Java 8 CompletableFuture
+	 *
+	 * @deprecated Will be removed once we completely remove Flink's futures
+	 */
+	@Deprecated
+	public static <T> java.util.concurrent.CompletableFuture<T> toJava(Future<T> flinkFuture) {
+		final java.util.concurrent.CompletableFuture<T> result = new java.util.concurrent.CompletableFuture<>();
+
+		flinkFuture.handle(
+			(t, throwable) -> {
+				if (throwable != null) {
+					result.completeExceptionally(throwable);
+				} else {
+					result.complete(t);
+				}
+
+				return null;
+			}
+		);
+
+		return result;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionProducerStateChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionProducerStateChecker.java
@@ -19,10 +19,11 @@
 package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Intermediate partition state checker to query the JobManager about the state
@@ -44,7 +45,7 @@ public interface PartitionProducerStateChecker {
 	 *
 	 * @return Future holding the execution state of the producing execution.
 	 */
-	Future<ExecutionState> requestPartitionProducerState(
+	CompletableFuture<ExecutionState> requestPartitionProducerState(
 			JobID jobId,
 			IntermediateDataSetID intermediateDataSetId,
 			ResultPartitionID resultPartitionId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcPartitionStateChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcPartitionStateChecker.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.taskexecutor.rpc;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.concurrent.Future;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.io.network.netty.PartitionProducerStateChecker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.util.Preconditions;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 public class RpcPartitionStateChecker implements PartitionProducerStateChecker {
 
@@ -40,11 +41,11 @@ public class RpcPartitionStateChecker implements PartitionProducerStateChecker {
 	}
 
 	@Override
-	public Future<ExecutionState> requestPartitionProducerState(
+	public CompletableFuture<ExecutionState> requestPartitionProducerState(
 			JobID jobId,
 			IntermediateDataSetID resultId,
 			ResultPartitionID partitionId) {
 
-		return jobMasterGateway.requestPartitionState(jobMasterLeaderId, resultId, partitionId);
+		return FutureUtils.toJava(jobMasterGateway.requestPartitionState(jobMasterLeaderId, resultId, partitionId));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ActorGatewayPartitionProducerStateChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ActorGatewayPartitionProducerStateChecker.java
@@ -19,8 +19,7 @@
 package org.apache.flink.runtime.taskmanager;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.concurrent.Future;
-import org.apache.flink.runtime.concurrent.impl.FlinkFuture;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.io.network.netty.PartitionProducerStateChecker;
@@ -28,6 +27,9 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.util.Preconditions;
+
+import java.util.concurrent.CompletableFuture;
+
 import scala.concurrent.duration.FiniteDuration;
 import scala.reflect.ClassTag$;
 
@@ -46,7 +48,7 @@ public class ActorGatewayPartitionProducerStateChecker implements PartitionProdu
 	}
 
 	@Override
-	public Future<ExecutionState> requestPartitionProducerState(
+	public CompletableFuture<ExecutionState> requestPartitionProducerState(
 			JobID jobId,
 			IntermediateDataSetID intermediateDataSetId,
 			ResultPartitionID resultPartitionId) {
@@ -60,7 +62,7 @@ public class ActorGatewayPartitionProducerStateChecker implements PartitionProdu
 			.ask(msg, timeout)
 			.mapTo(ClassTag$.MODULE$.<ExecutionState>apply(ExecutionState.class));
 
-		return new FlinkFuture<>(futureResponse);
+		return FutureUtils.toJava(futureResponse);
 	}
 
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.concurrent.Executors;
-import org.apache.flink.runtime.concurrent.impl.FlinkCompletableFuture;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.execution.CancelTaskException;
@@ -73,6 +72,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -640,7 +640,7 @@ public class TaskTest extends TestLogger {
 			// PartitionProducerDisposedException
 			Task task = createTask(InvokableBlockingInInvoke.class, libCache, network, consumableNotifier, partitionChecker, Executors.directExecutor());
 
-			FlinkCompletableFuture<ExecutionState> promise = new FlinkCompletableFuture<>();
+			CompletableFuture<ExecutionState> promise = new CompletableFuture<>();
 			when(partitionChecker.requestPartitionProducerState(eq(task.getJobID()), eq(resultId), eq(partitionId))).thenReturn(promise);
 
 			task.triggerPartitionProducerStateCheck(task.getJobID(), resultId, partitionId);
@@ -656,7 +656,7 @@ public class TaskTest extends TestLogger {
 			// Any other exception
 			Task task = createTask(InvokableBlockingInInvoke.class, libCache, network, consumableNotifier, partitionChecker, Executors.directExecutor());
 
-			FlinkCompletableFuture<ExecutionState> promise = new FlinkCompletableFuture<>();
+			CompletableFuture<ExecutionState> promise = new CompletableFuture<>();
 			when(partitionChecker.requestPartitionProducerState(eq(task.getJobID()), eq(resultId), eq(partitionId))).thenReturn(promise);
 
 			task.triggerPartitionProducerStateCheck(task.getJobID(), resultId, partitionId);
@@ -681,7 +681,7 @@ public class TaskTest extends TestLogger {
 
 				setInputGate(task, inputGate);
 
-				FlinkCompletableFuture<ExecutionState> promise = new FlinkCompletableFuture<>();
+				CompletableFuture<ExecutionState> promise = new CompletableFuture<>();
 				when(partitionChecker.requestPartitionProducerState(eq(task.getJobID()), eq(resultId), eq(partitionId))).thenReturn(promise);
 
 				task.triggerPartitionProducerStateCheck(task.getJobID(), resultId, partitionId);
@@ -712,7 +712,7 @@ public class TaskTest extends TestLogger {
 
 				setInputGate(task, inputGate);
 
-				FlinkCompletableFuture<ExecutionState> promise = new FlinkCompletableFuture<>();
+				CompletableFuture<ExecutionState> promise = new CompletableFuture<>();
 				when(partitionChecker.requestPartitionProducerState(eq(task.getJobID()), eq(resultId), eq(partitionId))).thenReturn(promise);
 
 				task.triggerPartitionProducerStateCheck(task.getJobID(), resultId, partitionId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.SubtaskState;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
-import org.apache.flink.runtime.concurrent.Future;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -66,6 +65,7 @@ import org.junit.Test;
 
 import java.net.URL;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
@@ -247,7 +247,7 @@ public class JvmExitOnFatalErrorTest {
 		private static final class NoOpPartitionProducerStateChecker implements PartitionProducerStateChecker {
 
 			@Override
-			public Future<ExecutionState> requestPartitionProducerState(
+			public CompletableFuture<ExecutionState> requestPartitionProducerState(
 					JobID jobId, IntermediateDataSetID intermediateDataSetId, ResultPartitionID r) {
 				return null;
 			}


### PR DESCRIPTION
## What is the purpose of the change

Replace Flink's futures with Java 8's CompletableFuture in Task.

This PR is based on #4429.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)

