### PR TITLE
[FLINK-6995] [docs] Enable is_latest attribute to false

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -42,7 +42,7 @@ download_url: "http://flink.apache.org/downloads.html"
 
 # Flag whether this is the latest stable version or not. If not, a warning
 # will be printed pointing to the docs of the latest stable version.
-is_latest: true
+is_latest: false
 is_stable: true
 
 previous_docs:


### PR DESCRIPTION
## What is the purpose of the change

Add a warning to flink1.2 document. This PR is based on https://github.com/apache/flink-web/pull/72,  and to make the warning message enable and appear. 

## Verifying this change

This change is a trivial work without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
