### PR TITLE
[FLINK-7227][Table API & SQL]Fix the the TableSource predicate push…

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/RexProgramExtractor.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/RexProgramExtractor.scala
@@ -20,10 +20,11 @@ package org.apache.flink.table.plan.util
 
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.rex._
+import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.sql.{SqlFunction, SqlPostfixOperator}
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.calcite.FlinkTypeFactory
-import org.apache.flink.table.expressions.{Expression, Literal, ResolvedFieldReference}
+import org.apache.flink.table.expressions.{And, Expression, Literal, Or, ResolvedFieldReference}
 import org.apache.flink.table.validate.FunctionCatalog
 import org.apache.flink.util.Preconditions
 
@@ -170,6 +171,10 @@ class RexNodeToExpressionConverter(
       None
     } else {
         call.getOperator match {
+          case SqlStdOperatorTable.OR =>
+            Option(operands.reduceLeft(Or))
+          case SqlStdOperatorTable.AND =>
+            Option(operands.reduceLeft(And))
           case function: SqlFunction =>
             lookupFunction(replace(function.getName), operands)
           case postfix: SqlPostfixOperator =>

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TestFilterableTableSource.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TestFilterableTableSource.scala
@@ -89,6 +89,9 @@ class TestFilterableTableSource(
               iterator.remove()
             case (_, _) =>
           }
+        case expr: BinaryExpression =>
+          newSource.filterPredicates += expr
+          iterator.remove()
       }
     }
 


### PR DESCRIPTION
… down issue for OR and AND expression with more than 2 predicates

## What is the purpose of the change
Currently, we can't push more than 2 predicates for OR expression in TableSource. In this PR, we want to solve this issue.


## Brief change log

  - Made changes in RexNodeToExpressionConverter  

For predicate push down, first we are converting expression to conjunctive normal form then passing to RexNodeToExpressionConverter. So issue was only generated for OR expression, but we handle this issue for non-conjunctive normal form to solve for AND expression.

## Verifying this change

  - Add tests to verify that RexNodeToExpressionConverter is handling conjunctive and non-conjunctive normal forms successfully.
      - RexProgramExtractorTest#testExtractORForPredicatePushDown
      - RexProgramExtractorTest#testExtractNonCnfANDForPredicatePushDown
      - RexProgramExtractorTest#testExtractCnfANDForPredicatePushDown

  - To verify predicate push down for OR and AND expression following test is added
      - AddTableSourceTest#testBatchFilterableFullyPushedDownORANDExpressions
      
      this test depends on TestFilterableTableSource#applyPredicate function, so we made changes in applyPredicate function to verify this test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:**no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
