### PR TITLE
FLINK-7369: Add more information for `Key group index out of range of key group range` exception

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/NestedMapsStateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/NestedMapsStateTable.java
@@ -98,11 +98,13 @@ public class NestedMapsStateTable<K, N, S> extends StateTable<K, N, S> {
 	 * Sets the given map for the given key-group.
 	 */
 	private void setMapForKeyGroup(int keyGroupId, Map<N, Map<K, S>> map) {
+		int offset = indexToOffset(keyGroupId);
 		try {
-			state[indexToOffset(keyGroupId)] = map;
+			state[offset] = map;
 		} catch (ArrayIndexOutOfBoundsException e) {
-			throw new IllegalArgumentException("Key group index out of range of key group range [" +
-					keyGroupOffset + ", " + (keyGroupOffset + state.length) + ").");
+			throw new IllegalArgumentException("Key group (groupId:" + keyGroupId +
+				"/offset:" + offset + ") index out of range of key group range [" +
+				keyGroupOffset + ", " + (keyGroupOffset + state.length) + ").");
 		}
 	}
 


### PR DESCRIPTION
When i got the following exception log, it make me confused that the index is more than `32` or less than `16`. So, we should add more information for it.

```java
java.lang.IllegalArgumentException: Key group index out of range of key group range [16, 32).
	at org.apache.flink.runtime.state.heap.NestedMapsStateTable.setMapForKeyGroup(NestedMapsStateTable.java:104)
	at org.apache.flink.runtime.state.heap.NestedMapsStateTable.putAndGetOld(NestedMapsStateTable.java:218)
	at org.apache.flink.runtime.state.heap.NestedMapsStateTable.put(NestedMapsStateTable.java:207)
	at org.apache.flink.runtime.state.heap.NestedMapsStateTable.put(NestedMapsStateTable.java:145)
	at org.apache.flink.runtime.state.heap.HeapValueState.update(HeapValueState.java:72)
	at org.apache.flink.cep.operator.AbstractKeyedCEPPatternOperator.updateNFA(AbstractKeyedCEPPatternOperator.java:276)
	at org.apache.flink.cep.operator.AbstractKeyedCEPPatternOperator.processElement(AbstractKeyedCEPPatternOperator.java:171)
	at org.apache.flink.streaming.runtime.io.StreamInputProcessor.processInput(StreamInputProcessor.java:206)
	at org.apache.flink.streaming.runtime.tasks.OneInputStreamTask.run(OneInputStreamTask.java:69)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.invoke(StreamTask.java:263)
	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:702)
	at java.lang.Thread.run(Thread.java:745)
```