### PR TITLE
[FLINK-7526] [TaskExecutor] Filter out duplicate JobManager gained leadership messages

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
@@ -299,4 +299,10 @@ public class TaskSlot {
 
 		return new SlotOffer(allocationId, index, resourceProfile);
 	}
+
+	@Override
+	public String toString() {
+		return "TaskSlot(index:" + index + ", state:" + state + ", resource profile: " + resourceProfile +
+			", allocationId: " + (allocationId != null ? allocationId.toString() : "none") + ", jobId: " + (jobId != null ? jobId.toString() : "none") + ')';
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -282,15 +282,15 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 	public int freeSlot(AllocationID allocationId, Throwable cause) throws SlotNotFoundException {
 		checkInit();
 
-		if (LOG.isDebugEnabled()) {
-			LOG.debug("Free slot {}.", allocationId, cause);
-		} else {
-			LOG.info("Free slot {}.", allocationId);
-		}
-
 		TaskSlot taskSlot = getTaskSlot(allocationId);
 
 		if (taskSlot != null) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Free slot {}.", taskSlot, cause);
+			} else {
+				LOG.info("Free slot {}.", taskSlot);
+			}
+
 			final JobID jobId = taskSlot.getJobId();
 
 			if (taskSlot.markFree()) {


### PR DESCRIPTION
## What is the purpose of the change

This commit filters out duplicate JobManager gained leadership messges coming from
the JobLeaderService. This avoid opening multiple connections to the JobManager
which consumes resources. Moreover, this commit properly closes all
JobManagerConnections in case of a shut down.

## Verifying this change

This change is already covered by existing tests, such as `TaskExecutorTest#testFilterOutDuplicateJobMasterRegistrations`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

