### PR TITLE
[FLINK-7124] [flip-6] Add test to verify rescaling JobGraphs works correctly

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphConstructionTest.java
@@ -40,9 +40,9 @@ import org.mockito.Matchers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.flink.configuration.Configuration;
@@ -50,14 +50,12 @@ import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.core.io.InputSplitSource;
 import org.apache.flink.runtime.JobException;
-import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 
@@ -130,7 +128,7 @@ public class ExecutionGraphConstructionTest {
 			fail("Job failed with exception: " + e.getMessage());
 		}
 		
-		verifyTestGraph(eg, jobId, v1, v2, v3, v4, v5);
+		verifyTestGraph(eg, v1, v2, v3, v4, v5);
 	}
 	
 	@Test
@@ -207,7 +205,7 @@ public class ExecutionGraphConstructionTest {
 		}
 		
 		// verify
-		verifyTestGraph(eg, jobId, v1, v2, v3, v4, v5);
+		verifyTestGraph(eg, v1, v2, v3, v4, v5);
 	}
 	
 	@Test
@@ -283,208 +281,18 @@ public class ExecutionGraphConstructionTest {
 		}
 		
 		// verify
-		verifyTestGraph(eg, jobId, v1, v2, v3, v4, v5);
+		verifyTestGraph(eg, v1, v2, v3, v4, v5);
 	}
 	
