### PR TITLE
[FLINK-7078] [rpc] Introduce FencedRpcEndpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -434,7 +434,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			log.info("JobManager for job {} ({}) was revoked leadership at {}.",
 				jobGraph.getName(), jobGraph.getJobID(), getAddress());
 
-			jobManager.getSelfGateway(JobMasterGateway.class).suspendExecution(new Exception("JobManager is no longer the leader."));
+			jobManager.suspend(new Exception("JobManager is no longer the leader."));
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -52,16 +52,6 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface JobMasterGateway extends CheckpointCoordinatorGateway {
 
-	// ------------------------------------------------------------------------
-	//  Job start and stop methods
-	// ------------------------------------------------------------------------
-
-	void startJobExecution();
-
-	void suspendExecution(Throwable cause);
-
-	// ------------------------------------------------------------------------
-
 	/**
 	 * Updates the task execution state for a given task.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FencedMainThreadExecutable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FencedMainThreadExecutable.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc;
+
+import org.apache.flink.api.common.time.Time;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Extended {@link MainThreadExecutable} interface which allows to run unfenced runnables
+ * in the main thread.
+ */
+public interface FencedMainThreadExecutable extends MainThreadExecutable {
+
+	/**
+	 * Run the given runnable in the main thread without attaching a fencing token.
+	 *
+	 * @param runnable to run in the main thread without validating the fencing token.
+	 */
+	void runAsyncWithoutFencing(Runnable runnable);
+
+	/**
+	 * Run the given callable in the main thread without attaching a fencing token.
+	 *
+	 * @param callable to run in the main thread without validating the fencing token.
+	 * @param timeout for the operation
+	 * @param <V> type of the callable result
+	 * @return Future containing the callable result
+	 */
+	<V> CompletableFuture<V> callAsyncWithoutFencing(Callable<V> callable, Time timeout);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FencedRpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FencedRpcEndpoint.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Base class for fenced {@link RpcEndpoint}. A fenced rpc endpoint expects all rpc messages
+ * being enriched with fencing tokens. Furthermore, the rpc endpoint has its own fencing token
+ * assigned. The rpc is then only executed if the attached fencing token equals the endpoint's own
+ * token.
+ *
+ * @param <F> type of the fencing token
+ */
+public class FencedRpcEndpoint<F extends Serializable> extends RpcEndpoint {
+
+	private volatile F fencingToken;
+	private volatile MainThreadExecutor fencedMainThreadExecutor;
+
+	protected FencedRpcEndpoint(RpcService rpcService, String endpointId, F initialFencingToken) {
+		super(rpcService, endpointId);
+
+		this.fencingToken = Preconditions.checkNotNull(initialFencingToken);
+		this.fencedMainThreadExecutor = new MainThreadExecutor(
+			getRpcService().fenceRpcServer(
+				rpcServer,
+				initialFencingToken));
+	}
+
+	protected FencedRpcEndpoint(RpcService rpcService, F initialFencingToken) {
+		this(rpcService, UUID.randomUUID().toString(), initialFencingToken);
+	}
+
+	public F getFencingToken() {
+		return fencingToken;
+	}
+
+	protected void setFencingToken(F newFencingToken) {
+		// this method should only be called from within the main thread
+		validateRunsInMainThread();
+
+		this.fencingToken = newFencingToken;
+
+		// setting a new fencing token entails that we need a new MainThreadExecutor
+		// which is bound to the new fencing token
+		MainThreadExecutable mainThreadExecutable = getRpcService().fenceRpcServer(
+			rpcServer,
+			newFencingToken);
+
+		this.fencedMainThreadExecutor = new MainThreadExecutor(mainThreadExecutable);
+	}
+
+	/**
+	 * Returns a main thread executor which is bound to the currently valid fencing token.
+	 * This means that runnables which are executed with this executor fail after the fencing
+	 * token has changed. This allows to scope operations by the fencing token.
+	 *
+	 * @return MainThreadExecutor bound to the current fencing token
+	 */
+	@Override
+	protected MainThreadExecutor getMainThreadExecutor() {
+		return fencedMainThreadExecutor;
+	}
+
+	/**
+	 * Run the given runnable in the main thread of the RpcEndpoint without checking the fencing
+	 * token. This allows to run operations outside of the fencing token scope.
+	 *
+	 * @param runnable to execute in the main thread of the rpc endpoint without checking the fencing token.
+	 */
+	protected void runAsyncWithoutFencing(Runnable runnable) {
+		if (rpcServer instanceof FencedMainThreadExecutable) {
+			((FencedMainThreadExecutable) rpcServer).runAsyncWithoutFencing(runnable);
+		} else {
+			throw new RuntimeException("FencedRpcEndpoint has not been started with a FencedMainThreadExecutable RpcServer.");
+		}
+	}
+
+	/**
+	 * Run the given callable in the main thread of the RpcEndpoint without checking the fencing
+	 * token. This allows to run operations outside of the fencing token scope.
+	 *
+	 * @param callable to run in the main thread of the rpc endpoint without checkint the fencing token.
+	 * @param timeout for the operation.
+	 * @return Future containing the callable result.
+	 */
+	protected <V> CompletableFuture<V> callAsyncWithoutFencing(Callable<V> callable, Time timeout) {
+		if (rpcServer instanceof FencedMainThreadExecutable) {
+			return ((FencedMainThreadExecutable) rpcServer).callAsyncWithoutFencing(callable, timeout);
+		} else {
+			throw new RuntimeException("FencedRpcEndpoint has not been started with a FencedMainThreadExecutable RpcServer.");
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FencedRpcGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FencedRpcGateway.java
@@ -16,12 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc.akka.messages;
+package org.apache.flink.runtime.rpc;
+
+import java.io.Serializable;
 
 /**
- * Controls the processing behaviour of the {@link org.apache.flink.runtime.rpc.akka.AkkaRpcActor}
+ * Fenced {@link RpcGateway}. This gateway allows to have access to the associated
+ * fencing token.
+ *
+ * @param <F> type of the fencing token
  */
-public enum Processing  {
-	START, // Unstashes all stashed messages and starts processing incoming messages
-	STOP // Stop processing messages and stashes all incoming messages
+public interface FencedRpcGateway<F extends Serializable> extends RpcGateway {
+
+	/**
+	 * Get the current fencing token.
+	 *
+	 * @return current fencing token
+	 */
+	F getFencingToken();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -66,14 +67,14 @@ public abstract class RpcEndpoint implements RpcGateway {
 	private final String endpointId;
 
 	/** Interface to access the underlying rpc server */
-	private final RpcServer rpcServer;
+	protected final RpcServer rpcServer;
+
+	/** A reference to the endpoint's main thread, if the current method is called by the main thread */
+	final AtomicReference<Thread> currentMainThread = new AtomicReference<>(null);
 
 	/** The main thread executor to be used to execute future callbacks in the main thread
 	 * of the executing rpc server. */
-	private final Executor mainThreadExecutor;
-
-	/** A reference to the endpoint's main thread, if the current method is called by the main thread */
-	final AtomicReference<Thread> currentMainThread = new AtomicReference<>(null); 
+	private final MainThreadExecutor mainThreadExecutor;
 
 	/**
 	 * Initializes the RPC endpoint.
@@ -208,7 +209,7 @@ public abstract class RpcEndpoint implements RpcGateway {
 	 *
 	 * @return Main thread execution context
 	 */
-	protected Executor getMainThreadExecutor() {
+	protected MainThreadExecutor getMainThreadExecutor() {
 		return mainThreadExecutor;
 	}
 
@@ -310,7 +311,7 @@ public abstract class RpcEndpoint implements RpcGateway {
 	/**
 	 * Executor which executes runnables in the main thread context.
 	 */
-	private static class MainThreadExecutor implements Executor {
+	protected static class MainThreadExecutor implements Executor {
 
 		private final MainThreadExecutable gateway;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -30,15 +30,19 @@ import akka.dispatch.Futures;
 import akka.dispatch.Mapper;
 import akka.pattern.Patterns;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.rpc.FencedMainThreadExecutable;
+import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
+import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcServer;
 import org.apache.flink.runtime.rpc.RpcUtils;
-import org.apache.flink.runtime.rpc.akka.messages.Shutdown;
+import org.apache.flink.runtime.rpc.messages.Shutdown;
 import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
 import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
@@ -49,6 +53,8 @@ import scala.concurrent.duration.FiniteDuration;
 
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.Serializable;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.util.HashSet;
@@ -61,6 +67,7 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableScheduledFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -131,60 +138,44 @@ public class AkkaRpcService implements RpcService {
 
 	// this method does not mutate state and is thus thread-safe
 	@Override
-	public <C extends RpcGateway> CompletableFuture<C> connect(final String address, final Class<C> clazz) {
-		checkState(!stopped, "RpcService is stopped");
+	public <C extends RpcGateway> CompletableFuture<C> connect(
+			final String address,
+			final Class<C> clazz) {
 
-		LOG.debug("Try to connect to remote RPC endpoint with address {}. Returning a {} gateway.",
-				address, clazz.getName());
+		return connectInternal(
+			address,
+			clazz,
+			(ActorRef actorRef) -> {
+				Tuple2<String, String> addressHostname = extractAddressHostname(actorRef);
 
-		final ActorSelection actorSel = actorSystem.actorSelection(address);
+				return new AkkaInvocationHandler(
+					addressHostname.f0,
+					addressHostname.f1,
+					actorRef,
+					timeout,
+					maximumFramesize,
+					null);
+			});
+	}
 
-		final scala.concurrent.Future<Object> identify = Patterns.ask(actorSel, new Identify(42), timeout.toMilliseconds());
-		final scala.concurrent.Future<C> resultFuture = identify.map(new Mapper<Object, C>(){
-			@Override
-			public C checkedApply(Object obj) throws Exception {
+	// this method does not mutate state and is thus thread-safe
+	@Override
+	public <F extends Serializable, C extends FencedRpcGateway<F>> CompletableFuture<C> connect(String address, F fencingToken, Class<C> clazz) {
+		return connectInternal(
+			address,
+			clazz,
+			(ActorRef actorRef) -> {
+				Tuple2<String, String> addressHostname = extractAddressHostname(actorRef);
 
-				ActorIdentity actorIdentity = (ActorIdentity) obj;
-
-				if (actorIdentity.getRef() == null) {
-					throw new RpcConnectionException("Could not connect to rpc endpoint under address " + address + '.');
-				} else {
-					ActorRef actorRef = actorIdentity.getRef();
-
-					final String address = AkkaUtils.getAkkaURL(actorSystem, actorRef);
-					final String hostname;
-					Option<String> host = actorRef.path().address().host();
-					if (host.isEmpty()) {
-						hostname = "localhost";
-					} else {
-						hostname = host.get();
-					}
-
-					InvocationHandler akkaInvocationHandler = new AkkaInvocationHandler(
-						address,
-						hostname,
-						actorRef,
-						timeout,
-						maximumFramesize,
-						null);
-
-					// Rather than using the System ClassLoader directly, we derive the ClassLoader
-					// from this class . That works better in cases where Flink runs embedded and all Flink
-					// code is loaded dynamically (for example from an OSGI bundle) through a custom ClassLoader
-					ClassLoader classLoader = AkkaRpcService.this.getClass().getClassLoader();
-
-					@SuppressWarnings("unchecked")
-					C proxy = (C) Proxy.newProxyInstance(
-						classLoader,
-						new Class<?>[]{clazz},
-						akkaInvocationHandler);
-
-					return proxy;
-				}
-			}
-		}, actorSystem.dispatcher());
-
-		return FutureUtils.toJava(resultFuture);
+				return new FencedAkkaInvocationHandler<>(
+					addressHostname.f0,
+					addressHostname.f1,
+					actorRef,
+					timeout,
+					maximumFramesize,
+					null,
+					() -> fencingToken);
+			});
 	}
 
 	@Override
@@ -192,7 +183,14 @@ public class AkkaRpcService implements RpcService {
 		checkNotNull(rpcEndpoint, "rpc endpoint");
 
 		CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
-		Props akkaRpcActorProps = Props.create(AkkaRpcActor.class, rpcEndpoint, terminationFuture);
+		final Props akkaRpcActorProps;
+
+		if (rpcEndpoint instanceof FencedRpcEndpoint) {
+			akkaRpcActorProps = Props.create(FencedAkkaRpcActor.class, rpcEndpoint, terminationFuture);
+		} else {
+			akkaRpcActorProps = Props.create(AkkaRpcActor.class, rpcEndpoint, terminationFuture);
+		}
+
 		ActorRef actorRef;
 
 		synchronized (lock) {
@@ -212,23 +210,39 @@ public class AkkaRpcService implements RpcService {
 			hostname = host.get();
 		}
 
-		InvocationHandler akkaInvocationHandler = new AkkaInvocationHandler(
-			address,
-			hostname,
-			actorRef,
-			timeout,
-			maximumFramesize,
-			terminationFuture);
+		Set<Class<?>> implementedRpcGateways = new HashSet<>(RpcUtils.extractImplementedRpcGateways(rpcEndpoint.getClass()));
+
+		implementedRpcGateways.add(RpcServer.class);
+		implementedRpcGateways.add(AkkaGateway.class);
+
+		final InvocationHandler akkaInvocationHandler;
+
+		if (rpcEndpoint instanceof FencedRpcEndpoint) {
+			// a FencedRpcEndpoint needs a FencedAkkaInvocationHandler
+			akkaInvocationHandler = new FencedAkkaInvocationHandler<>(
+				address,
+				hostname,
+				actorRef,
+				timeout,
+				maximumFramesize,
+				terminationFuture,
+				((FencedRpcEndpoint<?>) rpcEndpoint)::getFencingToken);
+
+			implementedRpcGateways.add(FencedMainThreadExecutable.class);
+		} else {
+			akkaInvocationHandler = new AkkaInvocationHandler(
+				address,
+				hostname,
+				actorRef,
+				timeout,
+				maximumFramesize,
+				terminationFuture);
+		}
 
 		// Rather than using the System ClassLoader directly, we derive the ClassLoader
 		// from this class . That works better in cases where Flink runs embedded and all Flink
 		// code is loaded dynamically (for example from an OSGI bundle) through a custom ClassLoader
 		ClassLoader classLoader = getClass().getClassLoader();
-
-		Set<Class<? extends RpcGateway>> implementedRpcGateways = RpcUtils.extractImplementedRpcGateways(rpcEndpoint.getClass());
-
-		implementedRpcGateways.add(RpcServer.class);
-		implementedRpcGateways.add(AkkaGateway.class);
 
 		@SuppressWarnings("unchecked")
 		RpcServer server = (RpcServer) Proxy.newProxyInstance(
@@ -237,6 +251,33 @@ public class AkkaRpcService implements RpcService {
 			akkaInvocationHandler);
 
 		return server;
+	}
+
+	@Override
+	public <F extends Serializable> RpcServer fenceRpcServer(RpcServer rpcServer, F fencingToken) {
+		if (rpcServer instanceof AkkaGateway) {
+
+			InvocationHandler fencedInvocationHandler = new FencedAkkaInvocationHandler<>(
+				rpcServer.getAddress(),
+				rpcServer.getHostname(),
+				((AkkaGateway) rpcServer).getRpcEndpoint(),
+				timeout,
+				maximumFramesize,
+				null,
+				() -> fencingToken);
+
+			// Rather than using the System ClassLoader directly, we derive the ClassLoader
+			// from this class . That works better in cases where Flink runs embedded and all Flink
+			// code is loaded dynamically (for example from an OSGI bundle) through a custom ClassLoader
+			ClassLoader classLoader = getClass().getClassLoader();
+
+			return (RpcServer) Proxy.newProxyInstance(
+				classLoader,
+				new Class<?>[]{RpcServer.class, AkkaGateway.class},
+				fencedInvocationHandler);
+		} else {
+			throw new RuntimeException("The given RpcServer must implement the AkkaGateway in order to fence it.");
+		}
 	}
 
 	@Override
@@ -315,6 +356,67 @@ public class AkkaRpcService implements RpcService {
 		Future<T> scalaFuture = Futures.future(callable, actorSystem.dispatcher());
 
 		return FutureUtils.toJava(scalaFuture);
+	}
+
+	// ---------------------------------------------------------------------------------------
+	// Private helper methods
+	// ---------------------------------------------------------------------------------------
+
+	private Tuple2<String, String> extractAddressHostname(ActorRef actorRef) {
+		final String actorAddress = AkkaUtils.getAkkaURL(actorSystem, actorRef);
+		final String hostname;
+		Option<String> host = actorRef.path().address().host();
+		if (host.isEmpty()) {
+			hostname = "localhost";
+		} else {
+			hostname = host.get();
+		}
+
+		return Tuple2.of(actorAddress, hostname);
+	}
+
+	private <C extends RpcGateway> CompletableFuture<C> connectInternal(
+			final String address,
+			final Class<C> clazz,
+			Function<ActorRef, InvocationHandler> invocationHandlerFactory) {
+		checkState(!stopped, "RpcService is stopped");
+
+		LOG.debug("Try to connect to remote RPC endpoint with address {}. Returning a {} gateway.",
+			address, clazz.getName());
+
+		final ActorSelection actorSel = actorSystem.actorSelection(address);
+
+		final Future<Object> identify = Patterns.ask(actorSel, new Identify(42), timeout.toMilliseconds());
+		final Future<C> resultFuture = identify.map(new Mapper<Object, C>(){
+			@Override
+			public C checkedApply(Object obj) throws Exception {
+
+				ActorIdentity actorIdentity = (ActorIdentity) obj;
+
+				if (actorIdentity.getRef() == null) {
+					throw new RpcConnectionException("Could not connect to rpc endpoint under address " + address + '.');
+				} else {
+					ActorRef actorRef = actorIdentity.getRef();
+
+					InvocationHandler invocationHandler = invocationHandlerFactory.apply(actorRef);
+
+					// Rather than using the System ClassLoader directly, we derive the ClassLoader
+					// from this class . That works better in cases where Flink runs embedded and all Flink
+					// code is loaded dynamically (for example from an OSGI bundle) through a custom ClassLoader
+					ClassLoader classLoader = AkkaRpcService.this.getClass().getClassLoader();
+
+					@SuppressWarnings("unchecked")
+					C proxy = (C) Proxy.newProxyInstance(
+						classLoader,
+						new Class<?>[]{clazz},
+						invocationHandler);
+
+					return proxy;
+				}
+			}
+		}, actorSystem.dispatcher());
+
+		return FutureUtils.toJava(resultFuture);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.rpc.FencedMainThreadExecutable;
+import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
+import org.apache.flink.runtime.rpc.FencedRpcGateway;
+import org.apache.flink.runtime.rpc.messages.CallAsync;
+import org.apache.flink.runtime.rpc.messages.FencedMessage;
+import org.apache.flink.runtime.rpc.messages.RunAsync;
+import org.apache.flink.runtime.rpc.messages.UnfencedMessage;
+import org.apache.flink.util.Preconditions;
+
+import akka.actor.ActorRef;
+import akka.pattern.Patterns;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Fenced extension of the {@link AkkaInvocationHandler}. This invocation handler will be used in combination
+ * with the {@link FencedRpcEndpoint}. The fencing is done by wrapping all messages in a {@link FencedMessage}.
+ *
+ * @param <F> type of the fencing token
+ */
+public class FencedAkkaInvocationHandler<F extends Serializable> extends AkkaInvocationHandler implements FencedMainThreadExecutable, FencedRpcGateway<F> {
+
+	private final Supplier<F> fencingTokenSupplier;
+
+	public FencedAkkaInvocationHandler(
+			String address,
+			String hostname,
+			ActorRef rpcEndpoint,
+			Time timeout,
+			long maximumFramesize,
+			@Nullable CompletableFuture<Void> terminationFuture,
+			Supplier<F> fencingTokenSupplier) {
+		super(address, hostname, rpcEndpoint, timeout, maximumFramesize, terminationFuture);
+
+		this.fencingTokenSupplier = Preconditions.checkNotNull(fencingTokenSupplier);
+	}
+
+	@Override
+	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+		Class<?> declaringClass = method.getDeclaringClass();
+
+		if (declaringClass.equals(FencedMainThreadExecutable.class) ||
+			declaringClass.equals(FencedRpcGateway.class)) {
+			return method.invoke(this, args);
+		} else {
+			return super.invoke(proxy, method, args);
+		}
+	}
+
+	@Override
+	public void runAsyncWithoutFencing(Runnable runnable) {
+		checkNotNull(runnable, "runnable");
+
+		if (isLocal) {
+			getRpcEndpoint().tell(
+				new UnfencedMessage<>(new RunAsync(runnable, 0L)), ActorRef.noSender());
+		} else {
+			throw new RuntimeException("Trying to send a Runnable to a remote actor at " +
+				getRpcEndpoint().path() + ". This is not supported.");
+		}
+	}
+
+	@Override
+	public <V> CompletableFuture<V> callAsyncWithoutFencing(Callable<V> callable, Time timeout) {
+		checkNotNull(callable, "callable");
+		checkNotNull(timeout, "timeout");
+
+		if (isLocal) {
+			@SuppressWarnings("unchecked")
+			CompletableFuture<V> resultFuture = (CompletableFuture<V>) FutureUtils.toJava(
+				Patterns.ask(
+					getRpcEndpoint(),
+					new UnfencedMessage<>(new CallAsync(callable)),
+					timeout.toMilliseconds()));
+
+			return resultFuture;
+		} else {
+			throw new RuntimeException("Trying to send a Runnable to a remote actor at " +
+				getRpcEndpoint().path() + ". This is not supported.");
+		}
+	}
+
+	@Override
+	public void tell(Object message) {
+		super.tell(fenceMessage(message));
+	}
+
+	@Override
+	public CompletableFuture<?> ask(Object message, Time timeout) {
+		return super.ask(fenceMessage(message), timeout);
+	}
+
+	@Override
+	public F getFencingToken() {
+		return fencingTokenSupplier.get();
+	}
+
+	private <P> FencedMessage<F, P> fenceMessage(P message) {
+		return new FencedMessage<>(fencingTokenSupplier.get(), message);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
+import org.apache.flink.runtime.rpc.akka.exceptions.AkkaUnknownMessageException;
+import org.apache.flink.runtime.rpc.exceptions.FencingTokenMismatchException;
+import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.messages.FencedMessage;
+import org.apache.flink.runtime.rpc.messages.UnfencedMessage;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Fenced extension of the {@link AkkaRpcActor}. This actor will be started for {@link FencedRpcEndpoint} and is
+ * responsible for filtering out invalid messages with respect to the current fencing token.
+ *
+ * @param <F> type of the fencing token
+ * @param <T> type of the RpcEndpoint
+ */
+public class FencedAkkaRpcActor<F extends Serializable, T extends FencedRpcEndpoint<F> & RpcGateway> extends AkkaRpcActor<T> {
+
+	public FencedAkkaRpcActor(T rpcEndpoint, CompletableFuture<Void> terminationFuture) {
+		super(rpcEndpoint, terminationFuture);
+	}
+
+	@Override
+	protected void handleMessage(Object message) {
+		if (message instanceof FencedMessage) {
+			@SuppressWarnings("unchecked")
+			FencedMessage<F, ?> fencedMessage = ((FencedMessage<F, ?>) message);
+
+			F fencingToken = fencedMessage.getFencingToken();
+
+			if (Objects.equals(rpcEndpoint.getFencingToken(), fencingToken)) {
+				super.handleMessage(fencedMessage.getPayload());
+			} else {
+				if (log.isDebugEnabled()) {
+					log.debug("Fencing token mismatch: Ignoring message {} because the fencing token {} did " +
+						"not match the expected fencing token {}.", message, fencingToken, rpcEndpoint.getFencingToken());
+				}
+
+				sendErrorIfSender(new FencingTokenMismatchException("Expected fencing token " + rpcEndpoint.getFencingToken() + ", actual fencing token " + fencingToken));
+			}
+		} else if (message instanceof UnfencedMessage) {
+			super.handleMessage(((UnfencedMessage<?>) message).getPayload());
+		} else {
+			if (log.isDebugEnabled()) {
+				log.debug("Unknown message type: Ignoring message {} because it is neither of type {} nor {}.",
+					message, FencedMessage.class.getSimpleName(), UnfencedMessage.class.getSimpleName());
+			}
+
+			sendErrorIfSender(new AkkaUnknownMessageException("Unknown message type: Ignoring message " + message +
+				" of type " + message.getClass().getSimpleName() + " because it is neither of type " +
+				FencedMessage.class.getSimpleName() + " nor " + UnfencedMessage.class.getSimpleName() + '.'));
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/exceptions/AkkaUnknownMessageException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/exceptions/AkkaUnknownMessageException.java
@@ -16,21 +16,25 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc.akka.messages;
-
-import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
+package org.apache.flink.runtime.rpc.akka.exceptions;
 
 /**
- * Shut down message used to trigger the shut down of an AkkaRpcActor. This
- * message is only intended for internal use by the {@link AkkaRpcService}.
+ * Exception which indicates that the AkkaRpcActor has received an
+ * unknown message type.
  */
-public final class Shutdown {
+public class AkkaUnknownMessageException extends AkkaRpcException {
 
-	private static Shutdown instance = new Shutdown();
+	private static final long serialVersionUID = 1691338049911020814L;
 
-	public static Shutdown getInstance() {
-		return instance;
+	public AkkaUnknownMessageException(String message) {
+		super(message);
 	}
 
-	private Shutdown() {}
+	public AkkaUnknownMessageException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public AkkaUnknownMessageException(Throwable cause) {
+		super(cause);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/exceptions/FencingTokenMismatchException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/exceptions/FencingTokenMismatchException.java
@@ -16,12 +16,27 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc.akka.messages;
+package org.apache.flink.runtime.rpc.exceptions;
+
+import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
+import org.apache.flink.runtime.rpc.exceptions.RpcException;
 
 /**
- * Controls the processing behaviour of the {@link org.apache.flink.runtime.rpc.akka.AkkaRpcActor}
+ * Exception which is thrown if the fencing tokens of a {@link FencedRpcEndpoint} do
+ * not match.
  */
-public enum Processing  {
-	START, // Unstashes all stashed messages and starts processing incoming messages
-	STOP // Stop processing messages and stashes all incoming messages
+public class FencingTokenMismatchException extends RpcException {
+	private static final long serialVersionUID = -500634972988881467L;
+
+	public FencingTokenMismatchException(String message) {
+		super(message);
+	}
+
+	public FencingTokenMismatchException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public FencingTokenMismatchException(Throwable cause) {
+		super(cause);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/CallAsync.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/CallAsync.java
@@ -16,12 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc.akka.messages;
+package org.apache.flink.runtime.rpc.messages;
+
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+import java.util.concurrent.Callable;
 
 /**
- * Controls the processing behaviour of the {@link org.apache.flink.runtime.rpc.akka.AkkaRpcActor}
+ * Message for asynchronous callable invocations
  */
-public enum Processing  {
-	START, // Unstashes all stashed messages and starts processing incoming messages
-	STOP // Stop processing messages and stashes all incoming messages
+public final class CallAsync implements Serializable {
+	private static final long serialVersionUID = 2834204738928484060L;
+
+	private transient Callable<?> callable;
+
+	public CallAsync(Callable<?> callable) {
+		this.callable = Preconditions.checkNotNull(callable);
+	}
+
+	public Callable<?> getCallable() {
+		return callable;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/ControlMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/ControlMessage.java
@@ -16,12 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc.akka.messages;
+package org.apache.flink.runtime.rpc.messages;
 
 /**
- * Controls the processing behaviour of the {@link org.apache.flink.runtime.rpc.akka.AkkaRpcActor}
+ * Base interface for control messages which are treated separately by the RPC server
+ * implementation.
  */
-public enum Processing  {
-	START, // Unstashes all stashed messages and starts processing incoming messages
-	STOP // Stop processing messages and stashes all incoming messages
+public interface ControlMessage {
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/FencedMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/FencedMessage.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.messages;
+
+import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+
+/**
+ * Wrapper class for fenced messages used by the {@link FencedRpcEndpoint}.
+ *
+ * @param <F> type of the fencing token
+ * @param <P> type of the payload
+ */
+public class FencedMessage<F extends Serializable, P> {
+	private final F fencingToken;
+	private final P payload;
+
+
+	public FencedMessage(F fencingToken, P payload) {
+		this.fencingToken = Preconditions.checkNotNull(fencingToken);
+		this.payload = Preconditions.checkNotNull(payload);
+	}
+
+	public F getFencingToken() {
+		return fencingToken;
+	}
+
+	public P getPayload() {
+		return payload;
+	}
+
+	@Override
+	public String toString() {
+		return "FencedMessage(" + fencingToken + ", " + payload + ')';
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/FencedMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/FencedMessage.java
@@ -18,37 +18,17 @@
 
 package org.apache.flink.runtime.rpc.messages;
 
-import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
-import org.apache.flink.util.Preconditions;
-
 import java.io.Serializable;
 
 /**
- * Wrapper class for fenced messages used by the {@link FencedRpcEndpoint}.
+ * Interface for fenced messages.
  *
  * @param <F> type of the fencing token
  * @param <P> type of the payload
  */
-public class FencedMessage<F extends Serializable, P> {
-	private final F fencingToken;
-	private final P payload;
+public interface FencedMessage<F extends Serializable, P> {
 
+	F getFencingToken();
 
-	public FencedMessage(F fencingToken, P payload) {
-		this.fencingToken = Preconditions.checkNotNull(fencingToken);
-		this.payload = Preconditions.checkNotNull(payload);
-	}
-
-	public F getFencingToken() {
-		return fencingToken;
-	}
-
-	public P getPayload() {
-		return payload;
-	}
-
-	@Override
-	public String toString() {
-		return "FencedMessage(" + fencingToken + ", " + payload + ')';
-	}
+	P getPayload();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/LocalFencedMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/LocalFencedMessage.java
@@ -18,32 +18,39 @@
 
 package org.apache.flink.runtime.rpc.messages;
 
-import org.apache.flink.runtime.rpc.FencedMainThreadExecutable;
 import org.apache.flink.util.Preconditions;
 
+import java.io.Serializable;
+
 /**
- * Wrapper class indicating a message which is not required to match the fencing token
- * as it is used by the {@link FencedMainThreadExecutable} to run code in the main thread without
- * a valid fencing token. This is required for operations which are not scoped by the current
- * fencing token (e.g. leadership grants).
+ * Local {@link FencedMessage} implementation. This message is used when the communication
+ * is local and thus does not require its payload to be serializable.
  *
- * <p>IMPORTANT: This message is only intended to be send locally.
- *
+ * @param <F> type of the fencing token
  * @param <P> type of the payload
  */
-public class UnfencedMessage<P> {
+public class LocalFencedMessage<F extends Serializable, P> implements FencedMessage<F, P> {
+
+	private final F fencingToken;
 	private final P payload;
 
-	public UnfencedMessage(P payload) {
+	public LocalFencedMessage(F fencingToken, P payload) {
+		this.fencingToken = Preconditions.checkNotNull(fencingToken);
 		this.payload = Preconditions.checkNotNull(payload);
 	}
 
+	@Override
+	public F getFencingToken() {
+		return fencingToken;
+	}
+
+	@Override
 	public P getPayload() {
 		return payload;
 	}
 
 	@Override
 	public String toString() {
-		return "UnfencedMessage(" + payload + ')';
+		return "LocalFencedMessage(" + fencingToken + ", " + payload + ')';
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/LocalRpcInvocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/LocalRpcInvocation.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc.akka.messages;
+package org.apache.flink.runtime.rpc.messages;
 
 import org.apache.flink.util.Preconditions;
 
@@ -31,10 +31,14 @@ public final class LocalRpcInvocation implements RpcInvocation {
 	private final Class<?>[] parameterTypes;
 	private final Object[] args;
 
+	private transient String toString;
+
 	public LocalRpcInvocation(String methodName, Class<?>[] parameterTypes, Object[] args) {
 		this.methodName = Preconditions.checkNotNull(methodName);
 		this.parameterTypes = Preconditions.checkNotNull(parameterTypes);
 		this.args = args;
+
+		toString = null;
 	}
 
 	@Override
@@ -50,5 +54,26 @@ public final class LocalRpcInvocation implements RpcInvocation {
 	@Override
 	public Object[] getArgs() {
 		return args;
+	}
+
+	@Override
+	public String toString() {
+		if (toString == null) {
+			StringBuilder paramTypeStringBuilder = new StringBuilder(parameterTypes.length * 5);
+
+			if (parameterTypes.length > 0) {
+				paramTypeStringBuilder.append(parameterTypes[0].getSimpleName());
+
+				for (int i = 1; i < parameterTypes.length; i++) {
+					paramTypeStringBuilder
+						.append(", ")
+						.append(parameterTypes[i].getSimpleName());
+				}
+			}
+
+			toString = "LocalRpcInvocation(" + methodName + '(' + paramTypeStringBuilder + "))";
+		}
+
+		return toString;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/RemoteFencedMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/RemoteFencedMessage.java
@@ -18,32 +18,40 @@
 
 package org.apache.flink.runtime.rpc.messages;
 
-import org.apache.flink.runtime.rpc.FencedMainThreadExecutable;
 import org.apache.flink.util.Preconditions;
 
+import java.io.Serializable;
+
 /**
- * Wrapper class indicating a message which is not required to match the fencing token
- * as it is used by the {@link FencedMainThreadExecutable} to run code in the main thread without
- * a valid fencing token. This is required for operations which are not scoped by the current
- * fencing token (e.g. leadership grants).
+ * Remote {@link FencedMessage} implementation. This message is used when the communication
+ * is remote and thus requires its payload to be serializable.
  *
- * <p>IMPORTANT: This message is only intended to be send locally.
- *
+ * @param <F> type of the fencing token
  * @param <P> type of the payload
  */
-public class UnfencedMessage<P> {
+public class RemoteFencedMessage<F extends Serializable, P extends Serializable> implements FencedMessage<F, P>, Serializable {
+	private static final long serialVersionUID = 4043136067468477742L;
+
+	private final F fencingToken;
 	private final P payload;
 
-	public UnfencedMessage(P payload) {
+	public RemoteFencedMessage(F fencingToken, P payload) {
+		this.fencingToken = Preconditions.checkNotNull(fencingToken);
 		this.payload = Preconditions.checkNotNull(payload);
 	}
 
+	@Override
+	public F getFencingToken() {
+		return fencingToken;
+	}
+
+	@Override
 	public P getPayload() {
 		return payload;
 	}
 
 	@Override
 	public String toString() {
-		return "UnfencedMessage(" + payload + ')';
+		return "RemoteFencedMessage(" + fencingToken + ", " + payload + ')';
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/RemoteRpcInvocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/RemoteRpcInvocation.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc.akka.messages;
+package org.apache.flink.runtime.rpc.messages;
 
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
@@ -42,6 +42,8 @@ public class RemoteRpcInvocation implements RpcInvocation, Serializable {
 
 	// Transient field which is lazily initialized upon first access to the invocation data
 	private transient RemoteRpcInvocation.MethodInvocation methodInvocation;
+
+	private transient String toString;
 
 	public  RemoteRpcInvocation(
 		final String methodName,
@@ -71,6 +73,35 @@ public class RemoteRpcInvocation implements RpcInvocation, Serializable {
 		deserializeMethodInvocation();
 
 		return methodInvocation.getArgs();
+	}
+
+	@Override
+	public String toString() {
+		if (toString == null) {
+
+			try {
+				Class<?>[] parameterTypes = getParameterTypes();
+				String methodName = getMethodName();
+
+				StringBuilder paramTypeStringBuilder = new StringBuilder(parameterTypes.length * 5);
+
+				if (parameterTypes.length > 0) {
+					paramTypeStringBuilder.append(parameterTypes[0].getSimpleName());
+
+					for (int i = 1; i < parameterTypes.length; i++) {
+						paramTypeStringBuilder
+							.append(", ")
+							.append(parameterTypes[i].getSimpleName());
+					}
+				}
+
+				toString = "RemoteRpcInvocation(" + methodName + '(' + paramTypeStringBuilder + "))";
+			} catch (IOException | ClassNotFoundException e) {
+				toString = "Could not deserialize RemoteRpcInvocation: " + e.getMessage();
+			}
+		}
+
+		return toString;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/RpcInvocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/RpcInvocation.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc.akka.messages;
+package org.apache.flink.runtime.rpc.messages;
 
 import java.io.IOException;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/RunAsync.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/RunAsync.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc.akka.messages;
+package org.apache.flink.runtime.rpc.messages;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -26,7 +26,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  */
 public final class RunAsync {
 
-	/** The runnable to be executed. Transient, so it gets lost upon serialization */ 
+	/** The runnable to be executed. Transient, so it gets lost upon serialization */
 	private final Runnable runnable;
 
 	/** The delay after which the runnable should be called */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/Shutdown.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/Shutdown.java
@@ -16,26 +16,21 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc.akka.messages;
+package org.apache.flink.runtime.rpc.messages;
 
-import org.apache.flink.util.Preconditions;
-
-import java.io.Serializable;
-import java.util.concurrent.Callable;
+import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 
 /**
- * Message for asynchronous callable invocations
+ * Shut down message used to trigger the shut down of an AkkaRpcActor. This
+ * message is only intended for internal use by the {@link AkkaRpcService}.
  */
-public final class CallAsync implements Serializable {
-	private static final long serialVersionUID = 2834204738928484060L;
+public final class Shutdown implements ControlMessage {
 
-	private transient Callable<?> callable;
+	private static Shutdown instance = new Shutdown();
 
-	public CallAsync(Callable<?> callable) {
-		this.callable = Preconditions.checkNotNull(callable);
+	public static Shutdown getInstance() {
+		return instance;
 	}
 
-	public Callable<?> getCallable() {
-		return callable;
-	}
+	private Shutdown() {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/UnfencedMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/UnfencedMessage.java
@@ -16,12 +16,32 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc.akka.messages;
+package org.apache.flink.runtime.rpc.messages;
+
+import org.apache.flink.runtime.rpc.FencedMainThreadExecutable;
+import org.apache.flink.util.Preconditions;
 
 /**
- * Controls the processing behaviour of the {@link org.apache.flink.runtime.rpc.akka.AkkaRpcActor}
+ * Wrapper class indicating a message which is not required to match the fencing token
+ * as it is used by the {@link FencedMainThreadExecutable} to run code in the main thread without
+ * a valid fencing token. This is required for operations which are not scoped by the current
+ * fencing token (e.g. leadership grants).
+ *
+ * @param <P> type of the payload
  */
-public enum Processing  {
-	START, // Unstashes all stashed messages and starts processing incoming messages
-	STOP // Stop processing messages and stashes all incoming messages
+public class UnfencedMessage<P> {
+	private final P payload;
+
+	public UnfencedMessage(P payload) {
+		this.payload = Preconditions.checkNotNull(payload);
+	}
+
+	public P getPayload() {
+		return payload;
+	}
+
+	@Override
+	public String toString() {
+		return "UnfencedMessage(" + payload + ')';
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerMockTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerMockTest.java
@@ -209,7 +209,7 @@ public class JobManagerRunnerMockTest extends TestLogger {
 		assertTrue(!jobCompletion.isJobFinished());
 
 		runner.revokeLeadership();
-		verify(jobManager).suspendExecution(any(Throwable.class));
+		verify(jobManager).suspend(any(Throwable.class));
 		assertFalse(runner.isShutdown());
 	}
 
@@ -224,7 +224,7 @@ public class JobManagerRunnerMockTest extends TestLogger {
 		assertTrue(!jobCompletion.isJobFinished());
 
 		runner.revokeLeadership();
-		verify(jobManager).suspendExecution(any(Throwable.class));
+		verify(jobManager).suspend(any(Throwable.class));
 		assertFalse(runner.isShutdown());
 
 		UUID leaderSessionID2 = UUID.randomUUID();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
@@ -1,0 +1,344 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.concurrent.FlinkFutureException;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.rpc.exceptions.FencingTokenMismatchException;
+import org.apache.flink.runtime.rpc.exceptions.RpcException;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class FencedRpcEndpointTest extends TestLogger {
+
+	private static final Time timeout = Time.seconds(10L);
+	private static RpcService rpcService;
+
+	@BeforeClass
+	public static void setup() {
+		rpcService = new TestingRpcService();
+	}
+
+	@AfterClass
+	public static void teardown() throws ExecutionException, InterruptedException, TimeoutException {
+		if (rpcService != null) {
+			rpcService.stopService();
+			rpcService.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		}
+	}
+
+	/**
+	 * Tests that the fencing token can be retrieved from the FencedRpcEndpoint and self
+	 * FencedRpcGateway. Moreover it tests that you can only set the fencing token from
+	 * the main thread.
+	 */
+	@Test
+	public void testFencingTokenSetting() throws Exception {
+		final UUID initialFencingToken = UUID.randomUUID();
+		final String value = "foobar";
+		FencedTestingEndpoint fencedTestingEndpoint = new FencedTestingEndpoint(rpcService, initialFencingToken, value);
+		FencedTestingGateway fencedTestingGateway = fencedTestingEndpoint.getSelfGateway(FencedTestingGateway.class);
+		FencedTestingGateway fencedGateway = fencedTestingEndpoint.getSelfGateway(FencedTestingGateway.class);
+
+		try {
+			fencedTestingEndpoint.start();
+
+			assertEquals(initialFencingToken, fencedGateway.getFencingToken());
+			assertEquals(initialFencingToken, fencedTestingEndpoint.getFencingToken());
+
+			final UUID newFencingToken = UUID.randomUUID();
+
+			try {
+				fencedTestingEndpoint.setFencingToken(newFencingToken);
+				fail("Fencing token can only be set from within the main thread.");
+			} catch (AssertionError ignored) {
+				// expected to fail
+			}
+
+			assertEquals(initialFencingToken, fencedTestingEndpoint.getFencingToken());
+
+			CompletableFuture<Acknowledge> setFencingFuture = fencedTestingGateway.rpcSetFencingToken(newFencingToken, timeout);
+
+			// wait for the completion of the set fencing token operation
+			setFencingFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+
+			// self gateway should adapt its fencing token
+			assertEquals(newFencingToken, fencedGateway.getFencingToken());
+			assertEquals(newFencingToken, fencedTestingEndpoint.getFencingToken());
+		} finally {
+			fencedTestingEndpoint.shutDown();
+			fencedTestingEndpoint.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		}
+	}
+
+	/**
+	 * Tests that messages with the wrong fencing token are filtered out.
+	 */
+	@Test
+	public void testFencing() throws Exception {
+		final UUID initialFencingToken = UUID.randomUUID();
+		final UUID wrongFencingToken = UUID.randomUUID();
+		final String value = "barfoo";
+		FencedTestingEndpoint fencedTestingEndpoint = new FencedTestingEndpoint(rpcService, initialFencingToken, value);
+
+		try {
+			fencedTestingEndpoint.start();
+
+			final FencedTestingGateway properFencedGateway = rpcService.connect(fencedTestingEndpoint.getAddress(), initialFencingToken, FencedTestingGateway.class)
+				.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			final FencedTestingGateway wronglyFencedGateway = rpcService.connect(fencedTestingEndpoint.getAddress(), wrongFencingToken, FencedTestingGateway.class)
+				.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+
+			assertEquals(value, properFencedGateway.foobar(timeout).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS));
+
+			try {
+				wronglyFencedGateway.foobar(timeout).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+				fail("This should fail since we have the wrong fencing token.");
+			} catch (ExecutionException e) {
+				assertTrue(ExceptionUtils.stripExecutionException(e) instanceof FencingTokenMismatchException);
+			}
+
+			final UUID newFencingToken = UUID.randomUUID();
+
+			CompletableFuture<Acknowledge> newFencingTokenFuture = properFencedGateway.rpcSetFencingToken(newFencingToken, timeout);
+
+			// wait for the new fencing token to be set
+			newFencingTokenFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+
+			// this should no longer work because of the new fencing token
+			try {
+				properFencedGateway.foobar(timeout).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+
+				fail("This should fail since we have the wrong fencing token by now.");
+			} catch (ExecutionException e) {
+				assertTrue(ExceptionUtils.stripExecutionException(e) instanceof FencingTokenMismatchException);
+			}
+
+		} finally {
+			fencedTestingEndpoint.shutDown();
+			fencedTestingEndpoint.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		}
+	}
+
+	/**
+	 * Tests that the self gateway always uses the current fencing token whereas the remote
+	 * gateway has a fixed fencing token.
+	 */
+	@Test
+	public void testRemoteAndSelfGateways() throws Exception {
+		final UUID initialFencingToken = UUID.randomUUID();
+		final UUID newFencingToken = UUID.randomUUID();
+		final String value = "foobar";
+
+		final FencedTestingEndpoint fencedTestingEndpoint = new FencedTestingEndpoint(rpcService, initialFencingToken, value);
+
+		try {
+			fencedTestingEndpoint.start();
+
+			FencedTestingGateway selfGateway = fencedTestingEndpoint.getSelfGateway(FencedTestingGateway.class);
+			FencedTestingGateway remoteGateway = rpcService.connect(fencedTestingEndpoint.getAddress(), initialFencingToken, FencedTestingGateway.class)
+				.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+
+			assertEquals(initialFencingToken, selfGateway.getFencingToken());
+			assertEquals(initialFencingToken, remoteGateway.getFencingToken());
+
+			assertEquals(value, selfGateway.foobar(timeout).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS));
+			assertEquals(value, remoteGateway.foobar(timeout).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS));
+
+			CompletableFuture<Acknowledge> newFencingTokenFuture = selfGateway.rpcSetFencingToken(newFencingToken, timeout);
+
+			// wait for the new fencing token to be set
+			newFencingTokenFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+
+			assertEquals(newFencingToken, selfGateway.getFencingToken());
+			assertNotEquals(newFencingToken, remoteGateway.getFencingToken());
+
+			assertEquals(value, selfGateway.foobar(timeout).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS));
+
+			try {
+				remoteGateway.foobar(timeout).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+				fail("This should have failed because we don't have the right fencing token.");
+			} catch (ExecutionException e) {
+				assertTrue(ExceptionUtils.stripExecutionException(e) instanceof FencingTokenMismatchException);
+			}
+		} finally {
+			fencedTestingEndpoint.shutDown();
+			fencedTestingEndpoint.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		}
+	}
+
+	/**
+	 * Tests that call via the MainThreadExecutor fail after the fencing token changes.
+	 */
+	@Test
+	public void testMainThreadExecutorUnderChangingFencingToken() throws Exception {
+		final Time shortTimeout = Time.milliseconds(100L);
+		final UUID initialFencingToken = UUID.randomUUID();
+		final String value = "foobar";
+		final FencedTestingEndpoint fencedTestingEndpoint = new FencedTestingEndpoint(rpcService, initialFencingToken, value);
+
+		try {
+			fencedTestingEndpoint.start();
+
+			FencedTestingGateway selfGateway = fencedTestingEndpoint.getSelfGateway(FencedTestingGateway.class);
+
+			CompletableFuture<Acknowledge> mainThreadExecutorComputation = selfGateway.triggerMainThreadExecutorComputation(timeout);
+
+			// we know that subsequent calls on the same gateway are executed sequentially
+			// therefore, we know that the change fencing token call is executed after the trigger MainThreadExecutor
+			// computation
+			final UUID newFencingToken = UUID.randomUUID();
+			CompletableFuture<Acknowledge> newFencingTokenFuture = selfGateway.rpcSetFencingToken(newFencingToken, timeout);
+
+			newFencingTokenFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+
+			// trigger the computation
+			CompletableFuture<Acknowledge> triggerFuture = selfGateway.triggerComputationLatch(timeout);
+
+			triggerFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+
+			// wait for the main thread executor computation to fail
+			try {
+				mainThreadExecutorComputation.get(shortTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+				fail("The MainThreadExecutor computation should be able to complete because it was filtered out leading to a timeout exception.");
+			} catch (TimeoutException ignored) {
+				// as predicted
+			}
+
+		} finally {
+			fencedTestingEndpoint.shutDown();
+			fencedTestingEndpoint.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		}
+	}
+
+	/**
+	 * Tests that all calls from an unfenced remote gateway are ignored and that one cannot obtain
+	 * the fencing token from such a gateway.
+	 */
+	@Test
+	public void testUnfencedRemoteGateway() throws Exception {
+		final UUID initialFencingToken = UUID.randomUUID();
+		final String value = "foobar";
+
+		final FencedTestingEndpoint fencedTestingEndpoint = new FencedTestingEndpoint(rpcService, initialFencingToken, value);
+
+		try {
+			fencedTestingEndpoint.start();
+
+			FencedTestingGateway unfencedGateway = rpcService.connect(fencedTestingEndpoint.getAddress(), FencedTestingGateway.class)
+				.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+
+			try {
+				unfencedGateway.foobar(timeout).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+				fail("This should have failed because we have an unfenced gateway.");
+			} catch (ExecutionException e) {
+				assertTrue(ExceptionUtils.stripExecutionException(e) instanceof RpcException);
+			}
+
+			try {
+				unfencedGateway.getFencingToken();
+				fail("We should not be able to call getFencingToken on an unfenced gateway.");
+			} catch (UnsupportedOperationException ignored) {
+				// we should not be able to call getFencingToken on an unfenced gateway
+			}
+		} finally {
+			fencedTestingEndpoint.shutDown();
+			fencedTestingEndpoint.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		}
+	}
+
+	public interface FencedTestingGateway extends FencedRpcGateway<UUID> {
+		CompletableFuture<String> foobar(@RpcTimeout Time timeout);
+
+		CompletableFuture<Acknowledge> rpcSetFencingToken(UUID fencingToken, @RpcTimeout Time timeout);
+
+		CompletableFuture<Acknowledge> triggerMainThreadExecutorComputation(@RpcTimeout Time timeout);
+
+		CompletableFuture<Acknowledge> triggerComputationLatch(@RpcTimeout Time timeout);
+	}
+
+	private static class FencedTestingEndpoint extends FencedRpcEndpoint<UUID> implements FencedTestingGateway {
+
+		private final OneShotLatch computationLatch;
+
+		private final String value;
+
+		protected FencedTestingEndpoint(RpcService rpcService, UUID initialFencingToken, String value) {
+			super(rpcService, initialFencingToken);
+
+			computationLatch = new OneShotLatch();
+
+			this.value = value;
+		}
+
+		@Override
+		public CompletableFuture<String> foobar(Time timeout) {
+			return CompletableFuture.completedFuture(value);
+		}
+
+		@Override
+		public CompletableFuture<Acknowledge> rpcSetFencingToken(UUID fencingToken, Time timeout) {
+			setFencingToken(fencingToken);
+
+			return CompletableFuture.completedFuture(Acknowledge.get());
+		}
+
+		@Override
+		public CompletableFuture<Acknowledge> triggerMainThreadExecutorComputation(Time timeout) {
+			return CompletableFuture.supplyAsync(
+				() -> {
+					try {
+						computationLatch.await();
+					} catch (InterruptedException e) {
+						throw new FlinkFutureException("Waiting on latch failed.", e);
+					}
+
+					return value;
+				},
+				getRpcService().getExecutor())
+			.thenApplyAsync(
+				(String v) -> Acknowledge.get(),
+				getMainThreadExecutor());
+		}
+
+		@Override
+		public CompletableFuture<Acknowledge> triggerComputationLatch(Time timeout) {
+			computationLatch.trigger();
+
+			return CompletableFuture.completedFuture(Acknowledge.get());
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Introduce `FencedRpcEndpoint` which requires all RPC messages to have a
fencing token attached. Based on the received fencing token and the
actual fencing token, the message will either be discarded if they are
not equal or it will be processed. That way we are able to filter out
old messages or messages which originate from a split brain situation.

This PR is based on #4573.

## Brief change log

- Introduce `FencedRpcEndpoint` which extends `RpcEndpoint` and adds fields for a fencing token
- Introduce `FencedRpcGateway` which should be implemented by a `FencedRpcEndpoint` and gives access to the current fencing token
- Introduce `FencedAkkaRpcActor` which filters out all messages which have not a proper fencing token attached
- Introduce `FencedAkkaInvocationHandler` which attaches to all messages a fencing token
- Introduce `FencedMainThreadExecutable` which allows to run code in the main thread without fencing token
- Add `RcpService#connect(String, F, Time)` with `F` being the fencing token to connect to a `FencedRpcEndpoint`
- Adapt the `AkkaRpcService` to start the correct `AkkaRpcActor` and instantiate the correct `InvocationHandler` when a `FencedRpcEndpoint` is started

- The self gateway always picks up the current fencing token from the `FencedRpcEndpoint`
- Remote gateways are bound to a fixed fencing token
- The `MainThreadExecutor` of the `FencedRpcEndpoint` is always bound to the current value of the fencing token

## Verifying this change

This change added tests and can be verified as follows:

- `FencedRpcEndpointTest` which tests the setting of fencing tokens and filtering of messages
- `AsyncCallsTest#testRunAsyncWithFencing` and `AsyncCallsTest#testRunAsyncWithoutFencing` which test the fencing of `runAsync` calls

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)

