### PR TITLE
[FLINK-7107] [flip6] Add option to start a Flip-6 Yarn session cluster

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendYarnAddressConfigurationTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendYarnAddressConfigurationTest.java
@@ -364,7 +364,8 @@ public class CliFrontendYarnAddressConfigurationTest extends TestLogger {
 			// override cluster descriptor to replace the YarnClient
 			protected AbstractYarnClusterDescriptor getClusterDescriptor(
 					Configuration configuration,
-					String configurationDirecotry) {
+					String configurationDirecotry,
+					boolean flip6) {
 				return new TestingYarnClusterDescriptor(configuration, configurationDirecotry);
 			}
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -184,7 +184,10 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		}
 
 		@Override
-		protected AbstractYarnClusterDescriptor getClusterDescriptor(Configuration configuration, String configurationDirectory) {
+		protected AbstractYarnClusterDescriptor getClusterDescriptor(
+			Configuration configuration,
+			String configurationDirectory,
+			boolean flip6) {
 			return new JarAgnosticClusterDescriptor(configuration, configurationDirectory);
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

The Flip-6 Yarn session cluster can now be started with yarn-session.sh --flip6. Per
default, the old Yarn application master will be started.

## Brief change log

  - `FlinkYarnSessionCli` accepts the `-f6` and `--flip6` option to start a Flip6 Yarn session cluster
  - Create the respective `AbstractYarnClusterDescriptor` depending on the existence of the `flip6` command line option

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

This change added tests and can be verified as follows:

  - Start a Flink Yarn session with the passed `-f6` or `--flip6` command line option, you should then see a Java process running `YarnSessionClusterEntrypoint`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - Not documented because it is a feature intended to be used by developers only

