### PR TITLE
[hotfix] [gelly] Explicit type can be replaced with <>

### DIFF
--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/ConnectedComponents.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/ConnectedComponents.java
@@ -46,8 +46,8 @@ extends DriverBase<K, VV, EV> {
 	@Override
 	public DataSet plan(Graph<K, VV, EV> graph) throws Exception {
 		return graph
-			.mapVertices(new MapVertices<K, VV>())
-			.run(new GSAConnectedComponents<K, K, EV>(Integer.MAX_VALUE));
+			.mapVertices(new MapVertices<>())
+			.run(new GSAConnectedComponents<>(Integer.MAX_VALUE));
 	}
 
 	/**

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/EdgeList.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/EdgeList.java
@@ -54,7 +54,7 @@ extends DriverBase<K, VV, EV> {
 
 		if (hasNullValueEdges(edges)) {
 			return edges
-				.map(new EdgeToTuple2Map<K, EV>())
+				.map(new EdgeToTuple2Map<>())
 				.name("Edge to Tuple2")
 				.setParallelism(parallelism.getValue().intValue());
 		} else {

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/parameter/Simplify.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/drivers/parameter/Simplify.java
@@ -115,15 +115,15 @@ implements Parameter<Ordering> {
 		switch (value) {
 			case DIRECTED:
 				graph = graph
-					.run(new org.apache.flink.graph.asm.simple.directed.Simplify<T, NullValue, NullValue>());
+					.run(new org.apache.flink.graph.asm.simple.directed.Simplify<>());
 				break;
 			case UNDIRECTED:
 				graph = graph
-					.run(new org.apache.flink.graph.asm.simple.undirected.Simplify<T, NullValue, NullValue>(false));
+					.run(new org.apache.flink.graph.asm.simple.undirected.Simplify<>(false));
 				break;
 			case UNDIRECTED_CLIP_AND_FLIP:
 				graph = graph
-					.run(new org.apache.flink.graph.asm.simple.undirected.Simplify<T, NullValue, NullValue>(true));
+					.run(new org.apache.flink.graph.asm.simple.undirected.Simplify<>(true));
 				break;
 		}
 

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/EuclideanGraphWeighing.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/EuclideanGraphWeighing.java
@@ -83,8 +83,8 @@ public class EuclideanGraphWeighing implements ProgramDescription {
 						Vertex<Long, Point> srcVertex = triplet.getSrcVertex();
 						Vertex<Long, Point> trgVertex = triplet.getTrgVertex();
 
-						return new Tuple3<Long, Long, Double>(srcVertex.getId(), trgVertex.getId(),
-								srcVertex.getValue().euclideanDistance(trgVertex.getValue()));
+						return new Tuple3<>(srcVertex.getId(), trgVertex.getId(),
+							srcVertex.getValue().euclideanDistance(trgVertex.getValue()));
 					}
 				});
 
@@ -186,7 +186,7 @@ public class EuclideanGraphWeighing implements ProgramDescription {
 
 						@Override
 						public Vertex<Long, Point> map(Tuple3<Long, Double, Double> value) throws Exception {
-							return new Vertex<Long, Point>(value.f0, new Point(value.f1, value.f2));
+							return new Vertex<>(value.f0, new Point(value.f1, value.f2));
 						}
 					});
 		} else {
@@ -203,7 +203,7 @@ public class EuclideanGraphWeighing implements ProgramDescription {
 
 						@Override
 						public Edge<Long, Double> map(Tuple2<Long, Long> tuple2) throws Exception {
-							return new Edge<Long, Double>(tuple2.f0, tuple2.f1, 0.0);
+							return new Edge<>(tuple2.f0, tuple2.f1, 0.0);
 						}
 					});
 		} else {

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/GSAPageRank.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/GSAPageRank.java
@@ -66,7 +66,7 @@ public class GSAPageRank<K> implements GraphAlgorithm<K, Double, Double, DataSet
 		parameters.setOptNumVertices(true);
 
 		return networkWithWeights.runGatherSumApplyIteration(new GatherRanks(), new SumRanks(),
-				new UpdateRanks<K>(beta), maxIterations, parameters)
+			new UpdateRanks<>(beta), maxIterations, parameters)
 				.getVertices();
 	}
 

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/GSASingleSourceShortestPaths.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/GSASingleSourceShortestPaths.java
@@ -179,7 +179,7 @@ public class GSASingleSourceShortestPaths implements ProgramDescription {
 					.fieldDelimiter("\t")
 					.lineDelimiter("\n")
 					.types(Long.class, Long.class, Double.class)
-					.map(new Tuple3ToEdgeMap<Long, Double>());
+					.map(new Tuple3ToEdgeMap<>());
 		} else {
 			return SingleSourceShortestPathsData.getDefaultEdgeDataSet(env);
 		}

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/IncrementalSSSP.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/IncrementalSSSP.java
@@ -265,7 +265,7 @@ public class IncrementalSSSP implements ProgramDescription {
 
 	private static Edge<Long, Double> getEdgeToBeRemoved() {
 		if (fileOutput) {
-			return new Edge<Long, Double>(srcEdgeToBeRemoved, trgEdgeToBeRemoved, valEdgeToBeRemoved);
+			return new Edge<>(srcEdgeToBeRemoved, trgEdgeToBeRemoved, valEdgeToBeRemoved);
 		} else {
 			return IncrementalSSSPData.getDefaultEdgeToBeRemoved();
 		}

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/MusicProfiles.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/MusicProfiles.java
@@ -144,7 +144,7 @@ public class MusicProfiles implements ProgramDescription {
 				.map(new MapFunction<Tuple2<Long, String>, Tuple2<String, Long>>() {
 					@Override
 					public Tuple2<String, Long> map(Tuple2<Long, String> tuple2) throws Exception {
-						return new Tuple2<String, Long>(tuple2.f1, tuple2.f0);
+						return new Tuple2<>(tuple2.f1, tuple2.f0);
 					}
 				});
 
@@ -154,7 +154,7 @@ public class MusicProfiles implements ProgramDescription {
 							public Long vertexJoin(Long vertexValue, Long inputValue) {
 								return inputValue;
 							}
-						}).run(new LabelPropagation<String, Long, NullValue>(maxIterations));
+						}).run(new LabelPropagation<>(maxIterations));
 
 		if (fileOutput) {
 			verticesWithCommunity.writeAsCsv(communitiesOutputPath, "\n", "\t");
@@ -172,7 +172,7 @@ public class MusicProfiles implements ProgramDescription {
 		public Tuple1<String> map(String value) {
 			String[] tokens = value.split("\\s+");
 			String songId = tokens[1].substring(1);
-			return new Tuple1<String>(songId);
+			return new Tuple1<>(songId);
 		}
 	}
 
@@ -211,7 +211,7 @@ public class MusicProfiles implements ProgramDescription {
 					topSong = edge.getTarget();
 				}
 			}
-			out.collect(new Tuple2<String, String>(vertex.getId(), topSong));
+			out.collect(new Tuple2<>(vertex.getId(), topSong));
 		}
 	}
 
@@ -219,14 +219,14 @@ public class MusicProfiles implements ProgramDescription {
 		Edge<String, NullValue>> {
 
 		public void reduce(Iterable<Edge<String, Integer>> edges, Collector<Edge<String, NullValue>> out) {
-			List<String> listeners = new ArrayList<String>();
+			List<String> listeners = new ArrayList<>();
 			for (Edge<String, Integer> edge : edges) {
 				listeners.add(edge.getSource());
 			}
 			for (int i = 0; i < listeners.size() - 1; i++) {
 				for (int j = i + 1; j < listeners.size(); j++) {
-					out.collect(new Edge<String, NullValue>(listeners.get(i),
-							listeners.get(j), NullValue.getInstance()));
+					out.collect(new Edge<>(listeners.get(i),
+						listeners.get(j), NullValue.getInstance()));
 				}
 			}
 		}

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/PageRank.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/PageRank.java
@@ -65,8 +65,8 @@ public class PageRank<K> implements GraphAlgorithm<K, Double, Double, DataSet<Ve
 		ScatterGatherConfiguration parameters = new ScatterGatherConfiguration();
 		parameters.setOptNumVertices(true);
 
-		return networkWithWeights.runScatterGatherIteration(new RankMessenger<K>(),
-				new VertexRankUpdater<K>(beta), maxIterations, parameters)
+		return networkWithWeights.runScatterGatherIteration(new RankMessenger<>(),
+			new VertexRankUpdater<>(beta), maxIterations, parameters)
 				.getVertices();
 	}
 

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/PregelSSSP.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/PregelSSSP.java
@@ -183,7 +183,7 @@ public class PregelSSSP implements ProgramDescription {
 					.fieldDelimiter("\t")
 					.ignoreComments("%")
 					.types(Long.class, Long.class, Double.class)
-					.map(new Tuple3ToEdgeMap<Long, Double>());
+					.map(new Tuple3ToEdgeMap<>());
 		} else {
 			return SingleSourceShortestPathsData.getDefaultEdgeDataSet(env);
 		}

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/SingleSourceShortestPaths.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/SingleSourceShortestPaths.java
@@ -188,7 +188,7 @@ public class SingleSourceShortestPaths implements ProgramDescription {
 					.lineDelimiter("\n")
 					.fieldDelimiter("\t")
 					.types(Long.class, Long.class, Double.class)
-					.map(new Tuple3ToEdgeMap<Long, Double>());
+					.map(new Tuple3ToEdgeMap<>());
 		} else {
 			return SingleSourceShortestPathsData.getDefaultEdgeDataSet(env);
 		}

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/CommunityDetectionData.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/CommunityDetectionData.java
@@ -43,40 +43,40 @@ public class CommunityDetectionData {
 
 	public static DataSet<Edge<Long, Double>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
 
-		List<Edge<Long, Double>> edges = new ArrayList<Edge<Long, Double>>();
-		edges.add(new Edge<Long, Double>(1L, 2L, 1.0));
-		edges.add(new Edge<Long, Double>(1L, 3L, 2.0));
-		edges.add(new Edge<Long, Double>(1L, 4L, 3.0));
-		edges.add(new Edge<Long, Double>(2L, 3L, 4.0));
-		edges.add(new Edge<Long, Double>(2L, 4L, 5.0));
-		edges.add(new Edge<Long, Double>(3L, 5L, 6.0));
-		edges.add(new Edge<Long, Double>(5L, 6L, 7.0));
-		edges.add(new Edge<Long, Double>(5L, 7L, 8.0));
-		edges.add(new Edge<Long, Double>(6L, 7L, 9.0));
-		edges.add(new Edge<Long, Double>(7L, 12L, 10.0));
-		edges.add(new Edge<Long, Double>(8L, 9L, 11.0));
-		edges.add(new Edge<Long, Double>(8L, 10L, 12.0));
-		edges.add(new Edge<Long, Double>(8L, 11L, 13.0));
-		edges.add(new Edge<Long, Double>(9L, 10L, 14.0));
-		edges.add(new Edge<Long, Double>(9L, 11L, 15.0));
-		edges.add(new Edge<Long, Double>(10L, 11L, 16.0));
-		edges.add(new Edge<Long, Double>(10L, 12L, 17.0));
-		edges.add(new Edge<Long, Double>(11L, 12L, 18.0));
+		List<Edge<Long, Double>> edges = new ArrayList<>();
+		edges.add(new Edge<>(1L, 2L, 1.0));
+		edges.add(new Edge<>(1L, 3L, 2.0));
+		edges.add(new Edge<>(1L, 4L, 3.0));
+		edges.add(new Edge<>(2L, 3L, 4.0));
+		edges.add(new Edge<>(2L, 4L, 5.0));
+		edges.add(new Edge<>(3L, 5L, 6.0));
+		edges.add(new Edge<>(5L, 6L, 7.0));
+		edges.add(new Edge<>(5L, 7L, 8.0));
+		edges.add(new Edge<>(6L, 7L, 9.0));
+		edges.add(new Edge<>(7L, 12L, 10.0));
+		edges.add(new Edge<>(8L, 9L, 11.0));
+		edges.add(new Edge<>(8L, 10L, 12.0));
+		edges.add(new Edge<>(8L, 11L, 13.0));
+		edges.add(new Edge<>(9L, 10L, 14.0));
+		edges.add(new Edge<>(9L, 11L, 15.0));
+		edges.add(new Edge<>(10L, 11L, 16.0));
+		edges.add(new Edge<>(10L, 12L, 17.0));
+		edges.add(new Edge<>(11L, 12L, 18.0));
 
 		return env.fromCollection(edges);
 	}
 
 	public static DataSet<Edge<Long, Double>> getSimpleEdgeDataSet(ExecutionEnvironment env) {
 
-		List<Edge<Long, Double>> edges = new ArrayList<Edge<Long, Double>>();
-		edges.add(new Edge<Long, Double>(1L, 2L, 1.0));
-		edges.add(new Edge<Long, Double>(1L, 3L, 2.0));
-		edges.add(new Edge<Long, Double>(1L, 4L, 3.0));
-		edges.add(new Edge<Long, Double>(1L, 5L, 4.0));
-		edges.add(new Edge<Long, Double>(2L, 6L, 5.0));
-		edges.add(new Edge<Long, Double>(6L, 7L, 6.0));
-		edges.add(new Edge<Long, Double>(6L, 8L, 7.0));
-		edges.add(new Edge<Long, Double>(7L, 8L, 8.0));
+		List<Edge<Long, Double>> edges = new ArrayList<>();
+		edges.add(new Edge<>(1L, 2L, 1.0));
+		edges.add(new Edge<>(1L, 3L, 2.0));
+		edges.add(new Edge<>(1L, 4L, 3.0));
+		edges.add(new Edge<>(1L, 5L, 4.0));
+		edges.add(new Edge<>(2L, 6L, 5.0));
+		edges.add(new Edge<>(6L, 7L, 6.0));
+		edges.add(new Edge<>(6L, 8L, 7.0));
+		edges.add(new Edge<>(7L, 8L, 8.0));
 
 		return env.fromCollection(edges);
 	}
@@ -84,11 +84,11 @@ public class CommunityDetectionData {
 	private CommunityDetectionData() {}
 
 	public static DataSet<Edge<Long, Double>> getTieEdgeDataSet(ExecutionEnvironment env) {
-		List<Edge<Long, Double>> edges = new ArrayList<Edge<Long, Double>>();
-		edges.add(new Edge<Long, Double>(1L, 2L, 1.0));
-		edges.add(new Edge<Long, Double>(1L, 3L, 1.0));
-		edges.add(new Edge<Long, Double>(1L, 4L, 1.0));
-		edges.add(new Edge<Long, Double>(1L, 5L, 1.0));
+		List<Edge<Long, Double>> edges = new ArrayList<>();
+		edges.add(new Edge<>(1L, 2L, 1.0));
+		edges.add(new Edge<>(1L, 3L, 1.0));
+		edges.add(new Edge<>(1L, 4L, 1.0));
+		edges.add(new Edge<>(1L, 5L, 1.0));
 
 		return env.fromCollection(edges);
 	}

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/EuclideanGraphData.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/EuclideanGraphData.java
@@ -40,10 +40,10 @@ public class EuclideanGraphData {
 
 	public static DataSet<Vertex<Long, EuclideanGraphWeighing.Point>> getDefaultVertexDataSet(ExecutionEnvironment env) {
 
-		List<Vertex<Long, EuclideanGraphWeighing.Point>> vertices = new ArrayList<Vertex<Long, EuclideanGraphWeighing.Point>>();
+		List<Vertex<Long, EuclideanGraphWeighing.Point>> vertices = new ArrayList<>();
 		for (int i = 1; i <= NUM_VERTICES; i++) {
-			vertices.add(new Vertex<Long, EuclideanGraphWeighing.Point>(new Long(i),
-					new EuclideanGraphWeighing.Point(new Double(i), new Double(i))));
+			vertices.add(new Vertex<>(new Long(i),
+				new EuclideanGraphWeighing.Point(new Double(i), new Double(i))));
 		}
 
 		return env.fromCollection(vertices);
@@ -55,23 +55,23 @@ public class EuclideanGraphData {
 
 	public static DataSet<Edge<Long, Double>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
 
-		List<Edge<Long, Double>> edges = new ArrayList<Edge<Long, Double>>();
-		edges.add(new Edge<Long, Double>(1L, 2L, 0.0));
-		edges.add(new Edge<Long, Double>(1L, 4L, 0.0));
-		edges.add(new Edge<Long, Double>(2L, 3L, 0.0));
-		edges.add(new Edge<Long, Double>(2L, 4L, 0.0));
-		edges.add(new Edge<Long, Double>(2L, 5L, 0.0));
-		edges.add(new Edge<Long, Double>(3L, 5L, 0.0));
-		edges.add(new Edge<Long, Double>(4L, 5L, 0.0));
-		edges.add(new Edge<Long, Double>(4L, 6L, 0.0));
-		edges.add(new Edge<Long, Double>(5L, 7L, 0.0));
-		edges.add(new Edge<Long, Double>(5L, 9L, 0.0));
-		edges.add(new Edge<Long, Double>(6L, 7L, 0.0));
-		edges.add(new Edge<Long, Double>(6L, 8L, 0.0));
-		edges.add(new Edge<Long, Double>(6L, 8L, 0.0));
-		edges.add(new Edge<Long, Double>(7L, 8L, 0.0));
-		edges.add(new Edge<Long, Double>(7L, 9L, 0.0));
-		edges.add(new Edge<Long, Double>(8L, 9L, 0.0));
+		List<Edge<Long, Double>> edges = new ArrayList<>();
+		edges.add(new Edge<>(1L, 2L, 0.0));
+		edges.add(new Edge<>(1L, 4L, 0.0));
+		edges.add(new Edge<>(2L, 3L, 0.0));
+		edges.add(new Edge<>(2L, 4L, 0.0));
+		edges.add(new Edge<>(2L, 5L, 0.0));
+		edges.add(new Edge<>(3L, 5L, 0.0));
+		edges.add(new Edge<>(4L, 5L, 0.0));
+		edges.add(new Edge<>(4L, 6L, 0.0));
+		edges.add(new Edge<>(5L, 7L, 0.0));
+		edges.add(new Edge<>(5L, 9L, 0.0));
+		edges.add(new Edge<>(6L, 7L, 0.0));
+		edges.add(new Edge<>(6L, 8L, 0.0));
+		edges.add(new Edge<>(6L, 8L, 0.0));
+		edges.add(new Edge<>(7L, 8L, 0.0));
+		edges.add(new Edge<>(7L, 9L, 0.0));
+		edges.add(new Edge<>(8L, 9L, 0.0));
 
 		return env.fromCollection(edges);
 	}

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/IncrementalSSSPData.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/IncrementalSSSPData.java
@@ -38,12 +38,12 @@ public class IncrementalSSSPData {
 
 	public static DataSet<Vertex<Long, Double>> getDefaultVertexDataSet(ExecutionEnvironment env) {
 
-		List<Vertex<Long, Double>> vertices = new ArrayList<Vertex<Long, Double>>();
-		vertices.add(new Vertex<Long, Double>(1L, 6.0));
-		vertices.add(new Vertex<Long, Double>(2L, 2.0));
-		vertices.add(new Vertex<Long, Double>(3L, 3.0));
-		vertices.add(new Vertex<Long, Double>(4L, 1.0));
-		vertices.add(new Vertex<Long, Double>(5L, 0.0));
+		List<Vertex<Long, Double>> vertices = new ArrayList<>();
+		vertices.add(new Vertex<>(1L, 6.0));
+		vertices.add(new Vertex<>(2L, 2.0));
+		vertices.add(new Vertex<>(3L, 3.0));
+		vertices.add(new Vertex<>(4L, 1.0));
+		vertices.add(new Vertex<>(5L, 0.0));
 
 		return env.fromCollection(vertices);
 	}
@@ -53,13 +53,13 @@ public class IncrementalSSSPData {
 
 	public static final DataSet<Edge<Long, Double>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
 
-		List<Edge<Long, Double>> edges = new ArrayList<Edge<Long, Double>>();
-		edges.add(new Edge<Long, Double>(1L, 3L, 3.0));
-		edges.add(new Edge<Long, Double>(2L, 4L, 3.0));
-		edges.add(new Edge<Long, Double>(2L, 5L, 2.0));
-		edges.add(new Edge<Long, Double>(3L, 2L, 1.0));
-		edges.add(new Edge<Long, Double>(3L, 5L, 5.0));
-		edges.add(new Edge<Long, Double>(4L, 5L, 1.0));
+		List<Edge<Long, Double>> edges = new ArrayList<>();
+		edges.add(new Edge<>(1L, 3L, 3.0));
+		edges.add(new Edge<>(2L, 4L, 3.0));
+		edges.add(new Edge<>(2L, 5L, 2.0));
+		edges.add(new Edge<>(3L, 2L, 1.0));
+		edges.add(new Edge<>(3L, 5L, 5.0));
+		edges.add(new Edge<>(4L, 5L, 1.0));
 
 		return env.fromCollection(edges);
 	}
@@ -68,11 +68,11 @@ public class IncrementalSSSPData {
 
 	public static final DataSet<Edge<Long, Double>> getDefaultEdgesInSSSP(ExecutionEnvironment env) {
 
-		List<Edge<Long, Double>> edges = new ArrayList<Edge<Long, Double>>();
-		edges.add(new Edge<Long, Double>(1L, 3L, 3.0));
-		edges.add(new Edge<Long, Double>(2L, 5L, 2.0));
-		edges.add(new Edge<Long, Double>(3L, 2L, 1.0));
-		edges.add(new Edge<Long, Double>(4L, 5L, 1.0));
+		List<Edge<Long, Double>> edges = new ArrayList<>();
+		edges.add(new Edge<>(1L, 3L, 3.0));
+		edges.add(new Edge<>(2L, 5L, 2.0));
+		edges.add(new Edge<>(3L, 2L, 1.0));
+		edges.add(new Edge<>(4L, 5L, 1.0));
 
 		return env.fromCollection(edges);
 	}
@@ -85,7 +85,7 @@ public class IncrementalSSSPData {
 
 	public static final Edge<Long, Double> getDefaultEdgeToBeRemoved() {
 
-		return new Edge<Long, Double>(2L, 5L, 2.0);
+		return new Edge<>(2L, 5L, 2.0);
 	}
 
 	public static final String RESULTED_VERTICES = "1," + Double.MAX_VALUE + "\n" + "2," + Double.MAX_VALUE + "\n"

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/LabelPropagationData.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/LabelPropagationData.java
@@ -55,58 +55,58 @@ public class LabelPropagationData {
 
 	public static final DataSet<Vertex<Long, Long>> getDefaultVertexSet(ExecutionEnvironment env) {
 
-		List<Vertex<Long, Long>> vertices = new ArrayList<Vertex<Long, Long>>();
-		vertices.add(new Vertex<Long, Long>(1L, 10L));
-		vertices.add(new Vertex<Long, Long>(2L, 10L));
-		vertices.add(new Vertex<Long, Long>(3L, 30L));
-		vertices.add(new Vertex<Long, Long>(4L, 40L));
-		vertices.add(new Vertex<Long, Long>(5L, 40L));
-		vertices.add(new Vertex<Long, Long>(6L, 40L));
-		vertices.add(new Vertex<Long, Long>(7L, 40L));
+		List<Vertex<Long, Long>> vertices = new ArrayList<>();
+		vertices.add(new Vertex<>(1L, 10L));
+		vertices.add(new Vertex<>(2L, 10L));
+		vertices.add(new Vertex<>(3L, 30L));
+		vertices.add(new Vertex<>(4L, 40L));
+		vertices.add(new Vertex<>(5L, 40L));
+		vertices.add(new Vertex<>(6L, 40L));
+		vertices.add(new Vertex<>(7L, 40L));
 
 		return env.fromCollection(vertices);
 	}
 
 	public static final DataSet<Edge<Long, NullValue>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
 
-		List<Edge<Long, NullValue>> edges = new ArrayList<Edge<Long, NullValue>>();
-		edges.add(new Edge<Long, NullValue>(1L, 3L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(2L, 3L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(4L, 7L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(5L, 7L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(6L, 7L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(7L, 3L, NullValue.getInstance()));
+		List<Edge<Long, NullValue>> edges = new ArrayList<>();
+		edges.add(new Edge<>(1L, 3L, NullValue.getInstance()));
+		edges.add(new Edge<>(2L, 3L, NullValue.getInstance()));
+		edges.add(new Edge<>(4L, 7L, NullValue.getInstance()));
+		edges.add(new Edge<>(5L, 7L, NullValue.getInstance()));
+		edges.add(new Edge<>(6L, 7L, NullValue.getInstance()));
+		edges.add(new Edge<>(7L, 3L, NullValue.getInstance()));
 
 		return env.fromCollection(edges);
 	}
 
 	public static final DataSet<Vertex<Long, Long>> getTieVertexSet(ExecutionEnvironment env) {
 
-		List<Vertex<Long, Long>> vertices = new ArrayList<Vertex<Long, Long>>();
-		vertices.add(new Vertex<Long, Long>(1L, 10L));
-		vertices.add(new Vertex<Long, Long>(2L, 10L));
-		vertices.add(new Vertex<Long, Long>(3L, 10L));
-		vertices.add(new Vertex<Long, Long>(4L, 10L));
-		vertices.add(new Vertex<Long, Long>(5L, 0L));
-		vertices.add(new Vertex<Long, Long>(6L, 20L));
-		vertices.add(new Vertex<Long, Long>(7L, 20L));
-		vertices.add(new Vertex<Long, Long>(8L, 20L));
-		vertices.add(new Vertex<Long, Long>(9L, 20L));
+		List<Vertex<Long, Long>> vertices = new ArrayList<>();
+		vertices.add(new Vertex<>(1L, 10L));
+		vertices.add(new Vertex<>(2L, 10L));
+		vertices.add(new Vertex<>(3L, 10L));
+		vertices.add(new Vertex<>(4L, 10L));
+		vertices.add(new Vertex<>(5L, 0L));
+		vertices.add(new Vertex<>(6L, 20L));
+		vertices.add(new Vertex<>(7L, 20L));
+		vertices.add(new Vertex<>(8L, 20L));
+		vertices.add(new Vertex<>(9L, 20L));
 
 		return env.fromCollection(vertices);
 	}
 
 	public static final DataSet<Edge<Long, NullValue>> getTieEdgeDataSet(ExecutionEnvironment env) {
 
-		List<Edge<Long, NullValue>> edges = new ArrayList<Edge<Long, NullValue>>();
-		edges.add(new Edge<Long, NullValue>(1L, 5L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(2L, 5L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(4L, 5L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(5L, 5L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(6L, 5L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(7L, 5L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(8L, 5L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(9L, 5L, NullValue.getInstance()));
+		List<Edge<Long, NullValue>> edges = new ArrayList<>();
+		edges.add(new Edge<>(1L, 5L, NullValue.getInstance()));
+		edges.add(new Edge<>(2L, 5L, NullValue.getInstance()));
+		edges.add(new Edge<>(4L, 5L, NullValue.getInstance()));
+		edges.add(new Edge<>(5L, 5L, NullValue.getInstance()));
+		edges.add(new Edge<>(6L, 5L, NullValue.getInstance()));
+		edges.add(new Edge<>(7L, 5L, NullValue.getInstance()));
+		edges.add(new Edge<>(8L, 5L, NullValue.getInstance()));
+		edges.add(new Edge<>(9L, 5L, NullValue.getInstance()));
 
 		return env.fromCollection(edges);
 	}

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/MusicProfilesData.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/MusicProfilesData.java
@@ -32,53 +32,53 @@ import java.util.List;
 public class MusicProfilesData {
 
 	public static DataSet<Tuple3<String, String, Integer>> getUserSongTriplets(ExecutionEnvironment env) {
-		List<Tuple3<String, String, Integer>> triplets = new ArrayList<Tuple3<String, String, Integer>>();
+		List<Tuple3<String, String, Integer>> triplets = new ArrayList<>();
 
-		triplets.add(new Tuple3<String, String, Integer>("user_1", "song_1", 100));
-		triplets.add(new Tuple3<String, String, Integer>("user_1", "song_2", 10));
-		triplets.add(new Tuple3<String, String, Integer>("user_1", "song_3", 20));
-		triplets.add(new Tuple3<String, String, Integer>("user_1", "song_4", 30));
-		triplets.add(new Tuple3<String, String, Integer>("user_1", "song_5", 1));
+		triplets.add(new Tuple3<>("user_1", "song_1", 100));
+		triplets.add(new Tuple3<>("user_1", "song_2", 10));
+		triplets.add(new Tuple3<>("user_1", "song_3", 20));
+		triplets.add(new Tuple3<>("user_1", "song_4", 30));
+		triplets.add(new Tuple3<>("user_1", "song_5", 1));
 
-		triplets.add(new Tuple3<String, String, Integer>("user_2", "song_6", 40));
-		triplets.add(new Tuple3<String, String, Integer>("user_2", "song_7", 10));
-		triplets.add(new Tuple3<String, String, Integer>("user_2", "song_8", 3));
+		triplets.add(new Tuple3<>("user_2", "song_6", 40));
+		triplets.add(new Tuple3<>("user_2", "song_7", 10));
+		triplets.add(new Tuple3<>("user_2", "song_8", 3));
 
-		triplets.add(new Tuple3<String, String, Integer>("user_3", "song_1", 100));
-		triplets.add(new Tuple3<String, String, Integer>("user_3", "song_2", 10));
-		triplets.add(new Tuple3<String, String, Integer>("user_3", "song_3", 20));
-		triplets.add(new Tuple3<String, String, Integer>("user_3", "song_8", 30));
-		triplets.add(new Tuple3<String, String, Integer>("user_3", "song_9", 1));
-		triplets.add(new Tuple3<String, String, Integer>("user_3", "song_10", 8));
-		triplets.add(new Tuple3<String, String, Integer>("user_3", "song_11", 90));
-		triplets.add(new Tuple3<String, String, Integer>("user_3", "song_12", 30));
-		triplets.add(new Tuple3<String, String, Integer>("user_3", "song_13", 34));
-		triplets.add(new Tuple3<String, String, Integer>("user_3", "song_14", 17));
+		triplets.add(new Tuple3<>("user_3", "song_1", 100));
+		triplets.add(new Tuple3<>("user_3", "song_2", 10));
+		triplets.add(new Tuple3<>("user_3", "song_3", 20));
+		triplets.add(new Tuple3<>("user_3", "song_8", 30));
+		triplets.add(new Tuple3<>("user_3", "song_9", 1));
+		triplets.add(new Tuple3<>("user_3", "song_10", 8));
+		triplets.add(new Tuple3<>("user_3", "song_11", 90));
+		triplets.add(new Tuple3<>("user_3", "song_12", 30));
+		triplets.add(new Tuple3<>("user_3", "song_13", 34));
+		triplets.add(new Tuple3<>("user_3", "song_14", 17));
 
-		triplets.add(new Tuple3<String, String, Integer>("user_4", "song_1", 100));
-		triplets.add(new Tuple3<String, String, Integer>("user_4", "song_6", 10));
-		triplets.add(new Tuple3<String, String, Integer>("user_4", "song_8", 20));
-		triplets.add(new Tuple3<String, String, Integer>("user_4", "song_12", 30));
-		triplets.add(new Tuple3<String, String, Integer>("user_4", "song_13", 1));
-		triplets.add(new Tuple3<String, String, Integer>("user_4", "song_15", 1));
+		triplets.add(new Tuple3<>("user_4", "song_1", 100));
+		triplets.add(new Tuple3<>("user_4", "song_6", 10));
+		triplets.add(new Tuple3<>("user_4", "song_8", 20));
+		triplets.add(new Tuple3<>("user_4", "song_12", 30));
+		triplets.add(new Tuple3<>("user_4", "song_13", 1));
+		triplets.add(new Tuple3<>("user_4", "song_15", 1));
 
-		triplets.add(new Tuple3<String, String, Integer>("user_5", "song_3", 300));
-		triplets.add(new Tuple3<String, String, Integer>("user_5", "song_4", 4));
-		triplets.add(new Tuple3<String, String, Integer>("user_5", "song_5", 5));
-		triplets.add(new Tuple3<String, String, Integer>("user_5", "song_8", 8));
-		triplets.add(new Tuple3<String, String, Integer>("user_5", "song_9", 9));
-		triplets.add(new Tuple3<String, String, Integer>("user_5", "song_10", 10));
-		triplets.add(new Tuple3<String, String, Integer>("user_5", "song_12", 12));
-		triplets.add(new Tuple3<String, String, Integer>("user_5", "song_13", 13));
-		triplets.add(new Tuple3<String, String, Integer>("user_5", "song_15", 15));
+		triplets.add(new Tuple3<>("user_5", "song_3", 300));
+		triplets.add(new Tuple3<>("user_5", "song_4", 4));
+		triplets.add(new Tuple3<>("user_5", "song_5", 5));
+		triplets.add(new Tuple3<>("user_5", "song_8", 8));
+		triplets.add(new Tuple3<>("user_5", "song_9", 9));
+		triplets.add(new Tuple3<>("user_5", "song_10", 10));
+		triplets.add(new Tuple3<>("user_5", "song_12", 12));
+		triplets.add(new Tuple3<>("user_5", "song_13", 13));
+		triplets.add(new Tuple3<>("user_5", "song_15", 15));
 
-		triplets.add(new Tuple3<String, String, Integer>("user_6", "song_6", 30));
+		triplets.add(new Tuple3<>("user_6", "song_6", 30));
 
 		return env.fromCollection(triplets);
 	}
 
 	public static DataSet<String> getMismatches(ExecutionEnvironment env) {
-		List<String> errors = new ArrayList<String>();
+		List<String> errors = new ArrayList<>();
 		errors.add("ERROR: <song_8 track_8> Sever");
 		errors.add("ERROR: <song_15 track_15> Black Trees");
 		return env.fromCollection(errors);

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/PageRankData.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/PageRankData.java
@@ -52,16 +52,16 @@ public class PageRankData {
 
 	public static final DataSet<Edge<Long, Double>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
 
-		List<Edge<Long, Double>> edges = new ArrayList<Edge<Long, Double>>();
-		edges.add(new Edge<Long, Double>(2L, 1L, 1.0));
-		edges.add(new Edge<Long, Double>(5L, 2L, 1.0));
-		edges.add(new Edge<Long, Double>(5L, 4L, 1.0));
-		edges.add(new Edge<Long, Double>(4L, 3L, 1.0));
-		edges.add(new Edge<Long, Double>(4L, 2L, 1.0));
-		edges.add(new Edge<Long, Double>(1L, 4L, 1.0));
-		edges.add(new Edge<Long, Double>(1L, 2L, 1.0));
-		edges.add(new Edge<Long, Double>(1L, 3L, 1.0));
-		edges.add(new Edge<Long, Double>(3L, 5L, 1.0));
+		List<Edge<Long, Double>> edges = new ArrayList<>();
+		edges.add(new Edge<>(2L, 1L, 1.0));
+		edges.add(new Edge<>(5L, 2L, 1.0));
+		edges.add(new Edge<>(5L, 4L, 1.0));
+		edges.add(new Edge<>(4L, 3L, 1.0));
+		edges.add(new Edge<>(4L, 2L, 1.0));
+		edges.add(new Edge<>(1L, 4L, 1.0));
+		edges.add(new Edge<>(1L, 2L, 1.0));
+		edges.add(new Edge<>(1L, 3L, 1.0));
+		edges.add(new Edge<>(3L, 5L, 1.0));
 
 		return env.fromCollection(edges);
 	}

--- a/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/TriangleCountData.java
+++ b/flink-libraries/flink-gelly-examples/src/main/java/org/apache/flink/graph/examples/data/TriangleCountData.java
@@ -45,16 +45,16 @@ public class TriangleCountData {
 
 	public static DataSet<Edge<Long, NullValue>> getDefaultEdgeDataSet(ExecutionEnvironment env) {
 
-		List<Edge<Long, NullValue>> edges = new ArrayList<Edge<Long, NullValue>>();
-		edges.add(new Edge<Long, NullValue>(1L, 2L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(1L, 3L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(2L, 3L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(2L, 6L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(3L, 4L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(3L, 5L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(3L, 6L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(4L, 5L, NullValue.getInstance()));
-		edges.add(new Edge<Long, NullValue>(6L, 7L, NullValue.getInstance()));
+		List<Edge<Long, NullValue>> edges = new ArrayList<>();
+		edges.add(new Edge<>(1L, 2L, NullValue.getInstance()));
+		edges.add(new Edge<>(1L, 3L, NullValue.getInstance()));
+		edges.add(new Edge<>(2L, 3L, NullValue.getInstance()));
+		edges.add(new Edge<>(2L, 6L, NullValue.getInstance()));
+		edges.add(new Edge<>(3L, 4L, NullValue.getInstance()));
+		edges.add(new Edge<>(3L, 5L, NullValue.getInstance()));
+		edges.add(new Edge<>(3L, 6L, NullValue.getInstance()));
+		edges.add(new Edge<>(4L, 5L, NullValue.getInstance()));
+		edges.add(new Edge<>(6L, 7L, NullValue.getInstance()));
 
 		return env.fromCollection(edges);
 	}

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/CommunityDetectionITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/CommunityDetectionITCase.java
@@ -53,7 +53,7 @@ public class CommunityDetectionITCase extends MultipleProgramsTestBase {
 		Graph<Long, Long, Double> inputGraph = Graph.fromDataSet(
 			CommunityDetectionData.getSimpleEdgeDataSet(env), new InitLabels(), env);
 
-		List<Vertex<Long, Long>> result = inputGraph.run(new CommunityDetection<Long>(1, CommunityDetectionData.DELTA))
+		List<Vertex<Long, Long>> result = inputGraph.run(new CommunityDetection<>(1, CommunityDetectionData.DELTA))
 			.getVertices().collect();
 
 		expected = CommunityDetectionData.COMMUNITIES_SINGLE_ITERATION;
@@ -69,7 +69,7 @@ public class CommunityDetectionITCase extends MultipleProgramsTestBase {
 		Graph<Long, Long, Double> inputGraph = Graph.fromDataSet(
 			CommunityDetectionData.getTieEdgeDataSet(env), new InitLabels(), env);
 
-		List<Vertex<Long, Long>> result = inputGraph.run(new CommunityDetection<Long>(1, CommunityDetectionData.DELTA))
+		List<Vertex<Long, Long>> result = inputGraph.run(new CommunityDetection<>(1, CommunityDetectionData.DELTA))
 			.getVertices().collect();
 		expected = CommunityDetectionData.COMMUNITIES_WITH_TIE;
 		compareResultAsTuples(result, expected);

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/LabelPropagationITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/LabelPropagationITCase.java
@@ -55,7 +55,7 @@ public class LabelPropagationITCase extends MultipleProgramsTestBase {
 			LabelPropagationData.getDefaultEdgeDataSet(env), env);
 
 		List<Vertex<Long, Long>> result = inputGraph
-			.run(new LabelPropagation<Long, Long, NullValue>(1))
+			.run(new LabelPropagation<>(1))
 			.collect();
 
 		expectedResult = LabelPropagationData.LABELS_AFTER_1_ITERATION;
@@ -74,7 +74,7 @@ public class LabelPropagationITCase extends MultipleProgramsTestBase {
 			LabelPropagationData.getTieEdgeDataSet(env), env);
 
 		List<Vertex<Long, Long>> result = inputGraph
-			.run(new LabelPropagation<Long, Long, NullValue>(1))
+			.run(new LabelPropagation<>(1))
 			.collect();
 
 		expectedResult = LabelPropagationData.LABELS_WITH_TIE;

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/SummarizationITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/SummarizationITCase.java
@@ -72,7 +72,7 @@ public class SummarizationITCase extends MultipleProgramsTestBase {
 		List<Edge<Long, EdgeValue<String>>> summarizedEdges = new ArrayList<>();
 
 		Graph<Long, Summarization.VertexValue<String>, EdgeValue<String>> output =
-				input.run(new Summarization<Long, String, String>());
+				input.run(new Summarization<>());
 
 		output.getVertices().output(new LocalCollectionOutputFormat<>(summarizedVertices));
 		output.getEdges().output(new LocalCollectionOutputFormat<>(summarizedEdges));
@@ -90,13 +90,13 @@ public class SummarizationITCase extends MultipleProgramsTestBase {
 				SummarizationData.getVertices(env),
 				SummarizationData.getEdges(env),
 				env)
-			.run(new TranslateEdgeValues<Long, String, String, NullValue>(new ToNullValue<String>()));
+			.run(new TranslateEdgeValues<>(new ToNullValue<>()));
 
 		List<Vertex<Long, Summarization.VertexValue<String>>> summarizedVertices = new ArrayList<>();
 		List<Edge<Long, EdgeValue<NullValue>>> summarizedEdges = new ArrayList<>();
 
 		Graph<Long, Summarization.VertexValue<String>, EdgeValue<NullValue>> output =
-				input.run(new Summarization<Long, String, NullValue>());
+				input.run(new Summarization<>());
 
 		output.getVertices().output(new LocalCollectionOutputFormat<>(summarizedVertices));
 		output.getEdges().output(new LocalCollectionOutputFormat<>(summarizedEdges));
@@ -115,14 +115,14 @@ public class SummarizationITCase extends MultipleProgramsTestBase {
 				SummarizationData.getVertices(env),
 				SummarizationData.getEdges(env),
 				env)
-			.run(new TranslateVertexValues<Long, String, Long, String>(new StringToLong()))
-			.run(new TranslateEdgeValues<Long, Long, String, Long>(new StringToLong()));
+			.run(new TranslateVertexValues<>(new StringToLong()))
+			.run(new TranslateEdgeValues<>(new StringToLong()));
 
 		List<Vertex<Long, Summarization.VertexValue<Long>>> summarizedVertices = new ArrayList<>();
 		List<Edge<Long, EdgeValue<Long>>> summarizedEdges = new ArrayList<>();
 
 		Graph<Long, Summarization.VertexValue<Long>, EdgeValue<Long>> output =
-			input.run(new Summarization<Long, Long, Long>());
+			input.run(new Summarization<>());
 
 		output.getVertices().output(new LocalCollectionOutputFormat<>(summarizedVertices));
 		output.getEdges().output(new LocalCollectionOutputFormat<>(summarizedEdges));

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/TriangleEnumeratorITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/library/TriangleEnumeratorITCase.java
@@ -50,7 +50,7 @@ public class TriangleEnumeratorITCase extends MultipleProgramsTestBase {
 		Graph<Long, NullValue, NullValue> graph = Graph.fromDataSet(TriangleCountData.getDefaultEdgeDataSet(env),
 				env);
 
-		List<Tuple3<Long, Long, Long>> actualOutput = graph.run(new TriangleEnumerator<Long, NullValue, NullValue>()).collect();
+		List<Tuple3<Long, Long, Long>> actualOutput = graph.run(new TriangleEnumerator<>()).collect();
 		List<Tuple3<Long, Long, Long>> expectedResult = TriangleCountData.getListOfTriangles();
 
 		Assert.assertEquals(expectedResult.size(), actualOutput.size());

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/test/GatherSumApplyITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/test/GatherSumApplyITCase.java
@@ -67,10 +67,10 @@ public class GatherSumApplyITCase extends MultipleProgramsTestBase {
 
 		Graph<Long, Long, NullValue> inputGraph = Graph.fromDataSet(
 			ConnectedComponentsDefaultData.getDefaultEdgeDataSet(env),
-			new IdentityMapper<Long>(), env);
+			new IdentityMapper<>(), env);
 
 		List<Vertex<Long, Long>> result = inputGraph.run(
-			new GSAConnectedComponents<Long, Long, NullValue>(16)).collect();
+			new GSAConnectedComponents<>(16)).collect();
 
 		compareResultAsTuples(result, expectedResultCC);
 	}
@@ -85,10 +85,10 @@ public class GatherSumApplyITCase extends MultipleProgramsTestBase {
 			new LongToLongValue());
 
 		Graph<LongValue, LongValue, NullValue> inputGraph = Graph.fromDataSet(
-			edges, new IdentityMapper<LongValue>(), env);
+			edges, new IdentityMapper<>(), env);
 
 		List<Vertex<LongValue, LongValue>> result = inputGraph.run(
-			new GSAConnectedComponents<LongValue, LongValue, NullValue>(16)).collect();
+			new GSAConnectedComponents<>(16)).collect();
 
 		compareResultAsTuples(result, expectedResultCC);
 	}
@@ -106,7 +106,7 @@ public class GatherSumApplyITCase extends MultipleProgramsTestBase {
 			new InitMapperSSSP(), env);
 
 		List<Vertex<Long, Double>> result = inputGraph.run(
-			new GSASingleSourceShortestPaths<Long, NullValue>(1L, 16)).collect();
+			new GSASingleSourceShortestPaths<>(1L, 16)).collect();
 
 		String expectedResult = "1,0.0\n" +
 			"2,12.0\n" +

--- a/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/test/examples/PageRankITCase.java
+++ b/flink-libraries/flink-gelly-examples/src/test/java/org/apache/flink/graph/test/examples/PageRankITCase.java
@@ -52,7 +52,7 @@ public class PageRankITCase extends MultipleProgramsTestBase {
 		Graph<Long, Double, Double> inputGraph = Graph.fromDataSet(
 			PageRankData.getDefaultEdgeDataSet(env), new InitMapper(), env);
 
-		List<Vertex<Long, Double>> result = inputGraph.run(new PageRank<Long>(0.85, 3))
+		List<Vertex<Long, Double>> result = inputGraph.run(new PageRank<>(0.85, 3))
 			.collect();
 
 		compareWithDelta(result, 0.01);
@@ -65,7 +65,7 @@ public class PageRankITCase extends MultipleProgramsTestBase {
 		Graph<Long, Double, Double> inputGraph = Graph.fromDataSet(
 			PageRankData.getDefaultEdgeDataSet(env), new InitMapper(), env);
 
-		List<Vertex<Long, Double>> result = inputGraph.run(new GSAPageRank<Long>(0.85, 3))
+		List<Vertex<Long, Double>> result = inputGraph.run(new GSAPageRank<>(0.85, 3))
 			.collect();
 
 		compareWithDelta(result, 0.01);
@@ -78,7 +78,7 @@ public class PageRankITCase extends MultipleProgramsTestBase {
 		Graph<Long, Double, Double> inputGraph = Graph.fromDataSet(
 			PageRankData.getDefaultEdgeDataSet(env), new InitMapper(), env);
 
-		List<Vertex<Long, Double>> result = inputGraph.run(new PageRank<Long>(0.85, 3))
+		List<Vertex<Long, Double>> result = inputGraph.run(new PageRank<>(0.85, 3))
 			.collect();
 
 		compareWithDelta(result, 0.01);
@@ -91,7 +91,7 @@ public class PageRankITCase extends MultipleProgramsTestBase {
 		Graph<Long, Double, Double> inputGraph = Graph.fromDataSet(
 			PageRankData.getDefaultEdgeDataSet(env), new InitMapper(), env);
 
-		List<Vertex<Long, Double>> result = inputGraph.run(new GSAPageRank<Long>(0.85, 3))
+		List<Vertex<Long, Double>> result = inputGraph.run(new GSAPageRank<>(0.85, 3))
 			.collect();
 
 		compareWithDelta(result, 0.01);

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
@@ -177,7 +177,7 @@ public class Graph<K, VV, EV> {
 			DataSet<Edge<K, EV>> edges, ExecutionEnvironment context) {
 
 		DataSet<Vertex<K, NullValue>> vertices = edges
-			.flatMap(new EmitSrcAndTarget<K, EV>())
+			.flatMap(new EmitSrcAndTarget<>())
 				.name("Source and target IDs")
 			.distinct()
 				.name("IDs");
@@ -221,7 +221,7 @@ public class Graph<K, VV, EV> {
 				Vertex.class, keyType, valueType);
 
 		DataSet<Vertex<K, VV>> vertices = edges
-			.flatMap(new EmitSrcAndTargetAsTuple1<K, EV>())
+			.flatMap(new EmitSrcAndTargetAsTuple1<>())
 				.name("Source and target IDs")
 			.distinct()
 				.name("IDs")
@@ -269,11 +269,11 @@ public class Graph<K, VV, EV> {
 			DataSet<Tuple3<K, K, EV>> edges, ExecutionEnvironment context) {
 
 		DataSet<Vertex<K, VV>> vertexDataSet = vertices
-			.map(new Tuple2ToVertexMap<K, VV>())
+			.map(new Tuple2ToVertexMap<>())
 				.name("Type conversion");
 
 		DataSet<Edge<K, EV>> edgeDataSet = edges
-			.map(new Tuple3ToEdgeMap<K, EV>())
+			.map(new Tuple3ToEdgeMap<>())
 				.name("Type conversion");
 
 		return fromDataSet(vertexDataSet, edgeDataSet, context);
@@ -296,7 +296,7 @@ public class Graph<K, VV, EV> {
 			ExecutionEnvironment context) {
 
 		DataSet<Edge<K, EV>> edgeDataSet = edges
-			.map(new Tuple3ToEdgeMap<K, EV>())
+			.map(new Tuple3ToEdgeMap<>())
 				.name("Type conversion");
 
 		return fromDataSet(edgeDataSet, context);
@@ -322,7 +322,7 @@ public class Graph<K, VV, EV> {
 			final MapFunction<K, VV> vertexValueInitializer, ExecutionEnvironment context) {
 
 		DataSet<Edge<K, EV>> edgeDataSet = edges
-			.map(new Tuple3ToEdgeMap<K, EV>())
+			.map(new Tuple3ToEdgeMap<>())
 				.name("Type conversion");
 
 		return fromDataSet(edgeDataSet, vertexValueInitializer, context);
@@ -343,7 +343,7 @@ public class Graph<K, VV, EV> {
 			ExecutionEnvironment context) {
 
 		DataSet<Edge<K, NullValue>> edgeDataSet = edges
-			.map(new Tuple2ToEdgeMap<K>())
+			.map(new Tuple2ToEdgeMap<>())
 				.name("To Edge");
 
 		return fromDataSet(edgeDataSet, context);
@@ -368,7 +368,7 @@ public class Graph<K, VV, EV> {
 			final MapFunction<K, VV> vertexValueInitializer, ExecutionEnvironment context) {
 
 		DataSet<Edge<K, NullValue>> edgeDataSet = edges
-			.map(new Tuple2ToEdgeMap<K>())
+			.map(new Tuple2ToEdgeMap<>())
 				.name("To Edge");
 
 		return fromDataSet(edgeDataSet, vertexValueInitializer, context);
@@ -465,14 +465,14 @@ public class Graph<K, VV, EV> {
 	 * @return the vertex DataSet as Tuple2.
 	 */
 	public DataSet<Tuple2<K, VV>> getVerticesAsTuple2() {
-		return vertices.map(new VertexToTuple2Map<K, VV>());
+		return vertices.map(new VertexToTuple2Map<>());
 	}
 
 	/**
 	 * @return the edge DataSet as Tuple3.
 	 */
 	public DataSet<Tuple3<K, K, EV>> getEdgesAsTuple3() {
-		return edges.map(new EdgeToTuple3Map<K, EV>());
+		return edges.map(new EdgeToTuple3Map<>());
 	}
 
 	/**
@@ -483,10 +483,10 @@ public class Graph<K, VV, EV> {
 	public DataSet<Triplet<K, VV, EV>> getTriplets() {
 		return this.getVertices()
 			.join(this.getEdges()).where(0).equalTo(0)
-			.with(new ProjectEdgeWithSrcValue<K, VV, EV>())
+			.with(new ProjectEdgeWithSrcValue<>())
 				.name("Project edge with source value")
 			.join(this.getVertices()).where(1).equalTo(0)
-			.with(new ProjectEdgeWithVertexValues<K, VV, EV>())
+			.with(new ProjectEdgeWithVertexValues<>())
 				.name("Project edge with vertex values");
 	}
 
@@ -628,7 +628,7 @@ public class Graph<K, VV, EV> {
 	 * @throws Exception
 	 */
 	public <NEW> Graph<NEW, VV, EV> translateGraphIds(TranslateFunction<K, NEW> translator) throws Exception {
-		return run(new TranslateGraphIds<K, NEW, VV, EV>(translator));
+		return run(new TranslateGraphIds<>(translator));
 	}
 
 	/**
@@ -640,7 +640,7 @@ public class Graph<K, VV, EV> {
 	 * @throws Exception
 	 */
 	public <NEW> Graph<K, NEW, EV> translateVertexValues(TranslateFunction<VV, NEW> translator) throws Exception {
-		return run(new TranslateVertexValues<K, VV, NEW, EV>(translator));
+		return run(new TranslateVertexValues<>(translator));
 	}
 
 	/**
@@ -652,7 +652,7 @@ public class Graph<K, VV, EV> {
 	 * @throws Exception
 	 */
 	public <NEW> Graph<K, VV, NEW> translateEdgeValues(TranslateFunction<EV, NEW> translator) throws Exception {
-		return run(new TranslateEdgeValues<K, VV, EV, NEW>(translator));
+		return run(new TranslateEdgeValues<>(translator));
 	}
 
 	/**
@@ -676,7 +676,7 @@ public class Graph<K, VV, EV> {
 
 		DataSet<Vertex<K, VV>> resultedVertices = this.getVertices()
 				.coGroup(inputDataSet).where(0).equalTo(0)
-				.with(new ApplyCoGroupToVertexValues<K, VV, T>(vertexJoinFunction))
+				.with(new ApplyCoGroupToVertexValues<>(vertexJoinFunction))
 					.name("Join with vertices");
 		return new Graph<>(resultedVertices, this.edges, this.context);
 	}
@@ -730,7 +730,7 @@ public class Graph<K, VV, EV> {
 
 		DataSet<Edge<K, EV>> resultedEdges = this.getEdges()
 				.coGroup(inputDataSet).where(0, 1).equalTo(0, 1)
-				.with(new ApplyCoGroupToEdgeValues<K, EV, T>(edgeJoinFunction))
+				.with(new ApplyCoGroupToEdgeValues<>(edgeJoinFunction))
 					.name("Join with edges");
 		return new Graph<>(this.vertices, resultedEdges, this.context);
 	}
@@ -787,7 +787,7 @@ public class Graph<K, VV, EV> {
 
 		DataSet<Edge<K, EV>> resultedEdges = this.getEdges()
 				.coGroup(inputDataSet).where(0).equalTo(0)
-				.with(new ApplyCoGroupToEdgeValuesOnEitherSourceOrTarget<K, EV, T>(edgeJoinFunction))
+				.with(new ApplyCoGroupToEdgeValuesOnEitherSourceOrTarget<>(edgeJoinFunction))
 					.name("Join with edges on source");
 
 		return new Graph<>(this.vertices, resultedEdges, this.context);
@@ -850,7 +850,7 @@ public class Graph<K, VV, EV> {
 
 		DataSet<Edge<K, EV>> resultedEdges = this.getEdges()
 				.coGroup(inputDataSet).where(1).equalTo(0)
-				.with(new ApplyCoGroupToEdgeValuesOnEitherSourceOrTarget<K, EV, T>(edgeJoinFunction))
+				.with(new ApplyCoGroupToEdgeValuesOnEitherSourceOrTarget<>(edgeJoinFunction))
 					.name("Join with edges on target");
 
 		return new Graph<>(this.vertices, resultedEdges, this.context);
@@ -869,9 +869,9 @@ public class Graph<K, VV, EV> {
 		DataSet<Vertex<K, VV>> filteredVertices = this.vertices.filter(vertexFilter);
 
 		DataSet<Edge<K, EV>> remainingEdges = this.edges.join(filteredVertices)
-				.where(0).equalTo(0).with(new ProjectEdge<K, VV, EV>())
+				.where(0).equalTo(0).with(new ProjectEdge<>())
 				.join(filteredVertices).where(1).equalTo(0)
-				.with(new ProjectEdge<K, VV, EV>()).name("Subgraph");
+				.with(new ProjectEdge<>()).name("Subgraph");
 
 		DataSet<Edge<K, EV>> filteredEdges = remainingEdges.filter(edgeFilter);
 
@@ -890,9 +890,9 @@ public class Graph<K, VV, EV> {
 		DataSet<Vertex<K, VV>> filteredVertices = this.vertices.filter(vertexFilter);
 
 		DataSet<Edge<K, EV>> remainingEdges = this.edges.join(filteredVertices)
-				.where(0).equalTo(0).with(new ProjectEdge<K, VV, EV>())
+				.where(0).equalTo(0).with(new ProjectEdge<>())
 				.join(filteredVertices).where(1).equalTo(0)
-				.with(new ProjectEdge<K, VV, EV>()).name("Filter on vertices");
+				.with(new ProjectEdge<>()).name("Filter on vertices");
 
 		return new Graph<>(filteredVertices, remainingEdges, this.context);
 	}
@@ -925,7 +925,7 @@ public class Graph<K, VV, EV> {
 	 */
 	public DataSet<Tuple2<K, LongValue>> outDegrees() {
 
-		return vertices.coGroup(edges).where(0).equalTo(0).with(new CountNeighborsCoGroup<K, VV, EV>())
+		return vertices.coGroup(edges).where(0).equalTo(0).with(new CountNeighborsCoGroup<>())
 			.name("Out-degree");
 	}
 
@@ -962,7 +962,7 @@ public class Graph<K, VV, EV> {
 	 */
 	public DataSet<Tuple2<K, LongValue>> inDegrees() {
 
-		return vertices.coGroup(edges).where(0).equalTo(1).with(new CountNeighborsCoGroup<K, VV, EV>())
+		return vertices.coGroup(edges).where(0).equalTo(1).with(new CountNeighborsCoGroup<>())
 			.name("In-degree");
 	}
 
@@ -985,7 +985,7 @@ public class Graph<K, VV, EV> {
 	public Graph<K, VV, EV> getUndirected() {
 
 		DataSet<Edge<K, EV>> undirectedEdges = edges.
-			flatMap(new RegularAndReversedEdgesMap<K, EV>()).name("To undirected graph");
+			flatMap(new RegularAndReversedEdgesMap<>()).name("To undirected graph");
 		return new Graph<>(vertices, undirectedEdges, this.context);
 	}
 
@@ -1014,7 +1014,7 @@ public class Graph<K, VV, EV> {
 			return vertices.coGroup(edges).where(0).equalTo(0)
 					.with(new ApplyCoGroupFunction<>(edgesFunction)).name("GroupReduce on out-edges");
 		case ALL:
-			return vertices.coGroup(edges.flatMap(new EmitOneEdgePerNode<K, EV>())
+			return vertices.coGroup(edges.flatMap(new EmitOneEdgePerNode<>())
 						.name("Emit edge"))
 					.where(0).equalTo(0).with(new ApplyCoGroupFunctionOnAllEdges<>(edgesFunction))
 						.name("GroupReduce on in- and out-edges");
@@ -1051,7 +1051,7 @@ public class Graph<K, VV, EV> {
 						.with(new ApplyCoGroupFunction<>(edgesFunction))
 							.name("GroupReduce on out-edges").returns(typeInfo);
 			case ALL:
-				return vertices.coGroup(edges.flatMap(new EmitOneEdgePerNode<K, EV>())
+				return vertices.coGroup(edges.flatMap(new EmitOneEdgePerNode<>())
 							.name("Emit edge"))
 						.where(0).equalTo(0).with(new ApplyCoGroupFunctionOnAllEdges<>(edgesFunction))
 							.name("GroupReduce on in- and out-edges").returns(typeInfo);
@@ -1105,17 +1105,17 @@ public class Graph<K, VV, EV> {
 
 		switch (direction) {
 			case IN:
-				return edges.map(new ProjectVertexIdMap<K, EV>(1)).name("Vertex ID")
+				return edges.map(new ProjectVertexIdMap<>(1)).name("Vertex ID")
 						.withForwardedFields("f1->f0")
 						.groupBy(0).reduceGroup(new ApplyGroupReduceFunction<>(edgesFunction))
 							.name("GroupReduce on in-edges").returns(typeInfo);
 			case OUT:
-				return edges.map(new ProjectVertexIdMap<K, EV>(0)).name("Vertex ID")
+				return edges.map(new ProjectVertexIdMap<>(0)).name("Vertex ID")
 						.withForwardedFields("f0")
 						.groupBy(0).reduceGroup(new ApplyGroupReduceFunction<>(edgesFunction))
 							.name("GroupReduce on out-edges").returns(typeInfo);
 			case ALL:
-				return edges.flatMap(new EmitOneEdgePerNode<K, EV>()).name("Emit edge")
+				return edges.flatMap(new EmitOneEdgePerNode<>()).name("Emit edge")
 						.groupBy(0).reduceGroup(new ApplyGroupReduceFunction<>(edgesFunction))
 							.name("GroupReduce on in- and out-edges").returns(typeInfo);
 			default:
@@ -1306,7 +1306,7 @@ public class Graph<K, VV, EV> {
 	 * @throws UnsupportedOperationException
 	 */
 	public Graph<K, VV, EV> reverse() throws UnsupportedOperationException {
-		DataSet<Edge<K, EV>> reversedEdges = edges.map(new ReverseEdgesMap<K, EV>()).name("Reverse edges");
+		DataSet<Edge<K, EV>> reversedEdges = edges.map(new ReverseEdgesMap<>()).name("Reverse edges");
 		return new Graph<>(vertices, reversedEdges, this.context);
 	}
 
@@ -1328,7 +1328,7 @@ public class Graph<K, VV, EV> {
 	 * @return The IDs of the vertices as DataSet
 	 */
 	public DataSet<K> getVertexIds() {
-		return vertices.map(new ExtractVertexIDMapper<K, VV>()).name("Vertex IDs");
+		return vertices.map(new ExtractVertexIDMapper<>()).name("Vertex IDs");
 	}
 
 	private static final class ExtractVertexIDMapper<K, VV>
@@ -1343,7 +1343,7 @@ public class Graph<K, VV, EV> {
 	 * @return The IDs of the edges as DataSet
 	 */
 	public DataSet<Tuple2<K, K>> getEdgeIds() {
-		return edges.map(new ExtractEdgeIDsMapper<K, EV>()).name("Edge IDs");
+		return edges.map(new ExtractEdgeIDsMapper<>()).name("Edge IDs");
 	}
 
 	@ForwardedFields("f0; f1")
@@ -1379,7 +1379,7 @@ public class Graph<K, VV, EV> {
 	public Graph<K, VV, EV> addVertices(List<Vertex<K, VV>> verticesToAdd) {
 		// Add the vertices
 		DataSet<Vertex<K, VV>> newVertices = this.vertices.coGroup(this.context.fromCollection(verticesToAdd))
-				.where(0).equalTo(0).with(new VerticesUnionCoGroup<K, VV>()).name("Add vertices");
+				.where(0).equalTo(0).with(new VerticesUnionCoGroup<>()).name("Add vertices");
 
 		return new Graph<>(newVertices, this.edges, this.context);
 	}
@@ -1433,9 +1433,9 @@ public class Graph<K, VV, EV> {
 
 		DataSet<Edge<K, EV>> validNewEdges = this.getVertices().join(newEdgesDataSet)
 				.where(0).equalTo(0)
-				.with(new JoinVerticesWithEdgesOnSrc<K, VV, EV>()).name("Join with source")
+				.with(new JoinVerticesWithEdgesOnSrc<>()).name("Join with source")
 				.join(this.getVertices()).where(1).equalTo(0)
-				.with(new JoinWithVerticesOnTrg<K, VV, EV>()).name("Join with target");
+				.with(new JoinWithVerticesOnTrg<>()).name("Join with target");
 
 		return Graph.fromDataSet(this.vertices, this.edges.union(validNewEdges), this.context);
 	}
@@ -1496,14 +1496,14 @@ public class Graph<K, VV, EV> {
 	private Graph<K, VV, EV> removeVertices(DataSet<Vertex<K, VV>> verticesToBeRemoved) {
 
 		DataSet<Vertex<K, VV>> newVertices = getVertices().coGroup(verticesToBeRemoved).where(0).equalTo(0)
-				.with(new VerticesRemovalCoGroup<K, VV>()).name("Remove vertices");
+				.with(new VerticesRemovalCoGroup<>()).name("Remove vertices");
 
 		DataSet <Edge< K, EV>> newEdges = newVertices.join(getEdges()).where(0).equalTo(0)
 				// if the edge source was removed, the edge will also be removed
-				.with(new ProjectEdgeToBeRemoved<K, VV, EV>()).name("Edges to be removed")
+				.with(new ProjectEdgeToBeRemoved<>()).name("Edges to be removed")
 				// if the edge target was removed, the edge will also be removed
 				.join(newVertices).where(1).equalTo(0)
-				.with(new ProjectEdge<K, VV, EV>()).name("Remove edges");
+				.with(new ProjectEdge<>()).name("Remove edges");
 
 		return new Graph<>(newVertices, newEdges, context);
 	}
@@ -1571,7 +1571,7 @@ public class Graph<K, VV, EV> {
 	public Graph<K, VV, EV> removeEdges(List<Edge<K, EV>> edgesToBeRemoved) {
 
 		DataSet<Edge<K, EV>> newEdges = getEdges().coGroup(this.context.fromCollection(edgesToBeRemoved))
-				.where(0, 1).equalTo(0, 1).with(new EdgeRemovalCoGroup<K, EV>()).name("Remove edges");
+				.where(0, 1).equalTo(0, 1).with(new EdgeRemovalCoGroup<>()).name("Remove edges");
 
 		return new Graph<>(this.vertices, newEdges, context);
 	}
@@ -1689,7 +1689,7 @@ public class Graph<K, VV, EV> {
 				.coGroup(edges)
 				.where(0, 1, 2)
 				.equalTo(0, 1, 2)
-				.with(new MatchingEdgeReducer<K, EV>())
+				.with(new MatchingEdgeReducer<>())
 					.name("Intersect edges");
 	}
 
@@ -1912,9 +1912,9 @@ public class Graph<K, VV, EV> {
 		case ALL:
 			// create <edge-sourceOrTargetVertex> pairs
 			DataSet<Tuple3<K, Edge<K, EV>, Vertex<K, VV>>> edgesWithNeighbors = edges
-					.flatMap(new EmitOneEdgeWithNeighborPerNode<K, EV>()).name("Forward and reverse edges")
+					.flatMap(new EmitOneEdgeWithNeighborPerNode<>()).name("Forward and reverse edges")
 					.join(this.vertices).where(1).equalTo(0)
-					.with(new ProjectEdgeWithNeighbor<K, VV, EV>()).name("Edge with vertex");
+					.with(new ProjectEdgeWithNeighbor<>()).name("Edge with vertex");
 
 			return vertices.coGroup(edgesWithNeighbors)
 					.where(0).equalTo(0)
@@ -1962,9 +1962,9 @@ public class Graph<K, VV, EV> {
 			case ALL:
 				// create <edge-sourceOrTargetVertex> pairs
 				DataSet<Tuple3<K, Edge<K, EV>, Vertex<K, VV>>> edgesWithNeighbors = edges
-						.flatMap(new EmitOneEdgeWithNeighborPerNode<K, EV>()).name("Forward and reverse edges")
+						.flatMap(new EmitOneEdgeWithNeighborPerNode<>()).name("Forward and reverse edges")
 						.join(this.vertices).where(1).equalTo(0)
-						.with(new ProjectEdgeWithNeighbor<K, VV, EV>()).name("Edge with vertex");
+						.with(new ProjectEdgeWithNeighbor<>()).name("Edge with vertex");
 
 				return vertices.coGroup(edgesWithNeighbors)
 						.where(0).equalTo(0)
@@ -1997,7 +1997,7 @@ public class Graph<K, VV, EV> {
 			// create <edge-sourceVertex> pairs
 			DataSet<Tuple3<K, Edge<K, EV>, Vertex<K, VV>>> edgesWithSources = edges
 					.join(this.vertices).where(0).equalTo(0)
-					.with(new ProjectVertexIdJoin<K, VV, EV>(1))
+					.with(new ProjectVertexIdJoin<>(1))
 					.withForwardedFieldsFirst("f1->f0").name("Edge with source vertex ID");
 			return edgesWithSources.groupBy(0).reduceGroup(
 				new ApplyNeighborGroupReduceFunction<>(neighborsFunction)).name("Neighbors function");
@@ -2005,16 +2005,16 @@ public class Graph<K, VV, EV> {
 			// create <edge-targetVertex> pairs
 			DataSet<Tuple3<K, Edge<K, EV>, Vertex<K, VV>>> edgesWithTargets = edges
 					.join(this.vertices).where(1).equalTo(0)
-					.with(new ProjectVertexIdJoin<K, VV, EV>(0))
+					.with(new ProjectVertexIdJoin<>(0))
 					.withForwardedFieldsFirst("f0").name("Edge with target vertex ID");
 			return edgesWithTargets.groupBy(0).reduceGroup(
 				new ApplyNeighborGroupReduceFunction<>(neighborsFunction)).name("Neighbors function");
 		case ALL:
 			// create <edge-sourceOrTargetVertex> pairs
 			DataSet<Tuple3<K, Edge<K, EV>, Vertex<K, VV>>> edgesWithNeighbors = edges
-					.flatMap(new EmitOneEdgeWithNeighborPerNode<K, EV>()).name("Forward and reverse edges")
+					.flatMap(new EmitOneEdgeWithNeighborPerNode<>()).name("Forward and reverse edges")
 					.join(this.vertices).where(1).equalTo(0)
-					.with(new ProjectEdgeWithNeighbor<K, VV, EV>()).name("Edge with vertex ID");
+					.with(new ProjectEdgeWithNeighbor<>()).name("Edge with vertex ID");
 
 			return edgesWithNeighbors.groupBy(0).reduceGroup(
 				new ApplyNeighborGroupReduceFunction<>(neighborsFunction)).name("Neighbors function");
@@ -2046,7 +2046,7 @@ public class Graph<K, VV, EV> {
 				// create <edge-sourceVertex> pairs
 				DataSet<Tuple3<K, Edge<K, EV>, Vertex<K, VV>>> edgesWithSources = edges
 						.join(this.vertices).where(0).equalTo(0)
-						.with(new ProjectVertexIdJoin<K, VV, EV>(1))
+						.with(new ProjectVertexIdJoin<>(1))
 						.withForwardedFieldsFirst("f1->f0").name("Edge with source vertex ID");
 				return edgesWithSources.groupBy(0).reduceGroup(
 					new ApplyNeighborGroupReduceFunction<>(neighborsFunction))
@@ -2055,7 +2055,7 @@ public class Graph<K, VV, EV> {
 				// create <edge-targetVertex> pairs
 				DataSet<Tuple3<K, Edge<K, EV>, Vertex<K, VV>>> edgesWithTargets = edges
 						.join(this.vertices).where(1).equalTo(0)
-						.with(new ProjectVertexIdJoin<K, VV, EV>(0))
+						.with(new ProjectVertexIdJoin<>(0))
 						.withForwardedFieldsFirst("f0").name("Edge with target vertex ID");
 				return edgesWithTargets.groupBy(0).reduceGroup(
 					new ApplyNeighborGroupReduceFunction<>(neighborsFunction))
@@ -2063,9 +2063,9 @@ public class Graph<K, VV, EV> {
 			case ALL:
 				// create <edge-sourceOrTargetVertex> pairs
 				DataSet<Tuple3<K, Edge<K, EV>, Vertex<K, VV>>> edgesWithNeighbors = edges
-						.flatMap(new EmitOneEdgeWithNeighborPerNode<K, EV>())
+						.flatMap(new EmitOneEdgeWithNeighborPerNode<>())
 						.join(this.vertices).where(1).equalTo(0)
-						.with(new ProjectEdgeWithNeighbor<K, VV, EV>()).name("Edge with vertex ID");
+						.with(new ProjectEdgeWithNeighbor<>()).name("Edge with vertex ID");
 
 				return edgesWithNeighbors.groupBy(0).reduceGroup(
 					new ApplyNeighborGroupReduceFunction<>(neighborsFunction))
@@ -2246,27 +2246,27 @@ public class Graph<K, VV, EV> {
 				// create <vertex-source value> pairs
 				final DataSet<Tuple2<K, VV>> verticesWithSourceNeighborValues = edges
 						.join(this.vertices).where(0).equalTo(0)
-						.with(new ProjectVertexWithNeighborValueJoin<K, VV, EV>(1))
+						.with(new ProjectVertexWithNeighborValueJoin<>(1))
 						.withForwardedFieldsFirst("f1->f0").name("Vertex with in-neighbor value");
-				return verticesWithSourceNeighborValues.groupBy(0).reduce(new ApplyNeighborReduceFunction<K, VV>(
-						reduceNeighborsFunction)).name("Neighbors function");
+				return verticesWithSourceNeighborValues.groupBy(0).reduce(new ApplyNeighborReduceFunction<>(
+					reduceNeighborsFunction)).name("Neighbors function");
 			case OUT:
 				// create <vertex-target value> pairs
 				DataSet<Tuple2<K, VV>> verticesWithTargetNeighborValues = edges
 						.join(this.vertices).where(1).equalTo(0)
-						.with(new ProjectVertexWithNeighborValueJoin<K, VV, EV>(0))
+						.with(new ProjectVertexWithNeighborValueJoin<>(0))
 						.withForwardedFieldsFirst("f0").name("Vertex with out-neighbor value");
-				return verticesWithTargetNeighborValues.groupBy(0).reduce(new ApplyNeighborReduceFunction<K, VV>(
-						reduceNeighborsFunction)).name("Neighbors function");
+				return verticesWithTargetNeighborValues.groupBy(0).reduce(new ApplyNeighborReduceFunction<>(
+					reduceNeighborsFunction)).name("Neighbors function");
 			case ALL:
 				// create <vertex-neighbor value> pairs
 				DataSet<Tuple2<K, VV>> verticesWithNeighborValues = edges
-						.flatMap(new EmitOneEdgeWithNeighborPerNode<K, EV>())
+						.flatMap(new EmitOneEdgeWithNeighborPerNode<>())
 						.join(this.vertices).where(1).equalTo(0)
-						.with(new ProjectNeighborValue<K, VV, EV>()).name("Vertex with neighbor value");
+						.with(new ProjectNeighborValue<>()).name("Vertex with neighbor value");
 
-				return verticesWithNeighborValues.groupBy(0).reduce(new ApplyNeighborReduceFunction<K, VV>(
-						reduceNeighborsFunction)).name("Neighbors function");
+				return verticesWithNeighborValues.groupBy(0).reduce(new ApplyNeighborReduceFunction<>(
+					reduceNeighborsFunction)).name("Neighbors function");
 			default:
 				throw new IllegalArgumentException("Illegal edge direction");
 		}
@@ -2306,22 +2306,22 @@ public class Graph<K, VV, EV> {
 
 		switch (direction) {
 			case IN:
-				return edges.map(new ProjectVertexWithEdgeValueMap<K, EV>(1))
+				return edges.map(new ProjectVertexWithEdgeValueMap<>(1))
 						.withForwardedFields("f1->f0")
 							.name("Vertex with in-edges")
-						.groupBy(0).reduce(new ApplyReduceFunction<K, EV>(reduceEdgesFunction))
+						.groupBy(0).reduce(new ApplyReduceFunction<>(reduceEdgesFunction))
 							.name("Reduce on edges");
 			case OUT:
-				return edges.map(new ProjectVertexWithEdgeValueMap<K, EV>(0))
+				return edges.map(new ProjectVertexWithEdgeValueMap<>(0))
 						.withForwardedFields("f0->f0")
 							.name("Vertex with out-edges")
-						.groupBy(0).reduce(new ApplyReduceFunction<K, EV>(reduceEdgesFunction))
+						.groupBy(0).reduce(new ApplyReduceFunction<>(reduceEdgesFunction))
 							.name("Reduce on edges");
 			case ALL:
-				return edges.flatMap(new EmitOneVertexWithEdgeValuePerNode<K, EV>())
+				return edges.flatMap(new EmitOneVertexWithEdgeValuePerNode<>())
 						.withForwardedFields("f2->f1")
 							.name("Vertex with all edges")
-						.groupBy(0).reduce(new ApplyReduceFunction<K, EV>(reduceEdgesFunction))
+						.groupBy(0).reduce(new ApplyReduceFunction<>(reduceEdgesFunction))
 							.name("Reduce on edges");
 			default:
 				throw new IllegalArgumentException("Illegal edge direction");

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/GraphCsvReader.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/GraphCsvReader.java
@@ -158,7 +158,7 @@ public class GraphCsvReader {
 		DataSet<Edge<K, NullValue>> edges = edgeReader
 			.types(vertexKey, vertexKey)
 				.name(GraphCsvReader.class.getName())
-			.map(new Tuple2ToEdgeMap<K>())
+			.map(new Tuple2ToEdgeMap<>())
 				.name("Type conversion");
 
 		return Graph.fromDataSet(edges, executionContext);
@@ -183,7 +183,7 @@ public class GraphCsvReader {
 		DataSet<Edge<K, NullValue>> edges = edgeReader
 			.types(vertexKey, vertexKey)
 				.name(GraphCsvReader.class.getName())
-			.map(new Tuple2ToEdgeMap<K>())
+			.map(new Tuple2ToEdgeMap<>())
 				.name("To Edge");
 
 		// the vertex value can be provided by an input file or a user-defined mapper
@@ -191,7 +191,7 @@ public class GraphCsvReader {
 			DataSet<Vertex<K, VV>> vertices = vertexReader
 				.types(vertexKey, vertexValue)
 					.name(GraphCsvReader.class.getName())
-				.map(new Tuple2ToVertexMap<K, VV>())
+				.map(new Tuple2ToVertexMap<>())
 					.name("Type conversion");
 
 			return Graph.fromDataSet(vertices, edges, executionContext);

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeDegreesPair.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeDegreesPair.java
@@ -58,7 +58,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Edge<K, Tuple3<EV, Degrees, Deg
 			.join(vertexDegrees, JoinHint.REPARTITION_HASH_SECOND)
 			.where(1)
 			.equalTo(0)
-			.with(new JoinEdgeDegreeWithVertexDegree<K, EV, Degrees>())
+			.with(new JoinEdgeDegreeWithVertexDegree<>())
 				.setParallelism(parallelism)
 				.name("Edge target degree");
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeSourceDegrees.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeSourceDegrees.java
@@ -52,7 +52,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Edge<K, Tuple2<EV, Degrees>>> {
 			.join(vertexDegrees, JoinHint.REPARTITION_HASH_SECOND)
 			.where(0)
 			.equalTo(0)
-			.with(new JoinEdgeWithVertexDegree<K, EV, Degrees>())
+			.with(new JoinEdgeWithVertexDegree<>())
 				.setParallelism(parallelism)
 				.name("Edge source degrees");
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeTargetDegrees.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeTargetDegrees.java
@@ -52,7 +52,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Edge<K, Tuple2<EV, Degrees>>> {
 			.join(vertexDegrees, JoinHint.REPARTITION_HASH_SECOND)
 			.where(1)
 			.equalTo(0)
-			.with(new JoinEdgeWithVertexDegree<K, EV, Degrees>())
+			.with(new JoinEdgeWithVertexDegree<>())
 				.setParallelism(parallelism)
 				.name("Edge target degrees");
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexDegrees.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexDegrees.java
@@ -93,18 +93,18 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Vertex<K, Degrees>> {
 			throws Exception {
 		// s, t, bitmask
 		DataSet<Tuple2<K, ByteValue>> vertexWithEdgeOrder = input.getEdges()
-			.flatMap(new EmitAndFlipEdge<K, EV>())
+			.flatMap(new EmitAndFlipEdge<>())
 				.setParallelism(parallelism)
 				.name("Emit and flip edge")
 			.groupBy(0, 1)
-			.reduceGroup(new ReduceBitmask<K>())
+			.reduceGroup(new ReduceBitmask<>())
 				.setParallelism(parallelism)
 				.name("Reduce bitmask");
 
 		// s, d(s)
 		DataSet<Vertex<K, Degrees>> vertexDegrees = vertexWithEdgeOrder
 			.groupBy(0)
-			.reduceGroup(new DegreeCount<K>())
+			.reduceGroup(new DegreeCount<>())
 				.setParallelism(parallelism)
 				.name("Degree count");
 
@@ -113,7 +113,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Vertex<K, Degrees>> {
 				.leftOuterJoin(vertexDegrees)
 				.where(0)
 				.equalTo(0)
-				.with(new JoinVertexWithVertexDegrees<K, VV>())
+				.with(new JoinVertexWithVertexDegrees<>())
 					.setParallelism(parallelism)
 					.name("Zero degree vertices");
 		}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexInDegree.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexInDegree.java
@@ -84,14 +84,14 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Vertex<K, LongValue>> {
 		// t
 		DataSet<Vertex<K, LongValue>> targetIds = input
 			.getEdges()
-			.map(new MapEdgeToTargetId<K, EV>())
+			.map(new MapEdgeToTargetId<>())
 				.setParallelism(parallelism)
 				.name("Edge to target ID");
 
 		// t, d(t)
 		DataSet<Vertex<K, LongValue>> targetDegree = targetIds
 			.groupBy(0)
-			.reduce(new DegreeCount<K>())
+			.reduce(new DegreeCount<>())
 			.setCombineHint(CombineHint.HASH)
 				.setParallelism(parallelism)
 				.name("Degree count");
@@ -101,7 +101,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Vertex<K, LongValue>> {
 				.leftOuterJoin(targetDegree)
 				.where(0)
 				.equalTo(0)
-				.with(new JoinVertexWithVertexDegree<K, VV>())
+				.with(new JoinVertexWithVertexDegree<>())
 					.setParallelism(parallelism)
 					.name("Zero degree vertices");
 		}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexOutDegree.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexOutDegree.java
@@ -84,14 +84,14 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Vertex<K, LongValue>> {
 		// s
 		DataSet<Vertex<K, LongValue>> sourceIds = input
 			.getEdges()
-			.map(new MapEdgeToSourceId<K, EV>())
+			.map(new MapEdgeToSourceId<>())
 				.setParallelism(parallelism)
 				.name("Edge to source ID");
 
 		// s, d(s)
 		DataSet<Vertex<K, LongValue>> sourceDegree = sourceIds
 			.groupBy(0)
-			.reduce(new DegreeCount<K>())
+			.reduce(new DegreeCount<>())
 			.setCombineHint(CombineHint.HASH)
 				.setParallelism(parallelism)
 				.name("Degree count");
@@ -101,7 +101,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Vertex<K, LongValue>> {
 				.leftOuterJoin(sourceDegree)
 				.where(0)
 				.equalTo(0)
-				.with(new JoinVertexWithVertexDegree<K, VV>())
+				.with(new JoinVertexWithVertexDegree<>())
 					.setParallelism(parallelism)
 					.name("Zero degree vertices");
 		}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeDegreePair.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeDegreePair.java
@@ -89,7 +89,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Edge<K, Tuple3<EV, LongValue, L
 			.join(vertexDegrees, JoinHint.REPARTITION_HASH_SECOND)
 			.where(1)
 			.equalTo(0)
-			.with(new JoinEdgeDegreeWithVertexDegree<K, EV, LongValue>())
+			.with(new JoinEdgeDegreeWithVertexDegree<>())
 				.setParallelism(parallelism)
 				.name("Edge target degree");
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeSourceDegree.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeSourceDegree.java
@@ -81,7 +81,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Edge<K, Tuple2<EV, LongValue>>>
 			.join(vertexDegrees, JoinHint.REPARTITION_HASH_SECOND)
 			.where(0)
 			.equalTo(0)
-			.with(new JoinEdgeWithVertexDegree<K, EV, LongValue>())
+			.with(new JoinEdgeWithVertexDegree<>())
 				.setParallelism(parallelism)
 				.name("Edge source degree");
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeTargetDegree.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeTargetDegree.java
@@ -81,7 +81,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Edge<K, Tuple2<EV, LongValue>>>
 			.join(vertexDegrees, JoinHint.REPARTITION_HASH_SECOND)
 			.where(1)
 			.equalTo(0)
-			.with(new JoinEdgeWithVertexDegree<K, EV, LongValue>())
+			.with(new JoinEdgeWithVertexDegree<>())
 				.setParallelism(parallelism)
 				.name("Edge target degree");
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/undirected/VertexDegree.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/undirected/VertexDegree.java
@@ -103,7 +103,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Vertex<K, LongValue>> {
 	public DataSet<Vertex<K, LongValue>> runInternal(Graph<K, VV, EV> input)
 			throws Exception {
 		MapFunction<Edge<K, EV>, Vertex<K, LongValue>> mapEdgeToId = reduceOnTargetId.get() ?
-			new MapEdgeToTargetId<K, EV>() : new MapEdgeToSourceId<K, EV>();
+			new MapEdgeToTargetId<>() : new MapEdgeToSourceId<>();
 
 		// v
 		DataSet<Vertex<K, LongValue>> vertexIds = input
@@ -115,7 +115,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Vertex<K, LongValue>> {
 		// v, deg(v)
 		DataSet<Vertex<K, LongValue>> degree = vertexIds
 			.groupBy(0)
-			.reduce(new DegreeCount<K>())
+			.reduce(new DegreeCount<>())
 			.setCombineHint(CombineHint.HASH)
 				.setParallelism(parallelism)
 				.name("Degree count");
@@ -126,7 +126,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Vertex<K, LongValue>> {
 				.leftOuterJoin(degree)
 				.where(0)
 				.equalTo(0)
-				.with(new JoinVertexWithVertexDegree<K, VV>())
+				.with(new JoinVertexWithVertexDegree<>())
 					.setParallelism(parallelism)
 					.name("Zero degree vertices");
 		}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/filter/undirected/MaximumDegree.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/filter/undirected/MaximumDegree.java
@@ -138,7 +138,7 @@ extends GraphAlgorithmWrappingGraph<K, VV, EV, K, VV, EV> {
 
 		// u, d(u) if d(u) > maximumDegree
 		DataSet<Tuple1<K>> highDegreeVertices = vertexDegree
-			.flatMap(new DegreeFilter<K>(maximumDegree))
+			.flatMap(new DegreeFilter<>(maximumDegree))
 				.setParallelism(parallelism)
 				.name("Filter high-degree vertices");
 
@@ -150,7 +150,7 @@ extends GraphAlgorithmWrappingGraph<K, VV, EV, K, VV, EV> {
 			.leftOuterJoin(highDegreeVertices, joinHint)
 			.where(0)
 			.equalTo(0)
-			.with(new ProjectVertex<K, VV>())
+			.with(new ProjectVertex<>())
 				.setParallelism(parallelism)
 				.name("Project low-degree vertices");
 
@@ -160,13 +160,13 @@ extends GraphAlgorithmWrappingGraph<K, VV, EV, K, VV, EV> {
 			.leftOuterJoin(highDegreeVertices, joinHint)
 			.where(reduceOnTargetId.get() ? 1 : 0)
 			.equalTo(0)
-				.with(new ProjectEdge<K, EV>())
+				.with(new ProjectEdge<>())
 				.setParallelism(parallelism)
 				.name("Project low-degree edges by " + (reduceOnTargetId.get() ? "target" : "source"))
 			.leftOuterJoin(highDegreeVertices, joinHint)
 			.where(reduceOnTargetId.get() ? 0 : 1)
 			.equalTo(0)
-			.with(new ProjectEdge<K, EV>())
+			.with(new ProjectEdge<>())
 				.setParallelism(parallelism)
 				.name("Project low-degree edges by " + (reduceOnTargetId.get() ? "source" : "target"));
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/simple/directed/Simplify.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/simple/directed/Simplify.java
@@ -41,7 +41,7 @@ extends GraphAlgorithmWrappingGraph<K, VV, EV, K, VV, EV> {
 		// Edges
 		DataSet<Edge<K, EV>> edges = input
 			.getEdges()
-			.filter(new RemoveSelfLoops<K, EV>())
+			.filter(new RemoveSelfLoops<>())
 				.setParallelism(parallelism)
 				.name("Remove self-loops")
 			.distinct(0, 1)

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/simple/undirected/Simplify.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/simple/undirected/Simplify.java
@@ -71,7 +71,7 @@ extends GraphAlgorithmWrappingGraph<K, VV, EV, K, VV, EV> {
 		// Edges
 		DataSet<Edge<K, EV>> edges = input
 			.getEdges()
-			.flatMap(new SymmetrizeAndRemoveSelfLoops<K, EV>(clipAndFlip))
+			.flatMap(new SymmetrizeAndRemoveSelfLoops<>(clipAndFlip))
 				.setParallelism(parallelism)
 				.name("Remove self-loops")
 			.distinct(0, 1)

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/Translate.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/translate/Translate.java
@@ -88,7 +88,7 @@ public class Translate {
 		TupleTypeInfo<Vertex<NEW, VV>> returnType = new TupleTypeInfo<>(vertexClass, newType, vertexValueType);
 
 		return vertices
-			.map(new TranslateVertexId<OLD, NEW, VV>(translator))
+			.map(new TranslateVertexId<>(translator))
 			.returns(returnType)
 				.setParallelism(parallelism)
 				.name("Translate vertex IDs");
@@ -172,7 +172,7 @@ public class Translate {
 		TupleTypeInfo<Edge<NEW, EV>> returnType = new TupleTypeInfo<>(edgeClass, newType, newType, edgeValueType);
 
 		return edges
-			.map(new TranslateEdgeId<OLD, NEW, EV>(translator))
+			.map(new TranslateEdgeId<>(translator))
 			.returns(returnType)
 				.setParallelism(parallelism)
 				.name("Translate edge IDs");
@@ -257,7 +257,7 @@ public class Translate {
 		TupleTypeInfo<Vertex<K, NEW>> returnType = new TupleTypeInfo<>(vertexClass, idType, newType);
 
 		return vertices
-			.map(new TranslateVertexValue<K, OLD, NEW>(translator))
+			.map(new TranslateVertexValue<>(translator))
 			.returns(returnType)
 				.setParallelism(parallelism)
 				.name("Translate vertex values");
@@ -341,7 +341,7 @@ public class Translate {
 		TupleTypeInfo<Edge<K, NEW>> returnType = new TupleTypeInfo<>(edgeClass, idType, idType, newType);
 
 		return edges
-			.map(new TranslateEdgeValue<K, OLD, NEW>(translator))
+			.map(new TranslateEdgeValue<>(translator))
 			.returns(returnType)
 				.setParallelism(parallelism)
 				.name("Translate edge values");

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/bipartite/BipartiteGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/bipartite/BipartiteGraph.java
@@ -128,7 +128,7 @@ public class BipartiteGraph<KT, KB, VVT, VVB, EV> {
 		DataSet<Edge<KT, Tuple2<EV, EV>>> newEdges = edges.join(edges)
 			.where(1)
 			.equalTo(1)
-			.with(new ProjectionTopSimple<KT, KB, EV>())
+			.with(new ProjectionTopSimple<>())
 				.name("Simple top projection");
 
 		return Graph.fromDataSet(topVertices, newEdges, context);
@@ -172,7 +172,7 @@ public class BipartiteGraph<KT, KB, VVT, VVB, EV> {
 		DataSet<Edge<KB, Tuple2<EV, EV>>> newEdges =  edges.join(edges)
 			.where(0)
 			.equalTo(0)
-			.with(new ProjectionBottomSimple<KT, KB, EV>())
+			.with(new ProjectionBottomSimple<>())
 			.name("Simple bottom projection");
 
 		return Graph.fromDataSet(bottomVertices, newEdges, context);
@@ -218,7 +218,7 @@ public class BipartiteGraph<KT, KB, VVT, VVB, EV> {
 		DataSet<Edge<KT, Projection<KB, VVB, VVT, EV>>> newEdges = edgesWithVertices.join(edgesWithVertices)
 			.where(1)
 			.equalTo(1)
-			.with(new ProjectionTopFull<KT, KB, EV, VVT, VVB>())
+			.with(new ProjectionTopFull<>())
 				.name("Full top projection");
 
 		return Graph.fromDataSet(topVertices, newEdges, context);
@@ -284,7 +284,7 @@ public class BipartiteGraph<KT, KB, VVT, VVB, EV> {
 		DataSet<Edge<KB, Projection<KT, VVT, VVB, EV>>> newEdges = edgesWithVertices.join(edgesWithVertices)
 			.where(0)
 			.equalTo(0)
-			.with(new ProjectionBottomFull<KT, KB, EV, VVT, VVB>())
+			.with(new ProjectionBottomFull<>())
 				.name("Full bottom projection");
 
 		return Graph.fromDataSet(bottomVertices, newEdges, context);

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/GraphGeneratorUtils.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/GraphGeneratorUtils.java
@@ -91,7 +91,7 @@ public class GraphGeneratorUtils {
 	 */
 	public static <K, EV> DataSet<Vertex<K, NullValue>> vertexSet(DataSet<Edge<K, EV>> edges, int parallelism) {
 		DataSet<Vertex<K, NullValue>> vertexSet = edges
-			.flatMap(new EmitSrcAndTarget<K, EV>())
+			.flatMap(new EmitSrcAndTarget<>())
 				.setParallelism(parallelism)
 				.name("Emit source and target labels");
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/RMatGraph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/RMatGraph.java
@@ -156,7 +156,7 @@ extends GraphGeneratorBase<LongValue, NullValue, NullValue> {
 			.rebalance()
 				.setParallelism(parallelism)
 				.name("Rebalance")
-			.flatMap(new GenerateEdges<T>(vertexCount, scale, a, b, c, noiseEnabled, noise))
+			.flatMap(new GenerateEdges<>(vertexCount, scale, a, b, c, noiseEnabled, noise))
 				.setParallelism(parallelism)
 				.name("RMat graph edges");
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/gsa/GSAConfiguration.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/gsa/GSAConfiguration.java
@@ -58,7 +58,7 @@ public class GSAConfiguration extends IterationConfiguration {
 	 * @param data The data set to be broadcasted.
 	 */
 	public void addBroadcastSetForGatherFunction(String name, DataSet<?> data) {
-		this.bcVarsGather.add(new Tuple2<String, DataSet<?>>(name, data));
+		this.bcVarsGather.add(new Tuple2<>(name, data));
 	}
 
 	/**
@@ -68,7 +68,7 @@ public class GSAConfiguration extends IterationConfiguration {
 	 * @param data The data set to be broadcasted.
 	 */
 	public void addBroadcastSetForSumFunction(String name, DataSet<?> data) {
-		this.bcVarsSum.add(new Tuple2<String, DataSet<?>>(name, data));
+		this.bcVarsSum.add(new Tuple2<>(name, data));
 	}
 
 	/**
@@ -78,7 +78,7 @@ public class GSAConfiguration extends IterationConfiguration {
 	 * @param data The data set to be broadcasted.
 	 */
 	public void addBroadcastSetForApplyFunction(String name, DataSet<?> data) {
-		this.bcVarsApply.add(new Tuple2<String, DataSet<?>>(name, data));
+		this.bcVarsApply.add(new Tuple2<>(name, data));
 	}
 
 	/**

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/gsa/GatherSumApplyIteration.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/gsa/GatherSumApplyIteration.java
@@ -169,24 +169,24 @@ public class GatherSumApplyIteration<K, VV, EV, M> implements CustomUnaryOperati
 			case OUT:
 				neighbors = iteration
 				.getWorkset().join(edgeDataSet)
-				.where(0).equalTo(0).with(new ProjectKeyWithNeighborOUT<K, VV, EV>());
+				.where(0).equalTo(0).with(new ProjectKeyWithNeighborOUT<>());
 				break;
 			case IN:
 				neighbors = iteration
 				.getWorkset().join(edgeDataSet)
-				.where(0).equalTo(1).with(new ProjectKeyWithNeighborIN<K, VV, EV>());
+				.where(0).equalTo(1).with(new ProjectKeyWithNeighborIN<>());
 				break;
 			case ALL:
 				neighbors =  iteration
 						.getWorkset().join(edgeDataSet)
-						.where(0).equalTo(0).with(new ProjectKeyWithNeighborOUT<K, VV, EV>()).union(iteration
+						.where(0).equalTo(0).with(new ProjectKeyWithNeighborOUT<>()).union(iteration
 								.getWorkset().join(edgeDataSet)
-								.where(0).equalTo(1).with(new ProjectKeyWithNeighborIN<K, VV, EV>()));
+								.where(0).equalTo(1).with(new ProjectKeyWithNeighborIN<>()));
 				break;
 			default:
 				neighbors = iteration
 						.getWorkset().join(edgeDataSet)
-						.where(0).equalTo(0).with(new ProjectKeyWithNeighborOUT<K, VV, EV>());
+						.where(0).equalTo(0).with(new ProjectKeyWithNeighborOUT<>());
 				break;
 		}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/CommunityDetection.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/CommunityDetection.java
@@ -73,14 +73,14 @@ public class CommunityDetection<K> implements GraphAlgorithm<K, Long, Double, Gr
 	public Graph<K, Long, Double> run(Graph<K, Long, Double> graph) {
 
 		DataSet<Vertex<K, Tuple2<Long, Double>>> initializedVertices = graph.getVertices()
-			.map(new AddScoreToVertexValuesMapper<K>());
+			.map(new AddScoreToVertexValuesMapper<>());
 
 		Graph<K, Tuple2<Long, Double>, Double> graphWithScoredVertices =
 			Graph.fromDataSet(initializedVertices, graph.getEdges(), graph.getContext()).getUndirected();
 
-		return graphWithScoredVertices.runScatterGatherIteration(new LabelMessenger<K>(),
-			new VertexLabelUpdater<K>(delta), maxIterations)
-				.mapVertices(new RemoveScoreFromVertexValuesMapper<K>());
+		return graphWithScoredVertices.runScatterGatherIteration(new LabelMessenger<>(),
+			new VertexLabelUpdater<>(delta), maxIterations)
+				.mapVertices(new RemoveScoreFromVertexValuesMapper<>());
 	}
 
 	@SuppressWarnings("serial")

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/ConnectedComponents.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/ConnectedComponents.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
@@ -73,12 +72,12 @@ public class ConnectedComponents<K, VV extends Comparable<VV>, EV>
 		TypeInformation<VV> valueTypeInfo = ((TupleTypeInfo<?>) graph.getVertices().getType()).getTypeAt(1);
 
 		Graph<K, VV, NullValue> undirectedGraph = graph
-			.mapEdges(new MapTo<Edge<K, EV>, NullValue>(NullValue.getInstance()))
+			.mapEdges(new MapTo<>(NullValue.getInstance()))
 			.getUndirected();
 
 		return undirectedGraph.runScatterGatherIteration(
-			new CCMessenger<K, VV>(valueTypeInfo),
-			new CCUpdater<K, VV>(),
+			new CCMessenger<>(valueTypeInfo),
+			new CCUpdater<>(),
 			maxIterations).getVertices();
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSAConnectedComponents.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSAConnectedComponents.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
@@ -74,13 +73,13 @@ public class GSAConnectedComponents<K, VV extends Comparable<VV>, EV>
 		TypeInformation<VV> valueTypeInfo = ((TupleTypeInfo<?>) graph.getVertices().getType()).getTypeAt(1);
 
 		Graph<K, VV, NullValue> undirectedGraph = graph
-			.mapEdges(new MapTo<Edge<K, EV>, NullValue>(NullValue.getInstance()))
+			.mapEdges(new MapTo<>(NullValue.getInstance()))
 			.getUndirected();
 
 		return undirectedGraph.runGatherSumApplyIteration(
 			new GatherNeighborIds<>(valueTypeInfo),
 			new SelectMinId<>(valueTypeInfo),
-			new UpdateComponentId<K, VV>(valueTypeInfo),
+			new UpdateComponentId<>(valueTypeInfo),
 			maxIterations).getVertices();
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSASingleSourceShortestPaths.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/GSASingleSourceShortestPaths.java
@@ -51,9 +51,9 @@ public class GSASingleSourceShortestPaths<K, VV> implements
 	@Override
 	public DataSet<Vertex<K, Double>> run(Graph<K, VV, Double> input) {
 
-		return input.mapVertices(new InitVerticesMapper<K, VV>(srcVertexId))
+		return input.mapVertices(new InitVerticesMapper<>(srcVertexId))
 				.runGatherSumApplyIteration(new CalculateDistances(), new ChooseMinDistance(),
-						new UpdateDistance<K>(), maxIterations)
+					new UpdateDistance<>(), maxIterations)
 						.getVertices();
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/LabelPropagation.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/LabelPropagation.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.GraphAlgorithm;
 import org.apache.flink.graph.Vertex;
@@ -77,9 +76,9 @@ public class LabelPropagation<K, VV extends Comparable<VV>, EV>
 		TypeInformation<VV> valueType = ((TupleTypeInfo<?>) input.getVertices().getType()).getTypeAt(1);
 		// iteratively adopt the most frequent label among the neighbors of each vertex
 		return input
-			.mapEdges(new MapTo<Edge<K, EV>, NullValue>(NullValue.getInstance()))
+			.mapEdges(new MapTo<>(NullValue.getInstance()))
 			.runScatterGatherIteration(
-				new SendNewLabelToNeighbors<K, VV>(valueType), new UpdateVertexLabel<K, VV>(), maxIterations)
+				new SendNewLabelToNeighbors<>(valueType), new UpdateVertexLabel<>(), maxIterations)
 			.getVertices();
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/SingleSourceShortestPaths.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/SingleSourceShortestPaths.java
@@ -51,8 +51,8 @@ public class SingleSourceShortestPaths<K, VV> implements GraphAlgorithm<K, VV, D
 	@Override
 	public DataSet<Vertex<K, Double>> run(Graph<K, VV, Double> input) {
 
-		return input.mapVertices(new InitVerticesMapper<K, VV>(srcVertexId))
-				.runScatterGatherIteration(new MinDistanceMessenger<K>(), new VertexDistanceUpdater<K>(),
+		return input.mapVertices(new InitVerticesMapper<>(srcVertexId))
+				.runScatterGatherIteration(new MinDistanceMessenger<>(), new VertexDistanceUpdater<>(),
 				maxIterations).getVertices();
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/Summarization.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/Summarization.java
@@ -102,11 +102,11 @@ public class Summarization<K, VV, EV>
 		// group vertices by value and create vertex group items
 		DataSet<VertexGroupItem<K, VV>> vertexGroupItems = input.getVertices()
 				.groupBy(1)
-				.reduceGroup(new VertexGroupReducer<K, VV>());
+				.reduceGroup(new VertexGroupReducer<>());
 		// create super vertices
 		DataSet<Vertex<K, VertexValue<VV>>> summarizedVertices = vertexGroupItems
-				.filter(new VertexGroupItemToSummarizedVertexFilter<K, VV>())
-				.map(new VertexGroupItemToSummarizedVertexMapper<K, VV>());
+				.filter(new VertexGroupItemToSummarizedVertexFilter<>())
+				.map(new VertexGroupItemToSummarizedVertexMapper<>());
 
 		// -------------------------
 		// build super edges
@@ -114,22 +114,22 @@ public class Summarization<K, VV, EV>
 
 		// create mapping between vertices and their representative
 		DataSet<VertexWithRepresentative<K>> vertexToRepresentativeMap = vertexGroupItems
-			.filter(new VertexGroupItemToRepresentativeFilter<K, VV>())
-			.map(new VertexGroupItemToVertexWithRepresentativeMapper<K, VV>());
+			.filter(new VertexGroupItemToRepresentativeFilter<>())
+			.map(new VertexGroupItemToVertexWithRepresentativeMapper<>());
 		// join edges with vertex representatives and update source and target identifiers
 		DataSet<Edge<K, EV>> edgesForGrouping = input.getEdges()
 				.join(vertexToRepresentativeMap)
 				.where(0) 	// source vertex id
 				.equalTo(0) // vertex id
-				.with(new SourceVertexJoinFunction<K, EV>())
+				.with(new SourceVertexJoinFunction<>())
 				.join(vertexToRepresentativeMap)
 				.where(1) 	// target vertex id
 				.equalTo(0) // vertex id
-				.with(new TargetVertexJoinFunction<K, EV>());
+				.with(new TargetVertexJoinFunction<>());
 		// create super edges
 		DataSet<Edge<K, EdgeValue<EV>>> summarizedEdges = edgesForGrouping
 				.groupBy(0, 1, 2) // group by source id (0), target id (1) and edge value (2)
-				.reduceGroup(new EdgeGroupReducer<K, EV>());
+				.reduceGroup(new EdgeGroupReducer<>());
 
 		return Graph.fromDataSet(summarizedVertices, summarizedEdges, input.getContext());
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/TriangleEnumerator.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/TriangleEnumerator.java
@@ -65,21 +65,21 @@ public class TriangleEnumerator<K extends Comparable<K>, VV, EV> implements
 		DataSet<Edge<K, EV>> edges = input.getEdges();
 
 		// annotate edges with degrees
-		DataSet<EdgeWithDegrees<K>> edgesWithDegrees = edges.flatMap(new EdgeDuplicator<K, EV>())
-				.groupBy(0).sortGroup(1, Order.ASCENDING).reduceGroup(new DegreeCounter<K, EV>())
-				.groupBy(EdgeWithDegrees.V1, EdgeWithDegrees.V2).reduce(new DegreeJoiner<K>());
+		DataSet<EdgeWithDegrees<K>> edgesWithDegrees = edges.flatMap(new EdgeDuplicator<>())
+				.groupBy(0).sortGroup(1, Order.ASCENDING).reduceGroup(new DegreeCounter<>())
+				.groupBy(EdgeWithDegrees.V1, EdgeWithDegrees.V2).reduce(new DegreeJoiner<>());
 
 		// project edges by degrees
-		DataSet<Edge<K, NullValue>> edgesByDegree = edgesWithDegrees.map(new EdgeByDegreeProjector<K>());
+		DataSet<Edge<K, NullValue>> edgesByDegree = edgesWithDegrees.map(new EdgeByDegreeProjector<>());
 		// project edges by vertex id
-		DataSet<Edge<K, NullValue>> edgesById = edgesByDegree.map(new EdgeByIdProjector<K>());
+		DataSet<Edge<K, NullValue>> edgesById = edgesByDegree.map(new EdgeByIdProjector<>());
 
 		DataSet<Tuple3<K, K, K>> triangles = edgesByDegree
 				// build triads
 				.groupBy(EdgeWithDegrees.V1).sortGroup(EdgeWithDegrees.V2, Order.ASCENDING)
-				.reduceGroup(new TriadBuilder<K>())
+				.reduceGroup(new TriadBuilder<>())
 				// filter triads
-				.join(edgesById, JoinHint.REPARTITION_HASH_SECOND).where(Triad.V2, Triad.V3).equalTo(0, 1).with(new TriadFilter<K>());
+				.join(edgesById, JoinHint.REPARTITION_HASH_SECOND).where(Triad.V2, Triad.V3).equalTo(0, 1).with(new TriadFilter<>());
 
 		return triangles;
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/LocalClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/LocalClusteringCoefficient.java
@@ -119,13 +119,13 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 
 		// u, edge count
 		DataSet<Tuple2<K, LongValue>> triangleVertices = triangles
-			.flatMap(new SplitTriangles<K>())
+			.flatMap(new SplitTriangles<>())
 				.name("Split triangle vertices");
 
 		// u, triangle count
 		DataSet<Tuple2<K, LongValue>> vertexTriangleCount = triangleVertices
 			.groupBy(0)
-			.reduce(new CountTriangles<K>())
+			.reduce(new CountTriangles<>())
 			.setCombineHint(CombineHint.HASH)
 				.name("Count triangles");
 
@@ -140,7 +140,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 			.leftOuterJoin(vertexTriangleCount)
 			.where(0)
 			.equalTo(0)
-			.with(new JoinVertexDegreeWithTriangleCount<K>())
+			.with(new JoinVertexDegreeWithTriangleCount<>())
 				.setParallelism(parallelism)
 				.name("Clustering coefficient");
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/TriangleListing.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/directed/TriangleListing.java
@@ -84,11 +84,11 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 		// u, v, bitmask where u < v
 		DataSet<Tuple3<K, K, ByteValue>> filteredByID = input
 			.getEdges()
-			.map(new OrderByID<K, EV>())
+			.map(new OrderByID<>())
 				.setParallelism(parallelism)
 				.name("Order by ID")
 			.groupBy(0, 1)
-			.reduceGroup(new ReduceBitmask<K>())
+			.reduceGroup(new ReduceBitmask<>())
 				.setParallelism(parallelism)
 				.name("Flatten by ID");
 
@@ -99,11 +99,11 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 
 		// u, v, bitmask where deg(u) < deg(v) or (deg(u) == deg(v) and u < v)
 		DataSet<Tuple3<K, K, ByteValue>> filteredByDegree = pairDegrees
-			.map(new OrderByDegree<K, EV>())
+			.map(new OrderByDegree<>())
 				.setParallelism(parallelism)
 				.name("Order by degree")
 			.groupBy(0, 1)
-			.reduceGroup(new ReduceBitmask<K>())
+			.reduceGroup(new ReduceBitmask<>())
 				.setParallelism(parallelism)
 				.name("Flatten by degree");
 
@@ -111,7 +111,7 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 		DataSet<Tuple4<K, K, K, ByteValue>> triplets = filteredByDegree
 			.groupBy(0)
 			.sortGroup(1, Order.ASCENDING)
-			.reduceGroup(new GenerateTriplets<K>())
+			.reduceGroup(new GenerateTriplets<>())
 				.name("Generate triplets");
 
 		// u, v, w, bitmask where (u, v), (u, w), and (v, w) are edges in graph
@@ -119,16 +119,16 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 			.join(filteredByID, JoinOperatorBase.JoinHint.REPARTITION_HASH_SECOND)
 			.where(1, 2)
 			.equalTo(0, 1)
-			.with(new ProjectTriangles<K>())
+			.with(new ProjectTriangles<>())
 				.name("Triangle listing");
 
 		if (permuteResults) {
 			triangles = triangles
-				.flatMap(new PermuteResult<K>())
+				.flatMap(new PermuteResult<>())
 					.name("Permute triangle vertices");
 		} else if (sortTriangleVertices.get()) {
 			triangles = triangles
-				.map(new SortTriangleVertices<K>())
+				.map(new SortTriangleVertices<>())
 					.name("Sort triangle vertices");
 		}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/LocalClusteringCoefficient.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/LocalClusteringCoefficient.java
@@ -118,13 +118,13 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 
 		// u, 1
 		DataSet<Tuple2<K, LongValue>> triangleVertices = triangles
-			.flatMap(new SplitTriangles<K>())
+			.flatMap(new SplitTriangles<>())
 				.name("Split triangle vertices");
 
 		// u, triangle count
 		DataSet<Tuple2<K, LongValue>> vertexTriangleCount = triangleVertices
 			.groupBy(0)
-			.reduce(new CountTriangles<K>())
+			.reduce(new CountTriangles<>())
 			.setCombineHint(CombineHint.HASH)
 				.name("Count triangles");
 
@@ -139,7 +139,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 			.leftOuterJoin(vertexTriangleCount)
 			.where(0)
 			.equalTo(0)
-			.with(new JoinVertexDegreeWithTriangleCount<K>())
+			.with(new JoinVertexDegreeWithTriangleCount<>())
 				.setParallelism(parallelism)
 				.name("Clustering coefficient");
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/TriangleListing.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/clustering/undirected/TriangleListing.java
@@ -83,7 +83,7 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 		// u, v where u < v
 		DataSet<Tuple2<K, K>> filteredByID = input
 			.getEdges()
-			.flatMap(new FilterByID<K, EV>())
+			.flatMap(new FilterByID<>())
 				.setParallelism(parallelism)
 				.name("Filter by ID");
 
@@ -94,7 +94,7 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 
 		// u, v where deg(u) < deg(v) or (deg(u) == deg(v) and u < v)
 		DataSet<Tuple2<K, K>> filteredByDegree = pairDegree
-			.flatMap(new FilterByDegree<K, EV>())
+			.flatMap(new FilterByDegree<>())
 				.setParallelism(parallelism)
 				.name("Filter by degree");
 
@@ -102,7 +102,7 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 		DataSet<Tuple3<K, K, K>> triplets = filteredByDegree
 			.groupBy(0)
 			.sortGroup(1, Order.ASCENDING)
-			.reduceGroup(new GenerateTriplets<K>())
+			.reduceGroup(new GenerateTriplets<>())
 				.name("Generate triplets");
 
 		// u, v, w where (u, v), (u, w), and (v, w) are edges in graph, v < w
@@ -110,16 +110,16 @@ extends TriangleListingBase<K, VV, EV, Result<K>> {
 			.join(filteredByID, JoinOperatorBase.JoinHint.REPARTITION_HASH_SECOND)
 			.where(1, 2)
 			.equalTo(0, 1)
-			.with(new ProjectTriangles<K>())
+			.with(new ProjectTriangles<>())
 				.name("Triangle listing");
 
 		if (permuteResults) {
 			triangles = triangles
-				.flatMap(new PermuteResult<K>())
+				.flatMap(new PermuteResult<>())
 					.name("Permute triangle vertices");
 		} else if (sortTriangleVertices.get()) {
 			triangles = triangles
-				.map(new SortTriangleVertices<K>())
+				.map(new SortTriangleVertices<>())
 					.name("Sort triangle vertices");
 		}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/HITS.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/HITS.java
@@ -129,17 +129,17 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 			throws Exception {
 		DataSet<Tuple2<K, K>> edges = input
 			.getEdges()
-			.map(new ExtractEdgeIDs<K, EV>())
+			.map(new ExtractEdgeIDs<>())
 				.setParallelism(parallelism)
 				.name("Extract edge IDs");
 
 		// ID, hub, authority
 		DataSet<Tuple3<K, DoubleValue, DoubleValue>> initialScores = edges
-			.map(new InitializeScores<K>())
+			.map(new InitializeScores<>())
 				.setParallelism(parallelism)
 				.name("Initial scores")
 			.groupBy(0)
-			.reduce(new SumScores<K>())
+			.reduce(new SumScores<>())
 			.setCombineHint(CombineHint.HASH)
 				.setParallelism(parallelism)
 				.name("Sum");
@@ -153,18 +153,18 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 			.coGroup(edges)
 			.where(0)
 			.equalTo(1)
-			.with(new Hubbiness<K>())
+			.with(new Hubbiness<>())
 				.setParallelism(parallelism)
 				.name("Hub")
 			.groupBy(0)
-			.reduce(new SumScore<K>())
+			.reduce(new SumScore<>())
 			.setCombineHint(CombineHint.HASH)
 				.setParallelism(parallelism)
 				.name("Sum");
 
 		// sum-of-hubbiness-squared
 		DataSet<DoubleValue> hubbinessSumSquared = hubbiness
-			.map(new Square<K>())
+			.map(new Square<>())
 				.setParallelism(parallelism)
 				.name("Square")
 			.reduce(new Sum())
@@ -177,18 +177,18 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 			.coGroup(edges)
 			.where(0)
 			.equalTo(0)
-			.with(new Authority<K>())
+			.with(new Authority<>())
 				.setParallelism(parallelism)
 				.name("Authority")
 			.groupBy(0)
-			.reduce(new SumScore<K>())
+			.reduce(new SumScore<>())
 			.setCombineHint(CombineHint.HASH)
 				.setParallelism(parallelism)
 				.name("Sum");
 
 		// sum-of-authority-squared
 		DataSet<DoubleValue> authoritySumSquared = authority
-			.map(new Square<K>())
+			.map(new Square<>())
 				.setParallelism(parallelism)
 				.name("Square")
 			.reduce(new Sum())
@@ -201,7 +201,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 			.fullOuterJoin(authority, JoinHint.REPARTITION_SORT_MERGE)
 			.where(0)
 			.equalTo(0)
-			.with(new JoinAndNormalizeHubAndAuthority<K>())
+			.with(new JoinAndNormalizeHubAndAuthority<>())
 			.withBroadcastSet(hubbinessSumSquared, HUBBINESS_SUM_SQUARED)
 			.withBroadcastSet(authoritySumSquared, AUTHORITY_SUM_SQUARED)
 				.setParallelism(parallelism)
@@ -214,7 +214,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 				.fullOuterJoin(scores, JoinHint.REPARTITION_SORT_MERGE)
 				.where(0)
 				.equalTo(0)
-				.with(new ChangeInScores<K>())
+				.with(new ChangeInScores<>())
 					.setParallelism(parallelism)
 					.name("Change in scores");
 
@@ -225,7 +225,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 
 		return iterative
 			.closeWith(passThrough)
-			.map(new TranslateResult<K>())
+			.map(new TranslateResult<>())
 				.setParallelism(parallelism)
 				.name("Map result");
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/PageRank.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/PageRank.java
@@ -151,20 +151,20 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		DataSet<Edge<K, LongValue>> edgeSourceDegree = input
 			.run(new EdgeSourceDegrees<K, VV, EV>()
 				.setParallelism(parallelism))
-			.map(new ExtractSourceDegree<K, EV>())
+			.map(new ExtractSourceDegree<>())
 				.setParallelism(parallelism)
 				.name("Extract source degree");
 
 		// vertices with zero in-edges
 		DataSet<Tuple2<K, DoubleValue>> sourceVertices = vertexDegree
-			.flatMap(new InitializeSourceVertices<K>())
+			.flatMap(new InitializeSourceVertices<>())
 			.withBroadcastSet(vertexCount, VERTEX_COUNT)
 				.setParallelism(parallelism)
 				.name("Initialize source vertex scores");
 
 		// s, initial pagerank(s)
 		DataSet<Tuple2<K, DoubleValue>> initialScores = vertexDegree
-			.map(new InitializeVertexScores<K>())
+			.map(new InitializeVertexScores<>())
 			.withBroadcastSet(vertexCount, VERTEX_COUNT)
 				.setParallelism(parallelism)
 				.name("Initialize scores");
@@ -178,18 +178,18 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 			.coGroup(edgeSourceDegree)
 			.where(0)
 			.equalTo(0)
-			.with(new SendScore<K>())
+			.with(new SendScore<>())
 				.setParallelism(parallelism)
 				.name("Send score")
 			.groupBy(0)
-			.reduce(new SumScore<K>())
+			.reduce(new SumScore<>())
 			.setCombineHint(CombineHint.HASH)
 				.setParallelism(parallelism)
 				.name("Sum");
 
 		// ignored ID, total pagerank
 		DataSet<Tuple2<K, DoubleValue>> sumOfScores = vertexScores
-			.reduce(new SumVertexScores<K>())
+			.reduce(new SumVertexScores<>())
 				.setParallelism(parallelism)
 				.name("Sum");
 
@@ -198,7 +198,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 			.union(sourceVertices)
 				.setParallelism(parallelism)
 				.name("Union with source vertices")
-			.map(new AdjustScores<K>(dampingFactor))
+			.map(new AdjustScores<>(dampingFactor))
 				.withBroadcastSet(sumOfScores, SUM_OF_SCORES)
 				.withBroadcastSet(vertexCount, VERTEX_COUNT)
 					.setParallelism(parallelism)
@@ -211,7 +211,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 				.join(adjustedScores)
 				.where(0)
 				.equalTo(0)
-				.with(new ChangeInScores<K>())
+				.with(new ChangeInScores<>())
 					.setParallelism(parallelism)
 					.name("Change in scores");
 
@@ -222,7 +222,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 
 		return iterative
 			.closeWith(passThrough)
-			.map(new TranslateResult<K>())
+			.map(new TranslateResult<>())
 				.setParallelism(parallelism)
 				.name("Map result");
 	}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/EdgeMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/directed/EdgeMetrics.java
@@ -92,15 +92,15 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 
 		// s, d(s), count of (u, v) where deg(u) < deg(v) or (deg(u) == deg(v) and u < v)
 		DataSet<Tuple3<K, Degrees, LongValue>> edgeStats = edgeDegreesPair
-			.flatMap(new EdgeStats<K, EV>())
+			.flatMap(new EdgeStats<>())
 				.setParallelism(parallelism)
 				.name("Edge stats")
 			.groupBy(0, 1)
-			.reduceGroup(new ReduceEdgeStats<K>())
+			.reduceGroup(new ReduceEdgeStats<>())
 				.setParallelism(parallelism)
 				.name("Reduce edge stats")
 			.groupBy(0)
-			.reduce(new SumEdgeStats<K>())
+			.reduce(new SumEdgeStats<>())
 			.setCombineHint(CombineHint.HASH)
 				.setParallelism(parallelism)
 				.name("Sum edge stats");

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/EdgeMetrics.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/metric/undirected/EdgeMetrics.java
@@ -103,11 +103,11 @@ extends GraphAnalyticBase<K, VV, EV, Result> {
 
 		// s, d(s), count of (u, v) where deg(u) < deg(v) or (deg(u) == deg(v) and u < v)
 		DataSet<Tuple3<K, LongValue, LongValue>> edgeStats = edgeDegreePair
-			.map(new EdgeStats<K, EV>())
+			.map(new EdgeStats<>())
 				.setParallelism(parallelism)
 				.name("Edge stats")
 			.groupBy(0)
-			.reduce(new SumEdgeStats<K>())
+			.reduce(new SumEdgeStats<>())
 			.setCombineHint(CombineHint.HASH)
 				.setParallelism(parallelism)
 				.name("Sum edge stats");

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/similarity/AdamicAdar.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/similarity/AdamicAdar.java
@@ -153,7 +153,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		DataSet<Tuple3<K, LongValue, FloatValue>> inverseLogDegree = input
 			.run(new VertexDegree<K, VV, EV>()
 				.setParallelism(parallelism))
-			.map(new VertexInverseLogDegree<K>())
+			.map(new VertexInverseLogDegree<>())
 				.setParallelism(parallelism)
 				.name("Vertex score");
 
@@ -172,7 +172,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		DataSet<Tuple4<IntValue, K, K, FloatValue>> groupSpans = sourceInverseLogDegree
 			.groupBy(0)
 			.sortGroup(1, Order.ASCENDING)
-			.reduceGroup(new GenerateGroupSpans<K>())
+			.reduceGroup(new GenerateGroupSpans<>())
 				.setParallelism(parallelism)
 				.name("Generate group spans");
 
@@ -181,7 +181,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 			.rebalance()
 				.setParallelism(parallelism)
 				.name("Rebalance")
-			.flatMap(new GenerateGroups<K>())
+			.flatMap(new GenerateGroups<>())
 				.setParallelism(parallelism)
 				.name("Generate groups");
 
@@ -189,19 +189,19 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		DataSet<Tuple3<K, K, FloatValue>> twoPaths = groups
 			.groupBy(0, 1)
 			.sortGroup(2, Order.ASCENDING)
-			.reduceGroup(new GenerateGroupPairs<K>())
+			.reduceGroup(new GenerateGroupPairs<>())
 				.name("Generate group pairs");
 
 		// t, u, adamic-adar score
 		GroupReduceOperator<Tuple3<K, K, FloatValue>, Result<K>> scores = twoPaths
 			.groupBy(0, 1)
-			.reduceGroup(new ComputeScores<K>(minimumScore, minimumRatio))
+			.reduceGroup(new ComputeScores<>(minimumScore, minimumRatio))
 				.name("Compute scores");
 
 		if (minimumRatio > 0.0f) {
 			// total score, number of pairs of neighbors
 			DataSet<Tuple2<FloatValue, LongValue>> sumOfScoresAndNumberOfNeighborPairs = inverseLogDegree
-				.map(new ComputeScoreFromVertex<K>())
+				.map(new ComputeScoreFromVertex<>())
 					.setParallelism(parallelism)
 					.name("Average score")
 				.sum(0)
@@ -213,7 +213,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 
 		if (mirrorResults) {
 			return scores
-				.flatMap(new MirrorResult<K, Result<K>>())
+				.flatMap(new MirrorResult<>())
 					.name("Mirror results");
 		} else {
 			return scores;

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/similarity/JaccardIndex.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/similarity/JaccardIndex.java
@@ -199,7 +199,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		DataSet<Tuple4<IntValue, K, K, IntValue>> groupSpans = neighborDegree
 			.groupBy(0)
 			.sortGroup(1, Order.ASCENDING)
-			.reduceGroup(new GenerateGroupSpans<K, EV>(groupSize))
+			.reduceGroup(new GenerateGroupSpans<>(groupSize))
 				.setParallelism(parallelism)
 				.name("Generate group spans");
 
@@ -208,7 +208,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 			.rebalance()
 				.setParallelism(parallelism)
 				.name("Rebalance")
-			.flatMap(new GenerateGroups<K>())
+			.flatMap(new GenerateGroups<>())
 				.setParallelism(parallelism)
 				.name("Generate groups");
 
@@ -216,20 +216,20 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 		DataSet<Tuple3<K, K, IntValue>> twoPaths = groups
 			.groupBy(0, 1)
 			.sortGroup(2, Order.ASCENDING)
-			.reduceGroup(new GenerateGroupPairs<K>(groupSize))
+			.reduceGroup(new GenerateGroupPairs<>(groupSize))
 				.name("Generate group pairs");
 
 		// t, u, intersection, union
 		DataSet<Result<K>> scores = twoPaths
 			.groupBy(0, 1)
-			.reduceGroup(new ComputeScores<K>(unboundedScores,
+			.reduceGroup(new ComputeScores<>(unboundedScores,
 					minimumScoreNumerator, minimumScoreDenominator,
 					maximumScoreNumerator, maximumScoreDenominator))
 				.name("Compute scores");
 
 		if (mirrorResults) {
 			scores = scores
-				.flatMap(new MirrorResult<K, Result<K>>())
+				.flatMap(new MirrorResult<>())
 					.name("Mirror results");
 		}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/pregel/VertexCentricConfiguration.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/pregel/VertexCentricConfiguration.java
@@ -48,7 +48,7 @@ public class VertexCentricConfiguration extends IterationConfiguration {
 	 * @param data The data set to be broadcasted.
 	 */
 	public void addBroadcastSet(String name, DataSet<?> data) {
-		this.bcVars.add(new Tuple2<String, DataSet<?>>(name, data));
+		this.bcVars.add(new Tuple2<>(name, data));
 	}
 
 	/**

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/pregel/VertexCentricIteration.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/pregel/VertexCentricIteration.java
@@ -176,9 +176,9 @@ public class VertexCentricIteration<K, VV, EV, Message>
 		DataSet<Tuple2<Vertex<K, VV>, Either<NullValue, Message>>> verticesWithMsgs =
 				iteration.getSolutionSet().join(iteration.getWorkset())
 				.where(0).equalTo(0)
-				.with(new AppendVertexState<K, VV, Message>())
-				.returns(new TupleTypeInfo<Tuple2<Vertex<K, VV>, Either<NullValue, Message>>>(
-						vertexType, nullableMsgTypeInfo));
+				.with(new AppendVertexState<>())
+				.returns(new TupleTypeInfo<>(
+					vertexType, nullableMsgTypeInfo));
 
 		VertexComputeUdf<K, VV, EV, Message> vertexUdf =
 			new VertexComputeUdf<>(computeFunction, intermediateTypeInfo);
@@ -190,11 +190,11 @@ public class VertexCentricIteration<K, VV, EV, Message>
 
 		// compute the solution set delta
 		DataSet<Vertex<K, VV>> solutionSetDelta = superstepComputation.flatMap(
-				new ProjectNewVertexValue<K, VV, Message>()).returns(vertexType);
+			new ProjectNewVertexValue<>()).returns(vertexType);
 
 		// compute the inbox of each vertex for the next superstep (new workset)
 		DataSet<Tuple2<K, Either<NullValue, Message>>> allMessages = superstepComputation.flatMap(
-				new ProjectMessages<K, VV, Message>()).returns(workSetTypeInfo);
+			new ProjectMessages<>()).returns(workSetTypeInfo);
 
 		DataSet<Tuple2<K, Either<NullValue, Message>>> newWorkSet = allMessages;
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/spargel/ScatterGatherConfiguration.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/spargel/ScatterGatherConfiguration.java
@@ -59,7 +59,7 @@ public class ScatterGatherConfiguration extends IterationConfiguration {
 	 * @param data The data set to be broadcasted.
 	 */
 	public void addBroadcastSetForScatterFunction(String name, DataSet<?> data) {
-		this.bcVarsScatter.add(new Tuple2<String, DataSet<?>>(name, data));
+		this.bcVarsScatter.add(new Tuple2<>(name, data));
 	}
 
 	/**
@@ -69,7 +69,7 @@ public class ScatterGatherConfiguration extends IterationConfiguration {
 	 * @param data The data set to be broadcasted.
 	 */
 	public void addBroadcastSetForGatherFunction(String name, DataSet<?> data) {
-		this.bcVarsGather.add(new Tuple2<String, DataSet<?>>(name, data));
+		this.bcVarsGather.add(new Tuple2<>(name, data));
 	}
 
 	/**

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/GraphUtils.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/utils/GraphUtils.java
@@ -46,7 +46,7 @@ public class GraphUtils {
 	 */
 	public static <T> DataSet<LongValue> count(DataSet<T> input) {
 		return input
-			.map(new MapTo<T, LongValue>(new LongValue(1)))
+			.map(new MapTo<>(new LongValue(1)))
 				.returns(LONG_VALUE_TYPE_INFO)
 				.name("Emit 1")
 			.reduce(new AddLongValue())

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/validation/InvalidVertexIdsValidator.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/validation/InvalidVertexIdsValidator.java
@@ -48,11 +48,11 @@ public class InvalidVertexIdsValidator<K, VV, EV> extends GraphValidator<K, VV, 
 	@Override
 	public boolean validate(Graph<K, VV, EV> graph) throws Exception {
 		DataSet<Tuple1<K>> edgeIds = graph.getEdges()
-				.flatMap(new MapEdgeIds<K, EV>()).distinct();
+				.flatMap(new MapEdgeIds<>()).distinct();
 		DataSet<K> invalidIds = graph.getVertices().coGroup(edgeIds).where(0)
-				.equalTo(0).with(new GroupInvalidIds<K, VV>()).first(1);
+				.equalTo(0).with(new GroupInvalidIds<>()).first(1);
 
-		return invalidIds.map(new KToTupleMap<K>()).count() == 0;
+		return invalidIds.map(new KToTupleMap<>()).count() == 0;
 	}
 
 	private static final class MapEdgeIds<K, EV> implements FlatMapFunction<Edge<K, EV>, Tuple1<K>> {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/AsmTestBase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/AsmTestBase.java
@@ -120,7 +120,7 @@ public class AsmTestBase {
 
 		return new RMatGraph<>(env, new JDKRandomGeneratorFactory(), vertexCount, edgeCount)
 			.generate()
-			.run(new org.apache.flink.graph.asm.simple.directed.Simplify<LongValue, NullValue, NullValue>());
+			.run(new org.apache.flink.graph.asm.simple.directed.Simplify<>());
 	}
 
 	/**
@@ -149,6 +149,6 @@ public class AsmTestBase {
 
 		return new RMatGraph<>(env, new JDKRandomGeneratorFactory(), vertexCount, edgeCount)
 			.generate()
-			.run(new org.apache.flink.graph.asm.simple.undirected.Simplify<LongValue, NullValue, NullValue>(false));
+			.run(new org.apache.flink.graph.asm.simple.undirected.Simplify<>(false));
 	}
 }

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeDegreesPairTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeDegreesPairTest.java
@@ -53,7 +53,7 @@ extends AsmTestBase {
 			"(5,3,((null),(1,1,0),(4,2,2)))";
 
 		DataSet<Edge<IntValue, Tuple3<NullValue, Degrees, Degrees>>> degreesPair = directedSimpleGraph
-			.run(new EdgeDegreesPair<IntValue, NullValue, NullValue>());
+			.run(new EdgeDegreesPair<>());
 
 		TestBaseUtils.compareResultAsText(degreesPair.collect(), expectedResult);
 	}
@@ -62,7 +62,7 @@ extends AsmTestBase {
 	public void testWithRMatGraph()
 			throws Exception {
 		DataSet<Edge<LongValue, Tuple3<NullValue, Degrees, Degrees>>> degreesPair = directedRMatGraph(10, 16)
-			.run(new EdgeDegreesPair<LongValue, NullValue, NullValue>());
+			.run(new EdgeDegreesPair<>());
 
 		Checksum checksum = new ChecksumHashCode<Edge<LongValue, Tuple3<NullValue, Degrees, Degrees>>>()
 			.run(degreesPair)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeSourceDegreesTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeSourceDegreesTest.java
@@ -53,7 +53,7 @@ extends AsmTestBase {
 			"(5,3,((null),(1,1,0)))";
 
 		DataSet<Edge<IntValue, Tuple2<NullValue, Degrees>>> sourceDegrees = directedSimpleGraph
-				.run(new EdgeSourceDegrees<IntValue, NullValue, NullValue>());
+				.run(new EdgeSourceDegrees<>());
 
 		TestBaseUtils.compareResultAsText(sourceDegrees.collect(), expectedResult);
 	}
@@ -62,7 +62,7 @@ extends AsmTestBase {
 	public void testWithRMatGraph()
 			throws Exception {
 		DataSet<Edge<LongValue, Tuple2<NullValue, Degrees>>> sourceDegrees = directedRMatGraph(10, 16)
-			.run(new EdgeSourceDegrees<LongValue, NullValue, NullValue>());
+			.run(new EdgeSourceDegrees<>());
 
 		Checksum checksum = new ChecksumHashCode<Edge<LongValue, Tuple2<NullValue, Degrees>>>()
 			.run(sourceDegrees)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeTargetDegreesTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/EdgeTargetDegreesTest.java
@@ -53,7 +53,7 @@ extends AsmTestBase {
 			"(5,3,((null),(4,2,2)))";
 
 		DataSet<Edge<IntValue, Tuple2<NullValue, Degrees>>> targetDegrees = directedSimpleGraph
-				.run(new EdgeTargetDegrees<IntValue, NullValue, NullValue>());
+				.run(new EdgeTargetDegrees<>());
 
 		TestBaseUtils.compareResultAsText(targetDegrees.collect(), expectedResult);
 	}
@@ -62,7 +62,7 @@ extends AsmTestBase {
 	public void testWithRMatGraph()
 			throws Exception {
 		DataSet<Edge<LongValue, Tuple2<NullValue, Degrees>>> targetDegrees = directedRMatGraph(10, 16)
-			.run(new EdgeTargetDegrees<LongValue, NullValue, NullValue>());
+			.run(new EdgeTargetDegrees<>());
 
 		Checksum checksum = new ChecksumHashCode<Edge<LongValue, Tuple2<NullValue, Degrees>>>()
 			.run(targetDegrees)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexDegreesTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexDegreesTest.java
@@ -43,7 +43,7 @@ extends AsmTestBase {
 	public void testWithSimpleDirectedGraph()
 			throws Exception {
 		DataSet<Vertex<IntValue, Degrees>> degrees = directedSimpleGraph
-			.run(new VertexDegrees<IntValue, NullValue, NullValue>());
+			.run(new VertexDegrees<>());
 
 		String expectedResult =
 			"(0,(2,2,0))\n" +
@@ -60,7 +60,7 @@ extends AsmTestBase {
 	public void testWithSimpleUndirectedGraph()
 			throws Exception {
 		DataSet<Vertex<IntValue, Degrees>> degrees = undirectedSimpleGraph
-			.run(new VertexDegrees<IntValue, NullValue, NullValue>());
+			.run(new VertexDegrees<>());
 
 		String expectedResult =
 			"(0,(2,2,2))\n" +
@@ -100,7 +100,7 @@ extends AsmTestBase {
 	public void testWithRMatGraph()
 	throws Exception {
 		DataSet<Vertex<LongValue, Degrees>> degrees = directedRMatGraph(10, 16)
-			.run(new VertexDegrees<LongValue, NullValue, NullValue>());
+			.run(new VertexDegrees<>());
 
 		Checksum checksum = new ChecksumHashCode<Vertex<LongValue, Degrees>>()
 			.run(degrees)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeDegreePairTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeDegreePairTest.java
@@ -59,7 +59,7 @@ extends AsmTestBase {
 			"(5,3,((null),1,4))";
 
 		DataSet<Edge<IntValue, Tuple3<NullValue, LongValue, LongValue>>> degreePairOnSourceId = undirectedSimpleGraph
-			.run(new EdgeDegreePair<IntValue, NullValue, NullValue>());
+			.run(new EdgeDegreePair<>());
 
 		TestBaseUtils.compareResultAsText(degreePairOnSourceId.collect(), expectedResult);
 
@@ -74,7 +74,7 @@ extends AsmTestBase {
 	public void testWithRMatGraph()
 			throws Exception {
 		DataSet<Edge<LongValue, Tuple3<NullValue, LongValue, LongValue>>> degreePairOnSourceId = undirectedRMatGraph(10, 16)
-			.run(new EdgeDegreePair<LongValue, NullValue, NullValue>());
+			.run(new EdgeDegreePair<>());
 
 		Checksum checksumOnSourceId = new ChecksumHashCode<Edge<LongValue, Tuple3<NullValue, LongValue, LongValue>>>()
 			.run(degreePairOnSourceId)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeSourceDegreeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeSourceDegreeTest.java
@@ -59,7 +59,7 @@ extends AsmTestBase {
 			"(5,3,((null),1))";
 
 		DataSet<Edge<IntValue, Tuple2<NullValue, LongValue>>> sourceDegreeOnSourceId = undirectedSimpleGraph
-			.run(new EdgeSourceDegree<IntValue, NullValue, NullValue>());
+			.run(new EdgeSourceDegree<>());
 
 		TestBaseUtils.compareResultAsText(sourceDegreeOnSourceId.collect(), expectedResult);
 
@@ -74,7 +74,7 @@ extends AsmTestBase {
 	public void testWithRMatGraph()
 			throws Exception {
 		DataSet<Edge<LongValue, Tuple2<NullValue, LongValue>>> sourceDegreeOnSourceId = undirectedRMatGraph(10, 16)
-			.run(new EdgeSourceDegree<LongValue, NullValue, NullValue>());
+			.run(new EdgeSourceDegree<>());
 
 		Checksum checksumOnSourceId = new ChecksumHashCode<Edge<LongValue, Tuple2<NullValue, LongValue>>>()
 			.run(sourceDegreeOnSourceId)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeTargetDegreeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/EdgeTargetDegreeTest.java
@@ -59,7 +59,7 @@ extends AsmTestBase {
 			"(5,3,((null),4))";
 
 		DataSet<Edge<IntValue, Tuple2<NullValue, LongValue>>> targetDegreeOnTargetId = undirectedSimpleGraph
-				.run(new EdgeTargetDegree<IntValue, NullValue, NullValue>());
+				.run(new EdgeTargetDegree<>());
 
 		TestBaseUtils.compareResultAsText(targetDegreeOnTargetId.collect(), expectedResult);
 
@@ -74,7 +74,7 @@ extends AsmTestBase {
 	public void testWithRMatGraph()
 			throws Exception {
 		DataSet<Edge<LongValue, Tuple2<NullValue, LongValue>>> targetDegreeOnTargetId = undirectedRMatGraph(10, 16)
-			.run(new EdgeSourceDegree<LongValue, NullValue, NullValue>());
+			.run(new EdgeSourceDegree<>());
 
 		Checksum checksumOnTargetId = new ChecksumHashCode<Edge<LongValue, Tuple2<NullValue, LongValue>>>()
 			.run(targetDegreeOnTargetId)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/VertexDegreeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/annotate/undirected/VertexDegreeTest.java
@@ -50,7 +50,7 @@ extends AsmTestBase {
 			"(5,1)";
 
 		DataSet<Vertex<IntValue, LongValue>> degreeOnSourceId = undirectedSimpleGraph
-			.run(new VertexDegree<IntValue, NullValue, NullValue>());
+			.run(new VertexDegree<>());
 
 		TestBaseUtils.compareResultAsText(degreeOnSourceId.collect(), expectedResult);
 
@@ -67,7 +67,7 @@ extends AsmTestBase {
 		long expectedDegree = completeGraphVertexCount - 1;
 
 		DataSet<Vertex<LongValue, LongValue>> degreeOnSourceId = completeGraph
-			.run(new VertexDegree<LongValue, NullValue, NullValue>());
+			.run(new VertexDegree<>());
 
 		for (Vertex<LongValue, LongValue> vertex : degreeOnSourceId.collect()) {
 			assertEquals(expectedDegree, vertex.getValue().getValue());
@@ -109,7 +109,7 @@ extends AsmTestBase {
 	public void testWithRMatGraph()
 			throws Exception {
 		DataSet<Vertex<LongValue, LongValue>> degreeOnSourceId = undirectedRMatGraph(10, 16)
-			.run(new VertexDegree<LongValue, NullValue, NullValue>());
+			.run(new VertexDegree<>());
 
 		Checksum checksumOnSourceId = new ChecksumHashCode<Vertex<LongValue, LongValue>>()
 			.run(degreeOnSourceId)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/filter/undirected/MaximumDegreeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/degree/filter/undirected/MaximumDegreeTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.graph.asm.dataset.ChecksumHashCode.Checksum;
 import org.apache.flink.graph.library.metric.ChecksumHashCode;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.IntValue;
-import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
 import org.junit.Test;
@@ -41,7 +40,7 @@ extends AsmTestBase {
 	public void testWithSimpleGraph()
 			throws Exception {
 		Graph<IntValue, NullValue, NullValue> graph = undirectedSimpleGraph
-			.run(new MaximumDegree<IntValue, NullValue, NullValue>(3));
+			.run(new MaximumDegree<>(3));
 
 		String expectedVerticesResult =
 			"(0,(null))\n" +
@@ -67,8 +66,8 @@ extends AsmTestBase {
 	public void testWithRMatGraph()
 			throws Exception {
 		Checksum checksum = undirectedRMatGraph(10, 16)
-			.run(new MaximumDegree<LongValue, NullValue, NullValue>(16))
-			.run(new ChecksumHashCode<LongValue, NullValue, NullValue>())
+			.run(new MaximumDegree<>(16))
+			.run(new ChecksumHashCode<>())
 			.execute();
 
 		assertEquals(805, checksum.getCount());

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/simple/directed/SimplifyTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/simple/directed/SimplifyTest.java
@@ -70,7 +70,7 @@ public class SimplifyTest {
 			"(1,0,(null))";
 
 		Graph<IntValue, NullValue, NullValue> simpleGraph = graph
-			.run(new Simplify<IntValue, NullValue, NullValue>());
+			.run(new Simplify<>());
 
 		TestBaseUtils.compareResultAsText(simpleGraph.getEdges().collect(), expectedResult);
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/simple/undirected/SimplifyTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/simple/undirected/SimplifyTest.java
@@ -71,7 +71,7 @@ public class SimplifyTest {
 			"(2,0,(null))";
 
 		Graph<IntValue, NullValue, NullValue> simpleGraph = graph
-			.run(new Simplify<IntValue, NullValue, NullValue>(false));
+			.run(new Simplify<>(false));
 
 		TestBaseUtils.compareResultAsText(simpleGraph.getEdges().collect(), expectedResult);
 	}
@@ -84,7 +84,7 @@ public class SimplifyTest {
 			"(1,0,(null))";
 
 		Graph<IntValue, NullValue, NullValue> simpleGraph = graph
-			.run(new Simplify<IntValue, NullValue, NullValue>(true));
+			.run(new Simplify<>(true));
 
 		TestBaseUtils.compareResultAsText(simpleGraph.getEdges().collect(), expectedResult);
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CirculantGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CirculantGraphTest.java
@@ -19,9 +19,7 @@
 package org.apache.flink.graph.generator;
 
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -82,8 +80,8 @@ extends GraphGeneratorTestBase {
 			.setParallelism(parallelism)
 			.generate();
 
-		graph.getVertices().output(new DiscardingOutputFormat<Vertex<LongValue, NullValue>>());
-		graph.getEdges().output(new DiscardingOutputFormat<Edge<LongValue, NullValue>>());
+		graph.getVertices().output(new DiscardingOutputFormat<>());
+		graph.getEdges().output(new DiscardingOutputFormat<>());
 
 		TestUtils.verifyParallelism(env, parallelism);
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CompleteGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CompleteGraphTest.java
@@ -19,9 +19,7 @@
 package org.apache.flink.graph.generator;
 
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -80,8 +78,8 @@ extends GraphGeneratorTestBase {
 			.setParallelism(parallelism)
 			.generate();
 
-		graph.getVertices().output(new DiscardingOutputFormat<Vertex<LongValue, NullValue>>());
-		graph.getEdges().output(new DiscardingOutputFormat<Edge<LongValue, NullValue>>());
+		graph.getVertices().output(new DiscardingOutputFormat<>());
+		graph.getEdges().output(new DiscardingOutputFormat<>());
 
 		TestUtils.verifyParallelism(env, parallelism);
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CycleGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CycleGraphTest.java
@@ -19,9 +19,7 @@
 package org.apache.flink.graph.generator;
 
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -79,8 +77,8 @@ extends GraphGeneratorTestBase {
 			.setParallelism(parallelism)
 			.generate();
 
-		graph.getVertices().output(new DiscardingOutputFormat<Vertex<LongValue, NullValue>>());
-		graph.getEdges().output(new DiscardingOutputFormat<Edge<LongValue, NullValue>>());
+		graph.getVertices().output(new DiscardingOutputFormat<>());
+		graph.getEdges().output(new DiscardingOutputFormat<>());
 
 		TestUtils.verifyParallelism(env, parallelism);
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/EchoGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/EchoGraphTest.java
@@ -19,9 +19,7 @@
 package org.apache.flink.graph.generator;
 
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -124,8 +122,8 @@ extends GraphGeneratorTestBase {
 			.setParallelism(parallelism)
 			.generate();
 
-		graph.getVertices().output(new DiscardingOutputFormat<Vertex<LongValue, NullValue>>());
-		graph.getEdges().output(new DiscardingOutputFormat<Edge<LongValue, NullValue>>());
+		graph.getVertices().output(new DiscardingOutputFormat<>());
+		graph.getEdges().output(new DiscardingOutputFormat<>());
 
 		TestUtils.verifyParallelism(env, parallelism);
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/EmptyGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/EmptyGraphTest.java
@@ -19,9 +19,7 @@
 package org.apache.flink.graph.generator;
 
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -74,8 +72,8 @@ extends GraphGeneratorTestBase {
 			.setParallelism(parallelism)
 			.generate();
 
-		graph.getVertices().output(new DiscardingOutputFormat<Vertex<LongValue, NullValue>>());
-		graph.getEdges().output(new DiscardingOutputFormat<Edge<LongValue, NullValue>>());
+		graph.getVertices().output(new DiscardingOutputFormat<>());
+		graph.getEdges().output(new DiscardingOutputFormat<>());
 
 		TestUtils.verifyParallelism(env, parallelism);
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/GridGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/GridGraphTest.java
@@ -19,9 +19,7 @@
 package org.apache.flink.graph.generator;
 
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -89,8 +87,8 @@ extends GraphGeneratorTestBase {
 			.setParallelism(parallelism)
 			.generate();
 
-		graph.getVertices().output(new DiscardingOutputFormat<Vertex<LongValue, NullValue>>());
-		graph.getEdges().output(new DiscardingOutputFormat<Edge<LongValue, NullValue>>());
+		graph.getVertices().output(new DiscardingOutputFormat<>());
+		graph.getEdges().output(new DiscardingOutputFormat<>());
 
 		TestUtils.verifyParallelism(env, parallelism);
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/HypercubeGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/HypercubeGraphTest.java
@@ -19,9 +19,7 @@
 package org.apache.flink.graph.generator;
 
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -81,8 +79,8 @@ extends GraphGeneratorTestBase {
 			.setParallelism(parallelism)
 			.generate();
 
-		graph.getVertices().output(new DiscardingOutputFormat<Vertex<LongValue, NullValue>>());
-		graph.getEdges().output(new DiscardingOutputFormat<Edge<LongValue, NullValue>>());
+		graph.getVertices().output(new DiscardingOutputFormat<>());
+		graph.getEdges().output(new DiscardingOutputFormat<>());
 
 		TestUtils.verifyParallelism(env, parallelism);
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/PathGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/PathGraphTest.java
@@ -19,9 +19,7 @@
 package org.apache.flink.graph.generator;
 
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -79,8 +77,8 @@ extends GraphGeneratorTestBase {
 			.setParallelism(parallelism)
 			.generate();
 
-		graph.getVertices().output(new DiscardingOutputFormat<Vertex<LongValue, NullValue>>());
-		graph.getEdges().output(new DiscardingOutputFormat<Edge<LongValue, NullValue>>());
+		graph.getVertices().output(new DiscardingOutputFormat<>());
+		graph.getEdges().output(new DiscardingOutputFormat<>());
 
 		TestUtils.verifyParallelism(env, parallelism);
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/RMatGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/RMatGraphTest.java
@@ -19,9 +19,7 @@
 package org.apache.flink.graph.generator;
 
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.generator.random.JDKRandomGeneratorFactory;
 import org.apache.flink.graph.generator.random.RandomGenerableFactory;
 import org.apache.flink.types.LongValue;
@@ -66,8 +64,8 @@ extends GraphGeneratorTestBase {
 			.setParallelism(parallelism)
 			.generate();
 
-		graph.getVertices().output(new DiscardingOutputFormat<Vertex<LongValue, NullValue>>());
-		graph.getEdges().output(new DiscardingOutputFormat<Edge<LongValue, NullValue>>());
+		graph.getVertices().output(new DiscardingOutputFormat<>());
+		graph.getEdges().output(new DiscardingOutputFormat<>());
 
 		TestUtils.verifyParallelism(env, parallelism);
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/SingletonEdgeGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/SingletonEdgeGraphTest.java
@@ -19,9 +19,7 @@
 package org.apache.flink.graph.generator;
 
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -80,8 +78,8 @@ extends GraphGeneratorTestBase {
 			.setParallelism(parallelism)
 			.generate();
 
-		graph.getVertices().output(new DiscardingOutputFormat<Vertex<LongValue, NullValue>>());
-		graph.getEdges().output(new DiscardingOutputFormat<Edge<LongValue, NullValue>>());
+		graph.getVertices().output(new DiscardingOutputFormat<>());
+		graph.getEdges().output(new DiscardingOutputFormat<>());
 
 		TestUtils.verifyParallelism(env, parallelism);
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/StarGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/StarGraphTest.java
@@ -19,9 +19,7 @@
 package org.apache.flink.graph.generator;
 
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
-import org.apache.flink.graph.Vertex;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.NullValue;
 
@@ -81,8 +79,8 @@ extends GraphGeneratorTestBase {
 			.setParallelism(parallelism)
 			.generate();
 
-		graph.getVertices().output(new DiscardingOutputFormat<Vertex<LongValue, NullValue>>());
-		graph.getEdges().output(new DiscardingOutputFormat<Edge<LongValue, NullValue>>());
+		graph.getVertices().output(new DiscardingOutputFormat<>());
+		graph.getEdges().output(new DiscardingOutputFormat<>());
 
 		TestUtils.verifyParallelism(env, parallelism);
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/gsa/GSACompilerTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/gsa/GSACompilerTest.java
@@ -60,7 +60,7 @@ public class GSACompilerTest extends CompilerTestBase {
 		// compose test program
 
 		DataSet<Edge<Long, NullValue>> edges = env.fromElements(new Tuple3<>(
-			1L, 2L, NullValue.getInstance())).map(new Tuple3ToEdgeMap<Long, NullValue>());
+			1L, 2L, NullValue.getInstance())).map(new Tuple3ToEdgeMap<>());
 
 		Graph<Long, Long, NullValue> graph = Graph.fromDataSet(edges, new InitVertices(), env);
 
@@ -68,7 +68,7 @@ public class GSACompilerTest extends CompilerTestBase {
 			new GatherNeighborIds(), new SelectMinId(),
 			new UpdateComponentId(), 100).getVertices();
 
-		result.output(new DiscardingOutputFormat<Vertex<Long, Long>>());
+		result.output(new DiscardingOutputFormat<>());
 
 		Plan p = env.createProgramPlan("GSA Connected Components");
 		OptimizedPlan op = compileNoStats(p);

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/gsa/GSATranslationTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/gsa/GSATranslationTest.java
@@ -72,7 +72,7 @@ public class GSATranslationTest {
 		// ------------ construct the test program ------------------
 
 		DataSet<Edge<Long, NullValue>> edges = env.fromElements(new Tuple3<>(
-			1L, 2L, NullValue.getInstance())).map(new Tuple3ToEdgeMap<Long, NullValue>());
+			1L, 2L, NullValue.getInstance())).map(new Tuple3ToEdgeMap<>());
 
 		Graph<Long, Long, NullValue> graph = Graph.fromDataSet(edges, new InitVertices(), env);
 
@@ -89,7 +89,7 @@ public class GSATranslationTest {
 			new GatherNeighborIds(), new SelectMinId(),
 			new UpdateComponentId(), NUM_ITERATIONS, parameters).getVertices();
 
-		result.output(new DiscardingOutputFormat<Vertex<Long, Long>>());
+		result.output(new DiscardingOutputFormat<>());
 
 		// ------------- validate the java program ----------------
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/ConnectedComponentsWithRandomisedEdgesITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/ConnectedComponentsWithRandomisedEdgesITCase.java
@@ -62,7 +62,7 @@ public class ConnectedComponentsWithRandomisedEdgesITCase extends JavaProgramTes
 
 		Graph<Long, Long, NullValue> graph = Graph.fromDataSet(initialVertices, edges, env);
 
-		DataSet<Vertex<Long, Long>> result = graph.run(new ConnectedComponents<Long, Long, NullValue>(100));
+		DataSet<Vertex<Long, Long>> result = graph.run(new ConnectedComponents<>(100));
 
 		result.writeAsCsv(resultPath, "\n", " ");
 		env.execute();

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/directed/LocalClusteringCoefficientTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/directed/LocalClusteringCoefficientTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.graph.library.clustering.directed.LocalClusteringCoeffic
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
-import org.apache.flink.types.NullValue;
 
 import org.apache.commons.math3.util.CombinatoricsUtils;
 import org.junit.Test;
@@ -52,7 +51,7 @@ extends AsmTestBase {
 			"(5,1,0)";
 
 		DataSet<Result<IntValue>> cc = directedSimpleGraph
-			.run(new LocalClusteringCoefficient<IntValue, NullValue, NullValue>());
+			.run(new LocalClusteringCoefficient<>());
 
 		TestBaseUtils.compareResultAsText(cc.collect(), expectedResult);
 	}
@@ -64,7 +63,7 @@ extends AsmTestBase {
 		long expectedTriangleCount = 2 * CombinatoricsUtils.binomialCoefficient((int) expectedDegree, 2);
 
 		DataSet<Result<LongValue>> cc = completeGraph
-			.run(new LocalClusteringCoefficient<LongValue, NullValue, NullValue>());
+			.run(new LocalClusteringCoefficient<>());
 
 		List<Result<LongValue>> results = cc.collect();
 
@@ -80,7 +79,7 @@ extends AsmTestBase {
 	public void testRMatGraph()
 			throws Exception {
 		DataSet<Result<LongValue>> cc = directedRMatGraph(10, 16)
-			.run(new LocalClusteringCoefficient<LongValue, NullValue, NullValue>());
+			.run(new LocalClusteringCoefficient<>());
 
 		Checksum checksum = new org.apache.flink.graph.asm.dataset.ChecksumHashCode<Result<LongValue>>()
 			.run(cc)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/directed/TriangleListingTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/directed/TriangleListingTest.java
@@ -95,7 +95,7 @@ extends AsmTestBase {
 		long expectedCount = completeGraphVertexCount * CombinatoricsUtils.binomialCoefficient((int) expectedDegree, 2) / 3;
 
 		DataSet<Result<LongValue>> tl = completeGraph
-			.run(new TriangleListing<LongValue, NullValue, NullValue>());
+			.run(new TriangleListing<>());
 
 		List<Result<LongValue>> results = tl.collect();
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/LocalClusteringCoefficientTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/LocalClusteringCoefficientTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.graph.library.clustering.undirected.LocalClusteringCoeff
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
-import org.apache.flink.types.NullValue;
 
 import org.apache.commons.math3.util.CombinatoricsUtils;
 import org.junit.Test;
@@ -53,7 +52,7 @@ extends AsmTestBase {
 			"(5,1,0)";
 
 		DataSet<Result<IntValue>> cc = undirectedSimpleGraph
-			.run(new LocalClusteringCoefficient<IntValue, NullValue, NullValue>());
+			.run(new LocalClusteringCoefficient<>());
 
 		TestBaseUtils.compareResultAsText(cc.collect(), expectedResult);
 	}
@@ -65,7 +64,7 @@ extends AsmTestBase {
 		long expectedTriangleCount = CombinatoricsUtils.binomialCoefficient((int) expectedDegree, 2);
 
 		DataSet<Result<LongValue>> cc = completeGraph
-			.run(new LocalClusteringCoefficient<LongValue, NullValue, NullValue>());
+			.run(new LocalClusteringCoefficient<>());
 
 		List<Result<LongValue>> results = cc.collect();
 
@@ -81,7 +80,7 @@ extends AsmTestBase {
 	public void testRMatGraph()
 			throws Exception {
 		DataSet<Result<LongValue>> cc = undirectedRMatGraph(10, 16)
-			.run(new LocalClusteringCoefficient<LongValue, NullValue, NullValue>());
+			.run(new LocalClusteringCoefficient<>());
 
 		Checksum checksum = new ChecksumHashCode<Result<LongValue>>()
 			.run(cc)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/TriangleListingTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/clustering/undirected/TriangleListingTest.java
@@ -95,7 +95,7 @@ extends AsmTestBase {
 		long expectedCount = completeGraphVertexCount * CombinatoricsUtils.binomialCoefficient((int) expectedDegree, 2) / 3;
 
 		DataSet<Result<LongValue>> tl = completeGraph
-			.run(new TriangleListing<LongValue, NullValue, NullValue>());
+			.run(new TriangleListing<>());
 
 		Checksum checksum = new ChecksumHashCode<Result<LongValue>>()
 			.run(tl)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/linkanalysis/HITSTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/linkanalysis/HITSTest.java
@@ -115,7 +115,7 @@ extends AsmTestBase {
 	public void testWithRMatGraph()
 			throws Exception {
 		DataSet<Result<LongValue>> hits = directedRMatGraph(10, 16)
-			.run(new HITS<LongValue, NullValue, NullValue>(0.000001));
+			.run(new HITS<>(0.000001));
 
 		Map<Long, Result<LongValue>> results = new HashMap<>();
 		for (Result<LongValue> result :  new Collect<Result<LongValue>>().run(hits).execute()) {

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/ChecksumHashCodeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/metric/ChecksumHashCodeTest.java
@@ -41,7 +41,7 @@ extends AsmTestBase {
 			env);
 
 		Checksum checksum = graph
-			.run(new ChecksumHashCode<Long, Long, Long>())
+			.run(new ChecksumHashCode<>())
 			.execute();
 
 		assertEquals(checksum.getCount(), 12L);

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/similarity/AdamicAdarTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/similarity/AdamicAdarTest.java
@@ -49,7 +49,7 @@ extends AsmTestBase {
 	public void testSimpleGraph()
 			throws Exception {
 		DataSet<Result<IntValue>> aa = undirectedSimpleGraph
-			.run(new AdamicAdar<IntValue, NullValue, NullValue>());
+			.run(new AdamicAdar<>());
 
 		String expectedResult =
 			"(0,1," + ilog[2] + ")\n" +
@@ -105,7 +105,7 @@ extends AsmTestBase {
 		float expectedScore = (completeGraphVertexCount - 2) / (float) Math.log(completeGraphVertexCount - 1);
 
 		DataSet<Result<LongValue>> aa = completeGraph
-			.run(new AdamicAdar<LongValue, NullValue, NullValue>());
+			.run(new AdamicAdar<>());
 
 		for (Result<LongValue> result : aa.collect()) {
 			assertEquals(expectedScore, result.getAdamicAdarScore().getValue(), 0.00001);
@@ -116,7 +116,7 @@ extends AsmTestBase {
 	public void testRMatGraph()
 			throws Exception {
 		DataSet<Result<LongValue>> aa = undirectedRMatGraph(8, 8)
-			.run(new AdamicAdar<LongValue, NullValue, NullValue>());
+			.run(new AdamicAdar<>());
 
 		assertEquals(13954, aa.count());
 	}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/similarity/JaccardIndexTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/similarity/JaccardIndexTest.java
@@ -42,7 +42,7 @@ extends AsmTestBase {
 	public void testSimpleGraph()
 			throws Exception {
 		DataSet<Result<IntValue>> ji = undirectedSimpleGraph
-			.run(new JaccardIndex<IntValue, NullValue, NullValue>());
+			.run(new JaccardIndex<>());
 
 		String expectedResult =
 			"(0,1,1,4)\n" +

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/pregel/PregelCompilerTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/pregel/PregelCompilerTest.java
@@ -61,7 +61,7 @@ public class PregelCompilerTest extends CompilerTestBase {
 
 			DataSet<Vertex<Long, Long>> initialVertices = env.fromElements(
 				new Tuple2<>(1L, 1L), new Tuple2<>(2L, 2L))
-				.map(new Tuple2ToVertexMap<Long, Long>());
+				.map(new Tuple2ToVertexMap<>());
 
 			DataSet<Edge<Long, NullValue>> edges = env.fromElements(new Tuple2<>(1L, 2L))
 				.map(new MapFunction<Tuple2<Long, Long>, Edge<Long, NullValue>>() {
@@ -76,7 +76,7 @@ public class PregelCompilerTest extends CompilerTestBase {
 			DataSet<Vertex<Long, Long>> result = graph.runVertexCentricIteration(
 				new CCCompute(), null, 100).getVertices();
 
-			result.output(new DiscardingOutputFormat<Vertex<Long, Long>>());
+			result.output(new DiscardingOutputFormat<>());
 		}
 
 		Plan p = env.createProgramPlan("Pregel Connected Components");
@@ -126,7 +126,7 @@ public class PregelCompilerTest extends CompilerTestBase {
 
 			DataSet<Vertex<Long, Long>> initialVertices = env.fromElements(
 				new Tuple2<>(1L, 1L), new Tuple2<>(2L, 2L))
-				.map(new Tuple2ToVertexMap<Long, Long>());
+				.map(new Tuple2ToVertexMap<>());
 
 			DataSet<Edge<Long, NullValue>> edges = env.fromElements(new Tuple2<>(1L, 2L))
 				.map(new MapFunction<Tuple2<Long, Long>, Edge<Long, NullValue>>() {
@@ -145,7 +145,7 @@ public class PregelCompilerTest extends CompilerTestBase {
 				new CCCompute(), null, 100, parameters)
 				.getVertices();
 
-			result.output(new DiscardingOutputFormat<Vertex<Long, Long>>());
+			result.output(new DiscardingOutputFormat<>());
 		}
 
 		Plan p = env.createProgramPlan("Pregel Connected Components");
@@ -192,7 +192,7 @@ public class PregelCompilerTest extends CompilerTestBase {
 
 			DataSet<Vertex<Long, Long>> initialVertices = env.fromElements(
 				new Tuple2<>(1L, 1L), new Tuple2<>(2L, 2L))
-				.map(new Tuple2ToVertexMap<Long, Long>());
+				.map(new Tuple2ToVertexMap<>());
 
 			DataSet<Edge<Long, NullValue>> edges = env.fromElements(new Tuple2<>(1L, 2L))
 				.map(new MapFunction<Tuple2<Long, Long>, Edge<Long, NullValue>>() {
@@ -207,7 +207,7 @@ public class PregelCompilerTest extends CompilerTestBase {
 			DataSet<Vertex<Long, Long>> result = graph.runVertexCentricIteration(
 				new CCCompute(), new CCCombiner(), 100).getVertices();
 
-			result.output(new DiscardingOutputFormat<Vertex<Long, Long>>());
+			result.output(new DiscardingOutputFormat<>());
 		}
 
 		Plan p = env.createProgramPlan("Pregel Connected Components");

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/pregel/PregelTranslationTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/pregel/PregelTranslationTest.java
@@ -88,7 +88,7 @@ public class PregelTranslationTest {
 		result = graph.runVertexCentricIteration(new MyCompute(), null,
 			NUM_ITERATIONS, parameters).getVertices();
 
-		result.output(new DiscardingOutputFormat<Vertex<String, Double>>());
+		result.output(new DiscardingOutputFormat<>());
 
 		// ------------- validate the java program ----------------
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/spargel/SpargelCompilerTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/spargel/SpargelCompilerTest.java
@@ -62,7 +62,7 @@ public class SpargelCompilerTest extends CompilerTestBase {
 		// compose test program
 		DataSet<Vertex<Long, Long>> initialVertices = env.fromElements(
 			new Tuple2<>(1L, 1L), new Tuple2<>(2L, 2L))
-			.map(new Tuple2ToVertexMap<Long, Long>());
+			.map(new Tuple2ToVertexMap<>());
 
 		DataSet<Edge<Long, NullValue>> edges = env.fromElements(new Tuple2<>(1L, 2L))
 			.map(new MapFunction<Tuple2<Long, Long>, Edge<Long, NullValue>>() {
@@ -75,11 +75,11 @@ public class SpargelCompilerTest extends CompilerTestBase {
 		Graph<Long, Long, NullValue> graph = Graph.fromDataSet(initialVertices, edges, env);
 
 		DataSet<Vertex<Long, Long>> result = graph.runScatterGatherIteration(
-			new ConnectedComponents.CCMessenger<Long, Long>(BasicTypeInfo.LONG_TYPE_INFO),
-			new ConnectedComponents.CCUpdater<Long, Long>(), 100)
+			new ConnectedComponents.CCMessenger<>(BasicTypeInfo.LONG_TYPE_INFO),
+			new ConnectedComponents.CCUpdater<>(), 100)
 			.getVertices();
 
-		result.output(new DiscardingOutputFormat<Vertex<Long, Long>>());
+		result.output(new DiscardingOutputFormat<>());
 
 		Plan p = env.createProgramPlan("Spargel Connected Components");
 		OptimizedPlan op = compileNoStats(p);
@@ -136,7 +136,7 @@ public class SpargelCompilerTest extends CompilerTestBase {
 
 		DataSet<Vertex<Long, Long>> initialVertices = env.fromElements(
 			new Tuple2<>(1L, 1L), new Tuple2<>(2L, 2L))
-			.map(new Tuple2ToVertexMap<Long, Long>());
+			.map(new Tuple2ToVertexMap<>());
 
 		DataSet<Edge<Long, NullValue>> edges = env.fromElements(new Tuple2<>(1L, 2L))
 			.map(new MapFunction<Tuple2<Long, Long>, Edge<Long, NullValue>>() {
@@ -153,11 +153,11 @@ public class SpargelCompilerTest extends CompilerTestBase {
 		parameters.addBroadcastSetForGatherFunction(broadcastVariableName, bcVar);
 
 		DataSet<Vertex<Long, Long>> result = graph.runScatterGatherIteration(
-			new ConnectedComponents.CCMessenger<Long, Long>(BasicTypeInfo.LONG_TYPE_INFO),
-			new ConnectedComponents.CCUpdater<Long, Long>(), 100)
+			new ConnectedComponents.CCMessenger<>(BasicTypeInfo.LONG_TYPE_INFO),
+			new ConnectedComponents.CCUpdater<>(), 100)
 			.getVertices();
 
-		result.output(new DiscardingOutputFormat<Vertex<Long, Long>>());
+		result.output(new DiscardingOutputFormat<>());
 
 		Plan p = env.createProgramPlan("Spargel Connected Components");
 		OptimizedPlan op = compileNoStats(p);

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/spargel/SpargelTranslationTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/spargel/SpargelTranslationTest.java
@@ -91,7 +91,7 @@ public class SpargelTranslationTest {
 		result = graph.runScatterGatherIteration(new MessageFunctionNoEdgeValue(), new UpdateFunction(),
 			NUM_ITERATIONS, parameters).getVertices();
 
-		result.output(new DiscardingOutputFormat<Vertex<String, Double>>());
+		result.output(new DiscardingOutputFormat<>());
 
 		// ------------- validate the java program ----------------
 
@@ -154,7 +154,7 @@ public class SpargelTranslationTest {
 		result = graph.runScatterGatherIteration(new MessageFunctionNoEdgeValue(), new UpdateFunction(),
 			NUM_ITERATIONS, parameters).getVertices();
 
-		result.output(new DiscardingOutputFormat<Vertex<String, Double>>());
+		result.output(new DiscardingOutputFormat<>());
 
 		// ------------- validate the java program ----------------
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/CollectionModeSuperstepITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/CollectionModeSuperstepITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.graph.test;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.Vertex;
 import org.apache.flink.graph.spargel.GatherFunction;
@@ -53,8 +52,9 @@ public class CollectionModeSuperstepITCase extends TestLogger {
 				new MessageFunction(), new UpdateFunction(), 10);
 
 		result.getVertices().map(
-				new VertexToTuple2Map<Long, Long>()).output(
-						new DiscardingOutputFormat<Tuple2<Long, Long>>());
+			new VertexToTuple2Map<>()).output(
+				new DiscardingOutputFormat<>());
+
 		env.execute();
 	}
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/ScatterGatherConfigurationITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/ScatterGatherConfigurationITCase.java
@@ -137,7 +137,7 @@ public class ScatterGatherConfigurationITCase extends MultipleProgramsTestBase {
 		Graph<Long, Long, Long> res = graph.runScatterGatherIteration(
 			new MessageFunctionDefault(), new UpdateFunctionDefault(), 5);
 
-		DataSet<Tuple2<Long, Long>> data = res.getVertices().map(new VertexToTuple2Map<Long, Long>());
+		DataSet<Tuple2<Long, Long>> data = res.getVertices().map(new VertexToTuple2Map<>());
 		List<Tuple2<Long, Long>> result = data.collect();
 
 		expectedResult = "1,6\n" +

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/DegreesWithExceptionITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/DegreesWithExceptionITCase.java
@@ -20,14 +20,12 @@ package org.apache.flink.graph.test.operations;
 
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.graph.test.TestGraphUtils;
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.apache.flink.test.util.TestEnvironment;
-import org.apache.flink.types.LongValue;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
@@ -77,7 +75,7 @@ public class DegreesWithExceptionITCase extends TestLogger {
 				TestGraphUtils.getLongLongEdgeInvalidSrcData(env), env);
 
 		try {
-			graph.outDegrees().output(new DiscardingOutputFormat<Tuple2<Long, LongValue>>());
+			graph.outDegrees().output(new DiscardingOutputFormat<>());
 			env.execute();
 
 			fail("graph.outDegrees() did not fail.");
@@ -100,7 +98,7 @@ public class DegreesWithExceptionITCase extends TestLogger {
 				TestGraphUtils.getLongLongEdgeInvalidTrgData(env), env);
 
 		try {
-			graph.inDegrees().output(new DiscardingOutputFormat<Tuple2<Long, LongValue>>());
+			graph.inDegrees().output(new DiscardingOutputFormat<>());
 			env.execute();
 
 			fail("graph.inDegrees() did not fail.");
@@ -123,7 +121,7 @@ public class DegreesWithExceptionITCase extends TestLogger {
 				TestGraphUtils.getLongLongEdgeInvalidTrgData(env), env);
 
 		try {
-			graph.getDegrees().output(new DiscardingOutputFormat<Tuple2<Long, LongValue>>());
+			graph.getDegrees().output(new DiscardingOutputFormat<>());
 			env.execute();
 
 			fail("graph.getDegrees() did not fail.");
@@ -146,7 +144,7 @@ public class DegreesWithExceptionITCase extends TestLogger {
 				TestGraphUtils.getLongLongEdgeInvalidSrcData(env), env);
 
 		try {
-			graph.getDegrees().output(new DiscardingOutputFormat<Tuple2<Long, LongValue>>());
+			graph.getDegrees().output(new DiscardingOutputFormat<>());
 			env.execute();
 
 			fail("graph.getDegrees() did not fail.");
@@ -169,7 +167,7 @@ public class DegreesWithExceptionITCase extends TestLogger {
 				TestGraphUtils.getLongLongEdgeInvalidSrcTrgData(env), env);
 
 		try {
-			graph.getDegrees().output(new DiscardingOutputFormat<Tuple2<Long, LongValue>>());
+			graph.getDegrees().output(new DiscardingOutputFormat<>());
 			env.execute();
 
 			fail("graph.getDegrees() did not fail.");

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphCreationITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/GraphCreationITCase.java
@@ -122,7 +122,7 @@ public class GraphCreationITCase extends MultipleProgramsTestBase {
 		DataSet<Edge<Long, Long>> edges = TestGraphUtils.getLongLongEdgeData(env);
 
 		Graph<Long, Long, Long> graph = Graph.fromDataSet(vertices, edges, env);
-		Boolean valid = graph.validate(new InvalidVertexIdsValidator<Long, Long, Long>());
+		Boolean valid = graph.validate(new InvalidVertexIdsValidator<>());
 
 		//env.fromElements(result).writeAsText(resultPath);
 
@@ -144,7 +144,7 @@ public class GraphCreationITCase extends MultipleProgramsTestBase {
 		DataSet<Edge<Long, Long>> edges = TestGraphUtils.getLongLongEdgeData(env);
 
 		Graph<Long, Long, Long> graph = Graph.fromDataSet(vertices, edges, env);
-		Boolean valid = graph.validate(new InvalidVertexIdsValidator<Long, Long, Long>());
+		Boolean valid = graph.validate(new InvalidVertexIdsValidator<>());
 
 		String res = valid.toString(); //env.fromElements(valid);
 		List<String> result = new LinkedList<>();

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/JoinWithEdgesITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/JoinWithEdgesITCase.java
@@ -62,7 +62,7 @@ public class JoinWithEdgesITCase extends MultipleProgramsTestBase {
 			TestGraphUtils.getLongLongEdgeData(env), env);
 
 		Graph<Long, Long, Long> res = graph.joinWithEdges(graph.getEdges()
-			.map(new EdgeToTuple3Map<Long, Long>()), new AddValuesMapper());
+			.map(new EdgeToTuple3Map<>()), new AddValuesMapper());
 
 		DataSet<Edge<Long, Long>> data = res.getEdges();
 		List<Edge<Long, Long>> result = data.collect();
@@ -90,7 +90,7 @@ public class JoinWithEdgesITCase extends MultipleProgramsTestBase {
 			TestGraphUtils.getLongLongEdgeData(env), env);
 
 		Graph<Long, Long, Long> res = graph.joinWithEdges(graph.getEdges().first(3)
-			.map(new EdgeToTuple3Map<Long, Long>()), new AddValuesMapper());
+			.map(new EdgeToTuple3Map<>()), new AddValuesMapper());
 
 		DataSet<Edge<Long, Long>> data = res.getEdges();
 		List<Edge<Long, Long>> result = data.collect();

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/JoinWithVerticesITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/JoinWithVerticesITCase.java
@@ -60,7 +60,7 @@ public class JoinWithVerticesITCase extends MultipleProgramsTestBase {
 			TestGraphUtils.getLongLongEdgeData(env), env);
 
 		Graph<Long, Long, Long> res = graph.joinWithVertices(graph.getVertices()
-			.map(new VertexToTuple2Map<Long, Long>()), new AddValuesMapper());
+			.map(new VertexToTuple2Map<>()), new AddValuesMapper());
 
 		DataSet<Vertex<Long, Long>> data = res.getVertices();
 		List<Vertex<Long, Long>> result = data.collect();
@@ -86,7 +86,7 @@ public class JoinWithVerticesITCase extends MultipleProgramsTestBase {
 			TestGraphUtils.getLongLongEdgeData(env), env);
 
 		Graph<Long, Long, Long> res = graph.joinWithVertices(graph.getVertices().first(3)
-			.map(new VertexToTuple2Map<Long, Long>()), new AddValuesMapper());
+			.map(new VertexToTuple2Map<>()), new AddValuesMapper());
 
 		DataSet<Vertex<Long, Long>> data = res.getVertices();
 		List<Vertex<Long, Long>> result = data.collect();

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/ReduceOnEdgesWithExceptionITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/ReduceOnEdgesWithExceptionITCase.java
@@ -84,7 +84,7 @@ public class ReduceOnEdgesWithExceptionITCase extends TestLogger {
 			DataSet<Tuple2<Long, Long>> verticesWithAllNeighbors =
 					graph.groupReduceOnEdges(new SelectNeighborsValueGreaterThanFour(), EdgeDirection.ALL);
 
-			verticesWithAllNeighbors.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
+			verticesWithAllNeighbors.output(new DiscardingOutputFormat<>());
 			env.execute();
 
 			fail("Expected an exception.");
@@ -110,7 +110,7 @@ public class ReduceOnEdgesWithExceptionITCase extends TestLogger {
 			DataSet<Tuple2<Long, Long>> verticesWithAllNeighbors =
 					graph.groupReduceOnEdges(new SelectNeighborsValueGreaterThanFour(), EdgeDirection.ALL);
 
-			verticesWithAllNeighbors.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
+			verticesWithAllNeighbors.output(new DiscardingOutputFormat<>());
 			env.execute();
 
 			fail("Expected an exception.");

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/ReduceOnNeighborsWithExceptionITCase.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/ReduceOnNeighborsWithExceptionITCase.java
@@ -86,7 +86,7 @@ public class ReduceOnNeighborsWithExceptionITCase extends TestLogger {
 			DataSet<Tuple2<Long, Long>> verticesWithSumOfOutNeighborValues =
 					graph.groupReduceOnNeighbors(new SumAllNeighbors(), EdgeDirection.ALL);
 
-			verticesWithSumOfOutNeighborValues.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
+			verticesWithSumOfOutNeighborValues.output(new DiscardingOutputFormat<>());
 			env.execute();
 
 			fail("Expected an exception.");
@@ -113,7 +113,7 @@ public class ReduceOnNeighborsWithExceptionITCase extends TestLogger {
 			DataSet<Tuple2<Long, Long>> verticesWithSumOfOutNeighborValues =
 					graph.groupReduceOnNeighbors(new SumAllNeighbors(), EdgeDirection.ALL);
 
-			verticesWithSumOfOutNeighborValues.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
+			verticesWithSumOfOutNeighborValues.output(new DiscardingOutputFormat<>());
 			env.execute();
 
 			fail("Expected an exception.");
@@ -140,7 +140,7 @@ public class ReduceOnNeighborsWithExceptionITCase extends TestLogger {
 			DataSet<Tuple2<Long, Long>> verticesWithSumOfAllNeighborValues =
 					graph.reduceOnNeighbors(new SumNeighbors(), EdgeDirection.ALL);
 
-			verticesWithSumOfAllNeighborValues.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
+			verticesWithSumOfAllNeighborValues.output(new DiscardingOutputFormat<>());
 			env.execute();
 		} catch (Exception e) {
 			// We expect the job to fail with an exception
@@ -165,7 +165,7 @@ public class ReduceOnNeighborsWithExceptionITCase extends TestLogger {
 			DataSet<Tuple2<Long, Long>> verticesWithSumOfAllNeighborValues =
 					graph.reduceOnNeighbors(new SumNeighbors(), EdgeDirection.ALL);
 
-			verticesWithSumOfAllNeighborValues.output(new DiscardingOutputFormat<Tuple2<Long, Long>>());
+			verticesWithSumOfAllNeighborValues.output(new DiscardingOutputFormat<>());
 			env.execute();
 		} catch (Exception e) {
 			// We expect the job to fail with an exception

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/TypeExtractorTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/test/operations/TypeExtractorTest.java
@@ -58,7 +58,7 @@ public class TypeExtractorTest {
 	public void testMapVerticesType() throws Exception {
 
 		// test type extraction in mapVertices
-		DataSet<Vertex<Long, Tuple2<Long, Integer>>> outVertices = inputGraph.mapVertices(new VertexMapper<Long>()).getVertices();
+		DataSet<Vertex<Long, Tuple2<Long, Integer>>> outVertices = inputGraph.mapVertices(new VertexMapper<>()).getVertices();
 		Assert.assertTrue(new TupleTypeInfo(Vertex.class, BasicTypeInfo.LONG_TYPE_INFO,
 			new TupleTypeInfo<Tuple2<Long, Integer>>(BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO))
 			.equals(outVertices.getType()));
@@ -68,7 +68,7 @@ public class TypeExtractorTest {
 	public void testMapEdgesType() throws Exception {
 
 		// test type extraction in mapEdges
-		DataSet<Edge<Long, Tuple2<Long, Integer>>> outEdges = inputGraph.mapEdges(new EdgeMapper<Long>()).getEdges();
+		DataSet<Edge<Long, Tuple2<Long, Integer>>> outEdges = inputGraph.mapEdges(new EdgeMapper<>()).getEdges();
 		Assert.assertTrue(new TupleTypeInfo(Edge.class, BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.LONG_TYPE_INFO,
 			new TupleTypeInfo<Tuple2<Long, Integer>>(BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO))
 			.equals(outEdges.getType()));
@@ -76,7 +76,7 @@ public class TypeExtractorTest {
 
 	@Test
 	public void testFromDataSet() throws Exception {
-		DataSet<Vertex<Long, Tuple2<Long, Integer>>> outVertices = Graph.fromDataSet(edges, new VertexInitializer<Long>(), env)
+		DataSet<Vertex<Long, Tuple2<Long, Integer>>> outVertices = Graph.fromDataSet(edges, new VertexInitializer<>(), env)
 			.getVertices();
 		Assert.assertTrue(new TupleTypeInfo(Vertex.class, BasicTypeInfo.LONG_TYPE_INFO,
 			new TupleTypeInfo<Tuple2<Long, Integer>>(BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO))
@@ -85,7 +85,7 @@ public class TypeExtractorTest {
 
 	@Test
 	public void testGroupReduceOnEdges() throws Exception {
-		DataSet<Tuple2<Long, Long>> output = inputGraph.groupReduceOnEdges(new EdgesGroupFunction<Long, Long>(), EdgeDirection.OUT);
+		DataSet<Tuple2<Long, Long>> output = inputGraph.groupReduceOnEdges(new EdgesGroupFunction<>(), EdgeDirection.OUT);
 		Assert.assertTrue((new TupleTypeInfo<Tuple2<Long, Long>>(BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.LONG_TYPE_INFO)).equals(output.getType()));
 	}
 
@@ -113,7 +113,7 @@ public class TypeExtractorTest {
 
 		@Override
 		public void iterateEdges(Iterable<Tuple2<K, Edge<K, EV>>> edges, Collector<Tuple2<K, EV>> out) throws Exception {
-			out.collect(new Tuple2<K, EV>());
+			out.collect(new Tuple2<>());
 		}
 	}
 


### PR DESCRIPTION
In Java 8 the diamond operator can be used in cases which would result in an error in Java 7. In Gelly we have often desired to use the diamond operator and only discovered an issue when running tests on TravisCI.