### PR TITLE
[FLINK-6864] Fix confusing "invalid POJO type" messages from TypeExtractor

### DIFF
--- a/docs/dev/types_serialization.md
+++ b/docs/dev/types_serialization.md
@@ -115,7 +115,7 @@ conditions are fulfilled:
   or have a public getter- and a setter- method that follows the Java beans
   naming conventions for getters and setters.
 
-Note that when a data type can't be recognized as a POJO type, it will be handled as GenericType.
+Note that when a data type can't be recognized as a POJO type, it will be processed as GenericType and serialized with Kryo.
 
 
 #### Creating a TypeInformation or TypeSerializer

--- a/docs/dev/types_serialization.md
+++ b/docs/dev/types_serialization.md
@@ -115,6 +115,8 @@ conditions are fulfilled:
   or have a public getter- and a setter- method that follows the Java beans
   naming conventions for getters and setters.
 
+Note that when a data type can't be recognized as a POJO type, it will be handled as GenericType.
+
 
 #### Creating a TypeInformation or TypeSerializer
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -1900,7 +1900,7 @@ public class TypeExtractor {
 			ParameterizedType parameterizedType, TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
 
 		if (!Modifier.isPublic(clazz.getModifiers())) {
-			LOG.info("Class " + clazz.getName() + " is not public, cannot treat it as a POJO type. Will be handled as GenericType");
+			LOG.info("Class " + clazz.getName() + " is not public, cannot treat it as a POJO type. Will be handled as GenericType.");
 			return new GenericTypeInfo<OUT>(clazz);
 		}
 
@@ -1915,7 +1915,7 @@ public class TypeExtractor {
 
 		List<Field> fields = getAllDeclaredFields(clazz, false);
 		if (fields.size() == 0) {
-			LOG.info("No fields detected for " + clazz + ". Cannot be used as a PojoType. Will be handled as GenericType");
+			LOG.info("No fields detected for " + clazz + ". Cannot be used as a PojoType. Will be handled as GenericType.");
 			return new GenericTypeInfo<OUT>(clazz);
 		}
 
@@ -1923,7 +1923,7 @@ public class TypeExtractor {
 		for (Field field : fields) {
 			Type fieldType = field.getGenericType();
 			if(!isValidPojoField(field, clazz, typeHierarchy)) {
-				LOG.info(clazz + " is not a valid POJO type because not all fields are valid POJO fields.");
+				LOG.info(clazz + " is not a valid POJO type because not all fields are valid POJO fields. Will be handled as GenericType.");
 				return null;
 			}
 			try {
@@ -1964,12 +1964,12 @@ public class TypeExtractor {
 				LOG.info(clazz + " is abstract or an interface, having a concrete " +
 						"type can increase performance.");
 			} else {
-				LOG.info(clazz + " must have a default constructor to be used as a POJO.");
+				LOG.info(clazz + " must have a default constructor to be used as a POJO. Will be handled as GenericType.");
 				return null;
 			}
 		}
 		if(defaultConstructor != null && !Modifier.isPublic(defaultConstructor.getModifiers())) {
-			LOG.info("The default constructor of " + clazz + " should be Public to be used as a POJO.");
+			LOG.info("The default constructor of " + clazz + " should be Public to be used as a POJO. Will be handled as GenericType.");
 			return null;
 		}
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -1900,7 +1900,9 @@ public class TypeExtractor {
 			ParameterizedType parameterizedType, TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
 
 		if (!Modifier.isPublic(clazz.getModifiers())) {
-			LOG.info("Class " + clazz.getName() + " is not public, cannot treat it as a POJO type. Will be handled as GenericType.");
+			LOG.info("Class " + clazz.getName() + " is not public, cannot treat it as a POJO type and " +
+				"will be handled as GenericType. Please read the Flink documentation on \"Data Types & Serialization\" " +
+				"for details on the impact to performance.");
 			return new GenericTypeInfo<OUT>(clazz);
 		}
 
@@ -1915,7 +1917,9 @@ public class TypeExtractor {
 
 		List<Field> fields = getAllDeclaredFields(clazz, false);
 		if (fields.size() == 0) {
-			LOG.info("No fields detected for " + clazz + ". Cannot be used as a PojoType. Will be handled as GenericType.");
+			LOG.info("No fields detected for " + clazz + ". Cannot be used as a PojoType and " +
+				"will be handled as GenericType. Please read the Flink documentation on \"Data Types & Serialization\" " +
+				"for details on the impact to performance.");
 			return new GenericTypeInfo<OUT>(clazz);
 		}
 
@@ -1923,7 +1927,9 @@ public class TypeExtractor {
 		for (Field field : fields) {
 			Type fieldType = field.getGenericType();
 			if(!isValidPojoField(field, clazz, typeHierarchy)) {
-				LOG.info(clazz + " is not a valid POJO type because not all fields are valid POJO fields. Will be handled as GenericType.");
+				LOG.info(clazz + " is not a valid POJO type because not all fields are valid POJO fields. " +
+					"Will be handled as GenericType. Please read the Flink documentation on \"Data Types & Serialization\" " +
+					"for details on the impact to performance.");
 				return null;
 			}
 			try {
@@ -1949,7 +1955,9 @@ public class TypeExtractor {
 		List<Method> methods = getAllDeclaredMethods(clazz);
 		for (Method method : methods) {
 			if (method.getName().equals("readObject") || method.getName().equals("writeObject")) {
-				LOG.info(clazz+" contains custom serialization methods we do not call.");
+				LOG.info(clazz+" contains custom serialization methods we do not call. " +
+									"Will be handled as GenericType. Please read the Flink documentation " +
+					"on \"Data Types & Serialization\" for details on the impact to performance.");
 				return null;
 			}
 		}
@@ -1964,12 +1972,16 @@ public class TypeExtractor {
 				LOG.info(clazz + " is abstract or an interface, having a concrete " +
 						"type can increase performance.");
 			} else {
-				LOG.info(clazz + " must have a default constructor to be used as a POJO. Will be handled as GenericType.");
+				LOG.info(clazz + " must have a default constructor to be used as a POJO. " +
+					"Will be handled as GenericType. Please read the Flink documentation on \"Data Types & Serialization\" " +
+					"for details on the impact to performance.");
 				return null;
 			}
 		}
 		if(defaultConstructor != null && !Modifier.isPublic(defaultConstructor.getModifiers())) {
-			LOG.info("The default constructor of " + clazz + " should be Public to be used as a POJO. Will be handled as GenericType.");
+			LOG.info("The default constructor of " + clazz + " should be Public to be used as a POJO. " +
+				"Will be handled as GenericType. Please read the Flink documentation on \"Data Types & Serialization\" " +
+				"for details on the impact to performance.");
 			return null;
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

Fix confusing "invalid POJO type" messages from TypeExtractor

## Brief change log

  - *Improve log about pojo in TypeExtractor*
  - *Add notice in types_serialization.cmd about rules-for-pojo-types*

## Verifying this change

This change needs no testing

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

