### PR TITLE
[FLINK-7384][cep] Unify event and processing time handling in the Abs…

### DIFF
--- a/docs/dev/libs/cep.md
+++ b/docs/dev/libs/cep.md
@@ -1526,6 +1526,34 @@ To guarantee that elements across watermarks are processed in event-time order, 
 *correctness of the watermark*, and considers as *late* elements whose timestamp is smaller than that of the last
 seen watermark. Late elements are not further processed.
 
+## Handling Processing Time
+
+While working in Processing Time user can set a `processing-time-interval` configuration parameter on `PatternStream`. This parameter tells
+how often partial-matches are checked for timeout. If one uses a custom `comparator` in Processing Time for elements
+that arrives at the same moment it also specifies for how long events shall be buffered before sorting. 
+The default value for that parameter is 100 ms.
+
+To change the default value you can set it on `PatternStream`:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+
+~~~java
+PatternStream<Event> patternStream = CEP.pattern(input, pattern);
+patternStream.setProcessingTimeInterval(200);
+~~~
+
+</div>
+<div data-lang="scala" markdown="1">
+
+~~~scala
+val patternStream: PatternStream[Event] = CEP.pattern(input, pattern)
+patternStream.setProcessingTimeInterval(200)
+~~~
+
+</div>
+</div>
+
 ## Examples
 
 The following example detects the pattern `start, middle(name = "error") -> end(name = "critical")` on a keyed data

