### PR TITLE
[FLINK-7347] [streaming] Keep ids for current checkpoint in a set instead of a list

### DIFF
--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
@@ -51,8 +51,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
-import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -180,12 +180,12 @@ public class RMQSourceTest {
 			testHarnessCopy.initializeState(data);
 			testHarnessCopy.open();
 
-			ArrayDeque<Tuple2<Long, List<String>>> deque = sourceCopy.getRestoredState();
-			List<String> messageIds = deque.getLast().f1;
+			ArrayDeque<Tuple2<Long, Set<String>>> deque = sourceCopy.getRestoredState();
+			Set<String> messageIds = deque.getLast().f1;
 
 			assertEquals(numIds, messageIds.size());
 			if (messageIds.size() > 0) {
-				assertEquals(lastSnapshotId, (long) Long.valueOf(messageIds.get(messageIds.size() - 1)));
+				assertTrue(messageIds.contains(Long.toString(lastSnapshotId)));
 			}
 
 			// check if the messages are being acknowledged and the transaction committed
@@ -339,7 +339,7 @@ public class RMQSourceTest {
 
 	private class RMQTestSource extends RMQSource<String> {
 
-		private ArrayDeque<Tuple2<Long, List<String>>> restoredState;
+		private ArrayDeque<Tuple2<Long, Set<String>>> restoredState;
 
 		public RMQTestSource() {
 			super(new RMQConnectionConfig.Builder().setHost("hostTest")
@@ -353,7 +353,7 @@ public class RMQSourceTest {
 			this.restoredState = this.pendingCheckpoints;
 		}
 
-		public ArrayDeque<Tuple2<Long, List<String>>> getRestoredState() {
+		public ArrayDeque<Tuple2<Long, Set<String>>> getRestoredState() {
 			return this.restoredState;
 		}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/MultipleIdsMessageAcknowledgingSourceBase.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/MultipleIdsMessageAcknowledgingSourceBase.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Abstract base class for data sources that receive elements from a message queue and
@@ -110,7 +111,8 @@ public abstract class MultipleIdsMessageAcknowledgingSourceBase<Type, UId, Sessi
 	 *                  means of de-duplicating messages when the acknowledgment after a checkpoint
 	 *                  fails.
 	 */
-	protected final void acknowledgeIDs(long checkpointId, List<UId> uniqueIds) {
+	@Override
+	protected final void acknowledgeIDs(long checkpointId, Set<UId> uniqueIds) {
 		LOG.debug("Acknowledging ids for checkpoint {}", checkpointId);
 		Iterator<Tuple2<Long, List<SessionId>>> iterator = sessionIdsPerSnapshot.iterator();
 		while (iterator.hasNext()) {


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/FLINK-7347

## What is the purpose of the change

This pull request changes the data structure used to store acknowledge-pending message ids from an `ArrayList` to a `HashSet`. This is done to eliminate an extremely inefficient call to the `removeAll` method in `MessageAcknowledgingSourceBase.notifyCheckpointComplete`.
The implementation of `removeAll` is such that if the set is smaller than the collection to remove, then the set is iterated and every item is checked for containment in the collection. The `contains` action on an `ArrayList` is very inefficient, and it is performed for every item the set.
In our pipeline we had about 10 million events processed, and the checkpoint was stuck on the `removeAll` call for hours.


## Brief change log

Keep ids for current checkpoint in a set instead of a list


## Verifying this change

This change is already covered by existing tests, such as `RMQSourceTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes** - performance should be improved
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **yes** - this should resolve the problem where checkpoints would get stuck on the call to `removeAll`

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

