### PR TITLE
[FLINK-7337] [table] Refactor internal handling of time indicator attributes.

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
@@ -23,10 +23,8 @@ import _root_.java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.plan.hep.HepMatchOrder
-import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.{RelNode, RelVisitor}
-import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode}
-import org.apache.calcite.sql.SqlKind
+import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeField, RelDataTypeFieldImpl, RelRecordType}
+import org.apache.calcite.rel.RelNode
 import org.apache.calcite.sql2rel.RelDecorrelator
 import org.apache.calcite.tools.{RuleSet, RuleSets}
 import org.apache.flink.api.common.functions.MapFunction
@@ -38,16 +36,16 @@ import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
 import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
-import org.apache.flink.table.calcite.RelTimeIndicatorConverter
+import org.apache.flink.table.calcite.{FlinkTypeFactory, RelTimeIndicatorConverter}
 import org.apache.flink.table.explain.PlanJsonParser
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.plan.nodes.FlinkConventions
-import org.apache.flink.table.plan.nodes.datastream.{DataStreamRel, UpdateAsRetractionTrait, _}
+import org.apache.flink.table.plan.nodes.datastream.{DataStreamRel, UpdateAsRetractionTrait}
 import org.apache.flink.table.plan.rules.FlinkRuleSets
 import org.apache.flink.table.plan.schema.{DataStreamTable, RowSchema, StreamTableSourceTable}
 import org.apache.flink.table.plan.util.UpdatingPlanChecker
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
-import org.apache.flink.table.runtime.{CRowInputJavaTupleOutputMapRunner, CRowInputMapRunner, CRowInputScalaTupleOutputMapRunner}
+import org.apache.flink.table.runtime.{CRowInputJavaTupleOutputMapRunner, CRowInputMapRunner, CRowInputScalaTupleOutputMapRunner, WrappingTimestampSetterProcessFunction}
 import org.apache.flink.table.sinks.{AppendStreamTableSink, RetractStreamTableSink, TableSink, UpsertStreamTableSink}
 import org.apache.flink.table.sources.{DefinedRowtimeAttribute, StreamTableSource, TableSource}
 import org.apache.flink.table.typeutils.TypeCheckUtils
@@ -270,11 +268,11 @@ abstract class StreamTableEnvironment(
     *                     valid Java class identifier.
     */
   private def getConversionMapperWithChanges[OUT](
-    physicalTypeInfo: TypeInformation[CRow],
-    schema: RowSchema,
-    requestedTypeInfo: TypeInformation[OUT],
-    functionName: String):
-  MapFunction[CRow, OUT] = {
+      physicalTypeInfo: TypeInformation[CRow],
+      schema: RowSchema,
+      requestedTypeInfo: TypeInformation[OUT],
+      functionName: String):
+    MapFunction[CRow, OUT] = {
 
     requestedTypeInfo match {
 
@@ -356,9 +354,7 @@ abstract class StreamTableEnvironment(
     val dataStreamTable = new DataStreamTable[T](
       dataStream,
       fieldIndexes,
-      fieldNames,
-      None,
-      None
+      fieldNames
     )
     registerTableInternal(name, dataStreamTable)
   }
@@ -393,12 +389,14 @@ abstract class StreamTableEnvironment(
           s"But is: ${execEnv.getStreamTimeCharacteristic}")
     }
 
+    // adjust field indexes and field names
+    val indexesWithIndicatorFields = adjustFieldIndexes(fieldIndexes, rowtime, proctime)
+    val namesWithIndicatorFields = adjustFieldNames(fieldNames, rowtime, proctime)
+
     val dataStreamTable = new DataStreamTable[T](
       dataStream,
-      fieldIndexes,
-      fieldNames,
-      rowtime,
-      proctime
+      indexesWithIndicatorFields,
+      namesWithIndicatorFields
     )
     registerTableInternal(name, dataStreamTable)
   }
@@ -499,6 +497,68 @@ abstract class StreamTableEnvironment(
     }
 
     (rowtime, proctime)
+  }
+
+  /**
+    * Injects markers for time indicator fields into the field indexes.
+    * A rowtime indicator is represented as -1, a proctime indicator as -2.
+    *
+    * @param fieldIndexes The field indexes into which the time indicators markers are injected.
+    * @param rowtime An optional rowtime indicator
+    * @param proctime An optional proctime indicator
+    * @return An adjusted array of field indexes.
+    */
+  private def adjustFieldIndexes(
+    fieldIndexes: Array[Int],
+    rowtime: Option[(Int, String)],
+    proctime: Option[(Int, String)]): Array[Int] = {
+
+    // inject rowtime field
+    val withRowtime = if (rowtime.isDefined) {
+      fieldIndexes.patch(rowtime.get._1, Seq(-1), 0) // -1 indicates rowtime
+    } else {
+      fieldIndexes
+    }
+
+    // inject proctime field
+    val withProctime = if (proctime.isDefined) {
+      withRowtime.patch(proctime.get._1, Seq(-2), 0) // -2 indicates proctime
+    } else {
+      withRowtime
+    }
+
+    withProctime
+  }
+
+  /**
+    * Injects names of time indicator fields into the list of field names.
+    *
+    * @param fieldNames The array of field names into which the time indicator field names are
+    *                   injected.
+    * @param rowtime An optional rowtime indicator
+    * @param proctime An optional proctime indicator
+    * @return An adjusted array of field names.
+    */
+  private def adjustFieldNames(
+    fieldNames: Array[String],
+    rowtime: Option[(Int, String)],
+    proctime: Option[(Int, String)]): Array[String] = {
+
+    // inject rowtime field
+    val withRowtime = if (rowtime.isDefined) {
+      fieldNames.patch(rowtime.get._1, Seq(rowtime.get._2), 0)
+    } else {
+      fieldNames
+    }
+
+    // inject proctime field
+    val withProctime = if (proctime.isDefined) {
+      withRowtime.patch(proctime.get._1, Seq(proctime.get._2), 0)
+    } else {
+      withRowtime
+    }
+
+    withProctime
   }
 
   /**
@@ -625,10 +685,21 @@ abstract class StreamTableEnvironment(
     val relNode = table.getRelNode
     val dataStreamPlan = optimize(relNode, updatesAsRetraction)
 
-    // we convert the logical row type to the output row type
-    val convertedOutputType = RelTimeIndicatorConverter.convertOutputType(relNode)
+    // zip original field names with optimized field types
+    val fieldTypes = relNode.getRowType.getFieldList.asScala
+      .zip(dataStreamPlan.getRowType.getFieldList.asScala)
+      // get name of original plan and type of optimized plan
+      .map(x => (x._1.getName, x._2.getType))
+      // add field indexes
+      .zipWithIndex
+      // build new field types
+      .map(x => new RelDataTypeFieldImpl(x._1._1, x._2, x._1._2))
 
-    translate(dataStreamPlan, convertedOutputType, queryConfig, withChangeFlag)
+    // build a record type from list of field types
+    val rowType = new RelRecordType(
+      fieldTypes.toList.asInstanceOf[List[RelDataTypeField]].asJava)
+
+    translate(dataStreamPlan, rowType, queryConfig, withChangeFlag)
   }
 
   /**
@@ -677,12 +748,43 @@ abstract class StreamTableEnvironment(
 
     val rootParallelism = plan.getParallelism
 
-    conversion match {
-      case mapFunction: MapFunction[CRow, A] =>
-        plan.map(mapFunction)
-          .returns(tpe)
-          .name(s"to: ${tpe.getTypeClass.getSimpleName}")
-          .setParallelism(rootParallelism)
+    val rowtimeFields = logicalType.getFieldList.asScala
+      .filter(f => FlinkTypeFactory.isRowtimeIndicatorType(f.getType))
+
+    if (rowtimeFields.isEmpty) {
+      // to rowtime field to set
+
+      conversion match {
+        case mapFunction: MapFunction[CRow, A] =>
+          plan.map(mapFunction)
+            .returns(tpe)
+            .name(s"to: ${tpe.getTypeClass.getSimpleName}")
+            .setParallelism(rootParallelism)
+      }
+    } else if (rowtimeFields.size == 1) {
+      // set the only rowtime field as event-time timestamp for DataStream
+
+      val mapFunction = conversion match {
+        case mapFunction: MapFunction[CRow, A] => mapFunction
+        case _ => new MapFunction[CRow, A] {
+          override def map(cRow: CRow): A = cRow.asInstanceOf[A]
+        }
+      }
+
+      plan.process(
+        new WrappingTimestampSetterProcessFunction[A](
+          mapFunction,
+          rowtimeFields.head.getIndex))
+        .returns(tpe)
+        .name(s"to: ${tpe.getTypeClass.getSimpleName}")
+        .setParallelism(rootParallelism)
+
+    } else {
+      throw new TableException(
+        s"Found more than one rowtime field: [${rowtimeFields.map(_.getName).mkString(", ")}] in " +
+          s"the table that should be converted to a DataStream.\n" +
+          s"Please select the rowtime field that should be used as event-time timestamp for the " +
+          s"DataStream by casting all other fields to TIMESTAMP or LONG.")
     }
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
@@ -729,15 +729,15 @@ abstract class TableEnvironment(val config: TableConfig) {
 
     // validate that at least the field types of physical and logical type match
     // we do that here to make sure that plan translation was correct
-    if (schema.physicalTypeInfo != inputTypeInfo) {
+    if (schema.typeInfo != inputTypeInfo) {
       throw TableException(
         s"The field types of physical and logical row types do not match. " +
-        s"Physical type is [${schema.physicalTypeInfo}], Logical type is [${inputTypeInfo}]. " +
+        s"Physical type is [${schema.typeInfo}], Logical type is [${inputTypeInfo}]. " +
         s"This is a bug and should not happen. Please file an issue.")
     }
 
-    val fieldTypes = schema.physicalFieldTypeInfo
-    val fieldNames = schema.physicalFieldNames
+    val fieldTypes = schema.fieldTypeInfos
+    val fieldNames = schema.fieldNames
 
     // validate requested type
     if (requestedTypeInfo.getArity != fieldTypes.length) {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/RelTimeIndicatorConverter.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/RelTimeIndicatorConverter.scala
@@ -27,7 +27,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.calcite.FlinkTypeFactory.{isRowtimeIndicatorType, _}
-import org.apache.flink.table.functions.ProcTimeMaterializationSqlFunction
+import org.apache.flink.table.functions.ProctimeSqlFunction
 import org.apache.flink.table.plan.logical.rel.LogicalWindowAggregate
 import org.apache.flink.table.plan.schema.TimeIndicatorRelDataType
 
@@ -247,7 +247,7 @@ class RelTimeIndicatorConverter(rexBuilder: RexBuilder) extends RelShuttle {
                 rexBuilder.makeAbstractCast(timestamp, expr)
               } else {
                 // generate proctime access
-                rexBuilder.makeCall(ProcTimeMaterializationSqlFunction, expr)
+                rexBuilder.makeCall(ProctimeSqlFunction, expr)
               }
             } else {
               expr
@@ -271,7 +271,7 @@ class RelTimeIndicatorConverter(rexBuilder: RexBuilder) extends RelShuttle {
               } else {
                 // generate proctime access
                 rexBuilder.makeCall(
-                  ProcTimeMaterializationSqlFunction,
+                  ProctimeSqlFunction,
                   new RexInputRef(field.getIndex, field.getType))
               }
             } else {
@@ -323,12 +323,12 @@ object RelTimeIndicatorConverter {
 
     var needsConversion = false
 
-    // materialize remaining proc time indicators
+    // materialize remaining proctime indicators
     val projects = convertedRoot.getRowType.getFieldList.map(field =>
       if (isProctimeIndicatorType(field.getType)) {
         needsConversion = true
         rexBuilder.makeCall(
-          ProcTimeMaterializationSqlFunction,
+          ProctimeSqlFunction,
           new RexInputRef(field.getIndex, field.getType))
       } else {
         new RexInputRef(field.getIndex, field.getType)
@@ -411,7 +411,7 @@ class RexTimeIndicatorMaterializer(
               rexBuilder.makeAbstractCast(timestamp, o)
             } else {
               // generate proctime access
-              rexBuilder.makeCall(ProcTimeMaterializationSqlFunction, o)
+              rexBuilder.makeCall(ProctimeSqlFunction, o)
             }
           } else {
             o

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/RelTimeIndicatorConverter.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/RelTimeIndicatorConverter.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.calcite
 
-import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFieldImpl, RelRecordType}
+import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core._
 import org.apache.calcite.rel.logical._
 import org.apache.calcite.rel.{RelNode, RelShuttle}
@@ -26,8 +26,8 @@ import org.apache.calcite.rex._
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo
 import org.apache.flink.table.api.{TableException, ValidationException}
-import org.apache.flink.table.calcite.FlinkTypeFactory.isTimeIndicatorType
-import org.apache.flink.table.functions.TimeMaterializationSqlFunction
+import org.apache.flink.table.calcite.FlinkTypeFactory.{isRowtimeIndicatorType, _}
+import org.apache.flink.table.functions.ProcTimeMaterializationSqlFunction
 import org.apache.flink.table.plan.logical.rel.LogicalWindowAggregate
 import org.apache.flink.table.plan.schema.TimeIndicatorRelDataType
 
@@ -242,9 +242,13 @@ class RelTimeIndicatorConverter(rexBuilder: RexBuilder) extends RelShuttle {
         case lp: LogicalProject =>
           val projects = lp.getProjects.zipWithIndex.map { case (expr, idx) =>
             if (isTimeIndicatorType(expr.getType) && refIndices.contains(idx)) {
-              rexBuilder.makeCall(
-                TimeMaterializationSqlFunction,
-                expr)
+              if (isRowtimeIndicatorType(expr.getType)) {
+                // cast rowtime indicator to regular timestamp
+                rexBuilder.makeAbstractCast(timestamp, expr)
+              } else {
+                // generate proctime access
+                rexBuilder.makeCall(ProcTimeMaterializationSqlFunction, expr)
+              }
             } else {
               expr
             }
@@ -259,9 +263,17 @@ class RelTimeIndicatorConverter(rexBuilder: RexBuilder) extends RelShuttle {
         case _ =>
           val projects = input.getRowType.getFieldList.map { field =>
             if (isTimeIndicatorType(field.getType) && refIndices.contains(field.getIndex)) {
-              rexBuilder.makeCall(
-                TimeMaterializationSqlFunction,
-                new RexInputRef(field.getIndex, field.getType))
+              if (isRowtimeIndicatorType(field.getType)) {
+                // cast rowtime indicator to regular timestamp
+                rexBuilder.makeAbstractCast(
+                  timestamp,
+                  new RexInputRef(field.getIndex, field.getType))
+              } else {
+                // generate proctime access
+                rexBuilder.makeCall(
+                  ProcTimeMaterializationSqlFunction,
+                  new RexInputRef(field.getIndex, field.getType))
+              }
             } else {
               new RexInputRef(field.getIndex, field.getType)
             }
@@ -311,19 +323,19 @@ object RelTimeIndicatorConverter {
 
     var needsConversion = false
 
-    // materialize all remaining time indicators
+    // materialize remaining proc time indicators
     val projects = convertedRoot.getRowType.getFieldList.map(field =>
-      if (isTimeIndicatorType(field.getType)) {
+      if (isProctimeIndicatorType(field.getType)) {
         needsConversion = true
         rexBuilder.makeCall(
-          TimeMaterializationSqlFunction,
+          ProcTimeMaterializationSqlFunction,
           new RexInputRef(field.getIndex, field.getType))
       } else {
         new RexInputRef(field.getIndex, field.getType)
       }
     )
 
-    // add final conversion
+    // add final conversion if necessary
     if (needsConversion) {
       LogicalProject.create(
       convertedRoot,
@@ -332,27 +344,6 @@ object RelTimeIndicatorConverter {
     } else {
       convertedRoot
     }
-  }
-
-  def convertOutputType(rootRel: RelNode): RelDataType = {
-
-    val timestamp = rootRel
-      .getCluster
-      .getRexBuilder
-      .getTypeFactory
-      .asInstanceOf[FlinkTypeFactory]
-      .createTypeFromTypeInfo(SqlTimeTypeInfo.TIMESTAMP, isNullable = false)
-
-    // convert all time indicators types to timestamps
-    val fields = rootRel.getRowType.getFieldList.map { field =>
-      if (isTimeIndicatorType(field.getType)) {
-        new RelDataTypeFieldImpl(field.getName, field.getIndex, timestamp)
-      } else {
-        field
-      }
-    }
-
-    new RelRecordType(fields)
   }
 
   /**
@@ -415,7 +406,13 @@ class RexTimeIndicatorMaterializer(
       case _ =>
         updatedCall.getOperands.map { o =>
           if (isTimeIndicatorType(o.getType)) {
-            rexBuilder.makeCall(TimeMaterializationSqlFunction, o)
+            if (isRowtimeIndicatorType(o.getType)) {
+              // cast rowtime indicator to regular timestamp
+              rexBuilder.makeAbstractCast(timestamp, o)
+            } else {
+              // generate proctime access
+              rexBuilder.makeCall(ProcTimeMaterializationSqlFunction, o)
+            }
           } else {
             o
           }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1198,7 +1198,6 @@ abstract class CodeGenerator(
         |""".stripMargin
     } else if (nullCheck) {
       s"""
-        |$tmpTypeTerm $tmpTerm = $fieldTerm;
         |boolean $nullTerm = $fieldTerm == null;
         |$resultTypeTerm $resultTerm;
         |if ($nullTerm) {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -935,9 +935,12 @@ object ScalarOperators {
     }
   }
 
-  def generateConcat(operands: Seq[GeneratedExpression]): GeneratedExpression = {
+  def generateConcat(
+      nullCheck: Boolean,
+      operands: Seq[GeneratedExpression])
+    : GeneratedExpression = {
 
-    generateCallIfArgsNotNull(true, STRING_TYPE_INFO, operands) {
+    generateCallIfArgsNotNull(nullCheck, STRING_TYPE_INFO, operands) {
       (terms) =>s"${qualifyMethod(BuiltInMethods.CONCAT)}(${terms.mkString(", ")})"
     }
   }
@@ -947,6 +950,8 @@ object ScalarOperators {
     val resultTerm = newName("result")
     val nullTerm = newName("isNull")
     val defaultValue = primitiveDefaultValue(Types.STRING)
+
+    val tempTerms = operands.tail.map(_ => newName("temp"))
 
     val operatorCode =
       s"""
@@ -958,11 +963,15 @@ object ScalarOperators {
         |  $nullTerm = true;
         |  $resultTerm = $defaultValue;
         |} else {
-        |
-        |  ${operands.tail.map(o => s"if (${o.nullTerm}) ${o.resultTerm} = null;").mkString("\n")}
+        |  ${operands.tail.zip(tempTerms).map {
+                case (o: GeneratedExpression, t: String) =>
+                  s"String $t;\n" +
+                  s"  if (${o.nullTerm}) $t = null; else $t = ${o.resultTerm};"
+              }.mkString("\n")
+            }
         |  $nullTerm = false;
-        |  $resultTerm = ${qualifyMethod(BuiltInMethods.CONCAT_WS)}(
-        |    ${operands.map(_.resultTerm).mkString(", ")});
+        |  $resultTerm = ${qualifyMethod(BuiltInMethods.CONCAT_WS)}
+        |   (${operands.head.resultTerm}, ${tempTerms.mkString(", ")});
         |}
         |""".stripMargin
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -17,8 +17,6 @@
  */
 package org.apache.flink.table.codegen.calls
 
