### PR TITLE
[FLINK-7547][build] AsyncFunction.scala extends Function, serialized

### DIFF
--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncFunction.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.scala.async
 
 import org.apache.flink.annotation.PublicEvolving
+import org.apache.flink.api.common.functions.Function
 
 /**
   * A function to trigger async I/O operations.
@@ -32,16 +33,16 @@ import org.apache.flink.annotation.PublicEvolving
   * An error can also be propagate to the async IO operator by
   * [[ResultFuture.completeExceptionally(Throwable)]].
   *
-  * @tparam IN The type of the input element
+  * @tparam IN  The type of the input element
   * @tparam OUT The type of the output elements
   */
 @PublicEvolving
-trait AsyncFunction[IN, OUT] {
+trait AsyncFunction[IN, OUT] extends Function {
 
   /**
     * Trigger the async operation for each stream input
     *
-    * @param input element coming from an upstream task
+    * @param input        element coming from an upstream task
     * @param resultFuture to be completed with the result data
     */
   def asyncInvoke(input: IN, resultFuture: ResultFuture[OUT]): Unit


### PR DESCRIPTION
fix [#issue FLINK-7547](https://issues.apache.org/jira/browse/FLINK-7547)
details:
org.apache.flink.streaming.api.scala.async.AsyncFunction is not declared Serializable, whereas org.apache.flink.streaming.api.functions.async.AsyncFunction is. This leads to the job not starting as the as async function can't be serialized during initialization.

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

