### PR TITLE
[FLINK-4500] [C* Connector] CassandraSinkBase implements CheckpointedFunction

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/AbstractCassandraTupleSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/AbstractCassandraTupleSink.java
@@ -32,9 +32,13 @@ public abstract class AbstractCassandraTupleSink<IN> extends CassandraSinkBase<I
 	private final String insertQuery;
 	private transient PreparedStatement ps;
 
-	public AbstractCassandraTupleSink(String insertQuery, ClusterBuilder builder) {
-		super(builder);
+	public AbstractCassandraTupleSink(String insertQuery, ClusterBuilder builder, boolean isFlushOnCheckpoint) {
+		super(builder, isFlushOnCheckpoint);
 		this.insertQuery = insertQuery;
+	}
+
+	public AbstractCassandraTupleSink(String insertQuery, ClusterBuilder builder) {
+		this(insertQuery, builder, true);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraPojoSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraPojoSink.java
@@ -46,9 +46,18 @@ public class CassandraPojoSink<IN> extends CassandraSinkBase<IN, ResultSet> {
 	 *
 	 * @param clazz Class instance
 	 */
-	public CassandraPojoSink(Class<IN> clazz, ClusterBuilder builder) {
-		super(builder);
+	public CassandraPojoSink(Class<IN> clazz, ClusterBuilder builder, boolean isFlushOnCheckpoint) {
+		super(builder, isFlushOnCheckpoint);
 		this.clazz = clazz;
+	}
+
+	/**
+	 * The main constructor for creating CassandraPojoSink.
+	 *
+	 * @param clazz Class instance
+	 */
+	public CassandraPojoSink(Class<IN> clazz, ClusterBuilder builder) {
+		this(clazz, builder, true);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraScalaProductSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraScalaProductSink.java
@@ -26,6 +26,11 @@ import scala.Product;
  * @param <IN> Type of the elements emitted by this sink, it must extend {@link Product}
  */
 public class CassandraScalaProductSink<IN extends Product> extends AbstractCassandraTupleSink<IN> {
+
+	public CassandraScalaProductSink(String insertQuery, ClusterBuilder builder, boolean isFlushOnCheckpoint) {
+		super(insertQuery, builder, isFlushOnCheckpoint);
+	}
+
 	public CassandraScalaProductSink(String insertQuery, ClusterBuilder builder) {
 		super(insertQuery, builder);
 	}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
@@ -233,6 +233,7 @@ public class CassandraSink<IN> {
 		protected String query;
 		protected CheckpointCommitter committer;
 		protected boolean isWriteAheadLogEnabled;
+		protected boolean isPendingOnFlush = true;
 
 		public CassandraSinkBuilder(DataStream<IN> input, TypeInformation<IN> typeInfo, TypeSerializer<IN> serializer) {
 			this.input = input;
@@ -320,6 +321,11 @@ public class CassandraSink<IN> {
 			return this;
 		}
 
+		public CassandraSinkBuilder<IN> disablePendingOnFlush() {
+			this.isPendingOnFlush = false;
+			return this;
+		}
+
 		/**
 		 * Finalizes the configuration of this sink.
 		 *
@@ -330,10 +336,10 @@ public class CassandraSink<IN> {
 			sanityCheck();
 			return isWriteAheadLogEnabled
 				? createWriteAheadSink()
-				: createSink();
+				: createSink(isPendingOnFlush);
 		}
 
-		protected abstract CassandraSink<IN> createSink() throws Exception;
+		protected abstract CassandraSink<IN> createSink(boolean isPendingOnFlush) throws Exception;
 
 		protected abstract CassandraSink<IN> createWriteAheadSink() throws Exception;
 
@@ -362,8 +368,8 @@ public class CassandraSink<IN> {
 		}
 
 		@Override
-		public CassandraSink<IN> createSink() throws Exception {
-			return new CassandraSink<>(input.addSink(new CassandraTupleSink<IN>(query, builder)).name("Cassandra Sink"));
+		public CassandraSink<IN> createSink(boolean isPendingOnFlush) throws Exception {
+			return new CassandraSink<>(input.addSink(new CassandraTupleSink<IN>(query, builder, isPendingOnFlush)).name("Cassandra Sink"));
 		}
 
 		@Override
@@ -392,8 +398,8 @@ public class CassandraSink<IN> {
 		}
 
 		@Override
-		public CassandraSink<IN> createSink() throws Exception {
-			return new CassandraSink<>(input.addSink(new CassandraPojoSink<>(typeInfo.getTypeClass(), builder)).name("Cassandra Sink"));
+		public CassandraSink<IN> createSink(boolean isPendingOnFlush) throws Exception {
+			return new CassandraSink<>(input.addSink(new CassandraPojoSink<>(typeInfo.getTypeClass(), builder, isPendingOnFlush)).name("Cassandra Sink"));
 		}
 
 		@Override
@@ -421,8 +427,8 @@ public class CassandraSink<IN> {
 		}
 
 		@Override
-		public CassandraSink<IN> createSink() throws Exception {
-			return new CassandraSink<>(input.addSink(new CassandraScalaProductSink<IN>(query, builder)).name("Cassandra Sink"));
+		public CassandraSink<IN> createSink(boolean isPendingOnFlush) throws Exception {
+			return new CassandraSink<>(input.addSink(new CassandraScalaProductSink<IN>(query, builder, isPendingOnFlush)).name("Cassandra Sink"));
 		}
 
 		@Override

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraTupleSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraTupleSink.java
@@ -25,6 +25,11 @@ import org.apache.flink.api.java.tuple.Tuple;
  * @param <IN> Type of the elements emitted by this sink, it must extend {@link Tuple}
  */
 public class CassandraTupleSink<IN extends Tuple> extends AbstractCassandraTupleSink<IN> {
+
+	public CassandraTupleSink(String insertQuery, ClusterBuilder builder, boolean isFlushOnCheckpoint) {
+		super(insertQuery, builder, isFlushOnCheckpoint);
+	}
+
 	public CassandraTupleSink(String insertQuery, ClusterBuilder builder) {
 		super(insertQuery, builder);
 	}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
@@ -1,0 +1,469 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.cassandra;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.operators.StreamSink;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Tests for the {@link CassandraSinkBase}.
+ */
+public class CassandraSinkBaseTest {
+
+	private static final Logger LOG = LoggerFactory.getLogger(CassandraSinkBaseTest.class);
+
+	private static final String DUMMY_QUERY_STMT = "CQL_Dummy_Stmt";
+
+	private static final String DUMMY_MESSAGE = "Dummy_msg";
+
+	private static final int MAX_THREAD_NUM = 3;
+
+	private static final int MAX_THREAD_POOL_SIZE = 2;
+
+	@BeforeClass
+	public static void doSetUp() throws Exception {
+
+	}
+
+	@BeforeClass
+	public static void doTearDown() throws Exception {
+
+	}
+
+	/**
+	 * Test ensures a NoHostAvailableException would be thrown if a contact point added does not exist.
+	 */
+	@Test(expected = NoHostAvailableException.class)
+	public void testCasHostNotFoundErrorHandling() throws Exception {
+		CassandraSinkBase base = new DummyCassandraSinkBase<>(new ClusterBuilder() {
+			@Override
+			protected Cluster buildCluster(Cluster.Builder builder) {
+				return builder
+					.addContactPoint("127.0.0.1")
+					.withoutJMXReporting()
+					.withoutMetrics().build();
+			}
+		});
+
+		base.open(new Configuration());
+		base.close();
+	}
+
+
+	///////////////////////
+	// Single Thread Test
+	///////////////////////
+
+	/**
+	 * Test ensures the message could be delivered successfully to sink.
+	 */
+	@Test
+	public void testSimpleSuccessfulPath() throws Exception {
+		ClusterBuilder builder = mock(ClusterBuilder.class);
+		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
+		casSinkFunc.setFlushOnCheckpoint(true);
+		casSinkFunc.open(new Configuration());
+
+		casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.IMMEDIATE_SUCCESS);
+
+		casSinkFunc.close();
+
+		//Final pending updates should be zero
+		Assert.assertEquals(0, casSinkFunc.getNumOfPendingRecords());
+	}
+
+	/**
+	 * Test ensures that an asyncError would be thrown on close() if previously message delivery failed.
+	 */
+	@Test
+	public void testAsyncErrorThrownOnClose() throws Exception {
+		ClusterBuilder builder = mock(ClusterBuilder.class);
+		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
+		casSinkFunc.setFlushOnCheckpoint(true);
+
+		casSinkFunc.open(new Configuration());
+
+		casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.IMMEDIATE_FAILURE);
+		try {
+
+			casSinkFunc.close();
+		} catch (IOException e) {
+			//expected async error from close()
+
+			Assert.assertTrue(e.getMessage().contains("Error while sending value"));
+
+			//Final pending updates should be zero
+			Assert.assertEquals(0, casSinkFunc.getNumOfPendingRecords());
+
+			//done
+			return;
+		}
+
+		Assert.fail();
+	}
+
+	/**
+	 * Test ensures that an asyncError would be thrown on invoke() if previously message delivery failed.
+	 */
+	//TODO: should unitfy error handling logic in CassandraSinkBase
+	//Exception would have been thrown from invoke(), but asyncError was not set null, hence it was rethrown in close()
+	@Ignore
+	@Test
+	public void testAsyncErrorThrownOnInvoke() throws Exception {
+		ClusterBuilder builder = mock(ClusterBuilder.class);
+		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
+		casSinkFunc.setFlushOnCheckpoint(true);
+
+		casSinkFunc.open(new Configuration());
+
+		casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.IMMEDIATE_FAILURE);
+		try {
+			casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.IMMEDIATE_SUCCESS);
+		} catch (IOException e) {
+			//expected async error thrown from invoke()
+
+			//Final pending updates should be zero
+			Assert.assertEquals(0, casSinkFunc.getNumOfPendingRecords());
+
+			casSinkFunc.close();
+
+			//done
+			return;
+		}
+
+		Assert.fail();
+	}
+
+	/**
+	 * Test ensures that an asyncError would be thrown when checkpoint performs if previously message delivery failed.
+	 */
+	@Test
+	public void testAsyncErrorThrownOnCheckpoint() throws Exception {
+		ClusterBuilder builder = mock(ClusterBuilder.class);
+		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
+		casSinkFunc.setFlushOnCheckpoint(true);
+
+		OneInputStreamOperatorTestHarness<String, Object> testHarness =
+			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(casSinkFunc));
+
+		testHarness.open();
+
+		casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.IMMEDIATE_FAILURE);
+
+		try {
+			testHarness.snapshot(123L, 123L);
+		} catch (Exception e) {
+			//expected async error from snapshotState()
+
+			Assert.assertTrue(e.getCause() instanceof IllegalStateException);
+			Assert.assertTrue(e.getCause().getMessage().contains("Failed to send data to Cassandra"));
+
+			//Final pending updates should be zero
+			Assert.assertEquals(0, casSinkFunc.getNumOfPendingRecords());
+
+			casSinkFunc.close();
+
+			//done
+			return;
+		}
+
+		Assert.fail();
+	}
+
+	///////////////////////
+	// Multi Thread Test
+	///////////////////////
+
+	/**
+	 * Test ensures that CassandraSinkBase would flush all in-flight message on close(), accompanied with concurrent
+	 * message delivery successfully via a thraedpool.
+	 */
+	@Test
+	public void testFlushOnPendingRecordsOnCloseWithSuccessfulMessage() throws Exception {
+		ClusterBuilder builder = mock(ClusterBuilder.class);
+
+		ExecutorService threadPool = Executors.newFixedThreadPool(MAX_THREAD_POOL_SIZE);
+		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
+		casSinkFunc.setFlushOnCheckpoint(true);
+
+		casSinkFunc.open(new Configuration());
+
+		for (int i = 0; i < MAX_THREAD_NUM; i++) {
+			threadPool.submit(() -> {
+				try {
+
+					casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.DELAYED_SUCCESS);
+				} catch (Exception e) {
+					LOG.error("Error while dispatching sending message to Cassandra sink => {} ", e);
+				}
+			});
+		}
+
+		//wait until the first message has been dispatched and invoked
+		Thread.sleep(500);
+
+		casSinkFunc.close();
+
+		threadPool.shutdown();
+		threadPool.awaitTermination(10, TimeUnit.SECONDS);
+
+		//Final pending updates should be zero
+		Assert.assertEquals(0, casSinkFunc.getNumOfPendingRecords());
+	}
+
+	/**
+	 * Test ensures that CassandraSinkBase would flush all in-flight message when checkpoint performs, accompanied
+	 * with concurrent message delivery successfully via a thraedpool.
+	 */
+	@Test
+	public void testFlushOnPendingRecordsOnCheckpoint() throws Exception {
+		ClusterBuilder builder = mock(ClusterBuilder.class);
+
+		ExecutorService threadPool = Executors.newFixedThreadPool(MAX_THREAD_POOL_SIZE);
+		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
+		casSinkFunc.setFlushOnCheckpoint(true);
+
+		OneInputStreamOperatorTestHarness<String, Object> testHarness =
+				new OneInputStreamOperatorTestHarness<>(new StreamSink<>(casSinkFunc));
+
+		testHarness.open();
+
+		casSinkFunc.open(new Configuration());
+
+		for (int i = 0; i < MAX_THREAD_NUM; i++) {
+			threadPool.submit(() -> {
+				try {
+
+					casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.DELAYED_SUCCESS);
+				} catch (Exception e) {
+					LOG.error("Error while dispatching sending message to Cassandra sink => {} ", e);
+				}
+			});
+			Thread.sleep(500);
+		}
+
+		//wait until the first message has been dispatched and invoked
+		Thread.sleep(500);
+
+		testHarness.snapshot(123L, 123L);
+
+		threadPool.shutdown();
+		threadPool.awaitTermination(10, TimeUnit.SECONDS);
+
+		Assert.assertEquals(0, casSinkFunc.getNumOfPendingRecords());
+
+		casSinkFunc.close();
+	}
+
+	/**
+	 * Test ensures that CassandraSinkBase would NOT flush all in-flight message when checkpoint performs.
+	 */
+	@Test
+	public void testDoNotFlushOnPendingRecordsOnCheckpoint() throws Exception {
+		ClusterBuilder builder = mock(ClusterBuilder.class);
+
+		ExecutorService threadPool = Executors.newFixedThreadPool(MAX_THREAD_POOL_SIZE);
+		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
+		casSinkFunc.setFlushOnCheckpoint(false);
+
+		OneInputStreamOperatorTestHarness<String, Object> testHarness =
+			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(casSinkFunc));
+
+		testHarness.open();
+
+		casSinkFunc.open(new Configuration());
+
+		for (int i = 0; i < MAX_THREAD_NUM; i++) {
+			threadPool.submit(() -> {
+				try {
+
+					casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.DELAYED_SUCCESS);
+				} catch (Exception e) {
+					LOG.error("Error while dispatching sending message to Cassandra sink => {} ", e);
+				}
+			});
+			Thread.sleep(500);
+		}
+
+		//wait until the first message has been dispatched and invoked
+		Thread.sleep(500);
+
+		testHarness.snapshot(123L, 123L);
+		//Final pending records # > 0
+		Assert.assertTrue(casSinkFunc.getNumOfPendingRecords() > 0);
+
+		threadPool.shutdown();
+		threadPool.awaitTermination(10, TimeUnit.SECONDS);
+
+		casSinkFunc.close();
+	}
+
+	/**
+	 * Test ensures that CassandraSinkBase would flush all in-flight message on close(), accompanied with concurrent
+	 * thread dispatched message failure via a thraedpool.
+	 */
+	@Test
+	public void testFlushOnPendingRecordsOnCloseWithFailedMessage() throws Exception {
+		ClusterBuilder builder = mock(ClusterBuilder.class);
+
+		ExecutorService threadPool = Executors.newFixedThreadPool(MAX_THREAD_POOL_SIZE);
+		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
+		casSinkFunc.setFlushOnCheckpoint(true);
+
+		casSinkFunc.open(new Configuration());
+		try {
+			for (int i = 0; i < MAX_THREAD_NUM; i++) {
+				threadPool.submit(() -> {
+					try {
+
+						casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.DELAYED_FAILURE);
+					} catch (Exception e) {
+						LOG.error("Error while dispatching sending message to Cassandra sink => {} ", e);
+					}
+
+				});
+			}
+			//wait until the first message has been dispatched and invoked
+			Thread.sleep(500);
+
+			casSinkFunc.close();
+		} catch (IOException e) {
+			//expected async error from close()
+		} finally {
+			//wait for all message dispatching threads to end
+			threadPool.shutdown();
+			threadPool.awaitTermination(10, TimeUnit.SECONDS);
+		}
+
+		//Final pending updates should be zero
+		Assert.assertEquals(0, casSinkFunc.getNumOfPendingRecords());
+	}
+
+	////////////////////////////////
+	// Utilities
+	///////////////////////////////
+
+	private enum PredeterminedResult {
+		IMMEDIATE_SUCCESS,
+		IMMEDIATE_FAILURE,
+		IMMEDIATE_CANCELLATION,
+		DELAYED_SUCCESS,
+		DELAYED_FAILURE
+	}
+
+	private static class DummyCassandraSinkBase<IN, V> extends CassandraSinkBase<IN, V> {
+
+		@SuppressWarnings("unchecked")
+		DummyCassandraSinkBase(ClusterBuilder clusterBuilder) {
+			super(clusterBuilder);
+		}
+
+		@Override
+		public ListenableFuture<V> send(IN value) {
+			return (ListenableFuture<V>) session.executeAsync(DUMMY_QUERY_STMT);
+		}
+
+	}
+
+	private static class MockCassandraSinkBase<IN> extends CassandraSinkBase<IN, ResultSet> {
+
+		@SuppressWarnings("unchecked")
+		MockCassandraSinkBase(ClusterBuilder clusterBuilder) {
+			super(clusterBuilder);
+
+			cluster = mock(Cluster.class);
+			session = mock(Session.class);
+			when(builder.getCluster()).thenReturn(cluster);
+			when(cluster.connect()).thenReturn(session);
+		}
+
+		public void invokeWithImmediateResult(IN value, PredeterminedResult result) throws Exception {
+			when(session.executeAsync(DUMMY_QUERY_STMT)).thenAnswer(new Answer<ResultSetFuture>() {
+					@Override
+					public ResultSetFuture answer(InvocationOnMock invocationOnMock) throws Throwable {
+						ResultSetFuture predeterminedFuture = null;
+
+						switch (result) {
+							case IMMEDIATE_FAILURE:
+								predeterminedFuture = ResultSetFutures.immediateFailedFuture(new IllegalStateException("Immediate Failure!"));
+								break;
+
+							case IMMEDIATE_CANCELLATION:
+								predeterminedFuture = ResultSetFutures.immediateCancelledFuture();
+								break;
+
+							case DELAYED_FAILURE:
+								predeterminedFuture = ResultSetFutures.delayedFailedFuture(new IllegalStateException("Delayed Failure!"));
+								break;
+
+							case DELAYED_SUCCESS:
+								predeterminedFuture = ResultSetFutures.delayedFuture(null);
+								break;
+							//If not specified, set result to Successful
+							default:
+							case IMMEDIATE_SUCCESS:
+								predeterminedFuture = ResultSetFutures.immediateFuture(null);
+								break;
+						}
+
+						log.info("Invoke with {} of {}", value, result.name());
+
+						return predeterminedFuture;
+					}
+				}
+			);
+			invoke(value);
+		}
+
+		@Override
+		public ListenableFuture<ResultSet> send(IN value) {
+			return (ListenableFuture<ResultSet>) session.executeAsync(DUMMY_QUERY_STMT);
+		}
+
+	}
+
+	public static void main(String[] args) throws Exception {
+
+	}
+
+}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
@@ -18,6 +18,8 @@
 package org.apache.flink.streaming.connectors.cassandra;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.core.testutils.MultiShotLatch;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 