-import java.lang.reflect.Method
-
 import org.apache.calcite.avatica.util.DateTimeUtils.MILLIS_PER_DAY
 import org.apache.calcite.avatica.util.{DateTimeUtils, TimeUnitRange}
 import org.apache.calcite.util.BuiltInMethod
@@ -937,13 +935,38 @@ object ScalarOperators {
     }
   }
 
-  def generateConcat(
-      method: Method,
-      operands: Seq[GeneratedExpression]): GeneratedExpression = {
+  def generateConcat(operands: Seq[GeneratedExpression]): GeneratedExpression = {
 
-    generateCallIfArgsNotNull(false, STRING_TYPE_INFO, operands) {
-      (terms) =>s"${qualifyMethod(method)}(${terms.mkString(", ")})"
+    generateCallIfArgsNotNull(true, STRING_TYPE_INFO, operands) {
+      (terms) =>s"${qualifyMethod(BuiltInMethods.CONCAT)}(${terms.mkString(", ")})"
     }
+  }
+
+  def generateConcatWs(operands: Seq[GeneratedExpression]): GeneratedExpression = {
+
+    val resultTerm = newName("result")
+    val nullTerm = newName("isNull")
+    val defaultValue = primitiveDefaultValue(Types.STRING)
+
+    val operatorCode =
+      s"""
+        |${operands.map(_.code).mkString("\n")}
+        |
+        |String $resultTerm;
+        |boolean $nullTerm;
+        |if (${operands.head.nullTerm}) {
+        |  $nullTerm = true;
+        |  $resultTerm = $defaultValue;
+        |} else {
+        |
+        |  ${operands.tail.map(o => s"if (${o.nullTerm}) ${o.resultTerm} = null;").mkString("\n")}
+        |  $nullTerm = false;
+        |  $resultTerm = ${qualifyMethod(BuiltInMethods.CONCAT_WS)}(
+        |    ${operands.map(_.resultTerm).mkString(", ")});
+        |}
+        |""".stripMargin
+
+    GeneratedExpression(resultTerm, nullTerm, operatorCode, Types.STRING)
   }
 
   def generateMapGet(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/ProcTimeMaterializationSqlFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/ProcTimeMaterializationSqlFunction.scala
@@ -22,12 +22,12 @@ import org.apache.calcite.sql.`type`._
 import org.apache.calcite.sql.validate.SqlMonotonicity
 
 /**
-  * Function that materializes a time attribute to the metadata timestamp. After materialization
-  * the result can be used in regular arithmetical calculations.
+  * Function that materializes a processing time attribute.
+  * After materialization the result can be used in regular arithmetical calculations.
   */
-object TimeMaterializationSqlFunction
+object ProcTimeMaterializationSqlFunction
   extends SqlFunction(
-    "TIME_MATERIALIZATION",
+    "PROCTIME",
     SqlKind.OTHER_FUNCTION,
     ReturnTypes.explicit(SqlTypeName.TIMESTAMP),
     InferTypes.RETURN_TYPE,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/ProctimeSqlFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/ProctimeSqlFunction.scala
@@ -25,7 +25,7 @@ import org.apache.calcite.sql.validate.SqlMonotonicity
   * Function that materializes a processing time attribute.
   * After materialization the result can be used in regular arithmetical calculations.
   */
-object ProcTimeMaterializationSqlFunction
+object ProctimeSqlFunction
   extends SqlFunction(
     "PROCTIME",
     SqlKind.OTHER_FUNCTION,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/CommonCalc.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/CommonCalc.scala
@@ -42,8 +42,8 @@ trait CommonCalc {
     GeneratedFunction[T, Row] = {
 
     val projection = generator.generateResultExpression(
-      returnSchema.physicalTypeInfo,
-      returnSchema.physicalFieldNames,
+      returnSchema.typeInfo,
+      returnSchema.fieldNames,
       calcProjection)
 
     // only projection
@@ -80,7 +80,7 @@ trait CommonCalc {
       ruleDescription,
       functionClass,
       body,
-      returnSchema.physicalTypeInfo)
+      returnSchema.typeInfo)
   }
 
   private[flink] def conditionToString(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/CommonCorrelate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/CommonCorrelate.scala
@@ -53,8 +53,6 @@ trait CommonCorrelate {
     functionClass: Class[T]):
   GeneratedFunction[T, Row] = {
 
-    val physicalRexCall = inputSchema.mapRexNode(rexCall)
-
     val functionGenerator = new FunctionCodeGenerator(
       config,
       false,
@@ -69,7 +67,7 @@ trait CommonCorrelate {
       .addReusableConstructor(classOf[TableFunctionCollector[_]])
       .head
 
-    val call = functionGenerator.generateExpression(physicalRexCall)
+    val call = functionGenerator.generateExpression(rexCall)
     var body =
       s"""
          |${call.resultTerm}.setCollector($collectorTerm);

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/CommonCorrelate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/CommonCorrelate.scala
@@ -56,7 +56,7 @@ trait CommonCorrelate {
     val functionGenerator = new FunctionCodeGenerator(
       config,
       false,
-      inputSchema.physicalTypeInfo,
+      inputSchema.typeInfo,
       Some(udtfTypeInfo),
       None,
       pojoFieldMapping)
@@ -88,8 +88,8 @@ trait CommonCorrelate {
       }
       val outerResultExpr = functionGenerator.generateResultExpression(
         input1AccessExprs ++ input2NullExprs,
-        returnSchema.physicalTypeInfo,
-        returnSchema.physicalFieldNames)
+        returnSchema.typeInfo,
+        returnSchema.fieldNames)
       body +=
         s"""
            |boolean hasOutput = $collectorTerm.isCollected();
@@ -106,7 +106,7 @@ trait CommonCorrelate {
       ruleDescription,
       functionClass,
       body,
-      returnSchema.physicalTypeInfo)
+      returnSchema.typeInfo)
   }
 
   /**
@@ -124,7 +124,7 @@ trait CommonCorrelate {
     val generator = new CollectorCodeGenerator(
       config,
       false,
-      inputSchema.physicalTypeInfo,
+      inputSchema.typeInfo,
       Some(udtfTypeInfo),
       None,
       pojoFieldMapping)
@@ -133,8 +133,8 @@ trait CommonCorrelate {
 
     val crossResultExpr = generator.generateResultExpression(
       input1AccessExprs ++ input2AccessExprs,
-      returnSchema.physicalTypeInfo,
-      returnSchema.physicalFieldNames)
+      returnSchema.typeInfo,
+      returnSchema.fieldNames)
 
     val collectorCode = if (condition.isEmpty) {
       s"""
@@ -146,7 +146,7 @@ trait CommonCorrelate {
       // adjust indicies of InputRefs to adhere to schema expected by generator
       val changeInputRefIndexShuttle = new RexShuttle {
         override def visitInputRef(inputRef: RexInputRef): RexNode = {
-          new RexInputRef(inputSchema.physicalArity + inputRef.getIndex, inputRef.getType)
+          new RexInputRef(inputSchema.arity + inputRef.getIndex, inputRef.getType)
         }
       }
       // Run generateExpression to add init statements (ScalarFunctions) of condition to generator.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/PhysicalTableSourceScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/PhysicalTableSourceScan.scala
@@ -39,9 +39,7 @@ abstract class PhysicalTableSourceScan(
     val flinkTypeFactory = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
     flinkTypeFactory.buildLogicalRowType(
       TableEnvironment.getFieldNames(tableSource),
-      TableEnvironment.getFieldTypes(tableSource.getReturnType),
-      None,
-      None)
+      TableEnvironment.getFieldTypes(tableSource.getReturnType))
   }
 
   override def explainTerms(pw: RelWriter): RelWriter = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/BatchTableSourceScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/BatchTableSourceScan.scala
@@ -42,9 +42,7 @@ class BatchTableSourceScan(
     val flinkTypeFactory = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
     flinkTypeFactory.buildLogicalRowType(
       TableEnvironment.getFieldNames(tableSource),
-      TableEnvironment.getFieldTypes(tableSource.getReturnType),
-      None,
-      None)
+      TableEnvironment.getFieldTypes(tableSource.getReturnType))
   }
 
   override def computeSelfCost (planner: RelOptPlanner, metadata: RelMetadataQuery): RelOptCost = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCalc.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCalc.scala
@@ -110,10 +110,6 @@ class DataStreamCalc(
     // filter out time attributes
     val projection = calcProgram.getProjectList.asScala
       .map(calcProgram.expandLocalRef)
-      // time indicator fields must not be part of the code generation
-      .filter(expr => !FlinkTypeFactory.isTimeIndicatorType(expr.getType))
-      // update indices
-      .map(expr => inputSchema.mapRexNode(expr))
 
     val generator = new FunctionCodeGenerator(config, false, inputSchema.physicalTypeInfo)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCalc.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCalc.scala
@@ -52,7 +52,7 @@ class DataStreamCalc(
   with CommonCalc
   with DataStreamRel {
 
-  override def deriveRowType(): RelDataType = schema.logicalType
+  override def deriveRowType(): RelDataType = schema.relDataType
 
   override def copy(traitSet: RelTraitSet, child: RelNode, program: RexProgram): Calc = {
     new DataStreamCalc(
@@ -100,7 +100,7 @@ class DataStreamCalc(
     val condition = if (calcProgram.getCondition != null) {
       val materializedCondition = RelTimeIndicatorConverter.convertExpression(
         calcProgram.expandLocalRef(calcProgram.getCondition),
-        inputSchema.logicalType,
+        inputSchema.relDataType,
         cluster.getRexBuilder)
       Some(materializedCondition)
     } else {
@@ -111,7 +111,7 @@ class DataStreamCalc(
     val projection = calcProgram.getProjectList.asScala
       .map(calcProgram.expandLocalRef)
 
-    val generator = new FunctionCodeGenerator(config, false, inputSchema.physicalTypeInfo)
+    val generator = new FunctionCodeGenerator(config, false, inputSchema.typeInfo)
 
     val genFunction = generateFunction(
       generator,
@@ -128,7 +128,7 @@ class DataStreamCalc(
     val processFunc = new CRowProcessRunner(
       genFunction.name,
       genFunction.code,
-      CRowTypeInfo(schema.physicalTypeInfo))
+      CRowTypeInfo(schema.typeInfo))
 
     inputDataStream
       .process(processFunc)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCorrelate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCorrelate.scala
@@ -50,7 +50,7 @@ class DataStreamCorrelate(
   with CommonCorrelate
   with DataStreamRel {
 
-  override def deriveRowType() = schema.logicalType
+  override def deriveRowType() = schema.relDataType
 
   override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
     new DataStreamCorrelate(
@@ -78,7 +78,7 @@ class DataStreamCorrelate(
     super.explainTerms(pw)
       .item("invocation", scan.getCall)
       .item("function", sqlFunction.getTableFunction.getClass.getCanonicalName)
-      .item("rowType", schema.logicalType)
+      .item("rowType", schema.relDataType)
       .item("joinType", joinType)
       .itemIf("condition", condition.orNull, condition.isDefined)
   }
@@ -130,7 +130,7 @@ class DataStreamCorrelate(
       .process(processFunc)
       // preserve input parallelism to ensure that acc and retract messages remain in order
       .setParallelism(inputParallelism)
-      .name(correlateOpName(rexCall, sqlFunction, schema.logicalType))
+      .name(correlateOpName(rexCall, sqlFunction, schema.relDataType))
   }
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamScan.scala
@@ -43,7 +43,7 @@ class DataStreamScan(
 
   val dataStreamTable: DataStreamTable[Any] = getTable.unwrap(classOf[DataStreamTable[Any]])
 
-  override def deriveRowType(): RelDataType = schema.logicalType
+  override def deriveRowType(): RelDataType = schema.relDataType
 
   override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
     new DataStreamScan(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamUnion.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamUnion.scala
@@ -38,7 +38,7 @@ class DataStreamUnion(
   extends BiRel(cluster, traitSet, leftNode, rightNode)
   with DataStreamRel {
 
-  override def deriveRowType() = schema.logicalType
+  override def deriveRowType() = schema.relDataType
 
   override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
     new DataStreamUnion(
@@ -55,7 +55,7 @@ class DataStreamUnion(
   }
 
   override def toString = {
-    s"Union All(union: (${schema.logicalFieldNames.mkString(", ")}))"
+    s"Union All(union: (${schema.fieldNames.mkString(", ")}))"
   }
 
   override def translateToPlan(
@@ -68,6 +68,6 @@ class DataStreamUnion(
   }
 
   private def unionSelectionToString: String = {
-    schema.logicalFieldNames.mkString(", ")
+    schema.fieldNames.mkString(", ")
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamWindowJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamWindowJoin.scala
@@ -54,7 +54,7 @@ class DataStreamWindowJoin(
     with CommonJoin
     with DataStreamRel {
 
-  override def deriveRowType(): RelDataType = schema.logicalType
+  override def deriveRowType(): RelDataType = schema.relDataType
 
   override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
     new DataStreamWindowJoin(
@@ -76,7 +76,7 @@ class DataStreamWindowJoin(
 
   override def toString: String = {
     joinToString(
-      schema.logicalType,
+      schema.relDataType,
       joinCondition,
       joinType,
       getExpressionString)
@@ -85,7 +85,7 @@ class DataStreamWindowJoin(
   override def explainTerms(pw: RelWriter): RelWriter = {
     joinExplainTerms(
       super.explainTerms(pw),
-      schema.logicalType,
+      schema.relDataType,
       joinCondition,
       joinType,
       getExpressionString)
@@ -117,8 +117,8 @@ class DataStreamWindowJoin(
     WindowJoinUtil.generateJoinFunction(
       config,
       joinType,
-      leftSchema.physicalTypeInfo,
-      rightSchema.physicalTypeInfo,
+      leftSchema.typeInfo,
+      rightSchema.typeInfo,
       schema,
       remainCondition,
       ruleDescription)
@@ -160,13 +160,13 @@ class DataStreamWindowJoin(
       leftKeys: Array[Int],
       rightKeys: Array[Int]): DataStream[CRow] = {
 
-    val returnTypeInfo = CRowTypeInfo(schema.physicalTypeInfo)
+    val returnTypeInfo = CRowTypeInfo(schema.typeInfo)
 
     val procInnerJoinFunc = new ProcTimeWindowInnerJoin(
       leftLowerBound,
       leftUpperBound,
-      leftSchema.physicalTypeInfo,
-      rightSchema.physicalTypeInfo,
+      leftSchema.typeInfo,
+      rightSchema.typeInfo,
       joinFunctionName,
       joinFunctionCode)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamScan.scala
@@ -18,14 +18,15 @@
 
 package org.apache.flink.table.plan.nodes.datastream
 
-import org.apache.flink.api.common.functions.MapFunction
 import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.table.api.TableConfig
+import org.apache.flink.table.codegen.FunctionCodeGenerator
 import org.apache.flink.table.plan.nodes.CommonScan
 import org.apache.flink.table.plan.schema.RowSchema
 import org.apache.flink.types.Row
 import org.apache.flink.table.plan.schema.FlinkTable
-import org.apache.flink.table.runtime.CRowOutputMapRunner
+import org.apache.flink.table.runtime.CRowOutputProcessRunner
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
 
 import scala.collection.JavaConverters._
@@ -45,24 +46,37 @@ trait StreamScan extends CommonScan[CRow] with DataStreamRel {
     // conversion
     if (needsConversion(input.getType, internalType)) {
 
-      val function = generatedConversionFunction(
+      val generator = new FunctionCodeGenerator(
         config,
-        classOf[MapFunction[Any, Row]],
+        false,
         inputType,
-        schema.physicalTypeInfo,
-        "DataStreamSourceConversion",
-        schema.physicalFieldNames,
+        None,
         Some(flinkTable.fieldIndexes))
 
-      val mapFunc = new CRowOutputMapRunner(
+      val conversion = generator.generateConverterResultExpression(
+        schema.physicalTypeInfo,
+        schema.physicalFieldNames)
+
+      val body =
+        s"""
+           |${conversion.code}
+           |${generator.collectorTerm}.collect(${conversion.resultTerm});
+           |""".stripMargin
+
+      val function = generator.generateFunction(
+        "DataStreamSourceConversion",
+        classOf[ProcessFunction[Any, Row]],
+        body,
+        schema.physicalTypeInfo)
+
+      val processFunc = new CRowOutputProcessRunner(
         function.name,
         function.code,
         internalType)
 
       val opName = s"from: (${getRowType.getFieldNames.asScala.toList.mkString(", ")})"
 
-      // TODO we need a ProcessFunction here
-      input.map(mapFunc).name(opName).returns(internalType)
+      input.process(processFunc).name(opName).returns(internalType)
     }
     // no conversion necessary, forward
     else {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamScan.scala
@@ -41,7 +41,7 @@ trait StreamScan extends CommonScan[CRow] with DataStreamRel {
     : DataStream[CRow] = {
 
     val inputType = input.getType
-    val internalType = CRowTypeInfo(schema.physicalTypeInfo)
+    val internalType = CRowTypeInfo(schema.typeInfo)
 
     // conversion
     if (needsConversion(input.getType, internalType)) {
@@ -54,8 +54,8 @@ trait StreamScan extends CommonScan[CRow] with DataStreamRel {
         Some(flinkTable.fieldIndexes))
 
       val conversion = generator.generateConverterResultExpression(
-        schema.physicalTypeInfo,
-        schema.physicalFieldNames)
+        schema.typeInfo,
+        schema.fieldNames)
 
       val body =
         s"""
@@ -67,7 +67,7 @@ trait StreamScan extends CommonScan[CRow] with DataStreamRel {
         "DataStreamSourceConversion",
         classOf[ProcessFunction[Any, Row]],
         body,
-        schema.physicalTypeInfo)
+        schema.typeInfo)
 
       val processFunc = new CRowOutputProcessRunner(
         function.name,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
@@ -30,6 +30,7 @@ import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.schema.TableSourceTable
 import org.apache.flink.table.sources.{DefinedProctimeAttribute, DefinedRowtimeAttribute, TableSource}
+import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 
 import scala.collection.JavaConverters._
 
@@ -51,29 +52,29 @@ class FlinkLogicalTableSourceScan(
     val fieldNames = TableEnvironment.getFieldNames(tableSource).toList
     val fieldTypes = TableEnvironment.getFieldTypes(tableSource.getReturnType).toList
 
-    val fieldCnt = fieldNames.length
+    val fields = fieldNames.zip(fieldTypes)
 
-    val rowtime = tableSource match {
+    val withRowtime = tableSource match {
       case timeSource: DefinedRowtimeAttribute if timeSource.getRowtimeAttribute != null =>
         val rowtimeAttribute = timeSource.getRowtimeAttribute
-        Some((fieldCnt, rowtimeAttribute))
+        fields :+ (rowtimeAttribute, TimeIndicatorTypeInfo.ROWTIME_INDICATOR)
       case _ =>
-        None
+        fields
     }
 
-    val proctime = tableSource match {
+    val withProctime = tableSource match {
       case timeSource: DefinedProctimeAttribute if timeSource.getProctimeAttribute != null =>
         val proctimeAttribute = timeSource.getProctimeAttribute
-        Some((fieldCnt + (if (rowtime.isDefined) 1 else 0), proctimeAttribute))
+        withRowtime :+ (proctimeAttribute, TimeIndicatorTypeInfo.PROCTIME_INDICATOR)
       case _ =>
-        None
+        withRowtime
     }
 
+    val (fieldNamesWithIndicators, fieldTypesWithIndicators) = withProctime.unzip
+
     flinkTypeFactory.buildLogicalRowType(
-      fieldNames,
-      fieldTypes,
-      rowtime,
-      proctime)
+      fieldNamesWithIndicators,
+      fieldTypesWithIndicators)
   }
 
   override def computeSelfCost(planner: RelOptPlanner, metadata: RelMetadataQuery): RelOptCost = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamWindowJoinRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamWindowJoinRule.scala
@@ -87,7 +87,7 @@ class DataStreamWindowJoinRule
     val (windowBounds, remainCondition) =
       WindowJoinUtil.extractWindowBoundsFromPredicate(
         joinInfo.getRemaining(join.getCluster.getRexBuilder),
-        leftRowSchema.logicalArity,
+        leftRowSchema.arity,
         join.getRowType,
         join.getCluster.getRexBuilder,
         TableConfig.DEFAULT)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/DataStreamTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/DataStreamTable.scala
@@ -18,27 +18,14 @@
 
 package org.apache.flink.table.plan.schema
 
-import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory}
 import org.apache.flink.streaming.api.datastream.DataStream
-import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.plan.stats.FlinkStatistic
 
 class DataStreamTable[T](
     val dataStream: DataStream[T],
     override val fieldIndexes: Array[Int],
     override val fieldNames: Array[String],
-    val rowtime: Option[(Int, String)],
-    val proctime: Option[(Int, String)],
     override val statistic: FlinkStatistic = FlinkStatistic.UNKNOWN)
   extends FlinkTable[T](dataStream.getType, fieldIndexes, fieldNames, statistic) {
 
-  override def getRowType(typeFactory: RelDataTypeFactory): RelDataType = {
-    val flinkTypeFactory = typeFactory.asInstanceOf[FlinkTypeFactory]
-
-    flinkTypeFactory.buildLogicalRowType(
-      fieldNames,
-      fieldTypes,
-      rowtime,
-      proctime)
-  }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/FlinkTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/FlinkTable.scala
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeutils.CompositeType
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.plan.stats.FlinkStatistic
+import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 
 abstract class FlinkTable[T](
     val typeInfo: TypeInformation[T],
@@ -49,12 +50,15 @@ abstract class FlinkTable[T](
     typeInfo match {
       case cType: CompositeType[_] =>
         // it is ok to leave out fields
-        if (fieldNames.length > cType.getArity) {
+        if (fieldIndexes.count(_ >= 0) > cType.getArity) {
           throw new TableException(
           s"Arity of type (" + cType.getFieldNames.deep + ") " +
             "must not be greater than number of field names " + fieldNames.deep + ".")
         }
-        fieldIndexes.map(cType.getTypeAt(_).asInstanceOf[TypeInformation[_]])
+        fieldIndexes.map {
+          case -1 => TimeIndicatorTypeInfo.ROWTIME_INDICATOR
+          case -2 => TimeIndicatorTypeInfo.PROCTIME_INDICATOR
+          case i => cType.getTypeAt(i).asInstanceOf[TypeInformation[_]]}
       case aType: AtomicType[_] =>
         if (fieldIndexes.length != 1 || fieldIndexes(0) != 0) {
           throw new TableException(
@@ -65,7 +69,7 @@ abstract class FlinkTable[T](
 
   override def getRowType(typeFactory: RelDataTypeFactory): RelDataType = {
     val flinkTypeFactory = typeFactory.asInstanceOf[FlinkTypeFactory]
-    flinkTypeFactory.buildLogicalRowType(fieldNames, fieldTypes, None, None)
+    flinkTypeFactory.buildLogicalRowType(fieldNames, fieldTypes)
   }
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/FlinkTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/FlinkTable.scala
@@ -56,8 +56,8 @@ abstract class FlinkTable[T](
             "must not be greater than number of field names " + fieldNames.deep + ".")
         }
         fieldIndexes.map {
-          case -1 => TimeIndicatorTypeInfo.ROWTIME_INDICATOR
-          case -2 => TimeIndicatorTypeInfo.PROCTIME_INDICATOR
+          case TimeIndicatorTypeInfo.ROWTIME_MARKER => TimeIndicatorTypeInfo.ROWTIME_INDICATOR
+          case TimeIndicatorTypeInfo.PROCTIME_MARKER => TimeIndicatorTypeInfo.PROCTIME_INDICATOR
           case i => cType.getTypeAt(i).asInstanceOf[TypeInformation[_]]}
       case aType: AtomicType[_] =>
         if (fieldIndexes.length != 1 || fieldIndexes(0) != 0) {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/RowSchema.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/RowSchema.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.plan.schema
 
-import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeField, RelRecordType}
+import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.calcite.FlinkTypeFactory
@@ -31,57 +31,35 @@ import scala.collection.JavaConversions._
   */
 class RowSchema(private val logicalRowType: RelDataType) {
 
-  private lazy val physicalRowFields: Seq[RelDataTypeField] = logicalRowType.getFieldList
-
-  private lazy val physicalRowType: RelDataType = new RelRecordType(physicalRowFields)
-
-  private lazy val physicalRowFieldTypes: Seq[TypeInformation[_]] = physicalRowFields map { f =>
-    FlinkTypeFactory.toTypeInfo(f.getType)
-  }
-
-  private lazy val physicalRowFieldNames: Seq[String] = physicalRowFields.map(_.getName)
+  private lazy val physicalRowFieldTypes: Seq[TypeInformation[_]] =
+    logicalRowType.getFieldList map { f => FlinkTypeFactory.toTypeInfo(f.getType) }
 
   private lazy val physicalRowTypeInfo: TypeInformation[Row] = new RowTypeInfo(
-    physicalRowFieldTypes.toArray, physicalRowFieldNames.toArray)
+    physicalRowFieldTypes.toArray, fieldNames.toArray)
 
   /**
-    * Returns the arity of the logical record.
+    * Returns the arity of the schema.
     */
-  def logicalArity: Int = logicalRowType.getFieldCount
+  def arity: Int = logicalRowType.getFieldCount
 
   /**
-    * Returns the arity of the physical record.
+    * Returns the [[RelDataType]] of the schema
     */
-  def physicalArity: Int = physicalTypeInfo.getArity
+  def relDataType: RelDataType = logicalRowType
 
   /**
-    * Returns a logical [[RelDataType]] including logical fields (i.e. time indicators).
+    * Returns the [[TypeInformation]] of of the schema
     */
-  def logicalType: RelDataType = logicalRowType
+  def typeInfo: TypeInformation[Row] = physicalRowTypeInfo
 
   /**
-    * Returns a physical [[RelDataType]] with no logical fields (i.e. time indicators).
+    * Returns the [[TypeInformation]] of fields of the schema
     */
-  def physicalType: RelDataType = physicalRowType
+  def fieldTypeInfos: Seq[TypeInformation[_]] = physicalRowFieldTypes
 
   /**
-    * Returns a physical [[TypeInformation]] of row with no logical fields (i.e. time indicators).
+    * Returns the fields names
     */
-  def physicalTypeInfo: TypeInformation[Row] = physicalRowTypeInfo
-
-  /**
-    * Returns [[TypeInformation]] of the row's fields with no logical fields (i.e. time indicators).
-    */
-  def physicalFieldTypeInfo: Seq[TypeInformation[_]] = physicalRowFieldTypes
-
-  /**
-    * Returns the logical fields names including logical fields (i.e. time indicators).
-    */
-  def logicalFieldNames: Seq[String] = logicalRowType.getFieldNames
-
-  /**
-    * Returns the physical fields names with no logical fields (i.e. time indicators).
-    */
-  def physicalFieldNames: Seq[String] = physicalRowFieldNames
+  def fieldNames: Seq[String] = logicalRowType.getFieldNames
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/RowSchema.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/RowSchema.scala
@@ -19,13 +19,9 @@
 package org.apache.flink.table.plan.schema
 
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeField, RelRecordType}
-import org.apache.calcite.rel.core.AggregateCall
-import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode, RexShuttle}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.RowTypeInfo
-import org.apache.flink.table.api.TableException
 import org.apache.flink.table.calcite.FlinkTypeFactory
-import org.apache.flink.table.functions.TimeMaterializationSqlFunction
 import org.apache.flink.types.Row
 
 import scala.collection.JavaConversions._
@@ -35,9 +31,7 @@ import scala.collection.JavaConversions._
   */
 class RowSchema(private val logicalRowType: RelDataType) {
 
-  private lazy val physicalRowFields: Seq[RelDataTypeField] = logicalRowType.getFieldList filter {
-    field => !FlinkTypeFactory.isTimeIndicatorType(field.getType)
-  }
+  private lazy val physicalRowFields: Seq[RelDataTypeField] = logicalRowType.getFieldList
 
   private lazy val physicalRowType: RelDataType = new RelRecordType(physicalRowFields)
 
@@ -49,43 +43,6 @@ class RowSchema(private val logicalRowType: RelDataType) {
 
   private lazy val physicalRowTypeInfo: TypeInformation[Row] = new RowTypeInfo(
     physicalRowFieldTypes.toArray, physicalRowFieldNames.toArray)
-
-  private lazy val indexMapping: Array[Int] = generateIndexMapping
-
-  private lazy val inputRefUpdater = new RexInputRefUpdater()
-
-  private def generateIndexMapping: Array[Int] = {
-    val mapping = new Array[Int](logicalRowType.getFieldCount)
-    var countTimeIndicators = 0
-    var i = 0
-    while (i < logicalRowType.getFieldCount) {
-      val t = logicalRowType.getFieldList.get(i).getType
-      if (FlinkTypeFactory.isTimeIndicatorType(t)) {
-        countTimeIndicators += 1
-        // no mapping
-        mapping(i) = -1
-      } else {
-        mapping(i) = i - countTimeIndicators
-      }
-      i += 1
-    }
-    mapping
-  }
-
-  private class RexInputRefUpdater extends RexShuttle {
-
-    override def visitInputRef(inputRef: RexInputRef): RexNode = {
-      new RexInputRef(mapIndex(inputRef.getIndex), inputRef.getType)
-    }
-
-    override def visitCall(call: RexCall): RexNode = call.getOperator match {
-      // we leave time indicators unchanged yet
-      // the index becomes invalid but right now we are only
-      // interested in the type of the input reference
-      case TimeMaterializationSqlFunction => call
-      case _ => super.visitCall(call)
-    }
-  }
 
   /**
     * Returns the arity of the logical record.
@@ -126,36 +83,5 @@ class RowSchema(private val logicalRowType: RelDataType) {
     * Returns the physical fields names with no logical fields (i.e. time indicators).
     */
   def physicalFieldNames: Seq[String] = physicalRowFieldNames
-
-  /**
-    * Converts logical indices to physical indices based on this schema.
-    */
-  def mapIndex(logicalIndex: Int): Int = {
-    val mappedIndex = indexMapping(logicalIndex)
-    if (mappedIndex < 0) {
-      throw new TableException("Invalid access to a logical field.")
-    } else {
-      mappedIndex
-    }
-  }
-
-  /**
-    * Converts logical indices of a aggregate call to physical ones.
-    */
-  def mapAggregateCall(logicalAggCall: AggregateCall): AggregateCall = {
-    logicalAggCall.copy(
-      logicalAggCall.getArgList.map(mapIndex(_).asInstanceOf[Integer]),
-      if (logicalAggCall.filterArg < 0) {
-        logicalAggCall.filterArg
-      } else {
-        mapIndex(logicalAggCall.filterArg)
-      }
-    )
-  }
-
-  /**
-    * Converts logical field references of a [[RexNode]] to physical ones.
-    */
-  def mapRexNode(logicalRexNode: RexNode): RexNode = logicalRexNode.accept(inputRefUpdater)
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowOutputProcessRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowOutputProcessRunner.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.operators.TimestampedCollector
+import org.apache.flink.table.codegen.Compiler
+import org.apache.flink.table.runtime.types.CRow
+import org.apache.flink.types.Row
+import org.apache.flink.util.Collector
+import org.slf4j.LoggerFactory
+
+/**
+  * ProcessRunner with [[CRow]] output.
+  */
+class CRowOutputProcessRunner(
+    name: String,
+    code: String,
+    @transient var returnType: TypeInformation[CRow])
+  extends ProcessFunction[Any, CRow]
+  with ResultTypeQueryable[CRow]
+  with Compiler[ProcessFunction[Any, Row]] {
+
+  val LOG = LoggerFactory.getLogger(this.getClass)
+
+  private var function: ProcessFunction[Any, Row] = _
+  private var cRowWrapper: CRowWrappingCollector = _
+
+  override def open(parameters: Configuration): Unit = {
+    LOG.debug(s"Compiling MapFunction: $name \n\n Code:\n$code")
+    val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
+    LOG.debug("Instantiating MapFunction.")
+    function = clazz.newInstance()
+
+    this.cRowWrapper = new CRowWrappingCollector()
+    this.cRowWrapper.setChange(true)
+  }
+
+  override def processElement(
+      in: Any,
+      ctx: ProcessFunction[Any, CRow]#Context,
+      out: Collector[CRow]): Unit = {
+
+    // remove timestamp from stream record
+    val tc = out.asInstanceOf[TimestampedCollector[_]]
+    tc.eraseTimestamp()
+
+    cRowWrapper.out = out
+    function.processElement(in, ctx.asInstanceOf[ProcessFunction[Any, Row]#Context], cRowWrapper)
+  }
+
+  override def getProducedType: TypeInformation[CRow] = returnType
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowOutputProcessRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowOutputProcessRunner.scala
@@ -46,9 +46,9 @@ class CRowOutputProcessRunner(
   private var cRowWrapper: CRowWrappingCollector = _
 
   override def open(parameters: Configuration): Unit = {
-    LOG.debug(s"Compiling MapFunction: $name \n\n Code:\n$code")
+    LOG.debug(s"Compiling ProcessFunction: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
-    LOG.debug("Instantiating MapFunction.")
+    LOG.debug("Instantiating ProcessFunction.")
     function = clazz.newInstance()
 
     this.cRowWrapper = new CRowWrappingCollector()

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/WrappingTimestampSetterProcessFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/WrappingTimestampSetterProcessFunction.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime
+
+import java.sql.Timestamp
+
+import org.apache.calcite.runtime.SqlFunctions
+import org.apache.flink.api.common.functions.{MapFunction, RichMapFunction}
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.operators.TimestampedCollector
+import org.apache.flink.table.runtime.types.CRow
+import org.apache.flink.util.Collector
+
+/**
+  * Wraps a ProcessFunction and sets a Timestamp field of a CRow as
+  * [[org.apache.flink.streaming.runtime.streamrecord.StreamRecord]] timestamp.
+  */
+class WrappingTimestampSetterProcessFunction[OUT](
+    function: MapFunction[CRow, OUT],
+    rowtimeIdx: Int)
+  extends ProcessFunction[CRow, OUT] {
+
+  override def open(parameters: Configuration): Unit = {
+    super.open(parameters)
+    function match {
+      case f: RichMapFunction[_, _] =>
+        f.setRuntimeContext(getRuntimeContext)
+        f.open(parameters)
+      case _ =>
+    }
+  }
+
+  override def processElement(
+      in: CRow,
+      ctx: ProcessFunction[CRow, OUT]#Context,
+      out: Collector[OUT]): Unit = {
+
+    val timestamp = SqlFunctions.toLong(in.row.getField(rowtimeIdx).asInstanceOf[Timestamp])
+    out.asInstanceOf[TimestampedCollector[_]].setAbsoluteTimestamp(timestamp)
+
+    out.collect(function.map(in))
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
@@ -1147,22 +1147,22 @@ object AggregateUtil {
 
     val propPos = properties.foldRight(
       (None: Option[Int], None: Option[Int], None: Option[Int], 0)) {
-      (p, x) => p match {
+      case (p, (s, e, t, i)) => p match {
         case NamedWindowProperty(_, prop) =>
           prop match {
-            case WindowStart(_) if x._1.isDefined =>
+            case WindowStart(_) if s.isDefined =>
               throw new TableException("Duplicate WindowStart property encountered. This is a bug.")
             case WindowStart(_) =>
-              (Some(x._4), x._2, x._3, x._4 - 1)
-            case WindowEnd(_) if x._2.isDefined =>
+              (Some(i), e, t, i - 1)
+            case WindowEnd(_) if e.isDefined =>
               throw new TableException("Duplicate WindowEnd property encountered. This is a bug.")
             case WindowEnd(_) =>
-              (x._1, Some(x._4), x._3, x._4 - 1)
-            case RowtimeAttribute(_) if x._3.isDefined =>
+              (s, Some(i), t, i - 1)
+            case RowtimeAttribute(_) if t.isDefined =>
               throw new TableException(
                 "Duplicate Window rowtime property encountered. This is a bug.")
             case RowtimeAttribute(_) =>
-              (x._1, x._2, Some(x._4), x._4 - 1)
+              (s, e, Some(i), i - 1)
           }
       }
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
@@ -35,7 +35,7 @@ import org.apache.flink.streaming.api.windowing.windows.{Window => DataStreamWin
 import org.apache.flink.table.api.{StreamQueryConfig, TableException}
 import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
 import org.apache.flink.table.calcite.FlinkTypeFactory
-import org.apache.flink.table.codegen.{AggregationCodeGenerator, CodeGenerator}
+import org.apache.flink.table.codegen.AggregationCodeGenerator
 import org.apache.flink.table.expressions.ExpressionUtils.isTimeIntervalLiteral
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.aggfunctions._
@@ -66,7 +66,7 @@ object AggregateUtil {
     * @param inputType Physical type of the row.
     * @param inputTypeInfo Physical type information of the row.
     * @param inputFieldTypeInfo Physical type information of the row's fields.
-    * @param isRowTimeType It is a tag that indicates whether the time type is rowTimeType
+    * @param rowTimeIdx The index of the rowtime field or None in case of processing time.
     * @param isPartitioned It is a tag that indicate whether the input is partitioned
     * @param isRowsClause It is a tag that indicates whether the OVER clause is ROWS clause
     */
@@ -77,7 +77,7 @@ object AggregateUtil {
       inputTypeInfo: TypeInformation[Row],
       inputFieldTypeInfo: Seq[TypeInformation[_]],
       queryConfig: StreamQueryConfig,
-      isRowTimeType: Boolean,
+      rowTimeIdx: Option[Int],
       isPartitioned: Boolean,
       isRowsClause: Boolean)
     : ProcessFunction[CRow, CRow] = {
@@ -111,13 +111,14 @@ object AggregateUtil {
       needReset = false
     )
 
-    if (isRowTimeType) {
+    if (rowTimeIdx.isDefined) {
       if (isRowsClause) {
         // ROWS unbounded over process function
         new RowTimeUnboundedRowsOver(
           genFunction,
           aggregationStateType,
           CRowTypeInfo(inputTypeInfo),
+          rowTimeIdx.get,
           queryConfig)
       } else {
         // RANGE unbounded over process function
@@ -125,6 +126,7 @@ object AggregateUtil {
           genFunction,
           aggregationStateType,
           CRowTypeInfo(inputTypeInfo),
+          rowTimeIdx.get,
           queryConfig)
       }
     } else {
@@ -207,7 +209,7 @@ object AggregateUtil {
     * @param inputFieldTypeInfo Physical type information of the row's fields.
     * @param precedingOffset the preceding offset
     * @param isRowsClause    It is a tag that indicates whether the OVER clause is ROWS clause
-    * @param isRowTimeType   It is a tag that indicates whether the time type is rowTimeType
+    * @param rowTimeIdx      The index of the rowtime field or None in case of processing time.
     * @return [[org.apache.flink.streaming.api.functions.ProcessFunction]]
     */
   private[flink] def createBoundedOverProcessFunction(
@@ -219,7 +221,7 @@ object AggregateUtil {
       precedingOffset: Long,
       queryConfig: StreamQueryConfig,
       isRowsClause: Boolean,
-      isRowTimeType: Boolean)
+      rowTimeIdx: Option[Int])
     : ProcessFunction[CRow, CRow] = {
 
     val needRetract = true
@@ -253,13 +255,14 @@ object AggregateUtil {
       needReset = true
     )
 
-    if (isRowTimeType) {
+    if (rowTimeIdx.isDefined) {
       if (isRowsClause) {
         new RowTimeBoundedRowsOver(
           genFunction,
           aggregationStateType,
           inputRowType,
           precedingOffset,
+          rowTimeIdx.get,
           queryConfig)
       } else {
         new RowTimeBoundedRangeOver(
@@ -267,6 +270,7 @@ object AggregateUtil {
           aggregationStateType,
           inputRowType,
           precedingOffset,
+          rowTimeIdx.get,
           queryConfig)
       }
     } else {
@@ -588,7 +592,7 @@ object AggregateUtil {
     window match {
       case TumblingGroupWindow(_, _, size) if isTimeInterval(size.resultType) =>
         // tumbling time window
-        val (startPos, endPos) = computeWindowStartEndPropertyPos(properties)
+        val (startPos, endPos, _) = computeWindowPropertyPos(properties)
         if (doAllSupportPartialMerge(aggregates)) {
           // for incremental aggregations
           new DataSetTumbleTimeWindowAggReduceCombineFunction(
@@ -615,7 +619,7 @@ object AggregateUtil {
           asLong(size))
 
       case SessionGroupWindow(_, _, gap) =>
-        val (startPos, endPos) = computeWindowStartEndPropertyPos(properties)
+        val (startPos, endPos, _) = computeWindowPropertyPos(properties)
         new DataSetSessionWindowAggReduceGroupFunction(
           genFinalAggFunction,
           keysAndAggregatesArity,
@@ -625,7 +629,7 @@ object AggregateUtil {
           isInputCombined)
 
       case SlidingGroupWindow(_, _, size, _) if isTimeInterval(size.resultType) =>
-        val (startPos, endPos) = computeWindowStartEndPropertyPos(properties)
+        val (startPos, endPos, _) = computeWindowPropertyPos(properties)
         if (doAllSupportPartialMerge(aggregates)) {
           // for partial aggregations
           new DataSetSlideWindowAggReduceCombineFunction(
@@ -951,10 +955,11 @@ object AggregateUtil {
     : AllWindowFunction[Row, CRow, DataStreamWindow] = {
 
     if (isTimeWindow(window)) {
-      val (startPos, endPos) = computeWindowStartEndPropertyPos(properties)
+      val (startPos, endPos, timePos) = computeWindowPropertyPos(properties)
       new IncrementalAggregateAllTimeWindowFunction(
         startPos,
         endPos,
+        timePos,
         finalRowArity)
         .asInstanceOf[AllWindowFunction[Row, CRow, DataStreamWindow]]
     } else {
@@ -975,12 +980,13 @@ object AggregateUtil {
     WindowFunction[Row, CRow, Tuple, DataStreamWindow] = {
 
     if (isTimeWindow(window)) {
-      val (startPos, endPos) = computeWindowStartEndPropertyPos(properties)
+      val (startPos, endPos, timePos) = computeWindowPropertyPos(properties)
       new IncrementalAggregateTimeWindowFunction(
         numGroupingKeys,
         numAggregates,
         startPos,
         endPos,
+        timePos,
         finalRowArity)
         .asInstanceOf[WindowFunction[Row, CRow, Tuple, DataStreamWindow]]
     } else {
@@ -1136,25 +1142,31 @@ object AggregateUtil {
     }
   }
 
-  private[flink] def computeWindowStartEndPropertyPos(
-      properties: Seq[NamedWindowProperty]): (Option[Int], Option[Int]) = {
+  private[flink] def computeWindowPropertyPos(
+      properties: Seq[NamedWindowProperty]): (Option[Int], Option[Int], Option[Int]) = {
 
-    val propPos = properties.foldRight((None: Option[Int], None: Option[Int], 0)) {
+    val propPos = properties.foldRight(
+      (None: Option[Int], None: Option[Int], None: Option[Int], 0)) {
       (p, x) => p match {
         case NamedWindowProperty(_, prop) =>
           prop match {
             case WindowStart(_) if x._1.isDefined =>
               throw new TableException("Duplicate WindowStart property encountered. This is a bug.")
             case WindowStart(_) =>
-              (Some(x._3), x._2, x._3 - 1)
+              (Some(x._4), x._2, x._3, x._4 - 1)
             case WindowEnd(_) if x._2.isDefined =>
               throw new TableException("Duplicate WindowEnd property encountered. This is a bug.")
             case WindowEnd(_) =>
-              (x._1, Some(x._3), x._3 - 1)
+              (x._1, Some(x._4), x._3, x._4 - 1)
+            case RowtimeAttribute(_) if x._3.isDefined =>
+              throw new TableException(
+                "Duplicate Window rowtime property encountered. This is a bug.")
+            case RowtimeAttribute(_) =>
+              (x._1, x._2, Some(x._4), x._4 - 1)
           }
       }
     }
-    (propPos._1, propPos._2)
+    (propPos._1, propPos._2, propPos._3)
   }
 
   private def transformToAggregateFunctions(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSessionWindowAggReduceGroupFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSessionWindowAggReduceGroupFunction.scala
@@ -78,7 +78,10 @@ class DataSetSessionWindowAggReduceGroupFunction(
 
     output = function.createOutputRow()
     accumulators = function.createAccumulators()
-    collector = new RowTimeWindowPropertyCollector(finalRowWindowStartPos, finalRowWindowEndPos)
+    collector = new RowTimeWindowPropertyCollector(
+      finalRowWindowStartPos,
+      finalRowWindowEndPos,
+      None)
   }
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSlideWindowAggReduceGroupFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSlideWindowAggReduceGroupFunction.scala
@@ -68,7 +68,10 @@ class DataSetSlideWindowAggReduceGroupFunction(
 
     output = function.createOutputRow()
     accumulators = function.createAccumulators()
-    collector = new RowTimeWindowPropertyCollector(finalRowWindowStartPos, finalRowWindowEndPos)
+    collector = new RowTimeWindowPropertyCollector(
+      finalRowWindowStartPos,
+      finalRowWindowEndPos,
+      None)
   }
 
   override def reduce(records: Iterable[Row], out: Collector[Row]): Unit = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetTumbleTimeWindowAggReduceGroupFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetTumbleTimeWindowAggReduceGroupFunction.scala
@@ -67,7 +67,7 @@ class DataSetTumbleTimeWindowAggReduceGroupFunction(
 
     output = function.createOutputRow()
     accumulators = function.createAccumulators()
-    collector = new RowTimeWindowPropertyCollector(windowStartPos, windowEndPos)
+    collector = new RowTimeWindowPropertyCollector(windowStartPos, windowEndPos, None)
   }
 
   override def reduce(records: Iterable[Row], out: Collector[Row]): Unit = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateAllTimeWindowFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateAllTimeWindowFunction.scala
@@ -29,13 +29,15 @@ import org.apache.flink.util.Collector
   *
   * Computes the final aggregate value from incrementally computed aggregates.
   *
-  * @param windowStartPos the start position of window
-  * @param windowEndPos   the end position of window
+  * @param windowStartOffset the offset of the window start property
+  * @param windowEndOffset   the offset of the window end property
+  * @param windowRowtimeOffset the offset of the window rowtime property
   * @param finalRowArity  The arity of the final output row.
   */
 class IncrementalAggregateAllTimeWindowFunction(
-    private val windowStartPos: Option[Int],
-    private val windowEndPos: Option[Int],
+    private val windowStartOffset: Option[Int],
+    private val windowEndOffset: Option[Int],
+    private val windowRowtimeOffset: Option[Int],
     private val finalRowArity: Int)
   extends IncrementalAggregateAllWindowFunction[TimeWindow](
     finalRowArity) {
@@ -43,7 +45,10 @@ class IncrementalAggregateAllTimeWindowFunction(
   private var collector: CRowTimeWindowPropertyCollector = _
 
   override def open(parameters: Configuration): Unit = {
-    collector = new CRowTimeWindowPropertyCollector(windowStartPos, windowEndPos)
+    collector = new CRowTimeWindowPropertyCollector(
+      windowStartOffset,
+      windowEndOffset,
+      windowRowtimeOffset)
     super.open(parameters)
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateTimeWindowFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateTimeWindowFunction.scala
@@ -29,15 +29,19 @@ import org.apache.flink.util.Collector
 /**
   * Computes the final aggregate value from incrementally computed aggreagtes.
   *
-  * @param windowStartPos the start position of window
-  * @param windowEndPos   the end position of window
-  * @param finalRowArity  The arity of the final output row
+  * @param numGroupingKey the number of grouping keys
+  * @param numAggregates the number of aggregates
+  * @param windowStartOffset the offset of the window start property
+  * @param windowEndOffset   the offset of the window end property
+  * @param windowRowtimeOffset the offset of the window rowtime property
+  * @param finalRowArity  The arity of the final output row.
   */
 class IncrementalAggregateTimeWindowFunction(
     private val numGroupingKey: Int,
     private val numAggregates: Int,
-    private val windowStartPos: Option[Int],
-    private val windowEndPos: Option[Int],
+    private val windowStartOffset: Option[Int],
+    private val windowEndOffset: Option[Int],
+    private val windowRowtimeOffset: Option[Int],
     private val finalRowArity: Int)
   extends IncrementalAggregateWindowFunction[TimeWindow](
     numGroupingKey,
@@ -47,7 +51,10 @@ class IncrementalAggregateTimeWindowFunction(
   private var collector: CRowTimeWindowPropertyCollector = _
 
   override def open(parameters: Configuration): Unit = {
-    collector = new CRowTimeWindowPropertyCollector(windowStartPos, windowEndPos)
+    collector = new CRowTimeWindowPropertyCollector(
+      windowStartOffset,
+      windowEndOffset,
+      windowRowtimeOffset)
     super.open(parameters)
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeBoundedRangeOver.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeBoundedRangeOver.scala
@@ -124,6 +124,7 @@ class ProcTimeBoundedRangeOver(
       return
     }
 
+    // remove timestamp set outside of ProcessFunction.
     out.asInstanceOf[TimestampedCollector[_]].eraseTimestamp()
 
     // we consider the original timestamp of events

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeBoundedRangeOver.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeBoundedRangeOver.scala
@@ -31,6 +31,7 @@ import org.apache.flink.api.java.typeutils.ListTypeInfo
 import java.util.{ArrayList, List => JList}
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo
+import org.apache.flink.streaming.api.operators.TimestampedCollector
 import org.apache.flink.table.api.StreamQueryConfig
 import org.apache.flink.table.codegen.{Compiler, GeneratedAggregationsFunction}
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
@@ -122,6 +123,8 @@ class ProcTimeBoundedRangeOver(
       cleanupState(rowMapState, accumulatorState)
       return
     }
+
+    out.asInstanceOf[TimestampedCollector[_]].eraseTimestamp()
 
     // we consider the original timestamp of events
     // that have registered this time trigger 1 ms ago

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeSortProcessFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeSortProcessFunction.scala
@@ -23,9 +23,10 @@ import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.types.Row
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
 import org.apache.flink.util.{Collector, Preconditions}
-
 import java.util.ArrayList
 import java.util.Collections
+
+import org.apache.flink.streaming.api.operators.TimestampedCollector
 
 
 /**
@@ -75,7 +76,9 @@ class ProcTimeSortProcessFunction(
     timestamp: Long,
     ctx: ProcessFunction[CRow, CRow]#OnTimerContext,
     out: Collector[CRow]): Unit = {
-    
+
+    out.asInstanceOf[TimestampedCollector[_]].eraseTimestamp()
+
     val iter =  bufferedEvents.get.iterator()
 
     // insert all rows into the sort buffer

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeSortProcessFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeSortProcessFunction.scala
@@ -77,6 +77,7 @@ class ProcTimeSortProcessFunction(
     ctx: ProcessFunction[CRow, CRow]#OnTimerContext,
     out: Collector[CRow]): Unit = {
 
+    // remove timestamp set outside of ProcessFunction.
     out.asInstanceOf[TimestampedCollector[_]].eraseTimestamp()
 
     val iter =  bufferedEvents.get.iterator()

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeBoundedRangeOver.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeBoundedRangeOver.scala
@@ -170,6 +170,7 @@ class RowTimeBoundedRangeOver(
       return
     }
 
+    // remove timestamp set outside of ProcessFunction.
     out.asInstanceOf[TimestampedCollector[_]].eraseTimestamp()
 
     // gets all window data from state for the calculation

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeBoundedRowsOver.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeBoundedRowsOver.scala
@@ -179,6 +179,7 @@ class RowTimeBoundedRowsOver(
       return
     }
 
+    // remove timestamp set outside of ProcessFunction.
     out.asInstanceOf[TimestampedCollector[_]].eraseTimestamp()
 
     // gets all window data from state for the calculation

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeSortProcessFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeSortProcessFunction.scala
@@ -17,6 +17,8 @@
  */
 package org.apache.flink.table.runtime.aggregate
 
+import java.sql.Timestamp
+
 import org.apache.flink.api.common.state.ValueState
 import org.apache.flink.api.common.state.ValueStateDescriptor
 import org.apache.flink.api.common.state.MapState
@@ -28,18 +30,22 @@ import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
 import org.apache.flink.types.Row
 import org.apache.flink.util.{Collector, Preconditions}
-
 import java.util.Collections
-import java.util.{List => JList, ArrayList => JArrayList}
+import java.util.{ArrayList => JArrayList, List => JList}
+
+import org.apache.calcite.runtime.SqlFunctions
+import org.apache.flink.streaming.api.operators.TimestampedCollector
 
 /**
  * ProcessFunction to sort on event-time and possibly addtional secondary sort attributes.
  *
   * @param inputRowType The data type of the input data.
+  * @param rowtimeIdx The index of the rowtime field.
   * @param rowComparator A comparator to sort rows.
  */
 class RowTimeSortProcessFunction(
     private val inputRowType: CRowTypeInfo,
+    private val rowtimeIdx: Int,
     private val rowComparator: Option[CollectionRowComparator])
   extends ProcessFunction[CRow, CRow] {
 
@@ -84,7 +90,7 @@ class RowTimeSortProcessFunction(
     val input = inputC.row
     
     // timestamp of the processed row
-    val rowtime = ctx.timestamp
+    val rowtime = SqlFunctions.toLong(input.getField(rowtimeIdx).asInstanceOf[Timestamp])
 
     val lastTriggeringTs = lastTriggeringTsState.value
 
@@ -105,13 +111,14 @@ class RowTimeSortProcessFunction(
       }
     }
   }
-  
-  
+
   override def onTimer(
     timestamp: Long,
     ctx: ProcessFunction[CRow, CRow]#OnTimerContext,
     out: Collector[CRow]): Unit = {
-    
+
+    out.asInstanceOf[TimestampedCollector[_]].eraseTimestamp()
+
     // gets all rows for the triggering timestamps
     val inputs: JList[Row] = dataState.get(timestamp)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeSortProcessFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeSortProcessFunction.scala
@@ -117,6 +117,7 @@ class RowTimeSortProcessFunction(
     ctx: ProcessFunction[CRow, CRow]#OnTimerContext,
     out: Collector[CRow]): Unit = {
 
+    // remove timestamp set outside of ProcessFunction.
     out.asInstanceOf[TimestampedCollector[_]].eraseTimestamp()
 
     // gets all rows for the triggering timestamps

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeUnboundedOver.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeUnboundedOver.scala
@@ -17,14 +17,16 @@
  */
 package org.apache.flink.table.runtime.aggregate
 
+import java.sql.Timestamp
 import java.util
 import java.util.{List => JList}
 
+import org.apache.calcite.runtime.SqlFunctions
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.types.Row
 import org.apache.flink.streaming.api.functions.ProcessFunction
-import org.apache.flink.util.{Collector, Preconditions}
+import org.apache.flink.util.Collector
 import org.apache.flink.api.common.state._
 import org.apache.flink.api.java.typeutils.ListTypeInfo
 import org.apache.flink.streaming.api.operators.TimestampedCollector
@@ -45,6 +47,7 @@ abstract class RowTimeUnboundedOver(
     genAggregations: GeneratedAggregationsFunction,
     intermediateType: TypeInformation[Row],
     inputType: TypeInformation[CRow],
+    rowTimeIdx: Int,
     queryConfig: StreamQueryConfig)
   extends ProcessFunctionWithCleanupState[CRow, CRow](queryConfig)
     with Compiler[GeneratedAggregations] {
@@ -108,7 +111,7 @@ abstract class RowTimeUnboundedOver(
     // register state-cleanup timer
     registerProcessingCleanupTimer(ctx, ctx.timerService().currentProcessingTime())
 
-    val timestamp = ctx.timestamp()
+    val timestamp = SqlFunctions.toLong(input.getField(rowTimeIdx).asInstanceOf[Timestamp])
     val curWatermark = ctx.timerService().currentWatermark()
 
     // discard late record
@@ -158,8 +161,8 @@ abstract class RowTimeUnboundedOver(
       return
     }
 
-    Preconditions.checkArgument(out.isInstanceOf[TimestampedCollector[CRow]])
-    val collector = out.asInstanceOf[TimestampedCollector[CRow]]
+    // remove StreamRecord timestamp
+    out.asInstanceOf[TimestampedCollector[_]].eraseTimestamp()
 
     val keyIterator = rowMapState.keys.iterator
     if (keyIterator.hasNext) {
@@ -188,10 +191,9 @@ abstract class RowTimeUnboundedOver(
       while (!sortedTimestamps.isEmpty) {
         val curTimestamp = sortedTimestamps.removeFirst()
         val curRowList = rowMapState.get(curTimestamp)
-        collector.setAbsoluteTimestamp(curTimestamp)
 
         // process the same timestamp datas, the mechanism is different according ROWS or RANGE
-        processElementsWithSameTimestamp(curRowList, lastAccumulator, collector)
+        processElementsWithSameTimestamp(curRowList, lastAccumulator, out)
 
         rowMapState.remove(curTimestamp)
       }
@@ -250,11 +252,13 @@ class RowTimeUnboundedRowsOver(
     genAggregations: GeneratedAggregationsFunction,
     intermediateType: TypeInformation[Row],
     inputType: TypeInformation[CRow],
+    rowTimeIdx: Int,
     queryConfig: StreamQueryConfig)
   extends RowTimeUnboundedOver(
     genAggregations: GeneratedAggregationsFunction,
     intermediateType,
     inputType,
+    rowTimeIdx,
     queryConfig) {
 
   override def processElementsWithSameTimestamp(
@@ -266,7 +270,6 @@ class RowTimeUnboundedRowsOver(
     while (i < curRowList.size) {
       val curRow = curRowList.get(i)
 
-      var j = 0
       // copy forwarded fields to output row
       function.setForwardedFields(curRow, output.row)
 
@@ -290,11 +293,13 @@ class RowTimeUnboundedRangeOver(
     genAggregations: GeneratedAggregationsFunction,
     intermediateType: TypeInformation[Row],
     inputType: TypeInformation[CRow],
+    rowTimeIdx: Int,
     queryConfig: StreamQueryConfig)
   extends RowTimeUnboundedOver(
     genAggregations: GeneratedAggregationsFunction,
     intermediateType,
     inputType,
+    rowTimeIdx,
     queryConfig) {
 
   override def processElementsWithSameTimestamp(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeUnboundedOver.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeUnboundedOver.scala
@@ -161,7 +161,7 @@ abstract class RowTimeUnboundedOver(
       return
     }
 
-    // remove StreamRecord timestamp
+    // remove timestamp set outside of ProcessFunction.
     out.asInstanceOf[TimestampedCollector[_]].eraseTimestamp()
 
     val keyIterator = rowMapState.keys.iterator

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/SortUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/SortUtil.scala
@@ -142,7 +142,7 @@ object SortUtil {
     }
 
     new RowComparator(
-      new RowSchema(inputType).physicalArity,
+      new RowSchema(inputType).arity,
       sortFields.toArray,
       fieldComps.toArray,
       new Array[TypeSerializer[AnyRef]](0), // not required because we only compare objects.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/SortUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/SortUtil.scala
@@ -60,6 +60,8 @@ object SortUtil {
     inputTypeInfo: TypeInformation[Row],
     execCfg: ExecutionConfig): ProcessFunction[CRow, CRow] = {
 
+    val rowtimeIdx = collationSort.getFieldCollations.get(0).getFieldIndex
+
     val collectionRowComparator = if (collationSort.getFieldCollations.size() > 1) {
 
       val rowComp = createRowComparator(
@@ -76,6 +78,7 @@ object SortUtil {
  
     new RowTimeSortProcessFunction(
       inputCRowType,
+      rowtimeIdx,
       collectionRowComparator)
 
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/TimeWindowPropertyCollector.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/TimeWindowPropertyCollector.scala
@@ -29,7 +29,8 @@ import org.apache.flink.util.Collector
   */
 abstract class TimeWindowPropertyCollector[T](
     windowStartOffset: Option[Int],
-    windowEndOffset: Option[Int])
+    windowEndOffset: Option[Int],
+    windowRowtimeOffset: Option[Int])
   extends Collector[T] {
 
   var wrappedCollector: Collector[T] = _
@@ -55,20 +56,32 @@ abstract class TimeWindowPropertyCollector[T](
         SqlFunctions.internalToTimestamp(windowEnd))
     }
 
+    if (windowRowtimeOffset.isDefined) {
+      output.setField(
+        lastFieldPos + windowRowtimeOffset.get,
+        SqlFunctions.internalToTimestamp(windowEnd - 1))
+    }
+
     wrappedCollector.collect(record)
   }
 
   override def close(): Unit = wrappedCollector.close()
 }
 
-class RowTimeWindowPropertyCollector(startOffset: Option[Int], endOffset: Option[Int])
-  extends TimeWindowPropertyCollector[Row](startOffset, endOffset) {
+class RowTimeWindowPropertyCollector(
+    startOffset: Option[Int],
+    endOffset: Option[Int],
+    rowtimeOffset: Option[Int])
+  extends TimeWindowPropertyCollector[Row](startOffset, endOffset, rowtimeOffset) {
 
   override def getRow(record: Row): Row = record
 }
 
-class CRowTimeWindowPropertyCollector(startOffset: Option[Int], endOffset: Option[Int])
-  extends TimeWindowPropertyCollector[CRow](startOffset, endOffset) {
+class CRowTimeWindowPropertyCollector(
+    startOffset: Option[Int],
+    endOffset: Option[Int],
+    rowtimeOffset: Option[Int])
+  extends TimeWindowPropertyCollector[CRow](startOffset, endOffset, rowtimeOffset) {
 
   override def getRow(record: CRow): Row = record.row
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/WindowJoinUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/WindowJoinUtil.scala
@@ -427,9 +427,8 @@ object WindowJoinUtil {
            |${generator.collectorTerm}.collect(${conversion.resultTerm});
            |""".stripMargin
       case Some(remainCondition) =>
-        // map logical field accesses to physical accesses
-        val physicalCondition = returnType.mapRexNode(remainCondition)
-        val genCond = generator.generateExpression(physicalCondition)
+        // generate code for remaining condition
+        val genCond = generator.generateExpression(remainCondition)
         s"""
            |${genCond.code}
            |if (${genCond.resultTerm}) {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/WindowJoinUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/WindowJoinUtil.scala
@@ -416,8 +416,8 @@ object WindowJoinUtil {
       Some(rightType))
 
     val conversion = generator.generateConverterResultExpression(
-      returnType.physicalTypeInfo,
-      returnType.physicalType.getFieldNames.asScala)
+      returnType.typeInfo,
+      returnType.fieldNames)
 
     // if other condition is none, then output the result directly
     val body = otherCondition match {
@@ -442,7 +442,7 @@ object WindowJoinUtil {
       ruleDescription,
       classOf[FlatJoinFunction[Row, Row, Row]],
       body,
-      returnType.physicalTypeInfo)
+      returnType.typeInfo)
   }
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/typeutils/TimeIndicatorTypeInfo.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/typeutils/TimeIndicatorTypeInfo.scala
@@ -40,6 +40,9 @@ class TimeIndicatorTypeInfo(val isEventTime: Boolean)
 
 object TimeIndicatorTypeInfo {
 
+  val ROWTIME_MARKER: Int = -1
+  val PROCTIME_MARKER: Int = -2
+
   val ROWTIME_INDICATOR = new TimeIndicatorTypeInfo(true)
   val PROCTIME_INDICATOR = new TimeIndicatorTypeInfo(false)
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/SortTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/SortTest.scala
@@ -41,7 +41,7 @@ class SortTest extends TableTestBase {
         unaryNode("DataStreamSort",
           streamTableNode(0),
           term("orderBy", "proctime ASC", "c ASC")),
-        term("select", "a", "TIME_MATERIALIZATION(proctime) AS proctime", "c"))
+        term("select", "a", "PROCTIME(proctime) AS proctime", "c"))
 
     streamUtil.verifySql(sqlQuery, expected)
   }
@@ -57,7 +57,7 @@ class SortTest extends TableTestBase {
         unaryNode("DataStreamSort",
           streamTableNode(0),
           term("orderBy", "rowtime ASC, c ASC")),
-        term("select", "a", "TIME_MATERIALIZATION(rowtime) AS rowtime", "c"))
+        term("select", "a", "rowtime", "c"))
        
     streamUtil.verifySql(sqlQuery, expected)
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/TableSourceTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/TableSourceTest.scala
@@ -43,7 +43,7 @@ class TableSourceTest extends TableTestBase {
       unaryNode(
         "DataStreamCalc",
         "StreamTableSourceScan(table=[[rowTimeT]], fields=[id, val, name, addTime])",
-        term("select", "TIME_MATERIALIZATION(addTime) AS addTime", "id", "name", "val")
+        term("select", "addTime", "id", "name", "val")
       )
     util.verifyTable(t, expected)
   }
@@ -90,7 +90,7 @@ class TableSourceTest extends TableTestBase {
       unaryNode(
         "DataStreamCalc",
         "StreamTableSourceScan(table=[[procTimeT]], fields=[id, val, name, pTime])",
-        term("select", "TIME_MATERIALIZATION(pTime) AS pTime", "id", "name", "val")
+        term("select", "PROCTIME(pTime) AS pTime", "id", "name", "val")
       )
     util.verifyTable(t, expected)
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/TimeIndicatorConversionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/TimeIndicatorConversionTest.scala
@@ -48,7 +48,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
     val expected = unaryNode(
       "DataStreamCalc",
       streamTableNode(0),
-      term("select", "FLOOR(TIME_MATERIALIZATION(rowtime)", "FLAG(DAY)) AS rowtime"),
+      term("select", "FLOOR(CAST(rowtime)", "FLAG(DAY)) AS rowtime"),
       term("where", ">(long, 0)")
     )
 
@@ -65,8 +65,8 @@ class TimeIndicatorConversionTest extends TableTestBase {
     val expected = unaryNode(
       "DataStreamCalc",
       streamTableNode(0),
-      term("select", "TIME_MATERIALIZATION(rowtime) AS rowtime", "long", "int",
-        "TIME_MATERIALIZATION(proctime) AS proctime")
+      term("select", "rowtime", "long", "int",
+        "PROCTIME(proctime) AS proctime")
     )
 
     util.verifyTable(result, expected)
@@ -84,7 +84,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
     val expected = unaryNode(
       "DataStreamCalc",
       streamTableNode(0),
-      term("select", "TIME_MATERIALIZATION(rowtime) AS rowtime"),
+      term("select", "rowtime"),
       term("where", ">(rowtime, 1990-12-02 12:11:11)")
     )
 
@@ -107,7 +107,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
         unaryNode(
           "DataStreamCalc",
           streamTableNode(0),
-          term("select", "long", "TIME_MATERIALIZATION(rowtime) AS rowtime")
+          term("select", "long", "CAST(rowtime) AS rowtime")
         ),
         term("groupBy", "rowtime"),
         term("select", "rowtime", "COUNT(long) AS TMP_0")
@@ -134,7 +134,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
         unaryNode(
           "DataStreamCalc",
           streamTableNode(0),
-          term("select", "TIME_MATERIALIZATION(rowtime) AS rowtime", "long")
+          term("select", "CAST(rowtime) AS rowtime", "long")
         ),
         term("groupBy", "long"),
         term("select", "long", "MIN(rowtime) AS TMP_0")
@@ -159,16 +159,13 @@ class TimeIndicatorConversionTest extends TableTestBase {
         "DataStreamCorrelate",
         streamTableNode(0),
         term("invocation",
-          s"${func.functionIdentifier}(TIME_MATERIALIZATION($$0), TIME_MATERIALIZATION($$3), '')"),
+          s"${func.functionIdentifier}(CAST($$0):TIMESTAMP(3) NOT NULL, PROCTIME($$3), '')"),
         term("function", func),
         term("rowType", "RecordType(TIME ATTRIBUTE(ROWTIME) rowtime, BIGINT long, INTEGER int, " +
           "TIME ATTRIBUTE(PROCTIME) proctime, VARCHAR(2147483647) s)"),
         term("joinType", "INNER")
       ),
-      term("select",
-        "TIME_MATERIALIZATION(rowtime) AS rowtime",
-        "TIME_MATERIALIZATION(proctime) AS proctime",
-        "s")
+      term("select", "rowtime", "PROCTIME(proctime) AS proctime", "s")
     )
 
     util.verifyTable(result, expected)
@@ -219,7 +216,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
         streamTableNode(0),
         term("union all", "rowtime", "long", "int")
       ),
-      term("select", "TIME_MATERIALIZATION(rowtime) AS rowtime")
+      term("select", "rowtime")
     )
 
     util.verifyTable(result, expected)
@@ -287,7 +284,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
         unaryNode(
           "DataStreamCalc",
           streamTableNode(0),
-          term("select", "TIME_MATERIALIZATION(proctime) AS proctime", "long")
+          term("select", "PROCTIME(proctime) AS proctime", "long")
         ),
         term("groupBy", "proctime"),
         term("select", "proctime", "COUNT(long) AS EXPR$0")
@@ -312,7 +309,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
         unaryNode(
           "DataStreamCalc",
           streamTableNode(0),
-          term("select", "long", "TIME_MATERIALIZATION(proctime) AS proctime")
+          term("select", "long", "PROCTIME(proctime) AS proctime")
         ),
         term("groupBy", "long"),
         term("select", "long", "MIN(proctime) AS EXPR$0")
@@ -368,7 +365,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
         unaryNode(
           "DataStreamCalc",
           streamTableNode(0),
-          term("select", "long", "rowtime", "TIME_MATERIALIZATION(rowtime) AS $f2")
+          term("select", "long", "rowtime", "CAST(rowtime) AS rowtime0")
         ),
         term("groupBy", "long"),
         term(
@@ -377,7 +374,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
             'w$,
             'rowtime,
             100.millis)),
-        term("select", "long", "MIN($f2) AS EXPR$0")
+        term("select", "long", "MIN(rowtime0) AS EXPR$0")
       ),
       term("select", "EXPR$0", "long")
     )

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/HarnessTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/HarnessTestBase.scala
@@ -46,12 +46,10 @@ class HarnessTestBase {
     UserDefinedFunctionUtils.serialize(new IntSumWithRetractAggFunction)
 
   protected val MinMaxRowType = new RowTypeInfo(Array[TypeInformation[_]](
-    INT_TYPE_INFO,
     LONG_TYPE_INFO,
-    INT_TYPE_INFO,
     STRING_TYPE_INFO,
     LONG_TYPE_INFO),
-    Array("a", "b", "c", "d", "e"))
+    Array("rowtime", "a", "b"))
 
   protected val SumRowType = new RowTypeInfo(Array[TypeInformation[_]](
     LONG_TYPE_INFO,
@@ -103,13 +101,13 @@ class HarnessTestBase {
       |
       |    org.apache.flink.table.functions.AggregateFunction baseClass0 =
       |      (org.apache.flink.table.functions.AggregateFunction) fmin;
-      |    output.setField(5, baseClass0.getValue(
+      |    output.setField(3, baseClass0.getValue(
       |      (org.apache.flink.table.functions.aggfunctions.MinWithRetractAccumulator)
       |      accs.getField(0)));
       |
       |    org.apache.flink.table.functions.AggregateFunction baseClass1 =
       |      (org.apache.flink.table.functions.AggregateFunction) fmax;
-      |    output.setField(6, baseClass1.getValue(
+      |    output.setField(4, baseClass1.getValue(
       |      (org.apache.flink.table.functions.aggfunctions.MaxWithRetractAccumulator)
       |      accs.getField(1)));
       |  }
@@ -121,12 +119,12 @@ class HarnessTestBase {
       |    fmin.accumulate(
       |      ((org.apache.flink.table.functions.aggfunctions.MinWithRetractAccumulator)
       |      accs.getField(0)),
-      |      (java.lang.Long) input.getField(4));
+      |      (java.lang.Long) input.getField(2));
       |
       |    fmax.accumulate(
       |      ((org.apache.flink.table.functions.aggfunctions.MaxWithRetractAccumulator)
       |      accs.getField(1)),
-      |      (java.lang.Long) input.getField(4));
+      |      (java.lang.Long) input.getField(2));
       |  }
       |
       |  public void retract(
@@ -136,12 +134,12 @@ class HarnessTestBase {
       |    fmin.retract(
       |      ((org.apache.flink.table.functions.aggfunctions.MinWithRetractAccumulator)
       |      accs.getField(0)),
-      |      (java.lang.Long) input.getField(4));
+      |      (java.lang.Long) input.getField(2));
       |
       |    fmax.retract(
       |      ((org.apache.flink.table.functions.aggfunctions.MaxWithRetractAccumulator)
       |      accs.getField(1)),
-      |      (java.lang.Long) input.getField(4));
+      |      (java.lang.Long) input.getField(2));
       |  }
       |
       |  public org.apache.flink.types.Row createAccumulators() {
@@ -166,12 +164,10 @@ class HarnessTestBase {
       |    output.setField(0, input.getField(0));
       |    output.setField(1, input.getField(1));
       |    output.setField(2, input.getField(2));
-      |    output.setField(3, input.getField(3));
-      |    output.setField(4, input.getField(4));
       |  }
       |
       |  public org.apache.flink.types.Row createOutputRow() {
-      |    return new org.apache.flink.types.Row(7);
+      |    return new org.apache.flink.types.Row(5);
       |  }
       |
       |/*******  This test does not use the following methods  *******/
@@ -326,7 +322,7 @@ object HarnessTestBase {
   /**
     * Return 0 for equal Rows and non zero for different rows
     */
-  class RowResultSortComparator(indexCounter: Int) extends Comparator[Object] with Serializable {
+  class RowResultSortComparator() extends Comparator[Object] with Serializable {
 
     override def compare(o1: Object, o2: Object): Int = {
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/JoinHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/JoinHarnessTest.scala
@@ -154,7 +154,7 @@ class JoinHarnessTest extends HarnessTestBase{
     expectedOutput.add(new StreamRecord(
       CRow(Row.of(2: JInt, "bbb2", 2: JInt, "Hello2"), true), 25))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verify(expectedOutput, result, new RowResultSortComparator())
 
     testHarness.close()
   }
@@ -227,7 +227,7 @@ class JoinHarnessTest extends HarnessTestBase{
     expectedOutput.add(new StreamRecord(
       CRow(Row.of(1: JInt, "aaa3", 1: JInt, "bbb12"), true), 12))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verify(expectedOutput, result, new RowResultSortComparator())
 
     testHarness.close()
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/NonWindowHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/NonWindowHarnessTest.scala
@@ -91,7 +91,7 @@ class NonWindowHarnessTest extends HarnessTestBase {
     expectedOutput.add(new StreamRecord(CRow(Row.of(9L: JLong, 18: JInt), true), 1))
     expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, 3: JInt), true), 1))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verify(expectedOutput, result, new RowResultSortComparator())
 
     testHarness.close()
   }
@@ -150,7 +150,7 @@ class NonWindowHarnessTest extends HarnessTestBase {
     expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, 2: JInt), false), 10))
     expectedOutput.add(new StreamRecord(CRow(Row.of(10L: JLong, 5: JInt), true), 10))
 
-    verify(expectedOutput, result, new RowResultSortComparator(0))
+    verify(expectedOutput, result, new RowResultSortComparator())
 
     testHarness.close()
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/OverWindowHarnessTest.scala
@@ -17,14 +17,15 @@
  */
 package org.apache.flink.table.runtime.harness
 
-import java.lang.{Integer => JInt, Long => JLong}
+import java.lang.{Long => JLong}
 import java.util.concurrent.ConcurrentLinkedQueue
 
+import org.apache.calcite.runtime.SqlFunctions.{internalToTimestamp => toTS}
 import org.apache.flink.api.common.time.Time
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo
 import org.apache.flink.streaming.api.operators.KeyedProcessOperator
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
-import org.apache.flink.table.api.StreamQueryConfig
+import org.apache.flink.table.api.{StreamQueryConfig, Types}
 import org.apache.flink.table.runtime.aggregate._
 import org.apache.flink.table.runtime.harness.HarnessTestBase._
 import org.apache.flink.table.runtime.types.CRow
@@ -48,8 +49,10 @@ class OverWindowHarnessTest extends HarnessTestBase{
         queryConfig))
 
     val testHarness =
-      createHarnessTester(processFunction,new TupleRowKeySelector[Integer](0),BasicTypeInfo
-        .INT_TYPE_INFO)
+      createHarnessTester(
+        processFunction,
+        new TupleRowKeySelector[String](1),
+        Types.STRING)
 
     testHarness.open()
 
@@ -57,91 +60,77 @@ class OverWindowHarnessTest extends HarnessTestBase{
     testHarness.setProcessingTime(1)
 
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 1L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "aaa", 1L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 10L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "bbb", 10L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 2L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "aaa", 2L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 3L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "aaa", 3L: JLong), true)))
 
     // register cleanup timer with 4100
     testHarness.setProcessingTime(1100)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 20L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "bbb", 20L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 4L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "aaa", 4L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 5L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "aaa", 5L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 6L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "aaa", 6L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 30L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "bbb", 30L: JLong), true)))
 
     // register cleanup timer with 6001
     testHarness.setProcessingTime(3001)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 7L: JLong), true), 2))
+      CRow(Row.of(toTS(2), "aaa", 7L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 8L: JLong), true), 2))
+      CRow(Row.of(toTS(2), "aaa", 8L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 9L: JLong), true), 2))
+      CRow(Row.of(toTS(2), "aaa", 9L: JLong), true)))
 
     // trigger cleanup timer and register cleanup timer with 9002
     testHarness.setProcessingTime(6002)
     testHarness.processElement(new StreamRecord(
-        CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 10L: JLong), true), 2))
+        CRow(Row.of(toTS(2), "aaa", 10L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong), true), 2))
+      CRow(Row.of(toTS(2), "bbb", 40L: JLong), true)))
 
     val result = testHarness.getOutput
 
     val expectedOutput = new ConcurrentLinkedQueue[Object]()
 
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 1L: JLong, 1L: JLong, 1L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "aaa", 1L: JLong, 1L: JLong, 1L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 10L: JLong, 10L: JLong, 10L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "bbb", 10L: JLong, 10L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 2L: JLong, 1L: JLong, 2L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "aaa", 2L: JLong, 1L: JLong, 2L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 3L: JLong, 2L: JLong, 3L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "aaa", 3L: JLong, 2L: JLong, 3L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 20L: JLong, 10L: JLong, 20L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "bbb", 20L: JLong, 10L: JLong, 20L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 4L: JLong, 3L: JLong, 4L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "aaa", 4L: JLong, 3L: JLong, 4L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 5L: JLong, 4L: JLong, 5L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "aaa", 5L: JLong, 4L: JLong, 5L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 6L: JLong, 5L: JLong, 6L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "aaa", 6L: JLong, 5L: JLong, 6L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 30L: JLong, 20L: JLong, 30L: JLong), true), 1))
+      CRow(Row.of(toTS(1), "bbb", 30L: JLong, 20L: JLong, 30L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 7L: JLong, 6L: JLong, 7L: JLong), true), 2))
+      CRow(Row.of(toTS(2), "aaa", 7L: JLong, 6L: JLong, 7L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 8L: JLong, 7L: JLong, 8L: JLong), true), 2))
+      CRow(Row.of(toTS(2), "aaa", 8L: JLong, 7L: JLong, 8L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 9L: JLong, 8L: JLong, 9L: JLong), true), 2))
+      CRow(Row.of(toTS(2), "aaa", 9L: JLong, 8L: JLong, 9L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 10L: JLong, 10L: JLong, 10L: JLong), true), 2))
+      CRow(Row.of(toTS(2), "aaa", 10L: JLong, 10L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong, 40L: JLong, 40L: JLong), true), 2))
+      CRow(Row.of(toTS(2), "bbb", 40L: JLong, 40L: JLong, 40L: JLong), true)))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verify(expectedOutput, result, new RowResultSortComparator())
 
     testHarness.close()
   }
@@ -163,59 +152,59 @@ class OverWindowHarnessTest extends HarnessTestBase{
     val testHarness =
       createHarnessTester(
         processFunction,
-        new TupleRowKeySelector[Integer](0),
-        BasicTypeInfo.INT_TYPE_INFO)
+        new TupleRowKeySelector[String](1),
+        Types.STRING)
 
     testHarness.open()
 
     // register cleanup timer with 3003
     testHarness.setProcessingTime(3)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 1L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 1L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 10L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "bbb", 10L: JLong), true)))
 
     testHarness.setProcessingTime(4)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 2L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 2L: JLong), true)))
 
     // trigger cleanup timer and register cleanup timer with 6003
     testHarness.setProcessingTime(3003)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 3L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 3L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 20L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "bbb", 20L: JLong), true)))
 
     testHarness.setProcessingTime(5)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 4L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 4L: JLong), true)))
 
     // register cleanup timer with 9002
     testHarness.setProcessingTime(6002)
 
     testHarness.setProcessingTime(7002)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 5L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 5L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 6L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 6L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 30L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "bbb", 30L: JLong), true)))
 
     // register cleanup timer with 14002
     testHarness.setProcessingTime(11002)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 7L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 7L: JLong), true)))
 
     testHarness.setProcessingTime(11004)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 8L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 8L: JLong), true)))
 
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 9L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 9L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 10L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 10L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "bbb", 40L: JLong), true)))
 
     testHarness.setProcessingTime(11006)
 
