### PR TITLE
Logging improvements in NetworkFailuresProxy

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/networking/NetworkFailureHandler.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/networking/NetworkFailureHandler.java
@@ -92,7 +92,14 @@ class NetworkFailureHandler extends SimpleChannelUpstreamHandler {
 		final Channel sourceChannel = event.getChannel();
 		sourceChannel.setReadable(false);
 
-		if (blocked.get()) {
+		boolean isBlocked = blocked.get();
+		LOG.debug("Attempt to open proxy channel from [%s] to [%s:%s] in state [blocked = %s]",
+			sourceChannel.getLocalAddress(),
+			remoteHost,
+			remotePort,
+			isBlocked);
+
+		if (isBlocked) {
 			sourceChannel.close();
 			return;
 		}

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/networking/NetworkFailuresProxy.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/networking/NetworkFailuresProxy.java
@@ -53,8 +53,6 @@ public class NetworkFailuresProxy implements AutoCloseable {
 	private final Set<NetworkFailureHandler> networkFailureHandlers = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
 	public NetworkFailuresProxy(int localPort, String remoteHost, int remotePort) {
-		LOG.info("Proxying [*:{}] to [{}:{}]", localPort, remoteHost, remotePort);
-
 		// Configure the bootstrap.
 		serverBootstrap = new ServerBootstrap(
 			new NioServerSocketChannelFactory(executor, executor));
@@ -83,6 +81,7 @@ public class NetworkFailuresProxy implements AutoCloseable {
 		});
 		channel = serverBootstrap.bind(new InetSocketAddress(localPort));
 
+		LOG.info("Proxying [*:{}] to [{}:{}]", getLocalPort(), remoteHost, remotePort);
 	}
 
 	/**


### PR DESCRIPTION
This PR consists of only one minor bug fix and one improvement in logging of `NetworkFailuresProxy` class used in tests. It's highly unlikely that it will brake anything. Change is covered by existing `NetworkFailuresProxyTest`.