@@ -29,7 +31,6 @@ import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -38,11 +39,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
@@ -55,20 +56,6 @@ public class CassandraSinkBaseTest {
 	private static final String DUMMY_QUERY_STMT = "CQL_Dummy_Stmt";
 
 	private static final String DUMMY_MESSAGE = "Dummy_msg";
-
-	private static final int MAX_THREAD_NUM = 3;
-
-	private static final int MAX_THREAD_POOL_SIZE = 2;
-
-	@BeforeClass
-	public static void doSetUp() throws Exception {
-
-	}
-
-	@BeforeClass
-	public static void doTearDown() throws Exception {
-
-	}
 
 	/**
 	 * Test ensures a NoHostAvailableException would be thrown if a contact point added does not exist.
@@ -86,13 +73,7 @@ public class CassandraSinkBaseTest {
 		});
 
 		base.open(new Configuration());
-		base.close();
 	}
-
-
-	///////////////////////
-	// Single Thread Test
-	///////////////////////
 
 	/**
 	 * Test ensures the message could be delivered successfully to sink.
@@ -100,15 +81,14 @@ public class CassandraSinkBaseTest {
 	@Test
 	public void testSimpleSuccessfulPath() throws Exception {
 		ClusterBuilder builder = mock(ClusterBuilder.class);
-		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
-		casSinkFunc.setFlushOnCheckpoint(true);
+		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase(builder);
 		casSinkFunc.open(new Configuration());
 
 		casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.IMMEDIATE_SUCCESS);
+		verify(casSinkFunc.getMockSession(), times(1)).executeAsync(any(String.class));
 
 		casSinkFunc.close();
 
-		//Final pending updates should be zero
 		Assert.assertEquals(0, casSinkFunc.getNumOfPendingRecords());
 	}
 
@@ -118,60 +98,49 @@ public class CassandraSinkBaseTest {
 	@Test
 	public void testAsyncErrorThrownOnClose() throws Exception {
 		ClusterBuilder builder = mock(ClusterBuilder.class);
-		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
-		casSinkFunc.setFlushOnCheckpoint(true);
+		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase(builder);
 
 		casSinkFunc.open(new Configuration());
 
 		casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.IMMEDIATE_FAILURE);
 		try {
-
 			casSinkFunc.close();
+
+			Assert.fail();
 		} catch (IOException e) {
 			//expected async error from close()
 
 			Assert.assertTrue(e.getMessage().contains("Error while sending value"));
-
-			//Final pending updates should be zero
 			Assert.assertEquals(0, casSinkFunc.getNumOfPendingRecords());
-
-			//done
-			return;
+			verify(casSinkFunc.getMockSession(), times(1)).executeAsync(any(String.class));
 		}
 
-		Assert.fail();
 	}
 
 	/**
 	 * Test ensures that an asyncError would be thrown on invoke() if previously message delivery failed.
 	 */
-	//TODO: should unitfy error handling logic in CassandraSinkBase
 	//Exception would have been thrown from invoke(), but asyncError was not set null, hence it was rethrown in close()
 	@Ignore
 	@Test
 	public void testAsyncErrorThrownOnInvoke() throws Exception {
 		ClusterBuilder builder = mock(ClusterBuilder.class);
-		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
-		casSinkFunc.setFlushOnCheckpoint(true);
+		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase(builder);
 
 		casSinkFunc.open(new Configuration());
 
 		casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.IMMEDIATE_FAILURE);
 		try {
 			casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.IMMEDIATE_SUCCESS);
+
+			Assert.fail();
 		} catch (IOException e) {
 			//expected async error thrown from invoke()
 
-			//Final pending updates should be zero
 			Assert.assertEquals(0, casSinkFunc.getNumOfPendingRecords());
 
 			casSinkFunc.close();
-
-			//done
-			return;
 		}