@@ -225,49 +214,35 @@ class OverWindowHarnessTest extends HarnessTestBase{
 
     // all elements at the same proc timestamp have the same value per key
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 1L: JLong, 1L: JLong, 1L: JLong), true), 4))
+      CRow(Row.of(toTS(0), "aaa", 1L: JLong, 1L: JLong, 1L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 10L: JLong, 10L: JLong, 10L: JLong), true), 4))
+      CRow(Row.of(toTS(0), "bbb", 10L: JLong, 10L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 2L: JLong, 1L: JLong, 2L: JLong), true), 5))
+      CRow(Row.of(toTS(0), "aaa", 2L: JLong, 1L: JLong, 2L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 3L: JLong, 3L: JLong, 4L: JLong), true), 3004))
+      CRow(Row.of(toTS(0), "aaa", 3L: JLong, 3L: JLong, 4L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(Row.of(
-        2: JInt, 0L: JLong, 0: JInt, "bbb", 20L: JLong, 20L: JLong, 20L: JLong), true), 3004))
+      CRow(Row.of(toTS(0), "bbb", 20L: JLong, 20L: JLong, 20L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 4L: JLong, 4L: JLong, 4L: JLong), true), 6))
+      CRow(Row.of(toTS(0), "aaa", 4L: JLong, 4L: JLong, 4L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 5L: JLong, 5L: JLong, 6L: JLong), true), 7003))
+      CRow(Row.of(toTS(0), "aaa", 5L: JLong, 5L: JLong, 6L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 6L: JLong, 5L: JLong, 6L: JLong), true), 7003))
+      CRow(Row.of(toTS(0), "aaa", 6L: JLong, 5L: JLong, 6L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 30L: JLong, 30L: JLong, 30L: JLong), true), 7003))
+      CRow(Row.of(toTS(0), "bbb", 30L: JLong, 30L: JLong, 30L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 7L: JLong, 7L: JLong, 7L: JLong), true), 11003))
+      CRow(Row.of(toTS(0), "aaa", 7L: JLong, 7L: JLong, 7L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(Row.of(
-        1: JInt, 11L: JLong, 1: JInt, "aaa", 8L: JLong, 7L: JLong, 10L: JLong), true), 11005))
+      CRow(Row.of(toTS(0), "aaa", 8L: JLong, 7L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(Row.of(
-        1: JInt, 11L: JLong, 1: JInt, "aaa", 9L: JLong, 7L: JLong, 10L: JLong), true), 11005))
+      CRow(Row.of(toTS(0), "aaa", 9L: JLong, 7L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 10L: JLong, 7L: JLong, 10L: JLong), true), 11005))
+      CRow(Row.of(toTS(0), "aaa", 10L: JLong, 7L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong, 40L: JLong, 40L: JLong), true), 11005))
+      CRow(Row.of(toTS(0), "bbb", 40L: JLong, 40L: JLong, 40L: JLong), true)))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verify(expectedOutput, result, new RowResultSortComparator())
 
     testHarness.close()
   }
