### PR TITLE
[FLINK-7366][kinesis connector] Upgrade kinesis producer library in flink-connector-kinesis

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -35,7 +35,7 @@ under the License.
 	<properties>
 		<aws.sdk.version>1.10.71</aws.sdk.version>
 		<aws.kinesis-kcl.version>1.6.2</aws.kinesis-kcl.version>
-		<aws.kinesis-kpl.version>0.10.2</aws.kinesis-kpl.version>
+		<aws.kinesis-kpl.version>0.12.5</aws.kinesis-kpl.version>
 	</properties>
 
 	<packaging>jar</packaging>

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -33,8 +33,8 @@ under the License.
 	<artifactId>flink-connector-kinesis_${scala.binary.version}</artifactId>
 	<name>flink-connector-kinesis</name>
 	<properties>
-		<aws.sdk.version>1.10.71</aws.sdk.version>
-		<aws.kinesis-kcl.version>1.6.2</aws.kinesis-kcl.version>
+		<aws.sdk.version>1.11.171</aws.sdk.version>
+		<aws.kinesis-kcl.version>1.8.1</aws.kinesis-kcl.version>
 		<aws.kinesis-kpl.version>0.12.5</aws.kinesis-kpl.version>
 	</properties>
 

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -33,8 +33,8 @@ under the License.
 	<artifactId>flink-connector-kinesis_${scala.binary.version}</artifactId>
 	<name>flink-connector-kinesis</name>
 	<properties>
-		<aws.sdk.version>1.11.171</aws.sdk.version>
-		<aws.kinesis-kcl.version>1.8.1</aws.kinesis-kcl.version>
+		<aws.sdk.version>1.10.71</aws.sdk.version>
+		<aws.kinesis-kcl.version>1.6.2</aws.kinesis-kcl.version>
 		<aws.kinesis-kpl.version>0.12.5</aws.kinesis-kpl.version>
 	</properties>
 


### PR DESCRIPTION
## What is the purpose of the change

We need to upgrade KPL and KCL to pick up the enhanced performance and stability for Flink to work better  with Kinesis. Upgrading KPL is specially necessary, because the KPL version Flink uses is old, and doesn't have good retry and error handling logic.

**Upgrade KPL:**

flink-connector-kinesis currently uses kinesis-producer-library 0.10.2, which is released in Nov 2015 by AWS. It's old. It's the fourth release, and thus problematic. It doesn't even have good retry logic, therefore Flink fails really frequently (about every 10 mins as we observed) when Flink writes too fast to Kinesis and receives RateLimitExceededException,

Quotes from https://github.com/awslabs/amazon-kinesis-producer/issues/56, "With the newer version of the KPL it uses the AWS C++ SDK which should offer additional retries." on Oct 2016. 0.12.5, the version we are upgrading to, is released in May 2017 and should have the enhanced retry logic.

**Upgrade KCL:**

Upgrade KCL from 1.6.2 to 1.8.1

**Upgrade AWS SDK:**

from 1.10.71 to 1.11.171

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

There should be any impact outside flink-connector-kinesis, because 1) KPL and KCL is only used in flink-connector-kinesis, and 2) AWS SDK in flink-connector-kinesis is shaded 

## Documentation

  - Does this pull request introduce a new feature? (no)
