### PR TITLE
[FLINK-7539] Made AvroOutputFormat default codec configurable.

### DIFF
--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -635,6 +635,10 @@ You have to configure `jobmanager.archive.fs.dir` in order to archive terminated
 
 - `historyserver.web.ssl.enabled`: Enable HTTPs access to the HistoryServer web frontend. This is applicable only when the global SSL flag security.ssl.enabled is set to true (DEFAULT: `false`).
 
+### Connectors
+
+- `connector.avro.output.codec`: Default codec to use when writing Avro datasets. One of `NULL`, `SNAPPY`, `BZIP2`, `DEFLATE`, `XZ` (DEFAULT: unset).
+
 ## Background
 
 

--- a/flink-connectors/flink-avro/src/main/java/org/apache/flink/api/java/io/AvroOptions.java
+++ b/flink-connectors/flink-avro/src/main/java/org/apache/flink/api/java/io/AvroOptions.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/**
+ * The set of configuration options relating to Avro connector.
+ */
+@PublicEvolving
+public class AvroOptions {
+	/**
+	 * Default codec to use when writing Avro datasets.
+	 */
+	public static final ConfigOption<String> OUTPUT_CODEC =
+		key("connector.avro.output.codec")
+			.noDefaultValue();
+
+	/** Not intended to be instantiated. */
+	private AvroOptions() {
+	}
+}


### PR DESCRIPTION
Implement site-wide codec defaults.

## Brief change log

- Added connector.avro.output.codec option

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs and JavaDocs