### PR TITLE
[FLINK-7348] [checkstyle] Allow redundant modifiers on methods / reve…

### DIFF
--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/wrappers/SpoutWrapper.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/wrappers/SpoutWrapper.java
@@ -240,7 +240,7 @@ public final class SpoutWrapper<OUT> extends RichParallelSourceFunction<OUT> imp
 	}
 
 	@Override
-	public void run(final SourceContext<OUT> ctx) throws Exception {
+	public final void run(final SourceContext<OUT> ctx) throws Exception {
 		final GlobalJobParameters config = super.getRuntimeContext().getExecutionConfig()
 				.getGlobalJobParameters();
 		StormConfig stormConfig = new StormConfig();

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/translation/PlanFilterOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/translation/PlanFilterOperator.java
@@ -53,7 +53,7 @@ public class PlanFilterOperator<T> extends FilterOperatorBase<T, FlatMapFunction
 		}
 
 		@Override
-		public void flatMap(T value, Collector<T> out) throws Exception {
+		public final void flatMap(T value, Collector<T> out) throws Exception {
 			if (this.wrappedFunction.filter(value)) {
 				out.collect(value);
 			}

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/pregel/MessageIterator.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/pregel/MessageIterator.java
@@ -43,7 +43,7 @@ public final class MessageIterator<Message> implements Iterator<Message>, Iterab
 	}
 
 	@Override
-	public boolean hasNext() {
+	public final boolean hasNext() {
 		if (first != null) {
 			return true;
 		}
@@ -53,7 +53,7 @@ public final class MessageIterator<Message> implements Iterator<Message>, Iterab
 	}
 
 	@Override
-	public Message next() {
+	public final Message next() {
 		if (first != null) {
 			Message toReturn = first;
 			first = null;
@@ -63,7 +63,7 @@ public final class MessageIterator<Message> implements Iterator<Message>, Iterab
 	}
 
 	@Override
-	public void remove() {
+	public final void remove() {
 		throw new UnsupportedOperationException();
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/spargel/MessageIterator.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/spargel/MessageIterator.java
@@ -36,17 +36,17 @@ public final class MessageIterator<Message> implements Iterator<Message>, Iterab
 	}
 
 	@Override
-	public boolean hasNext() {
+	public final boolean hasNext() {
 		return this.source.hasNext();
 	}
 
 	@Override
-	public Message next() {
+	public final Message next() {
 		return this.source.next().f1;
 	}
 
 	@Override
-	public void remove() {
+	public final void remove() {
 		throw new UnsupportedOperationException();
 	}
 

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -218,8 +218,10 @@ This file is based on the checkstyle file of Apache Beam.
     <module name="RedundantModifier">
       <!-- Checks for redundant modifiers on various symbol definitions.
         See: http://checkstyle.sourceforge.net/config_modifier.html#RedundantModifier
+        
+        We exclude METHOD_DEF to allow final methods in final classes to make them more future-proof.
       -->
-      <property name="tokens" value="METHOD_DEF, VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF, CLASS_DEF, ENUM_DEF"/>
+      <property name="tokens" value="VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF, CLASS_DEF, ENUM_DEF"/>
     </module>
 
     <!--


### PR DESCRIPTION
## What is the purpose of the change

Modify checkstyle rules to allow redundant modifiers, specifically to allow final methods in final classes to ensure they remain final even if the class is made non-final as a means of optimization.


## Brief change log

  - exclude `METHOD_DEF` from `RedundantModifier` checkstyle module
  - revert removals of final modifier on methods made due to this rule 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

