### PR TITLE
[FLINK-7504] Fence the ResourceManager

### DIFF
--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerConfiguration;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.slotmanager.ResourceManagerActions;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
@@ -326,7 +327,7 @@ public class MesosResourceManagerTest extends TestLogger {
 						slotManagerStarted.complete(true);
 						return null;
 					}
-				}).when(slotManager).start(any(UUID.class), any(Executor.class), any(ResourceManagerActions.class));
+				}).when(slotManager).start(any(ResourceManagerId.class), any(Executor.class), any(ResourceManagerActions.class));
 
 				when(slotManager.registerSlotRequest(any(SlotRequest.class))).thenReturn(true);
 			}
@@ -441,7 +442,7 @@ public class MesosResourceManagerTest extends TestLogger {
 		 */
 		public void registerJobMaster(MockJobMaster jobMaster) throws Exception  {
 			CompletableFuture<RegistrationResponse> registration = resourceManager.registerJobManager(
-				rmServices.rmLeaderSessionId, jobMaster.leaderSessionID, jobMaster.resourceID, jobMaster.address, jobMaster.jobID, timeout);
+				jobMaster.leaderSessionID, jobMaster.resourceID, jobMaster.address, jobMaster.jobID, timeout);
 			assertTrue(registration.get() instanceof JobMasterRegistrationSuccess);
 		}
 
