### PR TITLE
[FLINK-7400][cluster] fix off-heap limits set to conservatively in cluster environments

### DIFF
--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -451,7 +451,7 @@ of the JobManager, because the same ActorSystem is used. Its not possible to use
 
 ### YARN
 
-- `containerized.heap-cutoff-ratio`: (Default 0.25) Percentage of heap space to remove from containers started by YARN. When a user requests a certain amount of memory for each TaskManager container (for example 4 GB), we can not pass this amount as the maximum heap space for the JVM (`-Xmx` argument) because the JVM is also allocating memory outside the heap. YARN is very strict with killing containers which are using more memory than requested. Therefore, we remove a 15% of the memory from the requested heap as a safety margin.
+- `containerized.heap-cutoff-ratio`: (Default 0.25) Percentage of heap space to remove from containers started by YARN. When a user requests a certain amount of memory for each TaskManager container (for example 4 GB), we can not pass this amount as the maximum heap space for the JVM (`-Xmx` argument) because the JVM is also allocating memory outside the heap. YARN is very strict with killing containers which are using more memory than requested. Therefore, we remove this fraction of the memory from the requested heap as a safety margin and add it to the memory used off-heap.
 
 - `containerized.heap-cutoff-min`: (Default 600 MB) Minimum amount of memory to cut off the requested heap size.
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParameters.java
@@ -141,7 +141,8 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 
 		// (2) split the remaining Java memory between heap and off-heap
 		final long heapSizeMB = TaskManagerServices.calculateHeapSizeMB(javaMemorySizeMB, config);
-		final long offHeapSize = javaMemorySizeMB == heapSizeMB ? -1L : javaMemorySizeMB - heapSizeMB; 
+		// use the cut-off memory for off-heap (that was its intention)
+		final long offHeapSize = javaMemorySizeMB == heapSizeMB ? -1L : containerMemoryMB - heapSizeMB;
 
 		// (3) obtain the additional environment variables from the configuration
 		final HashMap<String, String> envVars = new HashMap<>();

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.client.JobClient;
+import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.test.util.TestBaseUtils;
@@ -124,20 +127,22 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 				"-ys", "2", //test that the job is executed with a DOP of 2
 				"-yjm", "768",
 				"-ytm", "1024", exampleJarLocation.getAbsolutePath()},
-				/* test succeeded after this string */
+			/* test succeeded after this string */
 			"Job execution complete",
-			/* prohibited strings: (we want to see "DataSink (...) (2/2) switched to FINISHED") */
+			/* prohibited strings: (to verify the parallelism) */
+			// (we should see "DataSink (...) (1/2)" and "DataSink (...) (2/2)" instead)
 			new String[]{"DataSink \\(.*\\) \\(1/1\\) switched to FINISHED"},
 			RunTypes.CLI_FRONTEND, 0, true);
 		LOG.info("Finished perJobYarnCluster()");
 	}
 
 	/**
-	 * Test per-job yarn cluster and memory calculations for off-heap use (see FLINK-7400).
+	 * Test per-job yarn cluster and memory calculations for off-heap use (see FLINK-7400) with the
+	 * same job as {@link #perJobYarnCluster()}.
 	 *
-	 * <p>This also tests the prefixed CliFrontend options for the YARN case
-	 * We also test if the requested parallelism of 2 is passed through.
-	 * The parallelism is requested at the YARN client (-ys).
+	 * <p>This ensures that with (any) pre-allocated off-heap memory by us, there is some off-heap
+	 * memory remaining for Flink's libraries. Creating task managers will thus fail if no off-heap
+	 * memory remains.
 	 */
 	@Test
 	public void perJobYarnClusterOffHeap() {
@@ -145,18 +150,34 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 		addTestAppender(JobClient.class, Level.INFO);
 		File exampleJarLocation = new File("target/programs/BatchWordCount.jar");
 		Assert.assertNotNull("Could not find wordcount jar", exampleJarLocation);
+
+		// set memory constraints (otherwise this is the same test as perJobYarnCluster() above)
+		final long taskManagerMemoryMB = 1024;
+		//noinspection NumericOverflow if the calculation of the total Java memory size overflows, default configuration parameters are wrong in the first place, so we can ignore this inspection
+		final long networkBuffersMB = TaskManagerServices
+			.calculateNetworkBufferMemory(
+				(taskManagerMemoryMB -
+					ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN.defaultValue()) << 20,
+				new Configuration()) >> 20;
+		final long offHeapMemory = taskManagerMemoryMB
+			- ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN.defaultValue()
+			// cutoff memory (will be added automatically)
+			- networkBuffersMB // amount of memory used for network buffers
+			- 100; // reserve something for the Java heap space
+
 		runWithArgs(new String[]{"run", "-m", "yarn-cluster",
 				"-yj", flinkUberjar.getAbsolutePath(), "-yt", flinkLibFolder.getAbsolutePath(),
 				"-yn", "1",
 				"-ys", "2", //test that the job is executed with a DOP of 2
 				"-yjm", "768",
-				"-ytm", "1024",
+				"-ytm", String.valueOf(taskManagerMemoryMB),
 				"-yD", "taskmanager.memory.off-heap=true",
-				"-yD", "taskmanager.memory.size=246", // this should fit!
+				"-yD", "taskmanager.memory.size=" + offHeapMemory,
 				"-yD", "taskmanager.memory.preallocate=true", exampleJarLocation.getAbsolutePath()},
-				/* test succeeded after this string */
+			/* test succeeded after this string */
 			"Job execution complete",
-			/* prohibited strings: (we want to see "DataSink (...) (2/2) switched to FINISHED") */
+			/* prohibited strings: (to verify the parallelism) */
+			// (we should see "DataSink (...) (1/2)" and "DataSink (...) (2/2)" instead)
 			new String[]{"DataSink \\(.*\\) \\(1/1\\) switched to FINISHED"},
 			RunTypes.CLI_FRONTEND, 0, true);
 		LOG.info("Finished perJobYarnCluster()");


### PR DESCRIPTION
## What is the purpose of the change

Inside `ContaineredTaskManagerParameters`, since #3648, the `offHeapSize` is set to the amount of memory Flink will use off-heap which will be set as the value for `-XX:MaxDirectMemorySize` in various cases, e.g. YARN or Mesos. This does not account for any off-heap use by other components than Flink, e.g. RocksDB, other libraries, or the JVM itself.

Please note that this affects at least all batch programs with the following options set (which do not make much sense for streaming):
```
taskmanager.memory.off-heap=true
taskmanager.memory.size=<any value>
taskmanager.memory.preallocate=true
```
If, instead, `taskmanager.memory.fraction` is used, programs may be safe due to https://issues.apache.org/jira/browse/FLINK-7401 but the actual additional buffer that we get from that may be too small, especially if RocksDB or other libraries using off-heap memory are used.

This PR adds the `cutoff` from the `containerized.heap-cutoff-ratio`/`containerized.heap-cutoff-min` configuration parameters to `offHeapSize` as implied by the description of these two options.

## Brief change log

- include the cut-off memory (removed from the container memory size for further calculations) into the off-heap part
- add a unit test verifying the bug fix in a YARN environment

## Verifying this change

This change added tests and can be verified as follows:

- added `YARNSessionCapacitySchedulerITCase#perJobYarnClusterOffHeap()` test that validates that we have enough memory available and the bounds are not too strict

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes: memory calculations)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)

