### PR TITLE
[FLINK-7407] [kafka] Adapt AbstractPartitionDiscoverer to handle non-contiguous partition metadata

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractPartitionDiscoverer.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractPartitionDiscoverer.java
@@ -244,8 +244,4 @@ public abstract class AbstractPartitionDiscoverer {
 	private boolean isUndiscoveredPartition(KafkaTopicPartition partition) {
 		return !discoveredPartitions.contains(partition);
 	}
-
-	public static boolean shouldAssignToThisSubtask(KafkaTopicPartition partition, int indexOfThisSubtask, int numParallelSubtasks) {
-		return Math.abs(partition.hashCode() % numParallelSubtasks) == indexOfThisSubtask;
-	}
 }

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractPartitionDiscoverer.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractPartitionDiscoverer.java
@@ -17,10 +17,10 @@
 
 package org.apache.flink.streaming.connectors.kafka.internals;
 
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -68,7 +68,7 @@ public abstract class AbstractPartitionDiscoverer {
 	 * to keep track of only the largest partition id because Kafka partition numbers are only
 	 * allowed to be increased and has incremental ids.
 	 */
-	private Map<String, Integer> topicsToLargestDiscoveredPartitionId;
+	private Set<KafkaTopicPartition> discoveredPartitions;
 
 	public AbstractPartitionDiscoverer(
 			KafkaTopicsDescriptor topicsDescriptor,
@@ -78,7 +78,7 @@ public abstract class AbstractPartitionDiscoverer {
 		this.topicsDescriptor = checkNotNull(topicsDescriptor);
 		this.indexOfThisSubtask = indexOfThisSubtask;
 		this.numParallelSubtasks = numParallelSubtasks;
-		this.topicsToLargestDiscoveredPartitionId = new HashMap<>();
+		this.discoveredPartitions = new HashSet<>();
 	}
 
 	/**
@@ -149,10 +149,6 @@ public abstract class AbstractPartitionDiscoverer {
 				if (newDiscoveredPartitions == null || newDiscoveredPartitions.isEmpty()) {
 					throw new RuntimeException("Unable to retrieve any partitions with KafkaTopicsDescriptor: " + topicsDescriptor);
 				} else {
-					// sort so that we make sure the topicsToLargestDiscoveredPartitionId state is updated
-					// with incremental partition ids of the same topics (otherwise some partition ids may be skipped)
-					KafkaTopicPartition.sort(newDiscoveredPartitions);
-
 					Iterator<KafkaTopicPartition> iter = newDiscoveredPartitions.iterator();
 					KafkaTopicPartition nextPartition;
 					while (iter.hasNext()) {
@@ -196,7 +192,7 @@ public abstract class AbstractPartitionDiscoverer {
 	 */
 	public boolean setAndCheckDiscoveredPartition(KafkaTopicPartition partition) {
 		if (isUndiscoveredPartition(partition)) {
-			topicsToLargestDiscoveredPartitionId.put(partition.getTopic(), partition.getPartition());
+			discoveredPartitions.add(partition);
 
 			return KafkaTopicPartitionAssigner.assign(partition, numParallelSubtasks) == indexOfThisSubtask;
 		}
@@ -246,8 +242,7 @@ public abstract class AbstractPartitionDiscoverer {
 	}
 
 	private boolean isUndiscoveredPartition(KafkaTopicPartition partition) {
-		return !topicsToLargestDiscoveredPartitionId.containsKey(partition.getTopic())
-			||  partition.getPartition() > topicsToLargestDiscoveredPartitionId.get(partition.getTopic());
+		return !discoveredPartitions.contains(partition);
 	}
 
 	public static boolean shouldAssignToThisSubtask(KafkaTopicPartition partition, int indexOfThisSubtask, int numParallelSubtasks) {

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicPartition.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicPartition.java
@@ -19,7 +19,6 @@ package org.apache.flink.streaming.connectors.kafka.internals;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -130,9 +129,5 @@ public final class KafkaTopicPartition implements Serializable {
 				return Integer.compare(p1.getPartition(), p2.getPartition());
 			}
 		}
-	}
-
-	public static void sort(List<KafkaTopicPartition> partitions) {
-		Collections.sort(partitions, new Comparator());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Previously, the `AbstractPartitionDiscoverer` tracked discovered partitions by keeping only the largest discovered partition id. All fetched partition metadata with ids smaller than this id would be
considered as discovered. This assumption of contiguous partition ids is too naive for corner cases where there may be undiscovered partitions that were temporarily unavailable before and were later on always shadowed by discovered partitions with larger partition ids.

## Brief change log

- Change the use of `Map<String, Integer> topicToLargestDiscoveredId` to a simple `Set<KafkaTopicPartition>` to track already discovered partitions.
- Minor `hotfix` to remove unused method in `AbstractPartitionDiscoverer`.

## Verifying this change

This change is verified by a new `AbstractPartitionDiscovererTest.testNonContiguousPartitionIdDiscovery` test. The test features the case where fetched partition metadata is non-contiguous and may have smaller missing partition ids.

Other aspects should be covered by existing tests in `AbstractPartitionDiscovererTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

