### PR TITLE
[FLINK-4534] Fix synchronization issue in BucketingSink

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
@@ -422,9 +422,11 @@ public class BucketingSink<T>
 
 	@Override
 	public void close() throws Exception {
-		if (state != null) {
-			for (Map.Entry<String, BucketState<T>> entry : state.bucketStates.entrySet()) {
-				closeCurrentPartFile(entry.getValue());
+		synchronized (state.bucketStates) {
+			if (state != null) {
+				for (Map.Entry<String, BucketState<T>> entry : state.bucketStates.entrySet()) {
+					closeCurrentPartFile(entry.getValue());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

Fix lacking of synchronization in BucketingSink#close method.

## Verifying this change

This change is a trivial work without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

