### PR TITLE
[FLINK-7440] [kinesis] Add various eager serializability checks on to Kinesis connector

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
@@ -45,6 +45,7 @@ import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeseri
 import org.apache.flink.streaming.connectors.kinesis.util.KinesisConfigUtil;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 
+import org.apache.flink.util.InstantiationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -176,6 +177,10 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 		// check the configuration properties for any conflicting settings
 		KinesisConfigUtil.validateConsumerConfiguration(this.configProps);
 
+		checkArgument(
+			InstantiationUtil.isSerializable(deserializer),
+			"The provided deserialization schema is not serializable: " + deserializer.getClass().getName() + ". " +
+				"Please check that it does not contain references to non-serializable instances.");
 		this.deserializer = checkNotNull(deserializer, "deserializer can not be null");
 
 		if (LOG.isInfoEnabled()) {

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis;
+
+import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisSerializationSchema;
+import org.apache.flink.streaming.util.serialization.SimpleStringSchema;
+import org.apache.flink.util.InstantiationUtil;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.nio.ByteBuffer;
+import java.util.Properties;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Suite of {@link FlinkKinesisProducer} tests.
+ */
+public class FlinkKinesisProducerTest {
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	// ----------------------------------------------------------------------
+	// Tests to verify serializability
+	// ----------------------------------------------------------------------
+
+	@Test
+	public void testCreateWithNonSerializableDeserializerFails() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("The provided serialization schema is not serializable");
+
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
+		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
+		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
+
+		new FlinkKinesisProducer<>(new NonSerializableSerializationSchema(), testConfig);
+	}
+
+	@Test
+	public void testCreateWithSerializableDeserializer() {
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
+		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
+		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
+
+		new FlinkKinesisProducer<>(new SerializableSerializationSchema(), testConfig);
+	}
+
+	@Test
+	public void testConfigureWithNonSerializableCustomPartitionerFails() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("The provided custom partitioner is not serializable");
+
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
+		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
+		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
+
+		new FlinkKinesisProducer<>(new SimpleStringSchema(), testConfig)
+			.setCustomPartitioner(new NonSerializableCustomPartitioner());
+	}
+
+	@Test
+	public void testConfigureWithSerializableCustomPartitioner() {
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
+		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
+		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
+
+		new FlinkKinesisProducer<>(new SimpleStringSchema(), testConfig)
+			.setCustomPartitioner(new SerializableCustomPartitioner());
+	}
+
+	@Test
+	public void testConsumerIsSerializable() {
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
+		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
+		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
+
+		FlinkKinesisProducer<String> consumer = new FlinkKinesisProducer<>(new SimpleStringSchema(), testConfig);
+		assertTrue(InstantiationUtil.isSerializable(consumer));
+	}
+
+	// ----------------------------------------------------------------------
+	// Utility test classes
+	// ----------------------------------------------------------------------
+
+	private final class NonSerializableSerializationSchema implements KinesisSerializationSchema<String> {
+		@Override
+		public ByteBuffer serialize(String element) {
+			return ByteBuffer.wrap(element.getBytes());
+		}
+
+		@Override
+		public String getTargetStream(String element) {
+			return "test-stream";
+		}
+	}
+
+	private static final class SerializableSerializationSchema implements KinesisSerializationSchema<String> {
+		@Override
+		public ByteBuffer serialize(String element) {
+			return ByteBuffer.wrap(element.getBytes());
+		}
+
+		@Override
+		public String getTargetStream(String element) {
+			return "test-stream";
+		}
+	}
+
+	private final class NonSerializableCustomPartitioner extends KinesisPartitioner<String> {
+		@Override
+		public String getPartitionId(String element) {
+			return "test-partition";
+		}
+	}
+
+	private static final class SerializableCustomPartitioner extends KinesisPartitioner<String> {
+		@Override
+		public String getPartitionId(String element) {
+			return "test-partition";
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This is a minor improvement for user experience for the Kinesis consumer and producer.
If the provided `KinesisDeserializationSchema`, `KinesisSerializationSchema`, `KinesisPartitioner` is not serializable, a more clear error message is shown instead of some vague "the implementation of RichSunkFunction is not serializable".

## Brief change log

Changes are broken up into 2 commits:
- for consumer: eagerly check serializability of `KinesisDeserializationSchema`, with better error msgs
- for producer: eagerly check serializability of `KinesisSerializationSchema` and `KinesisPartitioner`, with better error msgs.

## Verifying this change

Added new tests to both `FlinkKinesisConsumerTest` and `FlinkKinesisProducer` test, to verify that the expected error message is thrown (and also not thrown if the provided arg instances are serializable). Also included tests to check that `FlinkKinesisConsumer` and `FlinkKinesisProducer` themselves are serializable.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

