### PR TITLE
[FLINK-6563] [table] Add time indicator support to KafkaTableSource.

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010AvroTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010AvroTableSource.java
@@ -19,12 +19,17 @@
 package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
 
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.avro.specific.SpecificRecordBase;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -37,22 +42,102 @@ public class Kafka010AvroTableSource extends KafkaAvroTableSource {
 	 *
 	 * @param topic      Kafka topic to consume.
 	 * @param properties Properties for the Kafka consumer.
+	 * @param schema     Schema of the produced table.
 	 * @param record     Avro specific record.
 	 */
 	public Kafka010AvroTableSource(
 		String topic,
 		Properties properties,
+		TableSchema schema,
 		Class<? extends SpecificRecordBase> record) {
 
 		super(
 			topic,
 			properties,
+			schema,
 			record);
+	}
+
+	/**
+	 * Sets a mapping from schema fields to fields of the produced Avro record.
+	 *
+	 * <p>A field mapping is required if the fields of produced tables should be named different than
+	 * the fields of the Avro record.
+	 * The key of the provided Map refers to the field of the table schema,
+	 * the value to the field of the Avro record.</p>
+	 *
+	 * @param fieldMapping A mapping from schema fields to Avro fields.
+	 */
+	@Override
+	public void setFieldMapping(Map<String, String> fieldMapping) {
+		Preconditions.checkNotNull(fieldMapping, "FieldMapping must not be null.");
+		super.setFieldMapping(fieldMapping);
+	}
+
+	/**
+	 * Declares a field of the schema to be a processing time attribute.
+	 *
+	 * @param proctimeAttribute The name of the field that becomes the processing time field.
+	 */
+	@Override
+	public void setProctimeAttribute(String proctimeAttribute) {
+		Preconditions.checkNotNull(proctimeAttribute, "Processing time attribute must not be null.");
+		super.setProctimeAttribute(proctimeAttribute);
+	}
+
+	/**
+	 * Declares a field of the schema to be a rowtime attribute.
+	 *
+	 * @param rowtimeAttributeDescriptor The descriptor of the rowtime attribute.
+	 */
+	public void setRowtimeAttributeDescriptor(RowtimeAttributeDescriptor rowtimeAttributeDescriptor) {
+		Preconditions.checkNotNull(rowtimeAttributeDescriptor, "Rowtime attribute descriptor must not be null.");
+		super.setRowtimeAttributeDescriptors(Collections.singletonList(rowtimeAttributeDescriptor));
 	}
 
 	@Override
 	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer010<>(topic, deserializationSchema, properties);
+	}
+
+	/**
+	 * Returns a builder to configure and create a {@link Kafka010AvroTableSource}.
+	 * @return A builder to configure and create a {@link Kafka010AvroTableSource}.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * A builder to configure and create a {@link Kafka010AvroTableSource}.
+	 */
+	public static class Builder extends KafkaAvroTableSource.Builder<Kafka010AvroTableSource, Kafka010AvroTableSource.Builder> {
+
+		@Override
+		protected boolean supportsKafkaTimestamps() {
+			return true;
+		}
+
+		@Override
+		protected Kafka010AvroTableSource.Builder builder() {
+			return this;
+		}
+
+		/**
+		 * Builds and configures a {@link Kafka010AvroTableSource}.
+		 *
+		 * @return A configured {@link Kafka010AvroTableSource}.
+		 */
+		@Override
+		public Kafka010AvroTableSource build() {
+			Kafka010AvroTableSource tableSource = new Kafka010AvroTableSource(
+				getTopic(),
+				getKafkaProps(),
+				getTableSchema(),
+				getAvroRecordClass());
+			super.configureTableSource(tableSource);
+			return tableSource;
+		}
 	}
 }
 

--- a/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010JsonTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010JsonTableSource.java
@@ -18,11 +18,15 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -33,21 +37,105 @@ public class Kafka010JsonTableSource extends KafkaJsonTableSource {
 	/**
 	 * Creates a Kafka 0.10 JSON {@link StreamTableSource}.
 	 *
-	 * @param topic      Kafka topic to consume.
-	 * @param properties Properties for the Kafka consumer.
-	 * @param typeInfo   Type information describing the result type. The field names are used
-	 *                   to parse the JSON file and so are the types.
+	 * @param topic       Kafka topic to consume.
+	 * @param properties  Properties for the Kafka consumer.
+	 * @param tableSchema The schema of the table.
+	 * @param jsonSchema  The schema of the JSON messages to decode from Kafka.
 	 */
 	public Kafka010JsonTableSource(
-			String topic,
-			Properties properties,
-			TypeInformation<Row> typeInfo) {
+		String topic,
+		Properties properties,
+		TableSchema tableSchema,
+		TableSchema jsonSchema) {
 
-		super(topic, properties, typeInfo);
+		super(topic, properties, tableSchema, jsonSchema);
+	}
+
+	/**
+	 * Sets the flag that specifies the behavior in case of missing fields.
+	 * TableSource will fail for missing fields if set to true. If set to false, the missing field is set to null.
+	 *
+	 * @param failOnMissingField Flag that specifies the TableSource behavior in case of missing fields.
+	 */
+	@Override
+	public void setFailOnMissingField(boolean failOnMissingField) {
+		super.setFailOnMissingField(failOnMissingField);
+	}
+
+	/**
+	 * Sets the mapping from table schema fields to JSON schema fields.
+	 *
+	 * @param fieldMapping The mapping from table schema fields to JSON schema fields.
+	 */
+	@Override
+	public void setFieldMapping(Map<String, String> fieldMapping) {
+		Preconditions.checkNotNull(fieldMapping, "FieldMapping must not be null.");
+		super.setFieldMapping(fieldMapping);
+	}
+
+	/**
+	 * Declares a field of the schema to be a processing time attribute.
+	 *
+	 * @param proctimeAttribute The name of the field that becomes the processing time field.
+	 */
+	@Override
+	public void setProctimeAttribute(String proctimeAttribute) {
+		Preconditions.checkNotNull(proctimeAttribute, "Processing time attribute must not be null.");
+		super.setProctimeAttribute(proctimeAttribute);
+	}
+
+	/**
+	 * Declares a field of the schema to be a rowtime attribute.
+	 *
+	 * @param rowtimeAttributeDescriptor The descriptor of the rowtime attribute.
+	 */
+	public void setRowtimeAttributeDescriptor(RowtimeAttributeDescriptor rowtimeAttributeDescriptor) {
+		Preconditions.checkNotNull(rowtimeAttributeDescriptor, "Rowtime attribute descriptor must not be null.");
+		super.setRowtimeAttributeDescriptors(Collections.singletonList(rowtimeAttributeDescriptor));
 	}
 
 	@Override
 	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer010<>(topic, deserializationSchema, properties);
+	}
+
+	/**
+	 * Returns a builder to configure and create a {@link Kafka010JsonTableSource}.
+	 * @return A builder to configure and create a {@link Kafka010JsonTableSource}.
+	 */
+	public static Kafka010JsonTableSource.Builder builder() {
+		return new Kafka010JsonTableSource.Builder();
+	}
+
+	/**
+	 * A builder to configure and create a {@link Kafka010JsonTableSource}.
+	 */
+	public static class Builder extends KafkaJsonTableSource.Builder<Kafka010JsonTableSource, Kafka010JsonTableSource.Builder> {
+
+		@Override
+		protected boolean supportsKafkaTimestamps() {
+			return true;
+		}
+
+		@Override
+		protected Kafka010JsonTableSource.Builder builder() {
+			return this;
+		}
+
+		/**
+		 * Builds and configures a {@link Kafka010JsonTableSource}.
+		 *
+		 * @return A configured {@link Kafka010JsonTableSource}.
+		 */
+		@Override
+		public Kafka010JsonTableSource build() {
+			Kafka010JsonTableSource tableSource = new Kafka010JsonTableSource(
+				getTopic(),
+				getKafkaProps(),
+				getTableSchema(),
+				getJsonSchema());
+			super.configureTableSource(tableSource);
+			return tableSource;
+		}
 	}
 }

--- a/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSource.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
 
@@ -28,7 +29,10 @@ import java.util.Properties;
 /**
  * Kafka {@link StreamTableSource} for Kafka 0.10.
  */
