### PR TITLE
[FLINK-7354][tests] ignore "initialSeedUniquifierGenerator" thread in thread list

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
@@ -49,7 +49,12 @@ import static org.junit.Assert.fail;
  */
 public class LocalFlinkMiniClusterITCase extends TestLogger {
 
-	private static final String[] ALLOWED_THREAD_PREFIXES = { "initialSeedUniquifierGenerator" };
+	private static final String[] ALLOWED_THREAD_PREFIXES = {
+		// This is a daemon thread spawned by netty's ThreadLocalRandom class if no
+		// initialSeedUniquifier is set yet and it is sometimes spawned before this test and
+		// sometimes during this test.
+		"initialSeedUniquifierGenerator"
+	};
 
 	@Test
 	public void testLocalFlinkMiniClusterWithMultipleTaskManagers() {

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.fail;
  */
 public class LocalFlinkMiniClusterITCase extends TestLogger {
 
-	private static final String[] ALLOWED_THREAD_PREFIXES = { };
+	private static final String[] ALLOWED_THREAD_PREFIXES = { "initialSeedUniquifierGenerator" };
 
 	@Test
 	public void testLocalFlinkMiniClusterWithMultipleTaskManagers() {


### PR DESCRIPTION
## What is the purpose of the change

Netty may spawn a thread in its `ThreadLocalRandom` because of some secure random use which may be caught in our `LocalFlinkMiniClusterITCase` thread check as being started but not stopped by us. We can simply ignore this thread and solve the test instability.

Alternatively, we could solve this similarly to https://issues.apache.org/jira/browse/SOLR-10098 by setting `ThreadLocalRandom.setInitialSeedUniquifier(1L);` but that may be less future proof or even remove some randomness.

## Brief change log

  - ignore any spawned thread with prefix `"initialSeedUniquifierGenerator"`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

