### PR TITLE
[FLINK-7412][network] optimise NettyMessage.TaskEventRequest#readFrom() to read from netty buffers directly

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -450,12 +450,11 @@ abstract class NettyMessage {
 		}
 
 		static TaskEventRequest readFrom(ByteBuf buffer, ClassLoader classLoader) throws IOException {
-			// TODO Directly deserialize fromNetty's buffer
+			// directly deserialize fromNetty's buffer
 			int length = buffer.readInt();
-			ByteBuffer serializedEvent = ByteBuffer.allocate(length);
-
-			buffer.readBytes(serializedEvent);
-			serializedEvent.flip();
+			ByteBuffer serializedEvent = buffer.nioBuffer(buffer.readerIndex(), length);
+			// assume this event's content is read from the ByteBuf (positions are not shared!)
+			buffer.readerIndex(buffer.readerIndex() + length);
 
 			TaskEvent event =
 				(TaskEvent) EventSerializer.fromSerializedEvent(serializedEvent, classLoader);


### PR DESCRIPTION
## What is the purpose of the change

`NettyMessage.TaskEventRequest#readFrom()` had an outstanding TODO to read from the netty buffer directly, instead of copying to a `ByteBuffer` first and then deserializing the event.

~This PR is based on #4517.~

## Brief change log

- use `ByteBuf#nioBuffer()` to deserialize from a `ByteBuffer` instance wrapping netty's buffer contents 

## Verifying this change

This change is already covered by existing tests, such as `NettyMessageSerializationTest` as well as many other tests, especially IT cases, involving network.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes, if you consider network communication part of this)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