@@ -284,8 +259,8 @@ class OverWindowHarnessTest extends HarnessTestBase{
     val testHarness =
       createHarnessTester(
         processFunction,
-        new TupleRowKeySelector[Integer](0),
-        BasicTypeInfo.INT_TYPE_INFO)
+        new TupleRowKeySelector[String](1),
+        Types.STRING)
 
     testHarness.open()
 
@@ -293,85 +268,71 @@ class OverWindowHarnessTest extends HarnessTestBase{
     testHarness.setProcessingTime(1003)
 
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 1L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 1L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 10L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "bbb", 10L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 2L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 2L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 3L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 3L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 20L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "bbb", 20L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 4L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 4L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 5L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 5L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 6L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 6L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 30L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "bbb", 30L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 7L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 7L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 8L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 8L: JLong), true)))
 
     // trigger cleanup timer and register cleanup timer with 8003
     testHarness.setProcessingTime(5003)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 9L: JLong), true), 5003))
+      CRow(Row.of(toTS(0), "aaa", 9L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 10L: JLong), true), 5003))
+      CRow(Row.of(toTS(0), "aaa", 10L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong), true), 5003))
+      CRow(Row.of(toTS(0), "bbb", 40L: JLong), true)))
 
     val result = testHarness.getOutput
 
     val expectedOutput = new ConcurrentLinkedQueue[Object]()
 
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 1L: JLong, 1L: JLong, 1L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 1L: JLong, 1L: JLong, 1L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 10L: JLong, 10L: JLong, 10L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "bbb", 10L: JLong, 10L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 2L: JLong, 1L: JLong, 2L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 2L: JLong, 1L: JLong, 2L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 3L: JLong, 1L: JLong, 3L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 3L: JLong, 1L: JLong, 3L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 20L: JLong, 10L: JLong, 20L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "bbb", 20L: JLong, 10L: JLong, 20L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 4L: JLong, 1L: JLong, 4L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 4L: JLong, 1L: JLong, 4L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 5L: JLong, 1L: JLong, 5L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 5L: JLong, 1L: JLong, 5L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 6L: JLong, 1L: JLong, 6L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 6L: JLong, 1L: JLong, 6L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 30L: JLong, 10L: JLong, 30L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "bbb", 30L: JLong, 10L: JLong, 30L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 7L: JLong, 1L: JLong, 7L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 7L: JLong, 1L: JLong, 7L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 8L: JLong, 1L: JLong, 8L: JLong), true), 0))
+      CRow(Row.of(toTS(0), "aaa", 8L: JLong, 1L: JLong, 8L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 9L: JLong, 9L: JLong, 9L: JLong), true), 5003))
+      CRow(Row.of(toTS(0), "aaa", 9L: JLong, 9L: JLong, 9L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 10L: JLong, 9L: JLong, 10L: JLong), true), 5003))
+      CRow(Row.of(toTS(0), "aaa", 10L: JLong, 9L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong, 40L: JLong, 40L: JLong), true), 5003))
+      CRow(Row.of(toTS(0), "bbb", 40L: JLong, 40L: JLong, 40L: JLong), true)))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verify(expectedOutput, result, new RowResultSortComparator())
     testHarness.close()
   }
 
