### PR TITLE
[FLINK-7454][docs] update 'Monitoring Current Event Time' section of Flink doc

### DIFF
--- a/docs/monitoring/debugging_event_time.md
+++ b/docs/monitoring/debugging_event_time.md
@@ -31,11 +31,7 @@ Flink's [event time]({{ site.baseurl }}/dev/event_time.html) and watermark suppo
 out-of-order events. However, it's harder to understand what exactly is going on because the progress of time
 is tracked within the system.
 
-There are plans (see [FLINK-3427](https://issues.apache.org/jira/browse/FLINK-3427)) to show the current low watermark
-for each operator in the Flink web interface.
-
-Until this feature is implemented the current low watermark for each task can be accessed through the 
-[metrics system]({{ site.baseurl }}/monitoring/metrics.html).
+Low watermarks of each task can be accessed either from Flink web interface or Flink [metrics system]({{ site.baseurl }}/monitoring/metrics.html).
 
 Each Task in Flink exposes a metric called `currentLowWatermark` that represents the lowest watermark received
 by this task. This long value represents the "current event time".

--- a/docs/monitoring/debugging_event_time.md
+++ b/docs/monitoring/debugging_event_time.md
@@ -31,7 +31,7 @@ Flink's [event time]({{ site.baseurl }}/dev/event_time.html) and watermark suppo
 out-of-order events. However, it's harder to understand what exactly is going on because the progress of time
 is tracked within the system.
 
-Low watermarks of each task can be accessed from either Flink web interface or Flink [metrics system]({{ site.baseurl }}/monitoring/metrics.html).
+Low watermarks of each task can be accessed through Flink web interface or [metrics system]({{ site.baseurl }}/monitoring/metrics.html).
 
 Each Task in Flink exposes a metric called `currentLowWatermark` that represents the lowest watermark received
 by this task. This long value represents the "current event time".

--- a/docs/monitoring/debugging_event_time.md
+++ b/docs/monitoring/debugging_event_time.md
@@ -31,7 +31,7 @@ Flink's [event time]({{ site.baseurl }}/dev/event_time.html) and watermark suppo
 out-of-order events. However, it's harder to understand what exactly is going on because the progress of time
 is tracked within the system.
 
-Low watermarks of each task can be accessed either from Flink web interface or Flink [metrics system]({{ site.baseurl }}/monitoring/metrics.html).
+Low watermarks of each task can be accessed from either Flink web interface or Flink [metrics system]({{ site.baseurl }}/monitoring/metrics.html).
 
 Each Task in Flink exposes a metric called `currentLowWatermark` that represents the lowest watermark received
 by this task. This long value represents the "current event time".


### PR DESCRIPTION
## What is the purpose of the change

Since FLINK-3427 is done, there's no need to have the following doc in https://ci.apache.org/projects/flink/flink-docs-release-1.3/monitoring/debugging_event_time.html#monitoring-current-event-time

"There are plans (see FLINK-3427) to show the current low watermark for each operator in the Flink web interface.
Until this feature is implemented the current low watermark for each task can be accessed through the metrics system."

We can replace it with something like "Low watermarks of each task can be accessed from either Flink web interface or Flink metric system."

## Brief change log

Update doc.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

