### PR TITLE
[hotfix][table] Fix bug of testAggregateFunctionOperandTypeCheck

### DIFF
--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/validation/UserDefinedFunctionValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/validation/UserDefinedFunctionValidationTest.scala
@@ -21,7 +21,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils.Func0
-import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.WeightedAvg
+import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.OverAgg0
 import org.apache.flink.table.utils.TableTestBase
 import org.junit.Test
 
@@ -36,8 +36,8 @@ class UserDefinedFunctionValidationTest extends TableTestBase {
         "Expected: (int)")
     val util = streamTestUtil()
     util.addTable[(Int, String)]("t", 'a, 'b)
-    util.tableEnv.registerFunction("func",Func0)
-    util.verifySql("select func(b) from t","n/a")
+    util.tableEnv.registerFunction("func", Func0)
+    util.verifySql("select func(b) from t", "n/a")
   }
 
   @Test
@@ -46,15 +46,14 @@ class UserDefinedFunctionValidationTest extends TableTestBase {
     thrown.expectMessage(
       "Given parameters of function do not match any signature. \n" +
         "Actual: (java.lang.String, java.lang.Integer) \n" +
-        "Expected: (org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions." +
-        "WeightedAvgAccum, int, int), (org.apache.flink.table.runtime.utils." +
-        "JavaUserDefinedAggFunctions.WeightedAvgAccum, long, int)")
+        "Expected: (org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions" +
+        ".Accumulator0, long, int)")
 
     val util = streamTestUtil()
-    val weightAvgFun = new WeightedAvg
+    val agg = new OverAgg0
     util.addTable[(Int, String)]("t", 'a, 'b)
-    util.tableEnv.registerFunction("agg",weightAvgFun)
-    util.verifySql("select agg(b, a) from t","n/a")
+    util.tableEnv.registerFunction("agg", agg)
+    util.verifySql("select agg(b, a) from t", "n/a")
   }
 
 }


### PR DESCRIPTION
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

`UserDefinedFunctionUtils#signaturesToString` does not have the same result for AGG with multiple signatures in different JVMs， So In this PR. hot fix testAggregateFunctionOperandTypeCheck by using the AGG with a single signature.