@@ -387,63 +348,64 @@ class OverWindowHarnessTest extends HarnessTestBase{
         minMaxAggregationStateType,
         minMaxCRowType,
         4000,
+        0,
         new StreamQueryConfig().withIdleStateRetentionTime(Time.seconds(1), Time.seconds(2))))
 
     val testHarness =
       createHarnessTester(
         processFunction,
-        new TupleRowKeySelector[String](3),
+        new TupleRowKeySelector[String](1),
         BasicTypeInfo.STRING_TYPE_INFO)
 
     testHarness.open()
 
     testHarness.processWatermark(1)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 1L: JLong), true), 2))
+      CRow(Row.of(toTS(2), "aaa", 1L: JLong), true)))
 
     testHarness.processWatermark(2)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 10L: JLong), true), 3))
+      CRow(Row.of(toTS(3), "bbb", 10L: JLong), true)))
 
     testHarness.processWatermark(4000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 2L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "aaa", 2L: JLong), true)))
 
     testHarness.processWatermark(4001)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 3L: JLong), true), 4002))
+      CRow(Row.of(toTS(4002), "aaa", 3L: JLong), true)))
 
     testHarness.processWatermark(4002)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 0L: JLong, 0: JInt, "aaa", 4L: JLong), true), 4003))
+      CRow(Row.of(toTS(4003), "aaa", 4L: JLong), true)))
 
     testHarness.processWatermark(4800)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 11L: JLong, 1: JInt, "bbb", 25L: JLong), true), 4801))
