### PR TITLE
[FLINK-7499][io] fix double buffer release in SpillableSubpartitionView

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/BlockChannelWriterWithCallback.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/BlockChannelWriterWithCallback.java
@@ -26,7 +26,7 @@ public interface BlockChannelWriterWithCallback<T> extends FileIOChannel {
 	 * Writes the given block. The request may be executed synchronously, or asynchronously, depending
 	 * on the implementation.
 	 *
-	 * @param block The segment to be written.
+	 * @param block The segment to be written (transferring ownership to this writer).
 	 * @throws IOException Thrown, when the writer encounters an I/O error.
 	 */
 	void writeBlock(T block) throws IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -67,6 +67,7 @@ class PipelinedSubpartition extends ResultSubpartition {
 
 		synchronized (buffers) {
 			if (isFinished || isReleased) {
+				buffer.recycle();
 				return false;
 			}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -70,6 +70,18 @@ public abstract class ResultSubpartition {
 		return parent.getFailureCause();
 	}
 
+	/**
+	 * Adds the given buffer.
+	 *
+	 * <p>The request may be executed synchronously, or asynchronously, depending on the
+	 * implementation.
+	 *
+	 * @param buffer
+	 * 		the buffer to add (transferring ownership to this writer)
+	 *
+	 * @throws IOException
+	 * 		thrown in case of errors while adding the buffer
+	 */
 	abstract public boolean add(Buffer buffer) throws IOException;
 
 	abstract public void finish() throws IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -95,13 +95,12 @@ class SpillableSubpartition extends ResultSubpartition {
 				return false;
 			}
 
-			// The number of buffers are needed later when creating
-			// the read views. If you ever remove this line here,
-			// make sure to still count the number of buffers.
-			updateStatistics(buffer);
-
 			if (spillWriter == null) {
 				buffers.add(buffer);
+				// The number of buffers are needed later when creating
+				// the read views. If you ever remove this line here,
+				// make sure to still count the number of buffers.
+				updateStatistics(buffer);
 
 				return true;
 			}
@@ -109,6 +108,10 @@ class SpillableSubpartition extends ResultSubpartition {
 
 		// Didn't return early => go to disk
 		spillWriter.writeBlock(buffer);
+		synchronized (buffers) {
+			// See the note above, but only do this if the buffer was correctly added!
+			updateStatistics(buffer);
+		}
 
 		return true;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
@@ -108,11 +108,7 @@ class SpillableSubpartitionView implements ResultSubpartitionView {
 				for (int i = 0; i < numBuffers; i++) {
 					Buffer buffer = buffers.remove();
 					spilledBytes += buffer.getSize();
-					try {
-						spillWriter.writeBlock(buffer);
-					} finally {
-						buffer.recycle();
-					}
+					spillWriter.writeBlock(buffer);
 				}
 
 				spilledView = new SpilledSubpartitionView(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/AsynchronousBufferFileWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/AsynchronousBufferFileWriterTest.java
@@ -18,13 +18,17 @@
 
 package org.apache.flink.runtime.io.disk.iomanager;
 
+import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.util.TestNotificationListener;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
@@ -39,7 +43,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+/**
+ * Tests for {@link AsynchronousBufferFileWriter}.
+ */
 public class AsynchronousBufferFileWriterTest {
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
 
 	private static final IOManager ioManager = new IOManagerAsync();
 
@@ -64,6 +73,27 @@ public class AsynchronousBufferFileWriterTest {
 
 		handleRequest();
 		assertEquals("Didn't decrement number of outstanding requests.", 0, writer.getNumberOfOutstandingRequests());
+	}
+
+	@Test
+	public void testAddWithFailingWriter() throws Exception {
+		AsynchronousBufferFileWriter writer =
+			new AsynchronousBufferFileWriter(ioManager.createChannel(), new RequestQueue<>());
+		writer.close();
+
+		exception.expect(IOException.class);
+
+		Buffer buffer = new Buffer(MemorySegmentFactory.allocateUnpooledSegment(4096),
+			FreeingBufferRecycler.INSTANCE);
+		try {
+			writer.writeBlock(buffer);
+		} finally {
+			if (!buffer.isRecycled()) {
+				buffer.recycle();
+				Assert.fail("buffer not recycled");
+			}
+			assertEquals("Shouln't increment number of outstanding requests.", 0, writer.getNumberOfOutstandingRequests());
+		}
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerAsyncWithNoOpBufferFileWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerAsyncWithNoOpBufferFileWriter.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.disk.iomanager;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import java.io.IOException;
+
+/**
+ * An {@link IOManagerAsync} that creates {@link BufferFileWriter} instances which do nothing in their {@link BufferFileWriter#writeBlock(Object)} method.
+ *
+ * <p>Beware: the passed {@link Buffer} instances must be cleaned up manually!
+ */
+public class IOManagerAsyncWithNoOpBufferFileWriter extends IOManagerAsync {
+	@Override
+	public BufferFileWriter createBufferFileWriter(FileIOChannel.ID channelID)
+			throws IOException {
+		return new NoOpAsynchronousBufferFileWriter(channelID, getWriteRequestQueue(channelID));
+	}
+
+	/**
+	 * {@link BufferFileWriter} subclass with a no-op in {@link #writeBlock(Buffer)}.
+	 */
+	private static class NoOpAsynchronousBufferFileWriter extends AsynchronousBufferFileWriter {
+
+		private NoOpAsynchronousBufferFileWriter(
+				ID channelID,
+				RequestQueue<WriteRequest> requestQueue) throws IOException {
+			super(channelID, requestQueue);
+		}
+
+		@Override
+		public void writeBlock(Buffer buffer) throws IOException {
+			// do nothing
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static org.apache.flink.runtime.io.network.util.TestBufferFactory.BUFFER_SIZE;
 import static org.apache.flink.runtime.io.network.util.TestBufferFactory.createBuffer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -102,6 +103,8 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 
 		// Add data to the queue...
 		subpartition.add(createBuffer());
+		assertEquals(1, subpartition.getTotalNumberOfBuffers());
+		assertEquals(BUFFER_SIZE, subpartition.getTotalNumberOfBytes());
 
 		// ...should have resulted in a notification
 		verify(listener, times(1)).notifyBuffersAvailable(eq(1L));
@@ -112,6 +115,8 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 
 		// Add data to the queue...
 		subpartition.add(createBuffer());
+		assertEquals(2, subpartition.getTotalNumberOfBuffers());
+		assertEquals(2 * BUFFER_SIZE, subpartition.getTotalNumberOfBytes());
 		verify(listener, times(2)).notifyBuffersAvailable(eq(1L));
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -20,24 +20,40 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.util.TestBufferFactory;
 import org.apache.flink.runtime.taskmanager.TaskActions;
+
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+/**
+ * Tests for {@link ResultPartition}.
+ */
 public class ResultPartitionTest {
+
+	/** Asynchronous I/O manager. */
+	private static final IOManager ioManager = new IOManagerAsync();
+
+	@AfterClass
+	public static void shutdown() {
+		ioManager.shutdown();
+	}
 
 	/**
 	 * Tests the schedule or update consumers message sending behaviour depending on the relevant flags.
@@ -49,7 +65,11 @@ public class ResultPartitionTest {
 			ResultPartitionConsumableNotifier notifier = mock(ResultPartitionConsumableNotifier.class);
 			ResultPartition partition = createPartition(notifier, ResultPartitionType.PIPELINED, true);
 			partition.writeBuffer(TestBufferFactory.createBuffer(), 0);
-			verify(notifier, times(1)).notifyPartitionConsumable(any(JobID.class), any(ResultPartitionID.class), any(TaskActions.class));
+			verify(notifier, times(1))
+				.notifyPartitionConsumable(
+					eq(partition.getJobId()),
+					eq(partition.getPartitionId()),
+					any(TaskActions.class));
 		}
 
 		{
@@ -180,6 +200,45 @@ public class ResultPartitionTest {
 		assertTrue(buffer.isRecycled());
 	}
 
+	@Test
+	public void testAddOnPipelinedPartition() throws Exception {
+		testAddOnPartition(ResultPartitionType.PIPELINED);
+	}
+
+	@Test
+	public void testAddOnBlockingPartition() throws Exception {
+		testAddOnPartition(ResultPartitionType.BLOCKING);
+	}
+
+	/**
+	 * Tests {@link ResultPartition#writeBuffer(Buffer, int)} on a working partition.
+	 *
+	 * @param pipelined the result partition type to set up
+	 */
+	protected void testAddOnPartition(final ResultPartitionType pipelined)
+		throws Exception {
+		ResultPartitionConsumableNotifier notifier = mock(ResultPartitionConsumableNotifier.class);
+		ResultPartition partition = createPartition(notifier, pipelined, true);
+		Buffer buffer = TestBufferFactory.createBuffer();
+		try {
+			// partition.add() adds the buffer without recycling it (if not spilling)
+			partition.writeBuffer(buffer, 0);
+			assertFalse("buffer should not be recycled (still in the queue)", buffer.isRecycled());
+		} finally {
+			if (!buffer.isRecycled()) {
+				buffer.recycle();
+			}
+			// should have been notified for pipelined partitions
+			if (pipelined.isPipelined()) {
+				verify(notifier, times(1))
+					.notifyPartitionConsumable(
+						eq(partition.getJobId()),
+						eq(partition.getPartitionId()),
+						any(TaskActions.class));
+			}
+		}
+	}
+
 	// ------------------------------------------------------------------------
 
 	private static ResultPartition createPartition(
@@ -196,7 +255,7 @@ public class ResultPartitionTest {
 			1,
 			mock(ResultPartitionManager.class),
 			notifier,
-			mock(IOManager.class),
+			ioManager,
 			sendScheduleOrUpdateConsumersMessage);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionViewTest.java
@@ -44,6 +44,10 @@ import java.util.concurrent.TimeoutException;
 
 import static org.mockito.Mockito.mock;
 
+/**
+ * Tests for {@link SpillableSubpartitionView}, in addition to indirect tests via {@link
+ * SpillableSubpartitionTest}.
+ */
 public class SpilledSubpartitionViewTest {
 
 	private static final IOManager IO_MANAGER = new IOManagerAsync();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
@@ -21,8 +21,10 @@ package org.apache.flink.runtime.io.network.partition;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.util.TestBufferFactory;
 import org.apache.flink.util.TestLogger;
+
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -46,8 +48,12 @@ public abstract class SubpartitionTestBase extends TestLogger {
 
 		try {
 			subpartition.finish();
+			assertEquals(1, subpartition.getTotalNumberOfBuffers());
+			assertEquals(4, subpartition.getTotalNumberOfBytes());
 
 			assertFalse(subpartition.add(mock(Buffer.class)));
+			assertEquals(1, subpartition.getTotalNumberOfBuffers());
+			assertEquals(4, subpartition.getTotalNumberOfBytes());
 		} finally {
 			if (subpartition != null) {
 				subpartition.release();
@@ -61,8 +67,12 @@ public abstract class SubpartitionTestBase extends TestLogger {
 
 		try {
 			subpartition.release();
+			assertEquals(0, subpartition.getTotalNumberOfBuffers());
+			assertEquals(0, subpartition.getTotalNumberOfBytes());
 
 			assertFalse(subpartition.add(mock(Buffer.class)));
+			assertEquals(0, subpartition.getTotalNumberOfBuffers());
+			assertEquals(0, subpartition.getTotalNumberOfBytes());
 		} finally {
 			if (subpartition != null) {
 				subpartition.release();


### PR DESCRIPTION
## What is the purpose of the change

`SpillableSubpartitionView#releaseMemory()` recycled the given buffer twice: once asynchronously after the write operation initiated via `AsynchronousBufferFileWriter#writeBlock()`and once in SpillableSubpartitionView#releaseMemory() after adding the write operation to the queue. Additionally, other uses of `AsynchronousBufferFileWriter#writeBlock()` did not cleanup in an error case which was also not done by `AsynchronousBufferFileWriter#writeBlock()` itself.

This PR changes the behaviour of `AsynchronousBufferFileWriter#writeBlock()` to always take care of releasing the buffer, even after the (asynchronous) write operation failed.

## Brief change log

- let `AsynchronousBufferFileWriter#writeBlock()` take full recycling responsibility of the given buffer even in case of failures, similarly for `ResultSubpartition#add()` and `ResultPartition#add()`
- adapt uses of these functions to account for the change, e.g. `retain()` buffers if they are needed after the call
- remove the additional `recycle()` call in `SpillableSubpartitionView#releaseMemory()`
- adapt `SpillableSubpartitionTest` to find the duplicate `recycle()` calls
- add verious more tests to `ResultPartitionTest` and `SpillableSubpartitionTest` to verify buffer release behaviour for cases of failures as well as normal operation
- only update buffer statistics in `SpillableSubpartition#add()` if successful
- add tests for the statistics for cases of failures as well as normal operation

## Verifying this change

This change added further checks to `SpillableSubpartitionTest` to verify the intended behaviour

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