-
-		Assert.fail();
 	}
 
 	/**
@@ -180,8 +149,7 @@ public class CassandraSinkBaseTest {
 	@Test
 	public void testAsyncErrorThrownOnCheckpoint() throws Exception {
 		ClusterBuilder builder = mock(ClusterBuilder.class);
-		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
-		casSinkFunc.setFlushOnCheckpoint(true);
+		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase(builder);
 
 		OneInputStreamOperatorTestHarness<String, Object> testHarness =
 			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(casSinkFunc));
@@ -192,119 +160,113 @@ public class CassandraSinkBaseTest {
 
 		try {
 			testHarness.snapshot(123L, 123L);
+
+			Assert.fail();
 		} catch (Exception e) {
 			//expected async error from snapshotState()
 
 			Assert.assertTrue(e.getCause() instanceof IllegalStateException);
 			Assert.assertTrue(e.getCause().getMessage().contains("Failed to send data to Cassandra"));
-
-			//Final pending updates should be zero
 			Assert.assertEquals(0, casSinkFunc.getNumOfPendingRecords());
+			verify(casSinkFunc.getMockSession(), times(1)).executeAsync(any(String.class));
 
 			casSinkFunc.close();
-
-			//done
-			return;
 		}
-
-		Assert.fail();
 	}
 
-	///////////////////////
-	// Multi Thread Test
-	///////////////////////
-
 	/**
-	 * Test ensures that CassandraSinkBase would flush all in-flight message on close(), accompanied with concurrent
-	 * message delivery successfully via a thraedpool.
+	 * Test ensures that CassandraSinkBase would flush all in-flight message on close().
+	 * Add a 5000 ms timeout in case logic breaks.
 	 */
