### PR TITLE
[FLINK-7434][doc] scafolding with "sbt new"

### DIFF
--- a/docs/quickstart/scala_api_quickstart.md
+++ b/docs/quickstart/scala_api_quickstart.md
@@ -41,25 +41,20 @@ These templates help you to set up the project structure and to create the initi
 
 ### Create Project
 
+You can scafold a new project via either of the following two methods:
+
 <ul class="nav nav-tabs" style="border-bottom: none;">
-    <li class="active"><a href="#giter8" data-toggle="tab">Use <strong>Giter8</strong></a></li>
-    <li><a href="#clone-repository" data-toggle="tab">Clone <strong>repository</strong></a></li>
+    <li class="active"><a href="#sbt_template" data-toggle="tab">Use the <strong>sbt template</strong></a></li>
     <li><a href="#quickstart-script-sbt" data-toggle="tab">Run the <strong>quickstart script</strong></a></li>
 </ul>
 
 <div class="tab-content">
-    <div class="tab-pane active" id="giter8">
+    <div class="tab-pane active" id="sbt_template">
     {% highlight bash %}
-    $ g8 tillrohrmann/flink-project
+    $ sbt new tillrohrmann/flink-project.g8
     {% endhighlight %}
-    This will create a Flink project in the <strong>specified</strong> project directory from the <a href="https://github.com/tillrohrmann/flink-project.g8">flink-project template</a>.
-    If you haven't installed <a href="https://github.com/n8han/giter8">giter8</a>, then please follow this <a href="https://github.com/n8han/giter8#installation">installation guide</a>.
-    </div>
-    <div class="tab-pane" id="clone-repository">
-    {% highlight bash %}
-    $ git clone https://github.com/tillrohrmann/flink-project.git
-    {% endhighlight %}
-    This will create the Flink project in the directory <strong>flink-project</strong>.
+    This will will prompt you for a couple of parameters (project name, flink version...) and then create a Flink project from the <a href="https://github.com/tillrohrmann/flink-project.g8">flink-project template</a>.
+    You need sbt >= 0.13.13 to execute this command. You can follow this <a href="http://www.scala-sbt.org/download.html">installation guide</a> to obtain it if necessary.
     </div>
     <div class="tab-pane" id="quickstart-script-sbt">
     {% highlight bash %}


### PR DESCRIPTION

## What is the purpose of the change

Current [documentation for scala project scafolding from template](https://ci.apache.org/projects/flink/flink-docs-release-1.3/quickstart/scala_api_quickstart.html#create-project) mentions that giter8 needs to be installed. 

The purpose of this documentation update is to clarify that such installation is not required, making it easier to newcomers (and others) to start coding a flink project. 

## Brief change log

Documents  how to use `sbt new` instead of `giter8`.  `sbt` is very likely to already be installed since this is a commonly used developer tool, especially given that the target user here is a scala developer.  

Also, removes the reference to cloning the git project, since that method is more cumbersome for 2 reasons:
- requires the user to remove the `.git` folder after the `git clone`
- is not template based => folders and versions are hard-coded

Also, removing this method imply that one less template needs to be maintained. 

## Verifying this change

  -*Manually verified the change by running `./build_docs.sh -p` from inside the docker container available in `docs/docker`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? ( docs )

