### PR TITLE
[FLINK-6805] [Cassandra-Connector] Shade indirect netty4 dep in pom.xml

### DIFF
--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -39,6 +39,7 @@ under the License.
 	<properties>
 		<cassandra.version>2.2.5</cassandra.version>
 		<driver.version>3.0.0</driver.version>
+		<netty4.version>4.0.27.Final</netty4.version>
 	</properties>
 
 	<build>
@@ -72,6 +73,7 @@ under the License.
 									<include>com.datastax.cassandra:cassandra-driver-core</include>
 									<include>com.datastax.cassandra:cassandra-driver-mapping</include>
 									<include>com.google.guava:guava</include>
+									<include>io.netty:netty-*</include>
 								</includes>
 							</artifactSet>
 							<relocations>
@@ -82,6 +84,10 @@ under the License.
 										<exclude>com.google.protobuf.**</exclude>
 										<exclude>com.google.inject.**</exclude>
 									</excludes>
+								</relocation>
+								<relocation>
+									<pattern>io.netty</pattern>
+									<shadedPattern>org.apache.flink.shaded.netty4.io.netty</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>

--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -39,7 +39,6 @@ under the License.
 	<properties>
 		<cassandra.version>2.2.5</cassandra.version>
 		<driver.version>3.0.0</driver.version>
-		<netty4.version>4.0.27.Final</netty4.version>
 	</properties>
 
 	<build>
@@ -85,9 +84,14 @@ under the License.
 										<exclude>com.google.inject.**</exclude>
 									</excludes>
 								</relocation>
+								<!--
+									For the details of relocation pattern, refer the discussion at
+									https://github.com/apache/flink/pull/4545
+									FLINK-6805
+								-->
 								<relocation>
 									<pattern>io.netty</pattern>
-									<shadedPattern>org.apache.flink.shaded.netty4.io.netty</shadedPattern>
+									<shadedPattern>org.apache.flink.cassandra.shaded.io.netty</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>


### PR DESCRIPTION


## Brief change log
- To relocate various *indirect* netty4 dep of ver 4.0.33.Final to classpath of Flink's flavor using Maven shade plugin.

## Verifying this change
- Passed local `mvn clean verify` as well as TravisCI tests
- Result of shaded netty4 classes could be packaged as seen in [FLINK-6805-after.txt](https://github.com/apache/flink/files/1225091/FLINK-6805-after.txt)

## What is the purpose of the change
- Shade *(indirect)* netty4 dependencies to avoid class clash in the future. 

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (yes / no)  **slightly related**, shade a netty4 dep.
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know) no

## Documentation
  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) N.A.
