### PR TITLE
[FLINK-6982] [guava] Reduce guava dependency usages

### DIFF
--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -68,13 +68,6 @@ under the License.
 		<!-- test dependencies -->
 
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils-junit</artifactId>
 			<version>${project.version}</version>

--- a/flink-java/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
@@ -18,11 +18,10 @@
 
 package org.apache.flink.api.java.tuple;
 
-import com.google.common.io.Files;
+import org.apache.flink.util.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 /**
@@ -95,7 +94,7 @@ class TupleGenerator {
 	}
 
 	private static void insertCodeIntoFile(String code, File file) throws IOException {
-		String fileContent = Files.toString(file, StandardCharsets.UTF_8);
+		String fileContent = FileUtils.readFileUtf8(file);
 
 		try (Scanner s = new Scanner(fileContent)) {
 			StringBuilder sb = new StringBuilder();
@@ -137,7 +136,7 @@ class TupleGenerator {
 				sb.append(line).append("\n");
 			}
 			s.close();
-			Files.write(sb.toString(), file, StandardCharsets.UTF_8);
+			FileUtils.writeFileUtf8(file, sb.toString());
 		}
 	}
 

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.java.utils;
 
-import com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,8 +28,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * Tests for {@link ParameterTool}.
@@ -163,7 +164,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedBoolean() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean", "true"});
-		Assert.assertEquals(Sets.newHashSet("boolean"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertTrue(parameter.getBoolean("boolean"));
@@ -177,7 +178,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedBooleanWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean", "true"});
-		Assert.assertEquals(Sets.newHashSet("boolean"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertTrue(parameter.getBoolean("boolean", false));
@@ -191,7 +192,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedBooleanWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean"});
-		Assert.assertEquals(Sets.newHashSet("boolean"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
 
 		parameter.getBoolean("boolean");
 		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
@@ -202,7 +203,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedByte() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-byte", "1"});
-		Assert.assertEquals(Sets.newHashSet("byte"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("byte"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertEquals(1, parameter.getByte("byte"));
@@ -216,7 +217,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedByteWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-byte", "1"});
-		Assert.assertEquals(Sets.newHashSet("byte"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("byte"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertEquals(1, parameter.getByte("byte", (byte) 0));
@@ -230,7 +231,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedByteWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-byte"});
-		Assert.assertEquals(Sets.newHashSet("byte"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("byte"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -243,7 +244,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedShort() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-short", "2"});
-		Assert.assertEquals(Sets.newHashSet("short"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("short"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertEquals(2, parameter.getShort("short"));
@@ -257,7 +258,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedShortWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-short", "2"});
-		Assert.assertEquals(Sets.newHashSet("short"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("short"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertEquals(2, parameter.getShort("short", (short) 0));
@@ -271,7 +272,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedShortWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-short"});
-		Assert.assertEquals(Sets.newHashSet("short"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("short"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -284,7 +285,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedInt() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-int", "4"});
-		Assert.assertEquals(Sets.newHashSet("int"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("int"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertEquals(4, parameter.getInt("int"));
@@ -298,7 +299,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedIntWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-int", "4"});
-		Assert.assertEquals(Sets.newHashSet("int"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("int"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertEquals(4, parameter.getInt("int", 0));
@@ -312,7 +313,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedIntWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-int"});
-		Assert.assertEquals(Sets.newHashSet("int"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("int"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -325,7 +326,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedLong() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-long", "8"});
-		Assert.assertEquals(Sets.newHashSet("long"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("long"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertEquals(8, parameter.getLong("long"));
@@ -339,7 +340,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedLongWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-long", "8"});
-		Assert.assertEquals(Sets.newHashSet("long"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("long"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertEquals(8, parameter.getLong("long", 0));
@@ -353,7 +354,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedLongWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-long"});
-		Assert.assertEquals(Sets.newHashSet("long"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("long"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -366,7 +367,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedFloat() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-float", "4"});
-		Assert.assertEquals(Sets.newHashSet("float"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("float"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertEquals(4.0, parameter.getFloat("float"), 0.00001);
@@ -380,7 +381,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedFloatWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-float", "4"});
-		Assert.assertEquals(Sets.newHashSet("float"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("float"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertEquals(4.0, parameter.getFloat("float", 0.0f), 0.00001);
@@ -394,7 +395,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedFloatWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-float"});
-		Assert.assertEquals(Sets.newHashSet("float"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("float"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -407,7 +408,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedDouble() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-double", "8"});
-		Assert.assertEquals(Sets.newHashSet("double"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("double"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertEquals(8.0, parameter.getDouble("double"), 0.00001);
@@ -421,7 +422,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedDoubleWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-double", "8"});
-		Assert.assertEquals(Sets.newHashSet("double"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("double"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertEquals(8.0, parameter.getDouble("double", 0.0), 0.00001);
@@ -435,7 +436,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedDoubleWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-double"});
-		Assert.assertEquals(Sets.newHashSet("double"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("double"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -448,7 +449,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedString() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-string", "∞"});
-		Assert.assertEquals(Sets.newHashSet("string"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("string"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertEquals("∞", parameter.get("string"));
@@ -462,7 +463,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedStringWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-string", "∞"});
-		Assert.assertEquals(Sets.newHashSet("string"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("string"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertEquals("∞", parameter.get("string", "0.0"));
@@ -476,7 +477,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedStringWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-string"});
-		Assert.assertEquals(Sets.newHashSet("string"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("string"), parameter.getUnrequestedParameters());
 
 		parameter.get("string");
 		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
@@ -487,7 +488,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedHas() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean"});
-		Assert.assertEquals(Sets.newHashSet("boolean"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertTrue(parameter.has("boolean"));
@@ -501,7 +502,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedRequired() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-required", "∞"});
-		Assert.assertEquals(Sets.newHashSet("required"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("required"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertEquals("∞", parameter.getRequired("required"));
@@ -516,35 +517,35 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	public void testUnrequestedMultiple() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean", "true", "-byte", "1",
 			"-short", "2", "-int", "4", "-long", "8", "-float", "4.0", "-double", "8.0", "-string", "∞"});
-		Assert.assertEquals(Sets.newHashSet("boolean", "byte", "short", "int", "long", "float", "double", "string"),
+		Assert.assertEquals(createHashSet("boolean", "byte", "short", "int", "long", "float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
 		Assert.assertTrue(parameter.getBoolean("boolean"));
-		Assert.assertEquals(Sets.newHashSet("byte", "short", "int", "long", "float", "double", "string"),
+		Assert.assertEquals(createHashSet("byte", "short", "int", "long", "float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
 		Assert.assertEquals(1, parameter.getByte("byte"));
-		Assert.assertEquals(Sets.newHashSet("short", "int", "long", "float", "double", "string"),
+		Assert.assertEquals(createHashSet("short", "int", "long", "float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
 		Assert.assertEquals(2, parameter.getShort("short"));
-		Assert.assertEquals(Sets.newHashSet("int", "long", "float", "double", "string"),
+		Assert.assertEquals(createHashSet("int", "long", "float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
 		Assert.assertEquals(4, parameter.getInt("int"));
-		Assert.assertEquals(Sets.newHashSet("long", "float", "double", "string"),
+		Assert.assertEquals(createHashSet("long", "float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
 		Assert.assertEquals(8, parameter.getLong("long"));
-		Assert.assertEquals(Sets.newHashSet("float", "double", "string"),
+		Assert.assertEquals(createHashSet("float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
 		Assert.assertEquals(4.0, parameter.getFloat("float"), 0.00001);
-		Assert.assertEquals(Sets.newHashSet("double", "string"),
+		Assert.assertEquals(createHashSet("double", "string"),
 			parameter.getUnrequestedParameters());
 
 		Assert.assertEquals(8.0, parameter.getDouble("double"), 0.00001);
-		Assert.assertEquals(Sets.newHashSet("string"),
+		Assert.assertEquals(createHashSet("string"),
 			parameter.getUnrequestedParameters());
 
 		Assert.assertEquals("∞", parameter.get("string"));
@@ -566,5 +567,13 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		Assert.assertEquals("0", parameter.get("string", "0"));
 
 		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	private static <T> Set<T> createHashSet(T... elements) {
+		Set<T> set = new HashSet<>();
+		for (T element : elements) {
+			set.add(element);
+		}
+		return set;
 	}
 }

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -65,12 +65,6 @@ under the License.
 			<artifactId>asm</artifactId>
 			<version>${asm.version}</version>
 		</dependency>
-		
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
-		</dependency>
 
 		<!-- test dependencies -->
 

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -68,12 +68,6 @@ under the License.
 			<artifactId>asm</artifactId>
 			<version>${asm.version}</version>
 		</dependency>
-		
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
-		</dependency>
 
 		<!-- test dependencies -->
 

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -217,13 +217,6 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-statebackend-rocksdb_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>

--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorITCase.java
@@ -35,10 +35,9 @@ import org.apache.flink.test.util.JavaProgramTestBase;
 import org.apache.flink.types.StringValue;
 import org.apache.flink.util.Collector;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import org.junit.Assert;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -81,12 +80,12 @@ public class AccumulatorITCase extends JavaProgramTestBase {
 		Assert.assertEquals(Double.valueOf(getParallelism()), res.getAccumulatorResult("open-close-counter"));
 
 		// Test histogram (words per line distribution)
-		Map<Integer, Integer> dist = Maps.newHashMap();
+		Map<Integer, Integer> dist = new HashMap<>();
 		dist.put(1, 1); dist.put(2, 1); dist.put(3, 1);
 		Assert.assertEquals(dist, res.getAccumulatorResult("words-per-line"));
 
 		// Test distinct words (custom accumulator)
-		Set<StringValue> distinctWords = Sets.newHashSet();
+		Set<StringValue> distinctWords = new HashSet<>();
 		distinctWords.add(new StringValue("one"));
 		distinctWords.add(new StringValue("two"));
 		distinctWords.add(new StringValue("three"));

--- a/flink-tests/src/test/java/org/apache/flink/test/example/java/PageRankITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/java/PageRankITCase.java
@@ -22,9 +22,8 @@ package org.apache.flink.test.example.java;
 import org.apache.flink.examples.java.graph.PageRank;
 import org.apache.flink.test.testdata.PageRankData;
 import org.apache.flink.test.util.MultipleProgramsTestBase;
+import org.apache.flink.util.FileUtils;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -57,10 +56,10 @@ public class PageRankITCase extends MultipleProgramsTestBase {
 	public void before() throws Exception{
 		resultPath = tempFolder.newFile().toURI().toString();
 		File verticesFile = tempFolder.newFile();
-		Files.write(PageRankData.VERTICES, verticesFile, Charsets.UTF_8);
+		FileUtils.writeFileUtf8(verticesFile, PageRankData.VERTICES);
 
 		File edgesFile = tempFolder.newFile();
-		Files.write(PageRankData.EDGES, edgesFile, Charsets.UTF_8);
+		FileUtils.writeFileUtf8(edgesFile, PageRankData.EDGES);
 
 		verticesPath = verticesFile.toURI().toString();
 		edgesPath = edgesFile.toURI().toString();

--- a/flink-tests/src/test/java/org/apache/flink/test/example/scala/PageRankITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/scala/PageRankITCase.java
@@ -22,9 +22,8 @@ package org.apache.flink.test.example.scala;
 import org.apache.flink.examples.scala.graph.PageRankBasic;
 import org.apache.flink.test.testdata.PageRankData;
 import org.apache.flink.test.util.MultipleProgramsTestBase;
+import org.apache.flink.util.FileUtils;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -61,10 +60,10 @@ public class PageRankITCase extends MultipleProgramsTestBase {
 		resultPath = resultFile.toURI().toString();
 
 		File verticesFile = tempFolder.newFile();
-		Files.write(PageRankData.VERTICES, verticesFile, Charsets.UTF_8);
+		FileUtils.writeFileUtf8(verticesFile, PageRankData.VERTICES);
 
 		File edgesFile = tempFolder.newFile();
-		Files.write(PageRankData.EDGES, edgesFile, Charsets.UTF_8);
+		FileUtils.writeFileUtf8(edgesFile, PageRankData.EDGES);
 
 		verticesPath = verticesFile.toURI().toString();
 		edgesPath = edgesFile.toURI().toString();

--- a/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderITCase.java
@@ -30,9 +30,8 @@ import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.ShortValue;
 import org.apache.flink.types.StringValue;
+import org.apache.flink.util.FileUtils;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -59,7 +58,7 @@ public class CsvReaderITCase extends MultipleProgramsTestBase {
 
 	private String createInputData(String data) throws Exception {
 		File file = tempFolder.newFile("input");
-		Files.write(data, file, Charsets.UTF_8);
+		FileUtils.writeFileUtf8(file, data);
 
 		return file.toURI().toString();
 	}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/io/ScalaCsvReaderWithPOJOITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/io/ScalaCsvReaderWithPOJOITCase.scala
@@ -20,12 +20,11 @@ package org.apache.flink.api.scala.io
 
 import java.util.Locale
 
-import com.google.common.base.Charsets
-import com.google.common.io.Files
 import org.apache.flink.api.scala._
 import org.apache.flink.core.fs.FileSystem.WriteMode
-import org.apache.flink.test.util.{TestBaseUtils, MultipleProgramsTestBase}
+import org.apache.flink.test.util.{MultipleProgramsTestBase, TestBaseUtils}
 import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
+import org.apache.flink.util.FileUtils
 import org.junit.Assert._
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
@@ -53,7 +52,7 @@ class ScalaCsvReaderWithPOJOITCase(mode: TestExecutionMode) extends MultipleProg
 
   def createInputData(data: String): String = {
     val dataFile = tempFolder.newFile("data")
-    Files.write(data, dataFile, Charsets.UTF_8)
+    FileUtils.writeFileUtf8(dataFile, data)
     dataFile.toURI.toString
   }
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -30,9 +30,8 @@ import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.google.common.base.Joiner;
-import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.api.protocolrecords.StopContainersRequest;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -234,7 +233,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 			NodeManager nm = yarnCluster.getNodeManager(nmId);
 			ConcurrentMap<ContainerId, Container> containers = nm.getNMContext().getContainers();
 			for (Map.Entry<ContainerId, Container> entry : containers.entrySet()) {
-				String command = Joiner.on(" ").join(entry.getValue().getLaunchContext().getCommands());
+				String command = StringUtils.join(entry.getValue().getLaunchContext().getCommands(), " ");
 				if (command.contains(YarnTaskManager.class.getSimpleName())) {
 					taskManagerContainer = entry.getKey();
 					nodeManager = nm;
@@ -568,7 +567,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 		@SuppressWarnings("unchecked")
 		Set<String> applicationTags = (Set<String>) applicationTagsMethod.invoke(report);
 
-		Assert.assertEquals(applicationTags, Sets.newHashSet("test-tag"));
+		Assert.assertEquals(applicationTags, Collections.singleton("test-tag"));
 	}
 
 	@After

--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -83,12 +83,6 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
-		</dependency>
-
-		<dependency>
 			<groupId>com.data-artisans</groupId>
 			<artifactId>flakka-testkit_${scala.binary.version}</artifactId>
 			<scope>test</scope>

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnApplicationMasterRunnerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnApplicationMasterRunnerTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.util.OperatingSystem;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.junit.Assume;
@@ -37,6 +36,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.flink.yarn.YarnConfigKeys.ENV_APP_ID;
@@ -90,14 +91,15 @@ public class YarnApplicationMasterRunnerTest {
 			}
 		}).when(yarnConf).getStrings(anyString(), Mockito.<String> anyVararg());
 
-		Map<String, String> env = ImmutableMap.<String, String> builder()
-			.put(ENV_APP_ID, "foo")
-			.put(ENV_CLIENT_HOME_DIR, home.getAbsolutePath())
-			.put(ENV_CLIENT_SHIP_FILES, "")
-			.put(ENV_FLINK_CLASSPATH, "")
-			.put(ENV_HADOOP_USER_NAME, "foo")
-			.put(FLINK_JAR_PATH, root.toURI().toString())
-			.build();
+		Map<String, String> env = new HashMap<>();
+		env.put(ENV_APP_ID, "foo");
+		env.put(ENV_CLIENT_HOME_DIR, home.getAbsolutePath());
+		env.put(ENV_CLIENT_SHIP_FILES, "");
+		env.put(ENV_FLINK_CLASSPATH, "");
+		env.put(ENV_HADOOP_USER_NAME, "foo");
+		env.put(FLINK_JAR_PATH, root.toURI().toString());
+		env = Collections.unmodifiableMap(env);
+
 		ContaineredTaskManagerParameters tmParams = mock(ContaineredTaskManagerParameters.class);
 		Configuration taskManagerConf = new Configuration();
 


### PR DESCRIPTION
## What is the purpose of the change

This PR removes unnecessary guava dependencies from several modules. Instead of just replacing these with flink-shaded-guava i figured we can just remove them before integrating the shaded guava dependency.

For the most part this PR is only touching tests.

## Brief change log

  - remove unused guava dependency from `flink-scala` and `flink-streaming-scala`
  - removed guava usages from `flink-java`
  - removed guava usages from `flink-tests`
  - removed guava usages from `flink-yarn-tests`
  - removed guava usages from `flink-yarn`

## Verifying this change

This change is a trivial code cleanup, if it compiles and tests pass we're good.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

