### PR TITLE
[FLINK-7443] [metrics] MetricFetcher store and deserializer fields now final

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/metrics/MetricFetcher.java
@@ -58,8 +58,8 @@ public class MetricFetcher {
 	private final Executor executor;
 	private final Time timeout;
 
-	private MetricStore metrics = new MetricStore();
-	private MetricDumpDeserializer deserializer = new MetricDumpDeserializer();
+	private final MetricStore metrics = new MetricStore();
+	private final MetricDumpDeserializer deserializer = new MetricDumpDeserializer();
 
 	private long lastUpdateTime;
 


### PR DESCRIPTION
The MetricStore and MetricDumpDeserializer fields in the MetricFetcher should be final, as they are not meant to be overwritten and are even used for synchronization.
