### PR TITLE
 [FLINK-7476][streaming] Continue using previous transaction on failures

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunctionTest.java
@@ -24,6 +24,8 @@ import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.runtime.tasks.OperatorStateHandles;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.BufferedWriter;
@@ -31,7 +33,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -43,56 +44,53 @@ import java.util.UUID;
 import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link TwoPhaseCommitSinkFunction}.
  */
 public class TwoPhaseCommitSinkFunctionTest {
-	@Test
-	public void testNotifyOfCompletedCheckpoint() throws Exception {
-		File tmpDirectory = Files.createTempDirectory(this.getClass().getSimpleName() + "_tmp").toFile();
-		File targetDirectory = Files.createTempDirectory(this.getClass().getSimpleName() + "_target").toFile();
-		OneInputStreamOperatorTestHarness<String, Object> testHarness = createTestHarness(tmpDirectory, targetDirectory);
+	TestContext context;
 
-		testHarness.setup();
-		testHarness.open();
-		testHarness.processElement("42", 0);
-		testHarness.snapshot(0, 1);
-		testHarness.processElement("43", 2);
-		testHarness.snapshot(1, 3);
-		testHarness.processElement("44", 4);
-		testHarness.snapshot(2, 5);
-		testHarness.notifyOfCompletedCheckpoint(1);
-
-		assertExactlyOnceForDirectory(targetDirectory, Arrays.asList("42", "43"));
-		assertEquals(2, tmpDirectory.listFiles().length); // one for checkpointId 2 and second for the currentTransaction
-		testHarness.close();
+	@Before
+	public void setUp() throws Exception {
+		context = new TestContext();
 	}
 
-	public OneInputStreamOperatorTestHarness<String, Object> createTestHarness(File tmpDirectory, File targetDirectory) throws Exception {
-		tmpDirectory.deleteOnExit();
-		targetDirectory.deleteOnExit();
-		FileBasedSinkFunction sinkFunction = new FileBasedSinkFunction(tmpDirectory, targetDirectory);
-		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sinkFunction), StringSerializer.INSTANCE);
+	@After
+	public void tearDown() throws Exception {
+		context.close();
+	}
+
+	@Test
+	public void testNotifyOfCompletedCheckpoint() throws Exception {
+		context.harness.setup();
+		context.harness.open();
+		context.harness.processElement("42", 0);
+		context.harness.snapshot(0, 1);
+		context.harness.processElement("43", 2);
+		context.harness.snapshot(1, 3);
+		context.harness.processElement("44", 4);
+		context.harness.snapshot(2, 5);
+		context.harness.notifyOfCompletedCheckpoint(1);
+
+		assertExactlyOnceForDirectory(context.targetDirectory, Arrays.asList("42", "43"));
+		assertEquals(2, context.tmpDirectory.listFiles().length); // one for checkpointId 2 and second for the currentTransaction
 	}
 
 	@Test
 	public void testFailBeforeNotify() throws Exception {
-		File tmpDirectory = Files.createTempDirectory(this.getClass().getSimpleName() + "_tmp").toFile();
-		File targetDirectory = Files.createTempDirectory(this.getClass().getSimpleName() + "_target").toFile();
-		OneInputStreamOperatorTestHarness<String, Object> testHarness = createTestHarness(tmpDirectory, targetDirectory);
+		context.harness.open();
+		context.harness.processElement("42", 0);
+		context.harness.snapshot(0, 1);
+		context.harness.processElement("43", 2);
+		OperatorStateHandles snapshot = context.harness.snapshot(1, 3);
 
-		testHarness.setup();
-		testHarness.open();
-		testHarness.processElement("42", 0);
-		testHarness.snapshot(0, 1);
-		testHarness.processElement("43", 2);
-		OperatorStateHandles snapshot = testHarness.snapshot(1, 3);
-
-		assertTrue(tmpDirectory.setWritable(false));
+		assertTrue(context.tmpDirectory.setWritable(false));
 		try {
-			testHarness.processElement("44", 4);
-			testHarness.snapshot(2, 5);
+			context.harness.processElement("44", 4);
+			context.harness.snapshot(2, 5);
+			fail("something should fail");
 		}
 		catch (Exception ex) {
 			if (!(ex.getCause() instanceof FileNotFoundException)) {
@@ -100,17 +98,17 @@ public class TwoPhaseCommitSinkFunctionTest {
 			}
 			// ignore
 		}
-		testHarness.close();
+		context.close();
 
-		assertTrue(tmpDirectory.setWritable(true));
+		assertTrue(context.tmpDirectory.setWritable(true));
 
-		testHarness = createTestHarness(tmpDirectory, targetDirectory);
-		testHarness.setup();
-		testHarness.initializeState(snapshot);
-		testHarness.close();
+		context.open();
+		context.harness.initializeState(snapshot);
 
-		assertExactlyOnceForDirectory(targetDirectory, Arrays.asList("42", "43"));
-		assertEquals(0, tmpDirectory.listFiles().length);
+		assertExactlyOnceForDirectory(context.targetDirectory, Arrays.asList("42", "43"));
+		context.close();
+
+		assertEquals(0, context.tmpDirectory.listFiles().length);
 	}
 
 	private void assertExactlyOnceForDirectory(File targetDirectory, List<String> expectedValues) throws IOException {
@@ -184,11 +182,41 @@ public class TwoPhaseCommitSinkFunctionTest {
 
 	private static class FileTransaction {
 		private final File tmpFile;
-		private final transient Writer writer;
+		private final transient BufferedWriter writer;
 
 		public FileTransaction(File tmpFile) throws IOException {
 			this.tmpFile = tmpFile;
 			this.writer = new BufferedWriter(new FileWriter(tmpFile));
+		}
+
+		@Override
+		public String toString() {
+			return String.format("FileTransaction[%s]", tmpFile.getName());
+		}
+	}
+
+	private static class TestContext implements AutoCloseable {
+		public final File tmpDirectory = Files.createTempDirectory(TwoPhaseCommitSinkFunctionTest.class.getSimpleName() + "_tmp").toFile();
+		public final File targetDirectory = Files.createTempDirectory(TwoPhaseCommitSinkFunctionTest.class.getSimpleName() + "_target").toFile();
+
+		public FileBasedSinkFunction sinkFunction;
+		public OneInputStreamOperatorTestHarness<String, Object> harness;
+
+		private TestContext() throws Exception {
+			tmpDirectory.deleteOnExit();
+			targetDirectory.deleteOnExit();
+			open();
+		}
+
+		@Override
+		public void close() throws Exception {
+			harness.close();
+		}
+
+		public void open() throws Exception {
+			sinkFunction = new FileBasedSinkFunction(tmpDirectory, targetDirectory);
+			harness = new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sinkFunction), StringSerializer.INSTANCE);
+			harness.setup();
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -90,7 +90,7 @@ import static org.mockito.Mockito.when;
 /**
  * Base class for {@code AbstractStreamOperator} test harnesses.
  */
-public class AbstractStreamOperatorTestHarness<OUT> {
+public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 
 	protected final StreamOperator<OUT> operator;
 


### PR DESCRIPTION
First commit comes from #4557.

Previously when using TwoPhaseCommitSinkFunction, if there was some intermittent failure in "beginTransaction", not only the snapshot that triggered this call failed, but also any subsequent write requests would fail also. This caused such sink unusable until application restart.

This PR changes order of execution of the methods from `PublicEvolving` class that has not been yet released.

PR is covered by existing tests in `TwoPhaseCommitSinkFunctionTest` as well as two additional test cases (`testContinueWorkOnBeginTransactionFailure` would be failing before this PR).