-	private void verifyTestGraph(ExecutionGraph eg, JobID jobId,
+	private void verifyTestGraph(ExecutionGraph eg,
 				JobVertex v1, JobVertex v2, JobVertex v3,
 				JobVertex v4, JobVertex v5)
 	{
-		Map<JobVertexID, ExecutionJobVertex> vertices = eg.getAllVertices();
-		
-		// verify v1
-		{
-			ExecutionJobVertex e1 = vertices.get(v1.getID());
-			assertNotNull(e1);
-			
-			// basic properties
-			assertEquals(v1.getParallelism(), e1.getParallelism());
-			assertEquals(v1.getID(), e1.getJobVertexId());
-			assertEquals(jobId, e1.getJobId());
-			assertEquals(v1, e1.getJobVertex());
-			
-			// produced data sets
-			assertEquals(1, e1.getProducedDataSets().length);
-			assertEquals(v1.getProducedDataSets().get(0).getId(), e1.getProducedDataSets()[0].getId());
-			assertEquals(v1.getParallelism(), e1.getProducedDataSets()[0].getPartitions().length);
-			
-			// task vertices
-			assertEquals(v1.getParallelism(), e1.getTaskVertices().length);
-			
-			int num = 0;
-			for (ExecutionVertex ev : e1.getTaskVertices()) {
-				assertEquals(jobId, ev.getJobId());
-				assertEquals(v1.getID(), ev.getJobvertexId());
-				
-				assertEquals(v1.getParallelism(), ev.getTotalNumberOfParallelSubtasks());
-				assertEquals(num++, ev.getParallelSubtaskIndex());
-				
-				assertEquals(0, ev.getNumberOfInputs());
-				
-				assertTrue(ev.getStateTimestamp(ExecutionState.CREATED) > 0);
-			}
-		}
-		
-		// verify v2
-		{
-			ExecutionJobVertex e2 = vertices.get(v2.getID());
-			assertNotNull(e2);
-			
-			// produced data sets
-			assertEquals(1, e2.getProducedDataSets().length);
-			assertEquals(v2.getProducedDataSets().get(0).getId(), e2.getProducedDataSets()[0].getId());
-			assertEquals(v2.getParallelism(), e2.getProducedDataSets()[0].getPartitions().length);
-			
-			// task vertices
-			assertEquals(v2.getParallelism(), e2.getTaskVertices().length);
-			
-			int num = 0;
-			for (ExecutionVertex ev : e2.getTaskVertices()) {
-				assertEquals(jobId, ev.getJobId());
-				assertEquals(v2.getID(), ev.getJobvertexId());
-				
-				assertEquals(v2.getParallelism(), ev.getTotalNumberOfParallelSubtasks());
-				assertEquals(num++, ev.getParallelSubtaskIndex());
-				
-				assertEquals(1, ev.getNumberOfInputs());
-				ExecutionEdge[] inputs = ev.getInputEdges(0);
-				assertEquals(v1.getParallelism(), inputs.length);
-				
-				int sumOfPartitions = 0;
-				for (ExecutionEdge inEdge : inputs) {
-					assertEquals(0,inEdge.getInputNum());
-					sumOfPartitions += inEdge.getSource().getPartitionNumber();
-				}
-				
-				assertEquals(10, sumOfPartitions);
-			}
-		}
-		
-		// verify v3
-		{
-			ExecutionJobVertex e3 = vertices.get(v3.getID());
-			assertNotNull(e3);
-			
-			// produced data sets
-			assertEquals(2, e3.getProducedDataSets().length);
-			assertEquals(v3.getProducedDataSets().get(0).getId(), e3.getProducedDataSets()[0].getId());
-			assertEquals(v3.getProducedDataSets().get(1).getId(), e3.getProducedDataSets()[1].getId());
-			assertEquals(v3.getParallelism(), e3.getProducedDataSets()[0].getPartitions().length);
-			assertEquals(v3.getParallelism(), e3.getProducedDataSets()[1].getPartitions().length);
-			
-			// task vertices
-			assertEquals(v3.getParallelism(), e3.getTaskVertices().length);
-			
-			int num = 0;
-			for (ExecutionVertex ev : e3.getTaskVertices()) {
-				assertEquals(jobId, ev.getJobId());
-				assertEquals(v3.getID(), ev.getJobvertexId());
-				
-				assertEquals(v3.getParallelism(), ev.getTotalNumberOfParallelSubtasks());
-				assertEquals(num++, ev.getParallelSubtaskIndex());
-				
-				assertEquals(0, ev.getNumberOfInputs());
-			}
-		}
-
-		// verify v4
-		{
-			ExecutionJobVertex e4 = vertices.get(v4.getID());
-			assertNotNull(e4);
-			
-			// produced data sets
-			assertEquals(1, e4.getProducedDataSets().length);
-			assertEquals(v4.getProducedDataSets().get(0).getId(), e4.getProducedDataSets()[0].getId());
-			
-			// task vertices
-			assertEquals(v4.getParallelism(), e4.getTaskVertices().length);
-			
-			int num = 0;
-			for (ExecutionVertex ev : e4.getTaskVertices()) {
-				assertEquals(jobId, ev.getJobId());
-				assertEquals(v4.getID(), ev.getJobvertexId());
-				
-				assertEquals(v4.getParallelism(), ev.getTotalNumberOfParallelSubtasks());
-				assertEquals(num++, ev.getParallelSubtaskIndex());
-				
-				assertEquals(2, ev.getNumberOfInputs());
-				// first input
-				{
-					ExecutionEdge[] inputs = ev.getInputEdges(0);
-					assertEquals(v2.getParallelism(), inputs.length);
-					
-					int sumOfPartitions = 0;
-					for (ExecutionEdge inEdge : inputs) {
-						assertEquals(0, inEdge.getInputNum());
-						sumOfPartitions += inEdge.getSource().getPartitionNumber();
-					}
-					
-					assertEquals(21, sumOfPartitions);
-				}
-				// second input
-				{
-					ExecutionEdge[] inputs = ev.getInputEdges(1);
-					assertEquals(v3.getParallelism(), inputs.length);
-					
-					int sumOfPartitions = 0;
-					for (ExecutionEdge inEdge : inputs) {
-						assertEquals(1, inEdge.getInputNum());
-						sumOfPartitions += inEdge.getSource().getPartitionNumber();
-					}
-					
-					assertEquals(1, sumOfPartitions);
-				}
-			}
-		}
-		
-		// verify v5
-		{
-			ExecutionJobVertex e5 = vertices.get(v5.getID());
-			assertNotNull(e5);
-			
-			// produced data sets
-			assertEquals(0, e5.getProducedDataSets().length);
-			
-			// task vertices
-			assertEquals(v5.getParallelism(), e5.getTaskVertices().length);
-			
-			int num = 0;
-			for (ExecutionVertex ev : e5.getTaskVertices()) {
-				assertEquals(jobId, ev.getJobId());
-				assertEquals(v5.getID(), ev.getJobvertexId());
-				
-				assertEquals(v5.getParallelism(), ev.getTotalNumberOfParallelSubtasks());
-				assertEquals(num++, ev.getParallelSubtaskIndex());
-				
-				assertEquals(2, ev.getNumberOfInputs());
-				// first input
-				{
-					ExecutionEdge[] inputs = ev.getInputEdges(0);
-					assertEquals(v4.getParallelism(), inputs.length);
-					
-					int sumOfPartitions = 0;
-					for (ExecutionEdge inEdge : inputs) {
-						assertEquals(0, inEdge.getInputNum());
-						sumOfPartitions += inEdge.getSource().getPartitionNumber();
-					}
-					
-					assertEquals(55, sumOfPartitions);
-				}
-				// second input
-				{
-					ExecutionEdge[] inputs = ev.getInputEdges(1);
-					assertEquals(v3.getParallelism(), inputs.length);
-					
-					int sumOfPartitions = 0;
-					for (ExecutionEdge inEdge : inputs) {
-						assertEquals(1, inEdge.getInputNum());
-						sumOfPartitions += inEdge.getSource().getPartitionNumber();
-					}
-					
-					assertEquals(1, sumOfPartitions);
-				}
-			}
-		}
+		ExecutionGraphTestUtils.verifyGeneratedExecutionJobVertex(eg, v1, null, Collections.singletonList(v2));
+		ExecutionGraphTestUtils.verifyGeneratedExecutionJobVertex(eg, v2, Collections.singletonList(v1), Collections.singletonList(v4));
+		ExecutionGraphTestUtils.verifyGeneratedExecutionJobVertex(eg, v3, null, Arrays.asList(v4, v5));
+		ExecutionGraphTestUtils.verifyGeneratedExecutionJobVertex(eg, v4, Arrays.asList(v2, v3), Collections.singletonList(v5));
+		ExecutionGraphTestUtils.verifyGeneratedExecutionJobVertex(eg, v5, Arrays.asList(v4, v3), null);
 	}
 	
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRescalingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRescalingTest.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
+import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * This class contains tests that verify when rescaling a {@link JobGraph},
+ * constructed {@link ExecutionGraph}s are correct.
+ */
+public class ExecutionGraphRescalingTest {
+
+	private static final Logger TEST_LOGGER = LoggerFactory.getLogger(ExecutionGraphRescalingTest.class);
+
+	@Test
+	public void testExecutionGraphArbitraryDopConstructionTest() throws Exception {
+
+		final Configuration config = new Configuration();
+
+		final JobVertex[] jobVertices = createVerticesForSimpleBipartiteJobGraph();
+		final JobGraph jobGraph = new JobGraph(jobVertices);
+
+		// TODO rescaling the JobGraph is currently only supported if the
+		// TODO configured parallelism is ExecutionConfig.PARALLELISM_AUTO_MAX.
+		// TODO this limitation should be removed.
+		for (JobVertex jv : jobVertices) {
+			jv.setParallelism(ExecutionConfig.PARALLELISM_AUTO_MAX);
+		}
+
+		ExecutionGraph eg = ExecutionGraphBuilder.buildGraph(
+				null,
+				jobGraph,
+				config,
+				TestingUtils.defaultExecutor(),
+				TestingUtils.defaultExecutor(),
+				new Scheduler(TestingUtils.defaultExecutionContext()),
+				Thread.currentThread().getContextClassLoader(),
+				new StandaloneCheckpointRecoveryFactory(),
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy(),
+				new UnregisteredMetricsGroup(),
+				5,
+				TEST_LOGGER);
+
+		for (JobVertex jv : jobVertices) {
+			assertEquals(5, jv.getParallelism());
+		}
+		verifyGeneratedExecutionGraphOfSimpleBitartiteJobGraph(eg, jobVertices);
+
+		// --- verify scaling up works correctly ---
+
+		// TODO rescaling the JobGraph is currently only supported if the
+		// TODO configured parallelism is ExecutionConfig.PARALLELISM_AUTO_MAX.
+		// TODO this limitation should be removed.
+		for (JobVertex jv : jobVertices) {
+			jv.setParallelism(ExecutionConfig.PARALLELISM_AUTO_MAX);
+		}
+
+		eg = ExecutionGraphBuilder.buildGraph(
+				null,
+				jobGraph,
+				config,
+				TestingUtils.defaultExecutor(),
+				TestingUtils.defaultExecutor(),
+				new Scheduler(TestingUtils.defaultExecutionContext()),
+				Thread.currentThread().getContextClassLoader(),
+				new StandaloneCheckpointRecoveryFactory(),
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy(),
+				new UnregisteredMetricsGroup(),
+				10,
+				TEST_LOGGER);
+
+		for (JobVertex jv : jobVertices) {
+			assertEquals(10, jv.getParallelism());
+		}
+		verifyGeneratedExecutionGraphOfSimpleBitartiteJobGraph(eg, jobVertices);
+
+		// --- verify down scaling works correctly ---
+
+		// TODO rescaling the JobGraph is currently only supported if the
+		// TODO configured parallelism is ExecutionConfig.PARALLELISM_AUTO_MAX.
+		// TODO this limitation should be removed.
+		for (JobVertex jv : jobVertices) {
+			jv.setParallelism(ExecutionConfig.PARALLELISM_AUTO_MAX);
+		}
+
+		eg = ExecutionGraphBuilder.buildGraph(
+			null,
+			jobGraph,
+			config,
+			TestingUtils.defaultExecutor(),
+			TestingUtils.defaultExecutor(),
+			new Scheduler(TestingUtils.defaultExecutionContext()),
+			Thread.currentThread().getContextClassLoader(),
+			new StandaloneCheckpointRecoveryFactory(),
+			AkkaUtils.getDefaultTimeout(),
+			new NoRestartStrategy(),
+			new UnregisteredMetricsGroup(),
+			2,
+			TEST_LOGGER);
+
+		for (JobVertex jv : jobVertices) {
+			assertEquals(2, jv.getParallelism());
+		}
+		verifyGeneratedExecutionGraphOfSimpleBitartiteJobGraph(eg, jobVertices);
+	}
+
+	/**
+	 * Verifies that building an {@link ExecutionGraph} from a {@link JobGraph} with
+	 * parallelism higher than the maximum parallelism fails.
+	 *
+	 * TODO this test is ignored, since currently the rescale does not properly fail when rescaling to DOP above max.
+	 */
+	@Ignore
+	@Test
+	public void testExecutionGraphConstructionFailsRescaleDopExceedMaxParallelism() throws Exception {
+
+		final Configuration config = new Configuration();
+
+		final JobVertex[] jobVertices = createVerticesForSimpleBipartiteJobGraph();
+		final JobGraph jobGraph = new JobGraph(jobVertices);
+
+		for (JobVertex jv : jobVertices) {
+			jv.setParallelism(ExecutionConfig.PARALLELISM_AUTO_MAX);
+			jv.setMaxParallelism(5);
+		}
+
+		try {
+			ExecutionGraphBuilder.buildGraph(
+				null,
+				jobGraph,
+				config,
+				TestingUtils.defaultExecutor(),
+				TestingUtils.defaultExecutor(),
+				new Scheduler(TestingUtils.defaultExecutionContext()),
+				Thread.currentThread().getContextClassLoader(),
+				new StandaloneCheckpointRecoveryFactory(),
+				AkkaUtils.getDefaultTimeout(),
+				new NoRestartStrategy(),
+				new UnregisteredMetricsGroup(),
+				10, // this should fail because 10 is larger than the max parallelism 5
+				TEST_LOGGER);
+
+			fail("Building the ExecutionGraph with a parallelism higher than the max parallelism should fail.");
+		} catch (Exception e) {
+			// expected, ignore
+		}
+	}
+
+	private static JobVertex[] createVerticesForSimpleBipartiteJobGraph() {
+		JobVertex v1 = new JobVertex("vertex1");
+		JobVertex v2 = new JobVertex("vertex2");
+		JobVertex v3 = new JobVertex("vertex3");
+		JobVertex v4 = new JobVertex("vertex4");
+		JobVertex v5 = new JobVertex("vertex5");
+
+		JobVertex[] jobVertices = new JobVertex[]{v1, v2, v3, v4, v5};
+
+		for (JobVertex jobVertex : jobVertices) {
+			jobVertex.setInvokableClass(AbstractInvokable.class);
+		}
+
+		v2.connectNewDataSetAsInput(v1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+		v4.connectNewDataSetAsInput(v2, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+		v4.connectNewDataSetAsInput(v3, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+		v5.connectNewDataSetAsInput(v4, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+		v5.connectNewDataSetAsInput(v3, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+
+		return jobVertices;
+	}
+
+	private static void verifyGeneratedExecutionGraphOfSimpleBitartiteJobGraph(
+			ExecutionGraph generatedExecutionGraph, JobVertex[] jobVertices) {
+
+		ExecutionGraphTestUtils.verifyGeneratedExecutionJobVertex(
+				generatedExecutionGraph, jobVertices[0],
+				null, Collections.singletonList(jobVertices[1]));
+
+		ExecutionGraphTestUtils.verifyGeneratedExecutionJobVertex(
+				generatedExecutionGraph, jobVertices[1],
+				Collections.singletonList(jobVertices[0]), Collections.singletonList(jobVertices[3]));
+
+		ExecutionGraphTestUtils.verifyGeneratedExecutionJobVertex(
+				generatedExecutionGraph, jobVertices[2],
+				null, Arrays.asList(jobVertices[3], jobVertices[4]));
+
+		ExecutionGraphTestUtils.verifyGeneratedExecutionJobVertex(
+				generatedExecutionGraph, jobVertices[3],
+				Arrays.asList(jobVertices[1], jobVertices[2]), Collections.singletonList(jobVertices[4]));
+
+		ExecutionGraphTestUtils.verifyGeneratedExecutionJobVertex(
+				generatedExecutionGraph, jobVertices[4],
+				Arrays.asList(jobVertices[3], jobVertices[2]), null);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -64,14 +64,18 @@ import org.slf4j.LoggerFactory;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.ExecutionContext$;
 
+import javax.annotation.Nullable;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
@@ -446,5 +450,78 @@ public class ExecutionGraphTestUtils {
 	
 	public static ExecutionJobVertex getExecutionVertex(JobVertexID id) throws Exception {
 		return getExecutionVertex(id, TestingUtils.defaultExecutor());
+	}
+
+	// ------------------------------------------------------------------------
+	//  graph vertex verifications
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Verifies the generated {@link ExecutionJobVertex} for a given {@link JobVertex} in a {@link ExecutionGraph}
+	 *
+	 * @param executionGraph the generated execution graph
+	 * @param originJobVertex the vertex to verify for
+	 * @param inputJobVertices upstream vertices of the verified vertex, used to check inputs of generated vertex
+	 * @param outputJobVertices downstream vertices of the verified vertex, used to
+	 *                          check produced data sets of generated vertex
+	 */
+	public static void verifyGeneratedExecutionJobVertex(
+			ExecutionGraph executionGraph,
+			JobVertex originJobVertex,
+			@Nullable List<JobVertex> inputJobVertices,
+			@Nullable List<JobVertex> outputJobVertices) {
+
+		ExecutionJobVertex ejv = executionGraph.getAllVertices().get(originJobVertex.getID());
+		assertNotNull(ejv);
+
+		// verify basic properties
+		assertEquals(originJobVertex.getParallelism(), ejv.getParallelism());
+		assertEquals(executionGraph.getJobID(), ejv.getJobId());
+		assertEquals(originJobVertex.getID(), ejv.getJobVertexId());
+		assertEquals(originJobVertex, ejv.getJobVertex());
+
+		// verify produced data sets
+		if (outputJobVertices == null) {
+			assertEquals(0, ejv.getProducedDataSets().length);
+		} else {
+			assertEquals(outputJobVertices.size(), ejv.getProducedDataSets().length);
+			for (int i = 0; i < outputJobVertices.size(); i++) {
+				assertEquals(originJobVertex.getProducedDataSets().get(i).getId(), ejv.getProducedDataSets()[i].getId());
+				assertEquals(originJobVertex.getParallelism(), ejv.getProducedDataSets()[0].getPartitions().length);
+			}
+		}
+
+		// verify task vertices for their basic properties and their inputs
+		assertEquals(originJobVertex.getParallelism(), ejv.getTaskVertices().length);
+
+		int subtaskIndex = 0;
+		for (ExecutionVertex ev : ejv.getTaskVertices()) {
+			assertEquals(executionGraph.getJobID(), ev.getJobId());
+			assertEquals(originJobVertex.getID(), ev.getJobvertexId());
+
+			assertEquals(originJobVertex.getParallelism(), ev.getTotalNumberOfParallelSubtasks());
+			assertEquals(subtaskIndex, ev.getParallelSubtaskIndex());
+
+			if (inputJobVertices == null) {
+				assertEquals(0, ev.getNumberOfInputs());
+			} else {
+				assertEquals(inputJobVertices.size(), ev.getNumberOfInputs());
+
+				for (int i = 0; i < inputJobVertices.size(); i++) {
+					ExecutionEdge[] inputEdges = ev.getInputEdges(i);
+					assertEquals(inputJobVertices.get(i).getParallelism(), inputEdges.length);
+
+					int expectedPartitionNum = 0;
+					for (ExecutionEdge inEdge : inputEdges) {
+						assertEquals(i, inEdge.getInputNum());
+						assertEquals(expectedPartitionNum, inEdge.getSource().getPartitionNumber());
+
+						expectedPartitionNum++;
+					}
+				}
+			}
+
+			subtaskIndex++;
+		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds test to verify that rescaling `JobGraph`s to arbitrary valid DOPs works correctly, such that the generated `ExecutionGraph` of each rescale is correct.

## Brief change log

- Add `ExecutionGraphRescalingTest` class.
  - Contains a test that consecutively rescales (up and down) a given `JobGraph`.
  - Contains a test that rescales to DOP beyond max parallelism. `TODO` ignored for now since the test doesn't properly fail as expected.
- `[hotfix]` refactor `ExecutionGraphConstructionTest` to share utility graph validation code.

## Verifying this change

The changes themselves are a verification of existing features. See above.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: **no**

## Documentation

  - Does this pull request introduce a new feature? *no*
  - If yes, how is the feature documented? *not applicable*