-public class Kafka010TableSource extends Kafka09TableSource {
+public abstract class Kafka010TableSource extends KafkaTableSource {
+
+	// The deserialization schema for the Kafka records
+	private final DeserializationSchema<Row> deserializationSchema;
 
 	/**
 	 * Creates a Kafka 0.10 {@link StreamTableSource}.
@@ -43,9 +47,17 @@ public class Kafka010TableSource extends Kafka09TableSource {
 			String topic,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
+			TableSchema schema,
 			TypeInformation<Row> typeInfo) {
 
-		super(topic, properties, deserializationSchema, typeInfo);
+		super(topic, properties, schema, typeInfo);
+
+		this.deserializationSchema = deserializationSchema;
+	}
+
+	@Override
+	public DeserializationSchema<Row> getDeserializationSchema() {
+		return this.deserializationSchema;
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010AvroTableSourceTest.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010AvroTableSourceTest.java
@@ -18,25 +18,18 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.AvroRowDeserializationSchema;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.flink.types.Row;
 
-import java.util.Properties;
-
 /**
  * Tests for the {@link Kafka010AvroTableSource}.
  */
-public class Kafka010AvroTableSourceTest extends KafkaTableSourceTestBase {
+public class Kafka010AvroTableSourceTest extends KafkaAvroTableSourceTestBase {
 
 	@Override
-	protected KafkaTableSource createTableSource(String topic, Properties properties, TypeInformation<Row> typeInfo) {
-
-		return new Kafka010AvroTableSource(
-			topic,
-			properties,
-			AvroSpecificRecord.class);
+	protected KafkaTableSource.Builder getBuilder() {
+		return Kafka010AvroTableSource.builder();
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010JsonTableSourceTest.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010JsonTableSourceTest.java
@@ -18,21 +18,18 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.flink.streaming.util.serialization.JsonRowDeserializationSchema;
 import org.apache.flink.types.Row;
 
-import java.util.Properties;
-
 /**
  * Tests for the {@link Kafka010JsonTableSource}.
  */
-public class Kafka010JsonTableSourceTest extends KafkaTableSourceTestBase {
+public class Kafka010JsonTableSourceTest extends KafkaJsonTableSourceTestBase {
 
 	@Override
-	protected KafkaTableSource createTableSource(String topic, Properties properties, TypeInformation<Row> typeInfo) {
-		return new Kafka010JsonTableSource(topic, properties, typeInfo);
+	protected KafkaTableSource.Builder getBuilder() {
+		return Kafka010JsonTableSource.builder();
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011AvroTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011AvroTableSource.java
@@ -19,12 +19,17 @@
 package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
 
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.avro.specific.SpecificRecordBase;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -37,22 +42,102 @@ public class Kafka011AvroTableSource extends KafkaAvroTableSource {
 	 *
 	 * @param topic      Kafka topic to consume.
 	 * @param properties Properties for the Kafka consumer.
+	 * @param schema     Schema of the produced table.
 	 * @param record     Avro specific record.
 	 */
 	public Kafka011AvroTableSource(
 		String topic,
 		Properties properties,
+		TableSchema schema,
 		Class<? extends SpecificRecordBase> record) {
 
 		super(
 			topic,
 			properties,
+			schema,
 			record);
+	}
+
+	/**
+	 * Sets a mapping from schema fields to fields of the produced Avro record.
+	 *
+	 * <p>A field mapping is required if the fields of produced tables should be named different than
+	 * the fields of the Avro record.
+	 * The key of the provided Map refers to the field of the table schema,
+	 * the value to the field of the Avro record.</p>
+	 *
+	 * @param fieldMapping A mapping from schema fields to Avro fields.
+	 */
+	@Override
+	public void setFieldMapping(Map<String, String> fieldMapping) {
+		Preconditions.checkNotNull(fieldMapping, "FieldMapping must not be null.");
+		super.setFieldMapping(fieldMapping);
+	}
+
+	/**
+	 * Declares a field of the schema to be a processing time attribute.
+	 *
+	 * @param proctimeAttribute The name of the field that becomes the processing time field.
+	 */
+	@Override
+	public void setProctimeAttribute(String proctimeAttribute) {
+		Preconditions.checkNotNull(proctimeAttribute, "Processing time attribute must not be null.");
+		super.setProctimeAttribute(proctimeAttribute);
+	}
+
+	/**
+	 * Declares a field of the schema to be a rowtime attribute.
+	 *
+	 * @param rowtimeAttributeDescriptor The descriptor of the rowtime attribute.
+	 */
+	public void setRowtimeAttributeDescriptor(RowtimeAttributeDescriptor rowtimeAttributeDescriptor) {
+		Preconditions.checkNotNull(rowtimeAttributeDescriptor, "Rowtime attribute descriptor must not be null.");
+		super.setRowtimeAttributeDescriptors(Collections.singletonList(rowtimeAttributeDescriptor));
 	}
 
 	@Override
 	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer011<>(topic, deserializationSchema, properties);
+	}
+
+	/**
+	 * Returns a builder to configure and create a {@link Kafka011AvroTableSource}.
+	 * @return A builder to configure and create a {@link Kafka011AvroTableSource}.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * A builder to configure and create a {@link Kafka011AvroTableSource}.
+	 */
+	public static class Builder extends KafkaAvroTableSource.Builder<Kafka011AvroTableSource, Kafka011AvroTableSource.Builder> {
+
+		@Override
+		protected boolean supportsKafkaTimestamps() {
+			return true;
+		}
+
+		@Override
+		protected Kafka011AvroTableSource.Builder builder() {
+			return this;
+		}
+
+		/**
+		 * Builds and configures a {@link Kafka011AvroTableSource}.
+		 *
+		 * @return A configured {@link Kafka011AvroTableSource}.
+		 */
+		@Override
+		public Kafka011AvroTableSource build() {
+			Kafka011AvroTableSource tableSource = new Kafka011AvroTableSource(
+				getTopic(),
+				getKafkaProps(),
+				getTableSchema(),
+				getAvroRecordClass());
+			super.configureTableSource(tableSource);
+			return tableSource;
+		}
 	}
 }
 

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011JsonTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011JsonTableSource.java
@@ -18,11 +18,15 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -33,21 +37,105 @@ public class Kafka011JsonTableSource extends KafkaJsonTableSource {
 	/**
 	 * Creates a Kafka 0.11 JSON {@link StreamTableSource}.
 	 *
-	 * @param topic      Kafka topic to consume.
-	 * @param properties Properties for the Kafka consumer.
-	 * @param typeInfo   Type information describing the result type. The field names are used
-	 *                   to parse the JSON file and so are the types.
+	 * @param topic       Kafka topic to consume.
+	 * @param properties  Properties for the Kafka consumer.
+	 * @param tableSchema The schema of the table.
+	 * @param jsonSchema  The schema of the JSON messages to decode from Kafka.
 	 */
 	public Kafka011JsonTableSource(
-			String topic,
-			Properties properties,
-			TypeInformation<Row> typeInfo) {
+		String topic,
+		Properties properties,
+		TableSchema tableSchema,
+		TableSchema jsonSchema) {
 
-		super(topic, properties, typeInfo);
+		super(topic, properties, tableSchema, jsonSchema);
+	}
+
+	/**
+	 * Sets the flag that specifies the behavior in case of missing fields.
+	 * TableSource will fail for missing fields if set to true. If set to false, the missing field is set to null.
+	 *
+	 * @param failOnMissingField Flag that specifies the TableSource behavior in case of missing fields.
+	 */
+	@Override
+	public void setFailOnMissingField(boolean failOnMissingField) {
+		super.setFailOnMissingField(failOnMissingField);
+	}
+
+	/**
+	 * Sets the mapping from table schema fields to JSON schema fields.
+	 *
+	 * @param fieldMapping The mapping from table schema fields to JSON schema fields.
+	 */
+	@Override
+	public void setFieldMapping(Map<String, String> fieldMapping) {
+		Preconditions.checkNotNull(fieldMapping, "FieldMapping must not be null.");
+		super.setFieldMapping(fieldMapping);
+	}
+
+	/**
+	 * Declares a field of the schema to be a processing time attribute.
+	 *
+	 * @param proctimeAttribute The name of the field that becomes the processing time field.
+	 */
+	@Override
+	public void setProctimeAttribute(String proctimeAttribute) {
+		Preconditions.checkNotNull(proctimeAttribute, "Processing time attribute must not be null.");
+		super.setProctimeAttribute(proctimeAttribute);
+	}
+
+	/**
+	 * Declares a field of the schema to be a rowtime attribute.
+	 *
+	 * @param rowtimeAttributeDescriptor The descriptor of the rowtime attribute.
+	 */
+	public void setRowtimeAttributeDescriptor(RowtimeAttributeDescriptor rowtimeAttributeDescriptor) {
+		Preconditions.checkNotNull(rowtimeAttributeDescriptor, "Rowtime attribute descriptor must not be null.");
+		super.setRowtimeAttributeDescriptors(Collections.singletonList(rowtimeAttributeDescriptor));
 	}
 
 	@Override
 	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer011<>(topic, deserializationSchema, properties);
+	}
+
+	/**
+	 * Returns a builder to configure and create a {@link Kafka011JsonTableSource}.
+	 * @return A builder to configure and create a {@link Kafka011JsonTableSource}.
+	 */
+	public static Kafka011JsonTableSource.Builder builder() {
+		return new Kafka011JsonTableSource.Builder();
+	}
+
+	/**
+	 * A builder to configure and create a {@link Kafka011JsonTableSource}.
+	 */
+	public static class Builder extends KafkaJsonTableSource.Builder<Kafka011JsonTableSource, Kafka011JsonTableSource.Builder> {
+
+		@Override
+		protected boolean supportsKafkaTimestamps() {
+			return true;
+		}
+
+		@Override
+		protected Kafka011JsonTableSource.Builder builder() {
+			return this;
+		}
+
+		/**
+		 * Builds and configures a {@link Kafka011JsonTableSource}.
+		 *
+		 * @return A configured {@link Kafka011JsonTableSource}.
+		 */
+		@Override
+		public Kafka011JsonTableSource build() {
+			Kafka011JsonTableSource tableSource = new Kafka011JsonTableSource(
+				getTopic(),
+				getKafkaProps(),
+				getTableSchema(),
+				getJsonSchema());
+			super.configureTableSource(tableSource);
+			return tableSource;
+		}
 	}
 }

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSource.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
 
@@ -28,7 +29,10 @@ import java.util.Properties;
 /**
  * Kafka {@link StreamTableSource} for Kafka 0.11.
  */
-public class Kafka011TableSource extends Kafka09TableSource {
+public abstract class Kafka011TableSource extends KafkaTableSource {
+
+	// The deserialization schema for the Kafka records
+	private final DeserializationSchema<Row> deserializationSchema;
 
 	/**
 	 * Creates a Kafka 0.11 {@link StreamTableSource}.
@@ -43,13 +47,22 @@ public class Kafka011TableSource extends Kafka09TableSource {
 			String topic,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
+			TableSchema schema,
 			TypeInformation<Row> typeInfo) {
 
-		super(topic, properties, deserializationSchema, typeInfo);
+		super(topic, properties, schema, typeInfo);
+
+		this.deserializationSchema = deserializationSchema;
+	}
+
+	@Override
+	public DeserializationSchema<Row> getDeserializationSchema() {
+		return this.deserializationSchema;
 	}
 
 	@Override
 	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer011<>(topic, deserializationSchema, properties);
 	}
+
 }

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka011AvroTableSourceTest.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka011AvroTableSourceTest.java
@@ -18,25 +18,18 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.AvroRowDeserializationSchema;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.flink.types.Row;
 
-import java.util.Properties;
-
 /**
  * Tests for the {@link Kafka011AvroTableSource}.
  */
-public class Kafka011AvroTableSourceTest extends KafkaTableSourceTestBase {
+public class Kafka011AvroTableSourceTest extends KafkaAvroTableSourceTestBase {
 
 	@Override
-	protected KafkaTableSource createTableSource(String topic, Properties properties, TypeInformation<Row> typeInfo) {
-
-		return new Kafka011AvroTableSource(
-			topic,
-			properties,
-			AvroSpecificRecord.class);
+	protected KafkaTableSource.Builder getBuilder() {
+		return Kafka011AvroTableSource.builder();
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka011JsonTableSourceTest.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka011JsonTableSourceTest.java
@@ -18,21 +18,18 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.flink.streaming.util.serialization.JsonRowDeserializationSchema;
 import org.apache.flink.types.Row;
 
-import java.util.Properties;
-
 /**
  * Tests for the {@link Kafka011JsonTableSource}.
  */
-public class Kafka011JsonTableSourceTest extends KafkaTableSourceTestBase {
+public class Kafka011JsonTableSourceTest extends KafkaJsonTableSourceTestBase {
 
 	@Override
-	protected KafkaTableSource createTableSource(String topic, Properties properties, TypeInformation<Row> typeInfo) {
-		return new Kafka011JsonTableSource(topic, properties, typeInfo);
+	protected KafkaTableSource.Builder getBuilder() {
+		return Kafka011JsonTableSource.builder();
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08AvroTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08AvroTableSource.java
@@ -19,12 +19,17 @@
 package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
 
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.avro.specific.SpecificRecordBase;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -37,22 +42,102 @@ public class Kafka08AvroTableSource extends KafkaAvroTableSource {
 	 *
 	 * @param topic      Kafka topic to consume.
 	 * @param properties Properties for the Kafka consumer.
+	 * @param schema     Schema of the produced table.
 	 * @param record     Avro specific record.
 	 */
 	public Kafka08AvroTableSource(
 		String topic,
 		Properties properties,
+		TableSchema schema,
 		Class<? extends SpecificRecordBase> record) {
 
 		super(
 			topic,
 			properties,
+			schema,
 			record);
+	}
+
+	/**
+	 * Sets a mapping from schema fields to fields of the produced Avro record.
+	 *
+	 * <p>A field mapping is required if the fields of produced tables should be named different than
+	 * the fields of the Avro record.
+	 * The key of the provided Map refers to the field of the table schema,
+	 * the value to the field of the Avro record.</p>
+	 *
+	 * @param fieldMapping A mapping from schema fields to Avro fields.
+	 */
+	@Override
+	public void setFieldMapping(Map<String, String> fieldMapping) {
+		Preconditions.checkNotNull(fieldMapping, "FieldMapping must not be null.");
+		super.setFieldMapping(fieldMapping);
+	}
+
+	/**
+	 * Declares a field of the schema to be a processing time attribute.
+	 *
+	 * @param proctimeAttribute The name of the field that becomes the processing time field.
+	 */
+	@Override
+	public void setProctimeAttribute(String proctimeAttribute) {
+		Preconditions.checkNotNull(proctimeAttribute, "Processing time attribute must not be null.");
+		super.setProctimeAttribute(proctimeAttribute);
+	}
+
+	/**
+	 * Declares a field of the schema to be a rowtime attribute.
+	 *
+	 * @param rowtimeAttributeDescriptor The descriptor of the rowtime attribute.
+	 */
+	public void setRowtimeAttributeDescriptor(RowtimeAttributeDescriptor rowtimeAttributeDescriptor) {
+		Preconditions.checkNotNull(rowtimeAttributeDescriptor, "Rowtime attribute descriptor must not be null.");
+		super.setRowtimeAttributeDescriptors(Collections.singletonList(rowtimeAttributeDescriptor));
 	}
 
 	@Override
 	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer08<>(topic, deserializationSchema, properties);
+	}
+
+	/**
+	 * Returns a builder to configure and create a {@link Kafka08AvroTableSource}.
+	 * @return A builder to configure and create a {@link Kafka08AvroTableSource}.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * A builder to configure and create a {@link Kafka08AvroTableSource}.
+	 */
+	public static class Builder extends KafkaAvroTableSource.Builder<Kafka08AvroTableSource, Kafka08AvroTableSource.Builder> {
+
+		@Override
+		protected boolean supportsKafkaTimestamps() {
+			return false;
+		}
+
+		@Override
+		protected Kafka08AvroTableSource.Builder builder() {
+			return this;
+		}
+
+		/**
+		 * Builds and configures a {@link Kafka08AvroTableSource}.
+		 *
+		 * @return A configured {@link Kafka08AvroTableSource}.
+		 */
+		@Override
+		public Kafka08AvroTableSource build() {
+			Kafka08AvroTableSource tableSource = new Kafka08AvroTableSource(
+				getTopic(),
+				getKafkaProps(),
+				getTableSchema(),
+				getAvroRecordClass());
+			super.configureTableSource(tableSource);
+			return tableSource;
+		}
 	}
 }
 

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08JsonTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08JsonTableSource.java
@@ -18,11 +18,15 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -33,21 +37,105 @@ public class Kafka08JsonTableSource extends KafkaJsonTableSource {
 	/**
 	 * Creates a Kafka 0.8 JSON {@link StreamTableSource}.
 	 *
-	 * @param topic      Kafka topic to consume.
-	 * @param properties Properties for the Kafka consumer.
-	 * @param typeInfo   Type information describing the result type. The field names are used
-	 *                   to parse the JSON file and so are the types.
+	 * @param topic       Kafka topic to consume.
+	 * @param properties  Properties for the Kafka consumer.
+	 * @param tableSchema The schema of the table.
+	 * @param jsonSchema  The schema of the JSON messages to decode from Kafka.
 	 */
 	public Kafka08JsonTableSource(
-			String topic,
-			Properties properties,
-			TypeInformation<Row> typeInfo) {
+		String topic,
+		Properties properties,
+		TableSchema tableSchema,
+		TableSchema jsonSchema) {
 
-		super(topic, properties, typeInfo);
+		super(topic, properties, tableSchema, jsonSchema);
+	}
+
+	/**
+	 * Sets the flag that specifies the behavior in case of missing fields.
+	 * TableSource will fail for missing fields if set to true. If set to false, the missing field is set to null.
+	 *
+	 * @param failOnMissingField Flag that specifies the TableSource behavior in case of missing fields.
+	 */
+	@Override
+	public void setFailOnMissingField(boolean failOnMissingField) {
+		super.setFailOnMissingField(failOnMissingField);
+	}
+
+	/**
+	 * Sets the mapping from table schema fields to JSON schema fields.
+	 *
+	 * @param fieldMapping The mapping from table schema fields to JSON schema fields.
+	 */
+	@Override
+	public void setFieldMapping(Map<String, String> fieldMapping) {
+		Preconditions.checkNotNull(fieldMapping, "FieldMapping must not be null.");
+		super.setFieldMapping(fieldMapping);
+	}
+
+	/**
+	 * Declares a field of the schema to be a processing time attribute.
+	 *
+	 * @param proctimeAttribute The name of the field that becomes the processing time field.
+	 */
+	@Override
+	public void setProctimeAttribute(String proctimeAttribute) {
+		Preconditions.checkNotNull(proctimeAttribute, "Processing time attribute must not be null.");
+		super.setProctimeAttribute(proctimeAttribute);
+	}
+
+	/**
+	 * Declares a field of the schema to be a rowtime attribute.
+	 *
+	 * @param rowtimeAttributeDescriptor The descriptor of the rowtime attribute.
+	 */
+	public void setRowtimeAttributeDescriptor(RowtimeAttributeDescriptor rowtimeAttributeDescriptor) {
+		Preconditions.checkNotNull(rowtimeAttributeDescriptor, "Rowtime attribute descriptor must not be null.");
+		super.setRowtimeAttributeDescriptors(Collections.singletonList(rowtimeAttributeDescriptor));
 	}
 
 	@Override
 	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer08<>(topic, deserializationSchema, properties);
+	}
+
+	/**
+	 * Returns a builder to configure and create a {@link Kafka08JsonTableSource}.
+	 * @return A builder to configure and create a {@link Kafka08JsonTableSource}.
+	 */
+	public static Kafka08JsonTableSource.Builder builder() {
+		return new Kafka08JsonTableSource.Builder();
+	}
+
+	/**
+	 * A builder to configure and create a {@link Kafka08JsonTableSource}.
+	 */
+	public static class Builder extends KafkaJsonTableSource.Builder<Kafka08JsonTableSource, Kafka08JsonTableSource.Builder> {
+
+		@Override
+		protected boolean supportsKafkaTimestamps() {
+			return false;
+		}
+
+		@Override
+		protected Kafka08JsonTableSource.Builder builder() {
+			return this;
+		}
+
+		/**
+		 * Builds and configures a {@link Kafka08JsonTableSource}.
+		 *
+		 * @return A configured {@link Kafka08JsonTableSource}.
+		 */
+		@Override
+		public Kafka08JsonTableSource build() {
+			Kafka08JsonTableSource tableSource = new Kafka08JsonTableSource(
+				getTopic(),
+				getKafkaProps(),
+				getTableSchema(),
+				getJsonSchema());
+			super.configureTableSource(tableSource);
+			return tableSource;
+		}
 	}
 }

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08TableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08TableSource.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
 
@@ -28,7 +29,10 @@ import java.util.Properties;
 /**
  * Kafka {@link StreamTableSource} for Kafka 0.8.
  */
-public class Kafka08TableSource extends KafkaTableSource {
+public abstract class Kafka08TableSource extends KafkaTableSource {
+
+	// The deserialization schema for the Kafka records
+	private final DeserializationSchema<Row> deserializationSchema;
 
 	/**
 	 * Creates a Kafka 0.8 {@link StreamTableSource}.
@@ -43,9 +47,17 @@ public class Kafka08TableSource extends KafkaTableSource {
 			String topic,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
+			TableSchema schema,
 			TypeInformation<Row> typeInfo) {
 
-		super(topic, properties, deserializationSchema, typeInfo);
+		super(topic, properties, schema, typeInfo);
+
+		this.deserializationSchema = deserializationSchema;
+	}
+
+	@Override
+	public DeserializationSchema<Row> getDeserializationSchema() {
+		return this.deserializationSchema;
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08AvroTableSourceTest.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08AvroTableSourceTest.java
@@ -18,24 +18,18 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.AvroRowDeserializationSchema;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.flink.types.Row;
 
-import java.util.Properties;
-
 /**
  * Tests for the {@link Kafka08AvroTableSource}.
  */
-public class Kafka08AvroTableSourceTest extends KafkaTableSourceTestBase {
+public class Kafka08AvroTableSourceTest extends KafkaAvroTableSourceTestBase {
 
 	@Override
-	protected KafkaTableSource createTableSource(String topic, Properties properties, TypeInformation<Row> typeInfo) {
-		return new Kafka08AvroTableSource(
-			topic,
-			properties,
-			AvroSpecificRecord.class);
+	protected KafkaTableSource.Builder getBuilder() {
+		return Kafka08AvroTableSource.builder();
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08JsonTableSourceTest.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka08JsonTableSourceTest.java
@@ -18,21 +18,18 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.flink.streaming.util.serialization.JsonRowDeserializationSchema;
 import org.apache.flink.types.Row;
 
-import java.util.Properties;
-
 /**
  * Tests for the {@link Kafka08JsonTableSource}.
  */
-public class Kafka08JsonTableSourceTest extends KafkaTableSourceTestBase {
+public class Kafka08JsonTableSourceTest extends KafkaJsonTableSourceTestBase {
 
 	@Override
-	protected KafkaTableSource createTableSource(String topic, Properties properties, TypeInformation<Row> typeInfo) {
-		return new Kafka08JsonTableSource(topic, properties, typeInfo);
+	protected KafkaTableSource.Builder getBuilder() {
+		return Kafka08JsonTableSource.builder();
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09AvroTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09AvroTableSource.java
@@ -19,12 +19,17 @@
 package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
 
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.avro.specific.SpecificRecordBase;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -37,22 +42,102 @@ public class Kafka09AvroTableSource extends KafkaAvroTableSource {
 	 *
 	 * @param topic      Kafka topic to consume.
 	 * @param properties Properties for the Kafka consumer.
+	 * @param schema	 Schema of the produced table.
 	 * @param record     Avro specific record.
 	 */
 	public Kafka09AvroTableSource(
 		String topic,
 		Properties properties,
+		TableSchema schema,
 		Class<? extends SpecificRecordBase> record) {
 
 		super(
 			topic,
 			properties,
+			schema,
 			record);
+	}
+
+	/**
+	 * Sets a mapping from schema fields to fields of the produced Avro record.
+	 *
+	 * <p>A field mapping is required if the fields of produced tables should be named different than
+	 * the fields of the Avro record.
+	 * The key of the provided Map refers to the field of the table schema,
+	 * the value to the field of the Avro record.</p>
+	 *
+	 * @param fieldMapping A mapping from schema fields to Avro fields.
+	 */
+	@Override
+	public void setFieldMapping(Map<String, String> fieldMapping) {
+		Preconditions.checkNotNull(fieldMapping, "FieldMapping must not be null.");
+		super.setFieldMapping(fieldMapping);
+	}
+
+	/**
+	 * Declares a field of the schema to be a processing time attribute.
+	 *
+	 * @param proctimeAttribute The name of the field that becomes the processing time field.
+	 */
+	@Override
+	public void setProctimeAttribute(String proctimeAttribute) {
+		Preconditions.checkNotNull(proctimeAttribute, "Processing time attribute must not be null.");
+		super.setProctimeAttribute(proctimeAttribute);
+	}
+
+	/**
+	 * Declares a field of the schema to be a rowtime attribute.
+	 *
+	 * @param rowtimeAttributeDescriptor The descriptor of the rowtime attribute.
+	 */
+	public void setRowtimeAttributeDescriptor(RowtimeAttributeDescriptor rowtimeAttributeDescriptor) {
+		Preconditions.checkNotNull(rowtimeAttributeDescriptor, "Rowtime attribute descriptor must not be null.");
+		super.setRowtimeAttributeDescriptors(Collections.singletonList(rowtimeAttributeDescriptor));
 	}
 
 	@Override
 	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer09<>(topic, deserializationSchema, properties);
+	}
+
+	/**
+	 * Returns a builder to configure and create a {@link Kafka09AvroTableSource}.
+	 * @return A builder to configure and create a {@link Kafka09AvroTableSource}.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * A builder to configure and create a {@link Kafka09AvroTableSource}.
+	 */
+	public static class Builder extends KafkaAvroTableSource.Builder<Kafka09AvroTableSource, Kafka09AvroTableSource.Builder> {
+
+		@Override
+		protected boolean supportsKafkaTimestamps() {
+			return false;
+		}
+
+		@Override
+		protected Kafka09AvroTableSource.Builder builder() {
+			return this;
+		}
+
+		/**
+		 * Builds and configures a {@link Kafka09AvroTableSource}.
+		 *
+		 * @return A configured {@link Kafka09AvroTableSource}.
+		 */
+		@Override
+		public Kafka09AvroTableSource build() {
+			Kafka09AvroTableSource tableSource = new Kafka09AvroTableSource(
+				getTopic(),
+				getKafkaProps(),
+				getTableSchema(),
+				getAvroRecordClass());
+			super.configureTableSource(tableSource);
+			return tableSource;
+		}
 	}
 }
 

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09JsonTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09JsonTableSource.java
@@ -18,11 +18,15 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -33,21 +37,105 @@ public class Kafka09JsonTableSource extends KafkaJsonTableSource {
 	/**
 	 * Creates a Kafka 0.9 JSON {@link StreamTableSource}.
 	 *
-	 * @param topic      Kafka topic to consume.
-	 * @param properties Properties for the Kafka consumer.
-	 * @param typeInfo   Type information describing the result type. The field names are used
-	 *                   to parse the JSON file and so are the types.
+	 * @param topic       Kafka topic to consume.
+	 * @param properties  Properties for the Kafka consumer.
+	 * @param tableSchema The schema of the table.
+	 * @param jsonSchema  The schema of the JSON messages to decode from Kafka.
 	 */
 	public Kafka09JsonTableSource(
-			String topic,
-			Properties properties,
-			TypeInformation<Row> typeInfo) {
+		String topic,
+		Properties properties,
+		TableSchema tableSchema,
+		TableSchema jsonSchema) {
 
-		super(topic, properties, typeInfo);
+		super(topic, properties, tableSchema, jsonSchema);
+	}
+
+	/**
+	 * Sets the flag that specifies the behavior in case of missing fields.
+	 * TableSource will fail for missing fields if set to true. If set to false, the missing field is set to null.
+	 *
+	 * @param failOnMissingField Flag that specifies the TableSource behavior in case of missing fields.
+	 */
+	@Override
+	public void setFailOnMissingField(boolean failOnMissingField) {
+		super.setFailOnMissingField(failOnMissingField);
+	}
+
+	/**
+	 * Sets the mapping from table schema fields to JSON schema fields.
+	 *
+	 * @param fieldMapping The mapping from table schema fields to JSON schema fields.
+	 */
+	@Override
+	public void setFieldMapping(Map<String, String> fieldMapping) {
+		Preconditions.checkNotNull(fieldMapping, "FieldMapping must not be null.");
+		super.setFieldMapping(fieldMapping);
+	}
+
+	/**
+	 * Declares a field of the schema to be a processing time attribute.
+	 *
+	 * @param proctimeAttribute The name of the field that becomes the processing time field.
+	 */
+	@Override
+	public void setProctimeAttribute(String proctimeAttribute) {
+		Preconditions.checkNotNull(proctimeAttribute, "Processing time attribute must not be null.");
+		super.setProctimeAttribute(proctimeAttribute);
+	}
+
+	/**
+	 * Declares a field of the schema to be a rowtime attribute.
+	 *
+	 * @param rowtimeAttributeDescriptor The descriptor of the rowtime attribute.
+	 */
+	public void setRowtimeAttributeDescriptor(RowtimeAttributeDescriptor rowtimeAttributeDescriptor) {
+		Preconditions.checkNotNull(rowtimeAttributeDescriptor, "Rowtime attribute descriptor must not be null.");
+		super.setRowtimeAttributeDescriptors(Collections.singletonList(rowtimeAttributeDescriptor));
 	}
 
 	@Override
 	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer09<>(topic, deserializationSchema, properties);
+	}
+
+	/**
+	 * Returns a builder to configure and create a {@link Kafka09JsonTableSource}.
+	 * @return A builder to configure and create a {@link Kafka09JsonTableSource}.
+	 */
+	public static Kafka09JsonTableSource.Builder builder() {
+		return new Kafka09JsonTableSource.Builder();
+	}
+
+	/**
+	 * A builder to configure and create a {@link Kafka09JsonTableSource}.
+	 */
+	public static class Builder extends KafkaJsonTableSource.Builder<Kafka09JsonTableSource, Kafka09JsonTableSource.Builder> {
+
+		@Override
+		protected boolean supportsKafkaTimestamps() {
+			return false;
+		}
+
+		@Override
+		protected Kafka09JsonTableSource.Builder builder() {
+			return this;
+		}
+
+		/**
+		 * Builds and configures a {@link Kafka09JsonTableSource}.
+		 *
+		 * @return A configured {@link Kafka09JsonTableSource}.
+		 */
+		@Override
+		public Kafka09JsonTableSource build() {
+			Kafka09JsonTableSource tableSource = new Kafka09JsonTableSource(
+				getTopic(),
+				getKafkaProps(),
+				getTableSchema(),
+				getJsonSchema());
+			super.configureTableSource(tableSource);
+			return tableSource;
+		}
 	}
 }

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09TableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09TableSource.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.types.Row;
 
@@ -28,7 +29,10 @@ import java.util.Properties;
 /**
  * Kafka {@link StreamTableSource} for Kafka 0.9.
  */
-public class Kafka09TableSource extends KafkaTableSource {
+public abstract class Kafka09TableSource extends KafkaTableSource {
+
+	// The deserialization schema for the Kafka records
+	private final DeserializationSchema<Row> deserializationSchema;
 
 	/**
 	 * Creates a Kafka 0.9 {@link StreamTableSource}.
@@ -43,9 +47,17 @@ public class Kafka09TableSource extends KafkaTableSource {
 			String topic,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema,
+			TableSchema schema,
 			TypeInformation<Row> typeInfo) {
 
-		super(topic, properties, deserializationSchema, typeInfo);
+		super(topic, properties, schema, typeInfo);
+
+		this.deserializationSchema = deserializationSchema;
+	}
+
+	@Override
+	public DeserializationSchema<Row> getDeserializationSchema() {
+		return this.deserializationSchema;
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09AvroTableSourceTest.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09AvroTableSourceTest.java
@@ -18,25 +18,18 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.AvroRowDeserializationSchema;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.flink.types.Row;
 
-import java.util.Properties;
-
 /**
  * Tests for the {@link Kafka09AvroTableSource}.
  */
-public class Kafka09AvroTableSourceTest extends KafkaTableSourceTestBase {
+public class Kafka09AvroTableSourceTest extends KafkaAvroTableSourceTestBase {
 
 	@Override
-	protected KafkaTableSource createTableSource(String topic, Properties properties, TypeInformation<Row> typeInfo) {
-
-		return new Kafka09AvroTableSource(
-			topic,
-			properties,
-			AvroSpecificRecord.class);
+	protected KafkaTableSource.Builder getBuilder() {
+		return Kafka09AvroTableSource.builder();
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09JsonTableSourceTest.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09JsonTableSourceTest.java
@@ -18,21 +18,18 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.flink.streaming.util.serialization.JsonRowDeserializationSchema;
 import org.apache.flink.types.Row;
 
-import java.util.Properties;
-
 /**
  * Tests for the {@link Kafka09JsonTableSource}.
  */
-public class Kafka09JsonTableSourceTest extends KafkaTableSourceTestBase {
+public class Kafka09JsonTableSourceTest extends KafkaJsonTableSourceTestBase {
 
 	@Override
-	protected KafkaTableSource createTableSource(String topic, Properties properties, TypeInformation<Row> typeInfo) {
-		return new Kafka09JsonTableSource(topic, properties, typeInfo);
+	protected KafkaTableSource.Builder getBuilder() {
+		return Kafka09JsonTableSource.builder();
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSource.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSource.java
@@ -23,11 +23,23 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.util.serialization.DeserializationSchema;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.Types;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.sources.DefinedProctimeAttribute;
+import org.apache.flink.table.sources.DefinedRowtimeAttributes;
+import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
+import org.apache.flink.table.sources.tsextractors.StreamRecordTimestamp;
+import org.apache.flink.table.sources.tsextractors.TimestampExtractor;
+import org.apache.flink.table.sources.wmstrategies.WatermarkStrategy;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
+
+import scala.Option;
 
 /**
  * A version-agnostic Kafka {@link StreamTableSource}.
@@ -35,7 +47,11 @@ import java.util.Properties;
  * <p>The version-specific Kafka consumers need to extend this class and
  * override {@link #getKafkaConsumer(String, Properties, DeserializationSchema)}}.
  */
-public abstract class KafkaTableSource implements StreamTableSource<Row> {
+public abstract class KafkaTableSource
+	implements StreamTableSource<Row>, DefinedProctimeAttribute, DefinedRowtimeAttributes {
+
+	/** The schema of the table. */
+	private final TableSchema schema;
 
 	/** The Kafka topic to consume. */
 	private final String topic;
@@ -43,30 +59,33 @@ public abstract class KafkaTableSource implements StreamTableSource<Row> {
 	/** Properties for the Kafka consumer. */
 	private final Properties properties;
 
-	/** Deserialization schema to use for Kafka records. */
-	private final DeserializationSchema<Row> deserializationSchema;
-
 	/** Type information describing the result type. */
-	private final TypeInformation<Row> typeInfo;
+	private TypeInformation<Row> returnType;
+
+	/** Field name of the processing time attribute, null if no processing time field is defined. */
+	private String proctimeAttribute;
+
+	/** Descriptor for a rowtime attribute. */
+	private List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors;
 
 	/**
 	 * Creates a generic Kafka {@link StreamTableSource}.
 	 *
 	 * @param topic                 Kafka topic to consume.
 	 * @param properties            Properties for the Kafka consumer.
-	 * @param deserializationSchema Deserialization schema to use for Kafka records.
-	 * @param typeInfo              Type information describing the result type.
+	 * @param schema                Schema of the produced table.
+	 * @param returnType            Type information of the produced physical DataStream.
 	 */
-	KafkaTableSource(
+	protected KafkaTableSource(
 			String topic,
 			Properties properties,
-			DeserializationSchema<Row> deserializationSchema,
-			TypeInformation<Row> typeInfo) {
+			TableSchema schema,
+			TypeInformation<Row> returnType) {
 
-		this.topic = Preconditions.checkNotNull(topic, "Topic");
-		this.properties = Preconditions.checkNotNull(properties, "Properties");
-		this.deserializationSchema = Preconditions.checkNotNull(deserializationSchema, "Deserialization schema");
-		this.typeInfo = Preconditions.checkNotNull(typeInfo, "Type information");
+		this.topic = Preconditions.checkNotNull(topic, "Topic must not be null.");
+		this.properties = Preconditions.checkNotNull(properties, "Properties must not be null.");
+		this.schema = Preconditions.checkNotNull(schema, "Schema must not be null.");
+		this.returnType = Preconditions.checkNotNull(returnType, "Type information must not be null.");
 	}
 
 	/**
@@ -75,6 +94,8 @@ public abstract class KafkaTableSource implements StreamTableSource<Row> {
 	 */
 	@Override
 	public DataStream<Row> getDataStream(StreamExecutionEnvironment env) {
+
+		DeserializationSchema<Row> deserializationSchema = getDeserializationSchema();
 		// Version-specific Kafka consumer
 		FlinkKafkaConsumerBase<Row> kafkaConsumer = getKafkaConsumer(topic, properties, deserializationSchema);
 		return env.addSource(kafkaConsumer);
@@ -82,13 +103,64 @@ public abstract class KafkaTableSource implements StreamTableSource<Row> {
 
 	@Override
 	public TypeInformation<Row> getReturnType() {
-		return typeInfo;
+		return returnType;
 	}
 
 	@Override
 	public TableSchema getTableSchema() {
-		return TableSchema.fromTypeInfo(typeInfo);
+		return schema;
 	}
+
+	@Override
+	public String getProctimeAttribute() {
+		return proctimeAttribute;
+	}
+
+	@Override
+	public List<RowtimeAttributeDescriptor> getRowtimeAttributeDescriptors() {
+		return rowtimeAttributeDescriptors;
+	}
+
+	//////// SETTERS FOR OPTIONAL PARAMETERS
+
+	/**
+	 * Declares a field of the schema to be the processing time attribute.
+	 *
+	 * @param proctimeAttribute The name of the field that becomes the processing time field.
+	 */
+	protected void setProctimeAttribute(String proctimeAttribute) {
+		if (proctimeAttribute != null) {
+			// validate that field exists and is of correct type
+			Option<TypeInformation<?>> tpe = schema.getType(proctimeAttribute);
+			if (tpe.isEmpty()) {
+				throw new ValidationException("Processing time attribute " + proctimeAttribute + " is not present in TableSchema.");
+			} else if (tpe.get() != Types.SQL_TIMESTAMP()) {
+				throw new ValidationException("Processing time attribute " + proctimeAttribute + " is not of type SQL_TIMESTAMP.");
+			}
+		}
+		this.proctimeAttribute = proctimeAttribute;
+	}
+
+	/**
+	 * Declares a list of fields to be rowtime attributes.
+	 *
+	 * @param rowtimeAttributeDescriptors The descriptors of the rowtime attributes.
+	 */
+	protected void setRowtimeAttributeDescriptors(List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors) {
+		// validate that all declared fields exist and are of correct type
+		for (RowtimeAttributeDescriptor desc : rowtimeAttributeDescriptors) {
+			String rowtimeAttribute = desc.getAttributeName();
+			Option<TypeInformation<?>> tpe = schema.getType(rowtimeAttribute);
+			if (tpe.isEmpty()) {
+				throw new ValidationException("Rowtime attribute " + rowtimeAttribute + " is not present in TableSchema.");
+			} else if (tpe.get() != Types.SQL_TIMESTAMP()) {
+				throw new ValidationException("Rowtime attribute " + rowtimeAttribute + " is not of type SQL_TIMESTAMP.");
+			}
+		}
+		this.rowtimeAttributeDescriptors = rowtimeAttributeDescriptors;
+	}
+
+	//////// ABSTRACT METHODS FOR SUBCLASSES
 
 	/**
 	 * Returns the version-specific Kafka consumer.
@@ -108,12 +180,195 @@ public abstract class KafkaTableSource implements StreamTableSource<Row> {
 	 *
 	 * @return The deserialization schema
 	 */
-	protected DeserializationSchema<Row> getDeserializationSchema() {
-		return deserializationSchema;
-	}
+	protected abstract DeserializationSchema<Row> getDeserializationSchema();
 
-	@Override
-	public String explainSource() {
-		return "";
+	/**
+	 * Abstract builder for a {@link KafkaTableSource} to be extended by builders of subclasses of
+	 * KafkaTableSource.
+	 *
+	 * @param <T> Type of the KafkaTableSource produced by the builder.
+	 * @param <B> Type of the KafkaTableSource.Builder subclass.
+	 */
+	protected abstract static class Builder<T extends KafkaTableSource, B extends KafkaTableSource.Builder> {
+
+		private String topic;
+
+		private Properties kafkaProps;
+
+		private TableSchema schema;
+
+		private String proctimeAttribute;
+
+		private RowtimeAttributeDescriptor rowtimeAttributeDescriptor;
+
+		/**
+		 * Sets the topic from which the table is read.
+		 *
+		 * @param topic The topic from which the table is read.
+		 * @return The builder.
+		 */
+		public B forTopic(String topic) {
+			Preconditions.checkNotNull(topic, "Topic must not be null.");
+			Preconditions.checkArgument(this.topic == null, "Topic has already been set.");
+			this.topic = topic;
+			return builder();
+		}
+
+		/**
+		 * Sets the configuration properties for the Kafka consumer.
+		 *
+		 * @param props The configuration properties for the Kafka consumer.
+		 * @return The builder.
+		 */
+		public B withKafkaProperties(Properties props) {
+			Preconditions.checkNotNull(props, "Properties must not be null.");
+			Preconditions.checkArgument(this.kafkaProps == null, "Properties have already been set.");
+			this.kafkaProps = props;
+			return builder();
+		}
+
+		/**
+		 * Sets the schema of the produced table.
+		 *
+		 * @param schema The schema of the produced table.
+		 * @return The builder.
+		 */
+		public B withSchema(TableSchema schema) {
+			Preconditions.checkNotNull(schema, "Schema must not be null.");
+			Preconditions.checkArgument(this.schema == null, "Schema has already been set.");
+			this.schema = schema;
+			return builder();
+		}
+
+		/**
+		 * Configures a field of the table to be a processing time attribute.
+		 * The configured field must be present in the tabel schema and of type {@link Types#SQL_TIMESTAMP()}.
+		 *
+		 * @param proctimeAttribute The name of the processing time attribute in the table schema.
+		 * @return The builder.
+		 */
+		public B withProctimeAttribute(String proctimeAttribute) {
+			Preconditions.checkNotNull(proctimeAttribute, "Proctime attribute must not be null.");
+			Preconditions.checkArgument(!proctimeAttribute.isEmpty(), "Proctime attribute must not be empty.");
+			Preconditions.checkArgument(this.proctimeAttribute == null, "Proctime attribute has already been set.");
+			this.proctimeAttribute = proctimeAttribute;
+			return builder();
+		}
+
+		/**
+		 * Configures a field of the table to be a rowtime attribute.
+		 * The configured field must be present in the tabel schema and of type {@link Types#SQL_TIMESTAMP()}.
+		 *
+		 * @param rowtimeAttribute The name of the rowtime attribute in the table schema.
+		 * @param timestampExtractor The {@link TimestampExtractor} to extract the rowtime attribute from the physical type.
+		 * @param watermarkStrategy The {@link WatermarkStrategy} to generate watermarks for the rowtime attribute.
+		 * @return The builder.
+		 */
+		public B withRowtimeAttribute(
+				String rowtimeAttribute,
+				TimestampExtractor timestampExtractor,
+				WatermarkStrategy watermarkStrategy) {
+			Preconditions.checkNotNull(rowtimeAttribute, "Rowtime attribute must not be null.");
+			Preconditions.checkArgument(!rowtimeAttribute.isEmpty(), "Rowtime attribute must not be empty.");
+			Preconditions.checkNotNull(timestampExtractor, "Timestamp extractor must not be null.");
+			Preconditions.checkNotNull(watermarkStrategy, "Watermark assigner must not be null.");
+			Preconditions.checkArgument(this.rowtimeAttributeDescriptor == null,
+				"Currently, only one rowtime attribute is supported.");
+
+			this.rowtimeAttributeDescriptor = new RowtimeAttributeDescriptor(
+				rowtimeAttribute,
+				timestampExtractor,
+				watermarkStrategy);
+			return builder();
+		}
+
+		/**
+		 * Configures the Kafka timestamp to be a rowtime attribute.
+		 *
+		 * <p>Note: Kafka supports message timestamps only since version 0.10.</p>
+		 *
+		 * @param rowtimeAttribute The name of the rowtime attribute in the table schema.
+		 * @param watermarkStrategy The {@link WatermarkStrategy} to generate watermarks for the rowtime attribute.
+		 * @return The builder.
+		 */
+		public B withKafkaTimestampAsRowtimeAttribute(
+				String rowtimeAttribute,
+				WatermarkStrategy watermarkStrategy) {
+
+			Preconditions.checkNotNull(rowtimeAttribute, "Rowtime attribute must not be null.");
+			Preconditions.checkArgument(!rowtimeAttribute.isEmpty(), "Rowtime attribute must not be empty.");
+			Preconditions.checkNotNull(watermarkStrategy, "Watermark assigner must not be null.");
+			Preconditions.checkArgument(this.rowtimeAttributeDescriptor == null,
+				"Currently, only one rowtime attribute is supported.");
+			Preconditions.checkArgument(supportsKafkaTimestamps(), "Kafka timestamps are only supported since Kafka 0.10.");
+
+			this.rowtimeAttributeDescriptor = new RowtimeAttributeDescriptor(
+				rowtimeAttribute,
+				new StreamRecordTimestamp(),
+				watermarkStrategy);
+			return builder();
+		}
+
+		/**
+		 * Returns the configured topic.
+		 *
+		 * @return the configured topic.
+		 */
+		protected String getTopic() {
+			return this.topic;
+		}
+
+		/**
+		 * Returns the configured Kafka properties.
+		 *
+		 * @return the configured Kafka properties.
+		 */
+		protected Properties getKafkaProps() {
+			return this.kafkaProps;
+		}
+
+		/**
+		 * Returns the configured table schema.
+		 *
+		 * @return the configured table schema.
+		 */
+		protected TableSchema getTableSchema() {
+			return this.schema;
+		}
+
+		/**
+		 * True if the KafkaSource supports Kafka timestamps, false otherwise.
+		 *
+		 * @return True if the KafkaSource supports Kafka timestamps, false otherwise.
+		 */
+		protected abstract boolean supportsKafkaTimestamps();
+
+		/**
+		 * Configures a TableSource with optional parameters.
+		 *
+		 * @param tableSource The TableSource to configure.
+		 */
+		protected void configureTableSource(T tableSource) {
+			// configure processing time attributes
+			tableSource.setProctimeAttribute(proctimeAttribute);
+			// configure rowtime attributes
+			if (rowtimeAttributeDescriptor == null) {
+				tableSource.setRowtimeAttributeDescriptors(Collections.emptyList());
+			} else {
+				tableSource.setRowtimeAttributeDescriptors(Collections.singletonList(rowtimeAttributeDescriptor));
+			}
+		}
+
+		/**
+		 * Returns the builder.
+		 * @return the builder.
+		 */
+		protected abstract B builder();
+
+		/**
+		 * Builds the configured {@link KafkaTableSource}.
+		 * @return The configured {@link KafkaTableSource}.
+		 */
+		protected abstract KafkaTableSource build();
 	}
 }

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaAvroTableSourceTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaAvroTableSourceTestBase.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.connectors.kafka.testutils.AvroTestUtils;
+import org.apache.flink.table.api.Types;
+
+import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificRecordBase;
+
+import org.junit.Test;
+
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Abstract test base for all Kafka Avro table sources.
+ */
+public abstract class KafkaAvroTableSourceTestBase extends KafkaTableSourceTestBase {
+
+	@Override
+	protected void configureBuilder(KafkaTableSource.Builder builder) {
+		super.configureBuilder(builder);
+		((KafkaAvroTableSource.Builder) builder).forAvroRecordClass(SameFieldsAvroClass.class);
+	}
+
+	@Test
+	public void testSameFieldsAvroClass() {
+		KafkaAvroTableSource.Builder b = (KafkaAvroTableSource.Builder) getBuilder();
+		this.configureBuilder(b);
+
+		KafkaAvroTableSource source = (KafkaAvroTableSource) b.build();
+
+		// check return type
+		RowTypeInfo returnType = (RowTypeInfo) source.getReturnType();
+		assertNotNull(returnType);
+		assertEquals(5, returnType.getArity());
+		// check field names
+		assertEquals("field1", returnType.getFieldNames()[0]);
+		assertEquals("field2", returnType.getFieldNames()[1]);
+		assertEquals("time1", returnType.getFieldNames()[2]);
+		assertEquals("time2", returnType.getFieldNames()[3]);
+		assertEquals("field3", returnType.getFieldNames()[4]);
+		// check field types
+		assertEquals(Types.LONG(), returnType.getTypeAt(0));
+		assertEquals(Types.STRING(), returnType.getTypeAt(1));
+		assertEquals(Types.SQL_TIMESTAMP(), returnType.getTypeAt(2));
+		assertEquals(Types.SQL_TIMESTAMP(), returnType.getTypeAt(3));
+		assertEquals(Types.DOUBLE(), returnType.getTypeAt(4));
+
+		// check field mapping
+		assertNull(source.getFieldMapping());
+	}
+
+	@Test
+	public void testDifferentFieldsAvroClass() {
+		KafkaAvroTableSource.Builder b = (KafkaAvroTableSource.Builder) getBuilder();
+		super.configureBuilder(b);
+		b.withProctimeAttribute("time2");
+
+		Map<String, String> mapping = new HashMap<>();
+		mapping.put("field1", "otherField1");
+		mapping.put("field2", "otherField2");
+		mapping.put("field3", "otherField3");
+
+		// set Avro class with different fields
+		b.forAvroRecordClass(DifferentFieldsAvroClass.class);
+		b.withTableToAvroMapping(mapping);
+
+		KafkaAvroTableSource source = (KafkaAvroTableSource) b.build();
+
+		// check return type
+		RowTypeInfo returnType = (RowTypeInfo) source.getReturnType();
+		assertNotNull(returnType);
+		assertEquals(6, returnType.getArity());
+		// check field names
+		assertEquals("otherField1", returnType.getFieldNames()[0]);
+		assertEquals("otherField2", returnType.getFieldNames()[1]);
+		assertEquals("otherTime1", returnType.getFieldNames()[2]);
+		assertEquals("otherField3", returnType.getFieldNames()[3]);
+		assertEquals("otherField4", returnType.getFieldNames()[4]);
+		assertEquals("otherField5", returnType.getFieldNames()[5]);
+		// check field types
+		assertEquals(Types.LONG(), returnType.getTypeAt(0));
+		assertEquals(Types.STRING(), returnType.getTypeAt(1));
+		assertEquals(Types.SQL_TIMESTAMP(), returnType.getTypeAt(2));
+		assertEquals(Types.DOUBLE(), returnType.getTypeAt(3));
+		assertEquals(Types.BYTE(), returnType.getTypeAt(4));
+		assertEquals(Types.INT(), returnType.getTypeAt(5));
+
+		// check field mapping
+		Map<String, String> fieldMapping = source.getFieldMapping();
+		assertNotNull(fieldMapping);
+		assertEquals(3, fieldMapping.size());
+		assertEquals("otherField1", fieldMapping.get("field1"));
+		assertEquals("otherField2", fieldMapping.get("field2"));
+		assertEquals("otherField3", fieldMapping.get("field3"));
+	}
+
+	/**
+	 * Avro record that matches the table schema.
+	 */
+	@SuppressWarnings("unused")
+	public static class SameFieldsAvroClass extends SpecificRecordBase {
+
+		//CHECKSTYLE.OFF: StaticVariableNameCheck - Avro accesses this field by name via reflection.
+		public static Schema SCHEMA$ = AvroTestUtils.createFlatAvroSchema(FIELD_NAMES, FIELD_TYPES);
+		//CHECKSTYLE.ON: StaticVariableNameCheck
+
+		public Long field1;
+		public String field2;
+		public Timestamp time1;
+		public Timestamp time2;
+		public Double field3;
+
+		@Override
+		public Schema getSchema() {
+			return null;
+		}
+
+		@Override
+		public Object get(int field) {
+			return null;
+		}
+
+		@Override
+		public void put(int field, Object value) { }
+	}
+
+	/**
+	 * Avro record that does NOT match the table schema.
+	 */
+	@SuppressWarnings("unused")
+	public static class DifferentFieldsAvroClass extends SpecificRecordBase {
+
+		//CHECKSTYLE.OFF: StaticVariableNameCheck - Avro accesses this field by name via reflection.
+		public static Schema SCHEMA$ = AvroTestUtils.createFlatAvroSchema(
+			new String[]{"otherField1", "otherField2", "otherTime1", "otherField3", "otherField4", "otherField5"},
+			new TypeInformation[]{Types.LONG(), Types.STRING(), Types.SQL_TIMESTAMP(), Types.DOUBLE(), Types.BYTE(), Types.INT()});
+		//CHECKSTYLE.ON: StaticVariableNameCheck
+
+		public Long otherField1;
+		public String otherField2;
+		public Timestamp otherTime1;
+		public Double otherField3;
+		public Byte otherField4;
+		public Integer otherField5;
+
+		@Override
+		public Schema getSchema() {
+			return null;
+		}
+
+		@Override
+		public Object get(int field) {
+			return null;
+		}
+
+		@Override
+		public void put(int field, Object value) { }
+	}
+
+}

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaJsonTableSourceTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaJsonTableSourceTestBase.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka;
+
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.Types;
+import org.apache.flink.table.sources.tsextractors.ExistingField;
+import org.apache.flink.table.sources.wmstrategies.AscendingTimestamps;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Abstract test base for all Kafka JSON table sources.
+ */
+public abstract class KafkaJsonTableSourceTestBase extends KafkaTableSourceTestBase {
+
+	@Test
+	public void testJsonEqualsTableSchema() {
+		KafkaJsonTableSource.Builder b = (KafkaJsonTableSource.Builder) getBuilder();
+		this.configureBuilder(b);
+
+		KafkaJsonTableSource source = (KafkaJsonTableSource) b.build();
+
+		// check return type
+		RowTypeInfo returnType = (RowTypeInfo) source.getReturnType();
+		assertNotNull(returnType);
+		assertEquals(5, returnType.getArity());
+		// check field names
+		assertEquals("field1", returnType.getFieldNames()[0]);
+		assertEquals("field2", returnType.getFieldNames()[1]);
+		assertEquals("time1", returnType.getFieldNames()[2]);
+		assertEquals("time2", returnType.getFieldNames()[3]);
+		assertEquals("field3", returnType.getFieldNames()[4]);
+		// check field types
+		assertEquals(Types.LONG(), returnType.getTypeAt(0));
+		assertEquals(Types.STRING(), returnType.getTypeAt(1));
+		assertEquals(Types.SQL_TIMESTAMP(), returnType.getTypeAt(2));
+		assertEquals(Types.SQL_TIMESTAMP(), returnType.getTypeAt(3));
+		assertEquals(Types.DOUBLE(), returnType.getTypeAt(4));
+
+		// check field mapping
+		assertNull(source.getFieldMapping());
+	}
+
+	@Test
+	public void testCustomJsonSchemaWithMapping() {
+		KafkaJsonTableSource.Builder b = (KafkaJsonTableSource.Builder) getBuilder();
+		super.configureBuilder(b);
+		b.withProctimeAttribute("time2");
+
+		Map<String, String> mapping = new HashMap<>();
+		mapping.put("field1", "otherField1");
+		mapping.put("field2", "otherField2");
+		mapping.put("field3", "otherField3");
+
+		// set Avro class with different fields
+		b.forJsonSchema(TableSchema.builder()
+			.field("otherField1", Types.LONG())
+			.field("otherField2", Types.STRING())
+			.field("rowtime", Types.LONG())
+			.field("otherField3", Types.DOUBLE())
+			.field("otherField4", Types.BYTE())
+			.field("otherField5", Types.INT()).build());
+		b.withTableToJsonMapping(mapping);
+		b.withRowtimeAttribute("time1", new ExistingField("timeField1"), new AscendingTimestamps());
+
+		KafkaJsonTableSource source = (KafkaJsonTableSource) b.build();
+
+		// check return type
+		RowTypeInfo returnType = (RowTypeInfo) source.getReturnType();
+		assertNotNull(returnType);
+		assertEquals(6, returnType.getArity());
+		// check field names
+		assertEquals("otherField1", returnType.getFieldNames()[0]);
+		assertEquals("otherField2", returnType.getFieldNames()[1]);
+		assertEquals("rowtime", returnType.getFieldNames()[2]);
+		assertEquals("otherField3", returnType.getFieldNames()[3]);
+		assertEquals("otherField4", returnType.getFieldNames()[4]);
+		assertEquals("otherField5", returnType.getFieldNames()[5]);
+		// check field types
+		assertEquals(Types.LONG(), returnType.getTypeAt(0));
+		assertEquals(Types.STRING(), returnType.getTypeAt(1));
+		assertEquals(Types.LONG(), returnType.getTypeAt(2));
+		assertEquals(Types.DOUBLE(), returnType.getTypeAt(3));
+		assertEquals(Types.BYTE(), returnType.getTypeAt(4));
+		assertEquals(Types.INT(), returnType.getTypeAt(5));
+
+		// check field mapping
+		Map<String, String> fieldMapping = source.getFieldMapping();
+		assertNotNull(fieldMapping);
+		assertEquals(3, fieldMapping.size());
+		assertEquals("otherField1", fieldMapping.get("field1"));
+		assertEquals("otherField2", fieldMapping.get("field2"));
+		assertEquals("otherField3", fieldMapping.get("field3"));
+	}
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableSchema.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableSchema.scala
@@ -20,6 +20,8 @@ package org.apache.flink.table.api
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.CompositeType
 
+import _root_.scala.collection.mutable.ArrayBuffer
+
 /**
   * A TableSchema represents a Table's structure.
   */
@@ -154,4 +156,24 @@ object TableSchema {
     }
   }
 
+  def builder(): TableSchemaBuilder = {
+    new TableSchemaBuilder
+  }
+
+}
+
+class TableSchemaBuilder {
+
+  private val fieldNames: ArrayBuffer[String] = new ArrayBuffer[String]()
+  private val fieldTypes: ArrayBuffer[TypeInformation[_]] = new ArrayBuffer[TypeInformation[_]]()
+
+  def field(name: String, tpe: TypeInformation[_]): TableSchemaBuilder = {
+    fieldNames.append(name)
+    fieldTypes.append(tpe)
+    this
+  }
+
+  def build(): TableSchema = {
+    new TableSchema(fieldNames.toArray, fieldTypes.toArray)
+  }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/fieldExpression.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/fieldExpression.scala
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.api._
 import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
 import org.apache.flink.table.calcite.FlinkTypeFactory._
+import org.apache.flink.table.functions.sql.StreamRecordTimestampSqlFunction
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 import org.apache.flink.table.validate.{ValidationFailure, ValidationResult, ValidationSuccess}
 
@@ -163,9 +164,9 @@ case class RowtimeAttribute(expr: Expression) extends TimeAttribute(expr) {
 
   override private[flink] def validateInput(): ValidationResult = {
     child match {
-      case WindowReference(_, Some(tpe)) if isProctimeIndicatorType(tpe) =>
+      case WindowReference(_, Some(tpe: TypeInformation[_])) if isProctimeIndicatorType(tpe) =>
         ValidationFailure("A proctime window cannot provide a rowtime attribute.")
-      case WindowReference(_, Some(tpe)) if isRowtimeIndicatorType(tpe) =>
+      case WindowReference(_, Some(tpe: TypeInformation[_])) if isRowtimeIndicatorType(tpe) =>
         // rowtime window
         ValidationSuccess
       case WindowReference(_, Some(tpe)) if tpe == Types.LONG || tpe == Types.SQL_TIMESTAMP =>
@@ -181,7 +182,7 @@ case class RowtimeAttribute(expr: Expression) extends TimeAttribute(expr) {
 
   override def resultType: TypeInformation[_] = {
     child match {
-      case WindowReference(_, Some(tpe)) if isRowtimeIndicatorType(tpe) =>
+      case WindowReference(_, Some(tpe: TypeInformation[_])) if isRowtimeIndicatorType(tpe) =>
         // rowtime window
         TimeIndicatorTypeInfo.ROWTIME_INDICATOR
       case WindowReference(_, Some(tpe)) if tpe == Types.LONG || tpe == Types.SQL_TIMESTAMP =>
@@ -203,7 +204,7 @@ case class ProctimeAttribute(expr: Expression) extends TimeAttribute(expr) {
 
   override private[flink] def validateInput(): ValidationResult = {
     child match {
-      case WindowReference(_, Some(tpe)) if isTimeIndicatorType(tpe) =>
+      case WindowReference(_, Some(tpe: TypeInformation[_])) if isTimeIndicatorType(tpe) =>
         ValidationSuccess
       case WindowReference(_, _) =>
         ValidationFailure("Reference to a rowtime or proctime window required.")
@@ -220,4 +221,14 @@ case class ProctimeAttribute(expr: Expression) extends TimeAttribute(expr) {
     NamedWindowProperty(name, this)
 
   override def toString: String = s"proctime($child)"
+}
+
+/** Expression to access the timestamp of a StreamRecord. */
+case class StreamRecordTimestamp() extends LeafExpression {
+
+  override private[flink] def resultType = Types.LONG
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.getRexBuilder.makeCall(StreamRecordTimestampSqlFunction)
+  }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/StreamRecordTimestampSqlFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/StreamRecordTimestampSqlFunction.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.sql
+
+import org.apache.calcite.sql._
+import org.apache.calcite.sql.`type`._
+
+/**
+  * Function to access the timestamp of a StreamRecord.
+  */
+object StreamRecordTimestampSqlFunction extends SqlFunction(
+  "STREAMRECORD_TIMESTAMP",
+  SqlKind.OTHER_FUNCTION,
+  ReturnTypes.explicit(SqlTypeName.BIGINT),
+  InferTypes.RETURN_TYPE,
+  OperandTypes.family(SqlTypeFamily.NUMERIC),
+  SqlFunctionCategory.SYSTEM) {
+
+  override def getSyntax: SqlSyntax = SqlSyntax.FUNCTION
+
+  override def isDeterministic: Boolean = true
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamScan.scala
@@ -22,11 +22,14 @@ import org.apache.calcite.plan._
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.TableScan
+import org.apache.calcite.rex.RexNode
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.table.api.{StreamQueryConfig, StreamTableEnvironment}
+import org.apache.flink.table.expressions.Cast
 import org.apache.flink.table.plan.schema.RowSchema
 import org.apache.flink.table.plan.schema.DataStreamTable
 import org.apache.flink.table.runtime.types.CRow
+import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 
 /**
   * Flink RelNode which matches along with DataStreamSource.
@@ -61,7 +64,22 @@ class DataStreamScan(
     val config = tableEnv.getConfig
     val inputDataStream: DataStream[Any] = dataStreamTable.dataStream
     val fieldIdxs = dataStreamTable.fieldIndexes
-    convertToInternalRow(schema, inputDataStream, fieldIdxs, config, None)
+
+    // get expression to extract timestamp
+    val rowtimeExpr: Option[RexNode] =
+      if (fieldIdxs.contains(TimeIndicatorTypeInfo.ROWTIME_STREAM_MARKER)) {
+        // extract timestamp from StreamRecord
+        Some(
+          Cast(
+            org.apache.flink.table.expressions.StreamRecordTimestamp(),
+            TimeIndicatorTypeInfo.ROWTIME_INDICATOR)
+            .toRexNode(tableEnv.getRelBuilder))
+      } else {
+        None
+      }
+
+    // convert DataStream
+    convertToInternalRow(schema, inputDataStream, fieldIdxs, config, rowtimeExpr)
   }
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamTableSourceScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamTableSourceScan.scala
@@ -32,6 +32,7 @@ import org.apache.flink.table.plan.nodes.PhysicalTableSourceScan
 import org.apache.flink.table.plan.schema.RowSchema
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.table.sources._
+import org.apache.flink.table.sources.wmstrategies.{PeriodicWatermarkAssigner, PunctuatedWatermarkAssigner}
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 
 /** Flink RelNode to read data from an external source defined by a [[StreamTableSource]]. */

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/DefinedFieldMapping.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/DefinedFieldMapping.scala
@@ -22,6 +22,7 @@ import java.util.{Map => JMap}
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.api.TableSchema
+import org.apache.flink.table.sources.tsextractors.TimestampExtractor
 
 /**
   * The [[DefinedFieldMapping]] interface provides a mapping for the fields of the table schema

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/definedTimeAttributes.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/definedTimeAttributes.scala
@@ -22,6 +22,8 @@ import java.util
 
 import org.apache.flink.table.api.TableSchema
 import org.apache.flink.table.api.Types
+import org.apache.flink.table.sources.tsextractors.TimestampExtractor
+import org.apache.flink.table.sources.wmstrategies.WatermarkStrategy
 
 /**
   * Extends a [[TableSource]] to specify a processing time attribute.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/tsextractors/ExistingField.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/tsextractors/ExistingField.scala
@@ -16,20 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.sources
+package org.apache.flink.table.sources.tsextractors
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.api.{Types, ValidationException}
 import org.apache.flink.table.expressions.{Cast, Expression, ResolvedFieldReference}
-
-/**
-  * Provides the an expression to extract the timestamp for a rowtime attribute.
-  */
-abstract class TimestampExtractor extends FieldComputer[Long] {
-
-  /** Timestamp extractors compute the timestamp as Long. */
-  override def getReturnType: TypeInformation[Long] = Types.LONG.asInstanceOf[TypeInformation[Long]]
-}
 
 /**
   * Converts an existing [[Long]] or [[java.sql.Timestamp]] field into a rowtime attribute.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/tsextractors/StreamRecordTimestamp.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/tsextractors/StreamRecordTimestamp.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources.tsextractors
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.expressions.{Expression, ResolvedFieldReference}
+
+/**
+  * Extracts the timestamp of a StreamRecord into a rowtime attribute.
+  *
+  * Note: This extractor only works for StreamTableSources.
+  */
+class StreamRecordTimestamp extends TimestampExtractor {
+
+  /** No argument fields required. */
+  override def getArgumentFields: Array[String] = Array()
+
+  /** No validation required. */
+  @throws[ValidationException]
+  override def validateArgumentFields(physicalFieldTypes: Array[TypeInformation[_]]): Unit = { }
+
+  /**
+    * Returns an [[Expression]] that extracts the timestamp of a StreamRecord.
+    */
+  override def getExpression(fieldAccesses: Array[ResolvedFieldReference]): Expression = {
+    org.apache.flink.table.expressions.StreamRecordTimestamp()
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/tsextractors/TimestampExtractor.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/tsextractors/TimestampExtractor.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources.tsextractors
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.table.api.Types
+import org.apache.flink.table.sources.FieldComputer
+
+/**
+  * Provides the an expression to extract the timestamp for a rowtime attribute.
+  */
+abstract class TimestampExtractor extends FieldComputer[Long] {
+
+  /** Timestamp extractors compute the timestamp as Long. */
+  override def getReturnType: TypeInformation[Long] = Types.LONG.asInstanceOf[TypeInformation[Long]]
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/wmstrategies/AscendingTimestamps.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/wmstrategies/AscendingTimestamps.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources.wmstrategies
+
+import org.apache.flink.streaming.api.watermark.Watermark
+
+/**
+  * A watermark assigner for ascending rowtime attributes.
+  *
+  * Emits a watermark of the maximum observed timestamp so far minus 1.
+  * Rows that have a timestamp equal to the max timestamp are not late.
+  */
+class AscendingTimestamps extends PeriodicWatermarkAssigner {
+
+  var maxTimestamp: Long = Long.MinValue + 1
+
+  override def nextTimestamp(timestamp: Long): Unit = {
+    if (timestamp > maxTimestamp) {
+      maxTimestamp = timestamp
+    }
+  }
+
+  override def getWatermark: Watermark = new Watermark(maxTimestamp - 1)
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/wmstrategies/BoundedOutOfOrderTimestamps.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/wmstrategies/BoundedOutOfOrderTimestamps.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources.wmstrategies
+
+import org.apache.flink.streaming.api.watermark.Watermark
+
+/**
+  * A watermark assigner for rowtime attributes which are out-of-order by a bounded time interval.
+  *
+  * Emits watermarks which are the maximum observed timestamp minus the specified delay.
+  *
+  * @param delay The delay by which watermarks are behind the maximum observed timestamp.
+  */
+class BoundedOutOfOrderTimestamps(val delay: Long) extends PeriodicWatermarkAssigner {
+
+  var maxTimestamp: Long = Long.MinValue + delay
+
+  override def nextTimestamp(timestamp: Long): Unit = {
+    if (timestamp > maxTimestamp) {
+      maxTimestamp = timestamp
+    }
+  }
+
+  override def getWatermark: Watermark = new Watermark(maxTimestamp - delay)
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/wmstrategies/watermarkStrategies.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/wmstrategies/watermarkStrategies.scala
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.sources
+package org.apache.flink.table.sources.wmstrategies
 
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.types.Row
@@ -59,43 +59,4 @@ abstract class PunctuatedWatermarkAssigner extends WatermarkStrategy {
     * @return The watermark for this row or null if no watermark should be generated.
     */
   def getWatermark(row: Row, timestamp: Long): Watermark
-}
-
-/**
-  * A watermark assigner for ascending rowtime attributes.
-  *
-  * Emits a watermark of the maximum observed timestamp so far minus 1.
-  * Rows that have a timestamp equal to the max timestamp are not late.
-  */
-class AscendingWatermarks extends PeriodicWatermarkAssigner {
-
-  var maxTimestamp: Long = Long.MinValue + 1
-
-  override def nextTimestamp(timestamp: Long): Unit = {
-    if (timestamp > maxTimestamp) {
-      maxTimestamp = timestamp
-    }
-  }
-
-  override def getWatermark: Watermark = new Watermark(maxTimestamp - 1)
-}
-
-/**
-  * A watermark assigner for rowtime attributes which are out-of-order by a bounded time interval.
-  *
-  * Emits watermarks which are the maximum observed timestamp minus the specified delay.
-  *
-  * @param delay The delay by which watermarks are behind the maximum observed timestamp.
-  */
-class BoundedOutOfOrderWatermarks(val delay: Long) extends PeriodicWatermarkAssigner {
-
-  var maxTimestamp: Long = Long.MinValue + delay
-
-  override def nextTimestamp(timestamp: Long): Unit = {
-    if (timestamp > maxTimestamp) {
-      maxTimestamp = timestamp
-    }
-  }
-
-  override def getWatermark: Watermark = new Watermark(maxTimestamp - delay)
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/validation/TableSourceValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/validation/TableSourceValidationTest.scala
@@ -27,6 +27,8 @@ import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.{TableEnvironment, TableSchema, Types, ValidationException}
 import org.apache.flink.table.sources._
+import org.apache.flink.table.sources.tsextractors.ExistingField
+import org.apache.flink.table.sources.wmstrategies.AscendingTimestamps
 import org.apache.flink.table.utils.TestTableSourceWithTime
 import org.apache.flink.types.Row
 import org.junit.Test
@@ -188,7 +190,7 @@ class TableSourceValidationTest {
           Collections.singletonList(new RowtimeAttributeDescriptor(
             "rtime",
             new ExistingField("doesNotExist"),
-            new AscendingWatermarks))
+            new AscendingTimestamps))
         }
     }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/testTableSources.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/testTableSources.scala
@@ -30,6 +30,8 @@ import org.apache.flink.table.api.Types.{DOUBLE, INT, LONG, STRING}
 import org.apache.flink.table.api.TableSchema
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.sources._
+import org.apache.flink.table.sources.tsextractors.ExistingField
+import org.apache.flink.table.sources.wmstrategies.AscendingTimestamps
 import org.apache.flink.types.Row
 import org.apache.flink.util.Preconditions
 
@@ -63,7 +65,7 @@ class TestTableSourceWithTime[T](
       Collections.singletonList(new RowtimeAttributeDescriptor(
         rowtime,
         new ExistingField(rowtime),
-        new AscendingWatermarks))
+        new AscendingTimestamps))
     } else {
       Collections.EMPTY_LIST.asInstanceOf[util.List[RowtimeAttributeDescriptor]]
     }


### PR DESCRIPTION
## What is the purpose of the change

Add support for time indicators (processing time, ingestion time, event time) for Kafka table sources that extend `KafkaTableSource`.

The PR adds the following methods:
- `addProcTimeAttribute(String proctime)`: adds a processing time attribute to the table
- `addIngestionTimeAttribute(String ingestionTime)`: adds an ingestion time attribute to the table
- `setAscendingRowTimeAttribute(String rowtime)`: sets an existing attribute to be the row time attribute and automatically assigns watermarks for monotonically increasing attributes.
- `setBoundedOutOfOrderRowtimeAttribute(String rowtime, long watermarkDelay)`: sets an existing attribute to be the row time attribute and automatically assigns watermarks with a specified fixed delay.

So, event-time is currently only supported for ascending timestamps and timestamps which are out-of-order by a fixed delay.

## Brief change log

- `KafkaTableSource` implements `DefinedProcTimeAttribute` and `DefinedRowTimeAttribute` interfaces.
- Added methods to set different time attributes.
- Added tests to validate the time attribute methods.

## Verifying this change

- added `KafkaTableSource` test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **NOT YET** 

