### PR TITLE
[FLINK-7411][network] minor performance improvements in NettyMessage

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
@@ -264,12 +264,10 @@ public class PartitionRequestClientHandlerTest {
 		// Skip general header bytes
 		serialized.readBytes(NettyMessage.HEADER_LENGTH);
 
-		BufferResponse deserialized = new BufferResponse();
-
 		// Deserialize the bytes again. We have to go this way, because we only partly deserialize
 		// the header of the response and wait for a buffer from the buffer pool to copy the payload
 		// data into.
-		deserialized.readFrom(serialized);
+		BufferResponse deserialized = BufferResponse.readFrom(serialized);
 
 		return deserialized;
 	}


### PR DESCRIPTION
## What is the purpose of the change

This PR adds some (minor) performance improvements to `NettyMessage` which I came across: using a `switch` rather than multiple `if...ifelse...ifelse...` avoiding unneeded virtual method calls.

## Brief change log

- use a switch rather than multiple if conditions
- use static `readFrom` methods to create instances of the message sub types

## Verifying this change

This change is already covered by existing tests, such as `NettyMessageSerializationTest` as well as many other tests, especially IT cases, involving network.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes, if you consider network communication part of this)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

