### PR TITLE
[Flink-7243] [connectors] Add ParquetInputFormat 

### DIFF
--- a/flink-connectors/flink-parquet/pom.xml
+++ b/flink-connectors/flink-parquet/pom.xml
@@ -34,6 +34,10 @@ under the License.
 
     <packaging>jar</packaging>
 
+    <properties>
+        <parquet.version>1.8.2</parquet.version>
+    </properties>
+
     <dependencies>
 
         <!-- core dependencies -->
@@ -54,13 +58,13 @@ under the License.
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-column</artifactId>
-            <version>1.8.2</version>
+            <version>${parquet.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-hadoop</artifactId>
-            <version>1.8.2</version>
+            <version>${parquet.version}</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/flink-connectors/flink-parquet/pom.xml
+++ b/flink-connectors/flink-parquet/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-connectors</artifactId>
+        <version>1.4-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>flink-parquet_${scala.binary.version}</artifactId>
+    <name>flink-avro</name>
+
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <!-- core dependencies -->
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-shaded-hadoop2</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-column</artifactId>
+            <version>1.8.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop</artifactId>
+            <version>1.8.2</version>
+        </dependency>
+
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/flink-connectors/flink-parquet/pom.xml
+++ b/flink-connectors/flink-parquet/pom.xml
@@ -30,7 +30,7 @@ under the License.
     </parent>
 
     <artifactId>flink-parquet_${scala.binary.version}</artifactId>
-    <name>flink-avro</name>
+    <name>flink-parquet</name>
 
     <packaging>jar</packaging>
 

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetInputFormat.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetInputFormat.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.io.parquet;
+
+import org.apache.flink.api.common.io.FileInputFormat;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.JobID;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.TaskID;
+import org.apache.hadoop.mapreduce.TaskType;
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+
+import org.apache.parquet.filter2.compat.FilterCompat;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetInputSplit;
+import org.apache.parquet.hadoop.ParquetRecordReader;
+import org.apache.parquet.hadoop.metadata.FileMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.schema.MessageType;
+
+import java.io.IOException;
+
+/**
+ * The base InputFormat class to read from Parquet files.
+ * For specific input types the {@link #convert(Row, Object)} method need to be implemented.
+ *
+ * <p>Using {@link ParquetRecordReader} to read files instead of {@link org.apache.flink.core.fs.FSDataInputStream},
+ * we override {@link #open(FileInputSplit)} and {@link #close()} to change the behaviors.
+ *
+ * <p>Additionally, we should avoid reading all of the footers to create {@link org.apache.flink.core.io.InputSplit}.
+ * As mentioned in <a href="https://issues.apache.org/jira/browse/PARQUET-139">PARQUET-139</a>: "reading all of the
+ * footers to get row group information is a bottle-neck when working with a large number of files and can
+ * significantly delay a job because only one machine is working". Parquet was able to calculate splits based on the
+ * absolute offset without reading file footers. So we can use the result of {@link #createInputSplits(int)} directly.
+ */
+public abstract class ParquetInputFormat<T> extends FileInputFormat<T> {
+	private static final long serialVersionUID = 4308499696607786440L;
+
+	private final TypeInformation[] fieldTypes;
+	protected final String[] fieldNames;
+	/**
+	 * Stores filter instance as bytes, FilterPredicate is not serializable.
+	 */
+	private byte[] filterBytes;
+	private transient ParquetRecordReader<Row> recordReader;
+
+	public ParquetInputFormat(Path filePath, TypeInformation<?>[] fieldTypes, String[] fieldNames) {
+		super(filePath);
+		Preconditions.checkArgument(fieldNames != null && fieldNames.length > 0);
+		Preconditions.checkArgument(fieldTypes != null && fieldTypes.length == fieldNames.length);
+		this.fieldNames = fieldNames;
+		this.fieldTypes = fieldTypes;
+	}
+
+	public void setFilterPredicate(FilterPredicate filter) throws Exception {
+		if (filter != null) {
+			filterBytes = InstantiationUtil.serializeObject(filter);
+		} else {
+			filterBytes = null;
+		}
+	}
+
+	public FilterPredicate getFilterPredicate() {
+		if (filterBytes != null) {
+			try {
+				return InstantiationUtil.deserializeObject(filterBytes, Thread.currentThread().getContextClassLoader());
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public void open(FileInputSplit fileSplit) throws IOException {
+		ParquetInputSplit split = new ParquetInputSplit(
+				new org.apache.hadoop.fs.Path(fileSplit.getPath().toUri()),
+				fileSplit.getStart(),
+				fileSplit.getStart() + fileSplit.getLength(),
+				fileSplit.getLength(),
+				fileSplit.getHostnames(),
+				null
+		);
+
+		Configuration hadoopConf = new Configuration();
+		FilterPredicate filter = getFilterPredicate();
+		if (filter != null) {
+			org.apache.parquet.hadoop.ParquetInputFormat.setFilterPredicate(hadoopConf, filter);
+		}
+		checkSchema(hadoopConf, split);
+
+		ParquetReadSupport readSupport = new ParquetReadSupport(fieldTypes, fieldNames);
+		if (filter != null) {
+			recordReader = new ParquetRecordReader<>(readSupport, FilterCompat.get(filter));
+		} else {
+			recordReader = new ParquetRecordReader<>(readSupport);
+		}
+
+		TaskAttemptID attemptId = new TaskAttemptID(new TaskID(new JobID(), TaskType.MAP, 0), 0);
+		TaskAttemptContext taskAttemptContext = new TaskAttemptContextImpl(hadoopConf, attemptId);
+		try {
+			recordReader.initialize(split, taskAttemptContext);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (recordReader != null) {
+			recordReader.close();
+		}
+	}
+
+	@Override
+	public boolean reachedEnd() throws IOException {
+		try {
+			return !recordReader.nextKeyValue();
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public T nextRecord(T reuse) throws IOException {
+		try {
+			Row currentRow = recordReader.getCurrentValue();
+			return convert(currentRow, reuse);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * convert row to T.
+	 */
+	protected abstract T convert(Row current, T reuse);
+
+	/**
+	 * Check whether Parquet schema matches the given Flink schema.
+	 */
+	private void checkSchema(Configuration hadoopConf, ParquetInputSplit split) throws IOException {
+		ParquetMetadataConverter.MetadataFilter metadataFilter =
+				ParquetMetadataConverter.range(split.getStart(), split.getEnd());
+		ParquetMetadata parquetMetadata = ParquetFileReader.readFooter(hadoopConf, split.getPath(), metadataFilter);
+		FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
+		MessageType parquetSchema = fileMetaData.getSchema();
+
+		ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter();
+		Tuple2<String[], TypeInformation<?>[]> fieldNamesAndTypes =
+				schemaConverter.convertToTypeInformation(parquetSchema);
+		String[] parquetFieldNames = fieldNamesAndTypes.f0;
+		TypeInformation<?>[] parquetFieldTypes = fieldNamesAndTypes.f1;
+
+		for (int i = 0; i < fieldNames.length; ++i) {
+			String fieldName = fieldNames[i];
+			TypeInformation<?> fieldType = fieldTypes[i];
+			int index = ArrayUtils.indexOf(parquetFieldNames, fieldName);
+			if (index < 0) {
+				throw new IllegalArgumentException(fieldName + " can not be found in parquet schema");
+			}
+			TypeInformation<?> parquetFieldType = parquetFieldTypes[index];
+			if (!fieldType.equals(parquetFieldType)) {
+				throw new IllegalArgumentException(parquetFieldType + " can not be convert to " + fieldType);
+			}
+		}
+	}
+}

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetInputFormat.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetInputFormat.java
@@ -71,7 +71,7 @@ public abstract class ParquetInputFormat<T> extends FileInputFormat<T> {
 	private byte[] filterBytes;
 	private transient ParquetRecordReader<Row> recordReader;
 
-	public ParquetInputFormat(Path filePath, TypeInformation<?>[] fieldTypes, String[] fieldNames) {
+	protected ParquetInputFormat(Path filePath, TypeInformation<?>[] fieldTypes, String[] fieldNames) {
 		super(filePath);
 		Preconditions.checkArgument(fieldNames != null && fieldNames.length > 0);
 		Preconditions.checkArgument(fieldTypes != null && fieldTypes.length == fieldNames.length);
@@ -87,7 +87,7 @@ public abstract class ParquetInputFormat<T> extends FileInputFormat<T> {
 		}
 	}
 
-	public FilterPredicate getFilterPredicate() {
+	private FilterPredicate getFilterPredicate() {
 		if (filterBytes != null) {
 			try {
 				return InstantiationUtil.deserializeObject(filterBytes, Thread.currentThread().getContextClassLoader());
@@ -160,7 +160,10 @@ public abstract class ParquetInputFormat<T> extends FileInputFormat<T> {
 	}
 
 	/**
-	 * convert row to T.
+	 * convert the parquet row to specific type T.
+	 * NOTES: `current` is reused in {@link ParquetRecordConverter} to avoid creating row instance for each record,
+	 * so the implementation of this method should copy the values of `current` to `reuse` instead of return
+	 * `current` directly.
 	 */
 	protected abstract T convert(Row current, T reuse);
 

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetReadSupport.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetReadSupport.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.io.parquet;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.types.Row;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.hadoop.api.InitContext;
+import org.apache.parquet.hadoop.api.ReadSupport;
+import org.apache.parquet.io.api.GroupConverter;
+import org.apache.parquet.io.api.RecordMaterializer;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A Parquet {@link ReadSupport} implementation for reading Parquet records as {@link Row}.
+ */
+public class ParquetReadSupport extends ReadSupport<Row> {
+
+	private final String[] fieldNames;
+	private final TypeInformation<?>[] fieldTypes;
+
+	public ParquetReadSupport(TypeInformation<?>[] fieldTypes, String[] fieldNames) {
+		this.fieldNames = fieldNames;
+		this.fieldTypes = fieldTypes;
+	}
+
+	/**
+	 * Called on executor side before {@link #prepareForRead(Configuration, Map, MessageType, ReadContext)} and
+	 * instantiating actual Parquet record readers.
+	 * Responsible for figuring out Parquet requested schema used for column pruning.
+	 */
+	@Override
+	public ReadContext init(InitContext context) {
+		MessageType requestedSchema = clipParquetSchema(context.getFileSchema().asGroupType(), fieldNames);
+		return new ReadContext(requestedSchema, new HashMap<String, String>());
+	}
+
+	/**
+	 * Called on executor side after {@link #init(InitContext)}, before instantiating actual Parquet record readers.
+	 * Responsible for instantiating {@link RecordMaterializer}, which is used for converting Parquet  records to
+	 * {@link Row}.
+	 */
+	@Override
+	public RecordMaterializer<Row> prepareForRead(
+			Configuration configuration,
+			Map<String, String> keyValueMetaData,
+			MessageType fileSchema,
+			ReadContext readContext) {
+
+		GroupType parquetRequestedSchema = readContext.getRequestedSchema();
+		final ParquetRecordConverter recordConverter = new ParquetRecordConverter(parquetRequestedSchema, fieldTypes);
+
+		return new RecordMaterializer<Row>() {
+
+			@Override
+			public Row getCurrentRecord() {
+				return recordConverter.getCurrentRecord();
+			}
+
+			@Override
+			public GroupConverter getRootConverter() {
+				return recordConverter;
+			}
+		};
+	}
+
+	/**
+	 * Clips `parquetSchema` according to `fieldNames`.
+	 */
+	private MessageType clipParquetSchema(GroupType parquetSchema, String[] fieldNames) {
+		Type[] types = new Type[fieldNames.length];
+		for (int i = 0; i < fieldNames.length; ++i) {
+			String fieldName = fieldNames[i];
+			if (parquetSchema.getFieldIndex(fieldName) < 0) {
+				throw new IllegalArgumentException(fieldName + " does not exist");
+			}
+			types[i] = parquetSchema.getType(fieldName);
+		}
+		return Types.buildMessage().addFields(types).named("flink-parquet");
+	}
+
+}

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetRecordConverter.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetRecordConverter.java
@@ -247,7 +247,8 @@ public class ParquetRecordConverter extends GroupConverter {
 
 		@Override
 		protected void validatePrimitiveType(PrimitiveType type) {
-			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT32);
+			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT32 &&
+					(type.getOriginalType() == null || type.getOriginalType() == OriginalType.INT_32));
 		}
 
 		@Override
@@ -265,7 +266,8 @@ public class ParquetRecordConverter extends GroupConverter {
 
 		@Override
 		protected void validatePrimitiveType(PrimitiveType type) {
-			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT64);
+			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT64 &&
+					(type.getOriginalType() == null || type.getOriginalType() == OriginalType.INT_64));
 		}
 
 		@Override
@@ -369,7 +371,8 @@ public class ParquetRecordConverter extends GroupConverter {
 
 		@Override
 		protected void validatePrimitiveType(PrimitiveType type) {
-			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.BINARY);
+			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.BINARY &&
+					(type.getOriginalType() == null || type.getOriginalType() == OriginalType.BSON));
 		}
 
 		@Override

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetRecordConverter.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetRecordConverter.java
@@ -1,0 +1,387 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.io.parquet;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.io.api.Converter;
+import org.apache.parquet.io.api.GroupConverter;
+import org.apache.parquet.io.api.PrimitiveConverter;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link ParquetRecordConverter} is used to convert Parquet records into {@link Row}.
+ */
+public class ParquetRecordConverter extends GroupConverter {
+
+	private final Row currentRow;
+	private final List<Converter> fieldConverters;
+
+	/**
+	 * Currently supported {@link TypeInformation}s.
+	 */
+	private static final Map<TypeInformation, ConverterCreator> CONVERTER_CREATOR_MAP =
+			new HashMap<TypeInformation, ConverterCreator>() {
+				private static final long serialVersionUID = 2137301835386882070L;
+
+				{
+					put(BasicTypeInfo.STRING_TYPE_INFO, new StringConverterCreator());
+					put(BasicTypeInfo.BOOLEAN_TYPE_INFO, new BooleanConverterCreator());
+					put(BasicTypeInfo.BYTE_TYPE_INFO, new ByteConverterCreator());
+					put(BasicTypeInfo.SHORT_TYPE_INFO, new ShortConverterCreator());
+					put(BasicTypeInfo.INT_TYPE_INFO, new IntConverterCreator());
+					put(BasicTypeInfo.LONG_TYPE_INFO, new LongConverterCreator());
+					put(BasicTypeInfo.FLOAT_TYPE_INFO, new FloatConverterCreator());
+					put(BasicTypeInfo.DOUBLE_TYPE_INFO, new DoubleConverterCreator());
+					put(BasicTypeInfo.DATE_TYPE_INFO, new DateConverterCreator());
+					put(BasicTypeInfo.BIG_DEC_TYPE_INFO, new BigDecConverterCreator());
+					put(PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO, new ByteArrayConverterCreator());
+				}
+			};
+
+	public ParquetRecordConverter(GroupType parquetType, TypeInformation<?>[] fieldTypes) {
+		Preconditions.checkArgument(parquetType.getFieldCount() == fieldTypes.length);
+
+		int fieldCount = parquetType.getFieldCount();
+		currentRow = new Row(fieldCount);
+
+		fieldConverters = new ArrayList<>(fieldCount);
+		for (int i = 0; i < fieldCount; ++i) {
+			Type type = parquetType.getType(i);
+			TypeInformation<?> fieldType = fieldTypes[i];
+			ConverterCreator converterCreator = CONVERTER_CREATOR_MAP.get(fieldType);
+			if (converterCreator == null) {
+				throw new UnsupportedOperationException(fieldType + " is not support");
+			}
+			Converter converter = converterCreator.createConverter(type, new RowFieldSetter(currentRow, i));
+			fieldConverters.add(converter);
+		}
+	}
+
+	@Override
+	public Converter getConverter(int fieldIndex) {
+		return fieldConverters.get(fieldIndex);
+	}
+
+	public Row getCurrentRecord() {
+		return currentRow;
+	}
+
+	@Override
+	public void start() {
+		// clear last value for each field
+		for (int i = 0; i < currentRow.getArity(); ++i) {
+			currentRow.setField(i, null);
+		}
+	}
+
+	@Override
+	public void end() {
+	}
+
+	/**
+	 * Sets a value to the row at the specified position.
+	 */
+	private static class RowFieldSetter {
+		private final Row currentRow;
+		private final int position;
+
+		RowFieldSetter(Row currentRow, int position) {
+			this.currentRow = currentRow;
+			this.position = position;
+		}
+
+		public void set(Object value) {
+			currentRow.setField(position, value);
+		}
+	}
+
+	/**
+	 * A converter for primitive type.
+	 */
+	private abstract static class ParquetPrimitiveConverter extends PrimitiveConverter {
+
+		final RowFieldSetter fieldSetter;
+
+		ParquetPrimitiveConverter(RowFieldSetter fieldSetter) {
+			this.fieldSetter = fieldSetter;
+		}
+	}
+
+	/**
+	 * A {@link ConverterCreator} is used to create a new {@link Converter} for specified {@link Type}.
+	 */
+	private abstract static class ConverterCreator {
+
+		private Converter createConverter(Type type, RowFieldSetter fieldSetter) {
+			validateType(type);
+			return newConverter(fieldSetter);
+		}
+
+		protected abstract void validateType(Type type);
+
+		protected abstract Converter newConverter(RowFieldSetter fieldSetter);
+	}
+
+	/**
+	 * A {@link PrimitiveConverterCreator} is used to create a new {@link Converter} for specified
+	 * {@link PrimitiveType}.
+	 */
+	private abstract static class PrimitiveConverterCreator extends ConverterCreator {
+		@Override
+		protected void validateType(Type type) {
+			Preconditions.checkArgument(type.isPrimitive());
+			validatePrimitiveType(type.asPrimitiveType());
+		}
+
+		protected abstract void validatePrimitiveType(PrimitiveType type);
+	}
+
+	private static class StringConverterCreator extends PrimitiveConverterCreator {
+
+		@Override
+		protected void validatePrimitiveType(PrimitiveType type) {
+			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.BINARY);
+		}
+
+		@Override
+		protected Converter newConverter(RowFieldSetter fieldSetter) {
+			return new ParquetPrimitiveConverter(fieldSetter) {
+				@Override
+				public void addBinary(Binary value) {
+					fieldSetter.set(new String(value.getBytes()));
+				}
+			};
+		}
+	}
+
+	private static class BooleanConverterCreator extends PrimitiveConverterCreator {
+
+		@Override
+		protected void validatePrimitiveType(PrimitiveType type) {
+			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.BOOLEAN);
+		}
+
+		@Override
+		protected Converter newConverter(RowFieldSetter fieldSetter) {
+			return new ParquetPrimitiveConverter(fieldSetter) {
+				@Override
+				public void addBoolean(boolean value) {
+					fieldSetter.set(value);
+				}
+			};
+		}
+	}
+
+	private static class ByteConverterCreator extends PrimitiveConverterCreator {
+
+		@Override
+		protected void validatePrimitiveType(PrimitiveType type) {
+			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT32
+					&& type.getOriginalType() == OriginalType.INT_8);
+		}
+
+		@Override
+		protected Converter newConverter(RowFieldSetter fieldSetter) {
+			return new ParquetPrimitiveConverter(fieldSetter) {
+				@Override
+				public void addInt(int value) {
+					fieldSetter.set((byte) value);
+				}
+			};
+		}
+	}
+
+	private static class ShortConverterCreator extends PrimitiveConverterCreator {
+
+		@Override
+		protected void validatePrimitiveType(PrimitiveType type) {
+			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT32
+					&& type.getOriginalType() == OriginalType.INT_16);
+		}
+
+		@Override
+		protected Converter newConverter(RowFieldSetter fieldSetter) {
+			return new ParquetPrimitiveConverter(fieldSetter) {
+				@Override
+				public void addInt(int value) {
+					fieldSetter.set((short) value);
+				}
+			};
+		}
+	}
+
+	private static class IntConverterCreator extends PrimitiveConverterCreator {
+
+		@Override
+		protected void validatePrimitiveType(PrimitiveType type) {
+			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT32);
+		}
+
+		@Override
+		protected Converter newConverter(RowFieldSetter fieldSetter) {
+			return new ParquetPrimitiveConverter(fieldSetter) {
+				@Override
+				public void addInt(int value) {
+					fieldSetter.set(value);
+				}
+			};
+		}
+	}
+
+	private static class LongConverterCreator extends PrimitiveConverterCreator {
+
+		@Override
+		protected void validatePrimitiveType(PrimitiveType type) {
+			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT64);
+		}
+
+		@Override
+		protected Converter newConverter(RowFieldSetter fieldSetter) {
+			return new ParquetPrimitiveConverter(fieldSetter) {
+				@Override
+				public void addLong(long value) {
+					fieldSetter.set(value);
+				}
+			};
+		}
+	}
+
+	private static class FloatConverterCreator extends PrimitiveConverterCreator {
+
+		@Override
+		protected void validatePrimitiveType(PrimitiveType type) {
+			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.FLOAT);
+		}
+
+		@Override
+		protected Converter newConverter(RowFieldSetter fieldSetter) {
+			return new ParquetPrimitiveConverter(fieldSetter) {
+				@Override
+				public void addFloat(float value) {
+					fieldSetter.set(value);
+				}
+			};
+		}
+	}
+
+	private static class DoubleConverterCreator extends PrimitiveConverterCreator {
+
+		@Override
+		protected void validatePrimitiveType(PrimitiveType type) {
+			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.DOUBLE);
+		}
+
+		@Override
+		protected Converter newConverter(RowFieldSetter fieldSetter) {
+			return new ParquetPrimitiveConverter(fieldSetter) {
+				@Override
+				public void addDouble(double value) {
+					fieldSetter.set(value);
+				}
+			};
+		}
+	}
+
+	private static class DateConverterCreator extends PrimitiveConverterCreator {
+
+		@Override
+		protected void validatePrimitiveType(PrimitiveType type) {
+			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT32
+					&& type.getOriginalType() == OriginalType.DATE);
+		}
+
+		@Override
+		protected Converter newConverter(RowFieldSetter fieldSetter) {
+			return new ParquetPrimitiveConverter(fieldSetter) {
+				@Override
+				public void addInt(int value) {
+					fieldSetter.set(new Date(value));
+				}
+			};
+		}
+	}
+
+	private static class BigDecConverterCreator extends PrimitiveConverterCreator {
+
+		@Override
+		protected void validatePrimitiveType(PrimitiveType type) {
+			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT32 ||
+					type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT64 ||
+					type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.BINARY);
+			Preconditions.checkArgument(type.getOriginalType() == OriginalType.DECIMAL);
+		}
+
+		@Override
+		protected Converter newConverter(RowFieldSetter fieldSetter) {
+			return new ParquetPrimitiveConverter(fieldSetter) {
+				@Override
+				public void addInt(int value) {
+					fieldSetter.set(new BigDecimal(value));
+				}
+
+				@Override
+				public void addLong(long value) {
+					fieldSetter.set(new BigDecimal(value));
+				}
+
+				@Override
+				public void addBinary(Binary value) {
+					fieldSetter.set(new BigDecimal(new BigInteger(value.getBytes())));
+				}
+			};
+		}
+	}
+
+	private static class ByteArrayConverterCreator extends PrimitiveConverterCreator {
+
+		@Override
+		protected void validatePrimitiveType(PrimitiveType type) {
+			Preconditions.checkArgument(type.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.BINARY);
+		}
+
+		@Override
+		protected Converter newConverter(RowFieldSetter fieldSetter) {
+			return new ParquetPrimitiveConverter(fieldSetter) {
+
+				@Override
+				public void addBinary(Binary value) {
+					fieldSetter.set(value.getBytes());
+				}
+			};
+		}
+	}
+
+}

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetRecordConverter.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetRecordConverter.java
@@ -46,6 +46,9 @@ import java.util.Map;
  */
 public class ParquetRecordConverter extends GroupConverter {
 
+	/**
+	 * currentRow is reused to avoid creating row instance for each record.
+	 */
 	private final Row currentRow;
 	private final List<Converter> fieldConverters;
 

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetSchemaConverter.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetSchemaConverter.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.io.parquet;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+
+import java.util.List;
+
+/**
+ * A {@link ParquetSchemaConverter} is used to convert Parquet {@link MessageType} to
+ * Flink field-names and {@link TypeInformation}s, and vice versa.
+ */
+public class ParquetSchemaConverter {
+
+	/**
+	 * Converts Parquet {@link MessageType} to Flink field-name and {@link TypeInformation}.
+	 */
+	public Tuple2<String[], TypeInformation<?>[]> convertToTypeInformation(MessageType parquetSchema) {
+		List<Type> types = parquetSchema.asGroupType().getFields();
+		int len = types.size();
+		String[] fieldNames = new String[len];
+		TypeInformation<?>[] fieldTypes = new TypeInformation<?>[len];
+
+		for (int i = 0; i < len; ++i) {
+			Type type = types.get(i);
+			fieldNames[i] = type.getName();
+			switch (type.getRepetition()) {
+				case OPTIONAL:
+				case REQUIRED:
+					fieldTypes[i] = convertType(type);
+					break;
+				case REPEATED:
+					throw new UnsupportedOperationException(type + " is not supported");
+			}
+		}
+		return new Tuple2<>(fieldNames, fieldTypes);
+	}
+
+	/**
+	 * Converts a Parquet {@link Type} to a Flink {@link TypeInformation}.
+	 */
+	private TypeInformation<?> convertType(Type parquetType) {
+		if (parquetType.isPrimitive()) {
+			return convertPrimitiveType(parquetType.asPrimitiveType());
+		} else {
+			return convertGroupType(parquetType.asGroupType());
+		}
+	}
+
+	/**
+	 * Converts a primitive Parquet {@link Type} to a Flink {@link TypeInformation}.
+	 */
+	private TypeInformation<?> convertPrimitiveType(PrimitiveType primitiveType) {
+		PrimitiveType.PrimitiveTypeName typeName = primitiveType.getPrimitiveTypeName();
+		OriginalType originalType = primitiveType.getOriginalType();
+
+		switch (typeName) {
+			case BOOLEAN:
+				return BasicTypeInfo.BOOLEAN_TYPE_INFO;
+			case FLOAT:
+				return BasicTypeInfo.FLOAT_TYPE_INFO;
+			case DOUBLE:
+				return BasicTypeInfo.DOUBLE_TYPE_INFO;
+			case INT32:
+				return convertOriginalType_INT32(originalType);
+			case INT64:
+				return convertOriginalType_INT64(originalType);
+			case BINARY:
+				return convertOriginalType_BINARY(originalType);
+			case INT96:
+			case FIXED_LEN_BYTE_ARRAY:
+			default:
+				throw new UnsupportedOperationException(typeName + " is not supported");
+		}
+	}
+
+	private TypeInformation<?> convertOriginalType_INT32(OriginalType originalType) {
+		if (originalType == null) {
+			return BasicTypeInfo.INT_TYPE_INFO;
+		}
+		switch (originalType) {
+			case INT_8:
+				return BasicTypeInfo.BYTE_TYPE_INFO;
+			case INT_16:
+				return BasicTypeInfo.SHORT_TYPE_INFO;
+			case INT_32:
+				return BasicTypeInfo.INT_TYPE_INFO;
+			case DATE:
+				return BasicTypeInfo.DATE_TYPE_INFO;
+			case DECIMAL:
+				return BasicTypeInfo.BIG_DEC_TYPE_INFO;
+			case UINT_8:
+			case UINT_16:
+			case UINT_32:
+			case TIME_MILLIS:
+			default:
+				throw new UnsupportedOperationException(originalType + " is not supported");
+		}
+	}
+
+	private TypeInformation<?> convertOriginalType_INT64(OriginalType originalType) {
+		if (originalType == null) {
+			return BasicTypeInfo.LONG_TYPE_INFO;
+		}
+		switch (originalType) {
+			case INT_64:
+				return BasicTypeInfo.LONG_TYPE_INFO;
+			case DECIMAL:
+				return BasicTypeInfo.BIG_DEC_TYPE_INFO;
+			case TIMESTAMP_MILLIS:
+			case UINT_64:
+			default:
+				throw new UnsupportedOperationException(originalType + " is not supported");
+		}
+	}
+
+	private TypeInformation<?> convertOriginalType_BINARY(OriginalType originalType) {
+		if (originalType == null) {
+			return PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO;
+		}
+		switch (originalType) {
+			case UTF8:
+			case ENUM:
+			case JSON:
+				return BasicTypeInfo.STRING_TYPE_INFO;
+			case BSON:
+				return PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO;
+			case DECIMAL:
+				return BasicTypeInfo.BIG_DEC_TYPE_INFO;
+			default:
+				throw new UnsupportedOperationException(originalType + " is not supported");
+		}
+	}
+
+	/**
+	 * Converts a combined Parquet {@link Type} to a Flink {@link TypeInformation}.
+	 */
+	private TypeInformation<?> convertGroupType(GroupType groupType) {
+		throw new UnsupportedOperationException(groupType + " is not supported");
+	}
+
+}

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetSchemaConverter.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetSchemaConverter.java
@@ -34,12 +34,12 @@ import java.util.Map;
 
 /**
  * A {@link ParquetSchemaConverter} is used to convert Parquet {@link MessageType} to
- * Flink field-names and {@link TypeInformation}s, and vice versa.
+ * Flink field-name and {@link TypeInformation} pairs, and vice versa.
  */
 public class ParquetSchemaConverter {
 
 	/**
-	 * Converts Parquet {@link MessageType} to Flink field-name and {@link TypeInformation}.
+	 * Converts Parquet {@link MessageType} to Flink field-name and {@link TypeInformation} pairs.
 	 */
 	public Map<String, TypeInformation<?>> convertToTypeInformation(MessageType parquetSchema) {
 		List<Type> types = parquetSchema.asGroupType().getFields();

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetSchemaConverter.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/ParquetSchemaConverter.java
@@ -35,6 +35,8 @@ import java.util.Map;
 /**
  * A {@link ParquetSchemaConverter} is used to convert Parquet {@link MessageType} to
  * Flink field-name and {@link TypeInformation} pairs, and vice versa.
+ *
+ * TODO supports more Flink TypeInformation and Parquet MessageType
  */
 public class ParquetSchemaConverter {
 
@@ -51,7 +53,7 @@ public class ParquetSchemaConverter {
 				case REQUIRED:
 					result.put(name, convertType(type));
 					break;
-				case REPEATED:
+				default:
 					throw new UnsupportedOperationException(type + " is not supported");
 			}
 		}

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/PojoParquetInputFormat.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/PojoParquetInputFormat.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.io.parquet;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.PojoTypeInfo;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A subclass of {@link ParquetInputFormat} to read from Parquet files and convert to POJO type.
+ */
+public class PojoParquetInputFormat<OUT> extends ParquetInputFormat<OUT> {
+	private static final long serialVersionUID = -7396017155381358924L;
+
+	private final Class<OUT> pojoTypeClass;
+	private final TypeSerializer<OUT> pojoSerializer;
+	private transient Field[] pojoFields;
+
+	public PojoParquetInputFormat(Path filePath, PojoTypeInfo<OUT> pojoTypeInfo) {
+		this(filePath, pojoTypeInfo, pojoTypeInfo.getFieldNames());
+	}
+
+	public PojoParquetInputFormat(Path filePath, PojoTypeInfo<OUT> pojoTypeInfo, String[] fieldNames) {
+		super(filePath, extractTypeInfos(pojoTypeInfo, fieldNames), fieldNames);
+
+		this.pojoSerializer = pojoTypeInfo.createSerializer(new ExecutionConfig());
+		this.pojoTypeClass = pojoTypeInfo.getTypeClass();
+	}
+
+	@Override
+	public void open(FileInputSplit split) throws IOException {
+		super.open(split);
+
+		pojoFields = new Field[fieldNames.length];
+
+		final Map<String, Field> allFields = new HashMap<>();
+		findAllFields(pojoTypeClass, allFields);
+
+		for (int i = 0; i < fieldNames.length; i++) {
+			String fieldName = fieldNames[i];
+			pojoFields[i] = allFields.get(fieldName);
+
+			if (pojoFields[i] != null) {
+				pojoFields[i].setAccessible(true);
+			} else {
+				throw new RuntimeException(
+						"There is no field called \"" + fieldName + "\" in " + pojoTypeClass.getName());
+			}
+		}
+	}
+
+	@Override
+	public OUT convert(Row current, OUT reuse) {
+		if (reuse == null) {
+			reuse = pojoSerializer.createInstance();
+		}
+		for (int i = 0; i < current.getArity(); ++i) {
+			try {
+				pojoFields[i].set(reuse, current.getField(i));
+			} catch (IllegalAccessException e) {
+				throw new RuntimeException("Parsed value could not be set in POJO field \"" + fieldNames[i] + "\"", e);
+			}
+		}
+		return reuse;
+	}
+
+	/**
+	 * Finds all declared fields in a class and all its super classes.
+	 *
+	 * @param clazz Class for which all declared fields are found
+	 * @param allFields Map containing all found fields so far
+	 */
+	private void findAllFields(Class<?> clazz, Map<String, Field> allFields) {
+		for (Field field : clazz.getDeclaredFields()) {
+			allFields.put(field.getName(), field);
+		}
+
+		if (clazz.getSuperclass() != null) {
+			findAllFields(clazz.getSuperclass(), allFields);
+		}
+	}
+
+	/**
+	 * Extracts the {@link TypeInformation}s from {@link PojoTypeInfo} corresponding to the given fieldNames.
+	 */
+	private static <OUT> TypeInformation<?>[] extractTypeInfos(PojoTypeInfo<OUT> pojoTypeInfo, String[] fieldNames) {
+		Preconditions.checkNotNull(pojoTypeInfo);
+		Preconditions.checkNotNull(fieldNames);
+		Preconditions.checkArgument(pojoTypeInfo.getArity() >= fieldNames.length);
+
+		TypeInformation<?>[] fieldTypes = new TypeInformation<?>[fieldNames.length];
+		for (int i = 0; i < fieldNames.length; ++i) {
+			String fieldName = fieldNames[i];
+			Preconditions.checkNotNull(fieldName, "The field name cannot be null.");
+			int fieldPos = pojoTypeInfo.getFieldIndex(fieldName);
+			Preconditions.checkArgument(fieldPos >= 0, "Field \"" + fieldName + "\" is not a member of POJO class "
+					+ pojoTypeInfo.getTypeClass().getName());
+			fieldTypes[i] = pojoTypeInfo.getTypeAt(fieldPos);
+		}
+		return fieldTypes;
+	}
+
+}

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/PojoParquetInputFormat.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/PojoParquetInputFormat.java
@@ -47,9 +47,14 @@ public class PojoParquetInputFormat<OUT> extends ParquetInputFormat<OUT> {
 	}
 
 	public PojoParquetInputFormat(Path filePath, PojoTypeInfo<OUT> pojoTypeInfo, String[] fieldNames) {
+		this(filePath, pojoTypeInfo, fieldNames, new ExecutionConfig());
+	}
+
+	public PojoParquetInputFormat(Path filePath, PojoTypeInfo<OUT> pojoTypeInfo, String[] fieldNames,
+			ExecutionConfig config) {
 		super(filePath, extractTypeInfo(pojoTypeInfo, fieldNames), fieldNames);
 
-		this.pojoSerializer = pojoTypeInfo.createSerializer(new ExecutionConfig());
+		this.pojoSerializer = pojoTypeInfo.createSerializer(config);
 		this.pojoTypeClass = pojoTypeInfo.getTypeClass();
 	}
 

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/PojoParquetInputFormat.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/PojoParquetInputFormat.java
@@ -47,7 +47,7 @@ public class PojoParquetInputFormat<OUT> extends ParquetInputFormat<OUT> {
 	}
 
 	public PojoParquetInputFormat(Path filePath, PojoTypeInfo<OUT> pojoTypeInfo, String[] fieldNames) {
-		super(filePath, extractTypeInfos(pojoTypeInfo, fieldNames), fieldNames);
+		super(filePath, extractTypeInfo(pojoTypeInfo, fieldNames), fieldNames);
 
 		this.pojoSerializer = pojoTypeInfo.createSerializer(new ExecutionConfig());
 		this.pojoTypeClass = pojoTypeInfo.getTypeClass();
@@ -109,7 +109,7 @@ public class PojoParquetInputFormat<OUT> extends ParquetInputFormat<OUT> {
 	/**
 	 * Extracts the {@link TypeInformation}s from {@link PojoTypeInfo} corresponding to the given fieldNames.
 	 */
-	private static <OUT> TypeInformation<?>[] extractTypeInfos(PojoTypeInfo<OUT> pojoTypeInfo, String[] fieldNames) {
+	private static <OUT> TypeInformation<?>[] extractTypeInfo(PojoTypeInfo<OUT> pojoTypeInfo, String[] fieldNames) {
 		Preconditions.checkNotNull(pojoTypeInfo);
 		Preconditions.checkNotNull(fieldNames);
 		Preconditions.checkArgument(pojoTypeInfo.getArity() >= fieldNames.length);

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/RowParquetInputFormat.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/RowParquetInputFormat.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.io.parquet;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A subclass of {@link ParquetInputFormat} to read from Parquet files and convert to {@link Row}.
+ */
+public class RowParquetInputFormat extends ParquetInputFormat<Row> {
+
+	private static final long serialVersionUID = -2569974518641072339L;
+
+	public RowParquetInputFormat(Path filePath, TypeInformation[] fieldTypes, String[] fieldNames) {
+		super(filePath, fieldTypes, fieldNames);
+	}
+
+	@Override
+	public Row convert(Row current, Row reuse) {
+		if (reuse == null) {
+			return Row.copy(current);
+		} else {
+			Preconditions.checkArgument(current.getArity() == reuse.getArity());
+			for (int i = 0; i < current.getArity(); ++i) {
+				reuse.setField(i, current.getField(i));
+			}
+			return reuse;
+		}
+	}
+
+}

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/TupleParquetInputFormat.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/TupleParquetInputFormat.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.io.parquet;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.TupleTypeInfoBase;
+import org.apache.flink.api.java.typeutils.runtime.TupleSerializerBase;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A subclass of {@link ParquetInputFormat} to read from Parquet files and convert to Tuple.
+ */
+public class TupleParquetInputFormat<OUT> extends ParquetInputFormat<OUT> {
+	private static final long serialVersionUID = -9021324522796675550L;
+
+	private final TupleSerializerBase<OUT> tupleSerializer;
+
+	public TupleParquetInputFormat(Path filePath, TupleTypeInfoBase<OUT> tupleTypeInfo, String[] fieldNames) {
+		super(filePath, extractTypeInfos(tupleTypeInfo), fieldNames);
+		this.tupleSerializer = (TupleSerializerBase<OUT>) tupleTypeInfo.createSerializer(new ExecutionConfig());
+	}
+
+	@Override
+	public OUT convert(Row current, OUT reuse) {
+		Object[] values = new Object[current.getArity()];
+		for (int i = 0; i < current.getArity(); ++i) {
+			values[i] = current.getField(i);
+		}
+		if (reuse == null) {
+			return tupleSerializer.createInstance(values);
+		} else {
+			return tupleSerializer.createOrReuseInstance(values, reuse);
+		}
+	}
+
+	private static <OUT> TypeInformation<?>[] extractTypeInfos(TupleTypeInfoBase<OUT> tupleTypeInfo) {
+		Preconditions.checkNotNull(tupleTypeInfo);
+
+		TypeInformation<?>[] fieldTypes = new TypeInformation<?>[tupleTypeInfo.getArity()];
+		for (int i = 0; i < tupleTypeInfo.getArity(); ++i) {
+			fieldTypes[i] = tupleTypeInfo.getTypeAt(i);
+		}
+		return fieldTypes;
+	}
+
+}

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/TupleParquetInputFormat.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/TupleParquetInputFormat.java
@@ -35,8 +35,13 @@ public class TupleParquetInputFormat<OUT> extends ParquetInputFormat<OUT> {
 	private final TupleSerializerBase<OUT> tupleSerializer;
 
 	public TupleParquetInputFormat(Path filePath, TupleTypeInfoBase<OUT> tupleTypeInfo, String[] fieldNames) {
+		this(filePath, tupleTypeInfo, fieldNames, new ExecutionConfig());
+	}
+
+	public TupleParquetInputFormat(Path filePath, TupleTypeInfoBase<OUT> tupleTypeInfo, String[] fieldNames,
+			ExecutionConfig config) {
 		super(filePath, extractTypeInfo(tupleTypeInfo), fieldNames);
-		this.tupleSerializer = (TupleSerializerBase<OUT>) tupleTypeInfo.createSerializer(new ExecutionConfig());
+		this.tupleSerializer = (TupleSerializerBase<OUT>) tupleTypeInfo.createSerializer(config);
 	}
 
 	@Override

--- a/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/TupleParquetInputFormat.java
+++ b/flink-connectors/flink-parquet/src/main/java/org/apache/flink/api/io/parquet/TupleParquetInputFormat.java
@@ -35,7 +35,7 @@ public class TupleParquetInputFormat<OUT> extends ParquetInputFormat<OUT> {
 	private final TupleSerializerBase<OUT> tupleSerializer;
 
 	public TupleParquetInputFormat(Path filePath, TupleTypeInfoBase<OUT> tupleTypeInfo, String[] fieldNames) {
-		super(filePath, extractTypeInfos(tupleTypeInfo), fieldNames);
+		super(filePath, extractTypeInfo(tupleTypeInfo), fieldNames);
 		this.tupleSerializer = (TupleSerializerBase<OUT>) tupleTypeInfo.createSerializer(new ExecutionConfig());
 	}
 
@@ -52,7 +52,7 @@ public class TupleParquetInputFormat<OUT> extends ParquetInputFormat<OUT> {
 		}
 	}
 
-	private static <OUT> TypeInformation<?>[] extractTypeInfos(TupleTypeInfoBase<OUT> tupleTypeInfo) {
+	private static <OUT> TypeInformation<?>[] extractTypeInfo(TupleTypeInfoBase<OUT> tupleTypeInfo) {
 		Preconditions.checkNotNull(tupleTypeInfo);
 
 		TypeInformation<?>[] fieldTypes = new TypeInformation<?>[tupleTypeInfo.getArity()];

--- a/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/ParquetInputFormatTest.java
+++ b/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/ParquetInputFormatTest.java
@@ -1,0 +1,469 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.io.parquet;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.io.FileUtils;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.filter2.predicate.FilterApi;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetFileWriter;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.Types;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.List;
+import java.util.Random;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
+import static org.apache.parquet.filter2.predicate.FilterApi.doubleColumn;
+import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Tests for {@link ParquetInputFormat} and {@link RowParquetInputFormat}.
+ */
+public class ParquetInputFormatTest {
+
+	@Test
+	public void testIllegalConstructorArguments() {
+		org.apache.flink.core.fs.Path path = new org.apache.flink.core.fs.Path(getClass().getResource(".").getFile());
+
+		try {
+			// empty field name
+			new RowParquetInputFormat(path, new TypeInformation[]{BasicTypeInfo.INT_TYPE_INFO}, new String[0]);
+			assertFalse(true);
+		} catch (IllegalArgumentException e) {
+			assertTrue(true);
+		}
+
+		try {
+			// empty field type
+			new RowParquetInputFormat(path, new TypeInformation[0], new String[]{"f1", "f2"});
+			assertFalse(true);
+		} catch (IllegalArgumentException e) {
+			assertTrue(true);
+		}
+
+		try {
+			// the length of field types and field names is not equal
+			new RowParquetInputFormat(
+					path,
+					new TypeInformation[]{BasicTypeInfo.INT_TYPE_INFO},
+					new String[]{"f1", "f2"});
+			assertFalse(true);
+		} catch (IllegalArgumentException e) {
+			assertTrue(true);
+		}
+	}
+
+	@Test
+	public void testSplitOneFileWithOneRowGroup() throws IOException {
+		final File tmpFile = File.createTempFile("flink-parquet-test-data", ".parquet");
+		tmpFile.deleteOnExit();
+		Configuration conf = new Configuration();
+		genParquetFileWithOneField(conf, tmpFile.toString(), 100);
+
+		ParquetMetadata parquetMetadata = ParquetFileReader.readFooter(conf, new Path(tmpFile.toURI()), NO_FILTER);
+		List<BlockMetaData> blocks = parquetMetadata.getBlocks();
+		assertEquals(1, blocks.size());
+
+		RowParquetInputFormat inputFormat = new RowParquetInputFormat(
+				new org.apache.flink.core.fs.Path(tmpFile.toURI()),
+				new TypeInformation[]{BasicTypeInfo.DOUBLE_TYPE_INFO},
+				new String[]{"f1"});
+		FileInputSplit[] splits = inputFormat.createInputSplits(2);
+		assertEquals(2, splits.length);
+
+		// read first block
+		inputFormat.open(splits[0]);
+		checkResult(inputFormat, blocks.get(0).getRowCount());
+
+		// read second block
+		inputFormat.open(splits[1]);
+		checkResult(inputFormat, 0);
+	}
+
+	@Test
+	public void testSplitOneFileWithMultiRowGroup() throws IOException {
+		final File tmpFile = File.createTempFile("flink-parquet-test-data", ".parquet");
+		tmpFile.deleteOnExit();
+		Configuration conf = new Configuration();
+		genParquetFileWithOneField(conf, tmpFile.toString(), 200);
+
+		ParquetMetadata parquetMetadata = ParquetFileReader.readFooter(conf, new Path(tmpFile.toURI()), NO_FILTER);
+		List<BlockMetaData> blocks = parquetMetadata.getBlocks();
+		assertEquals(2, blocks.size());
+
+		RowParquetInputFormat inputFormat = new RowParquetInputFormat(
+				new org.apache.flink.core.fs.Path(tmpFile.toURI()),
+				new TypeInformation[]{BasicTypeInfo.DOUBLE_TYPE_INFO},
+				new String[]{"f1"});
+		FileInputSplit[] splits = inputFormat.createInputSplits(2);
+		assertEquals(2, splits.length);
+
+		// read first block
+		inputFormat.open(splits[0]);
+		checkResult(inputFormat, blocks.get(0).getRowCount());
+
+		// read second block
+		inputFormat.open(splits[1]);
+		checkResult(inputFormat, blocks.get(1).getRowCount());
+	}
+
+	private void checkResult(RowParquetInputFormat inputFormat, long expectedRowCount) throws IOException {
+		long totalCount = 0;
+		while (!inputFormat.reachedEnd()) {
+			totalCount++;
+			Row row = inputFormat.nextRecord(null);
+			assertEquals(1, row.getArity());
+			assertTrue(row.getField(0) instanceof Double);
+			double value = (double) row.getField(0);
+			assertTrue(0 <= value && value < 1);
+		}
+		assertEquals(expectedRowCount, totalCount);
+		inputFormat.close();
+	}
+
+	@Test
+	public void testSplitWithMultiFile() throws IOException {
+		final File path = new File(getClass().getResource(".").getFile() + "flink-parquet-test");
+		FileUtils.deleteDirectory(path);
+		if (path.exists()) {
+			throw new IOException(" can not delete path " + path);
+		}
+		if (!path.mkdirs()) {
+			throw new IOException("can not create path " + path);
+		}
+
+		File[] files = new File[3];
+		for (int i = 0; i < files.length; ++i) {
+			final File tmpFile = File.createTempFile("flink-parquet-test-data-" + i + "-", ".parquet", path);
+			tmpFile.deleteOnExit();
+			files[i] = tmpFile;
+		}
+
+		Configuration conf = new Configuration();
+
+		for (int i = 0; i < files.length; ++i) {
+			genParquetFileWithOneField(conf, files[i].toString(), 200 * (i + 1));
+		}
+
+		RowParquetInputFormat inputFormat = new RowParquetInputFormat(
+				new org.apache.flink.core.fs.Path(path.toURI()),
+				new TypeInformation[]{BasicTypeInfo.DOUBLE_TYPE_INFO},
+				new String[]{"f1"});
+		FileInputSplit[] splits = inputFormat.createInputSplits(2);
+		assertEquals(3, splits.length);
+
+		for (FileInputSplit split : splits) {
+			inputFormat.open(split);
+			int totalCount = 0;
+			while (!inputFormat.reachedEnd()) {
+				totalCount++;
+				inputFormat.nextRecord(null);
+			}
+			ParquetMetadata metadata = ParquetFileReader.readFooter(conf, new Path(split.getPath().toUri()), NO_FILTER);
+			int rowCount = 0;
+			for (BlockMetaData block : metadata.getBlocks()) {
+				rowCount += block.getRowCount();
+			}
+			assertEquals(rowCount, totalCount);
+		}
+	}
+
+	@Test
+	public void testSupportedTypeInfos() throws IOException {
+		final File tmpFile = File.createTempFile("flink-parquet-test-data", ".parquet");
+		tmpFile.deleteOnExit();
+		Configuration conf = new Configuration();
+		MessageType parquetSchema = Types.buildMessage().addFields(
+				Types.required(BOOLEAN).named("boolean"),
+				Types.required(FLOAT).named("float"),
+				Types.required(DOUBLE).named("double"),
+				Types.required(INT32).as(null).named("int_original_null"),
+				Types.required(INT32).as(OriginalType.INT_8).named("int32_original_int8"),
+				Types.required(INT32).as(OriginalType.INT_16).named("int32_original_int16"),
+				Types.required(INT32).as(OriginalType.INT_32).named("int32_original_int32"),
+				Types.required(INT32).as(OriginalType.DATE).named("int32_original_date"),
+				Types.required(INT32).as(OriginalType.DECIMAL).precision(9).scale(2).named("int32_original_decimal"),
+				Types.required(INT64).as(null).named("int64_original_null"),
+				Types.required(INT64).as(OriginalType.INT_64).named("int64_original_int64"),
+				Types.required(INT64).as(OriginalType.DECIMAL).precision(9).scale(2).named("int64_original_decimal"),
+				Types.required(BINARY).as(null).named("binary_original_null"),
+				Types.required(BINARY).as(OriginalType.UTF8).named("binary_original_uft8"),
+				Types.required(BINARY).as(OriginalType.ENUM).named("binary_original_enum"),
+				Types.required(BINARY).as(OriginalType.JSON).named("binary_original_json"),
+				Types.required(BINARY).as(OriginalType.BSON).named("binary_original_bson"),
+				Types.required(BINARY).as(OriginalType.DECIMAL).precision(9).scale(2).named("binary_original_decimal"))
+				.named("flink-parquet");
+
+		ParquetWriter writer = new ParquetWriter(parquetSchema, tmpFile.toString(), conf);
+		writer.write(writer.newGroup()
+				.append("boolean", true)
+				.append("float", 1.23f)
+				.append("double", 1.23456d)
+				.append("int_original_null", 123)
+				.append("int32_original_int8", Byte.MAX_VALUE)
+				.append("int32_original_int16", Short.MAX_VALUE)
+				.append("int32_original_int32", Integer.MAX_VALUE)
+				.append("int32_original_date", 1234567)
+				.append("int32_original_decimal", 123456789)
+				.append("int64_original_null", Long.MIN_VALUE)
+				.append("int64_original_int64", 1234567890L)
+				.append("int64_original_decimal", Long.MAX_VALUE)
+				.append("binary_original_null", Binary.EMPTY)
+				.append("binary_original_uft8", Binary.fromString("test-utf8"))
+				.append("binary_original_enum", Binary.fromString(OriginalType.ENUM.toString()))
+				.append("binary_original_json", Binary.fromString("{}"))
+				.append("binary_original_bson", Binary.fromString("bson"))
+				.append("binary_original_decimal", Binary.fromConstantByteArray(
+						new BigDecimal(123456789.123456789).unscaledValue().toByteArray())));
+		writer.close();
+
+		TypeInformation<?>[] fieldTypes = {
+				BasicTypeInfo.BOOLEAN_TYPE_INFO,
+				BasicTypeInfo.FLOAT_TYPE_INFO,
+				BasicTypeInfo.DOUBLE_TYPE_INFO,
+				BasicTypeInfo.INT_TYPE_INFO,
+				BasicTypeInfo.BYTE_TYPE_INFO,
+				BasicTypeInfo.SHORT_TYPE_INFO,
+				BasicTypeInfo.INT_TYPE_INFO,
+				BasicTypeInfo.DATE_TYPE_INFO,
+				BasicTypeInfo.BIG_DEC_TYPE_INFO,
+				BasicTypeInfo.LONG_TYPE_INFO,
+				BasicTypeInfo.LONG_TYPE_INFO,
+				BasicTypeInfo.BIG_DEC_TYPE_INFO,
+				PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO,
+				BasicTypeInfo.BIG_DEC_TYPE_INFO
+		};
+		String[] fieldNames = {
+				"boolean",
+				"float",
+				"double",
+				"int_original_null",
+				"int32_original_int8",
+				"int32_original_int16",
+				"int32_original_int32",
+				"int32_original_date",
+				"int32_original_decimal",
+				"int64_original_null",
+				"int64_original_int64",
+				"int64_original_decimal",
+				"binary_original_null",
+				"binary_original_uft8",
+				"binary_original_enum",
+				"binary_original_json",
+				"binary_original_bson",
+				"binary_original_decimal"};
+
+		RowParquetInputFormat inputFormat = new RowParquetInputFormat(
+				new org.apache.flink.core.fs.Path(tmpFile.toURI()), fieldTypes, fieldNames);
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+		assertEquals(1, splits.length);
+		inputFormat.open(splits[0]);
+
+		assertFalse(inputFormat.reachedEnd());
+		Row row = inputFormat.nextRecord(null);
+		assertEquals(18, row.getArity());
+		assertEquals(true, row.getField(0));
+		assertEquals(1.23f, row.getField(1));
+		assertEquals(1.23456d, row.getField(2));
+		assertEquals(123, row.getField(3));
+		assertEquals(Byte.MAX_VALUE, row.getField(4));
+		assertEquals(Short.MAX_VALUE, row.getField(5));
+		assertEquals(Integer.MAX_VALUE, row.getField(6));
+		assertEquals(new Date(1234567), row.getField(7));
+		assertEquals(new BigDecimal(123456789), row.getField(8));
+		assertEquals(Long.MIN_VALUE, row.getField(9));
+		assertEquals(1234567890L, row.getField(10));
+		assertEquals(new BigDecimal(Long.MAX_VALUE), row.getField(11));
+		assertArrayEquals(Binary.EMPTY.getBytes(), (byte[]) row.getField(12));
+		assertEquals("test-utf8", row.getField(13));
+		assertEquals(OriginalType.ENUM, OriginalType.valueOf(row.getField(14).toString()));
+		assertEquals("{}", row.getField(15));
+		assertArrayEquals("bson".getBytes(), (byte[]) row.getField(16));
+		assertEquals(new BigDecimal(123456789.123456789).unscaledValue(),
+				((BigDecimal) row.getField(17)).unscaledValue());
+
+		assertTrue(inputFormat.reachedEnd());
+	}
+
+	@Test
+	public void testReadNullableColumn() throws IOException {
+		final File tmpFile = File.createTempFile("flink-parquet-test-data", ".parquet");
+		tmpFile.deleteOnExit();
+		Configuration conf = new Configuration();
+		MessageType parquetSchema = Types.buildMessage()
+				.addFields(Types.required(INT32).named("f1"))
+				.addFields(Types.optional(BINARY).as(OriginalType.UTF8).named("f2"))
+				.named("flink-parquet");
+		ParquetWriter writer = new ParquetWriter(parquetSchema, tmpFile.toString(), conf);
+		writer.write(writer.newGroup().append("f1", 1).append("f2", "str1"));
+		writer.write(writer.newGroup().append("f1", 2)); // the value of f2 is null
+		writer.close();
+
+		RowParquetInputFormat inputFormat = new RowParquetInputFormat(
+				new org.apache.flink.core.fs.Path(tmpFile.toURI()),
+				new TypeInformation[]{BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO},
+				new String[]{"f1", "f2"});
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+		assertEquals(1, splits.length);
+		inputFormat.open(splits[0]);
+
+		assertFalse(inputFormat.reachedEnd());
+		Row row = inputFormat.nextRecord(null);
+		assertEquals(2, row.getArity());
+		assertEquals(1, row.getField(0));
+		assertEquals("str1", row.getField(1));
+
+		assertFalse(inputFormat.reachedEnd());
+		row = inputFormat.nextRecord(null);
+		assertEquals(2, row.getArity());
+		assertEquals(2, row.getField(0));
+		assertNull(row.getField(1));
+
+		assertTrue(inputFormat.reachedEnd());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testFieldNameNotFound() throws IOException {
+		String file = genParquetFileWithMultiFields();
+		RowParquetInputFormat inputFormat = new RowParquetInputFormat(
+				new org.apache.flink.core.fs.Path(file),
+				new TypeInformation[]{BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.DOUBLE_TYPE_INFO},
+				new String[]{"f1", "f4"});
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+		assertEquals(1, splits.length);
+		inputFormat.open(splits[0]);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSchemaNotMatch() throws IOException {
+		String file = genParquetFileWithMultiFields();
+		RowParquetInputFormat inputFormat = new RowParquetInputFormat(
+				new org.apache.flink.core.fs.Path(file),
+				new TypeInformation[]{BasicTypeInfo.DOUBLE_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO},
+				new String[]{"f1", "f2"});
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+		assertEquals(1, splits.length);
+		inputFormat.open(splits[0]);
+	}
+
+	@Test
+	public void testFilterPredicate() throws Exception {
+		String file = genParquetFileWithMultiFields();
+
+		RowParquetInputFormat inputFormat = new RowParquetInputFormat(
+				new org.apache.flink.core.fs.Path(file),
+				new TypeInformation[]{BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.DOUBLE_TYPE_INFO},
+				new String[]{"f1", "f3"});
+
+		FilterPredicate filter = FilterApi.and(
+				FilterApi.gtEq(FilterApi.intColumn("f1"), 100),
+				FilterApi.lt(doubleColumn("f3"), 0.5d));
+		inputFormat.setFilterPredicate(filter);
+		assertEquals(filter, inputFormat.getFilterPredicate());
+
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+		assertEquals(1, splits.length);
+		inputFormat.open(splits[0]);
+
+		while (!inputFormat.reachedEnd()) {
+			Row row = inputFormat.nextRecord(null);
+			assertEquals(2, row.getArity());
+			assertTrue((int) row.getField(0) >= 100);
+			assertTrue(0 < (double) row.getField(1) && (double) row.getField(1) < 0.5);
+		}
+	}
+
+	private void genParquetFileWithOneField(Configuration conf, String filePath, int recordCount) throws IOException {
+		MessageType parquetSchema = Types.buildMessage()
+				.addFields(Types.required(DOUBLE).named("f1"))
+				.named("flink-parquet");
+		ParquetWriter writer = new ParquetWriter(
+				parquetSchema,
+				filePath,
+				ParquetFileWriter.Mode.OVERWRITE,
+				CompressionCodecName.UNCOMPRESSED,
+				1024, // row group size
+				512, // page size
+				128, // dictionary page size
+				0, // max padding size
+				true,
+				false,
+				ParquetProperties.WriterVersion.PARQUET_2_0,
+				conf);
+		Random random = new Random();
+		for (int i = 0; i < recordCount; ++i) {
+			writer.write(writer.newGroup().append("f1", random.nextDouble()));
+		}
+		writer.close();
+	}
+
+	private String genParquetFileWithMultiFields() throws IOException {
+		final File tmpFile = File.createTempFile("flink-parquet-test-data", ".parquet");
+		tmpFile.deleteOnExit();
+		Configuration conf = new Configuration();
+		MessageType parquetSchema = Types.buildMessage()
+				.addFields(Types.required(INT32).named("f1"))
+				.addFields(Types.required(BINARY).as(OriginalType.UTF8).named("f2"))
+				.addFields(Types.required(DOUBLE).named("f3"))
+				.named("flink-parquet");
+		ParquetWriter writer = new ParquetWriter(parquetSchema, tmpFile.toString(), conf);
+		Random random = new Random();
+		for (int i = 0; i < 200; ++i) {
+			writer.write(writer.newGroup().append("f1", i).append("f2", "str" + i).append("f3", random.nextDouble()));
+		}
+		writer.close();
+		return tmpFile.toString();
+	}
+
+}

--- a/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/ParquetInputFormatTest.java
+++ b/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/ParquetInputFormatTest.java
@@ -410,7 +410,6 @@ public class ParquetInputFormatTest {
 				FilterApi.gtEq(FilterApi.intColumn("f1"), 100),
 				FilterApi.lt(doubleColumn("f3"), 0.5d));
 		inputFormat.setFilterPredicate(filter);
-		assertEquals(filter, inputFormat.getFilterPredicate());
 
 		FileInputSplit[] splits = inputFormat.createInputSplits(1);
 		assertEquals(1, splits.length);

--- a/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/ParquetRecordConverterTest.java
+++ b/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/ParquetRecordConverterTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.io.parquet;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.types.Row;
+
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.io.api.PrimitiveConverter;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.Types;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+import static junit.framework.Assert.assertEquals;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Tests for {@link ParquetRecordConverter}.
+ */
+public class ParquetRecordConverterTest {
+
+	@Test
+	public void testSupportedConverters() {
+		MessageType parquetSchema = Types.buildMessage().addFields(
+				Types.required(BOOLEAN).named("boolean"),
+				Types.required(FLOAT).named("float"),
+				Types.required(DOUBLE).named("double"),
+				Types.required(INT32).as(null).named("int_original_null"),
+				Types.required(INT32).as(OriginalType.INT_8).named("int32_original_int8"),
+				Types.required(INT32).as(OriginalType.INT_16).named("int32_original_int16"),
+				Types.required(INT32).as(OriginalType.INT_32).named("int32_original_int32"),
+				Types.required(INT32).as(OriginalType.DATE).named("int32_original_date"),
+				Types.required(INT32).as(OriginalType.DECIMAL).precision(9).scale(2).named("int32_original_decimal"),
+				Types.required(INT64).as(null).named("int64_original_null"),
+				Types.required(INT64).as(OriginalType.INT_64).named("int64_original_int64"),
+				Types.required(INT64).as(OriginalType.DECIMAL).precision(9).scale(2).named("int64_original_decimal"),
+				Types.required(BINARY).as(null).named("binary_original_null"),
+				Types.required(BINARY).as(OriginalType.UTF8).named("binary_original_uft8"),
+				Types.required(BINARY).as(OriginalType.ENUM).named("binary_original_enum"),
+				Types.required(BINARY).as(OriginalType.JSON).named("binary_original_json"),
+				Types.required(BINARY).as(OriginalType.BSON).named("binary_original_bson"),
+				Types.required(BINARY).as(OriginalType.DECIMAL).precision(9).scale(2).named("binary_original_decimal"))
+				.named("flink-parquet");
+
+		TypeInformation<?>[] fieldTypes = {
+				BasicTypeInfo.BOOLEAN_TYPE_INFO, // 0
+				BasicTypeInfo.FLOAT_TYPE_INFO, // 1
+				BasicTypeInfo.DOUBLE_TYPE_INFO, // 2
+				BasicTypeInfo.INT_TYPE_INFO, // 3
+				BasicTypeInfo.BYTE_TYPE_INFO, // 4
+				BasicTypeInfo.SHORT_TYPE_INFO, // 5
+				BasicTypeInfo.INT_TYPE_INFO, // 6
+				BasicTypeInfo.DATE_TYPE_INFO, // 7
+				BasicTypeInfo.BIG_DEC_TYPE_INFO, // 8
+				BasicTypeInfo.LONG_TYPE_INFO, // 9
+				BasicTypeInfo.LONG_TYPE_INFO, // 10
+				BasicTypeInfo.BIG_DEC_TYPE_INFO, // 11
+				PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO, // 12
+				BasicTypeInfo.STRING_TYPE_INFO, // 13
+				BasicTypeInfo.STRING_TYPE_INFO, // 14
+				BasicTypeInfo.STRING_TYPE_INFO, // 15
+				PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO, // 16
+				BasicTypeInfo.BIG_DEC_TYPE_INFO // 17
+		};
+		ParquetRecordConverter recordConverter = new ParquetRecordConverter(parquetSchema.asGroupType(), fieldTypes);
+
+		((PrimitiveConverter) recordConverter.getConverter(0)).addBoolean(true); // boolean
+		((PrimitiveConverter) recordConverter.getConverter(1)).addFloat(6.66f); // float
+		((PrimitiveConverter) recordConverter.getConverter(2)).addDouble(8.88d); // double
+		((PrimitiveConverter) recordConverter.getConverter(3)).addInt(5); // int
+		((PrimitiveConverter) recordConverter.getConverter(4)).addInt(8); // byte
+		((PrimitiveConverter) recordConverter.getConverter(5)).addInt(16); // short
+		((PrimitiveConverter) recordConverter.getConverter(6)).addInt(32); // int
+		((PrimitiveConverter) recordConverter.getConverter(7)).addInt(60); // date
+		((PrimitiveConverter) recordConverter.getConverter(8)).addInt(33); // int -> big_dec
+		((PrimitiveConverter) recordConverter.getConverter(9)).addLong(64L); // long
+		((PrimitiveConverter) recordConverter.getConverter(10)).addLong(Long.MAX_VALUE); // long
+		((PrimitiveConverter) recordConverter.getConverter(11)).addLong(66L); //long -> big_dec
+		((PrimitiveConverter) recordConverter.getConverter(12)).addBinary(Binary.fromString("binary")); // byte[]
+		((PrimitiveConverter) recordConverter.getConverter(13)).addBinary(Binary.fromString("utf8")); // string
+		((PrimitiveConverter) recordConverter.getConverter(14))
+				.addBinary(Binary.fromString(OriginalType.ENUM.toString())); // string
+		((PrimitiveConverter) recordConverter.getConverter(15)).addBinary(Binary.fromString("{}")); // string
+		((PrimitiveConverter) recordConverter.getConverter(16)).addBinary(Binary.fromString("bson")); // byte
+		((PrimitiveConverter) recordConverter.getConverter(17)).addBinary(
+				Binary.fromConstantByteArray(new BigDecimal(9.998).unscaledValue().toByteArray())); // binary -> big_dec
+
+		Row row = recordConverter.getCurrentRecord();
+		assertEquals(18, row.getArity());
+		assertEquals(true, row.getField(0));
+		assertEquals(6.66f, row.getField(1));
+		assertEquals(8.88d, row.getField(2));
+		assertEquals(5, row.getField(3));
+		assertEquals((byte) 8, row.getField(4));
+		assertEquals((short) 16, row.getField(5));
+		assertEquals(32, row.getField(6));
+		assertEquals(new Date(60), row.getField(7));
+		assertEquals(new BigDecimal(33), row.getField(8));
+		assertEquals(64L, row.getField(9));
+		assertEquals(Long.MAX_VALUE, row.getField(10));
+		assertEquals(new BigDecimal(66L), row.getField(11));
+		assertArrayEquals("binary".getBytes(), (byte[]) row.getField(12));
+		assertEquals("utf8", row.getField(13));
+		assertEquals(OriginalType.ENUM, OriginalType.valueOf(row.getField(14).toString()));
+		assertEquals("{}", row.getField(15));
+		assertArrayEquals("bson".getBytes(), (byte[]) row.getField(16));
+		assertEquals(new BigDecimal(9.998).unscaledValue(), ((BigDecimal) row.getField(17)).unscaledValue());
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUnsupportedConverters_BIG_INT() {
+		MessageType parquetSchema = Types.buildMessage()
+				.addFields(Types.required(INT64).named("int64"))
+				.named("flink-parquet");
+		TypeInformation<?>[] fieldTypes = {BasicTypeInfo.BIG_INT_TYPE_INFO};
+		new ParquetRecordConverter(parquetSchema.asGroupType(), fieldTypes);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUnsupportedConverters_CHAR() {
+		MessageType parquetSchema = Types.buildMessage()
+				.addFields(Types.required(BINARY).length(1).as(OriginalType.UTF8).named("char"))
+				.named("flink-parquet");
+		TypeInformation<?>[] fieldTypes = {BasicTypeInfo.CHAR_TYPE_INFO};
+		new ParquetRecordConverter(parquetSchema.asGroupType(), fieldTypes);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUnsupportedConverters_ARRAY() {
+		MessageType parquetSchema = Types.buildMessage()
+				.addFields(Types.repeated(BOOLEAN).named("repeated_boolean"))
+				.named("flink-parquet");
+		TypeInformation<?>[] fieldTypes = {PrimitiveArrayTypeInfo.BOOLEAN_PRIMITIVE_ARRAY_TYPE_INFO};
+		new ParquetRecordConverter(parquetSchema.asGroupType(), fieldTypes);
+	}
+
+}

--- a/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/ParquetSchemaConverterTest.java
+++ b/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/ParquetSchemaConverterTest.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.io.parquet;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.Types;
+import org.junit.Test;
+
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Tests for {@link ParquetSchemaConverter}.
+ */
+public class ParquetSchemaConverterTest {
+
+	@Test
+	public void testSupportedConversionWithRequired() throws Exception {
+		MessageType parquetSchema = Types.buildMessage().addFields(
+				Types.required(BOOLEAN).named("boolean"),
+				Types.required(FLOAT).named("float"),
+				Types.required(DOUBLE).named("double"),
+				Types.required(INT32).as(null).named("int_original_null"),
+				Types.required(INT32).as(OriginalType.INT_8).named("int32_original_int8"),
+				Types.required(INT32).as(OriginalType.INT_16).named("int32_original_int16"),
+				Types.required(INT32).as(OriginalType.INT_32).named("int32_original_int32"),
+				Types.required(INT32).as(OriginalType.DATE).named("int32_original_date"),
+				Types.required(INT32).as(OriginalType.DECIMAL).precision(9).scale(2).named("int32_original_decimal"),
+				Types.required(INT64).as(null).named("int64_original_null"),
+				Types.required(INT64).as(OriginalType.INT_64).named("int64_original_int64"),
+				Types.required(INT64).as(OriginalType.DECIMAL).precision(9).scale(2).named("int64_original_decimal"),
+				Types.required(BINARY).as(null).named("binary_original_null"),
+				Types.required(BINARY).as(OriginalType.UTF8).named("binary_original_uft8"),
+				Types.required(BINARY).as(OriginalType.ENUM).named("binary_original_enum"),
+				Types.required(BINARY).as(OriginalType.JSON).named("binary_original_json"),
+				Types.required(BINARY).as(OriginalType.BSON).named("binary_original_bson"),
+				Types.required(BINARY).as(OriginalType.DECIMAL).precision(9).scale(2).named("binary_original_decimal"))
+				.named("flink-parquet");
+
+		ParquetSchemaConverter converter = new ParquetSchemaConverter();
+		Tuple2<String[], TypeInformation<?>[]> fieldNamesAndTypes = converter.convertToTypeInformation(parquetSchema);
+		String[] expectedFieldNames = {
+				"boolean",
+				"float",
+				"double",
+				"int_original_null",
+				"int32_original_int8",
+				"int32_original_int16",
+				"int32_original_int32",
+				"int32_original_date",
+				"int32_original_decimal",
+				"int64_original_null",
+				"int64_original_int64",
+				"int64_original_decimal",
+				"binary_original_null",
+				"binary_original_uft8",
+				"binary_original_enum",
+				"binary_original_json",
+				"binary_original_bson",
+				"binary_original_decimal"};
+
+		TypeInformation<?>[] expectedFieldTypes = {
+				BasicTypeInfo.BOOLEAN_TYPE_INFO,
+				BasicTypeInfo.FLOAT_TYPE_INFO,
+				BasicTypeInfo.DOUBLE_TYPE_INFO,
+				BasicTypeInfo.INT_TYPE_INFO,
+				BasicTypeInfo.BYTE_TYPE_INFO,
+				BasicTypeInfo.SHORT_TYPE_INFO,
+				BasicTypeInfo.INT_TYPE_INFO,
+				BasicTypeInfo.DATE_TYPE_INFO,
+				BasicTypeInfo.BIG_DEC_TYPE_INFO,
+				BasicTypeInfo.LONG_TYPE_INFO,
+				BasicTypeInfo.LONG_TYPE_INFO,
+				BasicTypeInfo.BIG_DEC_TYPE_INFO,
+				PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO,
+				BasicTypeInfo.BIG_DEC_TYPE_INFO
+		};
+
+		assertArrayEquals(expectedFieldNames, fieldNamesAndTypes.f0);
+		assertArrayEquals(expectedFieldTypes, fieldNamesAndTypes.f1);
+	}
+
+	@Test
+	public void testSupportedConversionWithOptional() throws Exception {
+		MessageType parquetSchema = Types.buildMessage().addFields(
+				Types.optional(BOOLEAN).named("boolean"),
+				Types.optional(FLOAT).named("float"),
+				Types.optional(DOUBLE).named("double"),
+				Types.optional(INT32).as(null).named("int_original_null"),
+				Types.optional(INT32).as(OriginalType.INT_8).named("int32_original_int8"),
+				Types.optional(INT32).as(OriginalType.INT_16).named("int32_original_int16"),
+				Types.optional(INT32).as(OriginalType.INT_32).named("int32_original_int32"),
+				Types.optional(INT32).as(OriginalType.DATE).named("int32_original_date"),
+				Types.optional(INT32).as(OriginalType.DECIMAL).precision(9).scale(2).named("int32_original_decimal"),
+				Types.optional(INT64).as(null).named("int64_original_null"),
+				Types.optional(INT64).as(OriginalType.INT_64).named("int64_original_int64"),
+				Types.optional(INT64).as(OriginalType.DECIMAL).precision(9).scale(2).named("int64_original_decimal"),
+				Types.optional(BINARY).as(null).named("binary_original_null"),
+				Types.optional(BINARY).as(OriginalType.UTF8).named("binary_original_uft8"),
+				Types.optional(BINARY).as(OriginalType.ENUM).named("binary_original_enum"),
+				Types.optional(BINARY).as(OriginalType.JSON).named("binary_original_json"),
+				Types.optional(BINARY).as(OriginalType.BSON).named("binary_original_bson"),
+				Types.optional(BINARY).as(OriginalType.DECIMAL).precision(9).scale(2).named("binary_original_decimal"))
+				.named("flink-parquet");
+
+		ParquetSchemaConverter converter = new ParquetSchemaConverter();
+		Tuple2<String[], TypeInformation<?>[]> fieldNamesAndTypes = converter.convertToTypeInformation(parquetSchema);
+		String[] expectedFieldNames = {
+				"boolean",
+				"float",
+				"double",
+				"int_original_null",
+				"int32_original_int8",
+				"int32_original_int16",
+				"int32_original_int32",
+				"int32_original_date",
+				"int32_original_decimal",
+				"int64_original_null",
+				"int64_original_int64",
+				"int64_original_decimal",
+				"binary_original_null",
+				"binary_original_uft8",
+				"binary_original_enum",
+				"binary_original_json",
+				"binary_original_bson",
+				"binary_original_decimal"};
+
+		TypeInformation<?>[] expectedFieldTypes = {
+				BasicTypeInfo.BOOLEAN_TYPE_INFO,
+				BasicTypeInfo.FLOAT_TYPE_INFO,
+				BasicTypeInfo.DOUBLE_TYPE_INFO,
+				BasicTypeInfo.INT_TYPE_INFO,
+				BasicTypeInfo.BYTE_TYPE_INFO,
+				BasicTypeInfo.SHORT_TYPE_INFO,
+				BasicTypeInfo.INT_TYPE_INFO,
+				BasicTypeInfo.DATE_TYPE_INFO,
+				BasicTypeInfo.BIG_DEC_TYPE_INFO,
+				BasicTypeInfo.LONG_TYPE_INFO,
+				BasicTypeInfo.LONG_TYPE_INFO,
+				BasicTypeInfo.BIG_DEC_TYPE_INFO,
+				PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO,
+				BasicTypeInfo.BIG_DEC_TYPE_INFO
+		};
+
+		assertArrayEquals(expectedFieldNames, fieldNamesAndTypes.f0);
+		assertArrayEquals(expectedFieldTypes, fieldNamesAndTypes.f1);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUnsupportedConversion_REPEATED() {
+		MessageType parquetSchema = Types.buildMessage()
+				.addFields(Types.repeated(BOOLEAN).named("repeated_boolean"))
+				.named("flink-parquet");
+		new ParquetSchemaConverter().convertToTypeInformation(parquetSchema);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUnsupportedConversion_GroupType() {
+		MessageType parquetSchema = Types.buildMessage()
+				.addFields(Types.requiredGroup().addFields(
+						Types.required(BOOLEAN).named("boolean"),
+						Types.optional(INT32).named("int32")
+				).named("group_boolean"))
+				.named("flink-parquet");
+		new ParquetSchemaConverter().convertToTypeInformation(parquetSchema);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUnsupportedConversion_INT96() {
+		MessageType parquetSchema = Types.buildMessage()
+				.addField(Types.required(INT96).named("int96"))
+				.named("flink-parquet");
+		new ParquetSchemaConverter().convertToTypeInformation(parquetSchema);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUnsupportedConversion_FIXED_LEN_BYTE_ARRAY() {
+		MessageType parquetSchema = Types.buildMessage()
+				.addField(Types.required(FIXED_LEN_BYTE_ARRAY).length(10).named("fixed_len_byte_array"))
+				.named("flink-parquet");
+		new ParquetSchemaConverter().convertToTypeInformation(parquetSchema);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUnsupportedConversion_UINT8() {
+		MessageType parquetSchema = Types.buildMessage()
+				.addField(Types.required(INT32).as(OriginalType.UINT_8).named("int32_uint_8"))
+				.named("flink-parquet");
+		new ParquetSchemaConverter().convertToTypeInformation(parquetSchema);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUnsupportedConversion_UINT16() {
+		MessageType parquetSchema = Types.buildMessage()
+				.addField(Types.required(INT32).as(OriginalType.UINT_16).named("int32_uint_16"))
+				.named("flink-parquet");
+		new ParquetSchemaConverter().convertToTypeInformation(parquetSchema);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUnsupportedConversion_UINT32() {
+		MessageType parquetSchema = Types.buildMessage()
+				.addField(Types.required(INT32).as(OriginalType.UINT_32).named("int32_uint_32"))
+				.named("flink-parquet");
+		new ParquetSchemaConverter().convertToTypeInformation(parquetSchema);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUnsupportedConversion_UINT64() {
+		MessageType parquetSchema = Types.buildMessage()
+				.addField(Types.required(INT64).as(OriginalType.UINT_64).named("int64_uint_64"))
+				.named("flink-parquet");
+		new ParquetSchemaConverter().convertToTypeInformation(parquetSchema);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUnsupportedConversion_TIME_MILLIS() {
+		MessageType parquetSchema = Types.buildMessage()
+				.addField(Types.required(INT32).as(OriginalType.TIME_MILLIS).named("int32_time_millis"))
+				.named("flink-parquet");
+		new ParquetSchemaConverter().convertToTypeInformation(parquetSchema);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUnsupportedConversion_TIMESTAMP_MILLIS() {
+		MessageType parquetSchema = Types.buildMessage()
+				.addField(Types.required(INT64).as(OriginalType.TIMESTAMP_MILLIS).named("int64_timestamp_millis"))
+				.named("flink-parquet");
+		new ParquetSchemaConverter().convertToTypeInformation(parquetSchema);
+	}
+}

--- a/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/ParquetSchemaConverterTest.java
+++ b/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/ParquetSchemaConverterTest.java
@@ -21,12 +21,15 @@ package org.apache.flink.api.io.parquet;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.java.tuple.Tuple2;
 
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
@@ -36,7 +39,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for {@link ParquetSchemaConverter}.
@@ -45,142 +48,74 @@ public class ParquetSchemaConverterTest {
 
 	@Test
 	public void testSupportedConversionWithRequired() throws Exception {
-		MessageType parquetSchema = Types.buildMessage().addFields(
-				Types.required(BOOLEAN).named("boolean"),
-				Types.required(FLOAT).named("float"),
-				Types.required(DOUBLE).named("double"),
-				Types.required(INT32).as(null).named("int_original_null"),
-				Types.required(INT32).as(OriginalType.INT_8).named("int32_original_int8"),
-				Types.required(INT32).as(OriginalType.INT_16).named("int32_original_int16"),
-				Types.required(INT32).as(OriginalType.INT_32).named("int32_original_int32"),
-				Types.required(INT32).as(OriginalType.DATE).named("int32_original_date"),
-				Types.required(INT32).as(OriginalType.DECIMAL).precision(9).scale(2).named("int32_original_decimal"),
-				Types.required(INT64).as(null).named("int64_original_null"),
-				Types.required(INT64).as(OriginalType.INT_64).named("int64_original_int64"),
-				Types.required(INT64).as(OriginalType.DECIMAL).precision(9).scale(2).named("int64_original_decimal"),
-				Types.required(BINARY).as(null).named("binary_original_null"),
-				Types.required(BINARY).as(OriginalType.UTF8).named("binary_original_uft8"),
-				Types.required(BINARY).as(OriginalType.ENUM).named("binary_original_enum"),
-				Types.required(BINARY).as(OriginalType.JSON).named("binary_original_json"),
-				Types.required(BINARY).as(OriginalType.BSON).named("binary_original_bson"),
-				Types.required(BINARY).as(OriginalType.DECIMAL).precision(9).scale(2).named("binary_original_decimal"))
-				.named("flink-parquet");
-
-		ParquetSchemaConverter converter = new ParquetSchemaConverter();
-		Tuple2<String[], TypeInformation<?>[]> fieldNamesAndTypes = converter.convertToTypeInformation(parquetSchema);
-		String[] expectedFieldNames = {
-				"boolean",
-				"float",
-				"double",
-				"int_original_null",
-				"int32_original_int8",
-				"int32_original_int16",
-				"int32_original_int32",
-				"int32_original_date",
-				"int32_original_decimal",
-				"int64_original_null",
-				"int64_original_int64",
-				"int64_original_decimal",
-				"binary_original_null",
-				"binary_original_uft8",
-				"binary_original_enum",
-				"binary_original_json",
-				"binary_original_bson",
-				"binary_original_decimal"};
-
-		TypeInformation<?>[] expectedFieldTypes = {
-				BasicTypeInfo.BOOLEAN_TYPE_INFO,
-				BasicTypeInfo.FLOAT_TYPE_INFO,
-				BasicTypeInfo.DOUBLE_TYPE_INFO,
-				BasicTypeInfo.INT_TYPE_INFO,
-				BasicTypeInfo.BYTE_TYPE_INFO,
-				BasicTypeInfo.SHORT_TYPE_INFO,
-				BasicTypeInfo.INT_TYPE_INFO,
-				BasicTypeInfo.DATE_TYPE_INFO,
-				BasicTypeInfo.BIG_DEC_TYPE_INFO,
-				BasicTypeInfo.LONG_TYPE_INFO,
-				BasicTypeInfo.LONG_TYPE_INFO,
-				BasicTypeInfo.BIG_DEC_TYPE_INFO,
-				PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO,
-				BasicTypeInfo.STRING_TYPE_INFO,
-				BasicTypeInfo.STRING_TYPE_INFO,
-				BasicTypeInfo.STRING_TYPE_INFO,
-				PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO,
-				BasicTypeInfo.BIG_DEC_TYPE_INFO
-		};
-
-		assertArrayEquals(expectedFieldNames, fieldNamesAndTypes.f0);
-		assertArrayEquals(expectedFieldTypes, fieldNamesAndTypes.f1);
+		testSupportedConversion(true);
 	}
 
 	@Test
 	public void testSupportedConversionWithOptional() throws Exception {
+		testSupportedConversion(false);
+	}
+
+	private void testSupportedConversion(boolean required) {
+		Type.Repetition repetition = required ? Type.Repetition.REQUIRED : Type.Repetition.OPTIONAL;
+
 		MessageType parquetSchema = Types.buildMessage().addFields(
-				Types.optional(BOOLEAN).named("boolean"),
-				Types.optional(FLOAT).named("float"),
-				Types.optional(DOUBLE).named("double"),
-				Types.optional(INT32).as(null).named("int_original_null"),
-				Types.optional(INT32).as(OriginalType.INT_8).named("int32_original_int8"),
-				Types.optional(INT32).as(OriginalType.INT_16).named("int32_original_int16"),
-				Types.optional(INT32).as(OriginalType.INT_32).named("int32_original_int32"),
-				Types.optional(INT32).as(OriginalType.DATE).named("int32_original_date"),
-				Types.optional(INT32).as(OriginalType.DECIMAL).precision(9).scale(2).named("int32_original_decimal"),
-				Types.optional(INT64).as(null).named("int64_original_null"),
-				Types.optional(INT64).as(OriginalType.INT_64).named("int64_original_int64"),
-				Types.optional(INT64).as(OriginalType.DECIMAL).precision(9).scale(2).named("int64_original_decimal"),
-				Types.optional(BINARY).as(null).named("binary_original_null"),
-				Types.optional(BINARY).as(OriginalType.UTF8).named("binary_original_uft8"),
-				Types.optional(BINARY).as(OriginalType.ENUM).named("binary_original_enum"),
-				Types.optional(BINARY).as(OriginalType.JSON).named("binary_original_json"),
-				Types.optional(BINARY).as(OriginalType.BSON).named("binary_original_bson"),
-				Types.optional(BINARY).as(OriginalType.DECIMAL).precision(9).scale(2).named("binary_original_decimal"))
+				Types.primitive(BOOLEAN, repetition).named("boolean"),
+				Types.primitive(FLOAT, repetition).named("float"),
+				Types.primitive(DOUBLE, repetition).named("double"),
+				Types.primitive(INT32, repetition).as(null).named("int_original_null"),
+				Types.primitive(INT32, repetition).as(OriginalType.INT_8).named("int32_original_int8"),
+				Types.primitive(INT32, repetition).as(OriginalType.INT_16).named("int32_original_int16"),
+				Types.primitive(INT32, repetition).as(OriginalType.INT_32).named("int32_original_int32"),
+				Types.primitive(INT32, repetition).as(OriginalType.DATE).named("int32_original_date"),
+				Types.primitive(INT32, repetition).as(OriginalType.DECIMAL).precision(9).scale(2)
+						.named("int32_original_decimal"),
+				Types.primitive(INT64, repetition).as(null).named("int64_original_null"),
+				Types.primitive(INT64, repetition).as(OriginalType.INT_64).named("int64_original_int64"),
+				Types.primitive(INT64, repetition).as(OriginalType.DECIMAL).precision(18).scale(2)
+						.named("int64_original_decimal"),
+				Types.primitive(BINARY, repetition).as(null).named("binary_original_null"),
+				Types.primitive(BINARY, repetition).as(OriginalType.UTF8).named("binary_original_uft8"),
+				Types.primitive(BINARY, repetition).as(OriginalType.ENUM).named("binary_original_enum"),
+				Types.primitive(BINARY, repetition).as(OriginalType.JSON).named("binary_original_json"),
+				Types.primitive(BINARY, repetition).as(OriginalType.BSON).named("binary_original_bson"),
+				Types.primitive(BINARY, repetition).as(OriginalType.DECIMAL).precision(9).scale(2)
+						.named("binary_original_decimal"))
 				.named("flink-parquet");
 
 		ParquetSchemaConverter converter = new ParquetSchemaConverter();
-		Tuple2<String[], TypeInformation<?>[]> fieldNamesAndTypes = converter.convertToTypeInformation(parquetSchema);
-		String[] expectedFieldNames = {
-				"boolean",
-				"float",
-				"double",
-				"int_original_null",
-				"int32_original_int8",
-				"int32_original_int16",
-				"int32_original_int32",
-				"int32_original_date",
-				"int32_original_decimal",
-				"int64_original_null",
-				"int64_original_int64",
-				"int64_original_decimal",
-				"binary_original_null",
-				"binary_original_uft8",
-				"binary_original_enum",
-				"binary_original_json",
-				"binary_original_bson",
-				"binary_original_decimal"};
+		Map<String, TypeInformation<?>> fieldName2TypeMap = converter.convertToTypeInformation(parquetSchema);
 
-		TypeInformation<?>[] expectedFieldTypes = {
-				BasicTypeInfo.BOOLEAN_TYPE_INFO,
-				BasicTypeInfo.FLOAT_TYPE_INFO,
-				BasicTypeInfo.DOUBLE_TYPE_INFO,
-				BasicTypeInfo.INT_TYPE_INFO,
-				BasicTypeInfo.BYTE_TYPE_INFO,
-				BasicTypeInfo.SHORT_TYPE_INFO,
-				BasicTypeInfo.INT_TYPE_INFO,
-				BasicTypeInfo.DATE_TYPE_INFO,
-				BasicTypeInfo.BIG_DEC_TYPE_INFO,
-				BasicTypeInfo.LONG_TYPE_INFO,
-				BasicTypeInfo.LONG_TYPE_INFO,
-				BasicTypeInfo.BIG_DEC_TYPE_INFO,
-				PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO,
-				BasicTypeInfo.STRING_TYPE_INFO,
-				BasicTypeInfo.STRING_TYPE_INFO,
-				BasicTypeInfo.STRING_TYPE_INFO,
-				PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO,
-				BasicTypeInfo.BIG_DEC_TYPE_INFO
+		Map<String, TypeInformation<?>> expectedFieldName2TypeMap = new HashMap<String, TypeInformation<?>>() {
+			{
+				put("boolean", BasicTypeInfo.BOOLEAN_TYPE_INFO);
+				put("float", BasicTypeInfo.FLOAT_TYPE_INFO);
+				put("double", BasicTypeInfo.DOUBLE_TYPE_INFO);
+				put("int_original_null", BasicTypeInfo.INT_TYPE_INFO);
+				put("int32_original_int8", BasicTypeInfo.BYTE_TYPE_INFO);
+				put("int32_original_int16", BasicTypeInfo.SHORT_TYPE_INFO);
+				put("int32_original_int32", BasicTypeInfo.INT_TYPE_INFO);
+				put("int32_original_date", BasicTypeInfo.DATE_TYPE_INFO);
+				put("int32_original_decimal", BasicTypeInfo.BIG_DEC_TYPE_INFO);
+				put("int64_original_null", BasicTypeInfo.LONG_TYPE_INFO);
+				put("int64_original_int64", BasicTypeInfo.LONG_TYPE_INFO);
+				put("int64_original_decimal", BasicTypeInfo.BIG_DEC_TYPE_INFO);
+				put("binary_original_null", PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO);
+				put("binary_original_uft8", BasicTypeInfo.STRING_TYPE_INFO);
+				put("binary_original_enum", BasicTypeInfo.STRING_TYPE_INFO);
+				put("binary_original_json", BasicTypeInfo.STRING_TYPE_INFO);
+				put("binary_original_bson", PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO);
+				put("binary_original_decimal", BasicTypeInfo.BIG_DEC_TYPE_INFO);
+			}
 		};
 
-		assertArrayEquals(expectedFieldNames, fieldNamesAndTypes.f0);
-		assertArrayEquals(expectedFieldTypes, fieldNamesAndTypes.f1);
+		assertEquals(expectedFieldName2TypeMap.size(), fieldName2TypeMap.size());
+		for (Map.Entry<String, TypeInformation<?>> entry : expectedFieldName2TypeMap.entrySet()) {
+			String expectedFieldName = entry.getKey();
+			TypeInformation<?> expectedFieldType = entry.getValue();
+			TypeInformation<?> actualTypeInfo = fieldName2TypeMap.get(expectedFieldName);
+			assertEquals(expectedFieldType, actualTypeInfo);
+		}
 	}
 
 	@Test(expected = UnsupportedOperationException.class)

--- a/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/ParquetWriter.java
+++ b/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/ParquetWriter.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.io.parquet;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetFileWriter;
+import org.apache.parquet.hadoop.api.WriteSupport;
+import org.apache.parquet.hadoop.example.GroupWriteSupport;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.schema.MessageType;
+
+import java.io.IOException;
+
+/**
+ * A helper class to write data to Parquet File.
+ */
+public class ParquetWriter {
+
+	private org.apache.parquet.hadoop.ParquetWriter<Group> realWriter;
+	private SimpleGroupFactory factory;
+
+	public ParquetWriter(
+			MessageType parquetSchema,
+			String path,
+			ParquetFileWriter.Mode writeMode,
+			CompressionCodecName compressionCodecName,
+			int rowGroupSize,
+			int pageSize,
+			int dictionaryPageSize,
+			int maxPaddingSize,
+			boolean enableDictionary,
+			boolean validating,
+			ParquetProperties.WriterVersion writerVersion,
+			Configuration conf
+	) throws IOException {
+
+		GroupWriteSupport.setSchema(parquetSchema, conf);
+
+		realWriter = new Builder(new Path(path))
+				.withWriteMode(writeMode)
+				.withCompressionCodec(compressionCodecName)
+				.withRowGroupSize(rowGroupSize)
+				.withPageSize(pageSize)
+				.withDictionaryPageSize(dictionaryPageSize)
+				.withMaxPaddingSize(maxPaddingSize)
+				.withDictionaryEncoding(enableDictionary)
+				.withValidation(validating)
+				.withWriterVersion(writerVersion)
+				.withConf(conf)
+				.build();
+
+		factory = new SimpleGroupFactory(parquetSchema);
+	}
+
+	public ParquetWriter(
+			MessageType parquetSchema,
+			String path,
+			Configuration conf
+	) throws IOException {
+		this(parquetSchema,
+				path,
+				ParquetFileWriter.Mode.OVERWRITE,
+				CompressionCodecName.UNCOMPRESSED,
+				2048, // row group size
+				1024, // page size
+				512, // dictionary page size
+				0, // max padding size
+				true,
+				false,
+				ParquetProperties.WriterVersion.PARQUET_2_0,
+				conf);
+	}
+
+	public Group newGroup() {
+		return factory.newGroup();
+	}
+
+	public void write(Group group) throws IOException {
+		realWriter.write(group);
+	}
+
+	public void close() throws IOException {
+		realWriter.close();
+	}
+
+	/** */
+	private static class Builder extends org.apache.parquet.hadoop.ParquetWriter.Builder<Group, Builder> {
+
+		private Builder(Path file) {
+			super(file);
+		}
+
+		@Override
+		protected Builder self() {
+			return this;
+		}
+
+		@Override
+		protected WriteSupport<Group> getWriteSupport(Configuration conf) {
+			return new GroupWriteSupport();
+		}
+	}
+
+}

--- a/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/PojoParquetInputFormatTest.java
+++ b/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/PojoParquetInputFormatTest.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.io.parquet;
+
+import org.apache.flink.api.java.typeutils.PojoTypeInfo;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.Types;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static junit.framework.Assert.assertNull;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+
+/**
+ * Tests for {@link PojoParquetInputFormat}.
+ */
+public class PojoParquetInputFormatTest {
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testFieldNameNotFound() throws IOException {
+		PojoTypeInfo<PojoItem> typeInfo = (PojoTypeInfo<PojoItem>) TypeExtractor.createTypeInfo(PojoItem.class);
+		new PojoParquetInputFormat<>(new Path("/tmp"), typeInfo, new String[]{"field1", "field4"});
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testNullFieldName() throws IOException {
+		PojoTypeInfo<PojoItem> typeInfo = (PojoTypeInfo<PojoItem>) TypeExtractor.createTypeInfo(PojoItem.class);
+		new PojoParquetInputFormat<>(new Path("/tmp"), typeInfo, new String[]{"field1", null});
+	}
+
+	@Test
+	public void testPojoType() throws IOException {
+		final File tmpFile = genParquetFile();
+
+		PojoTypeInfo<PojoItem> typeInfo = (PojoTypeInfo<PojoItem>) TypeExtractor.createTypeInfo(PojoItem.class);
+		PojoParquetInputFormat<PojoItem> inputFormat = new PojoParquetInputFormat<>(
+				new Path(tmpFile.toURI()), typeInfo);
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+		assertEquals(1, splits.length);
+		inputFormat.open(splits[0]);
+
+		assertFalse(inputFormat.reachedEnd());
+		PojoItem item = inputFormat.nextRecord(null);
+		assertTrue(1 == item.field1);
+		assertEquals("str1", item.field2);
+		assertTrue(10L == item.field3);
+
+		assertFalse(inputFormat.reachedEnd());
+		item = inputFormat.nextRecord(null);
+		assertTrue(2 == item.field1);
+		assertNull(item.field2);
+		assertTrue(20L == item.field3);
+
+		assertFalse(inputFormat.reachedEnd());
+		item = inputFormat.nextRecord(null);
+		assertTrue(3 == item.field1);
+		assertEquals("str3", item.field2);
+		assertTrue(30L == item.field3);
+
+		assertTrue(inputFormat.reachedEnd());
+	}
+
+	@Test
+	public void testPojoTypeWithPartialFields() throws Exception {
+		final File tmpFile = genParquetFile();
+
+		PojoTypeInfo<PojoItem> typeInfo = (PojoTypeInfo<PojoItem>) TypeExtractor.createTypeInfo(PojoItem.class);
+		PojoParquetInputFormat<PojoItem> inputFormat = new PojoParquetInputFormat<>(
+				new Path(tmpFile.toURI()), typeInfo, new String[]{"field1", "field3"});
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+		assertEquals(1, splits.length);
+		inputFormat.open(splits[0]);
+
+		assertFalse(inputFormat.reachedEnd());
+		PojoItem item = inputFormat.nextRecord(null);
+		assertTrue(1 == item.field1);
+		assertEquals("", item.field2); // the value StringSerializer#createInstance is ""
+		assertTrue(10L == item.field3);
+
+		assertFalse(inputFormat.reachedEnd());
+		item = inputFormat.nextRecord(null);
+		assertTrue(2 == item.field1);
+		assertEquals("", item.field2); // the value StringSerializer#createInstance is ""
+		assertTrue(20L == item.field3);
+
+		assertFalse(inputFormat.reachedEnd());
+		item = inputFormat.nextRecord(null);
+		assertTrue(3 == item.field1);
+		assertEquals("", item.field2); // the value StringSerializer#createInstance is ""
+		assertTrue(30L == item.field3);
+
+		assertTrue(inputFormat.reachedEnd());
+	}
+
+	@Test
+	public void testPojoTypeWithPrivateField() throws IOException {
+		final File tmpFile = genParquetFile();
+
+		PojoTypeInfo<PrivatePojoItem> typeInfo =
+				(PojoTypeInfo<PrivatePojoItem>) TypeExtractor.createTypeInfo(PrivatePojoItem.class);
+		PojoParquetInputFormat<PrivatePojoItem> inputFormat = new PojoParquetInputFormat<>(
+				new org.apache.flink.core.fs.Path(tmpFile.toURI()), typeInfo);
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+		assertEquals(1, splits.length);
+		inputFormat.open(splits[0]);
+
+		assertFalse(inputFormat.reachedEnd());
+		PrivatePojoItem item = inputFormat.nextRecord(null);
+		assertTrue(1 == item.getField1());
+		assertEquals("str1", item.getField2());
+		assertTrue(10L == item.getField3());
+
+		assertFalse(inputFormat.reachedEnd());
+		item = inputFormat.nextRecord(null);
+		assertTrue(2 == item.getField1());
+		assertNull(item.getField2());
+		assertTrue(20L == item.getField3());
+
+		assertFalse(inputFormat.reachedEnd());
+		item = inputFormat.nextRecord(null);
+		assertTrue(3 == item.getField1());
+		assertEquals("str3", item.getField2());
+		assertTrue(30L == item.getField3());
+
+		assertTrue(inputFormat.reachedEnd());
+	}
+
+	@Test
+	public void testPojoSubclassType() throws Exception {
+		final File tmpFile = genParquetFile();
+
+		PojoTypeInfo<SubPOJO> typeInfo = (PojoTypeInfo<SubPOJO>) TypeExtractor.createTypeInfo(SubPOJO.class);
+		PojoParquetInputFormat<SubPOJO> inputFormat = new PojoParquetInputFormat<>(
+				new Path(tmpFile.toURI()), typeInfo);
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+		assertEquals(1, splits.length);
+		inputFormat.open(splits[0]);
+
+		assertFalse(inputFormat.reachedEnd());
+		SubPOJO pojo = inputFormat.nextRecord(null);
+		assertTrue(1 == pojo.field1);
+		assertEquals("str1", pojo.field2);
+		assertTrue(10L == pojo.field3);
+
+		assertFalse(inputFormat.reachedEnd());
+		pojo = inputFormat.nextRecord(null);
+		assertTrue(2 == pojo.field1);
+		assertNull(pojo.field2);
+		assertTrue(20L == pojo.field3);
+
+		assertFalse(inputFormat.reachedEnd());
+		pojo = inputFormat.nextRecord(null);
+		assertTrue(3 == pojo.field1);
+		assertEquals("str3", pojo.field2);
+		assertTrue(30L == pojo.field3);
+
+		assertTrue(inputFormat.reachedEnd());
+	}
+
+	private File genParquetFile() throws IOException {
+		final File tmpFile = File.createTempFile("flink-parquet-test-data", ".parquet");
+		tmpFile.deleteOnExit();
+		Configuration conf = new Configuration();
+		MessageType parquetSchema = Types.buildMessage()
+				.addFields(Types.required(INT32).named("field1"))
+				.addFields(Types.optional(BINARY).as(OriginalType.UTF8).named("field2"))
+				.addFields(Types.required(INT64).named("field3"))
+				.named("flink-parquet");
+		ParquetWriter writer = new ParquetWriter(parquetSchema, tmpFile.toString(), conf);
+		writer.write(writer.newGroup().append("field1", 1).append("field2", "str1").append("field3", 10L));
+		writer.write(writer.newGroup().append("field1", 2).append("field3", 20L));
+		writer.write(writer.newGroup().append("field1", 3).append("field2", "str3").append("field3", 30L));
+		writer.close();
+		return tmpFile;
+	}
+
+	/** */
+	public static class PojoItem {
+		public int field1;
+		public String field2;
+		public Long field3;
+	}
+
+	/** */
+	public static class PrivatePojoItem {
+		private int field1;
+		private String field2;
+		private Long field3;
+
+		public int getField1() {
+			return field1;
+		}
+
+		public void setField1(int field1) {
+			this.field1 = field1;
+		}
+
+		public String getField2() {
+			return field2;
+		}
+
+		public void setField2(String field2) {
+			this.field2 = field2;
+		}
+
+		public Long getField3() {
+			return field3;
+		}
+
+		public void setField3(Long field3) {
+			this.field3 = field3;
+		}
+	}
+
+	/** */
+	public static class POJO {
+		public int field1;
+		public String field2;
+
+		public POJO() {
+			this(0, "");
+		}
+
+		public POJO(int field1, String field2) {
+			this.field1 = field1;
+			this.field2 = field2;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj instanceof POJO) {
+				POJO other = (POJO) obj;
+				return field1 == other.field1 && field2.equals(other.field2);
+			} else {
+				return false;
+			}
+		}
+	}
+
+	/** */
+	public static class SubPOJO extends POJO {
+		public long field3;
+
+		public SubPOJO() {
+			this(0, "", 0L);
+		}
+
+		public SubPOJO(int field1, String field2, long field3) {
+			super(field1, field2);
+			this.field3 = field3;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj instanceof SubPOJO) {
+				SubPOJO other = (SubPOJO) obj;
+
+				return super.equals(other) && field3 == other.field3;
+			} else {
+				return false;
+			}
+		}
+	}
+}

--- a/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/TupleParquetInputFormatTest.java
+++ b/flink-connectors/flink-parquet/src/test/java/org/apache/flink/api/io/parquet/TupleParquetInputFormatTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.io.parquet;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.core.fs.FileInputSplit;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.Types;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+
+/**
+ * Tests for {@link TupleParquetInputFormat}.
+ */
+public class TupleParquetInputFormatTest {
+
+	@Test
+	public void testTupleType() throws IOException {
+		final File tmpFile = File.createTempFile("flink-parquet-test-data", ".parquet");
+		tmpFile.deleteOnExit();
+		Configuration conf = new Configuration();
+		MessageType parquetSchema = Types.buildMessage()
+				.addFields(Types.required(INT32).named("t1"))
+				.addFields(Types.optional(BINARY).as(OriginalType.UTF8).named("t2"))
+				.addFields(Types.required(INT64).named("t3"))
+				.named("flink-parquet");
+		ParquetWriter writer = new ParquetWriter(parquetSchema, tmpFile.toString(), conf);
+		writer.write(writer.newGroup().append("t1", 1).append("t2", "str1").append("t3", 10L));
+		writer.write(writer.newGroup().append("t1", 2).append("t3", 20L)); // the value of t2 is null
+		writer.write(writer.newGroup().append("t1", 3).append("t2", "str3").append("t3", 30L));
+		writer.close();
+
+		final TupleTypeInfo<Tuple3<Integer, String, Long>> typeInfo =
+				TupleTypeInfo.getBasicTupleTypeInfo(Integer.class, String.class, Long.class);
+		TupleParquetInputFormat<Tuple3<Integer, String, Long>> inputFormat = new TupleParquetInputFormat<>(
+				new org.apache.flink.core.fs.Path(tmpFile.toURI()),
+				typeInfo,
+				new String[]{"t1", "t2", "t3"});
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+		assertEquals(1, splits.length);
+		inputFormat.open(splits[0]);
+
+		assertFalse(inputFormat.reachedEnd());
+		Tuple3<Integer, String, Long> tuple3 = inputFormat.nextRecord(null);
+		assertEquals(new Tuple3<>(1, "str1", 10L), tuple3);
+
+		assertFalse(inputFormat.reachedEnd());
+		tuple3 = inputFormat.nextRecord(null);
+		assertEquals(new Tuple3<>(2, (String) null, 20L), tuple3);
+
+		assertFalse(inputFormat.reachedEnd());
+		tuple3 = inputFormat.nextRecord(null);
+		assertEquals(new Tuple3<>(3, "str3", 30L), tuple3);
+
+		assertTrue(inputFormat.reachedEnd());
+	}
+}

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -54,6 +54,7 @@ under the License.
 		<module>flink-connector-nifi</module>
 		<module>flink-connector-cassandra</module>
 		<module>flink-connector-filesystem</module>
+		<module>flink-parquet</module>
 	</modules>
 
 	<!-- override these root dependencies as 'provided', so they don't end up


### PR DESCRIPTION
## What is the purpose of the change

Add ParquetInputFormat to read from parquet files

## Brief change log
  - *Supports primary parquet types*
  - *Supports reading data with given columns instead of all columns*
  - *Supports reading data with filter*
  - *The return type of ParquetInputFormat supports Row, Tuple, POJO*

## Verifying this change

This change added tests and can be verified as follows:
 - *Added test that validates the correct of input split result with file or directory*
 - *Added test for reading with filter*
 - *Added test for  RowParquetInputFormat/TupleParquetInputFormat/PojoParquetInputFormat*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)

