### PR TITLE
[FLINK-7240] [tests] Stabilize ExternalizedCheckpointITCase

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -575,11 +575,11 @@ class JobManager(
       currentJobs.get(jobID) match {
         case Some((executionGraph, _)) =>
           // execute the cancellation asynchronously
+          val origSender = sender
           Future {
             executionGraph.cancel()
+            origSender ! decorateMessage(CancellationSuccess(jobID))
           }(context.dispatcher)
-
-          sender ! decorateMessage(CancellationSuccess(jobID))
         case None =>
           log.info(s"No job found with ID $jobID.")
           sender ! decorateMessage(

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingCluster.scala
@@ -44,7 +44,7 @@ import org.apache.flink.runtime.messages.JobManagerMessages._
 import org.apache.flink.runtime.metrics.MetricRegistry
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster
 import org.apache.flink.runtime.taskmanager.TaskManager
-import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.{CheckpointRequest, CheckpointRequestFailure, CheckpointRequestSuccess, ResponseSavepoint}
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages._
 import org.apache.flink.runtime.testingUtils.TestingMessages.Alive
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages.NotifyWhenRegisteredAtJobManager
 import org.apache.flink.runtime.testutils.TestingResourceManager
@@ -378,34 +378,46 @@ class TestingCluster(
   def requestCheckpoint(jobId: JobID, options : CheckpointOptions): String = {
     val jobManagerGateway = getLeaderGateway(timeout)
 
+    // wait until the cluster is ready to take a checkpoint.
+    val allRunning = jobManagerGateway.ask(
+      TestingJobManagerMessages.WaitForAllVerticesToBeRunning(jobId), timeout)
+
+    Await.ready(allRunning, timeout)
+
     // trigger checkpoint
     val result = Await.result(
       jobManagerGateway.ask(CheckpointRequest(jobId, options), timeout), timeout)
 
     result match {
       case success: CheckpointRequestSuccess => success.path
-      case fail: CheckpointRequestFailure => {
-        // TODO right now, this is a dirty way to detect whether the checkpoint
-        // failed because tasks were not ready.This would not be required if
-        // TestingJobManagerMessages.WaitForAllVerticesToBeRunning(...) works
-        // properly.
-        LOG.info("Test checkpoint attempt failed. Retry ...", fail.cause)
-        Thread.sleep(50)
-        requestCheckpoint(jobId, options)
-      }
+      case fail: CheckpointRequestFailure => throw fail.cause
       case _ => throw new IllegalStateException("Trigger checkpoint failed")
     }
   }
 
+  /**
+    * This cancels the given job and waits until it has been completely removed from
+    * the cluster.
+    *
+    * @param jobId identifying the job to cancel
+    * @throws Exception if something goes wrong
+    */
   @throws[Exception]
   def cancelJob(jobId: JobID): Unit = {
     if (getCurrentlyRunningJobsJava.contains(jobId)) {
       val jobManagerGateway = getLeaderGateway(timeout)
+      val jobRemoved = jobManagerGateway.ask(NotifyWhenJobRemoved(jobId), timeout)
       val cancelFuture = jobManagerGateway.ask(new JobManagerMessages.CancelJob(jobId), timeout)
       val result = Await.result(cancelFuture, timeout)
-      if (!result.isInstanceOf[JobManagerMessages.CancellationSuccess]) {
-        throw new Exception("Cancellation failed")
+
+      result match {
+        case CancellationFailure(_, cause) =>
+          throw new Exception("Cancellation failed", cause)
+        case _ => // noop
       }
+
+      // wait until the job has been removed
+      Await.result(jobRemoved, timeout)
     }
     else throw new IllegalStateException("Job is not running")
   }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ExternalizedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ExternalizedCheckpointITCase.java
@@ -231,6 +231,9 @@ public class ExternalizedCheckpointITCase extends TestLogger {
 		}
 	}
 
+	/**
+	 * Infinite source which notifies when all of its sub tasks have been started via the count down latch.
+	 */
 	public static class NotifyingInfiniteTupleSource extends ManualWindowSpeedITCase.InfiniteTupleSource {
 
 		private static final long serialVersionUID = 8120981235081181746L;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ExternalizedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ExternalizedCheckpointITCase.java
@@ -40,6 +40,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.test.state.ManualWindowSpeedITCase;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.curator.test.TestingServer;
 import org.junit.ClassRule;
@@ -54,7 +55,7 @@ import java.io.File;
  *
  * <p>This tests considers full and incremental checkpoints and was introduced to guard against problems like FLINK-6964.
  */
-public class ExternalizedCheckpointITCase {
+public class ExternalizedCheckpointITCase extends TestLogger {
 
 	private static final int PARALLELISM = 2;
 	private static final int NUM_TASK_MANAGERS = 2;
@@ -211,9 +212,6 @@ public class ExternalizedCheckpointITCase {
 
 				config.addAll(jobGraph.getJobConfiguration());
 				JobSubmissionResult submissionResult = cluster.submitJobDetached(jobGraph);
-
-				// let the job do some progress
-				Thread.sleep(200);
 
 				externalCheckpoint =
 					cluster.requestCheckpoint(submissionResult.getJobID(), CheckpointOptions.forFullCheckpoint());


### PR DESCRIPTION
## What is the purpose of the change

Stabilize `ExternalizedCheckpointITCase`.

## Brief change log

The problem was that the TestingCluster did not wait properly after canceling the
job that the job was also completely removed from the cluster before submitting
the next job. This could lead to a NoResourceAvailableException which ultimately
made the job fail.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

