### PR TITLE
[FLINK-7396] Don't put multiple directories in HADOOP_CONF_DIR in config.sh

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -342,11 +342,11 @@ if [ -z "$HADOOP_CONF_DIR" ]; then
         # HADOOP_HOME is set. Check if its a Hadoop 1.x or 2.x HADOOP_HOME path
         if [ -d "$HADOOP_HOME/conf" ]; then
             # its a Hadoop 1.x
-            HADOOP_CONF_DIR="$HADOOP_CONF_DIR:$HADOOP_HOME/conf"
+            HADOOP_CONF_DIR="$HADOOP_HOME/conf"
         fi
         if [ -d "$HADOOP_HOME/etc/hadoop" ]; then
             # Its Hadoop 2.2+
-            HADOOP_CONF_DIR="$HADOOP_CONF_DIR:$HADOOP_HOME/etc/hadoop"
+            HADOOP_CONF_DIR="$HADOOP_HOME/etc/hadoop"
         fi
     fi
 fi

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -336,16 +336,18 @@ if [ -z "${JVM_ARGS}" ]; then
     JVM_ARGS=""
 fi
 
-# Check if deprecated HADOOP_HOME is set.
-if [ -n "$HADOOP_HOME" ]; then
-    # HADOOP_HOME is set. Check if its a Hadoop 1.x or 2.x HADOOP_HOME path
-    if [ -d "$HADOOP_HOME/conf" ]; then
-        # its a Hadoop 1.x
-        HADOOP_CONF_DIR="$HADOOP_CONF_DIR:$HADOOP_HOME/conf"
-    fi
-    if [ -d "$HADOOP_HOME/etc/hadoop" ]; then
-        # Its Hadoop 2.2+
-        HADOOP_CONF_DIR="$HADOOP_CONF_DIR:$HADOOP_HOME/etc/hadoop"
+# Check if deprecated HADOOP_HOME is set, and specify config path to HADOOP_CONF_DIR if it's empty.
+if [ -z "$HADOOP_CONF_DIR" ]; then
+    if [ -n "$HADOOP_HOME" ]; then
+        # HADOOP_HOME is set. Check if its a Hadoop 1.x or 2.x HADOOP_HOME path
+        if [ -d "$HADOOP_HOME/conf" ]; then
+            # its a Hadoop 1.x
+            HADOOP_CONF_DIR="$HADOOP_CONF_DIR:$HADOOP_HOME/conf"
+        fi
+        if [ -d "$HADOOP_HOME/etc/hadoop" ]; then
+            # Its Hadoop 2.2+
+            HADOOP_CONF_DIR="$HADOOP_CONF_DIR:$HADOOP_HOME/etc/hadoop"
+        fi
     fi
 fi
 


### PR DESCRIPTION
## What is the purpose of the change

Fix put multiple directories in HADOOP_CONF_DIR in config.sh


## Brief change log

*(for example:)*
  - *Check whether HADOOP_CONF_DIR before put directory to it*


## Verifying this change

*(Please pick either of the following options)*

No test case

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

