### PR TITLE
[FLINK-7468][network] Implement sender backlog logic for credit-based

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/SequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/SequenceNumberingViewReader.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.io.network.netty;
 
-import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
 import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
@@ -85,18 +85,14 @@ class SequenceNumberingViewReader implements BufferAvailabilityListener {
 		return sequenceNumber;
 	}
 
-	int getBuffersInBacklog() {
-		return subpartitionView.getBuffersInBacklog();
-	}
-
 	public BufferAndAvailability getNextBuffer() throws IOException, InterruptedException {
-		Buffer next = subpartitionView.getNextBuffer();
+		BufferAndBacklog next = subpartitionView.getNextBuffer();
 		if (next != null) {
 			long remaining = numBuffersAvailable.decrementAndGet();
 			sequenceNumber++;
 
 			if (remaining >= 0) {
-				return new BufferAndAvailability(next, remaining > 0);
+				return new BufferAndAvailability(next.buffer(), remaining > 0, next.buffersInBacklog());
 			} else {
 				throw new IllegalStateException("no buffer available");
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/SequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/SequenceNumberingViewReader.java
@@ -85,6 +85,10 @@ class SequenceNumberingViewReader implements BufferAvailabilityListener {
 		return sequenceNumber;
 	}
 
+	int getBacklog() {
+		return subpartitionView.getBacklog();
+	}
+
 	public BufferAndAvailability getNextBuffer() throws IOException, InterruptedException {
 		Buffer next = subpartitionView.getNextBuffer();
 		if (next != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/SequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/SequenceNumberingViewReader.java
@@ -85,8 +85,8 @@ class SequenceNumberingViewReader implements BufferAvailabilityListener {
 		return sequenceNumber;
 	}
 
-	int getBacklog() {
-		return subpartitionView.getBacklog();
+	int getBuffersInBacklog() {
+		return subpartitionView.getBuffersInBacklog();
 	}
 
 	public BufferAndAvailability getNextBuffer() throws IOException, InterruptedException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -177,6 +178,7 @@ class PipelinedSubpartition extends ResultSubpartition {
 	}
 
 	@Override
+	@VisibleForTesting
 	public int getBuffersInBacklog() {
 		return buffersInBacklog;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -145,7 +145,13 @@ class PipelinedSubpartition extends ResultSubpartition {
 
 	Buffer pollBuffer() {
 		synchronized (buffers) {
-			return buffers.pollFirst();
+			Buffer buffer = buffers.pollFirst();
+
+			if (buffer != null && buffer.isBuffer()) {
+				backlog--;
+			}
+
+			return buffer;
 		}
 	}
 
@@ -205,8 +211,8 @@ class PipelinedSubpartition extends ResultSubpartition {
 		}
 
 		return String.format(
-				"PipelinedSubpartition [number of buffers: %d (%d bytes), finished? %s, read view? %s]",
-				numBuffers, numBytes, finished, hasReadView);
+			"PipelinedSubpartition [number of buffers: %d (%d bytes), backlog: %d, finished? %s, read view? %s]",
+			numBuffers, numBytes, backlog, finished, hasReadView);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -145,13 +145,7 @@ class PipelinedSubpartition extends ResultSubpartition {
 
 	Buffer pollBuffer() {
 		synchronized (buffers) {
-			Buffer buffer = buffers.pollFirst();
-
-			if (buffer != null && buffer.isBuffer()) {
-				backlog--;
-			}
-
-			return buffer;
+			return buffers.pollFirst();
 		}
 	}
 
@@ -211,8 +205,8 @@ class PipelinedSubpartition extends ResultSubpartition {
 		}
 
 		return String.format(
-			"PipelinedSubpartition [number of buffers: %d (%d bytes), backlog: %d, finished? %s, read view? %s]",
-			numBuffers, numBytes, backlog, finished, hasReadView);
+			"PipelinedSubpartition [number of buffers: %d (%d bytes), number of buffers in backlog: %d, finished? %s, read view? %s]",
+			numBuffers, numBytes, getBuffersInBacklog(), finished, hasReadView);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -49,7 +49,7 @@ class PipelinedSubpartitionView extends ResultSubpartitionView {
 
 	@Nullable
 	@Override
-	protected Buffer getNextBufferInternal() {
+	public Buffer getNextBuffer() {
 		return parent.pollBuffer();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -79,6 +79,11 @@ class PipelinedSubpartitionView implements ResultSubpartitionView {
 	}
 
 	@Override
+	public int getBacklog() {
+		return parent.backlog;
+	}
+
+	@Override
 	public String toString() {
 		return String.format("PipelinedSubpartitionView(index: %d) of ResultPartition %s",
 				parent.index,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
-import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -29,7 +29,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * View over a pipelined in-memory only subpartition.
  */
-class PipelinedSubpartitionView extends ResultSubpartitionView {
+class PipelinedSubpartitionView implements ResultSubpartitionView {
 
 	/** The subpartition this view belongs to. */
 	private final PipelinedSubpartition parent;
@@ -40,8 +40,6 @@ class PipelinedSubpartitionView extends ResultSubpartitionView {
 	private final AtomicBoolean isReleased;
 
 	PipelinedSubpartitionView(PipelinedSubpartition parent, BufferAvailabilityListener listener) {
-		super(parent);
-
 		this.parent = checkNotNull(parent);
 		this.availabilityListener = checkNotNull(listener);
 		this.isReleased = new AtomicBoolean();
@@ -49,7 +47,7 @@ class PipelinedSubpartitionView extends ResultSubpartitionView {
 
 	@Nullable
 	@Override
-	public Buffer getNextBuffer() {
+	public BufferAndBacklog getNextBuffer() {
 		return parent.pollBuffer();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -46,6 +47,7 @@ class PipelinedSubpartitionView extends ResultSubpartitionView {
 		this.isReleased = new AtomicBoolean();
 	}
 
+	@Nullable
 	@Override
 	protected Buffer getNextBufferInternal() {
 		return parent.pollBuffer();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -28,7 +28,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * View over a pipelined in-memory only subpartition.
  */
-class PipelinedSubpartitionView implements ResultSubpartitionView {
+class PipelinedSubpartitionView extends ResultSubpartitionView {
 
 	/** The subpartition this view belongs to. */
 	private final PipelinedSubpartition parent;
@@ -39,13 +39,15 @@ class PipelinedSubpartitionView implements ResultSubpartitionView {
 	private final AtomicBoolean isReleased;
 
 	PipelinedSubpartitionView(PipelinedSubpartition parent, BufferAvailabilityListener listener) {
+		super(parent);
+
 		this.parent = checkNotNull(parent);
 		this.availabilityListener = checkNotNull(listener);
 		this.isReleased = new AtomicBoolean();
 	}
 
 	@Override
-	public Buffer getNextBuffer() {
+	protected Buffer getNextBufferInternal() {
 		return parent.pollBuffer();
 	}
 
@@ -76,11 +78,6 @@ class PipelinedSubpartitionView implements ResultSubpartitionView {
 	@Override
 	public Throwable getFailureCause() {
 		return parent.getFailureCause();
-	}
-
-	@Override
-	public int getBacklog() {
-		return parent.backlog;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -41,31 +41,14 @@ public abstract class ResultSubpartition {
 	/** The total number of bytes (both data and event buffers) */
 	private long totalNumberOfBytes;
 
-	/** The number of non-event buffers currently in this subpartition */
-	private int buffersInBacklog;
-
 	public ResultSubpartition(int index, ResultPartition parent) {
 		this.index = index;
 		this.parent = parent;
 	}
 
 	protected void updateStatistics(Buffer buffer) {
-		if (buffer.isBuffer()) {
-			buffersInBacklog++;
-		}
-
 		totalNumberOfBuffers++;
 		totalNumberOfBytes += buffer.getSize();
-	}
-
-	protected void decreaseStatistics(Buffer buffer) {
-		if (buffer.isBuffer()) {
-			buffersInBacklog--;
-		}
-	}
-
-	protected int getBuffersInBacklog() {
-		return buffersInBacklog;
 	}
 
 	protected long getTotalNumberOfBuffers() {
@@ -98,6 +81,23 @@ public abstract class ResultSubpartition {
 	abstract int releaseMemory() throws IOException;
 
 	abstract public boolean isReleased();
+
+	/**
+	 * Gets the number of non-event buffers in this subpartition.
+	 */
+	abstract public int getBuffersInBacklog();
+
+	/**
+	 * Decreases the number of non-event buffers by one after fetching a non-event
+	 * buffer from this subpartition.
+	 */
+	abstract public void decreaseBuffersInBacklog(Buffer buffer);
+
+	/**
+	 * Increases the number of non-event buffers by one after adding a non-event
+	 * buffer into this subpartition.
+	 */
+	abstract public void increaseBuffersInBacklog(Buffer buffer);
 
 	/**
 	 * Makes a best effort to get the current size of the queue.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 
 import java.io.IOException;
@@ -86,7 +87,11 @@ public abstract class ResultSubpartition {
 
 	/**
 	 * Gets the number of non-event buffers in this subpartition.
+	 *
+	 * <p><strong>Beware:</strong> This method should only be used in tests in non-concurrent
+	 * access scenarios since it does not make any concurrency guarantees.
 	 */
+	@VisibleForTesting
 	abstract public int getBuffersInBacklog();
 
 	/**
@@ -100,7 +105,7 @@ public abstract class ResultSubpartition {
 
 	/**
 	 * A combination of a {@link Buffer} and the backlog length indicating
-	 * how many non-event buffers available in the subpartition.
+	 * how many non-event buffers are available in the subpartition.
 	 */
 	public static final class BufferAndBacklog {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -42,7 +42,7 @@ public abstract class ResultSubpartition {
 	private long totalNumberOfBytes;
 
 	/** The number of non-event buffers currently in this subpartition */
-	protected int backlog;
+	private int buffersInBacklog;
 
 	public ResultSubpartition(int index, ResultPartition parent) {
 		this.index = index;
@@ -51,11 +51,21 @@ public abstract class ResultSubpartition {
 
 	protected void updateStatistics(Buffer buffer) {
 		if (buffer.isBuffer()) {
-			backlog++;
+			buffersInBacklog++;
 		}
 
 		totalNumberOfBuffers++;
 		totalNumberOfBytes += buffer.getSize();
+	}
+
+	protected void decreaseStatistics(Buffer buffer) {
+		if (buffer.isBuffer()) {
+			buffersInBacklog--;
+		}
+	}
+
+	protected int getBuffersInBacklog() {
+		return buffersInBacklog;
 	}
 
 	protected long getTotalNumberOfBuffers() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -22,6 +22,8 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 
 import java.io.IOException;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * A single subpartition of a {@link ResultPartition} instance.
  */
@@ -88,22 +90,35 @@ public abstract class ResultSubpartition {
 	abstract public int getBuffersInBacklog();
 
 	/**
-	 * Decreases the number of non-event buffers by one after fetching a non-event
-	 * buffer from this subpartition.
-	 */
-	abstract public void decreaseBuffersInBacklog(Buffer buffer);
-
-	/**
-	 * Increases the number of non-event buffers by one after adding a non-event
-	 * buffer into this subpartition.
-	 */
-	abstract public void increaseBuffersInBacklog(Buffer buffer);
-
-	/**
 	 * Makes a best effort to get the current size of the queue.
 	 * This method must not acquire locks or interfere with the task and network threads in
 	 * any way.
 	 */
 	abstract public int unsynchronizedGetNumberOfQueuedBuffers();
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * A combination of a {@link Buffer} and the backlog length indicating
+	 * how many non-event buffers available in the subpartition.
+	 */
+	public static final class BufferAndBacklog {
+
+		private final Buffer buffer;
+		private final int buffersInBacklog;
+
+		public BufferAndBacklog(Buffer buffer, int buffersInBacklog) {
+			this.buffer = checkNotNull(buffer);
+			this.buffersInBacklog = buffersInBacklog;
+		}
+
+		public Buffer buffer() {
+			return buffer;
+		}
+
+		public int buffersInBacklog() {
+			return buffersInBacklog;
+		}
+	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -41,12 +41,19 @@ public abstract class ResultSubpartition {
 	/** The total number of bytes (both data and event buffers) */
 	private long totalNumberOfBytes;
 
+	/** The number of non-event buffers currently in this subpartition */
+	protected int backlog;
+
 	public ResultSubpartition(int index, ResultPartition parent) {
 		this.index = index;
 		this.parent = parent;
 	}
 
 	protected void updateStatistics(Buffer buffer) {
+		if (buffer.isBuffer()) {
+			backlog++;
+		}
+
 		totalNumberOfBuffers++;
 		totalNumberOfBytes += buffer.getSize();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -38,25 +38,14 @@ public abstract class ResultSubpartitionView {
 	}
 
 	/**
-	 * Returns the next {@link Buffer} instance of this queue iterator and also
-	 * decreases the related statistics.
+	 * Returns the number of non-event buffers in this result subpartition.
 	 */
-	@Nullable
-	public final Buffer getNextBuffer() throws IOException, InterruptedException {
-		Buffer buffer = getNextBufferInternal();
-		if (buffer != null) {
-			parent.decreaseStatistics(buffer);
-		}
-		return buffer;
-	}
-
 	public int getBuffersInBacklog() {
 		return parent.getBuffersInBacklog();
 	}
 
 	/**
-	 * The internal method used by {@link ResultSubpartitionView#getNextBuffer()}
-	 * to return the next {@link Buffer} instance of this queue iterator.
+	 * Returns the next {@link Buffer} instance of this queue iterator.
 	 *
 	 * <p>If there is currently no instance available, it will return <code>null</code>.
 	 * This might happen for example when a pipelined queue producer is slower
@@ -67,7 +56,7 @@ public abstract class ResultSubpartitionView {
 	 * after it has been consumed.
 	 */
 	@Nullable
-	protected abstract Buffer getNextBufferInternal() throws IOException, InterruptedException;
+	public abstract Buffer getNextBuffer() throws IOException, InterruptedException;
 
 	public abstract void notifyBuffersAvailable(long buffers) throws IOException;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -40,7 +41,8 @@ public abstract class ResultSubpartitionView {
 	 * Returns the next {@link Buffer} instance of this queue iterator and also
 	 * decreases the related statistics.
 	 */
-	public Buffer getNextBuffer() throws IOException, InterruptedException {
+	@Nullable
+	public final Buffer getNextBuffer() throws IOException, InterruptedException {
 		Buffer buffer = getNextBufferInternal();
 		if (buffer != null) {
 			parent.decreaseStatistics(buffer);
@@ -64,6 +66,7 @@ public abstract class ResultSubpartitionView {
 	 * buffer instance will eventually be recycled with {@link Buffer#recycle()}
 	 * after it has been consumed.
 	 */
+	@Nullable
 	protected abstract Buffer getNextBufferInternal() throws IOException, InterruptedException;
 
 	public abstract void notifyBuffersAvailable(long buffers) throws IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -50,4 +50,5 @@ public interface ResultSubpartitionView {
 
 	Throwable getFailureCause();
 
+	int getBacklog();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -19,30 +19,15 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
-
 /**
  * A view to consume a {@link ResultSubpartition} instance.
  */
-public abstract class ResultSubpartitionView {
-
-	/** The parent subpartition this view belongs to. */
-	private final ResultSubpartition parent;
-
-	public ResultSubpartitionView(ResultSubpartition parent) {
-		this.parent = checkNotNull(parent);
-	}
-
-	/**
-	 * Returns the number of non-event buffers in this result subpartition.
-	 */
-	public int getBuffersInBacklog() {
-		return parent.getBuffersInBacklog();
-	}
+public interface ResultSubpartitionView {
 
 	/**
 	 * Returns the next {@link Buffer} instance of this queue iterator.
@@ -56,15 +41,15 @@ public abstract class ResultSubpartitionView {
 	 * after it has been consumed.
 	 */
 	@Nullable
-	public abstract Buffer getNextBuffer() throws IOException, InterruptedException;
+	BufferAndBacklog getNextBuffer() throws IOException, InterruptedException;
 
-	public abstract void notifyBuffersAvailable(long buffers) throws IOException;
+	void notifyBuffersAvailable(long buffers) throws IOException;
 
-	public abstract void releaseAllResources() throws IOException;
+	void releaseAllResources() throws IOException;
 
-	public abstract void notifySubpartitionConsumed() throws IOException;
+	void notifySubpartitionConsumed() throws IOException;
 
-	public abstract boolean isReleased();
+	boolean isReleased();
 
-	public abstract Throwable getFailureCause();
+	Throwable getFailureCause();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.io.disk.iomanager.BufferFileWriter;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -244,21 +245,23 @@ class SpillableSubpartition extends ResultSubpartition {
 	}
 
 	@Override
+	@VisibleForTesting
 	public int getBuffersInBacklog() {
-		synchronized (buffers) {
-			return buffersInBacklog;
-		}
+		return buffersInBacklog;
 	}
 
 	/**
 	 * Decreases the number of non-event buffers by one after fetching a non-event
-	 * buffer from this subpartition.
+	 * buffer from this subpartition (for access by the subpartition views).
+	 *
+	 * @return backlog after the operator
 	 */
-	public void decreaseBuffersInBacklog(Buffer buffer) {
-		if (buffer != null && buffer.isBuffer()) {
-			synchronized (buffers) {
+	public int decreaseBuffersInBacklog(Buffer buffer) {
+		synchronized (buffers) {
+			if (buffer != null && buffer.isBuffer()) {
 				buffersInBacklog--;
 			}
+			return buffersInBacklog;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -246,9 +246,9 @@ class SpillableSubpartition extends ResultSubpartition {
 	@Override
 	public String toString() {
 		return String.format("SpillableSubpartition [%d number of buffers (%d bytes)," +
-				"%d backlog, finished? %s, read view? %s, spilled? %s]",
+				"%d buffers in backlog, finished? %s, read view? %s, spilled? %s]",
 			getTotalNumberOfBuffers(), getTotalNumberOfBytes(),
-			backlog, isFinished, readView != null, spillWriter != null);
+			getBuffersInBacklog(), isFinished, readView != null, spillWriter != null);
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -246,9 +246,9 @@ class SpillableSubpartition extends ResultSubpartition {
 	@Override
 	public String toString() {
 		return String.format("SpillableSubpartition [%d number of buffers (%d bytes)," +
-						"finished? %s, read view? %s, spilled? %s]",
-				getTotalNumberOfBuffers(), getTotalNumberOfBytes(), isFinished, readView != null,
-				spillWriter != null);
+				"%d backlog, finished? %s, read view? %s, spilled? %s]",
+			getTotalNumberOfBuffers(), getTotalNumberOfBytes(),
+			backlog, isFinished, readView != null, spillWriter != null);
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
@@ -145,6 +145,10 @@ class SpillableSubpartitionView implements ResultSubpartitionView {
 					listener.notifyBuffersAvailable(1);
 				}
 
+				if (current.isBuffer()) {
+					parent.backlog--;
+				}
+
 				return current;
 			}
 		} // else: spilled
@@ -200,6 +204,11 @@ class SpillableSubpartitionView implements ResultSubpartitionView {
 		} else {
 			return parent.getFailureCause();
 		}
+	}
+
+	@Override
+	public int getBacklog() {
+		return parent.backlog;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
@@ -137,7 +137,7 @@ class SpillableSubpartitionView extends ResultSubpartitionView {
 
 	@Nullable
 	@Override
-	protected Buffer getNextBufferInternal() throws IOException, InterruptedException {
+	public Buffer getNextBuffer() throws IOException, InterruptedException {
 		synchronized (buffers) {
 			if (isReleased.get()) {
 				return null;
@@ -149,13 +149,15 @@ class SpillableSubpartitionView extends ResultSubpartitionView {
 					listener.notifyBuffersAvailable(1);
 				}
 
+				parent.decreaseBuffersInBacklog(current);
+
 				return current;
 			}
 		} // else: spilled
 
 		SpilledSubpartitionView spilled = spilledView;
 		if (spilled != null) {
-			return spilled.getNextBufferInternal();
+			return spilled.getNextBuffer();
 		} else {
 			throw new IllegalStateException("No in-memory buffers available, but also nothing spilled.");
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -134,6 +135,7 @@ class SpillableSubpartitionView extends ResultSubpartitionView {
 		}
 	}
 
+	@Nullable
 	@Override
 	protected Buffer getNextBufferInternal() throws IOException, InterruptedException {
 		synchronized (buffers) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
@@ -148,8 +148,8 @@ class SpillableSubpartitionView implements ResultSubpartitionView {
 					listener.notifyBuffersAvailable(1);
 				}
 
-				parent.decreaseBuffersInBacklog(current);
-				return new BufferAndBacklog(current, parent.getBuffersInBacklog());
+				int newBacklog = parent.decreaseBuffersInBacklog(current);
+				return new BufferAndBacklog(current, newBacklog);
 			}
 		} // else: spilled
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionView.java
@@ -118,7 +118,7 @@ class SpilledSubpartitionView extends ResultSubpartitionView implements Notifica
 
 	@Nullable
 	@Override
-	protected Buffer getNextBufferInternal() throws IOException, InterruptedException {
+	public Buffer getNextBuffer() throws IOException, InterruptedException {
 		if (fileReader.hasReachedEndOfFile() || isSpillInProgress) {
 			return null;
 		}
@@ -127,6 +127,8 @@ class SpilledSubpartitionView extends ResultSubpartitionView implements Notifica
 		// this method don't happen before recycling buffers returned earlier.
 		Buffer buffer = bufferPool.requestBufferBlocking();
 		fileReader.readInto(buffer);
+
+		parent.decreaseBuffersInBacklog(buffer);
 
 		return buffer;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionView.java
@@ -127,9 +127,8 @@ class SpilledSubpartitionView implements ResultSubpartitionView, NotificationLis
 		Buffer buffer = bufferPool.requestBufferBlocking();
 		fileReader.readInto(buffer);
 
-		parent.decreaseBuffersInBacklog(buffer);
-
-		return new BufferAndBacklog(buffer, parent.getBuffersInBacklog());
+		int newBacklog = parent.decreaseBuffersInBacklog(buffer);
+		return new BufferAndBacklog(buffer, newBacklog);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionView.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.util.event.NotificationListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Queue;
@@ -115,6 +116,7 @@ class SpilledSubpartitionView extends ResultSubpartitionView implements Notifica
 		LOG.debug("Finished spilling. Notified about {} available buffers.", numberOfSpilledBuffers);
 	}
 
+	@Nullable
 	@Override
 	protected Buffer getNextBufferInternal() throws IOException, InterruptedException {
 		if (fileReader.hasReachedEndOfFile() || isSpillInProgress) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionView.java
@@ -124,6 +124,10 @@ class SpilledSubpartitionView implements ResultSubpartitionView, NotificationLis
 		Buffer buffer = bufferPool.requestBufferBlocking();
 		fileReader.readInto(buffer);
 
+		if (buffer != null && buffer.isBuffer()) {
+			parent.backlog--;
+		}
+
 		return buffer;
 	}
 
@@ -162,6 +166,11 @@ class SpilledSubpartitionView implements ResultSubpartitionView, NotificationLis
 	@Override
 	public Throwable getFailureCause() {
 		return parent.getFailureCause();
+	}
+
+	@Override
+	public int getBacklog() {
+		return parent.backlog;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -238,16 +238,19 @@ public abstract class InputChannel {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * A combination of a {@link Buffer} and a flag indicating availability of further buffers.
+	 * A combination of a {@link Buffer} and a flag indicating availability of further buffers,
+	 * and the backlog length indicating how many non-event buffers available in the subpartition.
 	 */
 	public static final class BufferAndAvailability {
 
 		private final Buffer buffer;
 		private final boolean moreAvailable;
+		private final int buffersInBacklog;
 
-		public BufferAndAvailability(Buffer buffer, boolean moreAvailable) {
+		public BufferAndAvailability(Buffer buffer, boolean moreAvailable, int buffersInBacklog) {
 			this.buffer = checkNotNull(buffer);
 			this.moreAvailable = moreAvailable;
+			this.buffersInBacklog = buffersInBacklog;
 		}
 
 		public Buffer buffer() {
@@ -256,6 +259,10 @@ public abstract class InputChannel {
 
 		public boolean moreAvailable() {
 			return moreAvailable;
+		}
+
+		public int buffersInBacklog() {
+			return buffersInBacklog;
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -34,9 +34,9 @@ import org.apache.flink.util.ExceptionUtils;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -300,7 +300,7 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 			// the available queue during releasing all resources.
 			if (isReleased.get()) {
 				try {
-					inputGate.returnExclusiveSegments(Arrays.asList(segment));
+					inputGate.returnExclusiveSegments(Collections.singletonList(segment));
 					return;
 				} catch (Throwable t) {
 					ExceptionUtils.rethrow(t);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -189,7 +189,7 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		}
 
 		numBytesIn.inc(next.getSizeUnsafe());
-		return new BufferAndAvailability(next, remaining > 0);
+		return new BufferAndAvailability(next, remaining > 0, senderBacklog.get());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -188,6 +189,7 @@ public class CancelPartitionRequestTest {
 			this.sync = checkNotNull(sync);
 		}
 
+		@Nullable
 		@Override
 		protected Buffer getNextBufferInternal() throws IOException, InterruptedException {
 			return bufferProvider.requestBufferBlocking();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -19,13 +19,12 @@
 package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
-import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
 import org.apache.flink.runtime.io.network.netty.NettyTestUtil.NettyServerAndClient;
 import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
-import org.apache.flink.runtime.io.network.partition.ResultSubpartition;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
 import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
@@ -176,23 +175,21 @@ public class CancelPartitionRequestTest {
 
 	// ---------------------------------------------------------------------------------------------
 
-	static class InfiniteSubpartitionView extends ResultSubpartitionView {
+	static class InfiniteSubpartitionView implements ResultSubpartitionView {
 
 		private final BufferProvider bufferProvider;
 
 		private final CountDownLatch sync;
 
 		public InfiniteSubpartitionView(BufferProvider bufferProvider, CountDownLatch sync) {
-			super(mock(ResultSubpartition.class));
-
 			this.bufferProvider = checkNotNull(bufferProvider);
 			this.sync = checkNotNull(sync);
 		}
 
 		@Nullable
 		@Override
-		public Buffer getNextBuffer() throws IOException, InterruptedException {
-			return bufferProvider.requestBufferBlocking();
+		public BufferAndBacklog getNextBuffer() throws IOException, InterruptedException {
+			return new BufferAndBacklog(bufferProvider.requestBufferBlocking(), 0);
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.network.netty.NettyTestUtil.NettyServerAndCli
 import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
 import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
@@ -174,19 +175,21 @@ public class CancelPartitionRequestTest {
 
 	// ---------------------------------------------------------------------------------------------
 
-	static class InfiniteSubpartitionView implements ResultSubpartitionView {
+	static class InfiniteSubpartitionView extends ResultSubpartitionView {
 
 		private final BufferProvider bufferProvider;
 
 		private final CountDownLatch sync;
 
 		public InfiniteSubpartitionView(BufferProvider bufferProvider, CountDownLatch sync) {
+			super(mock(ResultSubpartition.class));
+
 			this.bufferProvider = checkNotNull(bufferProvider);
 			this.sync = checkNotNull(sync);
 		}
 
 		@Override
-		public Buffer getNextBuffer() throws IOException, InterruptedException {
+		protected Buffer getNextBufferInternal() throws IOException, InterruptedException {
 			return bufferProvider.requestBufferBlocking();
 		}
 
@@ -211,11 +214,6 @@ public class CancelPartitionRequestTest {
 		@Override
 		public Throwable getFailureCause() {
 			return null;
-		}
-
-		@Override
-		public int getBacklog() {
-			return 0;
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -212,5 +212,10 @@ public class CancelPartitionRequestTest {
 		public Throwable getFailureCause() {
 			return null;
 		}
+
+		@Override
+		public int getBacklog() {
+			return 0;
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -191,7 +191,7 @@ public class CancelPartitionRequestTest {
 
 		@Nullable
 		@Override
-		protected Buffer getNextBufferInternal() throws IOException, InterruptedException {
+		public Buffer getNextBuffer() throws IOException, InterruptedException {
 			return bufferProvider.requestBufferBlocking();
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static org.apache.flink.runtime.io.network.util.TestBufferFactory.BUFFER_SIZE;
 import static org.apache.flink.runtime.io.network.util.TestBufferFactory.createBuffer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -103,16 +104,35 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 		// Add data to the queue...
 		subpartition.add(createBuffer());
 
+		assertEquals(1, subpartition.getTotalNumberOfBuffers());
+		assertEquals(1, subpartition.getBuffersInBacklog());
+		assertEquals(BUFFER_SIZE, subpartition.getTotalNumberOfBytes());
+
 		// ...should have resulted in a notification
 		verify(listener, times(1)).notifyBuffersAvailable(eq(1L));
 
 		// ...and one available result
 		assertNotNull(view.getNextBuffer());
 		assertNull(view.getNextBuffer());
+		assertEquals(0, subpartition.getBuffersInBacklog());
 
 		// Add data to the queue...
 		subpartition.add(createBuffer());
+
+		assertEquals(2, subpartition.getTotalNumberOfBuffers());
+		assertEquals(1, subpartition.getBuffersInBacklog());
+		assertEquals(2 * BUFFER_SIZE, subpartition.getTotalNumberOfBytes());
 		verify(listener, times(2)).notifyBuffersAvailable(eq(1L));
+
+		// Add event to the queue...
+		Buffer event = createBuffer();
+		event.tagAsEvent();
+		subpartition.add(event);
+
+		assertEquals(3, subpartition.getTotalNumberOfBuffers());
+		assertEquals(1, subpartition.getBuffersInBacklog());
+		assertEquals(3 * BUFFER_SIZE, subpartition.getTotalNumberOfBytes());
+		verify(listener, times(3)).notifyBuffersAvailable(eq(1L));
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.util.TestConsumerCallback;
 import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
@@ -112,7 +113,10 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 		verify(listener, times(1)).notifyBuffersAvailable(eq(1L));
 
 		// ...and one available result
-		assertNotNull(view.getNextBuffer());
+		BufferAndBacklog read = view.getNextBuffer();
+		assertNotNull(read);
+		assertEquals(0, subpartition.getBuffersInBacklog());
+		assertEquals(subpartition.getBuffersInBacklog(), read.buffersInBacklog());
 		assertNull(view.getNextBuffer());
 		assertEquals(0, subpartition.getBuffersInBacklog());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionTest.java
@@ -212,22 +212,26 @@ public class SpillableSubpartitionTest extends SubpartitionTestBase {
 		BufferAndBacklog read = reader.getNextBuffer();
 		assertNotNull(read);
 		assertEquals(2, partition.getBuffersInBacklog());
+		assertEquals(partition.getBuffersInBacklog(), read.buffersInBacklog());
 		read.buffer().recycle();
 
 		read = reader.getNextBuffer();
 		assertNotNull(read);
 		assertEquals(1, partition.getBuffersInBacklog());
+		assertEquals(partition.getBuffersInBacklog(), read.buffersInBacklog());
 		read.buffer().recycle();
 
 		read = reader.getNextBuffer();
 		assertNotNull(read);
 		assertEquals(0, partition.getBuffersInBacklog());
+		assertEquals(partition.getBuffersInBacklog(), read.buffersInBacklog());
 		read.buffer().recycle();
 
 		// End of partition
 		read = reader.getNextBuffer();
 		assertNotNull(read);
 		assertEquals(0, partition.getBuffersInBacklog());
+		assertEquals(partition.getBuffersInBacklog(), read.buffersInBacklog());
 		assertEquals(EndOfPartitionEvent.class, EventSerializer.fromBuffer(read.buffer(), ClassLoader.getSystemClassLoader()).getClass());
 		read.buffer().recycle();
 	}
@@ -261,6 +265,8 @@ public class SpillableSubpartitionTest extends SubpartitionTestBase {
 
 		BufferAndBacklog read = reader.getNextBuffer();
 		assertNotNull(read);
+		assertEquals(2, partition.getBuffersInBacklog());
+		assertEquals(partition.getBuffersInBacklog(), read.buffersInBacklog());
 		read.buffer().recycle();
 		assertEquals(2, listener.getNumNotifiedBuffers());
 
@@ -277,11 +283,13 @@ public class SpillableSubpartitionTest extends SubpartitionTestBase {
 		read = reader.getNextBuffer();
 		assertNotNull(read);
 		assertEquals(1, partition.getBuffersInBacklog());
+		assertEquals(partition.getBuffersInBacklog(), read.buffersInBacklog());
 		read.buffer().recycle();
 
 		read = reader.getNextBuffer();
 		assertNotNull(read);
 		assertEquals(0, partition.getBuffersInBacklog());
+		assertEquals(partition.getBuffersInBacklog(), read.buffersInBacklog());
 		read.buffer().recycle();
 
 		// End of partition

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionViewTest.java
@@ -72,7 +72,7 @@ public class SpilledSubpartitionViewTest {
 			false, new TestConsumerCallback.RecyclingCallback());
 
 		SpilledSubpartitionView view = new SpilledSubpartitionView(
-			mock(ResultSubpartition.class),
+			mock(SpillableSubpartition.class),
 			viewBufferPool.getMemorySegmentSize(),
 			writer,
 			numberOfBuffersToWrite + 1, // +1 for end-of-partition
@@ -98,7 +98,7 @@ public class SpilledSubpartitionViewTest {
 			false, new TestConsumerCallback.RecyclingCallback());
 
 		SpilledSubpartitionView view = new SpilledSubpartitionView(
-			mock(ResultSubpartition.class),
+			mock(SpillableSubpartition.class),
 			32 * 1024,
 			writer,
 			numberOfBuffersToWrite + 1,
@@ -139,7 +139,7 @@ public class SpilledSubpartitionViewTest {
 
 			BufferProvider inputBuffers = new TestPooledBufferProvider(2);
 
-			ResultSubpartition parent = mock(ResultSubpartition.class);
+			SpillableSubpartition parent = mock(SpillableSubpartition.class);
 
 			// Wait for writers to finish
 			for (BufferFileWriter writer : writers) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.io.network.util.TestBufferFactory;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -47,7 +48,14 @@ public abstract class SubpartitionTestBase extends TestLogger {
 		try {
 			subpartition.finish();
 
+			assertEquals(1, subpartition.getTotalNumberOfBuffers());
+			assertEquals(0, subpartition.getBuffersInBacklog());
+			assertEquals(4, subpartition.getTotalNumberOfBytes());
+
 			assertFalse(subpartition.add(mock(Buffer.class)));
+			assertEquals(1, subpartition.getTotalNumberOfBuffers());
+			assertEquals(0, subpartition.getBuffersInBacklog());
+			assertEquals(4, subpartition.getTotalNumberOfBytes());
 		} finally {
 			if (subpartition != null) {
 				subpartition.release();
@@ -62,7 +70,14 @@ public abstract class SubpartitionTestBase extends TestLogger {
 		try {
 			subpartition.release();
 
+			assertEquals(0, subpartition.getTotalNumberOfBuffers());
+			assertEquals(0, subpartition.getBuffersInBacklog());
+			assertEquals(0, subpartition.getTotalNumberOfBytes());
+
 			assertFalse(subpartition.add(mock(Buffer.class)));
+			assertEquals(0, subpartition.getTotalNumberOfBuffers());
+			assertEquals(0, subpartition.getBuffersInBacklog());
+			assertEquals(0, subpartition.getTotalNumberOfBytes());
 		} finally {
 			if (subpartition != null) {
 				subpartition.release();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.util.TestBufferFactory;
 import org.apache.flink.util.TestLogger;
 import org.junit.Test;
@@ -52,7 +54,9 @@ public abstract class SubpartitionTestBase extends TestLogger {
 			assertEquals(0, subpartition.getBuffersInBacklog());
 			assertEquals(4, subpartition.getTotalNumberOfBytes());
 
-			assertFalse(subpartition.add(mock(Buffer.class)));
+			Buffer buffer = new Buffer(MemorySegmentFactory.allocateUnpooledSegment(4096), FreeingBufferRecycler.INSTANCE);
+
+			assertFalse(subpartition.add(buffer));
 			assertEquals(1, subpartition.getTotalNumberOfBuffers());
 			assertEquals(0, subpartition.getBuffersInBacklog());
 			assertEquals(4, subpartition.getTotalNumberOfBytes());
@@ -74,7 +78,9 @@ public abstract class SubpartitionTestBase extends TestLogger {
 			assertEquals(0, subpartition.getBuffersInBacklog());
 			assertEquals(0, subpartition.getTotalNumberOfBytes());
 
-			assertFalse(subpartition.add(mock(Buffer.class)));
+			Buffer buffer = new Buffer(MemorySegmentFactory.allocateUnpooledSegment(4096), FreeingBufferRecycler.INSTANCE);
+
+			assertFalse(subpartition.add(buffer));
 			assertEquals(0, subpartition.getTotalNumberOfBuffers());
 			assertEquals(0, subpartition.getBuffersInBacklog());
 			assertEquals(0, subpartition.getTotalNumberOfBytes());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/IteratorWrappingTestSingleInputGate.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/IteratorWrappingTestSingleInputGate.java
@@ -78,11 +78,11 @@ public class IteratorWrappingTestSingleInputGate<T extends IOReadableWritable> e
 					hasData = inputIterator.next(reuse) != null;
 
 					// Call getCurrentBuffer to ensure size is set
-					return new InputChannel.BufferAndAvailability(serializer.getCurrentBuffer(), true);
+					return new InputChannel.BufferAndAvailability(serializer.getCurrentBuffer(), true, 0);
 				} else {
 					when(inputChannel.getInputChannel().isReleased()).thenReturn(true);
 
-					return new InputChannel.BufferAndAvailability(EventSerializer.toBuffer(EndOfPartitionEvent.INSTANCE), false);
+					return new InputChannel.BufferAndAvailability(EventSerializer.toBuffer(EndOfPartitionEvent.INSTANCE), false, 0);
 				}
 			}
 		};

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 import org.apache.flink.runtime.io.network.util.TestTaskEvent;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
@@ -124,7 +125,7 @@ public class SingleInputGateTest {
 
 		final ResultSubpartitionView iterator = mock(ResultSubpartitionView.class);
 		when(iterator.getNextBuffer()).thenReturn(
-			new Buffer(MemorySegmentFactory.allocateUnpooledSegment(1024), mock(BufferRecycler.class)));
+			new BufferAndBacklog(new Buffer(MemorySegmentFactory.allocateUnpooledSegment(1024), mock(BufferRecycler.class)), 0));
 
 		final ResultPartitionManager partitionManager = mock(ResultPartitionManager.class);
 		when(partitionManager.createSubpartitionView(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
@@ -55,9 +55,9 @@ public class TestInputChannel {
 
 	public TestInputChannel read(Buffer buffer) throws IOException, InterruptedException {
 		if (stubbing == null) {
-			stubbing = when(mock.getNextBuffer()).thenReturn(new InputChannel.BufferAndAvailability(buffer, true));
+			stubbing = when(mock.getNextBuffer()).thenReturn(new InputChannel.BufferAndAvailability(buffer, true, 0));
 		} else {
-			stubbing = stubbing.thenReturn(new InputChannel.BufferAndAvailability(buffer, true));
+			stubbing = stubbing.thenReturn(new InputChannel.BufferAndAvailability(buffer, true, 0));
 		}
 
 		return this;
@@ -77,7 +77,7 @@ public class TestInputChannel {
 				// Return true after finishing
 				when(mock.isReleased()).thenReturn(true);
 
-				return new InputChannel.BufferAndAvailability(EventSerializer.toBuffer(EndOfPartitionEvent.INSTANCE), false);
+				return new InputChannel.BufferAndAvailability(EventSerializer.toBuffer(EndOfPartitionEvent.INSTANCE), false, 0);
 			}
 		};
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
@@ -101,7 +101,7 @@ public class StreamTestSingleInputGate<T> extends TestSingleInputGate {
 					if (input != null && input.isStreamEnd()) {
 						when(inputChannels[channelIndex].getInputChannel().isReleased()).thenReturn(
 							true);
-						return new BufferAndAvailability(EventSerializer.toBuffer(EndOfPartitionEvent.INSTANCE), false);
+						return new BufferAndAvailability(EventSerializer.toBuffer(EndOfPartitionEvent.INSTANCE), false, 0);
 					} else if (input != null && input.isStreamRecord()) {
 						Object inputElement = input.getStreamRecord();
 						final Buffer buffer = new Buffer(
@@ -113,10 +113,10 @@ public class StreamTestSingleInputGate<T> extends TestSingleInputGate {
 						recordSerializer.addRecord(delegate);
 
 						// Call getCurrentBuffer to ensure size is set
-						return new BufferAndAvailability(recordSerializer.getCurrentBuffer(), false);
+						return new BufferAndAvailability(recordSerializer.getCurrentBuffer(), false, 0);
 					} else if (input != null && input.isEvent()) {
 						AbstractEvent event = input.getEvent();
-						return new BufferAndAvailability(EventSerializer.toBuffer(event), false);
+						return new BufferAndAvailability(EventSerializer.toBuffer(event), false, 0);
 					} else {
 						synchronized (inputQueues[channelIndex]) {
 							inputQueues[channelIndex].wait();


### PR DESCRIPTION
## What is the purpose of the change

Receivers should know how many buffers are available on the sender side (the backlog). The receivers use this information to decide how to distribute floating buffers. So the backlog is attached in `BufferResponse` by sender as an absolute value after the buffer being transferred.

## Brief change log

  - *Defines the `ResultSubpartitionView#getBacklog` method and implements it in sub classes*
  - *The `ResultSubpartition` increases the backlog when adding buffer and decreases it when polling buffer*

## Verifying this change

This change will be covered by the test case in next PR.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

