### PR TITLE
[FLINK-7501] Generalize RegisteredRpcConnection to support generic leader ids

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1045,7 +1045,7 @@ public class JobMaster extends RpcEndpoint implements JobMasterGateway {
 	//----------------------------------------------------------------------------------------------
 
 	private class ResourceManagerConnection
-			extends RegisteredRpcConnection<ResourceManagerGateway, JobMasterRegistrationSuccess>
+			extends RegisteredRpcConnection<UUID, ResourceManagerGateway, JobMasterRegistrationSuccess>
 	{
 		private final JobID jobID;
 
@@ -1075,8 +1075,8 @@ public class JobMaster extends RpcEndpoint implements JobMasterGateway {
 		}
 
 		@Override
-		protected RetryingRegistration<ResourceManagerGateway, JobMasterRegistrationSuccess> generateRegistration() {
-			return new RetryingRegistration<ResourceManagerGateway, JobMasterRegistrationSuccess>(
+		protected RetryingRegistration<UUID, ResourceManagerGateway, JobMasterRegistrationSuccess> generateRegistration() {
+			return new RetryingRegistration<UUID, ResourceManagerGateway, JobMasterRegistrationSuccess>(
 					log, getRpcService(), "ResourceManager", ResourceManagerGateway.class,
 					getTargetAddress(), getTargetLeaderId())
 			{

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistration.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.rpc.RpcService;
 
 import org.slf4j.Logger;
 
-import java.util.UUID;
+import java.io.Serializable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -43,10 +43,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * The registration can be canceled, for example when the target where it tries to register
  * at looses leader status.
  *
- * @param <Gateway> The type of the gateway to connect to.
- * @param <Success> The type of the successful registration responses.
+ * @param <F> The type of the fencing token
+ * @param <G> The type of the gateway to connect to.
+ * @param <S> The type of the successful registration responses.
  */
-public abstract class RetryingRegistration<Gateway extends RpcGateway, Success extends RegistrationResponse.Success> {
+public abstract class RetryingRegistration<F extends Serializable, G extends RpcGateway, S extends RegistrationResponse.Success> {
 
 	// ------------------------------------------------------------------------
 	//  default configuration values
@@ -74,13 +75,13 @@ public abstract class RetryingRegistration<Gateway extends RpcGateway, Success e
 
 	private final String targetName;
 
-	private final Class<Gateway> targetType;
+	private final Class<G> targetType;
 
 	private final String targetAddress;
 
-	private final UUID leaderId;
+	private final F fencingToken;
 
-	private final CompletableFuture<Tuple2<Gateway, Success>> completionFuture;
+	private final CompletableFuture<Tuple2<G, S>> completionFuture;
 
 	private final long initialRegistrationTimeout;
 
@@ -98,10 +99,10 @@ public abstract class RetryingRegistration<Gateway extends RpcGateway, Success e
 			Logger log,
 			RpcService rpcService,
 			String targetName,
-			Class<Gateway> targetType,
+			Class<G> targetType,
 			String targetAddress,
-			UUID leaderId) {
-		this(log, rpcService, targetName, targetType, targetAddress, leaderId,
+			F fencingToken) {
+		this(log, rpcService, targetName, targetType, targetAddress, fencingToken,
 				INITIAL_REGISTRATION_TIMEOUT_MILLIS, MAX_REGISTRATION_TIMEOUT_MILLIS,
 				ERROR_REGISTRATION_DELAY_MILLIS, REFUSED_REGISTRATION_DELAY_MILLIS);
 	}
@@ -110,9 +111,9 @@ public abstract class RetryingRegistration<Gateway extends RpcGateway, Success e
 			Logger log,
 			RpcService rpcService,
 			String targetName,
-			Class<Gateway> targetType,
+			Class<G> targetType,
 			String targetAddress,
-			UUID leaderId,
+			F fencingToken,
 			long initialRegistrationTimeout,
 			long maxRegistrationTimeout,
 			long delayOnError,
@@ -128,7 +129,7 @@ public abstract class RetryingRegistration<Gateway extends RpcGateway, Success e
 		this.targetName = checkNotNull(targetName);
 		this.targetType = checkNotNull(targetType);
 		this.targetAddress = checkNotNull(targetAddress);
-		this.leaderId = checkNotNull(leaderId);
+		this.fencingToken = checkNotNull(fencingToken);
 		this.initialRegistrationTimeout = initialRegistrationTimeout;
 		this.maxRegistrationTimeout = maxRegistrationTimeout;
 		this.delayOnError = delayOnError;
@@ -141,7 +142,7 @@ public abstract class RetryingRegistration<Gateway extends RpcGateway, Success e
 	//  completion and cancellation
 	// ------------------------------------------------------------------------
 
-	public CompletableFuture<Tuple2<Gateway, Success>> getFuture() {
+	public CompletableFuture<Tuple2<G, S>> getFuture() {
 		return completionFuture;
 	}
 
@@ -165,7 +166,7 @@ public abstract class RetryingRegistration<Gateway extends RpcGateway, Success e
 	// ------------------------------------------------------------------------
 
 	protected abstract CompletableFuture<RegistrationResponse> invokeRegistration(
-			Gateway gateway, UUID leaderId, long timeoutMillis) throws Exception;
+		G gateway, F fencingToken, long timeoutMillis) throws Exception;
 
 	/**
 	 * This method resolves the target address to a callable gateway and starts the
@@ -175,11 +176,11 @@ public abstract class RetryingRegistration<Gateway extends RpcGateway, Success e
 	public void startRegistration() {
 		try {
 			// trigger resolution of the resource manager address to a callable gateway
-			CompletableFuture<Gateway> resourceManagerFuture = rpcService.connect(targetAddress, targetType);
+			CompletableFuture<G> resourceManagerFuture = rpcService.connect(targetAddress, targetType);
 
 			// upon success, start the registration attempts
 			CompletableFuture<Void> resourceManagerAcceptFuture = resourceManagerFuture.thenAcceptAsync(
-				(Gateway result) -> {
+				(G result) -> {
 					log.info("Resolved {} address, beginning registration", targetName);
 					register(result, 1, initialRegistrationTimeout);
 				},
@@ -206,7 +207,7 @@ public abstract class RetryingRegistration<Gateway extends RpcGateway, Success e
 	 * depending on the result.
 	 */
 	@SuppressWarnings("unchecked")
-	private void register(final Gateway gateway, final int attempt, final long timeoutMillis) {
+	private void register(final G gateway, final int attempt, final long timeoutMillis) {
 		// eager check for canceling to avoid some unnecessary work
 		if (canceled) {
 			return;
@@ -214,7 +215,7 @@ public abstract class RetryingRegistration<Gateway extends RpcGateway, Success e
 
 		try {
 			log.info("Registration at {} attempt {} (timeout={}ms)", targetName, attempt, timeoutMillis);
-			CompletableFuture<RegistrationResponse> registrationFuture = invokeRegistration(gateway, leaderId, timeoutMillis);
+			CompletableFuture<RegistrationResponse> registrationFuture = invokeRegistration(gateway, fencingToken, timeoutMillis);
 
 			// if the registration was successful, let the TaskExecutor know
 			CompletableFuture<Void> registrationAcceptFuture = registrationFuture.thenAcceptAsync(
@@ -222,7 +223,7 @@ public abstract class RetryingRegistration<Gateway extends RpcGateway, Success e
 					if (!isCanceled()) {
 						if (result instanceof RegistrationResponse.Success) {
 							// registration successful!
-							Success success = (Success) result;
+							S success = (S) result;
 							completionFuture.complete(Tuple2.of(gateway, success));
 						}
 						else {
@@ -274,7 +275,7 @@ public abstract class RetryingRegistration<Gateway extends RpcGateway, Success e
 		}
 	}
 
-	private void registerLater(final Gateway gateway, final int attempt, final long timeoutMillis, long delay) {
+	private void registerLater(final G gateway, final int attempt, final long timeoutMillis, long delay) {
 		rpcService.scheduleRunnable(new Runnable() {
 			@Override
 			public void run() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobLeaderService.java
@@ -210,7 +210,7 @@ public class JobLeaderService {
 		private final JobID jobId;
 
 		/** Rpc connection to the job leader */
-		private RegisteredRpcConnection<JobMasterGateway, JMTMRegistrationSuccess> rpcConnection;
+		private RegisteredRpcConnection<UUID, JobMasterGateway, JMTMRegistrationSuccess> rpcConnection;
 
 		/** State of the listener */
 		private volatile boolean stopped;
@@ -299,7 +299,7 @@ public class JobLeaderService {
 		/**
 		 * Rpc connection for the job manager <--> task manager connection.
 		 */
-		private final class JobManagerRegisteredRpcConnection extends RegisteredRpcConnection<JobMasterGateway, JMTMRegistrationSuccess> {
+		private final class JobManagerRegisteredRpcConnection extends RegisteredRpcConnection<UUID, JobMasterGateway, JMTMRegistrationSuccess> {
 
 			JobManagerRegisteredRpcConnection(
 				Logger log,
@@ -310,7 +310,7 @@ public class JobLeaderService {
 			}
 
 			@Override
-			protected RetryingRegistration<JobMasterGateway, JMTMRegistrationSuccess> generateRegistration() {
+			protected RetryingRegistration<UUID, JobMasterGateway, JMTMRegistrationSuccess> generateRegistration() {
 				return new JobLeaderService.JobManagerRetryingRegistration(
 						LOG,
 						rpcService,
@@ -351,7 +351,7 @@ public class JobLeaderService {
 	 * Retrying registration for the job manager <--> task manager connection.
 	 */
 	private static final class JobManagerRetryingRegistration
-			extends RetryingRegistration<JobMasterGateway, JMTMRegistrationSuccess>
+			extends RetryingRegistration<UUID, JobMasterGateway, JMTMRegistrationSuccess>
 	{
 
 		private final String taskManagerRpcAddress;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
@@ -41,7 +41,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * The connection between a TaskExecutor and the ResourceManager.
  */
 public class TaskExecutorToResourceManagerConnection
-		extends RegisteredRpcConnection<ResourceManagerGateway, TaskExecutorRegistrationSuccess> {
+		extends RegisteredRpcConnection<UUID, ResourceManagerGateway, TaskExecutorRegistrationSuccess> {
 
 	private final RpcService rpcService;
 
@@ -79,7 +79,7 @@ public class TaskExecutorToResourceManagerConnection
 
 
 	@Override
-	protected RetryingRegistration<ResourceManagerGateway, TaskExecutorRegistrationSuccess> generateRegistration() {
+	protected RetryingRegistration<UUID, ResourceManagerGateway, TaskExecutorRegistrationSuccess> generateRegistration() {
 		return new TaskExecutorToResourceManagerConnection.ResourceManagerRegistration(
 			log,
 			rpcService,
@@ -127,7 +127,7 @@ public class TaskExecutorToResourceManagerConnection
 	// ------------------------------------------------------------------------
 
 	private static class ResourceManagerRegistration
-			extends RetryingRegistration<ResourceManagerGateway, TaskExecutorRegistrationSuccess> {
+			extends RetryingRegistration<UUID, ResourceManagerGateway, TaskExecutorRegistrationSuccess> {
 
 		private final String taskExecutorAddress;
 		

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RegisteredRpcConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RegisteredRpcConnectionTest.java
@@ -141,7 +141,7 @@ public class RegisteredRpcConnectionTest extends TestLogger {
 	//  test RegisteredRpcConnection
 	// ------------------------------------------------------------------------
 
-	private static class TestRpcConnection extends RegisteredRpcConnection<TestRegistrationGateway, TestRegistrationSuccess> {
+	private static class TestRpcConnection extends RegisteredRpcConnection<UUID, TestRegistrationGateway, TestRegistrationSuccess> {
 
 		private final RpcService rpcService;
 
@@ -155,7 +155,7 @@ public class RegisteredRpcConnectionTest extends TestLogger {
 		}
 
 		@Override
-		protected RetryingRegistration<TestRegistrationGateway, RetryingRegistrationTest.TestRegistrationSuccess> generateRegistration() {
+		protected RetryingRegistration<UUID, TestRegistrationGateway, RetryingRegistrationTest.TestRegistrationSuccess> generateRegistration() {
 			return new RetryingRegistrationTest.TestRetryingRegistration(rpcService, getTargetAddress(), getTargetLeaderId());
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
@@ -320,7 +320,7 @@ public class RetryingRegistrationTest extends TestLogger {
 		}
 	}
 
-	static class TestRetryingRegistration extends RetryingRegistration<TestRegistrationGateway, TestRegistrationSuccess> {
+	static class TestRetryingRegistration extends RetryingRegistration<UUID, TestRegistrationGateway, TestRegistrationSuccess> {
 
 		// we use shorter timeouts here to speed up the tests
 		static final long INITIAL_TIMEOUT = 20;


### PR DESCRIPTION
## What is the purpose of the change

The RegisteredRpcConnection now supports generic leader ids/fencing tokens. This
will allow to introduce component specific leader ids/fencing tokens.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

