### PR TITLE
[FLINK-7294]:[flink-mesos] mesos.resourcemanager.framework.role not working

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/Utils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/Utils.java
@@ -74,11 +74,12 @@ public class Utils {
 	/**
 	 * Construct a scalar resource value.
 	 */
-	public static Protos.Resource scalar(String name, double value) {
+	public static Protos.Resource scalar(String name, String role, double value) {
 		return Protos.Resource.newBuilder()
 			.setName(name)
 			.setType(Protos.Value.Type.SCALAR)
 			.setScalar(Protos.Value.Scalar.newBuilder().setValue(value))
+			.setRole(role)
 			.build();
 	}
 
@@ -92,11 +93,12 @@ public class Utils {
 	/**
 	 * Construct a ranges resource value.
 	 */
-	public static Protos.Resource ranges(String name, Protos.Value.Range... ranges) {
+	public static Protos.Resource ranges(String name, String role, Protos.Value.Range... ranges) {
 		return Protos.Resource.newBuilder()
 			.setName(name)
 			.setType(Protos.Value.Type.RANGES)
 			.setRanges(Protos.Value.Ranges.newBuilder().addAllRange(Arrays.asList(ranges)).build())
+			.setRole(role)
 			.build();
 	}
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -198,8 +198,8 @@ public class LaunchableMesosWorker implements LaunchableTask {
 			.setSlaveId(slaveId)
 			.setTaskId(taskID)
 			.setName(taskID.getValue())
-			.addResources(scalar("cpus", assignment.getRequest().getCPUs()))
-			.addResources(scalar("mem", assignment.getRequest().getMemory()));
+			.addResources(scalar("cpus", mesosConfiguration.frameworkInfo().getRole(), assignment.getRequest().getCPUs()))
+			.addResources(scalar("mem", mesosConfiguration.frameworkInfo().getRole(), assignment.getRequest().getMemory()));
 
 		final Protos.CommandInfo.Builder cmd = taskInfo.getCommandBuilder();
 		final Protos.Environment.Builder env = cmd.getEnvironmentBuilder();
@@ -224,7 +224,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		for (int i = 0; i < TM_PORT_KEYS.length; i++) {
 			int port = assignment.getAssignedPorts().get(i);
 			String key = TM_PORT_KEYS[i];
-			taskInfo.addResources(ranges("ports", range(port, port)));
+			taskInfo.addResources(ranges("ports", mesosConfiguration.frameworkInfo().getRole(), range(port, port)));
 			dynamicProperties.setInteger(key, port);
 		}
 

--- a/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/LaunchCoordinatorTest.scala
+++ b/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/LaunchCoordinatorTest.scala
@@ -121,10 +121,10 @@ class LaunchCoordinatorTest
       .setId(offerID)
       .setSlaveId(slave._1)
       .setHostname(slave._2)
-      .addResources(scalar("cpus", 0.75))
-      .addResources(scalar("mem", 4096.0))
-      .addResources(scalar("disk", 1024.0))
-      .addResources(ranges("ports", range(9000, 9001)))
+      .addResources(scalar("cpus", "*", 0.75))
+      .addResources(scalar("mem", "*", 4096.0))
+      .addResources(scalar("disk", "*", 1024.0))
+      .addResources(ranges("ports", "*", range(9000, 9001)))
       .build()
   }
 


### PR DESCRIPTION
Jira Issue: FLINK-7294

## What is the purpose of the change
This pull request uses role set in mesos.resourcemanager.framework.role and applies it for resources such as CPU, mem, ports.  Due to this framework considers resource offers coming from mesos-agents with specified role and is able to spawn up task-managers on mesos-agent running with specific role that role *. 

## Brief change log
  - Updated Utils.java to take in role information for constructing scalar / ranges resource values. 
  - Updated LaunchableMesosWorker to use framework role set in config.
  - Updated tests in LaunchCoordinatorTest.scala to pass role argument.

## Verifying this change
Part of change is already covered by existing tests, such as  LaunchCoordinatorTest.scala.
Also, manually verified the change by running a flink-mesos cluster with 1 job-manager and 3 task-managers. The flink was deployed on a mesos-cluster where mesos-workers were running with specific role and not role '*'.

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes, it affects deployment on Mesos.

## Documentation
  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented

@EronWright : PTAL. Thanks!