### PR TITLE
[FLINK-7642] [docs] Add very obvious warning about outdated docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -43,10 +43,11 @@ jira_url: "https://issues.apache.org/jira/browse/FLINK"
 github_url: "https://github.com/apache/flink"
 download_url: "http://flink.apache.org/downloads.html"
 
-# Flag whether this is the latest stable version or not. If not, a warning
-# will be printed pointing to the docs of the latest stable version.
-is_latest: false
+# Flag whether this is a stable version or not. Used for the quickstart page.
 is_stable: true
+
+# Flag to indicate whether an outdated warning should be shown.
+show_outdated_warning: true
 
 previous_docs:
   1.1: http://ci.apache.org/projects/flink/flink-docs-release-1.1

--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -54,12 +54,10 @@ under the License.
     <![endif]-->
   </head>
   <body>
-    {% if site.is_stable %}
-    {% unless site.is_latest %}
-    <div style="position:fixed; bottom:0; left:0; z-index:99999; width:100%; text-align:center; padding:15px; border-top:1px dashed #CE4B65; background:#f6f0e3; font-weight:bold">
+    {% if site.show_outdated_warning %}
+    <div style="position:fixed; bottom:0; left:0; z-index:99999; width:100%; text-align:center; padding:15px; border-top:5px solid #ECCCD1; background:#F2DEDE; color:#AD433F; font-weight:bold">
        This documentation is for an out-of-date version of Apache Flink. We recommend you use <a href="https://flink.apache.org/q/stable-docs.html">the latest stable version</a>.
     </div>
-    {% endunless %}
     {% endif %}
 
     <!-- Main content. -->

--- a/docs/_layouts/plain.html
+++ b/docs/_layouts/plain.html
@@ -53,5 +53,10 @@ under the License.
 </ol>
 
 <h1>{{ page.title }}{% if page.is_beta %} <span class="beta">Beta</span>{% endif %}</h1>
+{% if site.show_outdated_warning %}
+<div class="alert alert-danger" role="alert">
+  <strong>This documentation is for an out-of-date version of Apache Flink. We recommend you use <a href="https://flink.apache.org/q/stable-docs.html">the latest stable version</a>.</strong>
+</div>
+{% endif %}
 
 {{ content }}


### PR DESCRIPTION
## What is the purpose of the change

This pull requests make the warning about outdated docs more obvious.

![screen shot 2017-08-16 at 18 34 03](https://user-images.githubusercontent.com/1756620/29374684-93ac1abe-82b2-11e7-9b9b-5008ac33a8e5.png)

Please compare the screenshot to our current state: https://ci.apache.org/projects/flink/flink-docs-release-1.1/

If you like this, I would back/forward port this to all versions >= 1.0 and update the releasing Wiki page to add a note about updating the configuration of the docs.


## Brief change log
- Change the color of the outdated warning footer to red
- Rename the config key from `is_latest` to `show_outdated_warning`
- Add an outdated warning to every page before the actual content

## Verifying this change
- We don't have any tests for the docs
- You can manually check out my branch and build the docs 
