### PR TITLE
[FLINK-7563] [cep] Fix watermark semantics in cep and related tests.

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
@@ -162,10 +162,10 @@ public abstract class AbstractKeyedCEPPatternOperator<IN, KEY, OUT, F extends Fu
 			IN value = element.getValue();
 
 			// In event-time processing we assume correctness of the watermark.
-			// Events with timestamp smaller than the last seen watermark are considered late.
+			// Events with timestamp smaller than or equal with the last seen watermark are considered late.
 			// Late events are put in a dedicated side output, if the user has specified one.
 
-			if (timestamp >= lastWatermark) {
+			if (timestamp > lastWatermark) {
 
 				// we have an event with a valid timestamp, so
 				// we buffer it until we receive the proper watermark.

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
@@ -221,7 +221,7 @@ public abstract class AbstractKeyedCEPPatternOperator<IN, KEY, OUT, F extends Fu
 		NFA<IN> nfa = getNFA();
 
 		// STEP 2
-		while (!sortedTimestamps.isEmpty() && sortedTimestamps.peek() <= timerService.currentWatermark()) {
+		while (!sortedTimestamps.isEmpty() && sortedTimestamps.peek() < timerService.currentWatermark()) {
 			long timestamp = sortedTimestamps.poll();
 			sort(elementQueueState.get(timestamp)).forEachOrdered(
 				event -> processEvent(nfa, event, timestamp)

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
@@ -606,6 +606,7 @@ public class CEPOperatorTest extends TestLogger {
 			verifyWatermark(harness.getOutput().poll(), 11L);
 			verifyWatermark(harness.getOutput().poll(), 12L);
 
+			// this is a late event, because timestamp(12) = last watermark(12)
 			harness.processElement(new StreamRecord<Event>(middleEvent3, 12L));
 			harness.processElement(new StreamRecord<>(endEvent2, 13L));
 			harness.processWatermark(20L);
@@ -615,8 +616,9 @@ public class CEPOperatorTest extends TestLogger {
 			assertTrue(!operator2.hasNonEmptyPQ(42));
 			assertEquals(0L, harness.numEventTimeTimers());
 
+			assertEquals(3, harness.getOutput().size());
 			verifyPattern(harness.getOutput().poll(), startEvent2, middleEvent2, endEvent2);
-			verifyPattern(harness.getOutput().poll(), startEvent2, middleEvent3, endEvent2);
+
 			verifyWatermark(harness.getOutput().poll(), 20L);
 			verifyWatermark(harness.getOutput().poll(), 21L);
 		} finally {
@@ -873,9 +875,9 @@ public class CEPOperatorTest extends TestLogger {
 			harness.processElement(new StreamRecord<Event>(middleEvent2, 3));
 			harness.processElement(new StreamRecord<>(startEvent2, 4));
 			harness.processWatermark(5L);
-			harness.processElement(new StreamRecord<>(nextOne, 6));
+			harness.processElement(new StreamRecord<>(nextOne, 7));
 			harness.processElement(new StreamRecord<>(endEvent, 8));
-			harness.processElement(new StreamRecord<Event>(middleEvent4, 5));
+			harness.processElement(new StreamRecord<Event>(middleEvent4, 6));
 			harness.processWatermark(100L);
 
 			List<List<Event>> resultingPatterns = new ArrayList<>();


### PR DESCRIPTION
## What is the purpose of the change

Correct the watermark semantics in cep.

## Brief change log

-  use the logic that (timestamp <= watermark) is considered late.

## Verifying this change

This change is already covered by existing tests, such as `testCEPOperatorCleanupEventTime()`, and `testCEPOperatorSerializationWRocksDB()` in `CEPOperatorTest.java`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

