### PR TITLE
[FLINK-7457] Make Dispatcher highly available

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherException.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.util.FlinkException;
+
+/**
+ * Base class for {@link Dispatcher} related exceptions.
+ */
+public class DispatcherException extends FlinkException {
+	private static final long serialVersionUID = 3781733042984381286L;
+
+	public DispatcherException(String message) {
+		super(message);
+	}
+
+	public DispatcherException(Throwable cause) {
+		super(cause);
+	}
+
+	public DispatcherException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 
 import java.util.Collection;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -37,11 +38,13 @@ public interface DispatcherGateway extends RpcGateway {
 	 * Submit a job to the dispatcher.
 	 *
 	 * @param jobGraph JobGraph to submit
+	 * @param leaderSessionId leader session id
 	 * @param timeout RPC timeout
 	 * @return A future acknowledge if the submission succeeded
 	 */
 	CompletableFuture<Acknowledge> submitJob(
 		JobGraph jobGraph,
+		UUID leaderSessionId,
 		@RpcTimeout Time timeout);
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
@@ -73,6 +73,12 @@ public interface HighAvailabilityServices extends AutoCloseable {
 	LeaderRetrievalService getResourceManagerLeaderRetriever();
 
 	/**
+	 * Gets the leader retriever for the dispatcher. This leader retrieval service
+	 * is not always accessible.
+	 */
+	LeaderRetrievalService getDispatcherLeaderRetriever();
+
+	/**
 	 * Gets the leader retriever for the job JobMaster which is responsible for the given job
 	 *
 	 * @param jobID The identifier of the job.
@@ -98,6 +104,13 @@ public interface HighAvailabilityServices extends AutoCloseable {
 	 * @return Leader election service for the resource manager leader election
 	 */
 	LeaderElectionService getResourceManagerLeaderElectionService();
+
+	/**
+	 * Gets the leader election service for the cluster's dispatcher.
+	 *
+	 * @return Leader election service for the dispatcher leader election
+	 */
+	LeaderElectionService getDispatcherLeaderElectionService();
 
 	/**
 	 * Gets the leader election service for the given job.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.blob.BlobStoreService;
 import org.apache.flink.runtime.blob.BlobUtils;
+import org.apache.flink.runtime.dispatcher.Dispatcher;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServices;
 import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneHaServices;
 import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperHaServices;
@@ -87,8 +88,17 @@ public class HighAvailabilityServicesUtils {
 					ResourceManager.RESOURCE_MANAGER_NAME,
 					addressResolution,
 					configuration);
+				final String dispatcherRpcUrl = AkkaRpcServiceUtils.getRpcUrl(
+					hostnamePort.f0,
+					hostnamePort.f1,
+					Dispatcher.DISPATCHER_NAME,
+					addressResolution,
+					configuration);
 
-				return new StandaloneHaServices(resourceManagerRpcUrl, jobManagerRpcUrl);
+				return new StandaloneHaServices(
+					resourceManagerRpcUrl,
+					dispatcherRpcUrl,
+					jobManagerRpcUrl);
 			case ZOOKEEPER:
 				BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(configuration);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServices.java
@@ -45,11 +45,14 @@ public class EmbeddedHaServices extends AbstractNonHaServices {
 
 	private final EmbeddedLeaderService resourceManagerLeaderService;
 
+	private final EmbeddedLeaderService dispatcherLeaderService;
+
 	private final HashMap<JobID, EmbeddedLeaderService> jobManagerLeaderServices;
 
 	public EmbeddedHaServices(Executor executor) {
 		this.executor = Preconditions.checkNotNull(executor);
 		this.resourceManagerLeaderService = new EmbeddedLeaderService(executor);
+		this.dispatcherLeaderService = new EmbeddedLeaderService(executor);
 		this.jobManagerLeaderServices = new HashMap<>();
 	}
 
@@ -63,8 +66,18 @@ public class EmbeddedHaServices extends AbstractNonHaServices {
 	}
 
 	@Override
+	public LeaderRetrievalService getDispatcherLeaderRetriever() {
+		return dispatcherLeaderService.createLeaderRetrievalService();
+	}
+
+	@Override
 	public LeaderElectionService getResourceManagerLeaderElectionService() {
 		return resourceManagerLeaderService.createLeaderElectionService();
+	}
+
+	@Override
+	public LeaderElectionService getDispatcherLeaderElectionService() {
+		return dispatcherLeaderService.createLeaderElectionService();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServices.java
@@ -45,6 +45,9 @@ public class StandaloneHaServices extends AbstractNonHaServices {
 	/** The fix address of the ResourceManager */
 	private final String resourceManagerAddress;
 
+	/** The fix address of the Dispatcher */
+	private final String dispatcherAddress;
+
 	/** The fix address of the JobManager */
 	private final String jobManagerAddress;
 
@@ -53,8 +56,12 @@ public class StandaloneHaServices extends AbstractNonHaServices {
 	 * 
 	 * @param resourceManagerAddress    The fix address of the ResourceManager
 	 */
-	public StandaloneHaServices(String resourceManagerAddress, String jobManagerAddress) {
+	public StandaloneHaServices(
+		String resourceManagerAddress,
+		String dispatcherAddress,
+		String jobManagerAddress) {
 		this.resourceManagerAddress = checkNotNull(resourceManagerAddress, "resourceManagerAddress");
+		this.dispatcherAddress = checkNotNull(dispatcherAddress, "dispatcherAddress");
 		this.jobManagerAddress = checkNotNull(jobManagerAddress, "jobManagerAddress");
 	}
 
@@ -73,7 +80,25 @@ public class StandaloneHaServices extends AbstractNonHaServices {
 	}
 
 	@Override
+	public LeaderRetrievalService getDispatcherLeaderRetriever() {
+		synchronized (lock) {
+			checkNotShutdown();
+
+			return new StandaloneLeaderRetrievalService(dispatcherAddress, DEFAULT_LEADER_ID);
+		}
+	}
+
+	@Override
 	public LeaderElectionService getResourceManagerLeaderElectionService() {
+		synchronized (lock) {
+			checkNotShutdown();
+
+			return new StandaloneLeaderElectionService();
+		}
+	}
+
+	@Override
+	public LeaderElectionService getDispatcherLeaderElectionService() {
 		synchronized (lock) {
 			checkNotShutdown();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
@@ -82,6 +82,8 @@ public class ZooKeeperHaServices implements HighAvailabilityServices {
 
 	private static final String RESOURCE_MANAGER_LEADER_PATH = "/resource_manager_lock";
 
+	private static final String DISPATCHER_LEADER_PATH = "/dispatcher_lock";
+
 	private static final String JOB_MANAGER_LEADER_PATH = "/job_manager_lock";
 
 	// ------------------------------------------------------------------------
@@ -125,6 +127,11 @@ public class ZooKeeperHaServices implements HighAvailabilityServices {
 	}
 
 	@Override
+	public LeaderRetrievalService getDispatcherLeaderRetriever() {
+		return ZooKeeperUtils.createLeaderRetrievalService(client, configuration, DISPATCHER_LEADER_PATH);
+	}
+
+	@Override
 	public LeaderRetrievalService getJobManagerLeaderRetriever(JobID jobID) {
 		return ZooKeeperUtils.createLeaderRetrievalService(client, configuration, getPathForJobManager(jobID));
 	}
@@ -137,6 +144,11 @@ public class ZooKeeperHaServices implements HighAvailabilityServices {
 	@Override
 	public LeaderElectionService getResourceManagerLeaderElectionService() {
 		return ZooKeeperUtils.createLeaderElectionService(client, configuration, RESOURCE_MANAGER_LEADER_PATH);
+	}
+
+	@Override
+	public LeaderElectionService getDispatcherLeaderElectionService() {
+		return ZooKeeperUtils.createLeaderElectionService(client, configuration, DISPATCHER_LEADER_PATH);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
@@ -18,13 +18,21 @@
 
 package org.apache.flink.runtime.rpc;
 
+import org.apache.flink.api.common.time.Time;
+
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Utility functions for Flink's RPC implementation
  */
 public class RpcUtils {
+
+	public static final Time INF_TIMEOUT = Time.milliseconds(Long.MAX_VALUE);
+
 	/**
 	 * Extracts all {@link RpcGateway} interfaces implemented by the given clazz.
 	 *
@@ -45,6 +53,20 @@ public class RpcUtils {
 		}
 
 		return interfaces;
+	}
+
+	/**
+	 * Shuts the given {@link RpcEndpoint} down and awaits its termination.
+	 *
+	 * @param rpcEndpoint to terminate
+	 * @param timeout for this operation
+	 * @throws ExecutionException if a problem occurs
+	 * @throws InterruptedException if the operation has been interrupted
+	 * @throws TimeoutException if a timeout occurred
+	 */
+	public static void terminateRpcEndpoint(RpcEndpoint rpcEndpoint, Time timeout) throws ExecutionException, InterruptedException, TimeoutException {
+		rpcEndpoint.shutDown();
+		rpcEndpoint.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 	}
 
 	// We don't want this class to be instantiable

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -25,24 +25,33 @@ import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneHaServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
+import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,6 +61,23 @@ import static org.mockito.Mockito.when;
  */
 public class DispatcherTest extends TestLogger {
 
+	private static RpcService rpcService;
+	private static final Time timeout = Time.seconds(10L);
+
+	@BeforeClass
+	public static void setup() {
+		rpcService = new TestingRpcService();
+	}
+
+	@AfterClass
+	public static void teardown() {
+		if (rpcService != null) {
+			rpcService.stopService();
+
+			rpcService = null;
+		}
+	}
+
 	/**
 	 * Tests that we can submit a job to the Dispatcher which then spawns a
 	 * new JobManagerRunner.
@@ -59,34 +85,35 @@ public class DispatcherTest extends TestLogger {
 	@Test
 	public void testJobSubmission() throws Exception {
 		TestingFatalErrorHandler fatalErrorHandler = new TestingFatalErrorHandler();
-		RpcService rpcService = new TestingRpcService();
-		HighAvailabilityServices haServices = new StandaloneHaServices("localhost", "localhost");
+		HighAvailabilityServices haServices = new StandaloneHaServices(
+			"localhost",
+			"localhost",
+			"localhost");
 		HeartbeatServices heartbeatServices = new HeartbeatServices(1000L, 10000L);
 		JobManagerRunner jobManagerRunner = mock(JobManagerRunner.class);
 
-		final Time timeout = Time.seconds(5L);
 		final JobGraph jobGraph = mock(JobGraph.class);
 		final JobID jobId = new JobID();
 		when(jobGraph.getJobID()).thenReturn(jobId);
 
-		try {
-			final TestingDispatcher dispatcher = new TestingDispatcher(
-				rpcService,
-				Dispatcher.DISPATCHER_NAME,
-				new Configuration(),
-				haServices,
-				mock(BlobServer.class),
-				heartbeatServices,
-				mock(MetricRegistry.class),
-				fatalErrorHandler,
-				jobManagerRunner,
-				jobId);
+		final TestingDispatcher dispatcher = new TestingDispatcher(
+			rpcService,
+			Dispatcher.DISPATCHER_NAME,
+			new Configuration(),
+			haServices,
+			mock(BlobServer.class),
+			heartbeatServices,
+			mock(MetricRegistry.class),
+			fatalErrorHandler,
+			jobManagerRunner,
+			jobId);
 
+		try {
 			dispatcher.start();
 
 			DispatcherGateway dispatcherGateway = dispatcher.getSelfGateway(DispatcherGateway.class);
 
-			CompletableFuture<Acknowledge> acknowledgeFuture = dispatcherGateway.submitJob(jobGraph, timeout);
+			CompletableFuture<Acknowledge> acknowledgeFuture = dispatcherGateway.submitJob(jobGraph, HighAvailabilityServices.DEFAULT_LEADER_ID, timeout);
 
 			acknowledgeFuture.get();
 
@@ -95,7 +122,60 @@ public class DispatcherTest extends TestLogger {
 			// check that no error has occurred
 			fatalErrorHandler.rethrowError();
 		} finally {
-			rpcService.stopService();
+			RpcUtils.terminateRpcEndpoint(dispatcher, timeout);
+		}
+	}
+
+	/**
+	 * Tests that the dispatcher takes part in the leader election.
+	 */
+	@Test
+	public void testLeaderElection() throws Exception {
+		TestingFatalErrorHandler fatalErrorHandler = new TestingFatalErrorHandler();
+		TestingHighAvailabilityServices haServices = new TestingHighAvailabilityServices();
+
+		UUID expectedLeaderSessionId = UUID.randomUUID();
+		CompletableFuture<UUID> leaderSessionIdFuture = new CompletableFuture<>();
+		SubmittedJobGraphStore mockSubmittedJobGraphStore = mock(SubmittedJobGraphStore.class);
+		TestingLeaderElectionService testingLeaderElectionService = new TestingLeaderElectionService() {
+			@Override
+			public void confirmLeaderSessionID(UUID leaderSessionId) {
+				super.confirmLeaderSessionID(leaderSessionId);
+				leaderSessionIdFuture.complete(leaderSessionId);
+			}
+		};
+
+		haServices.setSubmittedJobGraphStore(mockSubmittedJobGraphStore);
+		haServices.setDispatcherLeaderElectionService(testingLeaderElectionService);
+		HeartbeatServices heartbeatServices = new HeartbeatServices(1000L, 1000L);
+		final JobID jobId = new JobID();
+
+		final TestingDispatcher dispatcher = new TestingDispatcher(
+			rpcService,
+			Dispatcher.DISPATCHER_NAME,
+			new Configuration(),
+			haServices,
+			mock(BlobServer.class),
+			heartbeatServices,
+			mock(MetricRegistry.class),
+			fatalErrorHandler,
+			mock(JobManagerRunner.class),
+			jobId);
+
+		try {
+			dispatcher.start();
+
+			assertFalse(leaderSessionIdFuture.isDone());
+
+			testingLeaderElectionService.isLeader(expectedLeaderSessionId);
+
+			UUID actualLeaderSessionId = leaderSessionIdFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+
+			assertEquals(expectedLeaderSessionId, actualLeaderSessionId);
+
+			verify(mockSubmittedJobGraphStore, Mockito.timeout(timeout.toMilliseconds()).atLeast(1)).getJobIds();
+		} finally {
+			RpcUtils.terminateRpcEndpoint(dispatcher, timeout);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingHighAvailabilityServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingHighAvailabilityServices.java
@@ -38,11 +38,15 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
 
 	private volatile LeaderRetrievalService resourceManagerLeaderRetriever;
 
+	private volatile LeaderRetrievalService dispatcherLeaderRetriever;
+
 	private ConcurrentHashMap<JobID, LeaderRetrievalService> jobMasterLeaderRetrievers = new ConcurrentHashMap<>();
 
 	private ConcurrentHashMap<JobID, LeaderElectionService> jobManagerLeaderElectionServices = new ConcurrentHashMap<>();
 
 	private volatile LeaderElectionService resourceManagerLeaderElectionService;
+
+	private volatile LeaderElectionService dispatcherLeaderElectionService;
 
 	private volatile CheckpointRecoveryFactory checkpointRecoveryFactory;
 
@@ -56,6 +60,10 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
 		this.resourceManagerLeaderRetriever = resourceManagerLeaderRetriever;
 	}
 
+	public void setDispatcherLeaderRetriever(LeaderRetrievalService dispatcherLeaderRetriever) {
+		this.dispatcherLeaderRetriever = dispatcherLeaderRetriever;
+	}
+
 	public void setJobMasterLeaderRetriever(JobID jobID, LeaderRetrievalService jobMasterLeaderRetriever) {
 		this.jobMasterLeaderRetrievers.put(jobID, jobMasterLeaderRetriever);
 	}
@@ -66,6 +74,10 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
 
 	public void setResourceManagerLeaderElectionService(LeaderElectionService leaderElectionService) {
 		this.resourceManagerLeaderElectionService = leaderElectionService;
+	}
+
+	public void setDispatcherLeaderElectionService(LeaderElectionService leaderElectionService) {
+		this.dispatcherLeaderElectionService = leaderElectionService;
 	}
 
 	public void setCheckpointRecoveryFactory(CheckpointRecoveryFactory checkpointRecoveryFactory) {
@@ -83,6 +95,16 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
 	@Override
 	public LeaderRetrievalService getResourceManagerLeaderRetriever() {
 		LeaderRetrievalService service = this.resourceManagerLeaderRetriever;
+		if (service != null) {
+			return service;
+		} else {
+			throw new IllegalStateException("ResourceManagerLeaderRetriever has not been set");
+		}
+	}
+
+	@Override
+	public LeaderRetrievalService getDispatcherLeaderRetriever() {
+		LeaderRetrievalService service = this.dispatcherLeaderRetriever;
 		if (service != null) {
 			return service;
 		} else {
@@ -113,6 +135,17 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
 			return service;
 		} else {
 			throw new IllegalStateException("ResourceManagerLeaderElectionService has not been set");
+		}
+	}
+
+	@Override
+	public LeaderElectionService getDispatcherLeaderElectionService() {
+		LeaderElectionService service = dispatcherLeaderElectionService;
+
+		if (service != null) {
+			return service;
+		} else {
+			throw new IllegalStateException("DispatcherLeaderElectionService has not been set");
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingManualHighAvailabilityServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingManualHighAvailabilityServices.java
@@ -45,14 +45,22 @@ public class TestingManualHighAvailabilityServices implements HighAvailabilitySe
 
 	private final ManualLeaderService resourceManagerLeaderService;
 
+	private final ManualLeaderService dispatcherLeaderService;
+
 	public TestingManualHighAvailabilityServices() {
 		jobManagerLeaderServices = new HashMap<>(4);
 		resourceManagerLeaderService = new ManualLeaderService();
+		dispatcherLeaderService = new ManualLeaderService();
 	}
 
 	@Override
 	public LeaderRetrievalService getResourceManagerLeaderRetriever() {
 		return resourceManagerLeaderService.createLeaderRetrievalService();
+	}
+
+	@Override
+	public LeaderRetrievalService getDispatcherLeaderRetriever() {
+		return dispatcherLeaderService.createLeaderRetrievalService();
 	}
 
 	@Override
@@ -70,6 +78,11 @@ public class TestingManualHighAvailabilityServices implements HighAvailabilitySe
 	@Override
 	public LeaderElectionService getResourceManagerLeaderElectionService() {
 		return resourceManagerLeaderService.createLeaderElectionService();
+	}
+
+	@Override
+	public LeaderElectionService getDispatcherLeaderElectionService() {
+		return dispatcherLeaderService.createLeaderElectionService();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServicesTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.verify;
 public class StandaloneHaServicesTest extends TestLogger {
 
 	private final String jobManagerAddress = "jobManager";
+	private final String dispatcherAddress = "dispatcher";
 	private final String resourceManagerAddress = "resourceManager";
 
 	private StandaloneHaServices standaloneHaServices;
@@ -46,7 +47,10 @@ public class StandaloneHaServicesTest extends TestLogger {
 	@Before
 	public void setupTest() {
 
-		standaloneHaServices = new StandaloneHaServices(resourceManagerAddress, jobManagerAddress);
+		standaloneHaServices = new StandaloneHaServices(
+			resourceManagerAddress,
+			dispatcherAddress,
+			jobManagerAddress);
 	}
 
 	@After

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -462,6 +462,7 @@ public class TaskExecutorTest extends TestLogger {
 		final ResourceID resourceID = ResourceID.generate();
 		final String resourceManagerAddress = "/resource/manager/address/one";
 		final ResourceID resourceManagerResourceId = new ResourceID(resourceManagerAddress);
+		final String dispatcherAddress = "localhost";
 		final String jobManagerAddress = "localhost";
 
 		final TestingRpcService rpc = new TestingRpcService();
@@ -483,6 +484,7 @@ public class TaskExecutorTest extends TestLogger {
 
 			StandaloneHaServices haServices = new StandaloneHaServices(
 				resourceManagerAddress,
+				dispatcherAddress,
 				jobManagerAddress);
 
 			final TaskSlotTable taskSlotTable = mock(TaskSlotTable.class);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/highavailability/YarnIntraNonHaMasterServices.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/highavailability/YarnIntraNonHaMasterServices.java
@@ -71,6 +71,9 @@ public class YarnIntraNonHaMasterServices extends AbstractYarnNonHaServices {
 	/** The embedded leader election service used by JobManagers to find the resource manager. */
 	private final SingleLeaderElectionService resourceManagerLeaderElectionService;
 
+	/** The embedded leader election service for the dispatcher. */
+	private final SingleLeaderElectionService dispatcherLeaderElectionService;
+
 	// ------------------------------------------------------------------------
 
 	/**
@@ -100,6 +103,7 @@ public class YarnIntraNonHaMasterServices extends AbstractYarnNonHaServices {
 		try {
 			this.dispatcher = Executors.newSingleThreadExecutor(new ServicesThreadFactory());
 			this.resourceManagerLeaderElectionService = new SingleLeaderElectionService(dispatcher, DEFAULT_LEADER_ID);
+			this.dispatcherLeaderElectionService = new SingleLeaderElectionService(dispatcher, DEFAULT_LEADER_ID);
 
 			// all good!
 			successful = true;
@@ -130,12 +134,33 @@ public class YarnIntraNonHaMasterServices extends AbstractYarnNonHaServices {
 	}
 
 	@Override
+	public LeaderRetrievalService getDispatcherLeaderRetriever() {
+		enter();
+
+		try {
+			return dispatcherLeaderElectionService.createLeaderRetrievalService();
+		} finally {
+			exit();
+		}
+	}
+
+	@Override
 	public LeaderElectionService getResourceManagerLeaderElectionService() {
 		enter();
 		try {
 			return resourceManagerLeaderElectionService;
 		}
 		finally {
+			exit();
+		}
+	}
+
+	@Override
+	public LeaderElectionService getDispatcherLeaderElectionService() {
+		enter();
+		try {
+			return dispatcherLeaderElectionService;
+		} finally {
 			exit();
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

This commit introduces a dispatcher leader election and retrieval service to the
HighAvailabilityServices. Moreover it adds code such that the Dispatcher now takes
part in the leader election process using the afore-mentioned services.

Let Dispatcher participate in leader election

Add test for Dispatcher leader election

## Brief change log

- Introduce `LeaderElectionService` and `LeaderElectionRetrievalService` for the `Dispatcher` to the `HighAvailabililtyServices`
- Let the `Dispatcher participate in the leader election process
- Guard `Dispatcher#submitJob` with leader session id

## Verifying this change

This change added tests and can be verified as follows:

- Added `DispatcherTest#testLeaderElection` which simulates a leader election process

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

