### PR TITLE
[FLINK-7502] [metrics] Improve PrometheusReporter

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -422,7 +422,7 @@ of your Flink distribution.
 
 Parameters:
 
-- `port` - (optional) the port the Prometheus exporter listens on, defaults to [9249](https://github.com/prometheus/prometheus/wiki/Default-port-allocations).
+- `port` - (optional) the port the Prometheus exporter listens on, defaults to [9249](https://github.com/prometheus/prometheus/wiki/Default-port-allocations). In order to be able to run several instances of the reporter on one host (e.g. when one TaskManager is colocated with the JobManager) it is advisable to use a port range like `9250-9260`.
 
 Example configuration:
 

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -438,11 +438,11 @@ Flink metric types are mapped to Prometheus metric types as follows:
 | Flink     | Prometheus | Note                                     |
 | --------- |------------|------------------------------------------|
 | Counter   | Gauge      |Prometheus counters cannot be decremented.|
-| Gauge     | Gauge      |                                          |
+| Gauge     | Gauge      |Only numbers and booleans are supported.  |
 | Histogram | Summary    |Quantiles .5, .75, .95, .98, .99 and .999 |
 | Meter     | Gauge      |The gauge exports the meter's rate.       |
 
-All Flink metrics variables, such as `<host>`, `<job_name>`, `<tm_id>`, `<subtask_index>`, `<task_name>` and `<operator_name>`, are exported to Prometheus as labels. 
+All Flink metrics variables (see [List of all Variables](#list-of-all-variables)) are exported to Prometheus as labels. 
 
 ### StatsD (org.apache.flink.metrics.statsd.StatsDReporter)
 

--- a/flink-metrics/flink-metrics-prometheus/pom.xml
+++ b/flink-metrics/flink-metrics-prometheus/pom.xml
@@ -62,14 +62,8 @@ under the License.
 
 		<dependency>
 			<groupId>io.prometheus</groupId>
-			<artifactId>simpleclient_servlet</artifactId>
+			<artifactId>simpleclient_httpserver</artifactId>
 			<version>${prometheus.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.nanohttpd</groupId>
-			<artifactId>nanohttpd</artifactId>
-			<version>2.2.0</version>
 		</dependency>
 
 		<!-- test dependencies -->
@@ -113,10 +107,6 @@ under the License.
 								<relocation>
 									<pattern>io.prometheus.client</pattern>
 									<shadedPattern>org.apache.flink.shaded.io.prometheus.client</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>fi.iki.elonen</pattern>
-									<shadedPattern>org.apache.flink.shaded.fi.iki.elonen</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
@@ -146,7 +146,11 @@ public class PrometheusReporter implements MetricReporter {
 
 	@Override
 	public void notifyOfRemovedMetric(final Metric metric, final String metricName, final MetricGroup group) {
-		CollectorRegistry.defaultRegistry.unregister(collectorsByMetricName.get(metricName));
+		try {
+			CollectorRegistry.defaultRegistry.unregister(collectorsByMetricName.get(metricName));
+		} catch (Exception e) {
+			LOG.warn("There was a problem unregistering metric {}.", metricName, e);
+		}
 		collectorsByMetricName.remove(metricName);
 	}
 

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
@@ -212,18 +212,22 @@ public class PrometheusReporter implements MetricReporter {
 			@Override
 			public double get() {
 				final Object value = gauge.getValue();
+				if (value == null) {
+					LOG.debug("Gauge {} is null-valued, defaulting to 0.", gauge);
+					return 0;
+				}
 				if (value instanceof Double) {
 					return (double) value;
 				}
 				if (value instanceof Number) {
 					return ((Number) value).doubleValue();
-				} else if (value instanceof Boolean) {
-					return ((Boolean) value) ? 1 : 0;
-				} else {
-					LOG.debug("Invalid type for Gauge {}: {}, only number types and booleans are supported by this reporter.",
-						gauge, value.getClass().getName());
-					return 0;
 				}
+				if (value instanceof Boolean) {
+					return ((Boolean) value) ? 1 : 0;
+				}
+				LOG.debug("Invalid type for Gauge {}: {}, only number types and booleans are supported by this reporter.",
+					gauge, value.getClass().getName());
+				return 0;
 			}
 		};
 	}

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
@@ -85,23 +85,20 @@ public class PrometheusReporter implements MetricReporter {
 	@Override
 	public void open(MetricConfig config) {
 		String portsConfig = config.getString(ARG_PORT, DEFAULT_PORT);
+		Iterator<Integer> ports = NetUtils.getPortRangeFromString(portsConfig);
 
-		if (portsConfig != null) {
-			Iterator<Integer> ports = NetUtils.getPortRangeFromString(portsConfig);
-
-			while (ports.hasNext()) {
-				int port = ports.next();
-				try {
-					httpServer = new HTTPServer(port);
-					LOG.info("Started PrometheusReporter HTTP server on port " + port + ".");
-					break;
-				} catch (IOException ioe) { //assume port conflict
-					LOG.debug("Could not start PrometheusReporter HTTP server on port " + port + ".", ioe);
-				}
+		while (ports.hasNext()) {
+			int port = ports.next();
+			try {
+				httpServer = new HTTPServer(port);
+				LOG.info("Started PrometheusReporter HTTP server on port {}.", port);
+				break;
+			} catch (IOException ioe) { //assume port conflict
+				LOG.debug("Could not start PrometheusReporter HTTP server on port {}.", port, ioe);
 			}
-			if (httpServer == null) {
-				throw new RuntimeException("Could not start PrometheusReporter HTTP server on any configured port. Ports: " + portsConfig);
-			}
+		}
+		if (httpServer == null) {
+			throw new RuntimeException("Could not start PrometheusReporter HTTP server on any configured port. Ports: " + portsConfig);
 		}
 	}
 
@@ -142,7 +139,7 @@ public class PrometheusReporter implements MetricReporter {
 		try {
 			collector.register();
 		} catch (Exception e) {
-			LOG.warn("There was a problem registering metric {}: {}", metricName, e);
+			LOG.warn("There was a problem registering metric {}.", metricName, e);
 		}
 		collectorsByMetricName.put(metricName, collector);
 	}

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.prometheus;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.util.TestMeter;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
+import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.runtime.metrics.util.TestingHistogram;
+import org.apache.flink.util.AbstractID;
+
+import com.mashape.unirest.http.exceptions.UnirestException;
+import io.prometheus.client.CollectorRegistry;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.apache.flink.metrics.prometheus.PrometheusReporterTest.createConfigWithOneReporter;
+import static org.apache.flink.metrics.prometheus.PrometheusReporterTest.pollMetrics;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test for {@link PrometheusReporter} that registers several instances of the same metric for different subtasks.
+ */
+public class PrometheusReporterTaskScopeTest {
+	private static final String[] LABEL_NAMES = {"job_id", "task_id", "task_attempt_id", "host", "task_name", "task_attempt_num", "job_name", "tm_id", "subtask_index"};
+
+	private static final String TASK_MANAGER_HOST = "taskManagerHostName";
+	private static final String TASK_MANAGER_ID = "taskManagerId";
+	private static final String JOB_NAME = "jobName";
+	private static final String TASK_NAME = "taskName";
+	private static final int ATTEMPT_NUMBER = 0;
+	private static final int SUBTASK_INDEX_1 = 0;
+	private static final int SUBTASK_INDEX_2 = 1;
+
+	private final MetricRegistry registry = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", "9429")));
+
+	private final JobID jobId = new JobID();
+	private final AbstractID taskId1 = new AbstractID();
+	private final AbstractID taskAttemptId1 = new AbstractID();
+	private final String[] labelValues1 = {jobId.toString(), taskId1.toString(), taskAttemptId1.toString(), TASK_MANAGER_HOST, TASK_NAME, "" + ATTEMPT_NUMBER, JOB_NAME, TASK_MANAGER_ID, "" + SUBTASK_INDEX_1};
+	private final AbstractID taskId2 = new AbstractID();
+	private final AbstractID taskAttemptId2 = new AbstractID();
+	private final String[] labelValues2 = {jobId.toString(), taskId2.toString(), taskAttemptId2.toString(), TASK_MANAGER_HOST, TASK_NAME, "" + ATTEMPT_NUMBER, JOB_NAME, TASK_MANAGER_ID, "" + SUBTASK_INDEX_2};
+
+	private final TaskManagerMetricGroup tmMetricGroup = new TaskManagerMetricGroup(registry, TASK_MANAGER_HOST, TASK_MANAGER_ID);
+	private final TaskManagerJobMetricGroup tmJobMetricGroup = new TaskManagerJobMetricGroup(registry, tmMetricGroup, jobId, JOB_NAME);
+	private final TaskMetricGroup taskMetricGroup1 = new TaskMetricGroup(registry, tmJobMetricGroup, taskId1, taskAttemptId1, TASK_NAME, SUBTASK_INDEX_1, ATTEMPT_NUMBER);
+	private final TaskMetricGroup taskMetricGroup2 = new TaskMetricGroup(registry, tmJobMetricGroup, taskId2, taskAttemptId2, TASK_NAME, SUBTASK_INDEX_2, ATTEMPT_NUMBER);
+
+	@Test
+	public void countersCanBeAddedSeveralTimesIfTheyDifferInLabels() throws UnirestException {
+		Counter counter1 = new SimpleCounter();
+		counter1.inc(1);
+		Counter counter2 = new SimpleCounter();
+		counter2.inc(2);
+
+		taskMetricGroup1.counter("my_counter", counter1);
+		taskMetricGroup2.counter("my_counter", counter2);
+
+		assertThat(CollectorRegistry.defaultRegistry.getSampleValue("flink_taskmanager_job_task_my_counter", LABEL_NAMES, labelValues1),
+			equalTo(1.));
+		assertThat(CollectorRegistry.defaultRegistry.getSampleValue("flink_taskmanager_job_task_my_counter", LABEL_NAMES, labelValues2),
+			equalTo(2.));
+	}
+
+	@Test
+	public void gaugesCanBeAddedSeveralTimesIfTheyDifferInLabels() throws UnirestException {
+		Gauge<Integer> gauge1 = new Gauge<Integer>() {
+			@Override
+			public Integer getValue() {
+				return 3;
+			}
+		};
+		Gauge<Integer> gauge2 = new Gauge<Integer>() {
+			@Override
+			public Integer getValue() {
+				return 4;
+			}
+		};
+
+		taskMetricGroup1.gauge("my_gauge", gauge1);
+		taskMetricGroup2.gauge("my_gauge", gauge2);
+
+		assertThat(CollectorRegistry.defaultRegistry.getSampleValue("flink_taskmanager_job_task_my_gauge", LABEL_NAMES, labelValues1),
+			equalTo(3.));
+		assertThat(CollectorRegistry.defaultRegistry.getSampleValue("flink_taskmanager_job_task_my_gauge", LABEL_NAMES, labelValues2),
+			equalTo(4.));
+	}
+
+	@Test
+	public void metersCanBeAddedSeveralTimesIfTheyDifferInLabels() throws UnirestException {
+		Meter meter = new TestMeter();
+
+		taskMetricGroup1.meter("my_meter", meter);
+		taskMetricGroup2.meter("my_meter", meter);
+
+		assertThat(CollectorRegistry.defaultRegistry.getSampleValue("flink_taskmanager_job_task_my_meter", LABEL_NAMES, labelValues1),
+			equalTo(5.));
+		assertThat(CollectorRegistry.defaultRegistry.getSampleValue("flink_taskmanager_job_task_my_meter", LABEL_NAMES, labelValues2),
+			equalTo(5.));
+	}
+
+	@Test
+	public void histogramsCanBeAddedSeveralTimesIfTheyDifferInLabels() throws UnirestException {
+		Histogram histogram = new TestingHistogram();
+
+		taskMetricGroup1.histogram("my_histogram", histogram);
+		taskMetricGroup2.histogram("my_histogram", histogram);
+
+		final String exportedMetrics = pollMetrics().getBody();
+		assertThat(exportedMetrics, containsString("subtask_index=\"0\",quantile=\"0.5\",} 0.5")); // histogram
+		assertThat(exportedMetrics, containsString("subtask_index=\"1\",quantile=\"0.5\",} 0.5")); // histogram
+
+		final String[] labelNamesWithQuantile = addToArray(LABEL_NAMES, "quantile");
+		for (Double quantile : PrometheusReporter.HistogramSummaryProxy.QUANTILES) {
+			assertThat(CollectorRegistry.defaultRegistry.getSampleValue("flink_taskmanager_job_task_my_histogram", labelNamesWithQuantile, addToArray(labelValues1, "" + quantile)),
+				equalTo(quantile));
+			assertThat(CollectorRegistry.defaultRegistry.getSampleValue("flink_taskmanager_job_task_my_histogram", labelNamesWithQuantile, addToArray(labelValues2, "" + quantile)),
+				equalTo(quantile));
+		}
+	}
+
+	@Test
+	public void removingSingleInstanceOfMetricDoesNotBreakOtherInstances() throws UnirestException {
+		Counter counter1 = new SimpleCounter();
+		counter1.inc(1);
+		Counter counter2 = new SimpleCounter();
+		counter2.inc(2);
+
+		taskMetricGroup1.counter("my_counter", counter1);
+		taskMetricGroup2.counter("my_counter", counter2);
+
+		assertThat(CollectorRegistry.defaultRegistry.getSampleValue("flink_taskmanager_job_task_my_counter", LABEL_NAMES, labelValues1),
+			equalTo(1.));
+		assertThat(CollectorRegistry.defaultRegistry.getSampleValue("flink_taskmanager_job_task_my_counter", LABEL_NAMES, labelValues2),
+			equalTo(2.));
+
+		taskMetricGroup2.close();
+		assertThat(CollectorRegistry.defaultRegistry.getSampleValue("flink_taskmanager_job_task_my_counter", LABEL_NAMES, labelValues1),
+			equalTo(1.));
+
+		taskMetricGroup1.close();
+		assertThat(CollectorRegistry.defaultRegistry.getSampleValue("flink_taskmanager_job_task_my_counter", LABEL_NAMES, labelValues1),
+			nullValue());
+	}
+
+	private String[] addToArray(String[] array, String element) {
+		final String[] labelNames = Arrays.copyOf(array, LABEL_NAMES.length + 1);
+		labelNames[LABEL_NAMES.length] = element;
+		return labelNames;
+	}
+
+	@After
+	public void shutdownRegistry() {
+		registry.shutdown();
+	}
+
+}

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -47,7 +47,6 @@ import org.junit.rules.ExpectedException;
 import java.util.Arrays;
 
 import static org.apache.flink.metrics.prometheus.PrometheusReporter.ARG_PORT;
-import static org.apache.flink.runtime.metrics.scope.ScopeFormat.SCOPE_SEPARATOR;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -262,10 +261,6 @@ public class PrometheusReporterTest extends TestLogger {
 
 	static HttpResponse<String> pollMetrics() throws UnirestException {
 		return Unirest.get("http://localhost:" + NON_DEFAULT_PORT + "/metrics").asString();
-	}
-
-	private static String getFullMetricName(String metricName) {
-		return HOST_NAME + SCOPE_SEPARATOR + "taskmanager" + SCOPE_SEPARATOR + TASK_MANAGER + SCOPE_SEPARATOR + metricName;
 	}
 
 	static Configuration createConfigWithOneReporter(String reporterName, String portString) {

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -166,16 +166,24 @@ public class PrometheusReporterTest extends TestLogger {
 	public void cannotStartTwoReportersOnSamePort() {
 		final MetricRegistry fixedPort1 = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", "12345")));
 		final MetricRegistry fixedPort2 = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test2", "12345")));
+
 		assertThat(fixedPort1.getReporters(), hasSize(1));
 		assertThat(fixedPort2.getReporters(), hasSize(0));
+
+		fixedPort1.shutdown();
+		fixedPort2.shutdown();
 	}
 
 	@Test
 	public void canStartTwoReportersWhenUsingPortRange() {
 		final MetricRegistry portRange1 = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", "9249-9252")));
 		final MetricRegistry portRange2 = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test2", "9249-9252")));
+
 		assertThat(portRange1.getReporters(), hasSize(1));
 		assertThat(portRange2.getReporters(), hasSize(1));
+
+		portRange1.shutdown();
+		portRange2.shutdown();
 	}
 
 	@Test
@@ -183,9 +191,14 @@ public class PrometheusReporterTest extends TestLogger {
 		final MetricRegistry smallPortRange1 = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", "9253-9254")));
 		final MetricRegistry smallPortRange2 = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test2", "9253-9254")));
 		final MetricRegistry smallPortRange3 = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test3", "9253-9254")));
+
 		assertThat(smallPortRange1.getReporters(), hasSize(1));
 		assertThat(smallPortRange2.getReporters(), hasSize(1));
 		assertThat(smallPortRange3.getReporters(), hasSize(0));
+
+		smallPortRange1.shutdown();
+		smallPortRange2.shutdown();
+		smallPortRange3.shutdown();
 	}
 
 	private String addMetricAndPollResponse(Metric metric, String metricName) throws UnirestException {

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -100,6 +100,18 @@ public class PrometheusReporterTest extends TestLogger {
 	}
 
 	@Test
+	public void nullGaugeDoesNotBreakReporter() throws UnirestException {
+		Gauge<Integer> testGauge = new Gauge<Integer>() {
+			@Override
+			public Integer getValue() {
+				return null;
+			}
+		};
+
+		assertThatGaugeIsExported(testGauge, "testGauge", "0.0");
+	}
+
+	@Test
 	public void meterRateIsReportedAsPrometheusGauge() throws UnirestException {
 		Meter testMeter = new TestMeter();
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@ under the License.
 		<curator.version>2.12.0</curator.version>
 		<jackson.version>2.7.4</jackson.version>
 		<metrics.version>3.1.5</metrics.version>
-		<prometheus.version>0.0.21</prometheus.version>
+		<prometheus.version>0.0.26</prometheus.version>
 		<junit.version>4.12</junit.version>
 		<mockito.version>1.10.19</mockito.version>
 		<powermock.version>1.6.5</powermock.version>


### PR DESCRIPTION
## What is the purpose of the change

*This pull request addresses several issues that came up when testing PrometheusReporter in a YARN environment. Most significantly, it is now possible to specify a port range similarly to how it is done for JmxReporter.*


## Brief change log

* Do not throw exception when same metric is added twice
* Add possibility to configure port range
* Bump prometheus.version 0.0.21 -> 0.0.26
* Use simpleclient_httpserver instead of nanohttpd


## Verifying this change

* The changed code is covered by existing test `PrometheusReporterTest`, test cases for new functionality were added.
* Test building the jar and adding it to Flink lib directory. Then configure Prometheus reporter and check endpoints in configured port range for metrics. In particular, test case where JobManager and one TaskManager are co-located – there now should be separately reported metrics endpoints.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes**, upgrade prometheus client
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**, `PrometheusReporter` is `@PublicEvolving`, but it has not been released as of now.
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **don't know**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **don't know**

## Documentation

  - Does this pull request introduce a new feature? **yes**, configurable port range
  - If yes, how is the feature documented? **docs**