### PR TITLE
[FLINK-7309][hotfix] fix NullPointerException when selecting null fields

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1181,8 +1181,12 @@ abstract class CodeGenerator(
 
     val wrappedCode = if (nullCheck && !isReference(fieldType)) {
       s"""
-        |$tmpTypeTerm $tmpTerm = $unboxedFieldCode;
-        |boolean $nullTerm = $tmpTerm == null;
+        |$tmpTypeTerm $tmpTerm = $defaultValue;
+        |boolean $nullTerm = $fieldTerm == null;
+        |if(!$nullTerm) {
+        |  $tmpTerm = $unboxedFieldCode;
+        |  $nullTerm = $tmpTerm == null;
+        |}
         |$resultTypeTerm $resultTerm;
         |if ($nullTerm) {
         |  $resultTerm = $defaultValue;
@@ -1193,12 +1197,18 @@ abstract class CodeGenerator(
         |""".stripMargin
     } else if (nullCheck) {
       s"""
-        |$resultTypeTerm $resultTerm = $unboxedFieldCode;
+        |$resultTypeTerm $resultTerm = $defaultValue;
         |boolean $nullTerm = $fieldTerm == null;
+        |if (!$nullTerm) {
+        |  $resultTerm = $unboxedFieldCode;
+        |}
         |""".stripMargin
     } else {
       s"""
-        |$resultTypeTerm $resultTerm = $unboxedFieldCode;
+        |$resultTypeTerm $resultTerm = $defaultValue;
+        |if ($fieldTerm != null) {
+        |  $resultTerm = $unboxedFieldCode;
+        |}
         |""".stripMargin
     }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1172,13 +1172,6 @@ abstract class CodeGenerator(
     val resultTypeTerm = primitiveTypeTermForTypeInfo(fieldType)
     val defaultValue = primitiveDefaultValue(fieldType)
 
-    // the initial value for result.
-    val initValue = fieldType match {
-        // special case for String
-      case BasicTypeInfo.STRING_TYPE_INFO => null
-      case _ => defaultValue
-    }
-
     // explicit unboxing
     val unboxedFieldCode = if (isTimePoint(fieldType)) {
       timePointToInternalCode(fieldType, fieldTerm)
@@ -1188,7 +1181,7 @@ abstract class CodeGenerator(
 
     val wrappedCode = if (nullCheck && !isReference(fieldType)) {
       s"""
-        |$tmpTypeTerm $tmpTerm = $initValue;
+        |$tmpTypeTerm $tmpTerm = $defaultValue;
         |boolean $nullTerm = $fieldTerm == null;
         |if(!$nullTerm) {
         |  $tmpTerm = $unboxedFieldCode;
@@ -1204,7 +1197,7 @@ abstract class CodeGenerator(
         |""".stripMargin
     } else if (nullCheck) {
       s"""
-        |$resultTypeTerm $resultTerm = $initValue;
+        |$resultTypeTerm $resultTerm = $defaultValue;
         |boolean $nullTerm = $fieldTerm == null;
         |if (!$nullTerm){
         |  $resultTerm = $unboxedFieldCode;
@@ -1212,10 +1205,7 @@ abstract class CodeGenerator(
         |""".stripMargin
     } else {
       s"""
-        |$resultTypeTerm $resultTerm = $initValue;
-        |if ($fieldTerm != null) {
-        |  $resultTerm = $unboxedFieldCode;
-        |}
+        |$resultTypeTerm $resultTerm = $unboxedFieldCode;
         |""".stripMargin
     }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1172,6 +1172,13 @@ abstract class CodeGenerator(
     val resultTypeTerm = primitiveTypeTermForTypeInfo(fieldType)
     val defaultValue = primitiveDefaultValue(fieldType)
 
+    // the initial value for result.
+    val initValue = fieldType match {
+        // special case for String
+      case BasicTypeInfo.STRING_TYPE_INFO => null
+      case _ => defaultValue
+    }
+
     // explicit unboxing
     val unboxedFieldCode = if (isTimePoint(fieldType)) {
       timePointToInternalCode(fieldType, fieldTerm)
@@ -1181,7 +1188,7 @@ abstract class CodeGenerator(
 
     val wrappedCode = if (nullCheck && !isReference(fieldType)) {
       s"""
-        |$tmpTypeTerm $tmpTerm = $defaultValue;
+        |$tmpTypeTerm $tmpTerm = $initValue;
         |boolean $nullTerm = $fieldTerm == null;
         |if(!$nullTerm) {
         |  $tmpTerm = $unboxedFieldCode;
@@ -1197,15 +1204,15 @@ abstract class CodeGenerator(
         |""".stripMargin
     } else if (nullCheck) {
       s"""
-        |$resultTypeTerm $resultTerm = $defaultValue;
+        |$resultTypeTerm $resultTerm = $initValue;
         |boolean $nullTerm = $fieldTerm == null;
-        |if (!$nullTerm) {
+        |if (!$nullTerm){
         |  $resultTerm = $unboxedFieldCode;
         |}
         |""".stripMargin
     } else {
       s"""
-        |$resultTypeTerm $resultTerm = $defaultValue;
+        |$resultTypeTerm $resultTerm = $initValue;
         |if ($fieldTerm != null) {
         |  $resultTerm = $unboxedFieldCode;
         |}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/TemporalTypesTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/TemporalTypesTest.scala
@@ -538,10 +538,31 @@ class TemporalTypesTest extends ExpressionTestBase {
       "1990-09-12 10:20:45.123")
   }
 
+  @Test
+  def testSelectNullValues(): Unit ={
+    testAllApis(
+      'f11,
+      "f11",
+      "f11",
+      "null"
+    )
+    testAllApis(
+      'f12,
+      "f12",
+      "f12",
+      "null"
+    )
+    testAllApis(
+      'f13,
+      "f13",
+      "f13",
+      "null"
+    )
+  }
   // ----------------------------------------------------------------------------------------------
 
   def testData: Row = {
-    val testData = new Row(11)
+    val testData = new Row(14)
     testData.setField(0, Date.valueOf("1990-10-14"))
     testData.setField(1, Time.valueOf("10:20:45"))
     testData.setField(2, Timestamp.valueOf("1990-10-14 10:20:45.123"))
@@ -553,6 +574,10 @@ class TemporalTypesTest extends ExpressionTestBase {
     testData.setField(8, 1467012213000L)
     testData.setField(9, 24)
     testData.setField(10, 12000L)
+    // null selection test.
+    testData.setField(11, null)
+    testData.setField(12, null)
+    testData.setField(13, null)
     testData
   }
 
@@ -568,6 +593,9 @@ class TemporalTypesTest extends ExpressionTestBase {
       Types.INT,
       Types.LONG,
       Types.INTERVAL_MONTHS,
-      Types.INTERVAL_MILLIS).asInstanceOf[TypeInformation[Any]]
+      Types.INTERVAL_MILLIS,
+      Types.SQL_DATE,
+      Types.SQL_TIME,
+      Types.SQL_TIMESTAMP).asInstanceOf[TypeInformation[Any]]
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.runtime.stream.sql
 
-import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, SqlTimeTypeInfo, TypeInformation}
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
@@ -313,35 +313,6 @@ class SqlITCase extends StreamingWithStateTestBase {
       "3,[(18,42.6)],18,42.6")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
-
-  @Test
-  def testSelectWithNullTimestamp(): Unit = {
-
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
-    StreamITCase.clear
-
-    val data = Seq(
-      Row.of(null, "empty")
-    )
-
-    implicit val tpe: TypeInformation[Row] = new RowTypeInfo(
-      SqlTimeTypeInfo.TIMESTAMP,
-      BasicTypeInfo.STRING_TYPE_INFO) // tpe is automatically
-
-    val stream = env.fromCollection(data)
-    tEnv.registerDataStream("T", stream, 'ts, 'event)
-
-    val sqlQuery = "SELECT * from T"
-
-    val result = tEnv.sql(sqlQuery).toAppendStream[Row]
-    result.addSink(new StreamITCase.StringSink[Row])
-    env.execute()
-
-    val expected = List("null,empty")
-    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
-  }
-
 
 }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.runtime.stream.sql
 
-import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, SqlTimeTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
@@ -313,6 +313,35 @@ class SqlITCase extends StreamingWithStateTestBase {
       "3,[(18,42.6)],18,42.6")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
+
+  @Test
+  def testSelectWithNullTimestamp(): Unit = {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
+    val data = Seq(
+      Row.of(null, "empty")
+    )
+
+    implicit val tpe: TypeInformation[Row] = new RowTypeInfo(
+      SqlTimeTypeInfo.TIMESTAMP,
+      BasicTypeInfo.STRING_TYPE_INFO) // tpe is automatically
+
+    val stream = env.fromCollection(data)
+    tEnv.registerDataStream("T", stream, 'ts, 'event)
+
+    val sqlQuery = "SELECT * from T"
+
+    val result = tEnv.sql(sqlQuery).toAppendStream[Row]
+    result.addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+
+    val expected = List("null,empty")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
 
 }
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request addresses FLINK-7309, adds null check before applying unboxing on input fields.

## Brief change log

- Add null check before applying unboxing on input fields.

## Verifying this change

This change added tests and can be verified as follows:
 - Added test case: select null field from a Timestamp type field.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