-	@Test
+	@Test(timeout = 5000)
 	public void testFlushOnPendingRecordsOnCloseWithSuccessfulMessage() throws Exception {
 		ClusterBuilder builder = mock(ClusterBuilder.class);
 
-		ExecutorService threadPool = Executors.newFixedThreadPool(MAX_THREAD_POOL_SIZE);
-		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
-		casSinkFunc.setFlushOnCheckpoint(true);
+		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase(builder, true, true);
 
-		casSinkFunc.open(new Configuration());
+		//Launch another thread to invoke(msg)
+		CheckedThread msgThread = new CheckedThread() {
+			@Override
+			public void go() throws Exception {
+				casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.IMMEDIATE_SUCCESS);
+			}
+		};
+		msgThread.start();
 
-		for (int i = 0; i < MAX_THREAD_NUM; i++) {
-			threadPool.submit(() -> {
-				try {
-
-					casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.DELAYED_SUCCESS);
-				} catch (Exception e) {
-					LOG.error("Error while dispatching sending message to Cassandra sink => {} ", e);
-				}
-			});
+		// the message should eventually get blocked until flushing was triggered
+		while (msgThread.getState() != Thread.State.WAITING) {
+			Thread.sleep(10);
 		}
 
-		//wait until the first message has been dispatched and invoked
-		Thread.sleep(500);
+		Assert.assertEquals(1, casSinkFunc.getNumOfPendingRecords());
+		casSinkFunc.simulateFlush();
 
