### PR TITLE
FLINK-7368: MetricStore makes cpu spin at 100%

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricFetcher.java
@@ -121,9 +121,7 @@ public class MetricFetcher {
 							for (JobDetails job : details.getFinishedJobs()) {
 								toRetain.add(job.getJobId().toString());
 							}
-							synchronized (metrics) {
-								metrics.jobs.keySet().retainAll(toRetain);
-							}
+							metrics.jobs.keySet().retainAll(toRetain);
 						}
 					}, ctx);
 				logErrorOnFailure(jobDetailsFuture, "Fetching of JobDetails failed.");
@@ -156,9 +154,8 @@ public class MetricFetcher {
 
 								queryMetrics(taskManagerQueryService);
 							}
-							synchronized (metrics) { // remove all metrics belonging to unregistered task managers
-								metrics.taskManagers.keySet().retainAll(activeTaskManagers);
-							}
+							// remove all metrics belonging to unregistered task managers
+							metrics.taskManagers.keySet().retainAll(activeTaskManagers);
 						}
 					}, ctx);
 				logErrorOnFailure(registeredTaskManagersFuture, "Fetchin list of registered TaskManagers failed.");

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricStore.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricStore.java
@@ -24,8 +24,8 @@ import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -48,8 +48,8 @@ public class MetricStore {
 	private static final Logger LOG = LoggerFactory.getLogger(MetricStore.class);
 
 	final JobManagerMetricStore jobManager = new JobManagerMetricStore();
-	final Map<String, TaskManagerMetricStore> taskManagers = new HashMap<>();
-	final Map<String, JobMetricStore> jobs = new HashMap<>();
+	final Map<String, TaskManagerMetricStore> taskManagers = new ConcurrentHashMap<>();
+	final Map<String, JobMetricStore> jobs = new ConcurrentHashMap<>();
 
 	// -----------------------------------------------------------------------------------------------------------------
 	// Adding metrics
@@ -248,7 +248,7 @@ public class MetricStore {
 	// sub MetricStore classes
 	// -----------------------------------------------------------------------------------------------------------------
 	private abstract static class ComponentMetricStore {
-		public final Map<String, String> metrics = new HashMap<>();
+		public final Map<String, String> metrics = new ConcurrentHashMap<>();
 
 		public String getMetric(String name, String defaultValue) {
 			String value = this.metrics.get(name);
@@ -268,7 +268,7 @@ public class MetricStore {
 	 * Sub-structure containing metrics of a single TaskManager.
 	 */
 	public static class TaskManagerMetricStore extends ComponentMetricStore {
-		public final Set<String> garbageCollectorNames = new HashSet<>();
+		public final Set<String> garbageCollectorNames = new ConcurrentSkipListSet<>();
 
 		public void addGarbageCollectorName(String name) {
 			garbageCollectorNames.add(name);
@@ -279,7 +279,7 @@ public class MetricStore {
 	 * Sub-structure containing metrics of a single Job.
 	 */
 	public static class JobMetricStore extends ComponentMetricStore {
-		private final Map<String, TaskMetricStore> tasks = new HashMap<>();
+		private final Map<String, TaskMetricStore> tasks = new ConcurrentHashMap<>();
 
 		public TaskMetricStore getTaskMetricStore(String taskID) {
 			return tasks.get(taskID);
@@ -290,7 +290,7 @@ public class MetricStore {
 	 * Sub-structure containing metrics of a single Task.
 	 */
 	public static class TaskMetricStore extends ComponentMetricStore {
-		private final Map<Integer, SubtaskMetricStore> subtasks = new HashMap<>();
+		private final Map<Integer, SubtaskMetricStore> subtasks = new ConcurrentHashMap<>();
 
 		public SubtaskMetricStore getSubtaskMetricStore(int subtaskIndex) {
 			return subtasks.get(subtaskIndex);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricStore.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricStore.java
@@ -24,10 +24,10 @@ import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 import static org.apache.flink.runtime.metrics.dump.MetricDump.METRIC_CATEGORY_COUNTER;
 import static org.apache.flink.runtime.metrics.dump.MetricDump.METRIC_CATEGORY_GAUGE;
@@ -200,7 +200,7 @@ public class MetricStore {
 	 * @return TaskManagerMetricStore for the given ID, or null if no store for the given argument exists
 	 */
 	public TaskManagerMetricStore getTaskManagerMetricStore(String tmID) {
-		return taskManagers.get(tmID);
+		return tmID == null ? null : taskManagers.get(tmID);
 	}
 
 	/**
@@ -210,7 +210,7 @@ public class MetricStore {
 	 * @return JobMetricStore for the given ID, or null if no store for the given argument exists
 	 */
 	public JobMetricStore getJobMetricStore(String jobID) {
-		return jobs.get(jobID);
+		return jobID == null ? null : jobs.get(jobID);
 	}
 
 	/**


### PR DESCRIPTION
Flink's `MetricStore` is not thread-safe. multi-treads may acess java' hashmap inside `MetricStore` and can tirgger hashmap's infinte loop. 

Recently I met the case that flink jobmanager consumed 100% cpu. A part of stacktrace is shown below. The full jstack is in the attachment.
{code:java}
"ForkJoinPool-1-worker-19" daemon prio=10 tid=0x00007fbdacac9800 nid=0x64c1 runnable [0x00007fbd7d1c2000]
   java.lang.Thread.State: RUNNABLE
        at java.util.HashMap.put(HashMap.java:494)
        at org.apache.flink.runtime.webmonitor.metrics.MetricStore.addMetric(MetricStore.java:176)
        at org.apache.flink.runtime.webmonitor.metrics.MetricStore.add(MetricStore.java:121)
        at org.apache.flink.runtime.webmonitor.metrics.MetricFetcher.addMetrics(MetricFetcher.java:198)
        at org.apache.flink.runtime.webmonitor.metrics.MetricFetcher.access$500(MetricFetcher.java:58)
        at org.apache.flink.runtime.webmonitor.metrics.MetricFetcher$4.onSuccess(MetricFetcher.java:188)
        at akka.dispatch.OnSuccess.internal(Future.scala:212)
        at akka.dispatch.japi$CallbackBridge.apply(Future.scala:175)
        at akka.dispatch.japi$CallbackBridge.apply(Future.scala:172)
        at scala.PartialFunction$class.applyOrElse(PartialFunction.scala:123)
        at scala.runtime.AbstractPartialFunction.applyOrElse(AbstractPartialFunction.scala:28)
        at scala.concurrent.Future$$anonfun$onSuccess$1.apply(Future.scala:117)
        at scala.concurrent.Future$$anonfun$onSuccess$1.apply(Future.scala:115)
        at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:32)
        at java.util.concurrent.ForkJoinTask$AdaptedRunnable.exec(ForkJoinTask.java:1265)
        at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:334)
        at java.util.concurrent.ForkJoinWorkerThread.execTask(ForkJoinWorkerThread.java:604)
        at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:784)
        at java.util.concurrent.ForkJoinPool.work(ForkJoinPool.java:646)
        at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:398)
{code}

There are 24 threads show same stacktrace as above to indicate they are spining at HashMap.put(HashMap.java:494) (I am using Java 1.7.0_6). Many posts indicate multi-threads accessing hashmap cause this problem and I reproduce the case as well. Even through `MetricFetcher` has a 10 seconds minimum inteverl between each metrics qurey, it still cannot guarntee query responses do not acess `MtricStore`'s hashmap concurrently. 
