### PR TITLE
[FLINK-7423] Always reuse an instance to get elements from the inputFormat

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
@@ -150,22 +150,25 @@ public class DataSourceTask<OT> extends AbstractInvokable {
 					final Collector<OT> output = new CountingCollector<>(this.output, numRecordsOut);
 
 					if (objectReuseEnabled) {
-						OT reuse = serializer.createInstance();
+						OT nextRecord = serializer.createInstance();
 
 						// as long as there is data to read
 						while (!this.taskCanceled && !format.reachedEnd()) {
 
-							OT returned;
-							if ((returned = format.nextRecord(reuse)) != null) {
-								output.collect(returned);
+							if ((nextRecord = format.nextRecord(nextRecord)) != null) {
+								output.collect(nextRecord);
+							} else {
+								break;
 							}
 						}
 					} else {
 						// as long as there is data to read
 						while (!this.taskCanceled && !format.reachedEnd()) {
-							OT returned;
-							if ((returned = format.nextRecord(serializer.createInstance())) != null) {
-								output.collect(returned);
+							OT nextRecord;
+							if ((nextRecord = format.nextRecord(serializer.createInstance())) != null) {
+								output.collect(nextRecord);
+							} else {
+								break;
 							}
 						}
 					}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/InputFormatSourceFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/InputFormatSourceFunction.java
@@ -80,15 +80,16 @@ public class InputFormatSourceFunction<OUT> extends RichParallelSourceFunction<O
 				((RichInputFormat) format).openInputFormat();
 			}
 
-			OUT reuse = serializer.createInstance();
+
 			while (isRunning) {
 				format.open(splitIterator.next());
+				OUT nextElement = serializer.createInstance();
 
 				// for each element we also check if cancel
 				// was called by checking the isRunning flag
 
 				while (isRunning && !format.reachedEnd()) {
-					OUT nextElement = format.nextRecord(reuse);
+					nextElement = format.nextRecord(nextElement);
 					if (nextElement != null) {
 						ctx.collect(nextElement);
 					} else {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/InputFormatSourceFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/InputFormatSourceFunction.java
@@ -80,7 +80,7 @@ public class InputFormatSourceFunction<OUT> extends RichParallelSourceFunction<O
 				((RichInputFormat) format).openInputFormat();
 			}
 
-			OUT nextElement = serializer.createInstance();
+			OUT reuse = serializer.createInstance();
 			while (isRunning) {
 				format.open(splitIterator.next());
 
@@ -88,7 +88,7 @@ public class InputFormatSourceFunction<OUT> extends RichParallelSourceFunction<O
 				// was called by checking the isRunning flag
 
 				while (isRunning && !format.reachedEnd()) {
-					nextElement = format.nextRecord(nextElement);
+					OUT nextElement = format.nextRecord(reuse);
 					if (nextElement != null) {
 						ctx.collect(nextElement);
 					} else {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/InputFormatSourceFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/InputFormatSourceFunctionTest.java
@@ -91,7 +91,6 @@ public class InputFormatSourceFunctionTest {
 		private boolean isConfigured = false;
 		private boolean isInputFormatOpen = false;
 		private boolean isSplitOpen = false;
-		private Integer savedReuse = null;
 
 		// end of split
 		private boolean eos = false;
@@ -178,11 +177,6 @@ public class InputFormatSourceFunctionTest {
 			Assert.assertTrue(isInputFormatOpen);
 			Assert.assertTrue(isConfigured);
 			Assert.assertTrue(isSplitOpen);
-			Assert.assertNotNull(reuse);
-			if (savedReuse == null) {
-				savedReuse = reuse;
-			}
-			Assert.assertTrue(reuse == savedReuse);
 
 			Assert.assertTrue(reachedEndCalls == ++nextRecordCalls);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/InputFormatSourceFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/InputFormatSourceFunctionTest.java
@@ -91,6 +91,7 @@ public class InputFormatSourceFunctionTest {
 		private boolean isConfigured = false;
 		private boolean isInputFormatOpen = false;
 		private boolean isSplitOpen = false;
+		private Integer savedReuse = null;
 
 		// end of split
 		private boolean eos = false;
@@ -177,6 +178,11 @@ public class InputFormatSourceFunctionTest {
 			Assert.assertTrue(isInputFormatOpen);
 			Assert.assertTrue(isConfigured);
 			Assert.assertTrue(isSplitOpen);
+			Assert.assertNotNull(reuse);
+			if (savedReuse == null) {
+				savedReuse = reuse;
+			}
+			Assert.assertTrue(reuse == savedReuse);
 
 			Assert.assertTrue(reachedEndCalls == ++nextRecordCalls);
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request fix a bug about getting elements from the inputFormat in InputFormatSourceFunction.java


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test in InputFormatSourceFunctionTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)