### PR TITLE
[FLINK-7444] [rpc] Make external calls non-blocking

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -416,7 +416,7 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 			// tell the launch coordinator to launch the new tasks
 			launchCoordinator.tell(new LaunchCoordinator.Launch(Collections.singletonList((LaunchableTask) launchable)), selfActor);
 		} catch (Exception ex) {
-			onFatalErrorAsync(new ResourceManagerException("Unable to request new workers.", ex));
+			onFatalError(new ResourceManagerException("Unable to request new workers.", ex));
 		}
 	}
 
@@ -447,7 +447,7 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 			}
 		}
 		catch (Exception e) {
-			onFatalErrorAsync(new ResourceManagerException("Unable to release a worker.", e));
+			onFatalError(new ResourceManagerException("Unable to release a worker.", e));
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -252,48 +252,40 @@ public abstract class Dispatcher extends RpcEndpoint implements DispatcherGatewa
 		public void jobFinished(JobExecutionResult result) {
 			log.info("Job {} finished.", jobId);
 
-			runAsync(new Runnable() {
-				@Override
-				public void run() {
+			runAsync(() -> {
 					try {
 						removeJob(jobId, true);
 					} catch (Exception e) {
 						log.warn("Could not properly remove job {} from the dispatcher.", jobId, e);
 					}
-				}
-			});
+				});
 		}
 
 		@Override
 		public void jobFailed(Throwable cause) {
 			log.info("Job {} failed.", jobId);
 
-			runAsync(new Runnable() {
-				@Override
-				public void run() {
+			runAsync(() -> {
 					try {
 						removeJob(jobId, true);
 					} catch (Exception e) {
 						log.warn("Could not properly remove job {} from the dispatcher.", jobId, e);
 					}
-				}
-			});
+				});
 		}
 
 		@Override
 		public void jobFinishedByOther() {
 			log.info("Job {} was finished by other JobManager.", jobId);
 
-			runAsync(new Runnable() {
-				@Override
-				public void run() {
+			runAsync(
+				() -> {
 					try {
 						removeJob(jobId, false);
 					} catch (Exception e) {
 						log.warn("Could not properly remove job {} from the dispatcher.", jobId, e);
 					}
-				}
-			});
+				});
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -864,20 +864,13 @@ public class JobMaster extends RpcEndpoint implements JobMasterGateway {
 	//----------------------------------------------------------------------------------------------
 
 	private void handleFatalError(final Throwable cause) {
-		runAsync(new Runnable() {
-			@Override
-			public void run() {
-				log.error("Fatal error occurred on JobManager, cause: {}", cause.getMessage(), cause);
 
-				try {
-					shutDown();
-				} catch (Exception e) {
-					cause.addSuppressed(e);
-				}
+		try {
+			log.error("Fatal error occurred on JobManager.", cause);
+		} catch (Throwable ignore) {}
 
-				errorHandler.onFatalError(cause);
-			}
-		});
+		// The fatal error handler implementation should make sure that this call is non-blocking
+		errorHandler.onFatalError(cause);
 	}
 
 	private void jobStatusChanged(final JobStatus newJobStatus, long timestamp, final Throwable error) {
@@ -897,7 +890,7 @@ public class JobMaster extends RpcEndpoint implements JobMasterGateway {
 						Map<String, Object> accumulatorResults = executionGraph.getAccumulators();
 						JobExecutionResult result = new JobExecutionResult(jobID, 0L, accumulatorResults); 
 
-						jobCompletionActions.jobFinished(result);
+						executor.execute(() -> jobCompletionActions.jobFinished(result));
 					}
 					catch (Exception e) {
 						log.error("Cannot fetch final accumulators for job {} ({})", jobName, jobID, e);
@@ -907,7 +900,7 @@ public class JobMaster extends RpcEndpoint implements JobMasterGateway {
 								"The job is registered as 'FINISHED (successful), but this notification describes " +
 								"a failure, since the resulting accumulators could not be fetched.", e);
 
-						jobCompletionActions.jobFailed(exception);
+						executor.execute(() ->jobCompletionActions.jobFailed(exception));
 					}
 					break;
 
@@ -915,7 +908,7 @@ public class JobMaster extends RpcEndpoint implements JobMasterGateway {
 					final JobExecutionException exception = new JobExecutionException(
 						jobID, "Job was cancelled.", new Exception("The job was cancelled"));
 
-					jobCompletionActions.jobFailed(exception);
+					executor.execute(() -> jobCompletionActions.jobFailed(exception));
 					break;
 				}
 
@@ -923,7 +916,7 @@ public class JobMaster extends RpcEndpoint implements JobMasterGateway {
 					final Throwable unpackedError = SerializedThrowable.get(error, userCodeLoader);
 					final JobExecutionException exception = new JobExecutionException(
 							jobID, "Job execution failed.", unpackedError);
-					jobCompletionActions.jobFailed(exception);
+					executor.execute(() -> jobCompletionActions.jobFailed(exception));
 					break;
 				}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -95,15 +95,13 @@ public class MiniCluster {
 	@GuardedBy("lock")
 	private ResourceManagerRunner[] resourceManagerRunners;
 
-	@GuardedBy("lock")
-	private TaskExecutor[] taskManagers;
+	private volatile TaskExecutor[] taskManagers;
 
 	@GuardedBy("lock")
 	private MiniClusterJobDispatcher jobDispatcher;
 
 	/** Flag marking the mini cluster as started/running */
-	@GuardedBy("lock")
-	private boolean running;
+	private volatile boolean running;
 
 	// ------------------------------------------------------------------------
 
@@ -150,6 +148,8 @@ public class MiniCluster {
 	@Deprecated
 	public MiniCluster(Configuration config, boolean singleRpcService) {
 		this(createConfig(config, singleRpcService));
+
+		running = false;
 	}
 
 	// ------------------------------------------------------------------------
@@ -645,17 +645,18 @@ public class MiniCluster {
 
 		@Override
 		public void onFatalError(Throwable exception) {
-			LOG.error("TaskManager #{} failed.", index, exception);
+			// first check if we are still running
+			if (running) {
+				LOG.error("TaskManager #{} failed.", index, exception);
 
-			try {
-				synchronized (lock) {
-					// note: if not running (after shutdown) taskManagers may be null!
-					if (running && taskManagers[index] != null) {
-						taskManagers[index].shutDown();
-					}
+				// let's check if there are still TaskManagers because there could be a concurrent
+				// shut down operation taking place
+				TaskExecutor[] currentTaskManagers = taskManagers;
+
+				if (currentTaskManagers != null) {
+					// the shutDown is asynchronous
+					currentTaskManagers[index].shutDown();
 				}
-			} catch (Exception e) {
-				LOG.error("TaskManager #{} could not be properly terminated.", index, e);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FatalErrorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FatalErrorHandler.java
@@ -18,7 +18,18 @@
 
 package org.apache.flink.runtime.rpc;
 
+/**
+ * Handler for fatal errors.
+ */
 public interface FatalErrorHandler {
 
+	/**
+	 * Being called when a fatal error occurs.
+	 *
+	 * <p>IMPORTANT: This call should never be blocking since it might be called from within
+	 * the main thread of an {@link RpcEndpoint}.
+	 *
+	 * @param exception cause
+	 */
 	void onFatalError(Throwable exception);
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptorV2.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptorV2.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.yarn;
 
-import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.yarn.entrypoint.YarnJobClusterEntrypoint;
 import org.apache.flink.yarn.entrypoint.YarnSessionClusterEntrypoint;
 
@@ -44,10 +42,5 @@ public class YarnClusterDescriptorV2 extends AbstractYarnClusterDescriptor {
 	@Override
 	protected String getYarnJobClusterEntrypoint() {
 		return YarnJobClusterEntrypoint.class.getName();
-	}
-
-	@Override
-	public YarnClusterClient deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
-		throw new UnsupportedOperationException("Cannot yet deploy a per-job yarn cluster.");
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -293,7 +293,7 @@ public class YarnResourceManager extends ResourceManager<ResourceID> implements 
 
 	@Override
 	public void onError(Throwable error) {
-		onFatalErrorAsync(error);
+		onFatalError(error);
 	}
 
 	//Utility methods


### PR DESCRIPTION
## What is the purpose of the change

Make all external calls from the RpcEndpoint's main thread non blocking by
executing them as a runnable in an Executor.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

