### PR TITLE
[hotifx][streaming] Simplify state of TwoPhaseCommitSinkFunction

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunctionTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.api.functions.sink;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.runtime.tasks.OperatorStateHandles;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -131,7 +130,7 @@ public class TwoPhaseCommitSinkFunctionTest {
 		public FileBasedSinkFunction(File tmpDirectory, File targetDirectory) {
 			super(
 				TypeInformation.of(FileTransaction.class),
-				TypeInformation.of(new TypeHint<List<Tuple2<Long, FileTransaction>>>() {}));
+				TypeInformation.of(new TypeHint<List<FileTransaction>>() {}));
 
 			if (!tmpDirectory.isDirectory() || !targetDirectory.isDirectory()) {
 				throw new IllegalArgumentException();


### PR DESCRIPTION
This change simplifies state of `TwoPhaseCommitSinkFunction`, by dropping unnecessary complication.

This change is already covered by existing tests, such as *TwoPhaseCommitSinkFunctionTest*.

It changes the public API annotated with `@PublicEvolving` (different constructor parameter) 
and it changes the way how `TwoPhaseCommitSinkFunction` is serialized on checkpoints/savepoints. However this code has not been released yet anywhere.