+      CRow(Row.of(toTS(4801), "bbb", 25L: JLong), true)))
 
     testHarness.processWatermark(6500)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 5L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 5L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 6L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 6L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 30L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "bbb", 30L: JLong), true)))
 
     testHarness.processWatermark(7000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 7L: JLong), true), 7001))
+      CRow(Row.of(toTS(7001), "aaa", 7L: JLong), true)))
 
     testHarness.processWatermark(8000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 8L: JLong), true), 8001))
+      CRow(Row.of(toTS(8001), "aaa", 8L: JLong), true)))
 
     testHarness.processWatermark(12000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 9L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 9L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 10L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 10L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "bbb", 40L: JLong), true)))
 
     testHarness.processWatermark(19000)
 
@@ -453,21 +415,22 @@ class OverWindowHarnessTest extends HarnessTestBase{
 
     // check that state is removed after max retention time
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 0L: JLong, 0: JInt, "ccc", 1L: JLong), true), 20001)) // clean-up 3000
+      CRow(Row.of(toTS(20001), "ccc", 1L: JLong), true))) // clean-up 3000
     testHarness.setProcessingTime(2500)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "ccc", 2L: JLong), true), 20002)) // clean-up 4500
+      CRow(Row.of(toTS(20002), "ccc", 2L: JLong), true))) // clean-up 4500
     testHarness.processWatermark(20010) // compute output
 
     assert(testHarness.numKeyedStateEntries() > 0) // check that we have state
     testHarness.setProcessingTime(4499)
     assert(testHarness.numKeyedStateEntries() > 0) // check that we have state
     testHarness.setProcessingTime(4500)
