### PR TITLE
[FLINK-7399] [checkstyle] Forbid imports from org.codehaus.jackson

### DIFF
--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -211,7 +211,7 @@ This file is based on the checkstyle file of Apache Beam.
     </module>
 
     <module name="IllegalImport">
-      <property name="illegalPkgs" value="autovalue.shaded, avro.shaded, com.google.api.client.repackaged, com.google.appengine.repackaged, io.netty"/>
+      <property name="illegalPkgs" value="autovalue.shaded, avro.shaded, com.google.api.client.repackaged, com.google.appengine.repackaged, org.codehaus.jackson, io.netty"/>
     </module>
 
     <module name="RedundantModifier">


### PR DESCRIPTION
## What is the purpose of the change

Flink uses `com.fasterxml.jackson` but pulls in the codehaus version from various dependencies. This PR forbids using the codehaus version using checkstyle.


## Brief change log

*(for example:)*
  - Add `org.codehaus.jackson` to the list of illegal packages of the `IllegalImport` module


## Verifying this change

1) Run `mvn checkstyle:check`, it should not fail.
2) Add some import from `org.codehaus.jackson`, running checkstyle should now fail,
