### PR TITLE
[FLINK-7489] Remove startJobExecution and suspendExecution from JobMasterGateway

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -434,7 +434,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			log.info("JobManager for job {} ({}) was revoked leadership at {}.",
 				jobGraph.getName(), jobGraph.getJobID(), getAddress());
 
-			jobManager.getSelfGateway(JobMasterGateway.class).suspendExecution(new Exception("JobManager is no longer the leader."));
+			jobManager.suspend(new Exception("JobManager is no longer the leader."));
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -52,16 +52,6 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface JobMasterGateway extends CheckpointCoordinatorGateway {
 
-	// ------------------------------------------------------------------------
-	//  Job start and stop methods
-	// ------------------------------------------------------------------------
-
-	void startJobExecution();
-
-	void suspendExecution(Throwable cause);
-
-	// ------------------------------------------------------------------------
-
 	/**
 	 * Updates the task execution state for a given task.
 	 *

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerMockTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerMockTest.java
@@ -209,7 +209,7 @@ public class JobManagerRunnerMockTest extends TestLogger {
 		assertTrue(!jobCompletion.isJobFinished());
 
 		runner.revokeLeadership();
-		verify(jobManager).suspendExecution(any(Throwable.class));
+		verify(jobManager).suspend(any(Throwable.class));
 		assertFalse(runner.isShutdown());
 	}
 
@@ -224,7 +224,7 @@ public class JobManagerRunnerMockTest extends TestLogger {
 		assertTrue(!jobCompletion.isJobFinished());
 
 		runner.revokeLeadership();
-		verify(jobManager).suspendExecution(any(Throwable.class));
+		verify(jobManager).suspend(any(Throwable.class));
 		assertFalse(runner.isShutdown());
 
 		UUID leaderSessionID2 = UUID.randomUUID();


### PR DESCRIPTION
## What is the purpose of the change

The job lifecycle methods `startJobExecution` and `suspendExecution` should not be exposed as RPCs. Therefore, this commit removes them from the JobMasterGateway definition.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