--- a/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/PatternStream.scala
+++ b/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/PatternStream.scala
@@ -50,6 +50,30 @@ class PatternStream[T](jPatternStream: JPatternStream[T]) {
   def getComparator: EventComparator[T] = jPatternStream.getComparator
 
   /**
+    * Retrieves current a processing time interval that tells how often time partial-matches are
+    * checked for timeout. If one is using a custom comparator in Processing Time for elements that
+    * arrived at the same moment it also specifies for how long events may be buffered before
+    * sorting. The default value for that parameter is 100 ms.
+    *
+    * <p><b>NOTE:</b> Applies only to ProcessingTime
+    */
+  def getProcessingTimeInterval: Long = jPatternStream.getProcessingTimeInterval
+
+  /**
+    * Sets a processing time interval that tells how often time partial-matches are checked for
+    * timeout. If one is using a custom comparator in Processing Time for elements that arrived at
+    * the same moment it also specifies for how long events may be buffered before sorting.
+    * The default value for that parameter is 100 ms.
+    *
+    * <p><b>NOTE:</b> Applies only to ProcessingTime
+    *
+    * @param processingTimeInterval processing time interval in milliseconds
+    */
+  def setProcessingTimeInterval(processingTimeInterval: Long): Unit = {
+    jPatternStream.setProcessingTimeInterval(processingTimeInterval)
+  }
+
+  /**
     * Applies a select function to the detected pattern sequence. For each pattern sequence the
     * provided [[PatternSelectFunction]] is called. The pattern select function can produce
     * exactly one resulting element.

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CEPOperatorUtils.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CEPOperatorUtils.java
@@ -59,24 +59,28 @@ public class CEPOperatorUtils {
 			final Pattern<IN, ?> pattern,
 			final EventComparator<IN> comparator,
 			final PatternSelectFunction<IN, OUT> selectFunction,
-			final TypeInformation<OUT> outTypeInfo) {
-		return createPatternStream(inputStream, pattern, outTypeInfo, false, comparator, new OperatorBuilder<IN, OUT>() {
-			@Override
-			public OneInputStreamOperator<IN, OUT> build(
-				TypeSerializer<IN> inputSerializer,
-				boolean isProcessingTime,
-				NFACompiler.NFAFactory<IN> nfaFactory,
-				EventComparator<IN> comparator,
-				AfterMatchSkipStrategy skipStrategy) {
-				return new SelectCepOperator<>(
-					inputSerializer,
-					isProcessingTime,
-					nfaFactory,
-					comparator,
-					skipStrategy,
-					selectFunction
-				);
-			}
+			final TypeInformation<OUT> outTypeInfo,
+			final long nfaProcessingInterval) {
+		return createPatternStream(inputStream, pattern, outTypeInfo, false, comparator,
+			nfaProcessingInterval, new OperatorBuilder<IN, OUT>() {
+				@Override
+				public OneInputStreamOperator<IN, OUT> build(
+					TypeSerializer<IN> inputSerializer,
+					boolean isProcessingTime,
+					long nfaProcessingInterval,
+					NFACompiler.NFAFactory<IN> nfaFactory,
+					EventComparator<IN> comparator,
+					AfterMatchSkipStrategy skipStrategy) {
+					return new SelectCepOperator<>(
+						inputSerializer,
+						isProcessingTime,
+						nfaProcessingInterval,
+						nfaFactory,
+						comparator,
+						skipStrategy,
+						selectFunction
+					);
+				}
 
 			@Override
 			public String getKeyedOperatorName() {
@@ -106,24 +110,28 @@ public class CEPOperatorUtils {
 			final Pattern<IN, ?> pattern,
 			final EventComparator<IN> comparator,
 			final PatternFlatSelectFunction<IN, OUT> selectFunction,
-			final TypeInformation<OUT> outTypeInfo) {
-		return createPatternStream(inputStream, pattern, outTypeInfo, false, comparator, new OperatorBuilder<IN, OUT>() {
-			@Override
-			public OneInputStreamOperator<IN, OUT> build(
-				TypeSerializer<IN> inputSerializer,
-				boolean isProcessingTime,
-				NFACompiler.NFAFactory<IN> nfaFactory,
-				EventComparator<IN> comparator,
-				AfterMatchSkipStrategy skipStrategy) {
-				return new FlatSelectCepOperator<>(
-					inputSerializer,
-					isProcessingTime,
-					nfaFactory,
-					comparator,
-					skipStrategy,
-					selectFunction
-				);
-			}
+			final TypeInformation<OUT> outTypeInfo,
+			final long nfaProcessingInterval) {
+		return createPatternStream(inputStream, pattern, outTypeInfo, false, comparator,
+			nfaProcessingInterval, new OperatorBuilder<IN, OUT>() {
+				@Override
+				public OneInputStreamOperator<IN, OUT> build(
+					TypeSerializer<IN> inputSerializer,
+					boolean isProcessingTime,
+					long nfaProcessingInterval,
+					NFACompiler.NFAFactory<IN> nfaFactory,
+					EventComparator<IN> comparator,
+					AfterMatchSkipStrategy skipStrategy) {
+					return new FlatSelectCepOperator<>(
+						inputSerializer,
+						isProcessingTime,
+						nfaProcessingInterval,
+						nfaFactory,
+						comparator,
+						skipStrategy,
+						selectFunction
+					);
+				}
 
 			@Override
 			public String getKeyedOperatorName() {
@@ -160,26 +168,30 @@ public class CEPOperatorUtils {
 			final PatternFlatSelectFunction<IN, OUT1> selectFunction,
 			final TypeInformation<OUT1> outTypeInfo,
 			final OutputTag<OUT2> outputTag,
-			final PatternFlatTimeoutFunction<IN, OUT2> timeoutFunction) {
-		return createPatternStream(inputStream, pattern, outTypeInfo, true, comparator, new OperatorBuilder<IN, OUT1>() {
-			@Override
-			public OneInputStreamOperator<IN, OUT1> build(
-				TypeSerializer<IN> inputSerializer,
-				boolean isProcessingTime,
-				NFACompiler.NFAFactory<IN> nfaFactory,
-				EventComparator<IN> comparator,
-				AfterMatchSkipStrategy skipStrategy) {
-				return new FlatSelectTimeoutCepOperator<>(
-					inputSerializer,
-					isProcessingTime,
-					nfaFactory,
-					comparator,
-					skipStrategy,
-					selectFunction,
-					timeoutFunction,
-					outputTag
-				);
-			}
+			final PatternFlatTimeoutFunction<IN, OUT2> timeoutFunction,
+			final long nfaProcessingInterval) {
+		return createPatternStream(inputStream, pattern, outTypeInfo, true, comparator,
+			nfaProcessingInterval, new OperatorBuilder<IN, OUT1>() {
+				@Override
+				public OneInputStreamOperator<IN, OUT1> build(
+					TypeSerializer<IN> inputSerializer,
+					boolean isProcessingTime,
+					long nfaProcessingInterval,
+					NFACompiler.NFAFactory<IN> nfaFactory,
+					EventComparator<IN> comparator,
+					AfterMatchSkipStrategy skipStrategy) {
+					return new FlatSelectTimeoutCepOperator<>(
+						inputSerializer,
+						isProcessingTime,
+						nfaProcessingInterval,
+						nfaFactory,
+						comparator,
+						skipStrategy,
+						selectFunction,
+						timeoutFunction,
+						outputTag
+					);
+				}
 
 			@Override
 			public String getKeyedOperatorName() {
@@ -216,26 +228,30 @@ public class CEPOperatorUtils {
 			final PatternSelectFunction<IN, OUT1> selectFunction,
 			final TypeInformation<OUT1> outTypeInfo,
 			final OutputTag<OUT2> outputTag,
-			final PatternTimeoutFunction<IN, OUT2> timeoutFunction) {
-		return createPatternStream(inputStream, pattern, outTypeInfo, true, comparator, new OperatorBuilder<IN, OUT1>() {
-			@Override
-			public OneInputStreamOperator<IN, OUT1> build(
-				TypeSerializer<IN> inputSerializer,
-				boolean isProcessingTime,
-				NFACompiler.NFAFactory<IN> nfaFactory,
-				EventComparator<IN> comparator,
-				AfterMatchSkipStrategy skipStrategy) {
-				return new SelectTimeoutCepOperator<>(
-					inputSerializer,
-					isProcessingTime,
-					nfaFactory,
-					comparator,
-					skipStrategy,
-					selectFunction,
-					timeoutFunction,
-					outputTag
-				);
-			}
+			final PatternTimeoutFunction<IN, OUT2> timeoutFunction,
+			final long nfaProcessingInterval) {
+		return createPatternStream(inputStream, pattern, outTypeInfo, true, comparator,
+			nfaProcessingInterval, new OperatorBuilder<IN, OUT1>() {
+				@Override
+				public OneInputStreamOperator<IN, OUT1> build(
+					TypeSerializer<IN> inputSerializer,
+					boolean isProcessingTime,
+					long nfaProcessingInterval,
+					NFACompiler.NFAFactory<IN> nfaFactory,
+					EventComparator<IN> comparator,
+					AfterMatchSkipStrategy skipStrategy) {
+					return new SelectTimeoutCepOperator<>(
+						inputSerializer,
+						isProcessingTime,
+						nfaProcessingInterval,
+						nfaFactory,
+						comparator,
+						skipStrategy,
+						selectFunction,
+						timeoutFunction,
+						outputTag
+					);
+				}
 
 			@Override
 			public String getKeyedOperatorName() {
@@ -255,6 +271,7 @@ public class CEPOperatorUtils {
 			final TypeInformation<OUT> outTypeInfo,
 			final boolean timeoutHandling,
 			final EventComparator<IN> comparator,
+			final long nfaProcessingInterval,
 			final OperatorBuilder<IN, OUT> operatorBuilder) {
 		final TypeSerializer<IN> inputSerializer = inputStream.getType().createSerializer(inputStream.getExecutionConfig());
 
@@ -275,6 +292,7 @@ public class CEPOperatorUtils {
 				operatorBuilder.build(
 					inputSerializer,
 					isProcessingTime,
+					nfaProcessingInterval,
 					nfaFactory,
 					comparator,
 					pattern.getAfterMatchSkipStrategy()));
@@ -287,6 +305,7 @@ public class CEPOperatorUtils {
 				operatorBuilder.build(
 					inputSerializer,
 					isProcessingTime,
+					nfaProcessingInterval,
 					nfaFactory,
 					comparator,
 					pattern.getAfterMatchSkipStrategy()
@@ -300,6 +319,7 @@ public class CEPOperatorUtils {
 			OneInputStreamOperator<IN, OUT> build(
 			TypeSerializer<IN> inputSerializer,
 			boolean isProcessingTime,
+			long nfaProcessingInterval,
 			NFACompiler.NFAFactory<IN> nfaFactory,
 			EventComparator<IN> comparator,
 			AfterMatchSkipStrategy skipStrategy);

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/FlatSelectCepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/FlatSelectCepOperator.java
@@ -42,11 +42,12 @@ public class FlatSelectCepOperator<IN, KEY, OUT>
 	public FlatSelectCepOperator(
 		TypeSerializer<IN> inputSerializer,
 		boolean isProcessingTime,
+		long nfaProcessingInterval,
 		NFACompiler.NFAFactory<IN> nfaFactory,
 		EventComparator<IN> comparator,
 		AfterMatchSkipStrategy skipStrategy,
 		PatternFlatSelectFunction<IN, OUT> function) {
-		super(inputSerializer, isProcessingTime, nfaFactory, comparator, skipStrategy, function);
+		super(inputSerializer, isProcessingTime, nfaProcessingInterval, nfaFactory, comparator, skipStrategy, function);
 	}
 
 	private transient TimestampedCollector<OUT> collector;

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/FlatSelectTimeoutCepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/FlatSelectTimeoutCepOperator.java
@@ -47,6 +47,7 @@ import java.util.Map;
 public class FlatSelectTimeoutCepOperator<IN, OUT1, OUT2, KEY> extends
 	AbstractKeyedCEPPatternOperator<IN, KEY, OUT1, FlatSelectTimeoutCepOperator.FlatSelectWrapper<IN, OUT1, OUT2>> {
 
+	private static final long serialVersionUID = -6459053031624344987L;
 	private transient TimestampedCollector<OUT1> collector;
 
 	private transient TimestampedSideOutputCollector<OUT2> sideOutputCollector;
@@ -56,6 +57,7 @@ public class FlatSelectTimeoutCepOperator<IN, OUT1, OUT2, KEY> extends
 	public FlatSelectTimeoutCepOperator(
 		TypeSerializer<IN> inputSerializer,
 		boolean isProcessingTime,
+		long nfaProcessingInterval,
 		NFACompiler.NFAFactory<IN> nfaFactory,
 		EventComparator<IN> comparator,
 		AfterMatchSkipStrategy skipStrategy,
@@ -65,6 +67,7 @@ public class FlatSelectTimeoutCepOperator<IN, OUT1, OUT2, KEY> extends
 		super(
 			inputSerializer,
 			isProcessingTime,
+			nfaProcessingInterval,
 			nfaFactory,
 			comparator,
 			skipStrategy,

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/SelectCepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/SelectCepOperator.java
@@ -37,14 +37,17 @@ import java.util.Map;
  */
 public class SelectCepOperator<IN, KEY, OUT>
 	extends AbstractKeyedCEPPatternOperator<IN, KEY, OUT, PatternSelectFunction<IN, OUT>> {
+	private static final long serialVersionUID = 4487469926249382728L;
+
 	public SelectCepOperator(
 		TypeSerializer<IN> inputSerializer,
 		boolean isProcessingTime,
+		long nfaProcessingInterval,
 		NFACompiler.NFAFactory<IN> nfaFactory,
 		EventComparator<IN> comparator,
 		AfterMatchSkipStrategy skipStrategy,
 		PatternSelectFunction<IN, OUT> function) {
-		super(inputSerializer, isProcessingTime, nfaFactory, comparator, skipStrategy, function);
+		super(inputSerializer, isProcessingTime, nfaProcessingInterval, nfaFactory, comparator, skipStrategy, function);
 	}
 
 	@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/SelectTimeoutCepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/SelectTimeoutCepOperator.java
@@ -46,11 +46,13 @@ import java.util.Map;
 public class SelectTimeoutCepOperator<IN, OUT1, OUT2, KEY>
 	extends AbstractKeyedCEPPatternOperator<IN, KEY, OUT1, SelectTimeoutCepOperator.SelectWrapper<IN, OUT1, OUT2>> {
 
+	private static final long serialVersionUID = 7343789580169612665L;
 	private OutputTag<OUT2> timedOutOutputTag;
 
 	public SelectTimeoutCepOperator(
 		TypeSerializer<IN> inputSerializer,
 		boolean isProcessingTime,
+		long nfaProcessingInterval,
 		NFACompiler.NFAFactory<IN> nfaFactory,
 		final EventComparator<IN> comparator,
 		AfterMatchSkipStrategy skipStrategy,
@@ -60,6 +62,7 @@ public class SelectTimeoutCepOperator<IN, OUT1, OUT2, KEY>
 		super(
 			inputSerializer,
 			isProcessingTime,
+			nfaProcessingInterval,
 			nfaFactory,
 			comparator,
 			skipStrategy,

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigrationTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigrationTest.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static org.apache.flink.cep.operator.CepOperatorTestUtilities.getKeyedCepOpearator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -100,7 +99,7 @@ public class CEPMigrationTest {
 
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
 				new KeyedOneInputStreamOperatorTestHarness<>(
-					getKeyedCepOpearator(false, new NFAFactory()),
+					CepOperatorTestUtilities.getKeyedCepOperator(false, new NFAFactory()),
 						keySelector,
 						BasicTypeInfo.INT_TYPE_INFO);
 
@@ -145,7 +144,7 @@ public class CEPMigrationTest {
 
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
 				new KeyedOneInputStreamOperatorTestHarness<>(
-						getKeyedCepOpearator(false, new NFAFactory()),
+						CepOperatorTestUtilities.getKeyedCepOperator(false, new NFAFactory()),
 						keySelector,
 						BasicTypeInfo.INT_TYPE_INFO);
 
@@ -209,7 +208,7 @@ public class CEPMigrationTest {
 			harness.close();
 
 			harness = new KeyedOneInputStreamOperatorTestHarness<>(
-				getKeyedCepOpearator(false, new NFAFactory()),
+				CepOperatorTestUtilities.getKeyedCepOperator(false, new NFAFactory()),
 				keySelector,
 				BasicTypeInfo.INT_TYPE_INFO);
 
@@ -264,7 +263,7 @@ public class CEPMigrationTest {
 
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
 				new KeyedOneInputStreamOperatorTestHarness<>(
-					getKeyedCepOpearator(false, new NFAFactory()),
+					CepOperatorTestUtilities.getKeyedCepOperator(false, new NFAFactory()),
 						keySelector,
 						BasicTypeInfo.INT_TYPE_INFO);
 
@@ -307,7 +306,7 @@ public class CEPMigrationTest {
 
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
 				new KeyedOneInputStreamOperatorTestHarness<>(
-					getKeyedCepOpearator(false, new NFAFactory()),
+					CepOperatorTestUtilities.getKeyedCepOperator(false, new NFAFactory()),
 						keySelector,
 						BasicTypeInfo.INT_TYPE_INFO);
 
@@ -385,7 +384,7 @@ public class CEPMigrationTest {
 			harness.close();
 
 			harness = new KeyedOneInputStreamOperatorTestHarness<>(
-				getKeyedCepOpearator(false, new NFAFactory()),
+				CepOperatorTestUtilities.getKeyedCepOperator(false, new NFAFactory()),
 				keySelector,
 				BasicTypeInfo.INT_TYPE_INFO);
 
@@ -439,7 +438,7 @@ public class CEPMigrationTest {
 
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
 				new KeyedOneInputStreamOperatorTestHarness<>(
-						getKeyedCepOpearator(false, new SinglePatternNFAFactory()),
+						CepOperatorTestUtilities.getKeyedCepOperator(false, new SinglePatternNFAFactory()),
 						keySelector,
 						BasicTypeInfo.INT_TYPE_INFO);
 
@@ -473,7 +472,7 @@ public class CEPMigrationTest {
 
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
 				new KeyedOneInputStreamOperatorTestHarness<>(
-						getKeyedCepOpearator(false, new SinglePatternNFAFactory()),
+						CepOperatorTestUtilities.getKeyedCepOperator(false, new SinglePatternNFAFactory()),
 						keySelector,
 						BasicTypeInfo.INT_TYPE_INFO);
 
@@ -531,7 +530,7 @@ public class CEPMigrationTest {
 
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
 			new KeyedOneInputStreamOperatorTestHarness<>(
-				getKeyedCepOpearator(false, new NFAComplexConditionsFactory()),
+				CepOperatorTestUtilities.getKeyedCepOperator(false, new NFAComplexConditionsFactory()),
 				keySelector,
 				BasicTypeInfo.INT_TYPE_INFO);
 
@@ -566,7 +565,7 @@ public class CEPMigrationTest {
 
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
 			new KeyedOneInputStreamOperatorTestHarness<>(
-				getKeyedCepOpearator(false, new NFAComplexConditionsFactory()),
+				CepOperatorTestUtilities.getKeyedCepOperator(false, new NFAComplexConditionsFactory()),
 				keySelector,
 				BasicTypeInfo.INT_TYPE_INFO);
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
@@ -255,6 +255,7 @@ public class CEPOperatorTest extends TestLogger {
 				new SelectTimeoutCepOperator<>(
 					Event.createTypeSerializer(),
 					false,
+					100,
 					new NFAFactory(true),
 					null,
 					null,
@@ -332,7 +333,7 @@ public class CEPOperatorTest extends TestLogger {
 	@Test
 	public void testKeyedCEPOperatorNFAUpdate() throws Exception {
 
-		SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator = CepOperatorTestUtilities.getKeyedCepOpearator(
+		SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator = CepOperatorTestUtilities.getKeyedCepOperator(
 			true,
 			new SimpleNFAFactory());
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness = CepOperatorTestUtilities.getCepTestHarness(
@@ -351,7 +352,7 @@ public class CEPOperatorTest extends TestLogger {
 			OperatorSubtaskState snapshot = harness.snapshot(0L, 0L);
 			harness.close();
 
-			operator = CepOperatorTestUtilities.getKeyedCepOpearator(true, new SimpleNFAFactory());
+			operator = CepOperatorTestUtilities.getKeyedCepOperator(true, new SimpleNFAFactory());
 			harness = CepOperatorTestUtilities.getCepTestHarness(operator);
 
 			harness.setup();
@@ -362,7 +363,7 @@ public class CEPOperatorTest extends TestLogger {
 			OperatorSubtaskState snapshot2 = harness.snapshot(0L, 0L);
 			harness.close();
 
-			operator = CepOperatorTestUtilities.getKeyedCepOpearator(true, new SimpleNFAFactory());
+			operator = CepOperatorTestUtilities.getKeyedCepOperator(true, new SimpleNFAFactory());
 			harness = CepOperatorTestUtilities.getCepTestHarness(operator);
 
 			harness.setup();
@@ -391,7 +392,7 @@ public class CEPOperatorTest extends TestLogger {
 		RocksDBStateBackend rocksDBStateBackend = new RocksDBStateBackend(new MemoryStateBackend());
 		rocksDBStateBackend.setDbStoragePath(rocksDbPath);
 
-		SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator = CepOperatorTestUtilities.getKeyedCepOpearator(
+		SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator = CepOperatorTestUtilities.getKeyedCepOperator(
 			true,
 			new SimpleNFAFactory());
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness = CepOperatorTestUtilities.getCepTestHarness(
@@ -412,7 +413,7 @@ public class CEPOperatorTest extends TestLogger {
 			OperatorSubtaskState snapshot = harness.snapshot(0L, 0L);
 			harness.close();
 
-			operator = CepOperatorTestUtilities.getKeyedCepOpearator(true, new SimpleNFAFactory());
+			operator = CepOperatorTestUtilities.getKeyedCepOperator(true, new SimpleNFAFactory());
 			harness = CepOperatorTestUtilities.getCepTestHarness(operator);
 
 			rocksDBStateBackend = new RocksDBStateBackend(new MemoryStateBackend());
@@ -426,7 +427,7 @@ public class CEPOperatorTest extends TestLogger {
 			OperatorSubtaskState snapshot2 = harness.snapshot(0L, 0L);
 			harness.close();
 
-			operator = CepOperatorTestUtilities.getKeyedCepOpearator(true, new SimpleNFAFactory());
+			operator = CepOperatorTestUtilities.getKeyedCepOperator(true, new SimpleNFAFactory());
 			harness = CepOperatorTestUtilities.getCepTestHarness(operator);
 
 			rocksDBStateBackend = new RocksDBStateBackend(new MemoryStateBackend());
@@ -453,7 +454,7 @@ public class CEPOperatorTest extends TestLogger {
 
 	@Test
 	public void testKeyedCEPOperatorNFAUpdateTimes() throws Exception {
-		SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator = CepOperatorTestUtilities.getKeyedCepOpearator(
+		SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator = CepOperatorTestUtilities.getKeyedCepOperator(
 			true,
 			new SimpleNFAFactory());
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness = CepOperatorTestUtilities.getCepTestHarness(operator);
@@ -495,7 +496,7 @@ public class CEPOperatorTest extends TestLogger {
 		RocksDBStateBackend rocksDBStateBackend = new RocksDBStateBackend(new MemoryStateBackend());
 		rocksDBStateBackend.setDbStoragePath(rocksDbPath);
 
-		SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator = CepOperatorTestUtilities.getKeyedCepOpearator(
+		SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator = CepOperatorTestUtilities.getKeyedCepOperator(
 			true,
 			new SimpleNFAFactory());
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness = CepOperatorTestUtilities.getCepTestHarness(
@@ -644,7 +645,7 @@ public class CEPOperatorTest extends TestLogger {
 		Event middle1Event3 = new Event(41, "a", 4.0);
 		Event middle2Event1 = new Event(41, "b", 5.0);
 
-		SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator = CepOperatorTestUtilities.getKeyedCepOpearator(
+		SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator = CepOperatorTestUtilities.getKeyedCepOperator(
 			false,
 			new ComplexNFAFactory());
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness = CepOperatorTestUtilities.getCepTestHarness(operator);
@@ -859,7 +860,7 @@ public class CEPOperatorTest extends TestLogger {
 			}
 		});
 
-		SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator = CepOperatorTestUtilities.getKeyedCepOpearator(
+		SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator = CepOperatorTestUtilities.getKeyedCepOperator(
 			false,
 			new NFACompiler.NFAFactory<Event>() {
 				private static final long serialVersionUID = 477082663248051994L;
@@ -930,7 +931,7 @@ public class CEPOperatorTest extends TestLogger {
 
 		Event startEventK2 = new Event(43, "start", 1.0);
 
-		SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator = getKeyedCepOperatorWithComparator(true);
+		SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator = getKeyedCepOperatorWithComparator(true, 1);
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness = CepOperatorTestUtilities.getCepTestHarness(operator);
 
 		try {
@@ -958,7 +959,7 @@ public class CEPOperatorTest extends TestLogger {
 			OperatorSubtaskState snapshot = harness.snapshot(0L, 0L);
 			harness.close();
 
-			SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator2 = getKeyedCepOperatorWithComparator(true);
+			SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator2 = getKeyedCepOperatorWithComparator(true, 1);
 			harness = CepOperatorTestUtilities.getCepTestHarness(operator2);
 			harness.setup();
 			harness.initializeState(snapshot);
@@ -1058,33 +1059,38 @@ public class CEPOperatorTest extends TestLogger {
 
 	private SelectCepOperator<Event, Integer, Map<String, List<Event>>> getKeyedCepOperator(
 		boolean isProcessingTime) {
-		return CepOperatorTestUtilities.getKeyedCepOpearator(isProcessingTime, new NFAFactory());
+		return CepOperatorTestUtilities.getKeyedCepOperator(isProcessingTime, new NFAFactory());
 	}
 
 	private SelectCepOperator<Event, Integer, Map<String, List<Event>>> getKeyedCepOperatorWithComparator(
 		boolean isProcessingTime) {
+		return getKeyedCepOperatorWithComparator(isProcessingTime, 100);
+	}
 
-		return CepOperatorTestUtilities.getKeyedCepOpearator(isProcessingTime, new NFAFactory(), new org.apache.flink.cep.EventComparator<Event>() {
+	private SelectCepOperator<Event, Integer, Map<String, List<Event>>> getKeyedCepOperatorWithComparator(
+		boolean isProcessingTime, long processingTimeInterval) {
+
+		return CepOperatorTestUtilities.getKeyedCepOperator(isProcessingTime, new NFAFactory(), new org.apache.flink.cep.EventComparator<Event>() {
 			@Override
 			public int compare(Event o1, Event o2) {
 				return Double.compare(o1.getPrice(), o2.getPrice());
 			}
-		});
+		}, processingTimeInterval);
 	}
 
 	private void compareMaps(List<List<Event>> actual, List<List<Event>> expected) {
 		Assert.assertEquals(expected.size(), actual.size());
 
 		for (List<Event> p: actual) {
-			Collections.sort(p, new EventComparator());
+			p.sort(new EventComparator());
 		}
 
 		for (List<Event> p: expected) {
-			Collections.sort(p, new EventComparator());
+			p.sort(new EventComparator());
 		}
 
-		Collections.sort(actual, new ListEventComparator());
-		Collections.sort(expected, new ListEventComparator());
+		actual.sort(new ListEventComparator());
+		expected.sort(new ListEventComparator());
 		Assert.assertArrayEquals(expected.toArray(), actual.toArray());
 	}
 
@@ -1132,7 +1138,7 @@ public class CEPOperatorTest extends TestLogger {
 	}
 
 	private SelectCepOperator<Event, Integer, Map<String, List<Event>>> getKeyedCepOpearator(boolean isProcessingTime) {
-		return CepOperatorTestUtilities.getKeyedCepOpearator(isProcessingTime, new CEPOperatorTest.NFAFactory());
+		return CepOperatorTestUtilities.getKeyedCepOperator(isProcessingTime, new CEPOperatorTest.NFAFactory());
 	}
 
 	private static class NFAFactory implements NFACompiler.NFAFactory<Event> {

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPRescalingTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPRescalingTest.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 
-import static org.apache.flink.cep.operator.CepOperatorTestUtilities.getKeyedCepOpearator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -372,7 +371,7 @@ public class CEPRescalingTest {
 
 		KeySelector<Event, Integer> keySelector = new TestKeySelector();
 		return new KeyedOneInputStreamOperatorTestHarness<>(
-			getKeyedCepOpearator(
+			CepOperatorTestUtilities.getKeyedCepOperator(
 				false,
 				new NFAFactory()),
 			keySelector,

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepOperatorTestUtilities.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepOperatorTestUtilities.java
@@ -55,20 +55,29 @@ public class CepOperatorTestUtilities {
 			BasicTypeInfo.INT_TYPE_INFO);
 	}
 
-	public static <K> SelectCepOperator<Event, K, Map<String, List<Event>>> getKeyedCepOpearator(
+	public static <K> SelectCepOperator<Event, K, Map<String, List<Event>>> getKeyedCepOperator(
 		boolean isProcessingTime,
 		NFACompiler.NFAFactory<Event> nfaFactory) {
 
-		return getKeyedCepOpearator(isProcessingTime, nfaFactory, null);
+		return getKeyedCepOperator(isProcessingTime, nfaFactory, null);
 	}
 
-	public static <K> SelectCepOperator<Event, K, Map<String, List<Event>>> getKeyedCepOpearator(
+	public static <K> SelectCepOperator<Event, K, Map<String, List<Event>>> getKeyedCepOperator(
 		boolean isProcessingTime,
 		NFACompiler.NFAFactory<Event> nfaFactory,
 		EventComparator<Event> comparator) {
+		return getKeyedCepOperator(isProcessingTime, nfaFactory, comparator, 100);
+	}
+
+	public static <K> SelectCepOperator<Event, K, Map<String, List<Event>>> getKeyedCepOperator(
+		boolean isProcessingTime,
+		NFACompiler.NFAFactory<Event> nfaFactory,
+		EventComparator<Event> comparator,
+		long nfaProcessingInterval) {
 		return new SelectCepOperator<>(
 			Event.createTypeSerializer(),
 			isProcessingTime,
+			nfaProcessingInterval,
 			nfaFactory,
 			comparator,
 			null,


### PR DESCRIPTION

## What is the purpose of the change

This PR introduces a new configuration parameter that allows partial matches to be timeouted without any subsequent events in the stream. Just based on the time. The timers in case of custom operators are also registered less often.

## Verifying this change

This change changed existing tests and can be verified as follows:

The *TODO* was removed from testCEPOperatorCleanupProcessingTime

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes, but just in CEP)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs / JavaDocs)

