### PR TITLE
[FLINK-7307] Add proper command line parsing tool to ClusterEntrypoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.entrypoint;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -36,6 +35,7 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.runtime.security.SecurityContext;
 import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.util.CommandLineParser;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
@@ -245,11 +245,8 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 		MetricRegistry metricRegistry) throws Exception;
 
 	protected static ClusterConfiguration parseArguments(String[] args) {
-		ParameterTool parameterTool = ParameterTool.fromArgs(args);
-
-		final String configDir = parameterTool.get("configDir", "");
-
-		return new ClusterConfiguration(configDir);
+		CommandLineParser commandLineParser = CommandLineParser.parse(args);
+		return new ClusterConfiguration(commandLineParser.getConfigDir(""));
 	}
 
 	protected static Configuration loadConfiguration(ClusterConfiguration clusterConfiguration) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/CommandLineParser.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/CommandLineParser.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.BootstrapTools;
+
+/**
+ * Command line arguments parser
+ */
+public class CommandLineParser {
+	private static final Option CONFIG_DIR_OPTION = new Option("c", "configDir", true, "Flink config file directory");
+
+	private static final Options CONFIG_OPTIONS = getConfigOptions();
+
+	private final CommandLine cmd;
+	private final Configuration dynamicProperties;
+
+	private CommandLineParser(CommandLine commandLine) {
+		cmd = commandLine;
+		dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
+	}
+
+	public static CommandLineParser parse(String[] args) {
+		DefaultParser parser = new DefaultParser();
+		try {
+			return new CommandLineParser(parser.parse(CONFIG_OPTIONS, args, true));
+		} catch (ParseException e) {
+			throw new RuntimeException("Parse args fail", e);
+		}
+	}
+
+	public String getConfigDir() {
+		return cmd.getOptionValue(CONFIG_DIR_OPTION.getOpt());
+	}
+
+	public String getConfigDir(String defaultValue) {
+		return cmd.getOptionValue(CONFIG_DIR_OPTION.getOpt(), defaultValue);
+	}
+
+	public Configuration getDynamicProperties() {
+		return dynamicProperties;
+	}
+
+	private static Options getConfigOptions() {
+		Options options = new Options();
+		options.addOption(CONFIG_DIR_OPTION);
+		options.addOption(BootstrapTools.newDynamicPropertiesOption());
+
+		return options;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/CommandLineParserTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/CommandLineParserTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.configuration.Configuration;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * Tests that validate the {@link CommandLineParser}.
+ */
+public class CommandLineParserTest {
+	@Test
+	public void testConfigDirArgs() {
+		String[] args = new String[]{"-configDir", "configDirPath1"};
+		CommandLineParser parser = CommandLineParser.parse(args);
+		String configDir = parser.getConfigDir("");
+		assertEquals("configDirPath1", configDir);
+
+		args = new String[]{"--configDir", "configDirPath2"};
+		parser = CommandLineParser.parse(args);
+		configDir = parser.getConfigDir("");
+		assertEquals("configDirPath2", configDir);
+
+		args = new String[]{"-c", "configDirPath3"};
+		parser = CommandLineParser.parse(args);
+		configDir = parser.getConfigDir("");
+		assertEquals("configDirPath3", configDir);
+
+		args = new String[]{"--c", "configDirPath4"};
+		parser = CommandLineParser.parse(args);
+		configDir = parser.getConfigDir("");
+		assertEquals("configDirPath4", configDir);
+	}
+
+	@Test
+	public void testInvalidConfig() {
+		String[] args = new String[]{"configDir", "configDirPath1"};
+		CommandLineParser parser = CommandLineParser.parse(args);
+		String configDir = parser.getConfigDir("");
+		assertEquals("", configDir);
+
+		args = new String[]{"---configDir", "configDirPath2"};
+		parser = CommandLineParser.parse(args);
+		configDir = parser.getConfigDir("");
+		assertEquals("", configDir);
+
+		args = new String[]{"c", "configDirPath3"};
+		parser = CommandLineParser.parse(args);
+		configDir = parser.getConfigDir("");
+		assertEquals("", configDir);
+
+		args = new String[]{"---c", "configDirPath4"};
+		parser = CommandLineParser.parse(args);
+		configDir = parser.getConfigDir("");
+		assertEquals("", configDir);
+
+		args = new String[]{"-f", "configDirFile"};
+		parser = CommandLineParser.parse(args);
+		configDir = parser.getConfigDir("");
+		assertEquals("", configDir);
+	}
+
+	@Test
+	public void testDynamicProperties() {
+		String[] args = new String[]{
+			"-configDir", "configDirPath",
+			"-D", "rpc.port=111",
+			"-D", "rpc.address=localhost"};
+		CommandLineParser parser = CommandLineParser.parse(args);
+		assertEquals("configDirPath", parser.getConfigDir());
+
+		Configuration dynamicProperties = parser.getDynamicProperties();
+		assertEquals("111", dynamicProperties.getString("rpc.port", ""));
+		assertEquals("localhost", dynamicProperties.getString("rpc.address", ""));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Add a proper command line parsing tool `CommandLineParser` to the entry point of the `ClusterEntrypoint#parseArguments`


## Brief change log

  - *Add command line parsing tool `CommandLineParser`*
  - *Use `CommandLineParser` instead of `ParameterTool` in `ClusterEntrypoint#parseArguments`*


## Verifying this change

*(Please pick either of the following options)*
This change added tests and can be verified as follows:

*(example:)*
  - *Added test case `CommandLineParserTest`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
