### PR TITLE
[FLINK-7415][Cassandra Connector] Add comments for cassandra-connector test classes

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/batch/connectors/cassandra/example/BatchExample.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/batch/connectors/cassandra/example/BatchExample.java
@@ -34,8 +34,9 @@ import java.util.ArrayList;
 /**
  * This is an example showing the to use the Cassandra Input-/OutputFormats in the Batch API.
  *
- * <p>The example assumes that a table exists in a local cassandra database, according to the following query:
- * CREATE TABLE test.batches (number int, strings text, PRIMARY KEY(number, strings));
+ * <p>The example assumes that a table exists in a local cassandra database, according to the following queries:
+ * CREATE KEYSPACE IF NOT EXISTS test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': ‘1’};
+ * CREATE TABLE IF NOT EXISTS test.batches (number int, strings text, PRIMARY KEY(number, strings));
  */
 public class BatchExample {
 	private static final String INSERT_QUERY = "INSERT INTO test.batches (number, strings) VALUES (?,?);";

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/example/CassandraPojoSinkExample.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/example/CassandraPojoSinkExample.java
@@ -32,7 +32,8 @@ import java.util.ArrayList;
  *
  * <p>Pojo's have to be annotated with datastax annotations to work with this sink.
  *
- * <p>The example assumes that a table exists in a local cassandra database, according to the following query:
+ * <p>The example assumes that a table exists in a local cassandra database, according to the following queries:
+ * CREATE KEYSPACE IF NOT EXISTS test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': ‘1’};
  * CREATE TABLE IF NOT EXISTS test.message(body txt PRIMARY KEY)
  */
 public class CassandraPojoSinkExample {

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/example/CassandraTupleSinkExample.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/example/CassandraTupleSinkExample.java
@@ -31,7 +31,8 @@ import java.util.ArrayList;
 /**
  * This is an example showing the to use the Tuple Cassandra Sink in the Streaming API.
  *
- * <p>The example assumes that a table exists in a local cassandra database, according to the following query:
+ * <p>The example assumes that a table exists in a local cassandra database, according to the following queries:
+ * CREATE KEYSPACE IF NOT EXISTS test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': ‘1’};
  * CREATE TABLE IF NOT EXISTS test.writetuple(element1 text PRIMARY KEY, element2 int)
  */
 public class CassandraTupleSinkExample {

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/example/CassandraTupleWriteAheadSinkExample.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/example/CassandraTupleWriteAheadSinkExample.java
@@ -36,7 +36,8 @@ import java.util.UUID;
 /**
  * This is an example showing the to use the Cassandra Sink (with write-ahead log) in the Streaming API.
  *
- * <p>The example assumes that a table exists in a local cassandra database, according to the following query:
+ * <p>The example assumes that a table exists in a local cassandra database, according to the following queries:
+ * CREATE KEYSPACE IF NOT EXISTS example WITH replication = {'class': 'SimpleStrategy', 'replication_factor': ‘1’};
  * CREATE TABLE example.values (id text, count int, PRIMARY KEY(id));
  *
  * <p>Important things to note are that checkpointing is enabled, a StateBackend is set and the enableWriteAheadLog() call


### PR DESCRIPTION
## What is the purpose of the change
Help beginners follow it with less confusion. 

## Brief change log
- Add comments for cassandra test classes

## Verifying this change



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)