-		casSinkFunc.close();
-
-		threadPool.shutdown();
-		threadPool.awaitTermination(10, TimeUnit.SECONDS);
-
-		//Final pending updates should be zero
+		// all in-flight message were flushed
 		Assert.assertEquals(0, casSinkFunc.getNumOfPendingRecords());
+		verify(casSinkFunc.getMockSession(), times(1)).executeAsync(any(String.class));
+		casSinkFunc.close();
 	}
 
 	/**
-	 * Test ensures that CassandraSinkBase would flush all in-flight message when checkpoint performs, accompanied
-	 * with concurrent message delivery successfully via a thraedpool.
+	 * Test ensures that CassandraSinkBase would flush all in-flight message when checkpoint perform
+	 * Add a 5000 ms timeout in case logic breaks.
 	 */
-	@Test
+	@Test(timeout = 5000)
 	public void testFlushOnPendingRecordsOnCheckpoint() throws Exception {
 		ClusterBuilder builder = mock(ClusterBuilder.class);
-
-		ExecutorService threadPool = Executors.newFixedThreadPool(MAX_THREAD_POOL_SIZE);
-		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
-		casSinkFunc.setFlushOnCheckpoint(true);
-
+		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase(builder, true, true);
 		OneInputStreamOperatorTestHarness<String, Object> testHarness =
-				new OneInputStreamOperatorTestHarness<>(new StreamSink<>(casSinkFunc));
+			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(casSinkFunc));
 
 		testHarness.open();
-
 		casSinkFunc.open(new Configuration());
 
-		for (int i = 0; i < MAX_THREAD_NUM; i++) {
-			threadPool.submit(() -> {
-				try {
+		//Launch another thread to invoke(msg)
+		CheckedThread msgThread = new CheckedThread() {
+			@Override
+			public void go() throws Exception {
+				casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.IMMEDIATE_SUCCESS);
+			}
+		};
+		msgThread.start();
 
-					casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.DELAYED_SUCCESS);
-				} catch (Exception e) {
-					LOG.error("Error while dispatching sending message to Cassandra sink => {} ", e);
-				}
-			});
-			Thread.sleep(500);
+		// the 1st message should eventually get blocked until flushing was triggered
+		while (msgThread.getState() != Thread.State.WAITING) {
+			Thread.sleep(10);
 		}
 
-		//wait until the first message has been dispatched and invoked
-		Thread.sleep(500);
+		Assert.assertEquals(1, casSinkFunc.getNumOfPendingRecords());
+		verify(casSinkFunc.getMockSession(), times(1)).executeAsync(any(String.class));
 
-		testHarness.snapshot(123L, 123L);
+		//Launch another thread to invoke(msg)
+		CheckedThread snapshotThread = new CheckedThread() {
+			@Override
+			public void go() throws Exception {
+				testHarness.snapshot(123L, 123L);
+			}
+		};
+		snapshotThread.start();
 
-		threadPool.shutdown();
-		threadPool.awaitTermination(10, TimeUnit.SECONDS);
+		//snapshot thread will eventually get blocked since there are still pending records
+		while (msgThread.getState() != Thread.State.WAITING) {
+			Thread.sleep(10);
+		}
+
+		// until all pending records were flushed to sink
+		casSinkFunc.simulateFlush();
 
 		Assert.assertEquals(0, casSinkFunc.getNumOfPendingRecords());
-
-		casSinkFunc.close();
 	}
 
 	/**
 	 * Test ensures that CassandraSinkBase would NOT flush all in-flight message when checkpoint performs.
+	 * Add a 5000 ms timeout in case logic breaks.
 	 */
-	@Test
+	@Test(timeout = 5000)
 	public void testDoNotFlushOnPendingRecordsOnCheckpoint() throws Exception {
 		ClusterBuilder builder = mock(ClusterBuilder.class);
 
-		ExecutorService threadPool = Executors.newFixedThreadPool(MAX_THREAD_POOL_SIZE);
-		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
-		casSinkFunc.setFlushOnCheckpoint(false);
+		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase(builder, false, true);
 
 		OneInputStreamOperatorTestHarness<String, Object> testHarness =
 			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(casSinkFunc));
