### PR TITLE
[FLINK-7376][Client] Cleanup options class and test classes in flink-clients

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -263,7 +263,6 @@ public class CliFrontend {
 
 		ClusterClient client = null;
 		try {
-
 			client = createClient(options, program);
 			client.setPrintStatusDuringExecution(options.getStdoutLogging());
 			client.setDetached(options.getDetachedMode());
@@ -332,7 +331,6 @@ public class CliFrontend {
 		}
 
 		// -------- build the packaged program -------------
-
 		PackagedProgram program;
 		try {
 			LOG.info("Building program from JAR file");
@@ -370,14 +368,10 @@ public class CliFrontend {
 			}
 
 			String description = program.getDescription();
-			if (description != null) {
-				System.out.println();
-				System.out.println(description);
+			if(description == null) {
+				description = "No description provided.";
 			}
-			else {
-				System.out.println();
-				System.out.println("No description provided.");
-			}
+			System.out.println(description);
 			return 0;
 		}
 		catch (Throwable t) {
@@ -540,7 +534,7 @@ public class CliFrontend {
 		String[] stopArgs = options.getArgs();
 		JobID jobId;
 
-		if (stopArgs.length > 0) {
+		if (stopArgs != null && stopArgs.length > 0) {
 			String jobIdString = stopArgs[0];
 			try {
 				jobId = new JobID(StringUtils.hexStringToByte(jobIdString));
@@ -608,7 +602,7 @@ public class CliFrontend {
 		// is set:
 		// - cancel -s <jobID> => default target dir (JobID parsed as opt arg)
 		// - cancel -s <targetDir> <jobID> => custom target dir (parsed correctly)
-		if (cleanedArgs.length > 0) {
+		if (cleanedArgs != null && cleanedArgs.length > 0) {
 			String jobIdString = cleanedArgs[0];
 			try {
 				jobId = new JobID(StringUtils.hexStringToByte(jobIdString));
@@ -706,7 +700,7 @@ public class CliFrontend {
 			String[] cleanedArgs = options.getArgs();
 			JobID jobId;
 
-			if (cleanedArgs.length >= 1) {
+			if (cleanedArgs != null && cleanedArgs.length >= 1) {
 				String jobIdString = cleanedArgs[0];
 				try {
 					jobId = new JobID(StringUtils.hexStringToByte(jobIdString));

--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -368,7 +368,7 @@ public class CliFrontend {
 			}
 
 			String description = program.getDescription();
-			if(description == null) {
+			if (description == null) {
 				description = "No description provided.";
 			}
 			System.out.println(description);

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CancelOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CancelOptions.java
@@ -27,8 +27,6 @@ import static org.apache.flink.client.cli.CliFrontendParser.CANCEL_WITH_SAVEPOIN
  */
 public class CancelOptions extends CommandLineOptions {
 
-	private final String[] args;
-
 	/** Flag indicating whether to cancel with a savepoint. */
 	private final boolean withSavepoint;
 
@@ -37,13 +35,8 @@ public class CancelOptions extends CommandLineOptions {
 
 	public CancelOptions(CommandLine line) {
 		super(line);
-		this.args = line.getArgs();
 		this.withSavepoint = line.hasOption(CANCEL_WITH_SAVEPOINT_OPTION.getOpt());
 		this.targetDirectory = line.getOptionValue(CANCEL_WITH_SAVEPOINT_OPTION.getOpt());
-	}
-
-	public String[] getArgs() {
-		return args == null ? new String[0] : args;
 	}
 
 	public boolean isWithSavepoint() {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CommandLineOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CommandLineOptions.java
@@ -35,11 +35,14 @@ public abstract class CommandLineOptions {
 
 	private final boolean printHelp;
 
+	private final String[] args;
+
 	protected CommandLineOptions(CommandLine line) {
 		this.commandLine = line;
 		this.printHelp = line.hasOption(HELP_OPTION.getOpt());
 		this.jobManagerAddress = line.hasOption(ADDRESS_OPTION.getOpt()) ?
-				line.getOptionValue(ADDRESS_OPTION.getOpt()) : null;
+			line.getOptionValue(ADDRESS_OPTION.getOpt()) : null;
+		this.args = line.getArgs();
 	}
 
 	public CommandLine getCommandLine() {
@@ -52,5 +55,9 @@ public abstract class CommandLineOptions {
 
 	public String getJobManagerAddress() {
 		return jobManagerAddress;
+	}
+
+	public String[] getArgs() {
+		return args;
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/SavepointOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/SavepointOptions.java
@@ -28,21 +28,15 @@ import static org.apache.flink.client.cli.CliFrontendParser.SAVEPOINT_DISPOSE_OP
  */
 public class SavepointOptions extends CommandLineOptions {
 
-	private final String[] args;
 	private boolean dispose;
 	private String disposeSavepointPath;
 	private String jarFile;
 
 	public SavepointOptions(CommandLine line) {
 		super(line);
-		args = line.getArgs();
 		dispose = line.hasOption(SAVEPOINT_DISPOSE_OPTION.getOpt());
 		disposeSavepointPath = line.getOptionValue(SAVEPOINT_DISPOSE_OPTION.getOpt());
 		jarFile = line.getOptionValue(JAR_OPTION.getOpt());
-	}
-
-	public String[] getArgs() {
-		return args == null ? new String[0] : args;
 	}
 
 	public boolean isDispose() {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/StopOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/StopOptions.java
@@ -25,14 +25,7 @@ import org.apache.commons.cli.CommandLine;
  */
 public class StopOptions extends CommandLineOptions {
 
-	private final String[] args;
-
 	public StopOptions(CommandLine line) {
 		super(line);
-		this.args = line.getArgs();
-	}
-
-	public String[] getArgs() {
-		return args == null ? new String[0] : args;
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendAddressConfigurationTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendAddressConfigurationTest.java
@@ -32,6 +32,7 @@ import org.junit.rules.TemporaryFolder;
 import java.net.InetSocketAddress;
 
 import static org.apache.flink.client.CliFrontendTestUtils.checkJobManagerAddress;
+import static org.apache.flink.client.CliFrontendTestUtils.pipeSystemOutToNull;
 import static org.junit.Assert.fail;
 
 /**
@@ -44,8 +45,8 @@ public class CliFrontendAddressConfigurationTest {
 	public TemporaryFolder folder = new TemporaryFolder();
 
 	@BeforeClass
-	public static void init() {
-		CliFrontendTestUtils.pipeSystemOutToNull();
+	public static void setup() {
+		pipeSystemOutToNull();
 	}
 
 	@Test

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendInfoTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendInfoTest.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.client;
 
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendInfoTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendInfoTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.client;
 
-import org.junit.Test;
+import org.junit.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -32,7 +32,6 @@ import static org.junit.Assert.fail;
 public class CliFrontendInfoTest {
 
 	private static PrintStream stdOut;
-	private static PrintStream capture;
 	private static ByteArrayOutputStream buffer;
 
 	@Test
@@ -62,9 +61,7 @@ public class CliFrontendInfoTest {
 
 	@Test
 	public void testShowExecutionPlan() {
-		replaceStdOut();
 		try {
-
 			String[] parameters = new String[] { CliFrontendTestUtils.getTestJarPath(), "-f", "true"};
 			CliFrontend testFrontend = new CliFrontend(CliFrontendTestUtils.getConfigDir());
 			int retCode = testFrontend.info(parameters);
@@ -74,14 +71,11 @@ public class CliFrontendInfoTest {
 		catch (Exception e) {
 			e.printStackTrace();
 			fail("Program caused an exception: " + e.getMessage());
-		} finally {
-			restoreStdOut();
 		}
 	}
 
 	@Test
 	public void testShowExecutionPlanWithParallelism() {
-		replaceStdOut();
 		try {
 			String[] parameters = {"-p", "17", CliFrontendTestUtils.getTestJarPath()};
 			CliFrontend testFrontend = new CliFrontend(CliFrontendTestUtils.getConfigDir());
@@ -92,19 +86,19 @@ public class CliFrontendInfoTest {
 		catch (Exception e) {
 			e.printStackTrace();
 			fail("Program caused an exception: " + e.getMessage());
-		} finally {
-			restoreStdOut();
 		}
 	}
 
-	private static void replaceStdOut() {
+	@Before
+	public void replaceStdOut() {
 		stdOut = System.out;
 		buffer = new ByteArrayOutputStream();
-		capture = new PrintStream(buffer);
+		PrintStream capture = new PrintStream(buffer);
 		System.setOut(capture);
 	}
 
-	private static void restoreStdOut() {
+	@After
+	public void restoreStdOut() {
 		System.setOut(stdOut);
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendListCancelTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendListCancelTest.java
@@ -61,11 +61,6 @@ public class CliFrontendListCancelTest {
 		actorSystem = null;
 	}
 
-	@BeforeClass
-	public static void init() {
-		CliFrontendTestUtils.pipeSystemOutToNull();
-	}
-
 	@Test
 	public void testCancel() {
 		try {
@@ -228,7 +223,6 @@ public class CliFrontendListCancelTest {
 			}
 		}
 		catch (Exception e) {
-			System.err.println(e.getMessage());
 			e.printStackTrace();
 			fail("Program caused an exception: " + e.getMessage());
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendPackageProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendPackageProgramTest.java
@@ -56,7 +56,7 @@ import static org.mockito.Mockito.when;
 public class CliFrontendPackageProgramTest {
 
 	@BeforeClass
-	public static void init() {
+	public static void setup() {
 		pipeSystemOutToNull();
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
@@ -28,6 +28,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.apache.flink.client.CliFrontendTestUtils.getTestJarPath;
+import static org.apache.flink.client.CliFrontendTestUtils.pipeSystemOutToNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -40,8 +41,8 @@ import static org.junit.Assert.fail;
 public class CliFrontendRunTest {
 
 	@BeforeClass
-	public static void init() {
-		CliFrontendTestUtils.pipeSystemOutToNull();
+	public static void setup() {
+		pipeSystemOutToNull();
 	}
 
 	@Test

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendSavepointTest.java
@@ -24,6 +24,8 @@ import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 
 import akka.dispatch.Futures;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -48,6 +50,7 @@ import static org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepo
 import static org.apache.flink.runtime.messages.JobManagerMessages.getDisposeSavepointSuccess;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -71,9 +74,7 @@ public class CliFrontendSavepointTest {
 	// ------------------------------------------------------------------------
 
 	@Test
-	public void testTriggerSavepointSuccess() throws Exception {
-		replaceStdOutAndStdErr();
-
+	public void testTriggerSavepointSuccess() {
 		try {
 			JobID jobId = new JobID();
 			ActorGateway jobManager = mock(ActorGateway.class);
@@ -102,15 +103,14 @@ public class CliFrontendSavepointTest {
 
 			assertTrue(buffer.toString().contains("expectedSavepointPath"));
 		}
-		finally {
-			restoreStdOutAndStdErr();
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
 		}
 	}
 
 	@Test
-	public void testTriggerSavepointFailure() throws Exception {
-		replaceStdOutAndStdErr();
-
+	public void testTriggerSavepointFailure() {
 		try {
 			JobID jobId = new JobID();
 			ActorGateway jobManager = mock(ActorGateway.class);
@@ -139,15 +139,14 @@ public class CliFrontendSavepointTest {
 
 			assertTrue(buffer.toString().contains("expectedTestException"));
 		}
-		finally {
-			restoreStdOutAndStdErr();
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
 		}
 	}
 
 	@Test
-	public void testTriggerSavepointFailureIllegalJobID() throws Exception {
-		replaceStdOutAndStdErr();
-
+	public void testTriggerSavepointFailureIllegalJobID() {
 		try {
 			CliFrontend frontend = new CliFrontend(CliFrontendTestUtils.getConfigDir());
 
@@ -157,15 +156,14 @@ public class CliFrontendSavepointTest {
 			assertTrue(returnCode != 0);
 			assertTrue(buffer.toString().contains("not a valid ID"));
 		}
-		finally {
-			restoreStdOutAndStdErr();
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
 		}
 	}
 
 	@Test
-	public void testTriggerSavepointFailureUnknownResponse() throws Exception {
-		replaceStdOutAndStdErr();
-
+	public void testTriggerSavepointFailureUnknownResponse() {
 		try {
 			JobID jobId = new JobID();
 			ActorGateway jobManager = mock(ActorGateway.class);
@@ -194,8 +192,9 @@ public class CliFrontendSavepointTest {
 			assertTrue(errMsg.contains("IllegalStateException"));
 			assertTrue(errMsg.contains("Unknown JobManager response"));
 		}
-		finally {
-			restoreStdOutAndStdErr();
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
 		}
 	}
 
@@ -204,9 +203,7 @@ public class CliFrontendSavepointTest {
 	 * forwarded correctly to the JM.
 	 */
 	@Test
-	public void testTriggerSavepointCustomTarget() throws Exception {
-		replaceStdOutAndStdErr();
-
+	public void testTriggerSavepointCustomTarget() {
 		try {
 			JobID jobId = new JobID();
 			Option<String> customTarget = Option.apply("customTargetDirectory");
@@ -234,8 +231,9 @@ public class CliFrontendSavepointTest {
 
 			assertTrue(buffer.toString().contains("expectedSavepointPath"));
 		}
-		finally {
-			restoreStdOutAndStdErr();
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
 		}
 	}
 
@@ -244,9 +242,7 @@ public class CliFrontendSavepointTest {
 	// ------------------------------------------------------------------------
 
 	@Test
-	public void testDisposeSavepointSuccess() throws Exception {
-		replaceStdOutAndStdErr();
-
+	public void testDisposeSavepointSuccess() {
 		try {
 			String savepointPath = "expectedSavepointPath";
 			ActorGateway jobManager = mock(ActorGateway.class);
@@ -274,8 +270,9 @@ public class CliFrontendSavepointTest {
 			assertTrue(outMsg.contains(savepointPath));
 			assertTrue(outMsg.contains("disposed"));
 		}
-		finally {
-			restoreStdOutAndStdErr();
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
 		}
 	}
 
@@ -284,9 +281,7 @@ public class CliFrontendSavepointTest {
 	 * note about the JAR option.
 	 */
 	@Test
-	public void testDisposeClassNotFoundException() throws Exception {
-		replaceStdOutAndStdErr();
-
+	public void testDisposeClassNotFoundException() {
 		try {
 			Future<Object> classNotFoundFailure = Futures
 					.<Object>successful(new DisposeSavepointFailure(new ClassNotFoundException("Test exception")));
@@ -305,8 +300,10 @@ public class CliFrontendSavepointTest {
 			String out = buffer.toString();
 			assertTrue(out.contains("Please provide the program jar with which you have created " +
 					"the savepoint via -j <JAR> for disposal"));
-		} finally {
-			restoreStdOutAndStdErr();
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
 		}
 	}
 
@@ -314,9 +311,7 @@ public class CliFrontendSavepointTest {
 	 * Tests disposal with a JAR file.
 	 */
 	@Test
-	public void testDisposeWithJar() throws Exception {
-		replaceStdOutAndStdErr();
-
+	public void testDisposeWithJar() {
 		try {
 			ActorGateway jobManager = mock(ActorGateway.class);
 			when(jobManager.ask(any(DisposeSavepoint.class), any(FiniteDuration.class)))
@@ -333,15 +328,15 @@ public class CliFrontendSavepointTest {
 
 			int returnCode = frontend.savepoint(parameters);
 			assertEquals(0, returnCode);
-		} finally {
-			restoreStdOutAndStdErr();
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
 		}
 	}
 
 	@Test
-	public void testDisposeSavepointFailure() throws Exception {
-		replaceStdOutAndStdErr();
-
+	public void testDisposeSavepointFailure() {
 		try {
 			String savepointPath = "expectedSavepointPath";
 			ActorGateway jobManager = mock(ActorGateway.class);
@@ -370,15 +365,14 @@ public class CliFrontendSavepointTest {
 
 			assertTrue(buffer.toString().contains("expectedTestException"));
 		}
-		finally {
-			restoreStdOutAndStdErr();
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
 		}
 	}
 
 	@Test
-	public void testDisposeSavepointFailureUnknownResponse() throws Exception {
-		replaceStdOutAndStdErr();
-
+	public void testDisposeSavepointFailureUnknownResponse() {
 		try {
 			String savepointPath = "expectedSavepointPath";
 			ActorGateway jobManager = mock(ActorGateway.class);
@@ -407,11 +401,10 @@ public class CliFrontendSavepointTest {
 			assertTrue(errMsg.contains("IllegalStateException"));
 			assertTrue(errMsg.contains("Unknown JobManager response"));
 		}
-		finally {
-			restoreStdOutAndStdErr();
+		catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
 		}
-
-		replaceStdOutAndStdErr();
 	}
 
 	// ------------------------------------------------------------------------
@@ -431,7 +424,8 @@ public class CliFrontendSavepointTest {
 		}
 	}
 
-	private static void replaceStdOutAndStdErr() {
+	@Before
+	public void replaceStdOutAndStdErr() {
 		stdOut = System.out;
 		stdErr = System.err;
 		buffer = new ByteArrayOutputStream();
@@ -440,7 +434,8 @@ public class CliFrontendSavepointTest {
 		System.setErr(capture);
 	}
 
-	private static void restoreStdOutAndStdErr() {
+	@After
+	public void restoreStdOutAndStdErr() {
 		System.setOut(stdOut);
 		System.setErr(stdErr);
 	}

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendTestUtils.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendTestUtils.java
@@ -45,7 +45,7 @@ public class CliFrontendTestUtils {
 		File f = new File("target/maven-test-jar.jar");
 		if (!f.exists()) {
 			throw new FileNotFoundException("Test jar not present. Invoke tests using maven "
-					+ "or build the jar using 'mvn process-test-classes' in flink-clients");
+				+ "or build the jar using 'mvn process-test-classes' in flink-clients");
 		}
 		return f.getAbsolutePath();
 	}
@@ -71,7 +71,8 @@ public class CliFrontendTestUtils {
 
 	private static final class BlackholeOutputSteam extends java.io.OutputStream {
 		@Override
-		public void write(int b){}
+		public void write(int b) {
+		}
 	}
 
 	public static void checkJobManagerAddress(Configuration config, String expectedAddress, int expectedPort) {
@@ -81,8 +82,4 @@ public class CliFrontendTestUtils {
 		assertEquals(expectedAddress, jobManagerAddress);
 		assertEquals(expectedPort, jobManagerPort);
 	}
-
-	// --------------------------------------------------------------------------------------------
-
-	private CliFrontendTestUtils() {}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/RemoteExecutorHostnameResolutionTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/RemoteExecutorHostnameResolutionTest.java
@@ -45,7 +45,7 @@ public class RemoteExecutorHostnameResolutionTest extends TestLogger {
 	private static final int port = 14451;
 
 	@BeforeClass
-	public static void check() {
+	public static void setup() {
 		checkPreconditions();
 	}
 
@@ -67,7 +67,7 @@ public class RemoteExecutorHostnameResolutionTest extends TestLogger {
 
 		InetSocketAddress add = new InetSocketAddress(nonExistingHostname, port);
 		RemoteExecutor exec = new RemoteExecutor(add, new Configuration(),
-				Collections.<URL>emptyList(), Collections.<URL>emptyList());
+			Collections.<URL>emptyList(), Collections.<URL>emptyList());
 		try {
 			exec.executePlan(getProgram());
 			fail("This should fail with an ProgramInvocationException");

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -83,7 +83,7 @@ public class ClientTest extends TestLogger {
 	private static final String FAIL_MESSAGE = "Invalid program should have thrown ProgramInvocationException.";
 
 	@Before
-	public void setUp() throws Exception {
+	public void setup() throws Exception {
 
 		ExecutionEnvironment env = ExecutionEnvironment.createLocalEnvironment();
 		env.generateSequence(1, 1000).output(new DiscardingOutputFormat<Long>());

--- a/flink-clients/src/test/java/org/apache/flink/client/program/LeaderRetrievalServiceHostnameResolutionTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/LeaderRetrievalServiceHostnameResolutionTest.java
@@ -43,7 +43,7 @@ public class LeaderRetrievalServiceHostnameResolutionTest extends TestLogger {
 	private static final String nonExistingHostname = "foo.bar.com.invalid";
 
 	@BeforeClass
-	public static void check() {
+	public static void setup() {
 		checkPreconditions();
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
@@ -19,45 +19,33 @@
 package org.apache.flink.client.program;
 
 import org.apache.flink.client.CliFrontendTestUtils;
-
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.PrintStream;
+
+import static org.apache.flink.client.CliFrontendTestUtils.pipeSystemOutToNull;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the {@link PackagedProgramTest}.
  */
 public class PackagedProgramTest {
 
+	@BeforeClass
+	public static void setup() {
+		pipeSystemOutToNull();
+	}
+
 	@Test
 	public void testGetPreviewPlan() {
 		try {
 			PackagedProgram prog = new PackagedProgram(new File(CliFrontendTestUtils.getTestJarPath()));
-
-			final PrintStream out = System.out;
-			final PrintStream err = System.err;
-			try {
-				System.setOut(new PrintStream(new NullOutputStream()));
-				System.setErr(new PrintStream(new NullOutputStream()));
-
-				Assert.assertNotNull(prog.getPreviewPlan());
-			}
-			finally {
-				System.setOut(out);
-				System.setErr(err);
-			}
-		}
-		catch (Exception e) {
-			System.err.println(e.getMessage());
+			Assert.assertNotNull(prog.getPreviewPlan());
+		} catch (Exception e) {
 			e.printStackTrace();
-			Assert.fail("Test is erroneous: " + e.getMessage());
+			fail("Test is erroneous: " + e.getMessage());
 		}
-	}
-
-	private static final class NullOutputStream extends java.io.OutputStream {
-		@Override
-		public void write(int b) {}
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
@@ -19,13 +19,14 @@
 package org.apache.flink.client.program;
 
 import org.apache.flink.client.CliFrontendTestUtils;
-import org.junit.Assert;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
 
 import static org.apache.flink.client.CliFrontendTestUtils.pipeSystemOutToNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 /**
@@ -42,7 +43,7 @@ public class PackagedProgramTest {
 	public void testGetPreviewPlan() {
 		try {
 			PackagedProgram prog = new PackagedProgram(new File(CliFrontendTestUtils.getTestJarPath()));
-			Assert.assertNotNull(prog.getPreviewPlan());
+			assertNotNull(prog.getPreviewPlan());
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail("Test is erroneous: " + e.getMessage());


### PR DESCRIPTION
## What is the purpose of the change

Keeping code clean.


## Brief change log

- Move the `args` field to the `CommandLineOptions`(parent class) 
- Clean up the test classes in `flink-clients` module


## Verifying this change

This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)