### PR TITLE
[FLINK-7500] Set JobMaster leader session id in main thread

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerMockTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerMockTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.BlobStore;
@@ -132,7 +133,7 @@ public class JobManagerRunnerMockTest extends TestLogger {
 		assertTrue(!jobCompletion.isJobFinished());
 		assertTrue(!jobCompletion.isJobFailed());
 
-		verify(jobManager).start(any(UUID.class));
+		verify(jobManager).start(any(UUID.class), any(Time.class));
 		
 		runner.shutdown();
 		verify(leaderElectionService).stop();
@@ -166,7 +167,7 @@ public class JobManagerRunnerMockTest extends TestLogger {
 
 		UUID leaderSessionID = UUID.randomUUID();
 		runner.grantLeadership(leaderSessionID);
-		verify(jobManager).start(leaderSessionID);
+		verify(jobManager).start(eq(leaderSessionID), any(Time.class));
 		assertTrue(!jobCompletion.isJobFinished());
 
 		// runner been told by JobManager that job is finished
@@ -186,7 +187,7 @@ public class JobManagerRunnerMockTest extends TestLogger {
 
 		UUID leaderSessionID = UUID.randomUUID();
 		runner.grantLeadership(leaderSessionID);
-		verify(jobManager).start(leaderSessionID);
+		verify(jobManager).start(eq(leaderSessionID), any(Time.class));
 		assertTrue(!jobCompletion.isJobFinished());
 
 		// runner been told by JobManager that job is failed
@@ -205,11 +206,11 @@ public class JobManagerRunnerMockTest extends TestLogger {
 
 		UUID leaderSessionID = UUID.randomUUID();
 		runner.grantLeadership(leaderSessionID);
-		verify(jobManager).start(leaderSessionID);
+		verify(jobManager).start(eq(leaderSessionID), any(Time.class));
 		assertTrue(!jobCompletion.isJobFinished());
 
 		runner.revokeLeadership();
-		verify(jobManager).suspend(any(Throwable.class));
+		verify(jobManager).suspend(any(Throwable.class), any(Time.class));
 		assertFalse(runner.isShutdown());
 	}
 
@@ -220,16 +221,16 @@ public class JobManagerRunnerMockTest extends TestLogger {
 
 		UUID leaderSessionID = UUID.randomUUID();
 		runner.grantLeadership(leaderSessionID);
-		verify(jobManager).start(leaderSessionID);
+		verify(jobManager).start(eq(leaderSessionID), any(Time.class));
 		assertTrue(!jobCompletion.isJobFinished());
 
 		runner.revokeLeadership();
-		verify(jobManager).suspend(any(Throwable.class));
+		verify(jobManager).suspend(any(Throwable.class), any(Time.class));
 		assertFalse(runner.isShutdown());
 
 		UUID leaderSessionID2 = UUID.randomUUID();
 		runner.grantLeadership(leaderSessionID2);
-		verify(jobManager).start(leaderSessionID2);
+		verify(jobManager).start(eq(leaderSessionID2), any(Time.class));
 	}
 
 	private static class TestingOnCompletionActions implements OnCompletionActions, FatalErrorHandler {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
 import org.apache.flink.runtime.leaderelection.TestingLeaderRetrievalService;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rpc.TestingRpcService;
@@ -110,13 +111,16 @@ public class JobMasterTest extends TestLogger {
 				blobServer,
 				mock(BlobLibraryCacheManager.class),
 				mock(RestartStrategyFactory.class),
-				Time.of(10, TimeUnit.SECONDS),
+				testingTimeout,
 				null,
 				mock(OnCompletionActions.class),
 				testingFatalErrorHandler,
 				new FlinkUserCodeClassLoader(new URL[0]));
 
-			jobMaster.start(jmLeaderId);
+			CompletableFuture<Acknowledge> startFuture = jobMaster.start(jmLeaderId, testingTimeout);
+
+			// wait for the start to complete
+			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 
 			final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
@@ -209,13 +213,16 @@ public class JobMasterTest extends TestLogger {
 				mock(BlobServer.class),
 				mock(BlobLibraryCacheManager.class),
 				mock(RestartStrategyFactory.class),
-				Time.of(10, TimeUnit.SECONDS),
+				testingTimeout,
 				null,
 				mock(OnCompletionActions.class),
 				testingFatalErrorHandler,
 				new FlinkUserCodeClassLoader(new URL[0]));
 
-			jobMaster.start(jmLeaderId);
+			CompletableFuture<Acknowledge> startFuture = jobMaster.start(jmLeaderId, testingTimeout);
+
+			// wait for the start operation to complete
+			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 
 			// define a leader and see that a registration happens
 			rmLeaderRetrievalService.notifyListener(resourceManagerAddress, rmLeaderId);


### PR DESCRIPTION
## What is the purpose of the change

This commit changes the JobMaster such that it's leader session id is only set
in the main thread. This is done by passing the leader session id to the
startJobExecution method. Moreover, this commit returns a future from the
start and suspend methods which can be used to wait on the completion of these
operations.

This PR is based on #4573.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

