### PR TITLE
[FLINK-7406][network] Implement Netty receiver incoming pipeline for credit-based

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedClientHandler.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.netty.exception.LocalTransportException;
+import org.apache.flink.runtime.io.network.netty.exception.RemoteTransportException;
+import org.apache.flink.runtime.io.network.netty.exception.TransportException;
+import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
+import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandlerAdapter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Channel handler to read the messages of buffer response or error response from the
+ * producer, to write and flush the unannounced credits for the producer.
+ */
+class CreditBasedClientHandler extends ChannelInboundHandlerAdapter {
+
+	private static final Logger LOG = LoggerFactory.getLogger(CreditBasedClientHandler.class);
+
+	/** Channels, which already requested partitions from the producers. */
+	private final ConcurrentMap<InputChannelID, RemoteInputChannel> inputChannels = new ConcurrentHashMap<>();
+
+	private final AtomicReference<Throwable> channelError = new AtomicReference<>();
+
+	/**
+	 * Set of cancelled partition requests. A request is cancelled iff an input channel is cleared
+	 * while data is still coming in for this channel.
+	 */
+	private final ConcurrentMap<InputChannelID, InputChannelID> cancelled = new ConcurrentHashMap<>();
+
+	private volatile ChannelHandlerContext ctx;
+
+	// ------------------------------------------------------------------------
+	// Input channel/receiver registration
+	// ------------------------------------------------------------------------
+
+	void addInputChannel(RemoteInputChannel listener) throws IOException {
+		checkError();
+
+		if (!inputChannels.containsKey(listener.getInputChannelId())) {
+			inputChannels.put(listener.getInputChannelId(), listener);
+		}
+	}
+
+	void removeInputChannel(RemoteInputChannel listener) {
+		inputChannels.remove(listener.getInputChannelId());
+	}
+
+	void cancelRequestFor(InputChannelID inputChannelId) {
+		if (inputChannelId == null || ctx == null) {
+			return;
+		}
+
+		if (cancelled.putIfAbsent(inputChannelId, inputChannelId) == null) {
+			ctx.writeAndFlush(new NettyMessage.CancelPartitionRequest(inputChannelId));
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	// Network events
+	// ------------------------------------------------------------------------
+
+	@Override
+	public void channelActive(final ChannelHandlerContext ctx) throws Exception {
+		if (this.ctx == null) {
+			this.ctx = ctx;
+		}
+
+		super.channelActive(ctx);
+	}
+
+	@Override
+	public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+		// Unexpected close. In normal operation, the client closes the connection after all input
+		// channels have been removed. This indicates a problem with the remote task manager.
+		if (!inputChannels.isEmpty()) {
+			final SocketAddress remoteAddr = ctx.channel().remoteAddress();
+
+			notifyAllChannelsOfErrorAndClose(new RemoteTransportException(
+				"Connection unexpectedly closed by remote task manager '" + remoteAddr + "'. "
+					+ "This might indicate that the remote task manager was lost.", remoteAddr));
+		}
+
+		super.channelInactive(ctx);
+	}
+
+	/**
+	 * Called on exceptions in the client handler pipeline.
+	 *
+	 * <p>Remote exceptions are received as regular payload.
+	 */
+	@Override
+	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+
+		if (cause instanceof TransportException) {
+			notifyAllChannelsOfErrorAndClose(cause);
+		} else {
+			final SocketAddress remoteAddr = ctx.channel().remoteAddress();
+
+			final TransportException tex;
+
+			// Improve on the connection reset by peer error message
+			if (cause instanceof IOException && cause.getMessage().equals("Connection reset by peer")) {
+				tex = new RemoteTransportException("Lost connection to task manager '" + remoteAddr + "'. " +
+					"This indicates that the remote task manager was lost.", remoteAddr, cause);
+			} else {
+				tex = new LocalTransportException(cause.getMessage(), ctx.channel().localAddress(), cause);
+			}
+
+			notifyAllChannelsOfErrorAndClose(tex);
+		}
+	}
+
+	@Override
+	public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+		try {
+			decodeMsg(msg);
+		} catch (Throwable t) {
+			notifyAllChannelsOfErrorAndClose(t);
+		}
+	}
+
+	private void notifyAllChannelsOfErrorAndClose(Throwable cause) {
+		if (channelError.compareAndSet(null, cause)) {
+			try {
+				for (RemoteInputChannel inputChannel : inputChannels.values()) {
+					inputChannel.onError(cause);
+				}
+			} catch (Throwable t) {
+				// We can only swallow the Exception at this point. :(
+				LOG.warn("An Exception was thrown during error notification of a remote input channel.", t);
+			} finally {
+				inputChannels.clear();
+
+				if (ctx != null) {
+					ctx.close();
+				}
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Checks for an error and rethrows it if one was reported.
+	 */
+	private void checkError() throws IOException {
+		final Throwable t = channelError.get();
+
+		if (t != null) {
+			if (t instanceof IOException) {
+				throw (IOException) t;
+			} else {
+				throw new IOException("There has been an error in the channel.", t);
+			}
+		}
+	}
+
+	private void decodeMsg(Object msg) throws Throwable {
+		final Class<?> msgClazz = msg.getClass();
+
+		// ---- Buffer --------------------------------------------------------
+		if (msgClazz == NettyMessage.BufferResponse.class) {
+			NettyMessage.BufferResponse bufferOrEvent = (NettyMessage.BufferResponse) msg;
+
+			RemoteInputChannel inputChannel = inputChannels.get(bufferOrEvent.receiverId);
+			if (inputChannel == null) {
+				bufferOrEvent.releaseBuffer();
+
+				cancelRequestFor(bufferOrEvent.receiverId);
+
+				return;
+			}
+
+			decodeBufferOrEvent(inputChannel, bufferOrEvent);
+
+		} else if (msgClazz == NettyMessage.ErrorResponse.class) {
+			// ---- Error ---------------------------------------------------------
+			NettyMessage.ErrorResponse error = (NettyMessage.ErrorResponse) msg;
+
+			SocketAddress remoteAddr = ctx.channel().remoteAddress();
+
+			if (error.isFatalError()) {
+				notifyAllChannelsOfErrorAndClose(new RemoteTransportException(
+					"Fatal error at remote task manager '" + remoteAddr + "'.",
+					remoteAddr,
+					error.cause));
+			} else {
+				RemoteInputChannel inputChannel = inputChannels.get(error.receiverId);
+
+				if (inputChannel != null) {
+					if (error.cause.getClass() == PartitionNotFoundException.class) {
+						inputChannel.onFailedPartitionRequest();
+					} else {
+						inputChannel.onError(new RemoteTransportException(
+							"Error at remote task manager '" + remoteAddr + "'.",
+							remoteAddr,
+							error.cause));
+					}
+				}
+			}
+		} else {
+			throw new IllegalStateException("Received unknown message from producer: " + msg.getClass());
+		}
+	}
+
+	private void decodeBufferOrEvent(RemoteInputChannel inputChannel, NettyMessage.BufferResponse bufferOrEvent) throws Throwable {
+		try {
+			if (bufferOrEvent.isBuffer()) {
+				// ---- Buffer ------------------------------------------------
+
+				// Early return for empty buffers. Otherwise Netty's readBytes() throws an
+				// IndexOutOfBoundsException.
+				if (bufferOrEvent.getSize() == 0) {
+					inputChannel.onEmptyBuffer(bufferOrEvent.sequenceNumber, bufferOrEvent.backlog);
+					return;
+				}
+
+				Buffer buffer = inputChannel.requestBuffer();
+				if (buffer != null) {
+					buffer.setSize(bufferOrEvent.getSize());
+					bufferOrEvent.getNettyBuffer().readBytes(buffer.getNioBuffer());
+
+					inputChannel.onBuffer(buffer, bufferOrEvent.sequenceNumber, bufferOrEvent.backlog);
+				} else if (inputChannel.isReleased()) {
+					cancelRequestFor(bufferOrEvent.receiverId);
+				} else {
+					throw new IllegalStateException("No buffer available in credit-based input channel.");
+				}
+			} else {
+				// ---- Event -------------------------------------------------
+				// TODO We can just keep the serialized data in the Netty buffer and release it later at the reader
+				byte[] byteArray = new byte[bufferOrEvent.getSize()];
+				bufferOrEvent.getNettyBuffer().readBytes(byteArray);
+
+				MemorySegment memSeg = MemorySegmentFactory.wrap(byteArray);
+				Buffer buffer = new Buffer(memSeg, FreeingBufferRecycler.INSTANCE, false);
+
+				inputChannel.onBuffer(buffer, bufferOrEvent.sequenceNumber, bufferOrEvent.backlog);
+			}
+		} finally {
+			bufferOrEvent.releaseBuffer();
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandler.java
@@ -276,7 +276,7 @@ class PartitionRequestClientHandler extends ChannelInboundHandlerAdapter {
 				// Early return for empty buffers. Otherwise Netty's readBytes() throws an
 				// IndexOutOfBoundsException.
 				if (bufferOrEvent.getSize() == 0) {
-					inputChannel.onEmptyBuffer(bufferOrEvent.sequenceNumber);
+					inputChannel.onEmptyBuffer(bufferOrEvent.sequenceNumber, -1);
 					return true;
 				}
 
@@ -295,7 +295,7 @@ class PartitionRequestClientHandler extends ChannelInboundHandlerAdapter {
 						buffer.setSize(bufferOrEvent.getSize());
 						bufferOrEvent.getNettyBuffer().readBytes(buffer.getNioBuffer());
 
-						inputChannel.onBuffer(buffer, bufferOrEvent.sequenceNumber);
+						inputChannel.onBuffer(buffer, bufferOrEvent.sequenceNumber, -1);
 
 						return true;
 					}
@@ -318,7 +318,7 @@ class PartitionRequestClientHandler extends ChannelInboundHandlerAdapter {
 				MemorySegment memSeg = MemorySegmentFactory.wrap(byteArray);
 				Buffer buffer = new Buffer(memSeg, FreeingBufferRecycler.INSTANCE, false);
 
-				inputChannel.onBuffer(buffer, bufferOrEvent.sequenceNumber);
+				inputChannel.onBuffer(buffer, bufferOrEvent.sequenceNumber, -1);
 
 				return true;
 			}
@@ -450,7 +450,7 @@ class PartitionRequestClientHandler extends ChannelInboundHandlerAdapter {
 				RemoteInputChannel inputChannel = inputChannels.get(stagedBufferResponse.receiverId);
 
 				if (inputChannel != null) {
-					inputChannel.onBuffer(buffer, stagedBufferResponse.sequenceNumber);
+					inputChannel.onBuffer(buffer, stagedBufferResponse.sequenceNumber, -1);
 
 					success = true;
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -193,7 +193,8 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 						BufferResponse msg = new BufferResponse(
 							next.buffer(),
 							reader.getSequenceNumber(),
-							reader.getReceiverId());
+							reader.getReceiverId(),
+							0);
 
 						if (isEndOfPartitionEvent(next.buffer())) {
 							reader.notifySubpartitionConsumed();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -32,6 +32,8 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.util.ExceptionUtils;
 
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.List;
@@ -82,17 +84,19 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 	/** The initial number of exclusive buffers assigned to this channel. */
 	private int initialCredit;
 
-	/** The current available buffers including both exclusive buffers and requested floating buffers. */
-	private final ArrayDeque<Buffer> availableBuffers = new ArrayDeque<>();
+	/** The available buffer queue wraps both exclusive and requested floating buffers. */
+	private final AvailableBufferQueue bufferQueue = new AvailableBufferQueue();
 
 	/** The number of available buffers that have not been announced to the producer yet. */
 	private final AtomicInteger unannouncedCredit = new AtomicInteger(0);
 
 	/** The number of unsent buffers in the producer's sub partition. */
-	private final AtomicInteger senderBacklog = new AtomicInteger(0);
+	@GuardedBy("bufferQueue")
+	private int senderBacklog;
 
 	/** The tag indicates whether this channel is waiting for additional floating buffers from the buffer pool. */
-	private final AtomicBoolean isWaitingForFloatingBuffers = new AtomicBoolean(false);
+	@GuardedBy("bufferQueue")
+	private boolean isWaitingForFloatingBuffers;
 
 	public RemoteInputChannel(
 		SingleInputGate inputGate,
@@ -134,9 +138,9 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 
 		this.initialCredit = segments.size();
 
-		synchronized(availableBuffers) {
+		synchronized(bufferQueue) {
 			for (MemorySegment segment : segments) {
-				availableBuffers.add(new Buffer(segment, this));
+				bufferQueue.addExclusiveBuffer(new Buffer(segment, this));
 			}
 		}
 	}
@@ -211,7 +215,7 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 	// ------------------------------------------------------------------------
 
 	@Override
-	boolean isReleased() {
+	public boolean isReleased() {
 		return isReleased.get();
 	}
 
@@ -227,7 +231,8 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 	void releaseAllResources() throws IOException {
 		if (isReleased.compareAndSet(false, true)) {
 
-			// Gather all exclusive buffers and recycle them to global pool in batch
+			// Gather all exclusive buffers and recycle them to global pool in batch, because
+			// we do not want to trigger redistribution of buffers after each recycle.
 			final List<MemorySegment> exclusiveRecyclingSegments = new ArrayList<>();
 
 			synchronized (receivedBuffers) {
@@ -240,15 +245,13 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 					}
 				}
 			}
-
-			synchronized (availableBuffers) {
+			synchronized (bufferQueue) {
 				Buffer buffer;
-				while ((buffer = availableBuffers.poll()) != null) {
-					if (buffer.getRecycler() == this) {
-						exclusiveRecyclingSegments.add(buffer.getMemorySegment());
-					} else {
-						buffer.recycle();
-					}
+				while ((buffer = bufferQueue.takeFloatingBuffer()) != null) {
+					buffer.recycle();
+				}
+				while ((buffer = bufferQueue.takeExclusiveBuffer()) != null) {
+					exclusiveRecyclingSegments.add(buffer.getMemorySegment());
 				}
 			}
 
@@ -287,17 +290,22 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 	}
 
 	/**
-	 * Exclusive buffer is recycled to this input channel directly and it may trigger notify
-	 * credit to producer.
+	 * Exclusive buffer is recycled to this input channel directly and it may trigger return extra
+	 * floating buffer and notify increased credit to the producer.
 	 *
 	 * @param segment The exclusive segment of this channel.
 	 */
 	@Override
 	public void recycle(MemorySegment segment) {
-		synchronized (availableBuffers) {
-			// Important: the isReleased check should be inside the synchronized block.
-			// that way the segment can also be returned to global pool after added into
-			// the available queue during releasing all resources.
+		boolean floatingBufferRecycled = false;
+
+		synchronized (bufferQueue) {
+			final int numRequiredBuffers = senderBacklog + initialCredit;
+			checkState(bufferQueue.getAvailableBufferSize() <= numRequiredBuffers,
+				"The number of available buffers " + bufferQueue.getAvailableBufferSize() + " should not exceed " + numRequiredBuffers);
+
+			// Important: check the isReleased state inside synchronized block, so there is no
+			// race condition when recycle and releaseAllResources running in parallel.
 			if (isReleased.get()) {
 				try {
 					inputGate.returnExclusiveSegments(Arrays.asList(segment));
@@ -306,62 +314,79 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 					ExceptionUtils.rethrow(t);
 				}
 			}
-			availableBuffers.add(new Buffer(segment, this));
+
+			// Recycle one extra floating buffer to always maintain (senderBacklog + initialCredit) buffers available.
+			if (bufferQueue.getAvailableBufferSize() == numRequiredBuffers) {
+				bufferQueue.takeFloatingBuffer().recycle();
+				floatingBufferRecycled = true;
+			}
+
+			bufferQueue.addExclusiveBuffer(new Buffer(segment, this));
 		}
 
-		if (unannouncedCredit.getAndAdd(1) == 0) {
+		if (!floatingBufferRecycled && unannouncedCredit.getAndAdd(1) == 0) {
 			notifyCreditAvailable();
 		}
 	}
 
 	public int getNumberOfAvailableBuffers() {
-		synchronized (availableBuffers) {
-			return availableBuffers.size();
+		synchronized (bufferQueue) {
+			return bufferQueue.getAvailableBufferSize();
 		}
 	}
 
 	/**
 	 * The Buffer pool notifies this channel of an available floating buffer. If the channel is released or
 	 * currently does not need extra buffers, the buffer should be recycled to the buffer pool. Otherwise,
-	 * the buffer will be added into the <tt>availableBuffers</tt> queue and the unannounced credit is
-	 * increased by one.
+	 * the buffer will be added into the <tt>bufferQueue</tt> and the unannounced credit is increased
+	 * by one.
 	 *
 	 * @param buffer Buffer that becomes available in buffer pool.
 	 * @return True when this channel is waiting for more floating buffers, otherwise false.
 	 */
 	@Override
 	public boolean notifyBufferAvailable(Buffer buffer) {
-		checkState(isWaitingForFloatingBuffers.get(), "This channel should be waiting for floating buffers.");
+		// Check the isReleased state outside synchronized block first to avoid
+		// deadlock with releaseAllResources running in parallel.
+		if (isReleased.get()) {
+			buffer.recycle();
+			return false;
+		}
 
-		synchronized (availableBuffers) {
-			// Important: the isReleased check should be inside the synchronized block.
-			if (isReleased.get() || availableBuffers.size() >= senderBacklog.get()) {
-				isWaitingForFloatingBuffers.set(false);
+		boolean needMoreBuffers = false;
+		synchronized (bufferQueue) {
+			checkState(isWaitingForFloatingBuffers, "This channel should be waiting for floating buffers.");
+
+			final int numRequiredBuffers = senderBacklog + initialCredit;
+			checkState(bufferQueue.getAvailableBufferSize() <= numRequiredBuffers,
+				"The number of available buffers " + bufferQueue.getAvailableBufferSize() + " should not exceed " + numRequiredBuffers);
+
+			// Important: double check the isReleased state inside synchronized block, so there is no
+			// race condition when notifyBufferAvailable and releaseAllResources running in parallel.
+			if (isReleased.get() || bufferQueue.getAvailableBufferSize() == numRequiredBuffers) {
 				buffer.recycle();
-
 				return false;
 			}
 
-			availableBuffers.add(buffer);
+			bufferQueue.addFloatingBuffer(buffer);
 
-			if (unannouncedCredit.getAndAdd(1) == 0) {
-				notifyCreditAvailable();
-			}
-
-			if (availableBuffers.size() >= senderBacklog.get()) {
-				isWaitingForFloatingBuffers.set(false);
-				return false;
+			if (bufferQueue.getAvailableBufferSize() == numRequiredBuffers) {
+				isWaitingForFloatingBuffers = false;
 			} else {
-				return true;
+				needMoreBuffers =  true;
 			}
 		}
+
+		if (unannouncedCredit.getAndAdd(1) == 0) {
+			notifyCreditAvailable();
+		}
+
+		return needMoreBuffers;
 	}
 
 	@Override
 	public void notifyBufferDestroyed() {
-		if (!isWaitingForFloatingBuffers.compareAndSet(true, false)) {
-			throw new IllegalStateException("This channel should be waiting for floating buffers currently.");
-		}
+		// Nothing to do actually.
 	}
 
 	// ------------------------------------------------------------------------
@@ -394,7 +419,63 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		return inputGate.getBufferProvider();
 	}
 
-	public void onBuffer(Buffer buffer, int sequenceNumber) {
+	/**
+	 * Requests buffer from input channel directly for receiving network data.
+	 * It should always return an available buffer in credit-based mode unless
+	 * the channel has been released.
+	 *
+	 * @return The available buffer.
+	 */
+	@Nullable
+	public Buffer requestBuffer() {
+		synchronized (bufferQueue) {
+			// Take the floating buffer first if possible.
+			if (bufferQueue.getFloatingBufferSize() > 0) {
+				return bufferQueue.takeFloatingBuffer();
+			} else {
+				return bufferQueue.takeExclusiveBuffer();
+			}
+		}
+	}
+
+	/**
+	 * Receives the backlog from the producer's buffer response. If the number of available
+	 * buffers is less than backlog + initialCredit, it will request floating buffers from the buffer
+	 * pool, and then notify unannounced credits to the producer.
+	 *
+	 * @param backlog The number of unsent buffers in the producer's sub partition.
+	 */
+	void onSenderBacklog(int backlog) throws IOException {
+		int numRequestedBuffers = 0;
+
+		synchronized (bufferQueue) {
+			// Important: check the isReleased state inside synchronized block, so there is no
+			// race condition when onSenderBacklog and releaseAllResources running in parallel.
+			if (isReleased.get()) {
+				return;
+			}
+
+			senderBacklog = backlog;
+
+			while (bufferQueue.getAvailableBufferSize() < senderBacklog + initialCredit && !isWaitingForFloatingBuffers) {
+				Buffer buffer = inputGate.getBufferPool().requestBuffer();
+				if (buffer != null) {
+					bufferQueue.addFloatingBuffer(buffer);
+					numRequestedBuffers++;
+				} else if (inputGate.getBufferProvider().addBufferListener(this)) {
+					// If the channel has not got enough buffers, register it as listener to wait for more floating buffers.
+					isWaitingForFloatingBuffers = true;
+					break;
+				}
+			}
+		}
+
+		if (numRequestedBuffers > 0 && unannouncedCredit.getAndAdd(numRequestedBuffers) == 0) {
+			notifyCreditAvailable();
+		}
+	}
+
+	public void onBuffer(Buffer buffer, int sequenceNumber, int backlog) throws IOException {
 		boolean success = false;
 
 		try {
@@ -416,6 +497,10 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 					}
 				}
 			}
+
+			if (success && backlog >= 0) {
+				onSenderBacklog(backlog);
+			}
 		} finally {
 			if (!success) {
 				buffer.recycle();
@@ -423,15 +508,22 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		}
 	}
 
-	public void onEmptyBuffer(int sequenceNumber) {
+	public void onEmptyBuffer(int sequenceNumber, int backlog) throws IOException {
+		boolean success = false;
+
 		synchronized (receivedBuffers) {
 			if (!isReleased.get()) {
 				if (expectedSequenceNumber == sequenceNumber) {
 					expectedSequenceNumber++;
+					success = true;
 				} else {
 					onError(new BufferReorderingException(expectedSequenceNumber, sequenceNumber));
 				}
 			}
+		}
+
+		if (success && backlog >= 0) {
+			onSenderBacklog(backlog);
 		}
 	}
 
@@ -460,6 +552,44 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		public String getMessage() {
 			return String.format("Buffer re-ordering: expected buffer with sequence number %d, but received %d.",
 				expectedSequenceNumber, actualSequenceNumber);
+		}
+	}
+
+	private class AvailableBufferQueue {
+
+		/** The current available floating buffers from the fixed buffer pool. */
+		private final ArrayDeque<Buffer> floatingBuffers;
+
+		/** The current available exclusive buffers from the global buffer pool. */
+		private final ArrayDeque<Buffer> exclusiveBuffers;
+
+		AvailableBufferQueue() {
+			this.exclusiveBuffers = new ArrayDeque<>();
+			this.floatingBuffers = new ArrayDeque<>();
+		}
+
+		void addExclusiveBuffer(Buffer buffer) {
+			exclusiveBuffers.add(buffer);
+		}
+
+		Buffer takeExclusiveBuffer() {
+			return exclusiveBuffers.poll();
+		}
+
+		void addFloatingBuffer(Buffer buffer) {
+			floatingBuffers.add(buffer);
+		}
+
+		Buffer takeFloatingBuffer() {
+			return floatingBuffers.poll();
+		}
+
+		int getFloatingBufferSize() {
+			return floatingBuffers.size();
+		}
+
+		int getAvailableBufferSize() {
+			return floatingBuffers.size() + exclusiveBuffers.size();
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -309,7 +309,7 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 			numAddedBuffers = bufferQueue.addExclusiveBuffer(new Buffer(segment, this), numRequiredBuffers);
 		}
 
-		if (numAddedBuffers > 0 && unannouncedCredit.getAndAdd(1) == 0) {
+		if (numAddedBuffers > 0 && unannouncedCredit.getAndAdd(numAddedBuffers) == 0) {
 			notifyCreditAvailable();
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
@@ -62,7 +62,7 @@ public class NettyMessageSerializationTest {
 				nioBuffer.putInt(i);
 			}
 
-			NettyMessage.BufferResponse expected = new NettyMessage.BufferResponse(buffer, random.nextInt(), new InputChannelID());
+			NettyMessage.BufferResponse expected = new NettyMessage.BufferResponse(buffer, random.nextInt(), new InputChannelID(), random.nextInt());
 			NettyMessage.BufferResponse actual = encodeAndDecode(expected);
 
 			// Verify recycle has been called on buffer instance
@@ -85,6 +85,7 @@ public class NettyMessageSerializationTest {
 
 			assertEquals(expected.sequenceNumber, actual.sequenceNumber);
 			assertEquals(expected.receiverId, actual.receiverId);
+			assertEquals(expected.backlog, actual.backlog);
 		}
 
 		{

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
@@ -30,23 +30,16 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.io.network.util.TestBufferFactory;
-import org.apache.flink.runtime.testutils.DiscardingRecycler;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.buffer.UnpooledByteBufAllocator;
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
-import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -80,19 +73,19 @@ public class PartitionRequestClientHandlerTest {
 		when(inputChannel.getInputChannelId()).thenReturn(new InputChannelID());
 		when(inputChannel.getBufferProvider()).thenReturn(bufferProvider);
 
-		final BufferResponse ReceivedBuffer = createBufferResponse(
-				TestBufferFactory.createBuffer(), 0, inputChannel.getInputChannelId());
+		final BufferResponse receivedBuffer = createBufferResponse(
+			TestBufferFactory.createBuffer(), 0, inputChannel.getInputChannelId(), 2);
 
 		final PartitionRequestClientHandler client = new PartitionRequestClientHandler();
 		client.addInputChannel(inputChannel);
 
-		client.channelRead(mock(ChannelHandlerContext.class), ReceivedBuffer);
+		client.channelRead(mock(ChannelHandlerContext.class), receivedBuffer);
 	}
 
 	/**
 	 * Tests a fix for FLINK-1761.
 	 *
-	 * <p> FLINK-1761 discovered an IndexOutOfBoundsException, when receiving buffers of size 0.
+	 * <p>FLINK-1761 discovered an IndexOutOfBoundsException, when receiving buffers of size 0.
 	 */
 	@Test
 	public void testReceiveEmptyBuffer() throws Exception {
@@ -108,10 +101,11 @@ public class PartitionRequestClientHandlerTest {
 		final Buffer emptyBuffer = TestBufferFactory.createBuffer();
 		emptyBuffer.setSize(0);
 
+		final int backlog = 2;
 		final BufferResponse receivedBuffer = createBufferResponse(
-				emptyBuffer, 0, inputChannel.getInputChannelId());
+			emptyBuffer, 0, inputChannel.getInputChannelId(), backlog);
 
-		final PartitionRequestClientHandler client = new PartitionRequestClientHandler();
+		final CreditBasedClientHandler client = new CreditBasedClientHandler();
 		client.addInputChannel(inputChannel);
 
 		// Read the empty buffer
@@ -119,6 +113,51 @@ public class PartitionRequestClientHandlerTest {
 
 		// This should not throw an exception
 		verify(inputChannel, never()).onError(any(Throwable.class));
+		verify(inputChannel, times(1)).onEmptyBuffer(0, backlog);
+	}
+
+	/**
+	 * Verifies that {@link RemoteInputChannel#onBuffer(Buffer, int, int)} is called when a
+	 * {@link BufferResponse} is received.
+	 */
+	@Test
+	public void testReceiveBuffer() throws Exception {
+		final Buffer buffer = TestBufferFactory.createBuffer();
+		final RemoteInputChannel inputChannel = mock(RemoteInputChannel.class);
+		when(inputChannel.getInputChannelId()).thenReturn(new InputChannelID());
+		when(inputChannel.requestBuffer()).thenReturn(buffer);
+
+		final int backlog = 2;
+		final BufferResponse bufferResponse = createBufferResponse(
+			TestBufferFactory.createBuffer(), 0, inputChannel.getInputChannelId(), backlog);
+
+		final CreditBasedClientHandler client = new CreditBasedClientHandler();
+		client.addInputChannel(inputChannel);
+
+		client.channelRead(mock(ChannelHandlerContext.class), bufferResponse);
+
+		verify(inputChannel, times(1)).onBuffer(buffer, 0, backlog);
+	}
+
+	/**
+	 * Verifies that {@link RemoteInputChannel#onError(Throwable)} is called when a
+	 * {@link BufferResponse} is received but no available buffer in input channel.
+	 */
+	@Test
+	public void testThrowExceptionForNoAvailableBuffer() throws Exception {
+		final RemoteInputChannel inputChannel = mock(RemoteInputChannel.class);
+		when(inputChannel.getInputChannelId()).thenReturn(new InputChannelID());
+		when(inputChannel.requestBuffer()).thenReturn(null);
+
+		final BufferResponse bufferResponse = createBufferResponse(
+			TestBufferFactory.createBuffer(), 0, inputChannel.getInputChannelId(), 2);
+
+		final CreditBasedClientHandler client = new CreditBasedClientHandler();
+		client.addInputChannel(inputChannel);
+
+		client.channelRead(mock(ChannelHandlerContext.class), bufferResponse);
+
+		verify(inputChannel, times(1)).onError(any(IllegalStateException.class));
 	}
 
 	/**
@@ -136,8 +175,8 @@ public class PartitionRequestClientHandlerTest {
 		when(inputChannel.getBufferProvider()).thenReturn(bufferProvider);
 
 		final ErrorResponse partitionNotFound = new ErrorResponse(
-				new PartitionNotFoundException(new ResultPartitionID()),
-				inputChannel.getInputChannelId());
+			new PartitionNotFoundException(new ResultPartitionID()),
+			inputChannel.getInputChannelId());
 
 		final PartitionRequestClientHandler client = new PartitionRequestClientHandler();
 		client.addInputChannel(inputChannel);
@@ -169,84 +208,7 @@ public class PartitionRequestClientHandlerTest {
 		client.cancelRequestFor(inputChannel.getInputChannelId());
 	}
 
-	/**
-	 * Tests that an unsuccessful message decode call for a staged message
-	 * does not leave the channel with auto read set to false.
-	 */
-	@Test
-	@SuppressWarnings("unchecked")
-	public void testAutoReadAfterUnsuccessfulStagedMessage() throws Exception {
-		PartitionRequestClientHandler handler = new PartitionRequestClientHandler();
-		EmbeddedChannel channel = new EmbeddedChannel(handler);
-
-		final AtomicReference<BufferListener> listener = new AtomicReference<>();
-
-		BufferProvider bufferProvider = mock(BufferProvider.class);
-		when(bufferProvider.addBufferListener(any(BufferListener.class))).thenAnswer(new Answer<Boolean>() {
-			@Override
-			@SuppressWarnings("unchecked")
-			public Boolean answer(InvocationOnMock invocation) throws Throwable {
-				listener.set((BufferListener) invocation.getArguments()[0]);
-				return true;
-			}
-		});
-
-		when(bufferProvider.requestBuffer()).thenReturn(null);
-
-		InputChannelID channelId = new InputChannelID(0, 0);
-		RemoteInputChannel inputChannel = mock(RemoteInputChannel.class);
-		when(inputChannel.getInputChannelId()).thenReturn(channelId);
-
-		// The 3rd staged msg has a null buffer provider
-		when(inputChannel.getBufferProvider()).thenReturn(bufferProvider, bufferProvider, null);
-
-		handler.addInputChannel(inputChannel);
-
-		BufferResponse msg = createBufferResponse(createBuffer(true), 0, channelId);
-
-		// Write 1st buffer msg. No buffer is available, therefore the buffer
-		// should be staged and auto read should be set to false.
-		assertTrue(channel.config().isAutoRead());
-		channel.writeInbound(msg);
-
-		// No buffer available, auto read false
-		assertFalse(channel.config().isAutoRead());
-
-		// Write more buffers... all staged.
-		msg = createBufferResponse(createBuffer(true), 1, channelId);
-		channel.writeInbound(msg);
-
-		msg = createBufferResponse(createBuffer(true), 2, channelId);
-		channel.writeInbound(msg);
-
-		// Notify about buffer => handle 1st msg
-		Buffer availableBuffer = createBuffer(false);
-		listener.get().notifyBufferAvailable(availableBuffer);
-
-		// Start processing of staged buffers (in run pending tasks). Make
-		// sure that the buffer provider acts like it's destroyed.
-		when(bufferProvider.addBufferListener(any(BufferListener.class))).thenReturn(false);
-		when(bufferProvider.isDestroyed()).thenReturn(true);
-
-		// Execute all tasks that are scheduled in the event loop. Further
-		// eventLoop().execute() calls are directly executed, if they are
-		// called in the scope of this call.
-		channel.runPendingTasks();
-
-		assertTrue(channel.config().isAutoRead());
-	}
-
 	// ---------------------------------------------------------------------------------------------
-
-	private static Buffer createBuffer(boolean fill) {
-		MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(1024, null);
-		if (fill) {
-			for (int i = 0; i < 1024; i++) {
-				segment.put(i, (byte) i);
-			}
-		}
-		return new Buffer(segment, DiscardingRecycler.INSTANCE, true);
-	}
 
 	/**
 	 * Returns a deserialized buffer message as it would be received during runtime.
@@ -254,10 +216,11 @@ public class PartitionRequestClientHandlerTest {
 	private BufferResponse createBufferResponse(
 			Buffer buffer,
 			int sequenceNumber,
-			InputChannelID receivingChannelId) throws IOException {
+			InputChannelID receivingChannelId,
+			int backlog) throws IOException {
 
 		// Mock buffer to serialize
-		BufferResponse resp = new BufferResponse(buffer, sequenceNumber, receivingChannelId);
+		BufferResponse resp = new BufferResponse(buffer, sequenceNumber, receivingChannelId, backlog);
 
 		ByteBuf serialized = resp.write(UnpooledByteBufAllocator.DEFAULT);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateConcurrentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateConcurrentTest.java
@@ -216,7 +216,7 @@ public class InputGateConcurrentTest {
 
 		@Override
 		void addBuffer(Buffer buffer) throws Exception {
-			channel.onBuffer(buffer, seq++);
+			channel.onBuffer(buffer, seq++, -1);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -206,9 +206,9 @@ public class InputGateFairnessTest {
 			channels[i] = channel;
 			
 			for (int p = 0; p < buffersPerChannel; p++) {
-				channel.onBuffer(mockBuffer, p);
+				channel.onBuffer(mockBuffer, p, -1);
 			}
-			channel.onBuffer(EventSerializer.toBuffer(EndOfPartitionEvent.INSTANCE), buffersPerChannel);
+			channel.onBuffer(EventSerializer.toBuffer(EndOfPartitionEvent.INSTANCE), buffersPerChannel, -1);
 
 			gate.setInputChannel(new IntermediateResultPartitionID(), channel);
 		}
@@ -263,7 +263,7 @@ public class InputGateFairnessTest {
 			gate.setInputChannel(new IntermediateResultPartitionID(), channel);
 		}
 
-		channels[11].onBuffer(mockBuffer, 0);
+		channels[11].onBuffer(mockBuffer, 0, -1);
 		channelSequenceNums[11]++;
 
 		// read all the buffers and the EOF event
@@ -325,7 +325,7 @@ public class InputGateFairnessTest {
 		Collections.shuffle(poss);
 
 		for (int i : poss) {
-			partitions[i].onBuffer(buffer, sequenceNumbers[i]++);
+			partitions[i].onBuffer(buffer, sequenceNumbers[i]++, -1);
 		}
 	}
 	


### PR DESCRIPTION
## What is the purpose of the change

Currently `PartitionRequestClientHandler` receives and reads BufferResponse from producer. It will request buffer from `BufferPool` for holding the message. If not got, the message is staged temporarily and `autoread` of channel is set false.

For credit-based mode, `PartitionRequestClientHandler` can always get buffer from `RemoteInputChannel` for reading messages from producer, and update backlog of producer to trigger requests of floating buffers.

In order not to affect the current process and existing cases, we implement a temporary netty handler called `CreditBasedClientHanlder` which will replace the current `PartitionRequestClientHandler` after all the codes are submitted.

## Brief change log

  - *Add backlog field in `BufferResponse` netty message*
  - *Define the `AvailableBufferQueue` class to wrap available floating buffers and exclusive buffers separately*
  - *Netty handler requests buffer from `RemoteInputChannel` directly*
  - *Netty handler updates the backlog of `RemoteInputChannel`, and it may trigger requests of floating buffers from `BufferPool`*
  - *Set method of `isReleased` as public in `RemoteInputChannel` for handler and test call*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that verifies the netty message serialization for 'BufferResponse`*
  - *Added test that verifies the logics of  `onBuffer` and `onEmptyBuffer`*
  - *Added test that verifies the exception case of requesting buffer from `InputChannel`*
  - *Added test to verify there is no race condition between `onSenderBacklog` and `recycle`*
  - *Added test to verify there is no race condition between `onSenderBacklog` and `releaseAllResources`*
  - *Added test to verify there is no race condition between `recycle` and `releaseAllResources`*
  - *Added test to verify the fair distribution of floating buffers for `InputChannel` listeners in `BufferPool`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
