### PR TITLE
[FLINK-7516][memory] do not allow copies into a read-only ByteBuffer

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Field;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.nio.ReadOnlyBufferException;
 
 /**
  * This class represents a piece of memory managed by Flink. The memory can be on-heap or off-heap,
@@ -305,6 +306,9 @@ public final class HybridMemorySegment extends MemorySegment {
 		// check the byte array offset and length
 		if ((offset | numBytes | (offset + numBytes)) < 0) {
 			throw new IndexOutOfBoundsException();
+		}
+		if (target.isReadOnly()) {
+			throw new ReadOnlyBufferException();
 		}
 
 		final int targetOffset = target.position();

--- a/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
@@ -307,9 +307,6 @@ public final class HybridMemorySegment extends MemorySegment {
 		if ((offset | numBytes | (offset + numBytes)) < 0) {
 			throw new IndexOutOfBoundsException();
 		}
-		if (target.isReadOnly()) {
-			throw new ReadOnlyBufferException();
-		}
 
 		final int targetOffset = target.position();
 		final int remaining = target.remaining();
@@ -319,6 +316,10 @@ public final class HybridMemorySegment extends MemorySegment {
 		}
 
 		if (target.isDirect()) {
+			if (target.isReadOnly()) {
+				throw new ReadOnlyBufferException();
+			}
+
 			// copy to the target memory directly
 			final long targetPointer = getAddress(target) + targetOffset;
 			final long sourcePointer = address + offset;

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegment.java
@@ -25,6 +25,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.ReadOnlyBufferException;
 
 /**
  * This class represents a piece of memory managed by Flink.
@@ -1151,6 +1152,7 @@ public abstract class MemorySegment {
 	 * @throws IndexOutOfBoundsException If the offset is invalid, or this segment does not
 	 *           contain the given number of bytes (starting from offset), or the target byte buffer does
 	 *           not have enough space for the bytes.
+	 * @throws ReadOnlyBufferException If the target buffer is read-only.
 	 */
 	public abstract void get(int offset, ByteBuffer target, int numBytes);
 

--- a/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/MemorySegmentTestBase.java
@@ -32,6 +32,7 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.ReadOnlyBufferException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Random;
@@ -1911,6 +1912,36 @@ public abstract class MemorySegmentTestBase {
 		target.get(result);
 
 		assertArrayEquals(bytes, result);
+	}
+
+	@Test(expected = ReadOnlyBufferException.class)
+	public void testHeapByteBufferGetReadOnly() {
+		testByteBufferGetReadOnly(false);
+	}
+
+	@Test(expected = ReadOnlyBufferException.class)
+	public void testOffHeapByteBufferGetReadOnly() {
+		testByteBufferGetReadOnly(true);
+	}
+
+	/**
+	 * Tries to write into a {@link ByteBuffer} instance which is read-only. This should fail with a
+	 * {@link ReadOnlyBufferException}.
+	 *
+	 * @param directBuffer
+	 * 		whether the {@link ByteBuffer} instance should be a direct byte buffer or not
+	 *
+	 * @throws ReadOnlyBufferException
+	 * 		expected exception due to writing to a read-only buffer
+	 */
+	private void testByteBufferGetReadOnly(boolean directBuffer) throws ReadOnlyBufferException {
+		MemorySegment seg = createSegment(pageSize);
+
+		ByteBuffer target = (directBuffer ?
+			ByteBuffer.allocateDirect(pageSize) :
+			ByteBuffer.allocate(pageSize)).asReadOnlyBuffer();
+
+		seg.get(0, target, pageSize);
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

`HybridMemorySegment#get(int, ByteBuffer, int)` allows writing into a read-only `ByteBuffer` but this operation should be forbidden.

## Brief change log

- throw a `ReadOnlyBufferException` if trying to write into a read-only `ByteBuffer`

## Verifying this change

This change added additional test methods to `MemorySegmentTestBase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)

