### PR TITLE
[FLINK-7507] [dispatcher] Fence Dispatcher

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
@@ -22,29 +22,26 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 
 import java.util.Collection;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 /**
  * Gateway for the Dispatcher component.
  */
-public interface DispatcherGateway extends RpcGateway {
+public interface DispatcherGateway extends FencedRpcGateway<DispatcherId> {
 
 	/**
 	 * Submit a job to the dispatcher.
 	 *
 	 * @param jobGraph JobGraph to submit
-	 * @param leaderSessionId leader session id
 	 * @param timeout RPC timeout
 	 * @return A future acknowledge if the submission succeeded
 	 */
 	CompletableFuture<Acknowledge> submitJob(
 		JobGraph jobGraph,
-		UUID leaderSessionId,
 		@RpcTimeout Time timeout);
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherId.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.util.AbstractID;
+
+import java.util.UUID;
+
+/**
+ * Fencing token of the {@link Dispatcher}.
+ */
+public class DispatcherId extends AbstractID {
+
+	private static final long serialVersionUID = -1654056277003743966L;
+
+	public DispatcherId(byte[] bytes) {
+		super(bytes);
+	}
+
+	public DispatcherId(long lowerPart, long upperPart) {
+		super(lowerPart, upperPart);
+	}
+
+	public DispatcherId(AbstractID id) {
+		super(id);
+	}
+
+	public DispatcherId() {}
+
+	public DispatcherId(UUID uuid) {
+		this(uuid.getLeastSignificantBits(), uuid.getMostSignificantBits());
+	}
+
+	public UUID toUUID() {
+		return new UUID(getUpperPart(), getLowerPart());
+	}
+
+	public static DispatcherId generate() {
+		return new DispatcherId();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -113,7 +113,7 @@ public class DispatcherTest extends TestLogger {
 
 			DispatcherGateway dispatcherGateway = dispatcher.getSelfGateway(DispatcherGateway.class);
 
-			CompletableFuture<Acknowledge> acknowledgeFuture = dispatcherGateway.submitJob(jobGraph, HighAvailabilityServices.DEFAULT_LEADER_ID, timeout);
+			CompletableFuture<Acknowledge> acknowledgeFuture = dispatcherGateway.submitJob(jobGraph, timeout);
 
 			acknowledgeFuture.get();
 


### PR DESCRIPTION
## What is the purpose of the change

Let the Dispatcher extend the FencedRpcEndpoint and introduce DispatcherId which
replaces the UUID as leader id/fencing token.

## Verifying this change

This change is already covered by existing tests, such as `FencedRpcEndpointTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

