### PR TITLE
[FLINK-7514][tests] fix BackPressureStatsTrackerITCase releasing buffers twice

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerITCase.java
@@ -61,6 +61,7 @@ import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.Al
 import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.ExecutionGraphFound;
 import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.RequestExecutionGraph;
 import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.WaitForAllVerticesToBeRunning;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Simple back pressured task test.
@@ -219,6 +220,7 @@ public class BackPressureStatsTrackerITCase extends TestLogger {
 							//
 							for (Buffer buf : buffers) {
 								buf.recycle();
+								assertTrue(buf.isRecycled());
 							}
 
 							// Wait for all buffers to be available. The tasks
@@ -277,10 +279,6 @@ public class BackPressureStatsTrackerITCase extends TestLogger {
 
 				highAvailabilityServices.closeAndCleanupAllData();
 
-				for (Buffer buf : buffers) {
-					buf.recycle();
-				}
-
 				testBufferPool.lazyDestroy();
 			}
 		}};
@@ -294,7 +292,7 @@ public class BackPressureStatsTrackerITCase extends TestLogger {
 			ExecutionJobVertex vertex) throws InterruptedException {
 
 		statsTracker.invalidateOperatorStatsCache();
-		Assert.assertTrue("Failed to trigger", statsTracker.triggerStackTraceSample(vertex));
+		assertTrue("Failed to trigger", statsTracker.triggerStackTraceSample(vertex));
 
 		// Sleep minimum duration
 		Thread.sleep(20 * 10);


### PR DESCRIPTION
## What is the purpose of the change

`BackPressureStatsTrackerITCase#testBackPressuredProducer()` is releasing its buffers twice which is fixed by this PR while making sure they are actually released.

## Brief change log

- remove duplicate `buf.recycle()`
- ensure buffers are released when expected

## Verifying this change

This change is part of the `BackPressureStatsTrackerITCase` test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

