### PR TITLE
[FLINK-7356][configuration] misleading s3 file uri in configuration file

### DIFF
--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -118,7 +118,7 @@ jobmanager.web.port: 8081
 # Directory for storing checkpoints in a Flink-supported filesystem
 # Note: State backend must be accessible from the JobManager and all TaskManagers.
 # Use "hdfs://" for HDFS setups, "file://" for UNIX/POSIX-compliant file systems,
-# (or any local file system under Windows), or "S3://" for S3 file system.
+# (or any local file system under Windows), or "s3://" with lower case 's' for S3 file system.
 #
 # state.backend.fs.checkpointdir: hdfs://namenode-host:port/flink-checkpoints
 


### PR DESCRIPTION
**(The sections below can be removed for hotfixes of typos)**

## What is the purpose of the change

*Correct the misleading example of s3 file uri in flink-conf.yaml file*

in https://github.com/apache/flink/blob/master/flink-dist/src/main/resources/flink-conf.yaml,
the comment in line 121 should say `"**s3**://" for S3 file system` rather than `"**S3**://" for S3 file system`, because `S3://xxx` is not recognized by AWS SDK.

## Brief change log

- Corrected the comment, and added extra text for alerting 


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
