### PR TITLE
[FLINK-7372] [JobGraph] Remove ActorGateway from JobGraph

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -322,8 +322,9 @@ public class ClientTest extends TestLogger {
 				getSender().tell(
 						decorateMessage(new JobManagerMessages.ResponseLeaderSessionID(leaderSessionID)),
 						getSelf());
-			}
-			else {
+			} else if (message instanceof JobManagerMessages.RequestBlobManagerPort$) {
+				getSender().tell(1337, getSelf());
+			} else {
 				getSender().tell(
 						decorateMessage(new Status.Failure(new Exception("Unknown message " + message))),
 						getSelf());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -22,15 +22,11 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.fs.FSDataInputStream;
-import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.blob.BlobClient;
 import org.apache.flink.runtime.blob.BlobKey;
-import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.util.SerializedValue;
-import scala.concurrent.duration.FiniteDuration;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -527,65 +523,24 @@ public class JobGraph implements Serializable {
 	}
 
 	/**
-	 * Uploads the previously added user jar file to the job manager through the job manager's BLOB server.
-	 *
-	 * @param serverAddress
-	 *        the network address of the BLOB server
-	 * @param blobClientConfig
-	 *        the blob client configuration
-	 * @throws IOException
-	 *         thrown if an I/O error occurs during the upload
-	 */
-	public void uploadRequiredJarFiles(InetSocketAddress serverAddress,
-			Configuration blobClientConfig) throws IOException {
-		if (this.userJars.isEmpty()) {
-			return;
-		}
-
-		BlobClient bc = null;
-		try {
-			bc = new BlobClient(serverAddress, blobClientConfig);
-
-			for (final Path jar : this.userJars) {
-
-				final FileSystem fs = jar.getFileSystem();
-				FSDataInputStream is = null;
-				try {
-					is = fs.open(jar);
-					final BlobKey key = bc.put(is);
-					this.userJarBlobKeys.add(key);
-				}
-				finally {
-					if (is != null) {
-						is.close();
-					}
-				}
-			}
-		}
-		finally {
-			if (bc != null) {
-				bc.close();
-			}
-		}
-	}
-
-	/**
 	 * Uploads the previously added user JAR files to the job manager through
 	 * the job manager's BLOB server. The respective port is retrieved from the
 	 * JobManager. This function issues a blocking call.
 	 *
-	 * @param jobManager JobManager actor gateway
-	 * @param askTimeout Ask timeout
+	 * @param blobServerAddress of the blob server to upload the jars to
 	 * @param blobClientConfig the blob client configuration
 	 * @throws IOException Thrown, if the file upload to the JobManager failed.
 	 */
-	public void uploadUserJars(ActorGateway jobManager, FiniteDuration askTimeout,
+	public void uploadUserJars(
+			InetSocketAddress blobServerAddress,
 			Configuration blobClientConfig) throws IOException {
-		List<BlobKey> blobKeys = BlobClient.uploadJarFiles(jobManager, askTimeout, blobClientConfig, userJars);
+		if (!userJars.isEmpty()) {
+			List<BlobKey> blobKeys = BlobClient.uploadJarFiles(blobServerAddress, blobClientConfig, userJars);
 
-		for (BlobKey blobKey : blobKeys) {
-			if (!userJarBlobKeys.contains(blobKey)) {
-				userJarBlobKeys.add(blobKey);
+			for (BlobKey blobKey : blobKeys) {
+				if (!userJarBlobKeys.contains(blobKey)) {
+					userJarBlobKeys.add(blobKey);
+				}
 			}
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorTest.java
@@ -347,6 +347,9 @@ public class JobClientActorTest extends TestLogger {
 
 		@Override
 		protected void handleMessage(Object message) throws Exception {
+			if (message instanceof RequestBlobManagerPort$) {
+				getSender().tell(1337, getSelf());
+			}
 		}
 
 		@Override
@@ -388,7 +391,9 @@ public class JobClientActorTest extends TestLogger {
 					testFuture.tell(Acknowledge.get(), getSelf());
 				}
 			}
-			else if (message instanceof RegisterTest) {
+			else if (message instanceof RequestBlobManagerPort$) {
+				getSender().tell(1337, getSelf());
+			} else if (message instanceof RegisterTest) {
 				testFuture = getSender();
 
 				if (jobAccepted) {


### PR DESCRIPTION
## What is the purpose of the change

The JobGraph has an unncessary dependency on the ActorGateway via its JobGraph#uploadUserJars method. In order to get rid of this dependency for future Flip-6 changes, this commit retrieves the BlobServer's address beforehand and directly passes it to this method as a `InetSocketAddress` instance.

## Brief change log

- Introduce `JobClient#retrieveBlobServerAddress` method which retrieves from the given `ActorGateway` the `BlobServer` address
- First retrieve `BlobServer` address using the aforementioned method wherever the `ActorGateway` was passed to the `JobGraph`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

