### PR TITLE
[FLINK-7517][network] let NettyBufferPool extend PooledByteBufAllocator

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyBufferPoolTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Tests for the {@link io.netty.buffer.PooledByteBufAllocator} wrapper.
+ * Tests for the {@link NettyBufferPool} wrapper.
  */
 public class NettyBufferPoolTest {
 


### PR DESCRIPTION
## What is the purpose of the change

`NettyBufferPool` wraps `PooledByteBufAllocator` but due to this, any allocated buffer's `alloc()` method is returning the wrapped `PooledByteBufAllocator` which allows heap buffers again. By extending the `PooledByteBufAllocator` instead, we prevent this loop hole and also fix Netty's invariant that a copy of a buffer should have the same allocator.

## Brief change log

- change `NettyBufferPool` from wrapping `PooledByteBufAllocator` into extending it

## Verifying this change

This change is already covered by existing tests, such as `NettyBufferPoolTest` since the behaviour does not change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
