### PR TITLE
[FLINK-7486]:[flink-mesos]:Support for adding unique attribute / grou…

### DIFF
--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -477,6 +477,8 @@ use the `env.java.opts` setting, which is the `%jvmopts%` variable in the String
 
 - `mesos.constraints.hard.hostattribute`: Constraints for task placement on mesos (**DEFAULT**: None).
 
+- `mesos.constraints.soft.balanced`: Soft Constraints for balancing the tasks across mesos based on agent attributes (**DEFAULT**: None).
+
 - `mesos.maximum-failed-tasks`: The maximum number of failed workers before the cluster fails (**DEFAULT**: Number of initial workers).
 May be set to -1 to disable this feature.
 

--- a/docs/ops/deployment/mesos.md
+++ b/docs/ops/deployment/mesos.md
@@ -226,6 +226,10 @@ When running Flink with Marathon, the whole Flink cluster including the job mana
 Takes a comma-separated list of key:value pairs corresponding to the attributes exposed by the target
 mesos agents.  Example: `az:eu-west-1a,series:t2`
 
+`mesos.constraints.soft.balanced`: Soft Constraints for balancing the tasks across mesos based on agent attributes (**DEFAULT**: None).
+Takes a comma-separated list of key=value pairs. Key corresponds to host attribute and value is number of expected unique values for given host attribute.
+Example: `az=3,rack_id=4`
+
 `mesos.maximum-failed-tasks`: The maximum number of failed workers before the cluster fails (**DEFAULT**: Number of initial workers).
 May be set to -1 to disable this feature.
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -155,7 +155,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 
 		@Override
 		public List<? extends VMTaskFitnessCalculator> getSoftConstraints() {
-			return null;
+			return params.softConstraints();
 		}
 
 		@Override

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
@@ -251,6 +251,7 @@ public class MesosFlinkResourceManagerTest extends TestLogger {
 				containeredParams,
 				Collections.<Protos.Volume>emptyList(),
 				Collections.<ConstraintEvaluator>emptyList(),
+				Collections.<MesosTaskManagerParameters.BalancedHostAttrConstraintParams>emptyList(),
 				"",
 				Option.<String>empty(),
 				Option.<String>empty());

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -251,8 +251,9 @@ public class MesosResourceManagerTest extends TestLogger {
 				new ContaineredTaskManagerParameters(1024, 768, 256, 4, new HashMap<String, String>());
 			MesosTaskManagerParameters tmParams = new MesosTaskManagerParameters(
 				1.0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
-				Collections.<Protos.Volume>emptyList(), Collections.<ConstraintEvaluator>emptyList(), "", Option.<String>empty(),
-				Option.<String>empty());
+				Collections.<Protos.Volume>emptyList(), Collections.<ConstraintEvaluator>emptyList(),
+				Collections.<MesosTaskManagerParameters.BalancedHostAttrConstraintParams>emptyList(),
+				"", Option.<String>empty(), Option.<String>empty());
 
 			// resource manager
 			rmConfiguration = new ResourceManagerConfiguration(


### PR DESCRIPTION
…p_by attribute constraints

JIRA issue: FLINK-7486
## What is the purpose of the change
- To be able to add soft constraint to balance the tasks across mesos-agents on basis of host constraint 

## Brief change log
- Added new config 'mesos.constraints.soft.balanced'
- Parsed the config in MesosTaskManagerParams and prepared list of BalancedConstraintParam objects
- Prepared Set of TaskIds from workersInNew and workersInLaunch in MesosResourceManager/MesosFlinkResourceManager. Used this Set in coTaskGetter to get co-task-ids
- Updated LaunchableMesosWorker to return soft constraints from BalancedConstraintParam objects

## Verifying this change
  - Manually verified the change by running flink on mesos cluster. The mesos worker had attributes AZ and hostname set. After adding the constraint, taskmanagers were launched on mesos-workers with unique AZ/hostname values.
 
## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: don't know
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes (flink deployment on mesos)

## Documentation
  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
     The feature is controlled by config 'mesos.constraints.soft.balanced' in flink-conf.yaml
      The config is documented in docs.

@EronWright : PTAL. Thanks!
