### PR TITLE
[FLINK-7515][network] allow actual 0-length content in NettyMessage#allocateBuffer()

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
-import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufAllocator;
@@ -48,6 +47,7 @@ import java.net.ProtocolException;
 import java.nio.ByteBuffer;
 import java.util.List;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -105,7 +105,7 @@ abstract class NettyMessage {
 	 * NettyMessageDecoder}
 	 */
 	private static ByteBuf allocateBuffer(ByteBufAllocator allocator, byte id, int length) {
-		Preconditions.checkArgument(length <= Integer.MAX_VALUE - HEADER_LENGTH);
+		checkArgument(length <= Integer.MAX_VALUE - HEADER_LENGTH);
 
 		final ByteBuf buffer;
 		if (length != -1) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufAllocator;
@@ -67,12 +68,53 @@ abstract class NettyMessage {
 
 	// ------------------------------------------------------------------------
 
+	/**
+	 * Allocates a new (header and contents) buffer and adds some header information for the frame
+	 * decoder.
+	 *
+	 * <p>Before sending the buffer, you must write the actual length after adding the contents as
+	 * an integer to position <tt>0</tt>!
+	 *
+	 * @param allocator
+	 * 		byte buffer allocator to use
+	 * @param id
+	 * 		{@link NettyMessage} subclass ID
+	 *
+	 * @return a newly allocated direct buffer with header data written for {@link
+	 * NettyMessageDecoder}
+	 */
 	private static ByteBuf allocateBuffer(ByteBufAllocator allocator, byte id) {
-		return allocateBuffer(allocator, id, 0);
+		return allocateBuffer(allocator, id, -1);
 	}
 
+	/**
+	 * Allocates a new (header and contents) buffer and adds some header information for the frame
+	 * decoder.
+	 *
+	 * <p>If the <tt>length</tt> is unknown, you must write the actual length after adding the
+	 * contents as an integer to position <tt>0</tt>!
+	 *
+	 * @param allocator
+	 * 		byte buffer allocator to use
+	 * @param id
+	 * 		{@link NettyMessage} subclass ID
+	 * @param length
+	 * 		content length (or <tt>-1</tt> if unknown)
+	 *
+	 * @return a newly allocated direct buffer with header data written for {@link
+	 * NettyMessageDecoder}
+	 */
 	private static ByteBuf allocateBuffer(ByteBufAllocator allocator, byte id, int length) {
-		final ByteBuf buffer = length != 0 ? allocator.directBuffer(HEADER_LENGTH + length) : allocator.directBuffer();
+		Preconditions.checkArgument(length <= Integer.MAX_VALUE - HEADER_LENGTH);
+
+		final ByteBuf buffer;
+		if (length != -1) {
+			buffer = allocator.directBuffer(HEADER_LENGTH + length);
+		} else {
+			// content length unknown -> start with the default initial size (rather than HEADER_LENGTH only):
+			buffer = allocator.directBuffer();
+		}
+
 		buffer.writeInt(HEADER_LENGTH + length);
 		buffer.writeInt(MAGIC_NUMBER);
 		buffer.writeByte(id);


### PR DESCRIPTION
## What is the purpose of the change

Previously, length "0" meant "unknown content length" but there are cases where the actual length is "0" and we do not need a larger buffer than the header size.

## Brief change log

- use -1 for tagging the special case of an unknown content length
- change buffers with 0-size content to start with the header size only

## Verifying this change

This change is already covered by existing tests, such as `NettyMessageSerializationTest` and many more network-related tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
