### PR TITLE
[FLINK-7487][tests] fix ClassLoaderITCase#testDisposeSavepointWithCustomKvState not self-contained

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -69,6 +69,7 @@ import scala.concurrent.duration.FiniteDuration;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -394,5 +395,6 @@ public class ClassLoaderITCase extends TestLogger {
 
 		// make sure, the execution is finished to not influence other test methods
 		invokeThread.join(deadline.timeLeft().toMillis());
+		assertFalse("Program invoke thread still running", invokeThread.isAlive());
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -391,5 +391,8 @@ public class ClassLoaderITCase extends TestLogger {
 		Future<?> cancelFuture = jm.ask(new JobManagerMessages.CancelJob(jobId), deadline.timeLeft());
 		Object response = Await.result(cancelFuture, deadline.timeLeft());
 		assertTrue("Unexpected response: " + response, response instanceof JobManagerMessages.CancellationSuccess);
+
+		// make sure, the execution is finished to not influence other test methods
+		invokeThread.join(deadline.timeLeft().toMillis());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

The cancellation of the job started in `ClassLoaderITCase#testDisposeSavepointWithCustomKvState()` may actually continue after the test method succeeds and may thus stop further jobs from being executed. This may result in a `NoResourceAvailableException`.

## Brief change log

- wait for the execution to finish in `ClassLoaderITCase#testDisposeSavepointWithCustomKvState()`

## Verifying this change

This change is fixing a unit test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

