### PR TITLE
[FLINK-7513][tests] remove TestBufferFactory#MOCK_BUFFER

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.netty.PartitionRequestClient;
 import org.apache.flink.runtime.io.network.partition.ProducerFailedException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -40,6 +41,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -55,12 +58,14 @@ public class RemoteInputChannelTest {
 		// Setup
 		final SingleInputGate inputGate = mock(SingleInputGate.class);
 		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
+		final Buffer buffer = TestBufferFactory.createBuffer();
+		buffer.retain(); // used twice
 
 		// The test
-		inputChannel.onBuffer(TestBufferFactory.getMockBuffer(), 0);
+		inputChannel.onBuffer(buffer, 0);
 
 		// This does not yet throw the exception, but sets the error at the channel.
-		inputChannel.onBuffer(TestBufferFactory.getMockBuffer(), 29);
+		inputChannel.onBuffer(buffer, 29);
 
 		try {
 			inputChannel.getNextBuffer();
@@ -68,6 +73,10 @@ public class RemoteInputChannelTest {
 			fail("Did not throw expected exception after enqueuing an out-of-order buffer.");
 		}
 		catch (Exception expected) {
+			assertFalse(buffer.isRecycled());
+			// free remaining buffer instances
+			inputChannel.releaseAllResources();
+			assertTrue(buffer.isRecycled());
 		}
 
 		// Need to notify the input gate for the out-of-order buffer as well. Otherwise the
@@ -84,6 +93,7 @@ public class RemoteInputChannelTest {
 
 		// Setup
 		final ExecutorService executor = Executors.newFixedThreadPool(2);
+		final Buffer buffer = TestBufferFactory.createBuffer();
 
 		try {
 			// Test
@@ -97,7 +107,10 @@ public class RemoteInputChannelTest {
 					public Void call() throws Exception {
 						while (true) {
 							for (int j = 0; j < 128; j++) {
-								inputChannel.onBuffer(TestBufferFactory.getMockBuffer(), j);
+								// this is the same buffer over and over again which will be
+								// recycled by the RemoteInputChannel
+								buffer.retain();
+								inputChannel.onBuffer(buffer, j);
 							}
 
 							if (inputChannel.isReleased()) {
@@ -132,6 +145,9 @@ public class RemoteInputChannelTest {
 		}
 		finally {
 			executor.shutdown();
+			assertFalse(buffer.isRecycled());
+			buffer.recycle();
+			assertTrue(buffer.isRecycled());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -59,10 +59,9 @@ public class RemoteInputChannelTest {
 		final SingleInputGate inputGate = mock(SingleInputGate.class);
 		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
 		final Buffer buffer = TestBufferFactory.createBuffer();
-		buffer.retain(); // used twice
 
 		// The test
-		inputChannel.onBuffer(buffer, 0);
+		inputChannel.onBuffer(buffer.retain(), 0);
 
 		// This does not yet throw the exception, but sets the error at the channel.
 		inputChannel.onBuffer(buffer, 29);
@@ -109,8 +108,7 @@ public class RemoteInputChannelTest {
 							for (int j = 0; j < 128; j++) {
 								// this is the same buffer over and over again which will be
 								// recycled by the RemoteInputChannel
-								buffer.retain();
-								inputChannel.onBuffer(buffer, j);
+								inputChannel.onBuffer(buffer.retain(), j);
 							}
 
 							if (inputChannel.isReleased()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestBufferFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestBufferFactory.java
@@ -36,8 +36,6 @@ public class TestBufferFactory {
 
 	private static final BufferRecycler RECYCLER = new DiscardingRecycler();
 
-	private static final Buffer MOCK_BUFFER = createBuffer();
-
 	private final int bufferSize;
 
 	private final BufferRecycler bufferRecycler;
@@ -88,9 +86,5 @@ public class TestBufferFactory {
 		checkArgument(bufferSize > 0);
 
 		return new Buffer(MemorySegmentFactory.allocateUnpooledSegment(bufferSize), RECYCLER);
-	}
-
-	public static Buffer getMockBuffer() {
-		return MOCK_BUFFER;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

The static `TestBufferFactory#MOCK_BUFFER` buffer did not allow proper reference counting and we should rather create test buffers in the tests which may also be released afterwards.

## Brief change log

- replace `TestBufferFactory#MOCK_BUFFER` use with `TestBufferFactory.createBuffer()`
- fix this buffer's reference counting and make sure it is correct

## Verifying this change

This change is already covered by existing tests, such as `RemoteInputChannelTest` which was the only user of `TestBufferFactory#MOCK_BUFFER`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