+    val x = testHarness.numKeyedStateEntries()
     assert(testHarness.numKeyedStateEntries() == 0) // check that all state is gone
 
     // check that state is only removed if all data was processed
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(3: JInt, 0L: JLong, 0: JInt, "ccc", 3L: JLong), true), 20011)) // clean-up 6500
+      CRow(Row.of(toTS(20011), "ccc", 3L: JLong), true))) // clean-up 6500
 
     assert(testHarness.numKeyedStateEntries() > 0) // check that we have state
     testHarness.setProcessingTime(6500) // clean-up attempt but rescheduled to 8500
@@ -487,59 +450,42 @@ class OverWindowHarnessTest extends HarnessTestBase{
 
     // all elements at the same row-time have the same value per key
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 1L: JLong, 1L: JLong, 1L: JLong), true), 2))
+      CRow(Row.of(toTS(2), "aaa", 1L: JLong, 1L: JLong, 1L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 10L: JLong, 10L: JLong, 10L: JLong), true), 3))
+      CRow(Row.of(toTS(3), "bbb", 10L: JLong, 10L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 2L: JLong, 1L: JLong, 2L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "aaa", 2L: JLong, 1L: JLong, 2L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 3L: JLong, 1L: JLong, 3L: JLong), true), 4002))
+      CRow(Row.of(toTS(4002), "aaa", 3L: JLong, 1L: JLong, 3L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 0L: JLong, 0: JInt, "aaa", 4L: JLong, 2L: JLong, 4L: JLong), true), 4003))
+      CRow(Row.of(toTS(4003), "aaa", 4L: JLong, 2L: JLong, 4L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 11L: JLong, 1: JInt, "bbb", 25L: JLong, 25L: JLong, 25L: JLong), true), 4801))
+      CRow(Row.of(toTS(4801), "bbb", 25L: JLong, 25L: JLong, 25L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 5L: JLong, 2L: JLong, 6L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 5L: JLong, 2L: JLong, 6L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 6L: JLong, 2L: JLong, 6L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 6L: JLong, 2L: JLong, 6L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 7L: JLong, 2L: JLong, 7L: JLong), true), 7001))
+      CRow(Row.of(toTS(7001), "aaa", 7L: JLong, 2L: JLong, 7L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 8L: JLong, 2L: JLong, 8L: JLong), true), 8001))
+      CRow(Row.of(toTS(8001), "aaa", 8L: JLong, 2L: JLong, 8L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 30L: JLong, 25L: JLong, 30L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "bbb", 30L: JLong, 25L: JLong, 30L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 9L: JLong, 8L: JLong, 10L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 9L: JLong, 8L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 10L: JLong, 8L: JLong, 10L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 10L: JLong, 8L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong, 40L: JLong, 40L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "bbb", 40L: JLong, 40L: JLong, 40L: JLong), true)))
 
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 0L: JLong, 0: JInt, "ccc", 1L: JLong, 1L: JLong, 1L: JLong), true), 20001))
+      CRow(Row.of(toTS(20001), "ccc", 1L: JLong, 1L: JLong, 1L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(2: JInt, 0L: JLong, 0: JInt, "ccc", 2L: JLong, 1L: JLong, 2L: JLong), true), 20002))
+      CRow(Row.of(toTS(20002), "ccc", 2L: JLong, 1L: JLong, 2L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(3: JInt, 0L: JLong, 0: JInt, "ccc", 3L: JLong, 3L: JLong, 3L: JLong), true), 20011))
+      CRow(Row.of(toTS(20011), "ccc", 3L: JLong, 3L: JLong, 3L: JLong), true)))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verify(expectedOutput, result, new RowResultSortComparator())
     testHarness.close()
   }
 
@@ -552,59 +498,60 @@ class OverWindowHarnessTest extends HarnessTestBase{
         minMaxAggregationStateType,
         minMaxCRowType,
         3,
+        0,
         new StreamQueryConfig().withIdleStateRetentionTime(Time.seconds(1), Time.seconds(2))))
 
     val testHarness =
       createHarnessTester(
         processFunction,
-        new TupleRowKeySelector[String](3),
+        new TupleRowKeySelector[String](1),
         BasicTypeInfo.STRING_TYPE_INFO)
 
     testHarness.open()
 
     testHarness.processWatermark(800)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 1L: JLong), true), 801))
+      CRow(Row.of(toTS(801), "aaa", 1L: JLong), true)))
 
     testHarness.processWatermark(2500)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 10L: JLong), true), 2501))
+      CRow(Row.of(toTS(2501), "bbb", 10L: JLong), true)))
 
     testHarness.processWatermark(4000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 2L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "aaa", 2L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 3L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "aaa", 3L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 20L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "bbb", 20L: JLong), true)))
 
     testHarness.processWatermark(4800)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 4L: JLong), true), 4801))
+      CRow(Row.of(toTS(4801), "aaa", 4L: JLong), true)))
 
     testHarness.processWatermark(6500)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 5L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 5L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 6L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 6L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 30L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "bbb", 30L: JLong), true)))
 
     testHarness.processWatermark(7000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 7L: JLong), true), 7001))
+      CRow(Row.of(toTS(7001), "aaa", 7L: JLong), true)))
 
     testHarness.processWatermark(8000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 8L: JLong), true), 8001))
+      CRow(Row.of(toTS(8001), "aaa", 8L: JLong), true)))
 
     testHarness.processWatermark(12000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 9L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 9L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 10L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 10L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "bbb", 40L: JLong), true)))
 
     testHarness.processWatermark(19000)
 
@@ -614,10 +561,10 @@ class OverWindowHarnessTest extends HarnessTestBase{
 
     // check that state is removed after max retention time
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 0L: JLong, 0: JInt, "ccc", 1L: JLong), true), 20001)) // clean-up 3000
+      CRow(Row.of(toTS(20001), "ccc", 1L: JLong), true))) // clean-up 3000
     testHarness.setProcessingTime(2500)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "ccc", 2L: JLong), true), 20002)) // clean-up 4500
+      CRow(Row.of(toTS(20002), "ccc", 2L: JLong), true))) // clean-up 4500
     testHarness.processWatermark(20010) // compute output
 
     assert(testHarness.numKeyedStateEntries() > 0) // check that we have state
@@ -628,7 +575,7 @@ class OverWindowHarnessTest extends HarnessTestBase{
 
     // check that state is only removed if all data was processed
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(3: JInt, 0L: JLong, 0: JInt, "ccc", 3L: JLong), true), 20011)) // clean-up 6500
+      CRow(Row.of(toTS(20011), "ccc", 3L: JLong), true))) // clean-up 6500
 
     assert(testHarness.numKeyedStateEntries() > 0) // check that we have state
     testHarness.setProcessingTime(6500) // clean-up attempt but rescheduled to 8500
@@ -648,59 +595,42 @@ class OverWindowHarnessTest extends HarnessTestBase{
     val expectedOutput = new ConcurrentLinkedQueue[Object]()
 
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 1L: JLong, 1L: JLong, 1L: JLong), true), 801))
+      CRow(Row.of(toTS(801), "aaa", 1L: JLong, 1L: JLong, 1L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 10L: JLong, 10L: JLong, 10L: JLong), true), 2501))
+      CRow(Row.of(toTS(2501), "bbb", 10L: JLong, 10L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 2L: JLong, 1L: JLong, 2L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "aaa", 2L: JLong, 1L: JLong, 2L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 3L: JLong, 1L: JLong, 3L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "aaa", 3L: JLong, 1L: JLong, 3L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 20L: JLong, 10L: JLong, 20L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "bbb", 20L: JLong, 10L: JLong, 20L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 4L: JLong, 2L: JLong, 4L: JLong), true), 4801))
+      CRow(Row.of(toTS(4801), "aaa", 4L: JLong, 2L: JLong, 4L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 5L: JLong, 3L: JLong, 5L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 5L: JLong, 3L: JLong, 5L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 6L: JLong, 4L: JLong, 6L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 6L: JLong, 4L: JLong, 6L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 30L: JLong, 10L: JLong, 30L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "bbb", 30L: JLong, 10L: JLong, 30L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 7L: JLong, 5L: JLong, 7L: JLong), true), 7001))
+      CRow(Row.of(toTS(7001), "aaa", 7L: JLong, 5L: JLong, 7L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 8L: JLong, 6L: JLong, 8L: JLong), true), 8001))
+      CRow(Row.of(toTS(8001), "aaa", 8L: JLong, 6L: JLong, 8L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 9L: JLong, 7L: JLong, 9L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 9L: JLong, 7L: JLong, 9L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 10L: JLong, 8L: JLong, 10L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 10L: JLong, 8L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong, 20L: JLong, 40L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "bbb", 40L: JLong, 20L: JLong, 40L: JLong), true)))
 
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 0L: JLong, 0: JInt, "ccc", 1L: JLong, 1L: JLong, 1L: JLong), true), 20001))
+      CRow(Row.of(toTS(20001), "ccc", 1L: JLong, 1L: JLong, 1L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(2: JInt, 0L: JLong, 0: JInt, "ccc", 2L: JLong, 1L: JLong, 2L: JLong), true), 20002))
+      CRow(Row.of(toTS(20002), "ccc", 2L: JLong, 1L: JLong, 2L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(3: JInt, 0L: JLong, 0: JInt, "ccc", 3L: JLong, 3L: JLong, 3L: JLong), true), 20011))
+      CRow(Row.of(toTS(20011), "ccc", 3L: JLong, 3L: JLong, 3L: JLong), true)))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verify(expectedOutput, result, new RowResultSortComparator())
     testHarness.close()
   }
 
@@ -715,12 +645,13 @@ class OverWindowHarnessTest extends HarnessTestBase{
         genMinMaxAggFunction,
         minMaxAggregationStateType,
         minMaxCRowType,
+        0,
         new StreamQueryConfig().withIdleStateRetentionTime(Time.seconds(1), Time.seconds(2))))
 
     val testHarness =
       createHarnessTester(
         processFunction,
-        new TupleRowKeySelector[String](3),
+        new TupleRowKeySelector[String](1),
         BasicTypeInfo.STRING_TYPE_INFO)
 
     testHarness.open()
