### PR TITLE
[FLINK-7352] [tests] Stabilize ExecutionGraphRestartTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleAckingTaskManagerGateway.java
@@ -33,8 +33,10 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.StackTrace;
 import org.apache.flink.runtime.messages.StackTraceSampleResponse;
 
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 /**
  * A TaskManagerGateway that simply acks the basic operations (deploy, cancel, update) and does not
@@ -43,6 +45,16 @@ import java.util.concurrent.CompletableFuture;
 public class SimpleAckingTaskManagerGateway implements TaskManagerGateway {
 
 	private final String address = UUID.randomUUID().toString();
+
+	private Optional<Consumer<ExecutionAttemptID>> optSubmitCondition;
+
+	public SimpleAckingTaskManagerGateway() {
+		optSubmitCondition = Optional.empty();
+	}
+
+	public void setCondition(Consumer<ExecutionAttemptID> predicate) {
+		optSubmitCondition = Optional.of(predicate);
+	}
 
 	@Override
 	public String getAddress() {
@@ -73,6 +85,7 @@ public class SimpleAckingTaskManagerGateway implements TaskManagerGateway {
 
 	@Override
 	public CompletableFuture<Acknowledge> submitTask(TaskDeploymentDescriptor tdd, Time timeout) {
+		optSubmitCondition.ifPresent(condition -> condition.accept(tdd.getExecutionAttemptId()));
 		return CompletableFuture.completedFuture(Acknowledge.get());
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Introduce an explicit waiting for the deployment of tasks. This replaces the loose
ordering induced by Thread.sleep and fixes the race conditions caused by it.

## Brief change log

- Introduce `WaitForTasks` consumer which is given to the `SimpleAckingTaskManagerGateway`
- Using a single `SimpleAckingTaskManagerGateway` to receive all task submission calls

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

