### PR TITLE
[FLINK-7561][streaming] Implement PreAggregationOperator

### DIFF
--- a/flink-contrib/flink-streaming-contrib/pom.xml
+++ b/flink-contrib/flink-streaming-contrib/pom.xml
@@ -66,6 +66,23 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/flink-contrib/flink-streaming-contrib/src/main/java/org/apache/flink/contrib/streaming/PreAggregationOperator.java
+++ b/flink-contrib/flink-streaming-contrib/src/main/java/org/apache/flink/contrib/streaming/PreAggregationOperator.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.MergingWindowAssigner;
+import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * This operator perform preliminary aggregation of the input values on non-keyed stream. This means that the output
+ * is not fully aggregated, but only partially. It should be placed before keyBy of the final aggregation.
+ * {@link DataStreamUtils#aggregateWithPreAggregation(DataStream, KeySelector, AggregateFunction, WindowAssigner)}
+ * provides a useful wrapper that automatically creates a matching final aggregation step.
+ *
+ * <p>Pre aggregation can be useful in couple of scenarios:
+ * <ol>
+ * 		<li>Performing keyBy operation with low number of distinct values in the key. In such case
+ * 		{@link PreAggregationOperator} can reduce both CPU usage and network usage, by pre-aggregating most of the
+ * 		values before shuffling them over the network.</li>
+ * 		<li>Increasing the parallelism above the number of distinct values for the task preceding the keyBy operation.</li>
+ * 		<li>Handling the data skew of some of the key values. Normally if there is a data skew, a lot of work can be
+ * 		dumped onto one single CPU core in the cluster. With pre aggregation some of that work can be performed in more
+ * 		distributed fashion by the {@link PreAggregationOperator}.</li>
+ * 		<li>Output partitioning of the data source is correlated with keyBy partitioning. For example when data source
+ * 		is partitioned by day and keyBy function shuffles the data based by day and hour.</li>
+ * </ol>
+ *
+ * <p>Because this operator performs only pre aggregation, it doesn't output the result of {@link AggregateFunction}
+ * but rather it outputs a tuple containing the Key, Window, and Accumulator, where Accumulator is a partially
+ * aggregated result {@link AggregateFunction}.
+ *
+ * <p>Keep in mind that {@link PreAggregationOperator} can have significant higher memory consumption compared to
+ * normal aggregation. If the input data are either not partitioned or the input partitioning is not correlated with
+ * the {@code keySelector}, each instance {@link PreAggregationOperator} can end up having each own accumulators entry
+ * per each key. In other words in that case memory consumption is expected to be {@code parallelism} times larger
+ * compared to what {@link org.apache.flink.streaming.runtime.operators.windowing.WindowOperator} would have.
+ *
+ * <p>It is expected that this operator should be followed by keyBy operation based on {@code tuple.f0} and after that
+ * followed by {@link org.apache.flink.streaming.runtime.operators.windowing.WindowOperator} which perform
+ * {@link AggregateFunction#merge(ACC, ACC)}.
+ *
+ * <p>Because currently {@link PreAggregationOperator} does not use {@link org.apache.flink.streaming.api.TimerService}
+ * only two elements triggering policies are supported:
+ * <ol>
+ * 		<li>Flush everything on any watermark.</li>
+ * 		<li>Iterate over each element in the state on each watermark and emit it if watermark's timestamp exceeds
+ * 		{@link Window#maxTimestamp()}.</li>
+ * </ol>
+ * The first option has a drawback that it will often unnecessary emit elements, that could potentially be further
+ * aggregated. The second one is quite CPU intensive if watermarks are emitted relatively often to the number of pre
+ * aggregated key values.
+ *
+ * <p>Other limitations and notes:
+ * <ol>
+ * 		<li>{@link MergingWindowAssigner} is not supported.</li>
+ * 		<li>{@link PreAggregationOperator} emits all of its data on each received watermark.</li>
+ * 		<li>On restoring from checkpoint keys can be randomly shuffled between {@link PreAggregationOperator}
+ * 		instances</li>.
+ * </ol>
+ */
+@PublicEvolving
+public class PreAggregationOperator<K, IN, ACC, W extends Window>
+	extends AbstractStreamOperator<Tuple3<K, W, ACC>>
+	implements OneInputStreamOperator<IN, Tuple3<K, W, ACC>>, Serializable {
+
+	protected final AggregateFunction<IN, ACC, ?> aggregateFunction;
+	protected final KeySelector<IN, K> keySelector;
+	protected final WindowAssigner<? super IN, W> windowAssigner;
+	protected final TypeInformation<K> keyTypeInformation;
+	protected final TypeInformation<ACC> accumulatorTypeInformation;
+	protected final boolean flushAllOnWatermark;
+	protected final Map<Tuple2<K, W>, ACC> aggregates = new HashMap<>();
+
+	protected transient WindowAssigner.WindowAssignerContext windowAssignerContext;
+	protected transient ListState<Tuple3<K, W, ACC>> aggregatesState;
+
+	/**
+	 * Creates {@link PreAggregationOperator}.
+	 *
+	 * @param aggregateFunction function used for aggregation. Note, {@link AggregateFunction#getResult(Object)} will
+	 *                          not be used.
+	 * @param keySelector
+	 * @param keyTypeInformation
+	 * @param accumulatorTypeInformation
+	 * @param windowAssigner
+	 * @param flushAllOnWatermark flag to control whether all elements should be emitted on any watermark. Check more
+	 *                            information in {@link PreAggregationOperator}.
+	 */
+	public PreAggregationOperator(
+			AggregateFunction<IN, ACC, ?> aggregateFunction,
+			KeySelector<IN, K> keySelector,
+			TypeInformation<K> keyTypeInformation,
+			TypeInformation<ACC> accumulatorTypeInformation,
+			WindowAssigner<? super IN, W> windowAssigner,
+			boolean flushAllOnWatermark) {
+		this.aggregateFunction = checkNotNull(aggregateFunction, "aggregateFunction is null");
+		this.keySelector = checkNotNull(keySelector, "keySelector is null");
+		this.windowAssigner = checkNotNull(windowAssigner, "windowAssigner is null");
+		this.keyTypeInformation = checkNotNull(keyTypeInformation, "keyTypeInformation is null");
+		this.accumulatorTypeInformation = checkNotNull(accumulatorTypeInformation, "accumulatorTypeInformation is null");
+		this.flushAllOnWatermark = flushAllOnWatermark;
+
+		checkNotNull(keyTypeInformation, "keyTypeInformation is null");
+		checkNotNull(accumulatorTypeInformation, "accumulatorTypeInformation is null");
+
+		checkArgument(!(windowAssigner instanceof MergingWindowAssigner),
+			"MergingWindowAssigner is not supported by the PreAggregationOperator");
+	}
+
+	@Override
+	public void open() throws Exception {
+		windowAssignerContext = new WindowAssigner.WindowAssignerContext() {
+			@Override
+			public long getCurrentProcessingTime() {
+				throw new UnsupportedOperationException(
+					"Using processing time with PreAggregationOperator would affect the results.");
+			}
+		};
+	}
+
+	@Override
+	public void initializeState(StateInitializationContext context) throws Exception {
+		super.initializeState(context);
+
+		TypeSerializer<Tuple3<K, W, ACC>> typeSerializer = new TupleSerializer<>(
+			(Class<Tuple3<K, W, ACC>>) (Class<?>) Tuple3.class,
+			new TypeSerializer<?>[] {
+				keyTypeInformation.createSerializer(getExecutionConfig()),
+				windowAssigner.getWindowSerializer(getExecutionConfig()),
+				accumulatorTypeInformation.createSerializer(getExecutionConfig())
+			});
+
+		ListStateDescriptor<Tuple3<K, W, ACC>> mapStateDescriptor = new ListStateDescriptor<>("map-state-descriptor", typeSerializer);
+
+		aggregatesState = context.getOperatorStateStore().getListState(mapStateDescriptor);
+
+		if (context.isRestored()) {
+			aggregates.clear();
+
+			for (Tuple3<K, W, ACC> tuple : aggregatesState.get()) {
+				Tuple2<K, W> key = new Tuple2<>(tuple.f0, tuple.f1);
+				ACC accumulator = aggregates.get(key);
+				if (accumulator != null) {
+					accumulator = aggregateFunction.merge(accumulator, tuple.f2);
+				}
+				else {
+					accumulator = tuple.f2;
+				}
+				aggregates.put(key, checkNotNull(accumulator, "accumulator is null"));
+			}
+		}
+	}
+
+	@Override
+	public void snapshotState(StateSnapshotContext context) throws Exception {
+		super.snapshotState(context);
+
+		aggregatesState.clear();
+		for (Map.Entry<Tuple2<K, W>, ACC> entry : aggregates.entrySet()) {
+			aggregatesState.add(new Tuple3<>(entry.getKey().f0, entry.getKey().f1, entry.getValue()));
+		}
+	}
+
+	@Override
+	public void processElement(StreamRecord<IN> streamRecord) throws Exception {
+		Collection<W> windows = windowAssigner.assignWindows(streamRecord.getValue(), streamRecord.getTimestamp(), windowAssignerContext);
+		K key = keySelector.getKey(streamRecord.getValue());
+
+		for (W window : windows) {
+			Tuple2<K, W> tuple = new Tuple2<>(key, window);
+			ACC accumulator = aggregates.get(tuple);
+
+			if (accumulator == null) {
+				accumulator = aggregateFunction.createAccumulator();
+			}
+
+			accumulator = aggregateFunction.add(streamRecord.getValue(), accumulator);
+			aggregates.put(tuple, accumulator);
+		}
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		if (flushAllOnWatermark) {
+			flush();
+		}
+		else {
+			trigger(mark.getTimestamp());
+		}
+		super.processWatermark(mark);
+	}
+
+	private void trigger(long timestamp) {
+		for (Iterator<Map.Entry<Tuple2<K, W>, ACC>> it = aggregates.entrySet().iterator(); it.hasNext();) {
+			Map.Entry<Tuple2<K, W>, ACC> entry = it.next();
+			Tuple2<K, W> key = entry.getKey();
+			ACC value = entry.getValue();
+			if (key.f1.maxTimestamp() <= timestamp) {
+				collect(key, value);
+				it.remove();
+			}
+		}
+	}
+
+	protected void flush() {
+		aggregates.forEach((key, value) -> collect(key, value));
+		aggregates.clear();
+	}
+
+	protected void collect(Tuple2<K, W> key, ACC value) {
+		output.collect(new StreamRecord<>(Tuple3.of(key.f0, key.f1, value), key.f1.maxTimestamp()));
+	}
+
+	@Override
+	public String toString() {
+		return String.format(
+			"%s(%s)",
+			this.getClass().getSimpleName(),
+			windowAssigner);
+	}
+}

--- a/flink-contrib/flink-streaming-contrib/src/test/java/org/apache/flink/contrib/streaming/PreAggregationOperatorITCase.java
+++ b/flink-contrib/flink-streaming-contrib/src/test/java/org/apache/flink/contrib/streaming/PreAggregationOperatorITCase.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.SlidingEventTimeWindows;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.util.TestStreamEnvironment;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link PreAggregationOperator}.
+ */
+public class PreAggregationOperatorITCase extends TestLogger {
+
+	private static LocalFlinkMiniCluster cluster;
+
+	@BeforeClass
+	public static void startCluster() {
+		cluster = new LocalFlinkMiniCluster(new Configuration(), false);
+		cluster.start();
+		TestStreamEnvironment.setAsContext(cluster, 1);
+	}
+
+	@AfterClass
+	public static void shutdownCluster() {
+		cluster.stop();
+		TestStreamEnvironment.unsetAsContext();
+	}
+
+	@Test
+	public void testPreAggregate() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		DataStream<Tuple2<Long, Long>> stream = env.generateSequence(0, (long) 19)
+			.assignTimestampsAndWatermarks(new WatermarksAssigner())
+			.map(new GenerateInput());
+
+		SlidingEventTimeWindows windows = SlidingEventTimeWindows.of(Time.milliseconds(10), Time.milliseconds(10));
+		SingleOutputStreamOperator<Long> result = DataStreamUtils.aggregateWithPreAggregation(
+			stream,
+			new FirstTupleFieldKeySelector(),
+			new SumSecondTupleFieldAggregation(),
+			windows,
+			false);
+
+		List<Long> actualResult = new ArrayList<>();
+		DataStreamUtils.collect(result).forEachRemaining(actualResult::add);
+
+		assertEquals(Arrays.asList(5L, 5L, 5L, 5L), actualResult);
+	}
+
+	private static class FirstTupleFieldKeySelector implements KeySelector<Tuple2<Long, Long>, Long> {
+		@Override
+		public Long getKey(Tuple2<Long, Long> value) throws Exception {
+			return value.f0;
+		}
+	}
+
+	private static class GenerateInput implements MapFunction<Long, Tuple2<Long, Long>> {
+		@Override
+		public Tuple2<Long, Long> map(Long value) throws Exception {
+			return Tuple2.of(value % 2, 1L);
+		}
+	}
+
+	private static class SumSecondTupleFieldAggregation implements AggregateFunction<Tuple2<Long, Long>, Long, Long> {
+		@Override
+		public Long createAccumulator() {
+			return new Long(0);
+		}
+
+		@Override
+		public Long add(Tuple2<Long, Long> value, Long accumulator) {
+			return accumulator + value.f1;
+		}
+
+		@Override
+		public Long getResult(Long accumulator) {
+			return accumulator;
+		}
+
+		@Override
+		public Long merge(Long a, Long b) {
+			return a + b;
+		}
+	}
+
+	private static class WatermarksAssigner implements AssignerWithPunctuatedWatermarks<Long> {
+		@Nullable
+		@Override
+		public Watermark checkAndGetNextWatermark(Long lastElement, long extractedTimestamp) {
+			return new Watermark(extractedTimestamp);
+		}
+
+		@Override
+		public long extractTimestamp(Long element, long previousElementTimestamp) {
+			return element;
+		}
+	}
+}

--- a/flink-contrib/flink-streaming-contrib/src/test/java/org/apache/flink/contrib/streaming/PreAggregationOperatorTest.java
+++ b/flink-contrib/flink-streaming-contrib/src/test/java/org/apache/flink/contrib/streaming/PreAggregationOperatorTest.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.OperatorStateHandles;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link PreAggregationOperator}.
+ */
+public class PreAggregationOperatorTest extends TestLogger {
+	private static final long WINDOW_SIZE = 100;
+
+	@Test
+	public void testWatermarkEmit() throws Exception {
+		try (OneInputStreamOperatorTestHarness<Record, Tuple3<Integer, TimeWindow, LongAccumulator>> testHarness =
+				createTestHarness(false)) {
+			testHarness.processElement(record(0, 40), 0);
+			testHarness.processElement(record(0, 2), 99);
+			assertOutput(testHarness);
+
+			testHarness.processWatermark(99);
+			assertOutput(
+				testHarness,
+				expectedOutput(0, 0, 100, 42));
+
+			assertEquals(99, testHarness.getCurrentWatermark());
+		}
+	}
+
+	@Test
+	public void testPreAggregate() throws Exception {
+		try (OneInputStreamOperatorTestHarness<Record, Tuple3<Integer, TimeWindow, LongAccumulator>> testHarness =
+				createTestHarness(false)) {
+			testHarness.processElement(record(0, 10), 0);
+			testHarness.processElement(record(0, 20), 10);
+			testHarness.processElement(record(1, 10), 10);
+			testHarness.processElement(record(0, 12), 50);
+			testHarness.processElement(record(1, 3), 50);
+			testHarness.processElement(record(0, 2), 110);
+			testHarness.processElement(record(0, 12), 120);
+			testHarness.processElement(record(0, 30), 150);
+
+			assertOutput(testHarness);
+
+			testHarness.processWatermark(90);
+			assertOutput(testHarness);
+
+			testHarness.processWatermark(110);
+			assertOutput(
+				testHarness,
+				expectedOutput(0, 0, 100, 42),
+				expectedOutput(1, 0, 100, 13));
+
+			testHarness.processWatermark(210);
+			assertOutput(
+				testHarness,
+				expectedOutput(0, 100, 200, 44));
+		}
+	}
+
+	@Test
+	public void testPreAggregateAndFlushAllOnWatermark() throws Exception {
+		try (OneInputStreamOperatorTestHarness<Record, Tuple3<Integer, TimeWindow, LongAccumulator>> testHarness =
+				createTestHarness(true)) {
+			testHarness.processElement(record(0, 10), 0);
+			testHarness.processElement(record(0, 20), 10);
+			testHarness.processElement(record(1, 10), 10);
+			testHarness.processElement(record(0, 12), 50);
+			testHarness.processElement(record(1, 3), 50);
+			testHarness.processElement(record(0, 2), 110);
+			testHarness.processElement(record(0, 12), 120);
+			testHarness.processElement(record(0, 30), 150);
+
+			assertOutput(testHarness);
+
+			testHarness.processWatermark(90);
+			assertOutput(
+				testHarness,
+				expectedOutput(0, 0, 100, 42),
+				expectedOutput(0, 100, 200, 44),
+				expectedOutput(1, 0, 100, 13));
+			assertOutput(testHarness);
+		}
+	}
+
+	@Test
+	public void testCheckpoint() throws Exception {
+		OperatorStateHandles snapshot1;
+		OperatorStateHandles snapshot2;
+
+		try (OneInputStreamOperatorTestHarness<Record, Tuple3<Integer, TimeWindow, LongAccumulator>> testHarness =
+				createTestHarness(true)) {
+
+			testHarness.processElement(record(0, 40), 0);
+			testHarness.processElement(record(0, 2), 10);
+			testHarness.processElement(record(1, 10), 10);
+			testHarness.processElement(record(1, 3), 50);
+
+			snapshot1 = testHarness.snapshot(0, 200);
+
+			testHarness.processElement(record(0, 44), 150);
+
+			snapshot2 = testHarness.snapshot(1, 300);
+		}
+
+		try (OneInputStreamOperatorTestHarness<Record, Tuple3<Integer, TimeWindow, LongAccumulator>> testHarness =
+				createTestHarness(true, snapshot1)) {
+
+			assertOutput(testHarness);
+			testHarness.processWatermark(90);
+			assertOutput(
+				testHarness,
+				expectedOutput(0, 0, 100, 42),
+				expectedOutput(1, 0, 100, 13));
+		}
+
+		try (OneInputStreamOperatorTestHarness<Record, Tuple3<Integer, TimeWindow, LongAccumulator>> testHarness =
+				createTestHarness(true, snapshot2)) {
+
+			assertOutput(testHarness);
+			testHarness.processWatermark(90);
+			assertOutput(
+				testHarness,
+				expectedOutput(0, 0, 100, 42),
+				expectedOutput(0, 100, 200, 44),
+				expectedOutput(1, 0, 100, 13));
+		}
+	}
+
+	private static void assertOutput(
+			OneInputStreamOperatorTestHarness<Record, Tuple3<Integer, TimeWindow, LongAccumulator>> testHarness,
+			StreamRecord<?>... records) {
+		List<?> actualOutput = extractOutput(testHarness);
+		testHarness.getOutput().clear();
+
+		assertEquals(
+			String.format("Expected %d elements, but got %s", records.length, actualOutput),
+			records.length,
+			actualOutput.size());
+
+		for (int i = 0; i < records.length; i++) {
+			assertEquals(records[i], actualOutput.get(i));
+		}
+	}
+
+	private static List<StreamRecord<? extends Tuple3<Integer, TimeWindow, LongAccumulator>>> extractOutput(
+			OneInputStreamOperatorTestHarness<Record, Tuple3<Integer, TimeWindow, LongAccumulator>> testHarness) {
+
+		return testHarness.extractOutputStreamRecords().stream()
+			.sorted((leftRecord, rightRecord) -> {
+				Tuple3<Integer, TimeWindow, LongAccumulator> left = leftRecord.getValue();
+				Tuple3<Integer, TimeWindow, LongAccumulator> right = rightRecord.getValue();
+				int keyCompare = left.f0.compareTo(right.f0);
+				if (keyCompare != 0) {
+					return keyCompare;
+				}
+				return Long.compare(left.f1.getStart(), right.f1.getStart());
+			})
+			.collect(Collectors.toList());
+	}
+
+	private static Record record(int key, long value) {
+		return new Record(key, value);
+	}
+
+	private static class Record {
+		public final int key;
+		public final long value;
+
+		public Record() {
+			this(0, 0L);
+		}
+
+		public Record(int key, long value) {
+			this.key = key;
+			this.value = value;
+		}
+	}
+
+	private static class LongAccumulator {
+		public long value;
+
+		public LongAccumulator(long value) {
+			this.value = value;
+		}
+
+		@Override
+		public int hashCode() {
+			return Long.hashCode(value);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj == null) {
+				return false;
+			}
+			if (!(obj instanceof LongAccumulator)) {
+				return false;
+			}
+			LongAccumulator other = (LongAccumulator) obj;
+			return value == other.value;
+		}
+	}
+
+	private static class RecordSumPreAggregation
+		implements AggregateFunction<Record, LongAccumulator, Void>, Serializable {
+		@Override
+		public LongAccumulator createAccumulator() {
+			return new LongAccumulator(0);
+		}
+
+		@Override
+		public LongAccumulator add(Record value, LongAccumulator accumulator) {
+			accumulator.value += value.value;
+			return accumulator;
+		}
+
+		@Override
+		public Void getResult(LongAccumulator accumulator) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public LongAccumulator merge(LongAccumulator a, LongAccumulator b) {
+			return new LongAccumulator(a.value + b.value);
+		}
+	}
+
+	private OneInputStreamOperatorTestHarness<Record, Tuple3<Integer, TimeWindow, LongAccumulator>> createTestHarness(
+			boolean flushAllOnWatermark) throws Exception {
+		return createTestHarness(flushAllOnWatermark, Optional.empty());
+	}
+
+	private OneInputStreamOperatorTestHarness<Record, Tuple3<Integer, TimeWindow, LongAccumulator>> createTestHarness(
+			boolean flushAllOnWatermark,
+			OperatorStateHandles snapshot) throws Exception {
+		return createTestHarness(flushAllOnWatermark, Optional.of(snapshot));
+	}
+
+	private OneInputStreamOperatorTestHarness<Record, Tuple3<Integer, TimeWindow, LongAccumulator>> createTestHarness(
+			boolean flushAllOnWatermark,
+			Optional<OperatorStateHandles> snapshot) throws Exception {
+
+		TumblingEventTimeWindows windowAssigner = TumblingEventTimeWindows.of(Time.milliseconds(WINDOW_SIZE));
+
+		PreAggregationOperator<Integer, Record, LongAccumulator, TimeWindow> preAggregationOperator = new PreAggregationOperator<>(
+			new RecordSumPreAggregation(),
+			record -> record.key,
+			TypeInformation.of(Integer.class),
+			TypeInformation.of(LongAccumulator.class),
+			windowAssigner,
+			flushAllOnWatermark);
+
+		OneInputStreamOperatorTestHarness<Record, Tuple3<Integer, TimeWindow, LongAccumulator>> testHarness =
+			new OneInputStreamOperatorTestHarness<>(preAggregationOperator);
+		testHarness.setup();
+		if (snapshot.isPresent()) {
+			testHarness.initializeState(snapshot.get());
+		}
+		testHarness.open();
+		return testHarness;
+	}
+
+	private static StreamRecord<Tuple3<Integer, TimeWindow, LongAccumulator>> expectedOutput(
+			int key,
+			long windowStart,
+			long windowEnd,
+			long value) {
+		TimeWindow timeWindow = new TimeWindow(windowStart, windowEnd);
+		return new StreamRecord<>(
+			Tuple3.of(key, timeWindow, new LongAccumulator(value)),
+			timeWindow.maxTimestamp());
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/GlobalWindow.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/GlobalWindow.java
@@ -89,7 +89,7 @@ public class GlobalWindow extends Window {
 
 		@Override
 		public int getLength() {
-			return 0;
+			return Byte.BYTES;
 		}
 
 		@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/TimeWindow.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/TimeWindow.java
@@ -157,7 +157,7 @@ public class TimeWindow extends Window {
 
 		@Override
 		public int getLength() {
-			return 0;
+			return Long.BYTES * 2;
 		}
 
 		@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/WindowTypeInformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/windows/WindowTypeInformation.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.windowing.windows;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link TypeInformation} for {@link Window}.
+ */
+@PublicEvolving
+public class WindowTypeInformation<W extends Window> extends TypeInformation<W> {
+
+	private WindowAssigner<?, W> windowAssigner;
+
+	public WindowTypeInformation(WindowAssigner<?, W> windowAssigner) {
+		this.windowAssigner = checkNotNull(windowAssigner);
+	}
+
+	@Override
+	public boolean isBasicType() {
+		return false;
+	}
+
+	@Override
+	public boolean isTupleType() {
+		return false;
+	}
+
+	@Override
+	public int getArity() {
+		return 1;
+	}
+
+	@Override
+	public int getTotalFields() {
+		return 1;
+	}
+
+	@Override
+	public Class<W> getTypeClass() {
+		return new TypeHint<W>() {}.getTypeInfo().getTypeClass();
+	}
+
+	@Override
+	public boolean isKeyType() {
+		return false;
+	}
+
+	@Override
+	public TypeSerializer<W> createSerializer(ExecutionConfig config) {
+		return windowAssigner.getWindowSerializer(config);
+	}
+
+	@Override
+	public String toString() {
+		return String.format("%s(%s)", this.getClass().getSimpleName(), windowAssigner);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof WindowTypeInformation) {
+			@SuppressWarnings("unchecked")
+			WindowTypeInformation<W> other = (WindowTypeInformation<W>) obj;
+			return other.canEqual(this) &&
+				windowAssigner.equals(other.windowAssigner);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof WindowTypeInformation;
+	}
+
+	@Override
+	public int hashCode() {
+		return windowAssigner.hashCode();
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

To improve performance in certain situations this PR adds basic implementation of pre-aggregation operator for DataStream API.

## Verifying this change

This change added `PreAggregationOperatorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented): extensive JavaDocs.

