### PR TITLE
[FLINK-7543] [REST] Simplify handler access to path/query parameters

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/HandlerRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/HandlerRequest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
 import org.apache.flink.runtime.rest.messages.RequestBody;
 import org.apache.flink.util.Preconditions;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,28 +84,36 @@ public class HandlerRequest<R extends RequestBody, M extends MessageParameters> 
 	}
 
 	/**
-	 * Returns the {@link MessagePathParameter} for the given class.
+	 * Returns the value of the {@link MessagePathParameter} for the given class.
 	 *
 	 * @param parameterClass class of the parameter
 	 * @param <X>            the value type that the parameter contains
 	 * @param <PP>           type of the path parameter
-	 * @return path parameter for the given class, or null if no parameter value exists for the given class
+	 * @return path parameter value for the given class
+	 * @throws IllegalStateException if no value is defined for the given parameter class
 	 */
-	@SuppressWarnings("unchecked")
-	public <X, PP extends MessagePathParameter<X>> PP getPathParameter(Class<PP> parameterClass) {
-		return (PP) pathParameters.get(parameterClass);
+	public <X, PP extends MessagePathParameter<X>> X getPathParameter(Class<PP> parameterClass) {
+		@SuppressWarnings("unchecked")
+		PP pathParameter = (PP) pathParameters.get(parameterClass);
+		Preconditions.checkState(pathParameter != null, "No parameter could be found for the given class.");
+		return pathParameter.getValue();
 	}
 
 	/**
-	 * Returns the {@link MessageQueryParameter} for the given class.
+	 * Returns the value of the {@link MessageQueryParameter} for the given class.
 	 *
 	 * @param parameterClass class of the parameter
 	 * @param <X>            the value type that the parameter contains
 	 * @param <QP>           type of the query parameter
-	 * @return query parameter for the given class, or null if no parameter value exists for the given class
+	 * @return query parameter value for the given class, or an empty list if no parameter value exists for the given class
 	 */
-	@SuppressWarnings("unchecked")
-	public <X, QP extends MessageQueryParameter<X>> QP getQueryParameter(Class<QP> parameterClass) {
-		return (QP) queryParameters.get(parameterClass);
+	public <X, QP extends MessageQueryParameter<X>> List<X> getQueryParameter(Class<QP> parameterClass) {
+		@SuppressWarnings("unchecked")
+		QP queryParameter = (QP) queryParameters.get(parameterClass);
+		if (queryParameter == null) {
+			return Collections.emptyList();
+		} else {
+			return queryParameter.getValue();
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessagePathParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessagePathParameter.java
@@ -23,7 +23,7 @@ package org.apache.flink.runtime.rest.messages;
  * "jobid" path parameter that is later replaced with an actual value.
  */
 public abstract class MessagePathParameter<X> extends MessageParameter<X> {
-	protected MessagePathParameter(String key, MessageParameterRequisiteness requisiteness) {
-		super(key, requisiteness);
+	protected MessagePathParameter(String key) {
+		super(key, MessageParameterRequisiteness.MANDATORY);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestEndpointITCase.java
@@ -230,7 +230,7 @@ public class RestEndpointITCase extends TestLogger {
 
 	static class JobIDPathParameter extends MessagePathParameter<JobID> {
 		JobIDPathParameter() {
-			super(JOB_ID_KEY, MessageParameterRequisiteness.MANDATORY);
+			super(JOB_ID_KEY);
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestEndpointITCase.java
@@ -131,16 +131,8 @@ public class RestEndpointITCase extends TestLogger {
 
 		@Override
 		protected CompletableFuture<TestResponse> handleRequest(@Nonnull HandlerRequest<TestRequest, TestParameters> request) throws RestHandlerException {
-			if (request.getPathParameter(JobIDPathParameter.class) == null) {
-				throw new RestHandlerException("Path parameter was missing.", HttpResponseStatus.INTERNAL_SERVER_ERROR);
-			} else {
-				Assert.assertEquals(request.getPathParameter(JobIDPathParameter.class).getValue(), PATH_JOB_ID);
-			}
-			if (request.getQueryParameter(JobIDQueryParameter.class) == null) {
-				throw new RestHandlerException("Query parameter was missing.", HttpResponseStatus.INTERNAL_SERVER_ERROR);
-			} else {
-				Assert.assertEquals(request.getQueryParameter(JobIDQueryParameter.class).getValue().get(0), QUERY_JOB_ID);
-			}
+			Assert.assertEquals(request.getPathParameter(JobIDPathParameter.class), PATH_JOB_ID);
+			Assert.assertEquals(request.getQueryParameter(JobIDQueryParameter.class).get(0), QUERY_JOB_ID);
 
 			if (request.getRequestBody().id == 1) {
 				synchronized (LOCK) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/MessageParametersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/MessageParametersTest.java
@@ -63,7 +63,7 @@ public class MessageParametersTest extends TestLogger {
 	private static class TestPathParameter extends MessagePathParameter<JobID> {
 
 		TestPathParameter() {
-			super("jobid", MessageParameterRequisiteness.MANDATORY);
+			super("jobid");
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

This PR simplifies the access to path/query parameters by directly returning the value contained in the parameter instead of the parameter itself.


## Brief change log

* make all path parameters mandatory
* simplify access in `HandlerRequest`
* simplify test code in `RestEndpointITCase`


## Verifying this change

This change is already covered by existing tests, such as `RestEndpointITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

