### PR TITLE
[hotfix][docs] add documentation for `taskmanager.exit-on-fatal-akka-error`

### DIFF
--- a/docs/setup/config.md
+++ b/docs/setup/config.md
@@ -295,6 +295,8 @@ The following parameters configure Flink's JobManager and TaskManagers.
 
 - `task.cancellation-interval`: Time interval between two successive task cancellation attempts in milliseconds (DEFAULT: **30000**).
 
+- `taskmanager.exit-on-fatal-akka-error`: Whether the TaskManager shall be terminated in case of a fatal Akka error (quarantining event). (DEFAULT: **false**)
+
 ### Distributed Coordination (via Akka)
 
 - `akka.ask.timeout`: Timeout used for all futures and blocking Akka calls. If Flink fails due to timeouts then you should try to increase this value. Timeouts can be caused by slow machines or a congested network. The timeout value requires a time-unit specifier (ms/s/min/h/d) (DEFAULT: **10 s**).


### PR DESCRIPTION
## What is the purpose of the change

When the quarantine monitor was added as of FLINK-3347, documentation for enabling it only went into the backport for the 1.2 and 1.1 branches, not into master and therefore not into the 1.3 release either. This adds it again and should also be applied to the `release-1.3` branch.

## Brief change log

- add configuration documentation for `taskmanager.exit-on-fatal-akka-error`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

