### PR TITLE
[FLINK-6787] Fix Job-/StoppingException extend FlinkException

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -382,7 +382,7 @@ public abstract class ClusterClient {
 				// invoke main method
 				prog.invokeInteractiveModeForExecution();
 				if (lastJobExecutionResult == null && factory.getLastEnvCreated() == null) {
-					throw new ProgramMissingJobException();
+					throw new ProgramMissingJobException("The program didn't contain a Flink job.");
 				}
 				if (isDetached()) {
 					// in detached mode, we execute the whole user code to extract the Flink job, afterwards we run it here

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ProgramMissingJobException.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ProgramMissingJobException.java
@@ -18,12 +18,18 @@
 
 package org.apache.flink.client.program;
 
+import org.apache.flink.util.FlinkException;
+
 /**
  * Exception used to indicate that no job was executed during the invocation of a Flink program.
  */
-public class ProgramMissingJobException extends Exception {
+public class ProgramMissingJobException extends FlinkException {
 	/**
 	 * Serial version UID for serialization interoperability.
 	 */
 	private static final long serialVersionUID = -1964276369605091101L;
+
+	public ProgramMissingJobException(String message) {
+		super(message);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/JobException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/JobException.java
@@ -18,10 +18,12 @@
 
 package org.apache.flink.runtime;
 
+import org.apache.flink.util.FlinkException;
+
 /**
  * Indicates that a job has failed.
  */
-public class JobException extends Exception {
+public class JobException extends FlinkException {
 
 	private static final long serialVersionUID = 1275864691743020176L;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/StoppingException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/StoppingException.java
@@ -18,10 +18,12 @@
 
 package org.apache.flink.runtime;
 
+import org.apache.flink.util.FlinkException;
+
 /**
  * Indicates that a job is not stoppable.
  */
-public class StoppingException extends Exception {
+public class StoppingException extends FlinkException {
 
 	private static final long serialVersionUID = -721315728140810694L;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActorConnectionTimeoutException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActorConnectionTimeoutException.java
@@ -18,11 +18,13 @@
 
 package org.apache.flink.runtime.client;
 
+import org.apache.flink.util.FlinkException;
+
 /**
  * Exception which is thrown when the {@link JobClientActor} wants to submit a job to
  * the job manager but has not found one after a given timeout interval.
  */
-public class JobClientActorConnectionTimeoutException extends Exception {
+public class JobClientActorConnectionTimeoutException extends FlinkException {
 	private static final long serialVersionUID = 2287747430528388637L;
 
 	public JobClientActorConnectionTimeoutException(String msg) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActorRegistrationTimeoutException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActorRegistrationTimeoutException.java
@@ -18,11 +18,13 @@
 
 package org.apache.flink.runtime.client;
 
+import org.apache.flink.util.FlinkException;
+
 /**
  * Exception which is thrown by the {@link JobClientActor} if it has not heard back from the job
  * manager after it has attempted to register for a job within a given timeout interval.
  */
-public class JobClientActorRegistrationTimeoutException extends Exception {
+public class JobClientActorRegistrationTimeoutException extends FlinkException {
 	private static final long serialVersionUID = 8762463142030454853L;
 
 	public JobClientActorRegistrationTimeoutException(String msg) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActorSubmissionTimeoutException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobClientActorSubmissionTimeoutException.java
@@ -18,11 +18,13 @@
 
 package org.apache.flink.runtime.client;
 
+import org.apache.flink.util.FlinkException;
+
 /**
  * Exception which is thrown by the {@link JobClientActor} if it has not heard back from the job
  * manager after it has submitted a job to it within a given timeout interval.
  */
-public class JobClientActorSubmissionTimeoutException extends Exception {
+public class JobClientActorSubmissionTimeoutException extends FlinkException {
 	private static final long serialVersionUID = 8762463142030454853L;
 
 	public JobClientActorSubmissionTimeoutException(String msg) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobExecutionException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobExecutionException.java
@@ -19,13 +19,14 @@
 package org.apache.flink.runtime.client;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.util.FlinkException;
 
 /**
  * This exception is the base exception for all exceptions that denote any failure during
  * the execution of a job. The JobExecutionException and its subclasses are thrown by
  * the {@link JobClient}.
  */
-public class JobExecutionException extends Exception {
+public class JobExecutionException extends FlinkException {
 
 	private static final long serialVersionUID = 2818087325120827525L;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerException.java
@@ -18,10 +18,12 @@
 
 package org.apache.flink.runtime.jobmaster;
 
+import org.apache.flink.util.FlinkException;
+
 /**
  * Base exception thrown by the {@link JobMaster}.
  */
-public class JobManagerException extends Exception {
+public class JobManagerException extends FlinkException {
 
 	private static final long serialVersionUID = -7290962952242188064L;
 


### PR DESCRIPTION
## What is the purpose of the change

Fix Job-/StoppingException extend FlinkException

## Brief change log

  - *Job-/StoppingException extend FlinkException instead of Exception*

## Verifying this change

*(Please pick either of the following options)*
This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

