### PR TITLE
[FLINK-7056][tests][hotfix] make sure the client and a created InputStream are closed

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -145,7 +145,7 @@ public class BlobClientTest {
 	 * @throws IOException
 	 *         thrown if an I/O error occurs while reading the input stream
 	 */
-	static void validateGet(final InputStream inputStream, final byte[] buf) throws IOException {
+	static void validateGetAndClose(final InputStream inputStream, final byte[] buf) throws IOException {
 		try {
 			byte[] receivedBuffer = new byte[buf.length];
 
@@ -182,7 +182,7 @@ public class BlobClientTest {
 	 * @throws IOException
 	 *         thrown if an I/O error occurs while reading the input stream or the file
 	 */
-	private static void validateGet(final InputStream inputStream, final File file) throws IOException {
+	private static void validateGetAndClose(final InputStream inputStream, final File file) throws IOException {
 
 		InputStream inputStream2 = null;
 		try {
@@ -237,8 +237,8 @@ public class BlobClientTest {
 			assertEquals(origKey, receivedKey);
 
 			// Retrieve the data
-			validateGet(client.get(receivedKey), testBuffer);
-			validateGet(client.get(jobId, receivedKey), testBuffer);
+			validateGetAndClose(client.get(receivedKey), testBuffer);
+			validateGetAndClose(client.get(jobId, receivedKey), testBuffer);
 
 			// Check reaction to invalid keys
 			try (InputStream ignored = client.get(new BlobKey())) {
@@ -310,8 +310,8 @@ public class BlobClientTest {
 			is = null;
 
 			// Retrieve the data
-			validateGet(client.get(receivedKey), testFile);
-			validateGet(client.get(jobId, receivedKey), testFile);
+			validateGetAndClose(client.get(receivedKey), testFile);
+			validateGetAndClose(client.get(jobId, receivedKey), testFile);
 		}
 		catch (Exception e) {
 			e.printStackTrace();
@@ -362,7 +362,7 @@ public class BlobClientTest {
 		assertEquals(1, blobKeys.size());
 
 		try (BlobClient blobClient = new BlobClient(serverAddress, blobClientConfig)) {
-			validateGet(blobClient.get(blobKeys.get(0)), testFile);
+			validateGetAndClose(blobClient.get(blobKeys.get(0)), testFile);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerDeleteTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.apache.flink.runtime.blob.BlobClientTest.validateGetAndClose;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -113,7 +114,7 @@ public class BlobServerDeleteTest extends TestLogger {
 			try {
 				// NOTE: the server will stall in its send operation until either the data is fully
 				//       read or the socket is closed, e.g. via a client.close() call
-				BlobClientTest.validateGet(client.get(jobId, key1), data);
+				validateGetAndClose(client.get(jobId, key1), data);
 			}
 			catch (IOException e) {
 				fail("Deleting a job-unrelated BLOB should not affect a job-related BLOB with the same key");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -49,7 +49,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.apache.flink.runtime.blob.BlobClientTest.validateGet;
+import static org.apache.flink.runtime.blob.BlobClientTest.validateGetAndClose;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -123,7 +123,7 @@ public class BlobServerGetTest extends TestLogger {
 			assertNotNull(key);
 			assertEquals(key, key2);
 			// request for jobId2 should succeed
-			validateGet(getFileHelper(client, jobId2, key), data);
+			validateGetAndClose(getFileHelper(client, jobId2, key), data);
 			// request for jobId1 should still fail
 			client = verifyDeleted(client, jobId1, key, serverAddress, config);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.apache.flink.runtime.blob.BlobClientTest.validateGet;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -122,7 +123,7 @@ public class BlobServerGetTest extends TestLogger {
 			assertNotNull(key);
 			assertEquals(key, key2);
 			// request for jobId2 should succeed
-			getFileHelper(client, jobId2, key);
+			validateGet(getFileHelper(client, jobId2, key), data);
 			// request for jobId1 should still fail
 			client = verifyDeleted(client, jobId1, key, serverAddress, config);
 
@@ -160,8 +161,7 @@ public class BlobServerGetTest extends TestLogger {
 	private static BlobClient verifyDeleted(
 			BlobClient client, JobID jobId, BlobKey key,
 			InetSocketAddress serverAddress, Configuration config) throws IOException {
-		try {
-			getFileHelper(client, jobId, key);
+		try (InputStream ignored = getFileHelper(client, jobId, key)) {
 			fail("This should not succeed.");
 		} catch (IOException e) {
 			// expected
@@ -227,6 +227,7 @@ public class BlobServerGetTest extends TestLogger {
 			catch (IOException e) {
 				// expected
 			}
+			is.close();
 		} finally {
 			if (client != null) {
 				client.close();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.apache.flink.runtime.blob.BlobClientTest.validateGetAndClose;
 import static org.apache.flink.runtime.blob.BlobServerGetTest.getFileHelper;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -255,7 +256,7 @@ public class BlobServerPutTest extends TestLogger {
 			client.close();
 			client = new BlobClient(serverAddress, config);
 
-			BlobClientTest.validateGet(getFileHelper(client, jobId, key1), data);
+			validateGetAndClose(getFileHelper(client, jobId, key1), data);
 		} finally {
 			client.close();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -47,7 +47,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static org.apache.flink.runtime.blob.BlobServerGetTest.getFileHelper;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -226,9 +225,9 @@ public class BlobServerPutTest extends TestLogger {
 	 * @param jobId
 	 * 		job ID or <tt>null</tt> if job-unrelated
 	 * @param key1
-	 * 		first key
+	 * 		first key for 44 bytes starting at byte 10 of data in the BLOB
 	 * @param key2
-	 * 		second key
+	 * 		second key for the complete data in the BLOB
 	 * @param data
 	 * 		expected data
 	 * @param serverAddress
@@ -241,12 +240,9 @@ public class BlobServerPutTest extends TestLogger {
 			InetSocketAddress serverAddress, Configuration config) throws IOException {
 
 		BlobClient client = new BlobClient(serverAddress, config);
-		InputStream is1 = null;
-		InputStream is2 = null;
 
-		try {
-			// one get request on the same client
-			is1 = getFileHelper(client, jobId, key2);
+		// one get request on the same client
+		try (InputStream is1 = getFileHelper(client, jobId, key2)) {
 			byte[] result1 = new byte[44];
 			BlobUtils.readFully(is1, result1, 0, result1.length, null);
 			is1.close();
@@ -255,20 +251,12 @@ public class BlobServerPutTest extends TestLogger {
 				assertEquals(data[j], result1[i]);
 			}
 
-			// close the client and create a new one for the remaining requests
+			// close the client and create a new one for the remaining request
 			client.close();
 			client = new BlobClient(serverAddress, config);
 
-			is2 = getFileHelper(client, jobId, key1);
-			BlobClientTest.validateGet(is2, data);
-			is2.close();
+			BlobClientTest.validateGet(getFileHelper(client, jobId, key1), data);
 		} finally {
-			if (is1 != null) {
-				is1.close();
-			}
-			if (is2 != null) {
-				is1.close();
-			}
 			client.close();
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

This fixes some stalling tests in the following cases: if the client is not closed and the inputstream of a GET operation was not fully read and the server has not yet sent all data packets, it may still hold the read lock and block any writing operations (also see FLINK-7467). As a result, a user reported `BlobServerDeleteTest#testDeleteSingleByBlobKey()` to hang.

## Brief change log

- (fully read and) close all `InputStream` instances returned by `BlobClient#get()`
- add missing `close` calls to `BlobClient` uses in the tests

## Verifying this change

This change is affects and fixes existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