@@ -728,47 +659,47 @@ class OverWindowHarnessTest extends HarnessTestBase{
     testHarness.setProcessingTime(1000)
     testHarness.processWatermark(800)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 1L: JLong), true), 801))
+      CRow(Row.of(toTS(801), "aaa", 1L: JLong), true)))
 
     testHarness.processWatermark(2500)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 10L: JLong), true), 2501))
+      CRow(Row.of(toTS(2501), "bbb", 10L: JLong), true)))
 
     testHarness.processWatermark(4000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 2L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "aaa", 2L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 3L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "aaa", 3L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 20L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "bbb", 20L: JLong), true)))
 
     testHarness.processWatermark(4800)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 4L: JLong), true), 4801))
+      CRow(Row.of(toTS(4801), "aaa", 4L: JLong), true)))
 
     testHarness.processWatermark(6500)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 5L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 5L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 6L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 6L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 30L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "bbb", 30L: JLong), true)))
 
     testHarness.processWatermark(7000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 7L: JLong), true), 7001))
+      CRow(Row.of(toTS(7001), "aaa", 7L: JLong), true)))
 
     testHarness.processWatermark(8000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 8L: JLong), true), 8001))
+      CRow(Row.of(toTS(8001), "aaa", 8L: JLong), true)))
 
     testHarness.processWatermark(12000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 9L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 9L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 10L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 10L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "bbb", 40L: JLong), true)))
 
     testHarness.processWatermark(19000)
 
@@ -781,10 +712,10 @@ class OverWindowHarnessTest extends HarnessTestBase{
 
     testHarness.processWatermark(20000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 0L: JLong, 0: JInt, "ccc", 1L: JLong), true), 20001)) // clean-up 5000
+      CRow(Row.of(toTS(20001), "ccc", 1L: JLong), true))) // clean-up 5000
     testHarness.setProcessingTime(2500)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "ccc", 2L: JLong), true), 20002)) // clean-up 5000
+      CRow(Row.of(toTS(20002), "ccc", 2L: JLong), true))) // clean-up 5000
 
     assert(testHarness.numKeyedStateEntries() > 0)
     testHarness.setProcessingTime(5000) // does not clean up, because data left. New timer 7000
@@ -802,56 +733,40 @@ class OverWindowHarnessTest extends HarnessTestBase{
 
     // all elements at the same row-time have the same value per key
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 1L: JLong, 1L: JLong, 1L: JLong), true), 801))
+      CRow(Row.of(toTS(801), "aaa", 1L: JLong, 1L: JLong, 1L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 10L: JLong, 10L: JLong, 10L: JLong), true), 2501))
+      CRow(Row.of(toTS(2501), "bbb", 10L: JLong, 10L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 2L: JLong, 1L: JLong, 3L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "aaa", 2L: JLong, 1L: JLong, 3L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 3L: JLong, 1L: JLong, 3L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "aaa", 3L: JLong, 1L: JLong, 3L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 20L: JLong, 10L: JLong, 20L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "bbb", 20L: JLong, 10L: JLong, 20L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 4L: JLong, 1L: JLong, 4L: JLong), true), 4801))
+      CRow(Row.of(toTS(4801), "aaa", 4L: JLong, 1L: JLong, 4L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 5L: JLong, 1L: JLong, 6L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 5L: JLong, 1L: JLong, 6L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 6L: JLong, 1L: JLong, 6L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 6L: JLong, 1L: JLong, 6L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 30L: JLong, 10L: JLong, 30L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "bbb", 30L: JLong, 10L: JLong, 30L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 7L: JLong, 1L: JLong, 7L: JLong), true), 7001))
+      CRow(Row.of(toTS(7001), "aaa", 7L: JLong, 1L: JLong, 7L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 8L: JLong, 1L: JLong, 8L: JLong), true), 8001))
+      CRow(Row.of(toTS(8001), "aaa", 8L: JLong, 1L: JLong, 8L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 9L: JLong, 1L: JLong, 10L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 9L: JLong, 1L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 10L: JLong, 1L: JLong, 10L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 10L: JLong, 1L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong, 10L: JLong, 40L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "bbb", 40L: JLong, 10L: JLong, 40L: JLong), true)))
 
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 0L: JLong, 0: JInt, "ccc", 1L: JLong, 1L: JLong, 1L: JLong), true), 20001))
+      CRow(Row.of(toTS(20001), "ccc", 1L: JLong, 1L: JLong, 1L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(2: JInt, 0L: JLong, 0: JInt, "ccc", 2L: JLong, 1L: JLong, 2L: JLong), true), 20002))
+      CRow(Row.of(toTS(20002), "ccc", 2L: JLong, 1L: JLong, 2L: JLong), true)))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verify(expectedOutput, result, new RowResultSortComparator())
     testHarness.close()
   }
 
@@ -863,12 +778,13 @@ class OverWindowHarnessTest extends HarnessTestBase{
         genMinMaxAggFunction,
         minMaxAggregationStateType,
         minMaxCRowType,
+        0,
         new StreamQueryConfig().withIdleStateRetentionTime(Time.seconds(1), Time.seconds(2))))
 
     val testHarness =
       createHarnessTester(
         processFunction,
-        new TupleRowKeySelector[String](3),
+        new TupleRowKeySelector[String](1),
         BasicTypeInfo.STRING_TYPE_INFO)
 
     testHarness.open()
@@ -876,47 +792,47 @@ class OverWindowHarnessTest extends HarnessTestBase{
     testHarness.setProcessingTime(1000)
     testHarness.processWatermark(800)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 1L: JLong), true), 801))
+      CRow(Row.of(toTS(801), "aaa", 1L: JLong), true)))
 
     testHarness.processWatermark(2500)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 10L: JLong), true), 2501))
+      CRow(Row.of(toTS(2501), "bbb", 10L: JLong), true)))
 
     testHarness.processWatermark(4000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 2L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "aaa", 2L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 3L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "aaa", 3L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 20L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "bbb", 20L: JLong), true)))
 
     testHarness.processWatermark(4800)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 4L: JLong), true), 4801))
+      CRow(Row.of(toTS(4801), "aaa", 4L: JLong), true)))
 
     testHarness.processWatermark(6500)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 5L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 5L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 6L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 6L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 30L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "bbb", 30L: JLong), true)))
 
     testHarness.processWatermark(7000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 7L: JLong), true), 7001))
+      CRow(Row.of(toTS(7001), "aaa", 7L: JLong), true)))
 
     testHarness.processWatermark(8000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 8L: JLong), true), 8001))
+      CRow(Row.of(toTS(8001), "aaa", 8L: JLong), true)))
 
     testHarness.processWatermark(12000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 9L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 9L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 10L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 10L: JLong), true)))
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "bbb", 40L: JLong), true)))
 
     testHarness.processWatermark(19000)
 
@@ -929,10 +845,10 @@ class OverWindowHarnessTest extends HarnessTestBase{
 
     testHarness.processWatermark(20000)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(1: JInt, 0L: JLong, 0: JInt, "ccc", 1L: JLong), true), 20001)) // clean-up 5000
+      CRow(Row.of(toTS(20001), "ccc", 1L: JLong), true))) // clean-up 5000
     testHarness.setProcessingTime(2500)
     testHarness.processElement(new StreamRecord(
-      CRow(Row.of(2: JInt, 0L: JLong, 0: JInt, "ccc", 2L: JLong), true), 20002)) // clean-up 5000
+      CRow(Row.of(toTS(20002), "ccc", 2L: JLong), true))) // clean-up 5000
 
     assert(testHarness.numKeyedStateEntries() > 0)
     testHarness.setProcessingTime(5000) // does not clean up, because data left. New timer 7000
@@ -949,56 +865,40 @@ class OverWindowHarnessTest extends HarnessTestBase{
     val expectedOutput = new ConcurrentLinkedQueue[Object]()
 
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 1L: JLong, 1L: JLong, 1L: JLong), true), 801))
+      CRow(Row.of(toTS(801), "aaa", 1L: JLong, 1L: JLong, 1L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 10L: JLong, 10L: JLong, 10L: JLong), true), 2501))
+      CRow(Row.of(toTS(2501), "bbb", 10L: JLong, 10L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 2L: JLong, 1L: JLong, 2L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "aaa", 2L: JLong, 1L: JLong, 2L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 3L: JLong, 1L: JLong, 3L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "aaa", 3L: JLong, 1L: JLong, 3L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 20L: JLong, 10L: JLong, 20L: JLong), true), 4001))
+      CRow(Row.of(toTS(4001), "bbb", 20L: JLong, 10L: JLong, 20L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 4L: JLong, 1L: JLong, 4L: JLong), true), 4801))
+      CRow(Row.of(toTS(4801), "aaa", 4L: JLong, 1L: JLong, 4L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 5L: JLong, 1L: JLong, 5L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 5L: JLong, 1L: JLong, 5L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 6L: JLong, 1L: JLong, 6L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "aaa", 6L: JLong, 1L: JLong, 6L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 30L: JLong, 10L: JLong, 30L: JLong), true), 6501))
+      CRow(Row.of(toTS(6501), "bbb", 30L: JLong, 10L: JLong, 30L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 7L: JLong, 1L: JLong, 7L: JLong), true), 7001))
+      CRow(Row.of(toTS(7001), "aaa", 7L: JLong, 1L: JLong, 7L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 8L: JLong, 1L: JLong, 8L: JLong), true), 8001))
+      CRow(Row.of(toTS(8001), "aaa", 8L: JLong, 1L: JLong, 8L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 9L: JLong, 1L: JLong, 9L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 9L: JLong, 1L: JLong, 9L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(1: JInt, 11L: JLong, 1: JInt, "aaa", 10L: JLong, 1L: JLong, 10L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "aaa", 10L: JLong, 1L: JLong, 10L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-      Row.of(2: JInt, 0L: JLong, 0: JInt, "bbb", 40L: JLong, 10L: JLong, 40L: JLong), true), 12001))
+      CRow(Row.of(toTS(12001), "bbb", 40L: JLong, 10L: JLong, 40L: JLong), true)))
 
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(1: JInt, 0L: JLong, 0: JInt, "ccc", 1L: JLong, 1L: JLong, 1L: JLong), true), 20001))
+      CRow(Row.of(toTS(20001), "ccc", 1L: JLong, 1L: JLong, 1L: JLong), true)))
     expectedOutput.add(new StreamRecord(
-      CRow(
-        Row.of(2: JInt, 0L: JLong, 0: JInt, "ccc", 2L: JLong, 1L: JLong, 2L: JLong), true), 20002))
+      CRow(Row.of(toTS(20002), "ccc", 2L: JLong, 1L: JLong, 2L: JLong), true)))
 
-    verify(expectedOutput, result, new RowResultSortComparator(6))
+    verify(expectedOutput, result, new RowResultSortComparator())
     testHarness.close()
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.stream.table
 
 import java.io.File
 import java.lang.{Boolean => JBool}
+import java.sql.Timestamp
 
 import org.apache.flink.api.common.functions.MapFunction
 import org.apache.flink.api.common.typeinfo.TypeInformation
@@ -28,19 +29,22 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.TableEnvironment
-import org.apache.flink.table.runtime.utils.StreamTestData
+import org.apache.flink.table.api.{TableEnvironment, TableException, Types}
+import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData}
 import org.apache.flink.table.sinks._
 import org.apache.flink.test.util.TestBaseUtils
 import org.apache.flink.types.Row
+import org.apache.flink.util.Collector
 import org.junit.Assert._
 import org.junit.Test
 
 import scala.collection.mutable
+import scala.collection.JavaConverters._
 
 class TableSinkITCase extends StreamingMultipleProgramsTestBase {
 
@@ -199,8 +203,6 @@ class TableSinkITCase extends StreamingMultipleProgramsTestBase {
 
   }
 
-
-
   @Test
   def testUpsertSinkOnAppendingTableWithFullKey1(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
@@ -347,6 +349,136 @@ class TableSinkITCase extends StreamingMultipleProgramsTestBase {
       "6,4",
       "6,2").sorted
     assertEquals(expected, retracted)
+  }
+
+  @Test
+  def testToAppendStreamRowtime(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
+    val t = StreamTestData.get3TupleDataStream(env)
+      .assignAscendingTimestamps(_._1.toLong)
+      .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
+
+    val r = t
+      .window(Tumble over 5.milli on 'rowtime as 'w)
+      .groupBy('num, 'w)
+      .select('num, 'w.rowtime, 'w.rowtime.cast(Types.LONG))
+
+    r.toAppendStream[Row]
+      .process(new ProcessFunction[Row, Row] {
+        override def processElement(
+          row: Row,
+          ctx: ProcessFunction[Row, Row]#Context,
+          out: Collector[Row]): Unit = {
+
+          val rowTS: Long = row.getField(2).asInstanceOf[Long]
+          if (ctx.timestamp() == rowTS) {
+            out.collect(row)
+          }
+        }
+      }).addSink(new StreamITCase.StringSink[Row])
+
+    env.execute()
+
+    val expected = List(
+      "1,1970-01-01 00:00:00.004,4",
+      "2,1970-01-01 00:00:00.004,4",
+      "3,1970-01-01 00:00:00.004,4",
+      "3,1970-01-01 00:00:00.009,9",
+      "4,1970-01-01 00:00:00.009,9",
+      "4,1970-01-01 00:00:00.014,14",
+      "5,1970-01-01 00:00:00.014,14",
+      "5,1970-01-01 00:00:00.019,19",
+      "6,1970-01-01 00:00:00.019,19",
+      "6,1970-01-01 00:00:00.024,24")
+
+    assertEquals(expected, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testToRetractStreamRowtime(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
+    val t = StreamTestData.get3TupleDataStream(env)
+      .assignAscendingTimestamps(_._1.toLong)
+      .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
+
+    val r = t
+      .window(Tumble over 5.milli on 'rowtime as 'w)
+      .groupBy('num, 'w)
+      .select('num, 'w.rowtime, 'w.rowtime.cast(Types.LONG))
+
+    r.toRetractStream[Row]
+      .process(new ProcessFunction[(Boolean, Row), Row] {
+        override def processElement(
+          row: (Boolean, Row),
+          ctx: ProcessFunction[(Boolean, Row), Row]#Context,
+          out: Collector[Row]): Unit = {
+
+          val rowTS: Long = row._2.getField(2).asInstanceOf[Long]
+          if (ctx.timestamp() == rowTS) {
+            out.collect(row._2)
+          }
+        }
+      }).addSink(new StreamITCase.StringSink[Row])
+
+    env.execute()
+
+    val expected = List(
+      "1,1970-01-01 00:00:00.004,4",
+      "2,1970-01-01 00:00:00.004,4",
+      "3,1970-01-01 00:00:00.004,4",
+      "3,1970-01-01 00:00:00.009,9",
+      "4,1970-01-01 00:00:00.009,9",
+      "4,1970-01-01 00:00:00.014,14",
+      "5,1970-01-01 00:00:00.014,14",
+      "5,1970-01-01 00:00:00.019,19",
+      "6,1970-01-01 00:00:00.019,19",
+      "6,1970-01-01 00:00:00.024,24")
+
+    assertEquals(expected, StreamITCase.testResults.sorted)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testToAppendStreamMultiRowtime(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    val t = StreamTestData.get3TupleDataStream(env)
+      .assignAscendingTimestamps(_._1.toLong)
+      .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
+
+    val r = t
+      .window(Tumble over 5.milli on 'rowtime as 'w)
+      .groupBy('num, 'w)
+      .select('num, 'w.rowtime, 'w.rowtime as 'rowtime2)
+
+    r.toAppendStream[Row]
+  }
+
+  @Test(expected = classOf[TableException])
+  def testToRetractStreamMultiRowtime(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    val t = StreamTestData.get3TupleDataStream(env)
+      .assignAscendingTimestamps(_._1.toLong)
+      .toTable(tEnv, 'id, 'num, 'text, 'rowtime.rowtime)
+
+    val r = t
+      .window(Tumble over 5.milli on 'rowtime as 'w)
+      .groupBy('num, 'w)
+      .select('num, 'w.rowtime, 'w.rowtime as 'rowtime2)
+
+    r.toRetractStream[Row]
   }
 
   /** Converts a list of retraction messages into a list of final results. */


### PR DESCRIPTION
## What is the purpose of the change

Handle time indicators attributes as physical fields in `Row`.
- support for multiple event-time time attributes (required for proper join handling)
- no distinction of logical and physical schema

## Brief change log

- Expand phyiscal Row schema for time indicators.
- Refactor computation of logical schema of tables to import.
- `StreamRecord` timestamps are moved into `Row` during initial conversion
- Refactor operators to use time attribute in Row instead of StreamRecord timestamp.
- timestamps are copied into `StreamRecord` when `Table` is converted into `DataStream`.
- Drive-by fix for NPE in `generateInputFieldUnboxing`

## Verifying this change

- Changes are mostly internal. 
- No new features or public APIs have been added. 
- All existing tests pass.
- Tests have been added to verify that time indicators are copied when `Table` is converted into `DataStream`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **na**