@@ -617,7 +618,7 @@ public class MesosResourceManagerTest extends TestLogger {
 
 			// send registration message
 			CompletableFuture<RegistrationResponse> successfulFuture =
-				resourceManager.registerTaskExecutor(rmServices.rmLeaderSessionId, task1Executor.address, task1Executor.resourceID, slotReport, timeout);
+				resourceManager.registerTaskExecutor(task1Executor.address, task1Executor.resourceID, slotReport, timeout);
 			RegistrationResponse response = successfulFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 			assertTrue(response instanceof TaskExecutorRegistrationSuccess);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotPool.java
@@ -121,9 +121,6 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway {
 	/** the leader id of job manager */
 	private UUID jobManagerLeaderId;
 
-	/** The leader id of resource manager */
-	private UUID resourceManagerLeaderId;
-
 	/** The gateway to communicate with resource manager */
 	private ResourceManagerGateway resourceManagerGateway;
 
@@ -199,7 +196,6 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway {
 
 		// do not accept any requests
 		jobManagerLeaderId = null;
-		resourceManagerLeaderId = null;
 		resourceManagerGateway = null;
 
 		// Clear (but not release!) the available slots. The TaskManagers should re-register them
@@ -240,8 +236,7 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public void connectToResourceManager(UUID resourceManagerLeaderId, ResourceManagerGateway resourceManagerGateway) {
-		this.resourceManagerLeaderId = checkNotNull(resourceManagerLeaderId);
+	public void connectToResourceManager(ResourceManagerGateway resourceManagerGateway) {
 		this.resourceManagerGateway = checkNotNull(resourceManagerGateway);
 
 		// work on all slots waiting for this connection
@@ -255,7 +250,6 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway {
 
 	@Override
 	public void disconnectResourceManager() {
-		this.resourceManagerLeaderId = null;
 		this.resourceManagerGateway = null;
 	}
 
@@ -319,7 +313,7 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway {
 		pendingRequests.put(allocationID, new PendingRequest(allocationID, future, resources));
 
 		CompletableFuture<Acknowledge> rmResponse = resourceManagerGateway.requestSlot(
-			jobManagerLeaderId, resourceManagerLeaderId,
+			jobManagerLeaderId,
 			new SlotRequest(jobId, allocationID, resources, jobManagerAddress),
 			resourceManagerRequestsTimeout);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotPoolGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotPoolGateway.java
@@ -33,7 +33,6 @@ import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 import java.util.Collection;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -55,10 +54,9 @@ public interface SlotPoolGateway extends RpcGateway {
 	 * Connects the SlotPool to the given ResourceManager. After this method is called, the
 	 * SlotPool will be able to request resources from the given ResourceManager.
 	 * 
-	 * @param resourceManagerLeaderId The leader session ID of the resource manager.
 	 * @param resourceManagerGateway  The RPC gateway for the resource manager.
 	 */
-	void connectToResourceManager(UUID resourceManagerLeaderId, ResourceManagerGateway resourceManagerGateway);
+	void connectToResourceManager(ResourceManagerGateway resourceManagerGateway);
 
 	/**
 	 * Disconnects the slot pool from its current Resource Manager. After this call, the pool will not

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.query.KvStateID;
 import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.query.KvStateServerAddress;
 import org.apache.flink.runtime.registration.RegistrationResponse;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.state.internal.InternalKvState;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -123,12 +124,12 @@ public interface JobMasterGateway extends CheckpointCoordinatorGateway {
 	 * Disconnects the resource manager from the job manager because of the given cause.
 	 *
 	 * @param jobManagerLeaderId identifying the job manager leader id
-	 * @param resourceManagerLeaderId identifying the resource manager leader id
+	 * @param resourceManagerId identifying the resource manager leader id
 	 * @param cause of the disconnect
 	 */
 	void disconnectResourceManager(
 		final UUID jobManagerLeaderId,
-		final UUID resourceManagerLeaderId,
+		final ResourceManagerId resourceManagerId,
 		final Exception cause);
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterRegistrationSuccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterRegistrationSuccess.java
@@ -20,8 +20,7 @@ package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.registration.RegistrationResponse;
-
-import java.util.UUID;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -34,16 +33,16 @@ public class JobMasterRegistrationSuccess extends RegistrationResponse.Success {
 
 	private final long heartbeatInterval;
 
-	private final UUID resourceManagerLeaderId;
+	private final ResourceManagerId resourceManagerId;
 
 	private final ResourceID resourceManagerResourceId;
 
 	public JobMasterRegistrationSuccess(
 			final long heartbeatInterval,
-			final UUID resourceManagerLeaderId,
+			final ResourceManagerId resourceManagerId,
 			final ResourceID resourceManagerResourceId) {
 		this.heartbeatInterval = heartbeatInterval;
-		this.resourceManagerLeaderId = checkNotNull(resourceManagerLeaderId);
+		this.resourceManagerId = checkNotNull(resourceManagerId);
 		this.resourceManagerResourceId = checkNotNull(resourceManagerResourceId);
 	}
 
@@ -56,8 +55,8 @@ public class JobMasterRegistrationSuccess extends RegistrationResponse.Success {
 		return heartbeatInterval;
 	}
 
-	public UUID getResourceManagerLeaderId() {
-		return resourceManagerLeaderId;
+	public ResourceManagerId getResourceManagerId() {
+		return resourceManagerId;
 	}
 
 	public ResourceID getResourceManagerResourceId() {
@@ -68,7 +67,7 @@ public class JobMasterRegistrationSuccess extends RegistrationResponse.Success {
 	public String toString() {
 		return "JobMasterRegistrationSuccess{" +
 			"heartbeatInterval=" + heartbeatInterval +
-			", resourceManagerLeaderId=" + resourceManagerLeaderId +
+			", resourceManagerLeaderId=" + resourceManagerId +
 			", resourceManagerResourceId=" + resourceManagerResourceId +
 			'}';
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerRunner;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -419,14 +420,14 @@ public class MiniCluster {
 			final LeaderAddressAndId addressAndId = addressAndIdFuture.get();
 
 			final ResourceManagerGateway resourceManager = 
-					commonRpcService.connect(addressAndId.leaderAddress(), ResourceManagerGateway.class).get();
+					commonRpcService.connect(addressAndId.leaderAddress(), new ResourceManagerId(addressAndId.leaderId()), ResourceManagerGateway.class).get();
 
 			final int numTaskManagersToWaitFor = taskManagers.length;
 
 			// poll and wait until enough TaskManagers are available
 			while (true) {
 				int numTaskManagersAvailable = 
-						resourceManager.getNumberOfRegisteredTaskManagers(addressAndId.leaderId()).get();
+						resourceManager.getNumberOfRegisteredTaskManagers().get();
 
 				if (numTaskManagersAvailable >= numTaskManagersToWaitFor) {
 					break;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -26,11 +26,12 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -38,69 +39,61 @@ import java.util.concurrent.CompletableFuture;
 /**
  * The {@link ResourceManager}'s RPC gateway interface.
  */
-public interface ResourceManagerGateway extends RpcGateway {
+public interface ResourceManagerGateway extends FencedRpcGateway<ResourceManagerId> {
 
 	/**
 	 * Register a {@link JobMaster} at the resource manager.
 	 *
-	 * @param resourceManagerLeaderId The fencing token for the ResourceManager leader
 	 * @param jobMasterLeaderId The fencing token for the JobMaster leader
-	 * @param jobMasterResourceId   The resource ID of the JobMaster that registers
-	 * @param jobMasterAddress        The address of the JobMaster that registers
-	 * @param jobID                   The Job ID of the JobMaster that registers
-	 * @param timeout                 Timeout for the future to complete
+	 * @param jobMasterResourceId The resource ID of the JobMaster that registers
+	 * @param jobMasterAddress The address of the JobMaster that registers
+	 * @param jobId The Job ID of the JobMaster that registers
+	 * @param timeout Timeout for the future to complete
 	 * @return Future registration response
 	 */
 	CompletableFuture<RegistrationResponse> registerJobManager(
-		UUID resourceManagerLeaderId,
 		UUID jobMasterLeaderId,
 		ResourceID jobMasterResourceId,
 		String jobMasterAddress,
-		JobID jobID,
+		JobID jobId,
 		@RpcTimeout Time timeout);
 
 	/**
 	 * Requests a slot from the resource manager.
 	 *
-	 * @param resourceManagerLeaderID leader if of the ResourceMaster
 	 * @param jobMasterLeaderID leader if of the JobMaster
 	 * @param slotRequest The slot to request
 	 * @return The confirmation that the slot gets allocated
 	 */
 	CompletableFuture<Acknowledge> requestSlot(
-		UUID resourceManagerLeaderID,
 		UUID jobMasterLeaderID,
 		SlotRequest slotRequest,
 		@RpcTimeout Time timeout);
 
 	/**
-	 * Register a {@link org.apache.flink.runtime.taskexecutor.TaskExecutor} at the resource manager.
+	 * Register a {@link TaskExecutor} at the resource manager.
 	 *
-	 * @param resourceManagerLeaderId  The fencing token for the ResourceManager leader
-	 * @param taskExecutorAddress     The address of the TaskExecutor that registers
-	 * @param resourceID              The resource ID of the TaskExecutor that registers
-	 * @param slotReport              The slot report containing free and allocated task slots
-	 * @param timeout                 The timeout for the response.
+	 * @param taskExecutorAddress The address of the TaskExecutor that registers
+	 * @param resourceId The resource ID of the TaskExecutor that registers
+	 * @param slotReport The slot report containing free and allocated task slots
+	 * @param timeout The timeout for the response.
 	 *
 	 * @return The future to the response by the ResourceManager.
 	 */
 	CompletableFuture<RegistrationResponse> registerTaskExecutor(
-		UUID resourceManagerLeaderId,
 		String taskExecutorAddress,
-		ResourceID resourceID,
+		ResourceID resourceId,
 		SlotReport slotReport,
 		@RpcTimeout Time timeout);
 
 	/**
 	 * Sent by the TaskExecutor to notify the ResourceManager that a slot has become available.
 	 *
-	 * @param resourceManagerLeaderId The ResourceManager leader id
 	 * @param instanceId TaskExecutor's instance id
 	 * @param slotID The SlotID of the freed slot
 	 * @param oldAllocationId to which the slot has been allocated
 	 */
 	void notifySlotAvailable(
-		UUID resourceManagerLeaderId,
 		InstanceID instanceId,
 		SlotID slotID,
 		AllocationID oldAllocationId);
@@ -130,10 +123,9 @@ public interface ResourceManagerGateway extends RpcGateway {
 	/**
 	 * Gets the currently registered number of TaskManagers.
 	 * 
-	 * @param leaderSessionId The leader session ID with which to address the ResourceManager.
 	 * @return The future to the number of registered TaskManagers.
 	 */
-	CompletableFuture<Integer> getNumberOfRegisteredTaskManagers(UUID leaderSessionId);
+	CompletableFuture<Integer> getNumberOfRegisteredTaskManagers();
 
 	/**
 	 * Sends the heartbeat to resource manager from task manager

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerId.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager;
+
+import org.apache.flink.util.AbstractID;
+
+import java.util.UUID;
+
+/**
+ * Fencing token for the {@link ResourceManager}.
+ */
+public class ResourceManagerId extends AbstractID {
+
+	private static final long serialVersionUID = -6042820142662137374L;
+
+	public ResourceManagerId(byte[] bytes) {
+		super(bytes);
+	}
+
+	public ResourceManagerId(long lowerPart, long upperPart) {
+		super(lowerPart, upperPart);
+	}
+
+	public ResourceManagerId(AbstractID id) {
+		super(id);
+	}
+
+	public ResourceManagerId() {
+	}
+
+	public ResourceManagerId(UUID uuid) {
+		this(uuid.getLeastSignificantBits(), uuid.getMostSignificantBits());
+	}
+
+	public UUID toUUID() {
+		return new UUID(getUpperPart(), getLowerPart());
+	}
+
+	public static ResourceManagerId generate() {
+		return new ResourceManagerId();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobLeaderService.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -325,7 +326,7 @@ public class JobLeaderService {
 			@Override
 			protected void onRegistrationSuccess(JMTMRegistrationSuccess success) {
 				// filter out old registration attempts
-				if (getTargetLeaderId().equals(currentLeaderId)) {
+				if (Objects.equals(getTargetLeaderId(), currentLeaderId)) {
 					log.info("Successful registration at job manager {} for job {}.", getTargetAddress(), jobId);
 
 					jobLeaderListener.jobManagerGainedLeadership(jobId, getTargetGateway(), getTargetLeaderId(), success);
@@ -337,8 +338,8 @@ public class JobLeaderService {
 			@Override
 			protected void onRegistrationFailure(Throwable failure) {
 				// filter out old registration attempts
-				if (getTargetLeaderId().equals(currentLeaderId)) {
-					log.info("Failed to register at job manager {} for job {}.", getTargetAddress(), jobId);
+				if (Objects.equals(getTargetLeaderId(), currentLeaderId)) {
+					log.info("Failed to register at job  manager {} for job {}.", getTargetAddress(), jobId);
 					jobLeaderListener.handleError(failure);
 				} else {
 					log.debug("Obsolete JobManager registration failure from {} with leader session ID {}.", getTargetAddress(), getTargetLeaderId(), failure);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.PartitionInfo;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.taskmanager.Task;
@@ -44,8 +45,11 @@ public interface TaskExecutorGateway extends RpcGateway {
 	 * Requests a slot from the TaskManager
 	 *
 	 * @param slotId slot id for the request
+	 * @param jobId for which to request a slot
 	 * @param allocationId id for the request
-	 * @param resourceManagerLeaderId current leader id of the ResourceManager
+	 * @param targetAddress to which to offer the requested slots
+	 * @param resourceManagerId current leader id of the ResourceManager
+	 * @param timeout for the operation
 	 * @return answer to the slot request
 	 */
 	CompletableFuture<Acknowledge> requestSlot(
@@ -53,7 +57,7 @@ public interface TaskExecutorGateway extends RpcGateway {
 		JobID jobId,
 		AllocationID allocationId,
 		String targetAddress,
-		UUID resourceManagerLeaderId,
+		ResourceManagerId resourceManagerId,
 		@RpcTimeout Time timeout);
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.registration.RegisteredRpcConnection;
 import org.apache.flink.runtime.registration.RegistrationConnectionListener;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.registration.RetryingRegistration;
@@ -31,7 +32,6 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -41,7 +41,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * The connection between a TaskExecutor and the ResourceManager.
  */
 public class TaskExecutorToResourceManagerConnection
-		extends RegisteredRpcConnection<UUID, ResourceManagerGateway, TaskExecutorRegistrationSuccess> {
+		extends RegisteredRpcConnection<ResourceManagerId, ResourceManagerGateway, TaskExecutorRegistrationSuccess> {
 
 	private final RpcService rpcService;
 
@@ -64,11 +64,11 @@ public class TaskExecutorToResourceManagerConnection
 			ResourceID taskManagerResourceId,
 			SlotReport slotReport,
 			String resourceManagerAddress,
-			UUID resourceManagerLeaderId,
+			ResourceManagerId resourceManagerId,
 			Executor executor,
 			RegistrationConnectionListener<TaskExecutorRegistrationSuccess> registrationListener) {
 
-		super(log, resourceManagerAddress, resourceManagerLeaderId, executor);
+		super(log, resourceManagerAddress, resourceManagerId, executor);
 
 		this.rpcService = Preconditions.checkNotNull(rpcService);
 		this.taskManagerAddress = Preconditions.checkNotNull(taskManagerAddress);
@@ -79,7 +79,7 @@ public class TaskExecutorToResourceManagerConnection
 
 
 	@Override
-	protected RetryingRegistration<UUID, ResourceManagerGateway, TaskExecutorRegistrationSuccess> generateRegistration() {
+	protected RetryingRegistration<ResourceManagerId, ResourceManagerGateway, TaskExecutorRegistrationSuccess> generateRegistration() {
 		return new TaskExecutorToResourceManagerConnection.ResourceManagerRegistration(
 			log,
 			rpcService,
@@ -127,7 +127,7 @@ public class TaskExecutorToResourceManagerConnection
 	// ------------------------------------------------------------------------
 
 	private static class ResourceManagerRegistration
-			extends RetryingRegistration<UUID, ResourceManagerGateway, TaskExecutorRegistrationSuccess> {
+			extends RetryingRegistration<ResourceManagerId, ResourceManagerGateway, TaskExecutorRegistrationSuccess> {
 
 		private final String taskExecutorAddress;
 		
@@ -139,12 +139,12 @@ public class TaskExecutorToResourceManagerConnection
 				Logger log,
 				RpcService rpcService,
 				String targetAddress,
-				UUID leaderId,
+				ResourceManagerId resourceManagerId,
 				String taskExecutorAddress,
 				ResourceID resourceID,
 				SlotReport slotReport) {
 
-			super(log, rpcService, "ResourceManager", ResourceManagerGateway.class, targetAddress, leaderId);
+			super(log, rpcService, "ResourceManager", ResourceManagerGateway.class, targetAddress, resourceManagerId);
 			this.taskExecutorAddress = checkNotNull(taskExecutorAddress);
 			this.resourceID = checkNotNull(resourceID);
 			this.slotReport = checkNotNull(slotReport);
@@ -152,10 +152,10 @@ public class TaskExecutorToResourceManagerConnection
 
 		@Override
 		protected CompletableFuture<RegistrationResponse> invokeRegistration(
-				ResourceManagerGateway resourceManager, UUID leaderId, long timeoutMillis) throws Exception {
+				ResourceManagerGateway resourceManager, ResourceManagerId fencingToken, long timeoutMillis) throws Exception {
 
 			Time timeout = Time.milliseconds(timeoutMillis);
-			return resourceManager.registerTaskExecutor(leaderId, taskExecutorAddress, resourceID, slotReport, timeout);
+			return resourceManager.registerTaskExecutor(taskExecutorAddress, resourceID, slotReport, timeout);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ResourceManagerTest.java
@@ -49,6 +49,7 @@ import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerConfiguration;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.StandaloneResourceManager;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.TestingRpcService;
@@ -532,7 +533,6 @@ public class ResourceManagerTest extends TestLogger {
 			final SlotReport slotReport = new SlotReport();
 			// test registration response successful and it will trigger monitor heartbeat target, schedule heartbeat request at interval time
 			CompletableFuture<RegistrationResponse> successfulFuture = rmGateway.registerTaskExecutor(
-				rmLeaderSessionId,
 				taskManagerAddress,
 				taskManagerResourceID,
 				slotReport,
@@ -576,7 +576,7 @@ public class ResourceManagerTest extends TestLogger {
 		final String jobMasterAddress = "jm";
 		final ResourceID jmResourceId = new ResourceID(jobMasterAddress);
 		final ResourceID rmResourceId = ResourceID.generate();
-		final UUID rmLeaderId = UUID.randomUUID();
+		final ResourceManagerId rmLeaderId = ResourceManagerId.generate();
 		final UUID jmLeaderId = UUID.randomUUID();
 		final JobID jobId = new JobID();
 
@@ -629,11 +629,10 @@ public class ResourceManagerTest extends TestLogger {
 
 			final ResourceManagerGateway rmGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
 
-			rmLeaderElectionService.isLeader(rmLeaderId).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			rmLeaderElectionService.isLeader(rmLeaderId.toUUID()).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 
 			// test registration response successful and it will trigger monitor heartbeat target, schedule heartbeat request at interval time
 			CompletableFuture<RegistrationResponse> successfulFuture = rmGateway.registerJobManager(
-				rmLeaderId,
 				jmLeaderId,
 				jmResourceId,
 				jobMasterAddress,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SlotPoolTest.java
@@ -88,7 +88,7 @@ public class SlotPoolTest extends TestLogger {
 			assertFalse(future.isDone());
 
 			ArgumentCaptor<SlotRequest> slotRequestArgumentCaptor = ArgumentCaptor.forClass(SlotRequest.class);
-			verify(resourceManagerGateway, Mockito.timeout(timeout.toMilliseconds())).requestSlot(any(UUID.class), any(UUID.class), slotRequestArgumentCaptor.capture(), any(Time.class));
+			verify(resourceManagerGateway, Mockito.timeout(timeout.toMilliseconds())).requestSlot(any(UUID.class), slotRequestArgumentCaptor.capture(), any(Time.class));
 
 			final SlotRequest slotRequest = slotRequestArgumentCaptor.getValue();
 
@@ -125,7 +125,7 @@ public class SlotPoolTest extends TestLogger {
 
 			ArgumentCaptor<SlotRequest> slotRequestArgumentCaptor = ArgumentCaptor.forClass(SlotRequest.class);
 			verify(resourceManagerGateway, Mockito.timeout(timeout.toMilliseconds()).times(2))
-				.requestSlot(any(UUID.class), any(UUID.class), slotRequestArgumentCaptor.capture(), any(Time.class));
+				.requestSlot(any(UUID.class), slotRequestArgumentCaptor.capture(), any(Time.class));
 
 			final List<SlotRequest> slotRequests = slotRequestArgumentCaptor.getAllValues();
 
@@ -168,7 +168,7 @@ public class SlotPoolTest extends TestLogger {
 			assertFalse(future1.isDone());
 
 			ArgumentCaptor<SlotRequest> slotRequestArgumentCaptor = ArgumentCaptor.forClass(SlotRequest.class);
-			verify(resourceManagerGateway, Mockito.timeout(timeout.toMilliseconds())).requestSlot(any(UUID.class), any(UUID.class), slotRequestArgumentCaptor.capture(), any(Time.class));
+			verify(resourceManagerGateway, Mockito.timeout(timeout.toMilliseconds())).requestSlot(any(UUID.class), slotRequestArgumentCaptor.capture(), any(Time.class));
 
 			final SlotRequest slotRequest = slotRequestArgumentCaptor.getValue();
 
@@ -211,7 +211,7 @@ public class SlotPoolTest extends TestLogger {
 			assertFalse(future.isDone());
 
 			ArgumentCaptor<SlotRequest> slotRequestArgumentCaptor = ArgumentCaptor.forClass(SlotRequest.class);
-			verify(resourceManagerGateway, Mockito.timeout(timeout.toMilliseconds())).requestSlot(any(UUID.class), any(UUID.class), slotRequestArgumentCaptor.capture(), any(Time.class));
+			verify(resourceManagerGateway, Mockito.timeout(timeout.toMilliseconds())).requestSlot(any(UUID.class), slotRequestArgumentCaptor.capture(), any(Time.class));
 
 			final SlotRequest slotRequest = slotRequestArgumentCaptor.getValue();
 
@@ -266,7 +266,7 @@ public class SlotPoolTest extends TestLogger {
 			CompletableFuture<SimpleSlot> future1 = slotPoolGateway.allocateSlot(mock(ScheduledUnit.class), DEFAULT_TESTING_PROFILE, null, timeout);
 
 			ArgumentCaptor<SlotRequest> slotRequestArgumentCaptor = ArgumentCaptor.forClass(SlotRequest.class);
-			verify(resourceManagerGateway, Mockito.timeout(timeout.toMilliseconds())).requestSlot(any(UUID.class), any(UUID.class), slotRequestArgumentCaptor.capture(), any(Time.class));
+			verify(resourceManagerGateway, Mockito.timeout(timeout.toMilliseconds())).requestSlot(any(UUID.class), slotRequestArgumentCaptor.capture(), any(Time.class));
 
 			final SlotRequest slotRequest = slotRequestArgumentCaptor.getValue();
 
@@ -297,7 +297,7 @@ public class SlotPoolTest extends TestLogger {
 	private static ResourceManagerGateway createResourceManagerGatewayMock() {
 		ResourceManagerGateway resourceManagerGateway = mock(ResourceManagerGateway.class);
 		when(resourceManagerGateway
-			.requestSlot(any(UUID.class), any(UUID.class), any(SlotRequest.class), any(Time.class)))
+			.requestSlot(any(UUID.class), any(SlotRequest.class), any(Time.class)))
 			.thenReturn(mock(CompletableFuture.class, RETURNS_MOCKS));
 
 		return resourceManagerGateway;
@@ -310,7 +310,7 @@ public class SlotPoolTest extends TestLogger {
 
 		slotPool.start(UUID.randomUUID(), jobManagerAddress);
 
-		slotPool.connectToResourceManager(UUID.randomUUID(), resourceManagerGateway);
+		slotPool.connectToResourceManager(resourceManagerGateway);
 
 		return slotPool.getSelfGateway(SlotPoolGateway.class);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryTest.java
@@ -205,6 +205,10 @@ public class MetricRegistryTest extends TestLogger {
 		MetricRegistry registry = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(config));
 
 		long start = System.currentTimeMillis();
+
+		// only start counting from now on
+		TestReporter3.reportCount = 0;
+
 		for (int x = 0; x < 10; x++) {
 			Thread.sleep(100);
 			int reportCount = TestReporter3.reportCount;
@@ -218,7 +222,7 @@ public class MetricRegistryTest extends TestLogger {
 			 * or after T=50.
 			 */
 			long maxAllowedReports = (curT - start) / 50 + 2;
-			Assert.assertTrue("Too many report were triggered.", maxAllowedReports >= reportCount);
+			Assert.assertTrue("Too many reports were triggered.", maxAllowedReports >= reportCount);
 		}
 		Assert.assertTrue("No report was triggered.", TestReporter3.reportCount > 0);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -27,15 +27,20 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterRegistrationSuccess;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingLeaderRetrievalService;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.registration.RegistrationResponse;
+import org.apache.flink.runtime.rpc.exceptions.FencingTokenMismatchException;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 import org.junit.After;
 import org.junit.Before;
@@ -43,9 +48,11 @@ import org.junit.Test;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class ResourceManagerJobMasterTest extends TestLogger {
@@ -71,18 +78,15 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 	public void testRegisterJobMaster() throws Exception {
 		String jobMasterAddress = "/jobMasterAddress1";
 		JobID jobID = mockJobMaster(jobMasterAddress);
-		TestingLeaderElectionService resourceManagerLeaderElectionService = new TestingLeaderElectionService();
 		UUID jmLeaderID = UUID.randomUUID();
 		final ResourceID jmResourceId = new ResourceID(jobMasterAddress);
 		TestingLeaderRetrievalService jobMasterLeaderRetrievalService = new TestingLeaderRetrievalService(jobMasterAddress, jmLeaderID);
 		TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
-		final ResourceManager<?> resourceManager = createAndStartResourceManager(resourceManagerLeaderElectionService, jobID, jobMasterLeaderRetrievalService, testingFatalErrorHandler);
+		final ResourceManager<?> resourceManager = createAndStartResourceManager(mock(LeaderElectionService.class), jobID, jobMasterLeaderRetrievalService, testingFatalErrorHandler);
 		final ResourceManagerGateway rmGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
-		final UUID rmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
 
 		// test response successful
 		CompletableFuture<RegistrationResponse> successfulFuture = rmGateway.registerJobManager(
-			rmLeaderSessionId,
 			jmLeaderID,
 			jmResourceId,
 			jobMasterAddress,
@@ -103,25 +107,28 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 	public void testRegisterJobMasterWithUnmatchedLeaderSessionId1() throws Exception {
 		String jobMasterAddress = "/jobMasterAddress1";
 		JobID jobID = mockJobMaster(jobMasterAddress);
-		TestingLeaderElectionService resourceManagerLeaderElectionService = new TestingLeaderElectionService();
 		UUID jmLeaderID = UUID.randomUUID();
 		final ResourceID jmResourceId = new ResourceID(jobMasterAddress);
 		TestingLeaderRetrievalService jobMasterLeaderRetrievalService = new TestingLeaderRetrievalService(jobMasterAddress, jmLeaderID);
 		TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
-		final ResourceManager<?> resourceManager = createAndStartResourceManager(resourceManagerLeaderElectionService, jobID, jobMasterLeaderRetrievalService, testingFatalErrorHandler);
-		final ResourceManagerGateway rmGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
-		final UUID rmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
+		final ResourceManager<?> resourceManager = createAndStartResourceManager(mock(LeaderElectionService.class), jobID, jobMasterLeaderRetrievalService, testingFatalErrorHandler);
+		final ResourceManagerGateway wronglyFencedGateway = rpcService.connect(resourceManager.getAddress(), ResourceManagerId.generate(), ResourceManagerGateway.class)
+			.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 
 		// test throw exception when receive a registration from job master which takes unmatched leaderSessionId
-		UUID differentLeaderSessionID = UUID.randomUUID();
-		CompletableFuture<RegistrationResponse> unMatchedLeaderFuture = rmGateway.registerJobManager(
-			differentLeaderSessionID,
+		CompletableFuture<RegistrationResponse> unMatchedLeaderFuture = wronglyFencedGateway.registerJobManager(
 			jmLeaderID,
 			jmResourceId,
 			jobMasterAddress,
 			jobID,
 			timeout);
-		assertTrue(unMatchedLeaderFuture.get(5, TimeUnit.SECONDS) instanceof RegistrationResponse.Decline);
+
+		try {
+			unMatchedLeaderFuture.get(5L, TimeUnit.SECONDS);
+			fail("Should fail because we are using the wrong fencing token.");
+		} catch (ExecutionException e) {
+			assertTrue(ExceptionUtils.stripExecutionException(e) instanceof FencingTokenMismatchException);
+		}
 
 		if (testingFatalErrorHandler.hasExceptionOccurred()) {
 			testingFatalErrorHandler.rethrowError();
@@ -142,14 +149,11 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 		TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
 		final ResourceManager<?> resourceManager = createAndStartResourceManager(resourceManagerLeaderElectionService, jobID, jobMasterLeaderRetrievalService, testingFatalErrorHandler);
 		final ResourceManagerGateway rmGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
-		final UUID rmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
-		final UUID jmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
 		final ResourceID jmResourceId = new ResourceID(jobMasterAddress);
 
 		// test throw exception when receive a registration from job master which takes unmatched leaderSessionId
 		UUID differentLeaderSessionID = UUID.randomUUID();
 		CompletableFuture<RegistrationResponse> unMatchedLeaderFuture = rmGateway.registerJobManager(
-			rmLeaderSessionId,
 			differentLeaderSessionID,
 			jmResourceId,
 			jobMasterAddress,
@@ -176,15 +180,12 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 		TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
 		final ResourceManager<?> resourceManager = createAndStartResourceManager(resourceManagerLeaderElectionService, jobID, jobMasterLeaderRetrievalService, testingFatalErrorHandler);
 		final ResourceManagerGateway rmGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
-		final UUID rmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
-		final UUID jmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
 		final ResourceID jmResourceId = new ResourceID(jobMasterAddress);
 
 		// test throw exception when receive a registration from job master which takes invalid address
 		String invalidAddress = "/jobMasterAddress2";
 		CompletableFuture<RegistrationResponse> invalidAddressFuture = rmGateway.registerJobManager(
-			rmLeaderSessionId,
-			jmLeaderSessionId,
+			HighAvailabilityServices.DEFAULT_LEADER_ID,
 			jmResourceId,
 			invalidAddress,
 			jobID,
@@ -214,24 +215,22 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 			jobMasterLeaderRetrievalService,
 			testingFatalErrorHandler);
 		final ResourceManagerGateway rmGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
-		final UUID rmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
-		final UUID jmLeaderSessionId = grantResourceManagerLeadership(resourceManagerLeaderElectionService);
 		final ResourceID jmResourceId = new ResourceID(jobMasterAddress);
 
 		JobID unknownJobIDToHAServices = new JobID();
-		// verify return RegistrationResponse.Decline when failed to start a job master Leader retrieval listener
-		CompletableFuture<RegistrationResponse> declineFuture = rmGateway.registerJobManager(
-			rmLeaderSessionId,
-			jmLeaderSessionId,
+
+		// this should fail because we try to register a job leader listener for an unknown job id
+		CompletableFuture<RegistrationResponse> registrationFuture = rmGateway.registerJobManager(
+			HighAvailabilityServices.DEFAULT_LEADER_ID,
 			jmResourceId,
 			jobMasterAddress,
 			unknownJobIDToHAServices,
 			timeout);
-		RegistrationResponse response = declineFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-		assertTrue(response instanceof RegistrationResponse.Decline);
 
-		if (testingFatalErrorHandler.hasExceptionOccurred()) {
-			testingFatalErrorHandler.rethrowError();
+		try {
+			registrationFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		} catch (ExecutionException e) {
+			assertTrue(ExceptionUtils.stripExecutionException(e) instanceof ResourceManagerException);
 		}
 	}
 
@@ -243,9 +242,9 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 	}
 
 	private ResourceManager createAndStartResourceManager(
-			TestingLeaderElectionService resourceManagerLeaderElectionService,
+			LeaderElectionService resourceManagerLeaderElectionService,
 			JobID jobID,
-			TestingLeaderRetrievalService jobMasterLeaderRetrievalService,
+			LeaderRetrievalService jobMasterLeaderRetrievalService,
 			FatalErrorHandler fatalErrorHandler) throws Exception {
 		ResourceID rmResourceId = ResourceID.generate();
 		TestingHighAvailabilityServices highAvailabilityServices = new TestingHighAvailabilityServices();
@@ -283,11 +282,4 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 		resourceManager.start();
 		return resourceManager;
 	}
-
-	private UUID grantResourceManagerLeadership(TestingLeaderElectionService resourceManagerLeaderElectionService) {
-		UUID leaderSessionId = UUID.randomUUID();
-		resourceManagerLeaderElectionService.isLeader(leaderSessionId);
-		return leaderSessionId;
-	}
-
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.concurrent.FlinkFutureException;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
@@ -43,7 +44,6 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Arrays;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -74,7 +74,7 @@ public class SlotManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testTaskManagerRegistration() throws Exception {
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
 
 		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
@@ -88,7 +88,7 @@ public class SlotManagerTest extends TestLogger {
 		final SlotStatus slotStatus2 = new SlotStatus(slotId2, resourceProfile);
 		final SlotReport slotReport = new SlotReport(Arrays.asList(slotStatus1, slotStatus2));
 
-		try (SlotManager slotManager = createSlotManager(leaderId, resourceManagerActions)) {
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 			slotManager.registerTaskManager(taskManagerConnection, slotReport);
 
 			assertTrue("The number registered slots does not equal the expected number.",2 == slotManager.getNumberRegisteredSlots());
@@ -103,7 +103,7 @@ public class SlotManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testTaskManagerUnregistration() throws Exception {
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
 		final JobID jobId = new JobID();
 
@@ -113,7 +113,7 @@ public class SlotManagerTest extends TestLogger {
 			any(JobID.class),
 			any(AllocationID.class),
 			anyString(),
-			eq(leaderId),
+			eq(resourceManagerId),
 			any(Time.class))).thenReturn(new CompletableFuture<>());
 
 		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(taskExecutorGateway);
@@ -134,7 +134,7 @@ public class SlotManagerTest extends TestLogger {
 			resourceProfile,
 			"foobar");
 
-		try (SlotManager slotManager = createSlotManager(leaderId, resourceManagerActions)) {
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 			slotManager.registerTaskManager(taskManagerConnection, slotReport);
 
 			assertTrue("The number registered slots does not equal the expected number.",2 == slotManager.getNumberRegisteredSlots());
@@ -166,7 +166,7 @@ public class SlotManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testSlotRequestWithoutFreeSlots() throws Exception {
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceProfile resourceProfile = new ResourceProfile(42.0, 1337);
 		final SlotRequest slotRequest = new SlotRequest(
 			new JobID(),
@@ -176,7 +176,7 @@ public class SlotManagerTest extends TestLogger {
 
 		ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
 
-		try (SlotManager slotManager = createSlotManager(leaderId, resourceManagerActions)) {
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 
 			slotManager.registerSlotRequest(slotRequest);
 
@@ -189,7 +189,7 @@ public class SlotManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testSlotRequestWithResourceAllocationFailure() throws Exception {
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceProfile resourceProfile = new ResourceProfile(42.0, 1337);
 		final SlotRequest slotRequest = new SlotRequest(
 			new JobID(),
@@ -200,7 +200,7 @@ public class SlotManagerTest extends TestLogger {
 		ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
 		doThrow(new ResourceManagerException("Test exception")).when(resourceManagerActions).allocateResource(any(ResourceProfile.class));
 
-		try (SlotManager slotManager = createSlotManager(leaderId, resourceManagerActions)) {
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 
 			slotManager.registerSlotRequest(slotRequest);
 
@@ -216,7 +216,7 @@ public class SlotManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testSlotRequestWithFreeSlot() throws Exception {
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceID resourceID = ResourceID.generate();
 		final JobID jobId = new JobID();
 		final SlotID slotId = new SlotID(resourceID, 0);
@@ -231,7 +231,7 @@ public class SlotManagerTest extends TestLogger {
 
 		ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
 
-		try (SlotManager slotManager = createSlotManager(leaderId, resourceManagerActions)) {
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 
 			// accept an incoming slot request
 			final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
@@ -240,7 +240,7 @@ public class SlotManagerTest extends TestLogger {
 				eq(jobId),
 				eq(allocationId),
 				anyString(),
-				eq(leaderId),
+				eq(resourceManagerId),
 				any(Time.class))).thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
 
 			final TaskExecutorConnection taskExecutorConnection = new TaskExecutorConnection(taskExecutorGateway);
@@ -254,7 +254,7 @@ public class SlotManagerTest extends TestLogger {
 
 			assertTrue("The slot request should be accepted", slotManager.registerSlotRequest(slotRequest));
 
-			verify(taskExecutorGateway).requestSlot(eq(slotId), eq(jobId), eq(allocationId), eq(targetAddress), eq(leaderId), any(Time.class));
+			verify(taskExecutorGateway).requestSlot(eq(slotId), eq(jobId), eq(allocationId), eq(targetAddress), eq(resourceManagerId), any(Time.class));
 
 			TaskManagerSlot slot = slotManager.getSlot(slotId);
 
@@ -268,7 +268,7 @@ public class SlotManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testUnregisterPendingSlotRequest() throws Exception {
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
 		final SlotID slotId = new SlotID(ResourceID.generate(), 0);
 		final AllocationID allocationId = new AllocationID();
@@ -279,7 +279,7 @@ public class SlotManagerTest extends TestLogger {
 			any(JobID.class),
 			any(AllocationID.class),
 			anyString(),
-			eq(leaderId),
+			eq(resourceManagerId),
 			any(Time.class))).thenReturn(new CompletableFuture<>());
 
 		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
@@ -290,7 +290,7 @@ public class SlotManagerTest extends TestLogger {
 
 		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(taskExecutorGateway);
 
-		try (SlotManager slotManager = createSlotManager(leaderId, resourceManagerActions)) {
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 			slotManager.registerTaskManager(taskManagerConnection, slotReport);
 
 			TaskManagerSlot slot = slotManager.getSlot(slotId);
@@ -315,7 +315,7 @@ public class SlotManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testFulfillingPendingSlotRequest() throws Exception {
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceID resourceID = ResourceID.generate();
 		final JobID jobId = new JobID();
 		final SlotID slotId = new SlotID(resourceID, 0);
@@ -337,7 +337,7 @@ public class SlotManagerTest extends TestLogger {
 			eq(jobId),
 			eq(allocationId),
 			anyString(),
-			eq(leaderId),
+			eq(resourceManagerId),
 			any(Time.class))).thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
 
 		final TaskExecutorConnection taskExecutorConnection = new TaskExecutorConnection(taskExecutorGateway);
@@ -345,7 +345,7 @@ public class SlotManagerTest extends TestLogger {
 		final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile);
 		final SlotReport slotReport = new SlotReport(slotStatus);
 
-		try (SlotManager slotManager = createSlotManager(leaderId, resourceManagerActions)) {
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 
 			assertTrue("The slot request should be accepted", slotManager.registerSlotRequest(slotRequest));
 
@@ -355,7 +355,7 @@ public class SlotManagerTest extends TestLogger {
 				taskExecutorConnection,
 				slotReport);
 
-			verify(taskExecutorGateway).requestSlot(eq(slotId), eq(jobId), eq(allocationId), eq(targetAddress), eq(leaderId), any(Time.class));
+			verify(taskExecutorGateway).requestSlot(eq(slotId), eq(jobId), eq(allocationId), eq(targetAddress), eq(resourceManagerId), any(Time.class));
 
 			TaskManagerSlot slot = slotManager.getSlot(slotId);
 
@@ -368,7 +368,7 @@ public class SlotManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testFreeSlot() throws Exception {
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceID resourceID = ResourceID.generate();
 		final JobID jobId = new JobID();
 		final SlotID slotId = new SlotID(resourceID, 0);
@@ -385,7 +385,7 @@ public class SlotManagerTest extends TestLogger {
 		final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile, jobId, allocationId);
 		final SlotReport slotReport = new SlotReport(slotStatus);
 
-		try (SlotManager slotManager = createSlotManager(leaderId, resourceManagerActions)) {
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 
 			slotManager.registerTaskManager(
 				taskExecutorConnection,
@@ -414,8 +414,7 @@ public class SlotManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testDuplicatePendingSlotRequest() throws Exception {
-
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
 		final AllocationID allocationId = new AllocationID();
 		final ResourceProfile resourceProfile1 = new ResourceProfile(1.0, 2);
@@ -423,7 +422,7 @@ public class SlotManagerTest extends TestLogger {
 		final SlotRequest slotRequest1 = new SlotRequest(new JobID(), allocationId, resourceProfile1, "foobar");
 		final SlotRequest slotRequest2 = new SlotRequest(new JobID(), allocationId, resourceProfile2, "barfoo");
 
-		try (SlotManager slotManager = createSlotManager(leaderId, resourceManagerActions)) {
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 			assertTrue(slotManager.registerSlotRequest(slotRequest1));
 			assertFalse(slotManager.registerSlotRequest(slotRequest2));
 		}
@@ -439,7 +438,7 @@ public class SlotManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testDuplicatePendingSlotRequestAfterSlotReport() throws Exception {
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
@@ -454,7 +453,7 @@ public class SlotManagerTest extends TestLogger {
 
 		final SlotRequest slotRequest = new SlotRequest(jobId, allocationId, resourceProfile, "foobar");
 
-		try (SlotManager slotManager = createSlotManager(leaderId, resourceManagerActions)) {
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 			slotManager.registerTaskManager(taskManagerConnection, slotReport);
 
 			assertFalse(slotManager.registerSlotRequest(slotRequest));
@@ -467,7 +466,7 @@ public class SlotManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testDuplicatePendingSlotRequestAfterSuccessfulAllocation() throws Exception {
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
 		final AllocationID allocationId = new AllocationID();
 		final ResourceProfile resourceProfile1 = new ResourceProfile(1.0, 2);
@@ -481,7 +480,7 @@ public class SlotManagerTest extends TestLogger {
 			any(JobID.class),
 			any(AllocationID.class),
 			anyString(),
-			eq(leaderId),
+			eq(resourceManagerId),
 			any(Time.class))).thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
 
 		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(taskExecutorGateway);
@@ -490,7 +489,7 @@ public class SlotManagerTest extends TestLogger {
 		final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile1);
 		final SlotReport slotReport = new SlotReport(slotStatus);
 
-		try (SlotManager slotManager = createSlotManager(leaderId, resourceManagerActions)) {
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 			slotManager.registerTaskManager(taskManagerConnection, slotReport);
 			assertTrue(slotManager.registerSlotRequest(slotRequest1));
 
@@ -512,7 +511,7 @@ public class SlotManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testAcceptingDuplicateSlotRequestAfterAllocationRelease() throws Exception {
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
 		final AllocationID allocationId = new AllocationID();
 		final ResourceProfile resourceProfile1 = new ResourceProfile(1.0, 2);
@@ -526,7 +525,7 @@ public class SlotManagerTest extends TestLogger {
 			any(JobID.class),
 			any(AllocationID.class),
 			anyString(),
-			eq(leaderId),
+			eq(resourceManagerId),
 			any(Time.class))).thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
 
 		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(taskExecutorGateway);
@@ -535,7 +534,7 @@ public class SlotManagerTest extends TestLogger {
 		final SlotStatus slotStatus = new SlotStatus(slotId, new ResourceProfile(2.0, 2));
 		final SlotReport slotReport = new SlotReport(slotStatus);
 
-		try (SlotManager slotManager = createSlotManager(leaderId, resourceManagerActions)) {
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 			slotManager.registerTaskManager(taskManagerConnection, slotReport);
 			assertTrue(slotManager.registerSlotRequest(slotRequest1));
 
@@ -565,7 +564,7 @@ public class SlotManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testReceivingUnknownSlotReport() throws Exception {
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
 
 		final InstanceID unknownInstanceID = new InstanceID();
@@ -574,7 +573,7 @@ public class SlotManagerTest extends TestLogger {
 		final SlotStatus unknownSlotStatus = new SlotStatus(unknownSlotId, unknownResourceProfile);
 		final SlotReport unknownSlotReport = new SlotReport(unknownSlotStatus);
 
-		try (SlotManager slotManager = createSlotManager(leaderId, resourceManagerActions)) {
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 			// check that we don't have any slots registered
 			assertTrue(0 == slotManager.getNumberRegisteredSlots());
 
@@ -591,7 +590,7 @@ public class SlotManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testUpdateSlotReport() throws Exception {
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
 
 		final JobID jobId = new JobID();
@@ -614,7 +613,7 @@ public class SlotManagerTest extends TestLogger {
 		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
 		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(taskExecutorGateway);
 
-		try (SlotManager slotManager = createSlotManager(leaderId, resourceManagerActions)) {
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 			// check that we don't have any slots registered
 			assertTrue(0 == slotManager.getNumberRegisteredSlots());
 
@@ -651,7 +650,7 @@ public class SlotManagerTest extends TestLogger {
 		final long tmTimeout = 500L;
 
 		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 
 		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
 		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(taskExecutorGateway);
@@ -669,7 +668,7 @@ public class SlotManagerTest extends TestLogger {
 			TestingUtils.infiniteTime(),
 			Time.milliseconds(tmTimeout))) {
 
-			slotManager.start(leaderId, mainThreadExecutor, resourceManagerActions);
+			slotManager.start(resourceManagerId, mainThreadExecutor, resourceManagerActions);
 
 			mainThreadExecutor.execute(new Runnable() {
 				@Override
@@ -693,7 +692,7 @@ public class SlotManagerTest extends TestLogger {
 		final long allocationTimeout = 50L;
 
 		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
 
@@ -708,7 +707,7 @@ public class SlotManagerTest extends TestLogger {
 			Time.milliseconds(allocationTimeout),
 			TestingUtils.infiniteTime())) {
 
-			slotManager.start(leaderId, mainThreadExecutor, resourceManagerActions);
+			slotManager.start(resourceManagerId, mainThreadExecutor, resourceManagerActions);
 
 			final AtomicReference<Exception> atomicException = new AtomicReference<>(null);
 
@@ -740,7 +739,7 @@ public class SlotManagerTest extends TestLogger {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testTaskManagerSlotRequestTimeoutHandling() throws Exception {
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
 
 		final JobID jobId = new JobID();
@@ -756,7 +755,7 @@ public class SlotManagerTest extends TestLogger {
 			any(JobID.class),
 			eq(allocationId),
 			anyString(),
-			any(UUID.class),
+			any(ResourceManagerId.class),
 			any(Time.class))).thenReturn(slotRequestFuture1, slotRequestFuture2);
 
 		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(taskExecutorGateway);
@@ -768,7 +767,7 @@ public class SlotManagerTest extends TestLogger {
 		final SlotStatus slotStatus2 = new SlotStatus(slotId2, resourceProfile);
 		final SlotReport slotReport = new SlotReport(Arrays.asList(slotStatus1, slotStatus2));
 
-		try (SlotManager slotManager = createSlotManager(leaderId, resourceManagerActions)) {
+		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 
 			slotManager.registerTaskManager(taskManagerConnection, slotReport);
 
@@ -781,7 +780,7 @@ public class SlotManagerTest extends TestLogger {
 				eq(jobId),
 				eq(allocationId),
 				anyString(),
-				eq(leaderId),
+				eq(resourceManagerId),
 				any(Time.class));
 
 			TaskManagerSlot failedSlot = slotManager.getSlot(slotIdCaptor.getValue());
@@ -794,7 +793,7 @@ public class SlotManagerTest extends TestLogger {
 				eq(jobId),
 				eq(allocationId),
 				anyString(),
-				eq(leaderId),
+				eq(resourceManagerId),
 				any(Time.class));
 
 			// the second attempt succeeds
@@ -819,7 +818,7 @@ public class SlotManagerTest extends TestLogger {
 	@SuppressWarnings("unchecked")
 	public void testSlotReportWhileActiveSlotRequest() throws Exception {
 		final long verifyTimeout = 1000L;
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
 
 		final JobID jobId = new JobID();
@@ -834,7 +833,7 @@ public class SlotManagerTest extends TestLogger {
 			any(JobID.class),
 			eq(allocationId),
 			anyString(),
-			any(UUID.class),
+			any(ResourceManagerId.class),
 			any(Time.class))).thenReturn(slotRequestFuture1, CompletableFuture.completedFuture(Acknowledge.get()));
 
 		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(taskExecutorGateway);
@@ -854,7 +853,7 @@ public class SlotManagerTest extends TestLogger {
 			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime())) {
 
-			slotManager.start(leaderId, mainThreadExecutor, resourceManagerActions);
+			slotManager.start(resourceManagerId, mainThreadExecutor, resourceManagerActions);
 
 			CompletableFuture<Void> registrationFuture = CompletableFuture.supplyAsync(
 				() -> {
@@ -882,7 +881,7 @@ public class SlotManagerTest extends TestLogger {
 				eq(jobId),
 				eq(allocationId),
 				anyString(),
-				eq(leaderId),
+				eq(resourceManagerId),
 				any(Time.class));
 
 			final SlotID requestedSlotId = slotIdCaptor.getValue();
@@ -908,7 +907,7 @@ public class SlotManagerTest extends TestLogger {
 				eq(jobId),
 				eq(allocationId),
 				anyString(),
-				eq(leaderId),
+				eq(resourceManagerId),
 				any(Time.class));
 
 			final SlotID requestedSlotId2 = slotIdCaptor.getValue();
@@ -935,7 +934,7 @@ public class SlotManagerTest extends TestLogger {
 		final long taskManagerTimeout = 50L;
 		final long verifyTimeout = taskManagerTimeout * 10L;
 
-		final UUID leaderId = UUID.randomUUID();
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
 		final ScheduledExecutor scheduledExecutor = TestingUtils.defaultScheduledExecutor();
 
@@ -952,7 +951,7 @@ public class SlotManagerTest extends TestLogger {
 			eq(jobId),
 			eq(allocationId),
 			anyString(),
-			eq(leaderId),
+			eq(resourceManagerId),
 			any(Time.class))).thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
 
 		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(taskExecutorGateway);
@@ -971,7 +970,7 @@ public class SlotManagerTest extends TestLogger {
 			TestingUtils.infiniteTime(),
 			Time.of(taskManagerTimeout, TimeUnit.MILLISECONDS))) {
 
-			slotManager.start(leaderId, mainThreadExecutor, resourceManagerActions);
+			slotManager.start(resourceManagerId, mainThreadExecutor, resourceManagerActions);
 
 			CompletableFuture.supplyAsync(
 				() -> {
@@ -991,7 +990,7 @@ public class SlotManagerTest extends TestLogger {
 				eq(jobId),
 				eq(allocationId),
 				anyString(),
-				eq(leaderId),
+				eq(resourceManagerId),
 				any(Time.class));
 
 			CompletableFuture<Boolean> idleFuture = CompletableFuture.supplyAsync(
@@ -1023,14 +1022,14 @@ public class SlotManagerTest extends TestLogger {
 		}
 	}
 
-	private SlotManager createSlotManager(UUID leaderId, ResourceManagerActions resourceManagerActions) {
+	private SlotManager createSlotManager(ResourceManagerId resourceManagerId, ResourceManagerActions resourceManagerActions) {
 		SlotManager slotManager = new SlotManager(
 			TestingUtils.defaultScheduledExecutor(),
 			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime());
 
-		slotManager.start(leaderId, Executors.directExecutor(), resourceManagerActions);
+		slotManager.start(resourceManagerId, Executors.directExecutor(), resourceManagerActions);
 
 		return slotManager;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
@@ -39,7 +40,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.Collections;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -77,7 +77,7 @@ public class SlotProtocolTest extends TestLogger {
 	public void testSlotsUnavailableRequest() throws Exception {
 		final JobID jobID = new JobID();
 
-		final UUID rmLeaderID = UUID.randomUUID();
+		final ResourceManagerId rmLeaderID = ResourceManagerId.generate();
 
 		try (SlotManager slotManager = new SlotManager(
 			scheduledExecutor,
@@ -103,7 +103,7 @@ public class SlotProtocolTest extends TestLogger {
 			TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
 			Mockito.when(
 				taskExecutorGateway
-					.requestSlot(any(SlotID.class), any(JobID.class), any(AllocationID.class), any(String.class), any(UUID.class), any(Time.class)))
+					.requestSlot(any(SlotID.class), any(JobID.class), any(AllocationID.class), any(String.class), any(ResourceManagerId.class), any(Time.class)))
 				.thenReturn(mock(CompletableFuture.class));
 
 			final ResourceID resourceID = ResourceID.generate();
@@ -118,7 +118,7 @@ public class SlotProtocolTest extends TestLogger {
 
 			// 4) Slot becomes available and TaskExecutor gets a SlotRequest
 			verify(taskExecutorGateway, timeout(5000L))
-				.requestSlot(eq(slotID), eq(jobID), eq(allocationID), any(String.class), any(UUID.class), any(Time.class));
+				.requestSlot(eq(slotID), eq(jobID), eq(allocationID), any(String.class), any(ResourceManagerId.class), any(Time.class));
 		}
 	}
 
@@ -133,12 +133,12 @@ public class SlotProtocolTest extends TestLogger {
 	public void testSlotAvailableRequest() throws Exception {
 		final JobID jobID = new JobID();
 
-		final UUID rmLeaderID = UUID.randomUUID();
+		final ResourceManagerId rmLeaderID = ResourceManagerId.generate();
 
 		TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
 		Mockito.when(
 			taskExecutorGateway
-				.requestSlot(any(SlotID.class), any(JobID.class), any(AllocationID.class), any(String.class), any(UUID.class), any(Time.class)))
+				.requestSlot(any(SlotID.class), any(JobID.class), any(AllocationID.class), any(String.class), any(ResourceManagerId.class), any(Time.class)))
 			.thenReturn(mock(CompletableFuture.class));
 
 		try (SlotManager slotManager = new SlotManager(
@@ -171,7 +171,7 @@ public class SlotProtocolTest extends TestLogger {
 
 			// a SlotRequest is routed to the TaskExecutor
 			verify(taskExecutorGateway, timeout(5000))
-				.requestSlot(eq(slotID), eq(jobID), eq(allocationID), any(String.class), any(UUID.class), any(Time.class));
+				.requestSlot(eq(slotID), eq(jobID), eq(allocationID), any(String.class), any(ResourceManagerId.class), any(Time.class));
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -193,7 +193,6 @@ public class TaskExecutorITCase extends TestLogger {
 			rmLeaderRetrievalService.notifyListener(rmAddress, rmLeaderId);
 
 			CompletableFuture<RegistrationResponse> registrationResponseFuture = rmGateway.registerJobManager(
-				rmLeaderId,
 				jmLeaderId,
 				jmResourceId,
 				jmAddress,
@@ -204,7 +203,7 @@ public class TaskExecutorITCase extends TestLogger {
 
 			assertTrue(registrationResponse instanceof JobMasterRegistrationSuccess);
 
-			CompletableFuture<Acknowledge> slotAck = rmGateway.requestSlot(jmLeaderId, rmLeaderId, slotRequest, timeout);
+			CompletableFuture<Acknowledge> slotAck = rmGateway.requestSlot(jmLeaderId, slotRequest, timeout);
 
 			slotAck.get();
 


### PR DESCRIPTION
## What is the purpose of the change

Properly fences the ResourceManager by letting it extend the FencedRpcEndpoint.
Moreover, this PR introduces a ResourceManagerId which replaces the UUID as
leader id/fencing token. This will give us more type safety when defining rpc
interfaces.

This PR is based on #4580 and #4578.

## Brief change log

- Let `ResourceManager` extend from `FencedRpcEndpoint`
- Introduce the `ResourceManagerId` which replaces the `ResourceManager's` leader id
- Adapt the `ResourceManagerGateway` to not require explicitly sending the `ResourceManagerId` (this is implicitly done by the `FencedAkkaInvocationHandler`)
- Change the `RetryingRegistration` to connect to `FencedRpcEndpoints`

## Verifying this change

This change is already covered by existing tests, such as the `FencedRpcEndpointTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