@@ -313,70 +275,28 @@ public class CassandraSinkBaseTest {
 
 		casSinkFunc.open(new Configuration());
 
-		for (int i = 0; i < MAX_THREAD_NUM; i++) {
-			threadPool.submit(() -> {
-				try {
-
-					casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.DELAYED_SUCCESS);
-				} catch (Exception e) {
-					LOG.error("Error while dispatching sending message to Cassandra sink => {} ", e);
-				}
-			});
-			Thread.sleep(500);
-		}
-
-		//wait until the first message has been dispatched and invoked
-		Thread.sleep(500);
-
-		testHarness.snapshot(123L, 123L);
-		//Final pending records # > 0
-		Assert.assertTrue(casSinkFunc.getNumOfPendingRecords() > 0);
-
-		threadPool.shutdown();
-		threadPool.awaitTermination(10, TimeUnit.SECONDS);
-
-		casSinkFunc.close();
-	}
-
-	/**
-	 * Test ensures that CassandraSinkBase would flush all in-flight message on close(), accompanied with concurrent
-	 * thread dispatched message failure via a thraedpool.
-	 */
-	@Test
-	public void testFlushOnPendingRecordsOnCloseWithFailedMessage() throws Exception {
-		ClusterBuilder builder = mock(ClusterBuilder.class);
-
-		ExecutorService threadPool = Executors.newFixedThreadPool(MAX_THREAD_POOL_SIZE);
-		MockCassandraSinkBase casSinkFunc = new MockCassandraSinkBase<>(builder);
-		casSinkFunc.setFlushOnCheckpoint(true);
-
-		casSinkFunc.open(new Configuration());
-		try {
-			for (int i = 0; i < MAX_THREAD_NUM; i++) {
-				threadPool.submit(() -> {
-					try {
-
-						casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.DELAYED_FAILURE);
-					} catch (Exception e) {
-						LOG.error("Error while dispatching sending message to Cassandra sink => {} ", e);
-					}
-
-				});
+		//Launch another thread to invoke(msg)
+		CheckedThread msgThread = new CheckedThread() {
+			@Override
+			public void go() throws Exception {
+				casSinkFunc.invokeWithImmediateResult(DUMMY_MESSAGE, PredeterminedResult.IMMEDIATE_SUCCESS);
 			}
-			//wait until the first message has been dispatched and invoked
-			Thread.sleep(500);
+		};
+		msgThread.start();
 
-			casSinkFunc.close();
-		} catch (IOException e) {
-			//expected async error from close()
-		} finally {
-			//wait for all message dispatching threads to end
-			threadPool.shutdown();
-			threadPool.awaitTermination(10, TimeUnit.SECONDS);
+		// the 1st message should eventually get blocked until flushing was triggered
+		while (msgThread.getState() != Thread.State.WAITING) {
+			Thread.sleep(10);
 		}
 
-		//Final pending updates should be zero
-		Assert.assertEquals(0, casSinkFunc.getNumOfPendingRecords());
+		Assert.assertEquals(1, casSinkFunc.getNumOfPendingRecords());
+
+		verify(casSinkFunc.getMockSession(), times(1)).executeAsync(any(String.class));
+
+		// This operation will not block thread
+		testHarness.snapshot(123L, 123L);
+
+		Assert.assertEquals(1, casSinkFunc.getNumOfPendingRecords());
 	}
 
 	////////////////////////////////
@@ -386,16 +306,13 @@ public class CassandraSinkBaseTest {
 	private enum PredeterminedResult {
 		IMMEDIATE_SUCCESS,
 		IMMEDIATE_FAILURE,
-		IMMEDIATE_CANCELLATION,
-		DELAYED_SUCCESS,
-		DELAYED_FAILURE
 	}
 
 	private static class DummyCassandraSinkBase<IN, V> extends CassandraSinkBase<IN, V> {
 
 		@SuppressWarnings("unchecked")
 		DummyCassandraSinkBase(ClusterBuilder clusterBuilder) {
-			super(clusterBuilder);
+			super(clusterBuilder, true);
 		}
 
 		@Override
@@ -405,19 +322,73 @@ public class CassandraSinkBaseTest {
 
 	}
 
-	private static class MockCassandraSinkBase<IN> extends CassandraSinkBase<IN, ResultSet> {
+	private static class MockCassandraSinkBase extends CassandraSinkBase<String, ResultSet> {
 
-		@SuppressWarnings("unchecked")
-		MockCassandraSinkBase(ClusterBuilder clusterBuilder) {
-			super(clusterBuilder);
+		private transient MultiShotLatch flushLatch;
+
+		/**
+		 * A message callback to wait indeifinitely on flush latch until a manual flush is triggered.
+		 * Only for testing purposes.
+		 */
+		private class FlushLatchedMessageCallback extends DefaultMessageCallback<ResultSet> {
+			@Override
+			public void onSuccess(ResultSet ignored) {
+				try {
+					flushLatch.await();
+				} catch (InterruptedException e) {
+					log.error("latch await() failed: ", e);
+				}
+
+				super.onSuccess(ignored);
+			}
+
+			@Override
+			public void onFailure(Throwable t) {
+				try {
+					flushLatch.await();
+				} catch (InterruptedException e) {
+					log.error("latch await() failed: ", e);
+				}
+
+				super.onFailure(t);
+			}
+		}
+
+		MockCassandraSinkBase(ClusterBuilder clusterBuilder, boolean flushOnCheckpoint, boolean isWaitOnMsgCallback) {
+			super(clusterBuilder, flushOnCheckpoint);
 
 			cluster = mock(Cluster.class);
 			session = mock(Session.class);
 			when(builder.getCluster()).thenReturn(cluster);
 			when(cluster.connect()).thenReturn(session);
+
+			this.flushLatch = new MultiShotLatch();
+
+			//Overwrite the default message callback
+			if (isWaitOnMsgCallback) {
+				this.callback = new FlushLatchedMessageCallback();
+			}
 		}
 
-		public void invokeWithImmediateResult(IN value, PredeterminedResult result) throws Exception {
+		MockCassandraSinkBase(ClusterBuilder clusterBuilder, boolean flushOnCheckpoint) {
+			this(clusterBuilder, flushOnCheckpoint, false);
+		}
+
+		MockCassandraSinkBase(ClusterBuilder clusterBuilder) {
+			this(clusterBuilder, true);
+		}
+
+		/**
+		 * Intends to trigger all awaited message threads.
+		 *
+		 * @throws InterruptedException
+		 */
+		protected void simulateFlush() throws InterruptedException {
+			flushLatch.trigger();
+			this.flushPending();
+		}
+
+		public void invokeWithImmediateResult(String value, PredeterminedResult result) throws Exception {
 			when(session.executeAsync(DUMMY_QUERY_STMT)).thenAnswer(new Answer<ResultSetFuture>() {
 					@Override
 					public ResultSetFuture answer(InvocationOnMock invocationOnMock) throws Throwable {
@@ -426,18 +397,6 @@ public class CassandraSinkBaseTest {
 						switch (result) {
 							case IMMEDIATE_FAILURE:
 								predeterminedFuture = ResultSetFutures.immediateFailedFuture(new IllegalStateException("Immediate Failure!"));
-								break;
-
-							case IMMEDIATE_CANCELLATION:
-								predeterminedFuture = ResultSetFutures.immediateCancelledFuture();
-								break;
-
-							case DELAYED_FAILURE:
-								predeterminedFuture = ResultSetFutures.delayedFailedFuture(new IllegalStateException("Delayed Failure!"));
-								break;
-
-							case DELAYED_SUCCESS:
-								predeterminedFuture = ResultSetFutures.delayedFuture(null);
 								break;
 							//If not specified, set result to Successful
 							default:
@@ -452,18 +411,19 @@ public class CassandraSinkBaseTest {
 					}
 				}
 			);
+
 			invoke(value);
+
+		}
+
+		public Session getMockSession() {
+			return this.session;
 		}
 
 		@Override
-		public ListenableFuture<ResultSet> send(IN value) {
+		public ListenableFuture<ResultSet> send(String value) {
 			return (ListenableFuture<ResultSet>) session.executeAsync(DUMMY_QUERY_STMT);
 		}
 
 	}
-
-	public static void main(String[] args) throws Exception {
-
-	}
-
 }

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/ResultSetFutures.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/ResultSetFutures.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -48,19 +47,6 @@ public class ResultSetFutures {
 	public static ResultSetFuture immediateFailedFuture(Throwable throwable) {
 		checkNotNull(throwable);
 		return new ImmediateFailedResultSetFuture(throwable);
-	}
-
-	public static ResultSetFuture immediateCancelledFuture() {
-		return new ImmediateCancelledResultSetFuture();
-	}
-
-	public static ResultSetFuture delayedFuture(@Nullable ResultSet value) {
-		return new DelayedSuccessfulResultSetFuture(value);
-	}
-
-	public static ResultSetFuture delayedFailedFuture(Throwable throwable) {
-		checkNotNull(throwable);
-		return new DelayedFailedResultSetFuture(throwable);
 	}
 
 	/**
@@ -147,64 +133,6 @@ public class ResultSetFutures {
 
 		@Override
 		public ResultSet get() throws ExecutionException {
-			throw new ExecutionException(thrown);
-		}
-	}
-
-	private static class ImmediateCancelledResultSetFuture extends ImmediateResultSetFuture {
-
-		protected final CancellationException thrown;
-
-		ImmediateCancelledResultSetFuture() {
-			this.thrown = new CancellationException("Immediate cancelled future.");
-		}
-
-		@Override
-		public boolean isCancelled() {
-			return true;
-		}
-
-		@Override
-		public ResultSet get() {
-			throw thrown;
-		}
-	}
-
-	/**
-	 * A type of {@link ResultSetFuture} that returns result with a delay. There are 2 types supported
-	 * 1. Future was successful.
-	 * 2. Future has failed with an exception.
-	 */
-	private static class DelayedSuccessfulResultSetFuture extends ImmediateSuccessfulResultSetFuture {
-
-		DelayedSuccessfulResultSetFuture(@Nullable ResultSet value) {
-			super(value);
-		}
-
-		public ResultSet get() {
-			try {
-				Thread.sleep(3000);
-			} catch (InterruptedException e) {
-				throw new RuntimeException("Interrupted, unfinished " + this.getClass().getName() + " task");
-			} finally {
-				return value;
-			}
-		}
-	}
-
-	private static class DelayedFailedResultSetFuture<V> extends ImmediateFailedResultSetFuture<V> {
-
-		DelayedFailedResultSetFuture(Throwable thrown) {
-			super(thrown);
-		}
-
-		public ResultSet get() throws ExecutionException {
-			try {
-				Thread.sleep(3000);
-			} catch (InterruptedException e) {
-				throw new RuntimeException("Interrupted, unfinished " + this.getClass().getName() + " task");
-			}
-
 			throw new ExecutionException(thrown);
 		}
 	}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/ResultSetFutures.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/ResultSetFutures.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.cassandra;
+
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.ResultSetFuture;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Test utilities for {@link com.datastax.driver.core.ResultSetFuture} from Datastax Java driver.
+ */
+public class ResultSetFutures {
+
+	private ResultSetFutures() {
+	}
+
+	public static ResultSetFuture immediateFuture(@Nullable ResultSet value) {
+		return new ImmediateSuccessfulResultSetFuture(value);
+	}
+
+	public static ResultSetFuture immediateFailedFuture(Throwable throwable) {
+		checkNotNull(throwable);
+		return new ImmediateFailedResultSetFuture(throwable);
+	}
+
+	public static ResultSetFuture immediateCancelledFuture() {
+		return new ImmediateCancelledResultSetFuture();
+	}
+
+	public static ResultSetFuture delayedFuture(@Nullable ResultSet value) {
+		return new DelayedSuccessfulResultSetFuture(value);
+	}
+
+	public static ResultSetFuture delayedFailedFuture(Throwable throwable) {
+		checkNotNull(throwable);
+		return new DelayedFailedResultSetFuture(throwable);
+	}
+
+	/**
+	 * A type of {@link ResultSetFuture} that returns result immediately. Currently there are three types
+	 * 1. Future was successful
+	 * 2. Future has failed with an exception
+	 * 3. Future was cancelled.
+	 */
+	private abstract static class ImmediateResultSetFuture implements ResultSetFuture {
+
+		@Override
+		public ResultSet getUninterruptibly() {
+			return null;
+		}
+
+		@Override
+		public ResultSet getUninterruptibly(long timeout, TimeUnit unit) throws TimeoutException {
+			return null;
+		}
+
+		private static final Logger log = LoggerFactory.getLogger(ImmediateResultSetFuture.class);
+
+		@Override
+		public void addListener(Runnable listener, Executor executor) {
+			checkNotNull(listener, "Runnable was null.");
+			checkNotNull(executor, "Executor was null.");
+			try {
+				executor.execute(listener);
+			} catch (RuntimeException e) {
+				// ResultSetFuture's contract is that it will not throw unchecked
+				// exceptions, so log the bad runnable and/or executor and swallow it.
+				log.error("RuntimeException while executing runnable "
+					+ listener + " with executor " + executor, e);
+			}
+		}
+
+		@Override
+		public boolean cancel(boolean mayInterruptIfRunning) {
+			return false;
+		}
+
+		@Override
+		public abstract ResultSet get() throws ExecutionException;
+
+		@Override
+		public ResultSet get(long timeout, TimeUnit unit) throws ExecutionException {
+			checkNotNull(unit);
+			return get();
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return false;
+		}
+
+		@Override
+		public boolean isDone() {
+			return true;
+		}
+	}
+
+	private static class ImmediateSuccessfulResultSetFuture extends ImmediateResultSetFuture {
+
+		@Nullable
+		protected final ResultSet value;
+
+		ImmediateSuccessfulResultSetFuture(@Nullable ResultSet value) {
+			this.value = value;
+		}
+
+		@Override
+		public ResultSet get() {
+			return value;
+		}
+	}
+
+	private static class ImmediateFailedResultSetFuture<V> extends ImmediateResultSetFuture {
+
+		protected final Throwable thrown;
+
+		ImmediateFailedResultSetFuture(Throwable thrown) {
+			this.thrown = thrown;
+		}
+
+		@Override
+		public ResultSet get() throws ExecutionException {
+			throw new ExecutionException(thrown);
+		}
+	}
+
+	private static class ImmediateCancelledResultSetFuture extends ImmediateResultSetFuture {
+
+		protected final CancellationException thrown;
+
+		ImmediateCancelledResultSetFuture() {
+			this.thrown = new CancellationException("Immediate cancelled future.");
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return true;
+		}
+
+		@Override
+		public ResultSet get() {
+			throw thrown;
+		}
+	}
+
+	/**
+	 * A type of {@link ResultSetFuture} that returns result with a delay. There are 2 types supported
+	 * 1. Future was successful.
+	 * 2. Future has failed with an exception.
+	 */
+	private static class DelayedSuccessfulResultSetFuture extends ImmediateSuccessfulResultSetFuture {
+
+		DelayedSuccessfulResultSetFuture(@Nullable ResultSet value) {
+			super(value);
+		}
+
+		public ResultSet get() {
+			try {
+				Thread.sleep(3000);
+			} catch (InterruptedException e) {
+				throw new RuntimeException("Interrupted, unfinished " + this.getClass().getName() + " task");
+			} finally {
+				return value;
+			}
+		}
+	}
+
+	private static class DelayedFailedResultSetFuture<V> extends ImmediateFailedResultSetFuture<V> {
+
+		DelayedFailedResultSetFuture(Throwable thrown) {
+			super(thrown);
+		}
+
+		public ResultSet get() throws ExecutionException {
+			try {
+				Thread.sleep(3000);
+			} catch (InterruptedException e) {
+				throw new RuntimeException("Interrupted, unfinished " + this.getClass().getName() + " task");
+			}
+
+			throw new ExecutionException(thrown);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-cassandra/src/test/resources/log4j-test.properties
+++ b/flink-connectors/flink-connector-cassandra/src/test/resources/log4j-test.properties
@@ -16,12 +16,15 @@
 # limitations under the License.
 ################################################################################
 
-log4j.rootLogger=OFF, testlogger
+log4j.rootLogger=INFO, testlogger
 
 log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
 log4j.appender.testlogger.target= System.err
 log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
 log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+
+# enable all log for some test classes
+log4j.logger.org.apache.flink.streaming.connectors.cassandra.CassandraSinkBaseTest$MockCassandraSinkBase=ALL
 
 # suppress the irrelevant (wrong) warnings from the netty channel handler
 log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, testlogger

--- a/tools/maven/suppressions.xml
+++ b/tools/maven/suppressions.xml
@@ -30,7 +30,7 @@ under the License.
 
 		<!-- Cassandra connectors have to use guava directly -->
 		<suppress
-			files="AbstractCassandraTupleSink.java|CassandraInputFormat.java|CassandraOutputFormat.java|CassandraSinkBase.java|CassandraPojoSink.java|CassandraTupleWriteAheadSink.java"
+			files="AbstractCassandraTupleSink.java|CassandraInputFormat.java|CassandraOutputFormat.java|CassandraSinkBase.java|CassandraPojoSink.java|CassandraTupleWriteAheadSink.java|CassandraSinkBaseTest.java"
 			checks="IllegalImport"/>
 		<!-- Kinesis producer has to use guava directly -->
 		<suppress


### PR DESCRIPTION
## What is the purpose of the change
Have CassandraSinkBase to implement CheckpointedFunction so that all in-flight mutation message could be sent to C* sink before a checkpoint performs. As a result, the checkpoint would be complete. 

## Brief change log

* Implement CheckpointedFunction to (optionally) wait on all pending records being flushed to the C* sink before checkpoint performs (or closing connection).
* Add debugging message in CassandraSinkBase.
* Add unit tests for simple / multi-threaded message dispatching for successful / failed scenarios
* Add unit tests for failure handling logics on errors thrown at different stages.
* Add unit tests for flushing pending records when checkpoint performs.
* Provide a Immediate / Delayed type of ResultSetFuture for testing purposes.
* Add CassandraBaseTest in suppression list to use guava imports
* In log4j-test settings, change root log level to INFO and enable ALL level against some test classes.


## Verifying this change

This change is already covered by existing tests, such as *CassandraBaseTest*.

This change added tests and can be verified as follows:

* Add unit tests for simple / multi-threaded message dispatching for successful / failed scenarios
* Add unit tests for failure handling logics on errors thrown at different stages.
* Add unit tests for flushing pending records when checkpoint performs.
* Provide a Immediate / Delayed type of ResultSetFuture for testing purposes.
* Add CassandraBaseTest in suppression list to use guava imports

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no** (maybe) )
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

