### PR TITLE
[FLINK-7375] Replace ActorGateway with JobManagerGateway in JobClient

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -322,8 +322,9 @@ public class ClientTest extends TestLogger {
 				getSender().tell(
 						decorateMessage(new JobManagerMessages.ResponseLeaderSessionID(leaderSessionID)),
 						getSelf());
-			}
-			else {
+			} else if (message instanceof JobManagerMessages.RequestBlobManagerPort$) {
+				getSender().tell(1337, getSelf());
+			} else {
 				getSender().tell(
 						decorateMessage(new Status.Failure(new Exception("Unknown message " + message))),
 						getSelf());

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -43,8 +43,8 @@ import org.apache.flink.runtime.akka.FlinkUntypedActor;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.messages.JobManagerMessages;
-import org.apache.flink.runtime.util.SerializedThrowable;
 import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.TestLogger;
 
 import akka.actor.ActorSystem;

--- a/flink-core/src/main/java/org/apache/flink/util/SerializedThrowable.java
+++ b/flink-core/src/main/java/org/apache/flink/util/SerializedThrowable.java
@@ -16,10 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.util;
-
-import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.InstantiationUtil;
+package org.apache.flink.util;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/BackPressureStatsTrackerITCase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.MemoryType;
+import org.apache.flink.runtime.akka.AkkaJobManagerGateway;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.client.JobClient;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
@@ -156,10 +157,10 @@ public class BackPressureStatsTrackerITCase extends TestLogger {
 
 							// Submit the job and wait until it is running
 							JobClient.submitJobDetached(
-									jm,
+									new AkkaJobManagerGateway(jm),
 									config,
 									jobGraph,
-									deadline,
+									Time.milliseconds(deadline.toMillis()),
 									ClassLoader.getSystemClassLoader());
 
 							jm.tell(new WaitForAllVerticesToBeRunning(jobGraph.getJobID()), testActor);

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/StackTraceSampleCoordinatorITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.webmonitor;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaJobManagerGateway;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.client.JobClient;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
@@ -131,10 +132,10 @@ public class StackTraceSampleCoordinatorITCase extends TestLogger {
 							for (int i = 0; i < maxAttempts; i++, sleepTime *= 2) {
 								// Submit the job and wait until it is running
 								JobClient.submitJobDetached(
-										jm,
+										new AkkaJobManagerGateway(jm),
 										config,
 										jobGraph,
-										deadline,
+										Time.milliseconds(deadline.toMillis()),
 										ClassLoader.getSystemClassLoader());
 
 								jm.tell(new WaitForAllVerticesToBeRunning(jobGraph.getJobID()), testActor);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/akka/AkkaJobManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/akka/AkkaJobManagerGateway.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.akka;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.FlinkFutureException;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobManagerGateway;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import scala.Option;
+import scala.reflect.ClassTag$;
+
+/**
+ * Implementation of the {@link JobManagerGateway} for the {@link ActorGateway}.
+ */
+public class AkkaJobManagerGateway implements JobManagerGateway {
+
+	private final ActorGateway jobManagerGateway;
+	private final String hostname;
+
+	public AkkaJobManagerGateway(ActorGateway jobManagerGateway) {
+		this.jobManagerGateway = Preconditions.checkNotNull(jobManagerGateway);
+
+		final Option<String> optHostname = jobManagerGateway.actor().path().address().host();
+
+		hostname = optHostname.isDefined() ? optHostname.get() : "localhost";
+	}
+
+	@Override
+	public String getAddress() {
+		return jobManagerGateway.path();
+	}
+
+	@Override
+	public String getHostname() {
+		return hostname;
+	}
+
+	@Override
+	public CompletableFuture<Optional<JobManagerMessages.ClassloadingProps>> requestClassloadingProps(JobID jobId, Time timeout) {
+		return FutureUtils
+			.toJava(jobManagerGateway
+				.ask(
+					new JobManagerMessages.RequestClassloadingProps(jobId),
+					FutureUtils.toFiniteDuration(timeout)))
+			.thenApply(
+				(Object response) -> {
+					if (response instanceof JobManagerMessages.ClassloadingProps) {
+						return Optional.of(((JobManagerMessages.ClassloadingProps) response));
+					} else if (response instanceof JobManagerMessages.JobNotFound) {
+						return Optional.empty();
+					} else {
+						throw new FlinkFutureException("Unknown response: " + response + '.');
+					}
+				});
+	}
+
+	@Override
+	public CompletableFuture<Integer> requestBlobServerPort(Time timeout) {
+		return FutureUtils.toJava(
+			jobManagerGateway
+				.ask(JobManagerMessages.getRequestBlobManagerPort(), FutureUtils.toFiniteDuration(timeout))
+				.mapTo(ClassTag$.MODULE$.apply(Integer.class)));
+	}
+
+	@Override
+	public CompletableFuture<Acknowledge> submitJob(JobGraph jobGraph, ListeningBehaviour listeningBehaviour, Time timeout) {
+		return FutureUtils
+			.toJava(
+				jobManagerGateway.ask(
+					new JobManagerMessages.SubmitJob(
+						jobGraph,
+						listeningBehaviour),
+					FutureUtils.toFiniteDuration(timeout)))
+			.thenApply(
+				(Object response) -> {
+					if (response instanceof JobManagerMessages.JobSubmitSuccess) {
+						JobManagerMessages.JobSubmitSuccess success = ((JobManagerMessages.JobSubmitSuccess) response);
+
+						if (Objects.equals(success.jobId(), jobGraph.getJobID())) {
+							return Acknowledge.get();
+						} else {
+							throw new FlinkFutureException("JobManager responded for wrong Job. This Job: " +
+								jobGraph.getJobID() + ", response: " + success.jobId());
+						}
+					} else if (response instanceof JobManagerMessages.JobResultFailure) {
+						JobManagerMessages.JobResultFailure failure = ((JobManagerMessages.JobResultFailure) response);
+
+						throw new FlinkFutureException("Job submission failed.", failure.cause());
+					} else {
+						throw new FlinkFutureException("Unknown response to SubmitJob message: " + response + '.');
+					}
+				}
+			);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClient.java
@@ -28,19 +28,21 @@ import akka.pattern.Patterns;
 import akka.util.Timeout;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.ListeningBehaviour;
 import org.apache.flink.runtime.blob.BlobCache;
 import org.apache.flink.runtime.blob.BlobKey;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoader;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobManagerGateway;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.JobClientMessages;
 import org.apache.flink.runtime.messages.JobManagerMessages;
-import org.apache.flink.runtime.util.SerializedThrowable;
+import org.apache.flink.util.SerializedThrowable;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.NetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,13 +53,13 @@ import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
-import scala.reflect.ClassTag$;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -144,7 +146,6 @@ public class JobClient {
 	 */
 	public static JobListeningContext attachToRunningJob(
 			JobID jobID,
-			ActorGateway jobManagerGateWay,
 			Configuration configuration,
 			ActorSystem actorSystem,
 			HighAvailabilityServices highAvailabilityServices,
@@ -152,7 +153,6 @@ public class JobClient {
 			boolean sysoutLogUpdates) {
 
 		checkNotNull(jobID, "The jobID must not be null.");
-		checkNotNull(jobManagerGateWay, "The jobManagerGateWay must not be null.");
 		checkNotNull(configuration, "The configuration must not be null.");
 		checkNotNull(actorSystem, "The actorSystem must not be null.");
 		checkNotNull(highAvailabilityServices, "The high availability services must not be null.");
@@ -193,36 +193,37 @@ public class JobClient {
 	 * @throws JobRetrievalException if anything goes wrong
 	 */
 	public static ClassLoader retrieveClassLoader(
-		JobID jobID,
-		ActorGateway jobManager,
-		Configuration config,
-		HighAvailabilityServices highAvailabilityServices)
+			JobID jobID,
+			JobManagerGateway jobManager,
+			Configuration config,
+			HighAvailabilityServices highAvailabilityServices,
+			Time timeout)
 		throws JobRetrievalException {
 
-		final Object jmAnswer;
+		final CompletableFuture<Optional<JobManagerMessages.ClassloadingProps>> clPropsFuture = jobManager
+			.requestClassloadingProps(jobID, timeout);
+
+		final Optional<JobManagerMessages.ClassloadingProps> optProps;
+
 		try {
-			jmAnswer = Await.result(
-				jobManager.ask(
-					new JobManagerMessages.RequestClassloadingProps(jobID),
-					AkkaUtils.getDefaultTimeoutAsFiniteDuration()),
-				AkkaUtils.getDefaultTimeoutAsFiniteDuration());
+			optProps = clPropsFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 		} catch (Exception e) {
-			throw new JobRetrievalException(jobID, "Couldn't retrieve class loading properties from JobManager.", e);
+			throw new JobRetrievalException(jobID, "Could not retrieve the class loading properties from JobManager.", e);
 		}
 
-		if (jmAnswer instanceof JobManagerMessages.ClassloadingProps) {
-			JobManagerMessages.ClassloadingProps props = ((JobManagerMessages.ClassloadingProps) jmAnswer);
+		if (optProps.isPresent()) {
+			JobManagerMessages.ClassloadingProps props = optProps.get();
 
-			Option<String> jmHost = jobManager.actor().path().address().host();
-			String jmHostname = jmHost.isDefined() ? jmHost.get() : "localhost";
-			InetSocketAddress serverAddress = new InetSocketAddress(jmHostname, props.blobManagerPort());
+			InetSocketAddress serverAddress = new InetSocketAddress(jobManager.getHostname(), props.blobManagerPort());
 			final BlobCache blobClient;
 			try {
 				// TODO: Fix lifecycle of BlobCache to properly close it upon usage
 				blobClient = new BlobCache(serverAddress, config, highAvailabilityServices.createBlobStore());
 			} catch (IOException e) {
-				throw new JobRetrievalException(jobID,
-					"Failed to setup blob cache", e);
+				throw new JobRetrievalException(
+					jobID,
+					"Failed to setup BlobCache.",
+					e);
 			}
 
 			final Collection<BlobKey> requiredJarFiles = props.requiredJarFiles();
@@ -250,10 +251,8 @@ public class JobClient {
 			}
 
 			return new FlinkUserCodeClassLoader(allURLs, JobClient.class.getClassLoader());
-		} else if (jmAnswer instanceof JobManagerMessages.JobNotFound) {
-			throw new JobRetrievalException(jobID, "Couldn't retrieve class loader. Job " + jobID + " not found");
 		} else {
-			throw new JobRetrievalException(jobID, "Unknown response from JobManager: " + jmAnswer);
+			throw new JobRetrievalException(jobID, "Couldn't retrieve class loader. Job " + jobID + " not found");
 		}
 	}
 
@@ -407,13 +406,13 @@ public class JobClient {
 	 * @param jobManagerGateway Gateway to the JobManager which will execute the jobs
 	 * @param config The cluster wide configuration.
 	 * @param jobGraph The job
-	 * @param timeout  Timeout in which the JobManager must have responded.
+	 * @param timeout Timeout in which the JobManager must have responded.
 	 */
 	public static void submitJobDetached(
-			ActorGateway jobManagerGateway,
+			JobManagerGateway jobManagerGateway,
 			Configuration config,
 			JobGraph jobGraph,
-			FiniteDuration timeout,
+			Time timeout,
 			ClassLoader classLoader) throws JobExecutionException {
 
 		checkNotNull(jobManagerGateway, "The jobManagerGateway must not be null.");
@@ -427,7 +426,7 @@ public class JobClient {
 		final InetSocketAddress blobServerAddress;
 
 		try {
-			blobServerAddress = blobServerAddressFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+			blobServerAddress = blobServerAddressFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 		} catch (Exception e) {
 			throw new JobSubmissionException(jobGraph.getJobID(), "Could not retrieve BlobServer address.", e);
 		}
@@ -440,51 +439,26 @@ public class JobClient {
 				"Could not upload the program's JAR files to the JobManager.", e);
 		}
 
-		Object result;
+		CompletableFuture<Acknowledge> submissionFuture = jobManagerGateway.submitJob(jobGraph, ListeningBehaviour.DETACHED, timeout);
+
 		try {
-			Future<Object> future = jobManagerGateway.ask(
-				new JobManagerMessages.SubmitJob(
-					jobGraph,
-					ListeningBehaviour.DETACHED // only receive the Acknowledge for the job submission message
-				),
-				timeout);
-
-			result = Await.result(future, timeout);
-		}
-		catch (TimeoutException e) {
+			submissionFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		} catch (TimeoutException e) {
 			throw new JobTimeoutException(jobGraph.getJobID(),
-					"JobManager did not respond within " + timeout.toString(), e);
-		}
-		catch (Throwable t) {
-			throw new JobSubmissionException(jobGraph.getJobID(),
-					"Failed to send job to JobManager: " + t.getMessage(), t.getCause());
-		}
+				"JobManager did not respond within " + timeout, e);
+		} catch (Throwable throwable) {
+			Throwable stripped = ExceptionUtils.stripExecutionException(throwable);
 
-		if (result instanceof JobManagerMessages.JobSubmitSuccess) {
-			JobID respondedID = ((JobManagerMessages.JobSubmitSuccess) result).jobId();
-
-			// validate response
-			if (!respondedID.equals(jobGraph.getJobID())) {
-				throw new JobExecutionException(jobGraph.getJobID(),
-						"JobManager responded for wrong Job. This Job: " +
-						jobGraph.getJobID() + ", response: " + respondedID);
-			}
-		}
-		else if (result instanceof JobManagerMessages.JobResultFailure) {
 			try {
-				SerializedThrowable t = ((JobManagerMessages.JobResultFailure) result).cause();
-				throw t.deserializeError(classLoader);
+				ExceptionUtils.tryDeserializeAndThrow(stripped, classLoader);
+			} catch (JobExecutionException jee) {
+				throw jee;
+			} catch (Throwable t) {
+				throw new JobExecutionException(
+					jobGraph.getJobID(),
+					"JobSubmission failed.",
+					t);
 			}
-			catch (JobExecutionException e) {
-				throw e;
-			}
-			catch (Throwable t) {
-				throw new JobExecutionException(jobGraph.getJobID(),
-						"JobSubmission failed: " + t.getMessage(), t);
-			}
-		}
-		else {
-			throw new JobExecutionException(jobGraph.getJobID(), "Unexpected response from JobManager: " + result);
 		}
 	}
 
@@ -496,16 +470,12 @@ public class JobClient {
 	 * @return CompletableFuture containing the BlobServer address
 	 */
 	public static CompletableFuture<InetSocketAddress> retrieveBlobServerAddress(
-			ActorGateway jobManagerGateway,
-			FiniteDuration timeout) {
+			JobManagerGateway jobManagerGateway,
+			Time timeout) {
 
-		CompletableFuture<Integer> futureBlobPort = FutureUtils.toJava(
-			jobManagerGateway
-				.ask(JobManagerMessages.getRequestBlobManagerPort(), timeout)
-				.mapTo(ClassTag$.MODULE$.apply(Integer.class)));
+		CompletableFuture<Integer> futureBlobPort = jobManagerGateway.requestBlobServerPort(timeout);
 
-		final Option<String> jmHost = jobManagerGateway.actor().path().address().host();
-		final String jmHostname = jmHost.isDefined() ? jmHost.get() : "localhost";
+		final String jmHostname = jobManagerGateway.getHostname();
 
 		return futureBlobPort.thenApply(
 			(Integer blobPort) -> new InetSocketAddress(jmHostname, blobPort));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActor.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.messages.JobClientMessages;
 import org.apache.flink.runtime.messages.JobClientMessages.JobManagerActorRef;
 import org.apache.flink.runtime.messages.JobClientMessages.JobManagerLeaderAddress;
 import org.apache.flink.runtime.messages.JobManagerMessages;
-import org.apache.flink.runtime.util.SerializedThrowable;
+import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.Preconditions;
 import scala.concurrent.duration.FiniteDuration;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobListeningContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobListeningContext.java
@@ -20,7 +20,9 @@ package org.apache.flink.runtime.client;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaJobManagerGateway;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.instance.ActorGateway;
@@ -136,9 +138,10 @@ public final class JobListeningContext {
 			// lazily initializes the class loader when it is needed
 			classLoader = JobClient.retrieveClassLoader(
 				jobID,
-				getJobManager(),
+				new AkkaJobManagerGateway(getJobManager()),
 				configuration,
-				highAvailabilityServices);
+				highAvailabilityServices,
+				Time.milliseconds(timeout.toMillis()));
 			LOG.info("Reconstructed class loader for Job {}", jobID);
 		}
 		return classLoader;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/messages/FatalErrorOccurred.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/messages/FatalErrorOccurred.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.clusterframework.messages;
 
-import org.apache.flink.runtime.util.SerializedThrowable;
+import org.apache.flink.util.SerializedThrowable;
 
 import java.io.Serializable;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.concurrent;
 
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.util.Preconditions;
 
 import akka.dispatch.OnComplete;
@@ -29,10 +30,12 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
 import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -290,6 +293,16 @@ public class FutureUtils {
 		result.completeExceptionally(cause);
 
 		return result;
+	}
+
+	/**
+	 * Converts Flink time into a {@link FiniteDuration}.
+	 *
+	 * @param time to convert into a FiniteDuration
+	 * @return FiniteDuration with the length of the given time
+	 */
+	public static FiniteDuration toFiniteDuration(Time time) {
+		return new FiniteDuration(time.toMilliseconds(), TimeUnit.MILLISECONDS);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -63,7 +63,7 @@ import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableExceptio
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
-import org.apache.flink.runtime.util.SerializedThrowable;
+import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkRuntimeException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/StatusListenerMessenger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/StatusListenerMessenger.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.messages.ExecutionGraphMessages;
-import org.apache.flink.runtime.util.SerializedThrowable;
+import org.apache.flink.util.SerializedThrowable;
 
 import java.util.UUID;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ProducerFailedException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ProducerFailedException.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.runtime.execution.CancelTaskException;
-import org.apache.flink.runtime.util.SerializedThrowable;
+import org.apache.flink.util.SerializedThrowable;
 
 /**
  * Network-stack level Exception to notify remote receiver about a failed

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -524,8 +524,8 @@ public class JobGraph implements Serializable {
 
 	/**
 	 * Uploads the previously added user JAR files to the job manager through
-	 * the job manager's BLOB server. The respective port is retrieved from the
-	 * JobManager. This function issues a blocking call.
+	 * the job manager's BLOB server. The BLOB servers' address is given as a
+	 * parameter. This function issues a blocking call.
 	 *
 	 * @param blobServerAddress of the blob server to upload the jars to
 	 * @param blobClientConfig the blob client configuration

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -22,15 +22,11 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.fs.FSDataInputStream;
-import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.blob.BlobClient;
 import org.apache.flink.runtime.blob.BlobKey;
-import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.util.SerializedValue;
-import scala.concurrent.duration.FiniteDuration;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -527,65 +523,24 @@ public class JobGraph implements Serializable {
 	}
 
 	/**
-	 * Uploads the previously added user jar file to the job manager through the job manager's BLOB server.
-	 *
-	 * @param serverAddress
-	 *        the network address of the BLOB server
-	 * @param blobClientConfig
-	 *        the blob client configuration
-	 * @throws IOException
-	 *         thrown if an I/O error occurs during the upload
-	 */
-	public void uploadRequiredJarFiles(InetSocketAddress serverAddress,
-			Configuration blobClientConfig) throws IOException {
-		if (this.userJars.isEmpty()) {
-			return;
-		}
-
-		BlobClient bc = null;
-		try {
-			bc = new BlobClient(serverAddress, blobClientConfig);
-
-			for (final Path jar : this.userJars) {
-
-				final FileSystem fs = jar.getFileSystem();
-				FSDataInputStream is = null;
-				try {
-					is = fs.open(jar);
-					final BlobKey key = bc.put(is);
-					this.userJarBlobKeys.add(key);
-				}
-				finally {
-					if (is != null) {
-						is.close();
-					}
-				}
-			}
-		}
-		finally {
-			if (bc != null) {
-				bc.close();
-			}
-		}
-	}
-
-	/**
 	 * Uploads the previously added user JAR files to the job manager through
 	 * the job manager's BLOB server. The respective port is retrieved from the
 	 * JobManager. This function issues a blocking call.
 	 *
-	 * @param jobManager JobManager actor gateway
-	 * @param askTimeout Ask timeout
+	 * @param blobServerAddress of the blob server to upload the jars to
 	 * @param blobClientConfig the blob client configuration
 	 * @throws IOException Thrown, if the file upload to the JobManager failed.
 	 */
-	public void uploadUserJars(ActorGateway jobManager, FiniteDuration askTimeout,
+	public void uploadUserJars(
+			InetSocketAddress blobServerAddress,
 			Configuration blobClientConfig) throws IOException {
-		List<BlobKey> blobKeys = BlobClient.uploadJarFiles(jobManager, askTimeout, blobClientConfig, userJars);
+		if (!userJars.isEmpty()) {
+			List<BlobKey> blobKeys = BlobClient.uploadJarFiles(blobServerAddress, blobClientConfig, userJars);
 
-		for (BlobKey blobKey : blobKeys) {
-			if (!userJarBlobKeys.contains(blobKey)) {
-				userJarBlobKeys.add(blobKey);
+			for (BlobKey blobKey : blobKeys) {
+				if (!userJarBlobKeys.contains(blobKey)) {
+					userJarBlobKeys.add(blobKey);
+				}
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerGateway.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.akka.ListeningBehaviour;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.rpc.RpcGateway;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Public JobManager gateway.
+ *
+ * <p>This interface constitutes the operations an external component can
+ * trigger on the JobManager.
+ */
+public interface JobManagerGateway extends RpcGateway {
+
+	/**
+	 * Requests the class loading properties for the given JobID.
+	 *
+	 * @param jobId for which the class loading properties are requested
+	 * @param timeout for this operation
+	 * @return Future containing the optional class loading properties if they could be retrieved from the JobManager.
+	 */
+	CompletableFuture<Optional<JobManagerMessages.ClassloadingProps>> requestClassloadingProps(JobID jobId, Time timeout);
+
+	/**
+	 * Requests the BlobServer port.
+	 *
+	 * @param timeout for this operation
+	 * @return Future containing the BlobServer port
+	 */
+	CompletableFuture<Integer> requestBlobServerPort(Time timeout);
+
+	/**
+	 * Submits a job to the JobManager.
+	 *
+	 * @param jobGraph to submit
+	 * @param listeningBehaviour of the client
+	 * @param timeout for this operation
+	 * @return Future containing an Acknowledge message if the submission succeeded
+	 */
+	CompletableFuture<Acknowledge> submitJob(JobGraph jobGraph, ListeningBehaviour listeningBehaviour, Time timeout);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -91,7 +91,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
-import org.apache.flink.runtime.util.SerializedThrowable;
+import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.InstantiationUtil;
 
 import org.slf4j.Logger;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpoint.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.checkpoint.decline.CheckpointDeclineTaskNotCheck
 import org.apache.flink.runtime.checkpoint.decline.CheckpointDeclineTaskNotReadyException;
 import org.apache.flink.runtime.checkpoint.decline.InputEndOfStreamException;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.util.SerializedThrowable;
+import org.apache.flink.util.SerializedThrowable;
 
 /**
  * This message is sent from the {@link org.apache.flink.runtime.taskmanager.TaskManager} to the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskExecutionState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskExecutionState.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.executiongraph.IOMetrics;
-import org.apache.flink.runtime.util.SerializedThrowable;
+import org.apache.flink.util.SerializedThrowable;
 
 import java.io.Serializable;
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -84,7 +84,7 @@ import org.apache.flink.runtime.taskmanager.TaskManager
 import org.apache.flink.runtime.util._
 import org.apache.flink.runtime.webmonitor.{WebMonitor, WebMonitorUtils}
 import org.apache.flink.runtime.{FlinkActor, LeaderSessionMessageFilter, LogMessages}
-import org.apache.flink.util.{InstantiationUtil, NetUtils}
+import org.apache.flink.util.{InstantiationUtil, NetUtils, SerializedThrowable}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/JobManagerMessages.scala
@@ -32,7 +32,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID
 import org.apache.flink.runtime.jobgraph.{IntermediateDataSetID, JobGraph, JobStatus, JobVertexID}
 import org.apache.flink.runtime.jobmanager.SubmittedJobGraph
 import org.apache.flink.runtime.messages.checkpoint.AbstractCheckpointMessage
-import org.apache.flink.runtime.util.SerializedThrowable
+import org.apache.flink.util.SerializedThrowable
 
 import scala.collection.JavaConverters._
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
@@ -26,10 +26,11 @@ import akka.pattern.Patterns.gracefulStop
 import akka.pattern.ask
 import akka.actor.{ActorRef, ActorSystem}
 import com.typesafe.config.Config
+import org.apache.flink.api.common.time.Time
 import org.apache.flink.api.common.{JobExecutionResult, JobID, JobSubmissionResult}
 import org.apache.flink.configuration.{AkkaOptions, ConfigConstants, Configuration, JobManagerOptions, TaskManagerOptions}
 import org.apache.flink.core.fs.Path
-import org.apache.flink.runtime.akka.AkkaUtils
+import org.apache.flink.runtime.akka.{AkkaJobManagerGateway, AkkaUtils}
 import org.apache.flink.runtime.client.{JobClient, JobExecutionException}
 import org.apache.flink.runtime.concurrent.{Executors => FlinkExecutors}
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoader
@@ -582,10 +583,11 @@ abstract class FlinkMiniCluster(
           e)
       }
 
-    JobClient.submitJobDetached(jobManagerGateway,
+    JobClient.submitJobDetached(
+      new AkkaJobManagerGateway(jobManagerGateway),
       configuration,
       jobGraph,
-      timeout,
+      Time.milliseconds(timeout.toMillis),
       userCodeClassLoader)
 
     new JobSubmissionResult(jobGraph.getJobID)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorTest.java
@@ -347,6 +347,9 @@ public class JobClientActorTest extends TestLogger {
 
 		@Override
 		protected void handleMessage(Object message) throws Exception {
+			if (message instanceof RequestBlobManagerPort$) {
+				getSender().tell(1337, getSelf());
+			}
 		}
 
 		@Override
@@ -388,7 +391,9 @@ public class JobClientActorTest extends TestLogger {
 					testFuture.tell(Acknowledge.get(), getSelf());
 				}
 			}
-			else if (message instanceof RegisterTest) {
+			else if (message instanceof RequestBlobManagerPort$) {
+				getSender().tell(1337, getSelf());
+			} else if (message instanceof RegisterTest) {
 				testFuture = getSender();
 
 				if (jobAccepted) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ProducerFailedExceptionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ProducerFailedExceptionTest.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.runtime.execution.CancelTaskException;
-import org.apache.flink.runtime.util.SerializedThrowable;
+import org.apache.flink.util.SerializedThrowable;
 
 import org.junit.Test;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/SerializedThrowableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/SerializedThrowableTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.core.memory.MemoryUtils;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.SerializedThrowable;
 
 import org.junit.Test;
 


### PR DESCRIPTION
## What is the purpose of the change

In order to make the JobClient code independent of Akka, this PR replaces the
ActorGateway parameters by JobManagerGateway. AkkaJobManagerGateway is the
respective implementation of the JobManagerGateway for Akka. Moreover, this
PR introduces useful ExceptionUtils method for handling of Future exceptions.
Additionally, the SerializedThrowable has been moved to flink-core.

This PR is based on #4483.

## Brief change log

- Replace `ActorGateway` by `JobManagerGateway` in `JobClient`
- `AkkaJobManagerGateway` is the Akka based implementation of `JobManagerGateway`
- `ExceptionUtils` contain new functions to handle future exceptions
- `SerializedThrowable` has been moved to `flink-core`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

