### PR TITLE
[FLINK-7221] [jdbc] Throw exception if execution of last JDBC batch fails.

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
@@ -19,7 +19,6 @@
 package org.apache.flink.api.java.io.jdbc;
 
 import org.apache.flink.api.common.io.RichOutputFormat;
-import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.types.Row;
 
@@ -33,10 +32,10 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 /**
- * OutputFormat to write tuples into a database.
+ * OutputFormat to write Rows into a JDBC database.
  * The OutputFormat has to be configured using the supplied OutputFormatBuilder.
  *
- * @see Tuple
+ * @see Row
  * @see DriverManager
  */
 public class JDBCOutputFormat extends RichOutputFormat<Row> {
@@ -56,7 +55,7 @@ public class JDBCOutputFormat extends RichOutputFormat<Row> {
 
 	private int batchCount = 0;
 
-	public int[] typesArray;
+	private int[] typesArray;
 
 	public JDBCOutputFormat() {
 	}
@@ -201,12 +200,18 @@ public class JDBCOutputFormat extends RichOutputFormat<Row> {
 			}
 			upload.addBatch();
 			batchCount++;
-			if (batchCount >= batchInterval) {
+		} catch (SQLException e) {
+			throw new RuntimeException("Preparation of JDBC statement failed.", e);
+		}
+
+		if (batchCount >= batchInterval) {
+			// execute batch
+			try {
 				upload.executeBatch();
 				batchCount = 0;
+			} catch (SQLException e) {
+				throw new RuntimeException("Execution of JDBC statement failed.", e);
 			}
-		} catch (SQLException | IllegalArgumentException e) {
-			throw new IllegalArgumentException("writeRecord() failed", e);
 		}
 	}
 
@@ -217,26 +222,32 @@ public class JDBCOutputFormat extends RichOutputFormat<Row> {
 	 */
 	@Override
 	public void close() throws IOException {
-		try {
-			if (upload != null) {
+		if (upload != null) {
+			// execute last batch
+			try {
 				upload.executeBatch();
+			} catch (SQLException e) {
+				throw new RuntimeException("Execution of JDBC statement failed.", e);
+			}
+			// close the connection
+			try {
 				upload.close();
+			} catch (SQLException e) {
+				LOG.info("JDBC statement could not be closed: " + e.getMessage());
+			} finally {
+				upload = null;
 			}
-		} catch (SQLException se) {
-			LOG.info("Inputformat couldn't be closed - " + se.getMessage());
-		} finally {
-			upload = null;
-			batchCount = 0;
 		}
+		batchCount = 0;
 
-		try {
-			if (dbConn != null) {
+		if (dbConn != null) {
+			try {
 				dbConn.close();
+			} catch (SQLException se) {
+				LOG.info("JDBC connection could not be closed: " + se.getMessage());
+			} finally {
+				dbConn = null;
 			}
-		} catch (SQLException se) {
-			LOG.info("Inputformat couldn't be closed - " + se.getMessage());
-		} finally {
-			dbConn = null;
 		}
 	}
 

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCFullTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCFullTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.java.io.jdbc.JDBCInputFormat.JDBCInputFormatBuilder;
 import org.apache.flink.api.java.io.jdbc.split.NumericBetweenParametersProvider;
 import org.apache.flink.types.Row;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,6 +32,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
 import java.sql.Types;
 
 /**
@@ -89,6 +91,19 @@ public class JDBCFullTest extends JDBCTestBase {
 				count++;
 			}
 			Assert.assertEquals(JDBCTestBase.TEST_DATA.length, count);
+		}
+	}
+
+	@After
+	public void clearOutputTable() throws Exception {
+		Class.forName(DRIVER_CLASS);
+		try (
+			Connection conn = DriverManager.getConnection(DB_URL);
+			Statement stat = conn.createStatement()) {
+			stat.execute("DELETE FROM " + OUTPUT_TABLE);
+
+			stat.close();
+			conn.close();
 		}
 	}
 

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormatTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormatTest.java
@@ -30,6 +30,8 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
 
 /**
  * Tests for the {@link JDBCOutputFormat}.
@@ -84,7 +86,7 @@ public class JDBCOutputFormatTest extends JDBCTestBase {
 				.finish();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = RuntimeException.class)
 	public void testIncompatibleTypes() throws IOException {
 		jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
 				.setDrivername(DRIVER_CLASS)
@@ -101,6 +103,60 @@ public class JDBCOutputFormatTest extends JDBCTestBase {
 		row.setField(4, "imthewrongtype");
 
 		jdbcOutputFormat.writeRecord(row);
+		jdbcOutputFormat.close();
+	}
+
+	@Test(expected = RuntimeException.class)
+	public void testExceptionOnInvalidType() throws IOException {
+		jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
+			.setDrivername(DRIVER_CLASS)
+			.setDBUrl(DB_URL)
+			.setQuery(String.format(INSERT_TEMPLATE, OUTPUT_TABLE))
+			.setSqlTypes(new int[] {
+				Types.INTEGER,
+				Types.VARCHAR,
+				Types.VARCHAR,
+				Types.DOUBLE,
+				Types.INTEGER})
+			.finish();
+		jdbcOutputFormat.open(0, 1);
+
+		JDBCTestBase.TestEntry entry = TEST_DATA[0];
+		Row row = new Row(5);
+		row.setField(0, entry.id);
+		row.setField(1, entry.title);
+		row.setField(2, entry.author);
+		row.setField(3, 0L); // use incompatible type (Long instead of Double)
+		row.setField(4, entry.qty);
+		jdbcOutputFormat.writeRecord(row);
+	}
+
+	@Test(expected = RuntimeException.class)
+	public void testExceptionOnClose() throws IOException {
+
+		jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
+			.setDrivername(DRIVER_CLASS)
+			.setDBUrl(DB_URL)
+			.setQuery(String.format(INSERT_TEMPLATE, OUTPUT_TABLE))
+			.setSqlTypes(new int[] {
+				Types.INTEGER,
+				Types.VARCHAR,
+				Types.VARCHAR,
+				Types.DOUBLE,
+				Types.INTEGER})
+			.finish();
+		jdbcOutputFormat.open(0, 1);
+
+		JDBCTestBase.TestEntry entry = TEST_DATA[0];
+		Row row = new Row(5);
+		row.setField(0, entry.id);
+		row.setField(1, entry.title);
+		row.setField(2, entry.author);
+		row.setField(3, entry.price);
+		row.setField(4, entry.qty);
+		jdbcOutputFormat.writeRecord(row);
+		jdbcOutputFormat.writeRecord(row); // writing the same record twice must yield a unique key violation.
+
 		jdbcOutputFormat.close();
 	}
 
@@ -141,6 +197,19 @@ public class JDBCOutputFormatTest extends JDBCTestBase {
 				recordCount++;
 			}
 			Assert.assertEquals(TEST_DATA.length, recordCount);
+		}
+	}
+
+	@After
+	public void clearOutputTable() throws Exception {
+		Class.forName(DRIVER_CLASS);
+		try (
+			Connection conn = DriverManager.getConnection(DB_URL);
+			Statement stat = conn.createStatement()) {
+			stat.execute("DELETE FROM " + OUTPUT_TABLE);
+
+			stat.close();
+			conn.close();
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Ensure that that an exception is thrown if the execution of the last JDBC batch fails.
At the moment, only an INFO log is emitted which does not inform the user that data was lost.

## Brief change log

* Throw exception in `JDBCOutputFormat.close()` if execution of last JDBC fails.
* Split try-catch block in `JDBCOutputFormat.writeRecord()` into statement generation and batch execution.
* Exception are changed from `IllegalArgumentException` to more generic `RuntimeException` because they are not caused by illegal arguments.
* Add and fix test cases.

## Verifying this change

* The fix is verify by `JDBCOutputFormatTest.testExceptionOnClose()` 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

