### PR TITLE
[FLINK-7572][table]Improve TableSchema and FlinkTable validation exce…

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableSchema.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableSchema.scala
@@ -28,17 +28,28 @@ class TableSchema(
 
   if (columnNames.length != columnTypes.length) {
     throw new TableException(
-      "Number of column indexes and column names must be equal.")
+      s"Number of column indexes and column names must be equal." +
+        s"\nColumn names count is [${columnNames.length}]" +
+        s"\nColumn types count is [${columnTypes.length}]" +
+        s"\nColumn names:${columnNames.mkString("[ ", ", ", " ]")}" +
+        s"\nColumn types:${columnTypes.mkString("[ ", ", ", " ]")}")
   }
 
   // check uniqueness of field names
   if (columnNames.toSet.size != columnTypes.length) {
+    val columnNameBuffer = columnNames.toBuffer
+    val duplicate = columnNames.filter(
+      name => columnNameBuffer.-=(name).contains(name))
+
     throw new TableException(
-      "Table column names must be unique.")
+      s"Table column names must be unique." +
+        s"\nThe duplicate columns are: ${duplicate.mkString("[ ", ", ", " ]")}" +
+        s"\nAll column names: ${columnNames.mkString("[ ", ", ", " ]")}")
   }
 
   val columnNameToIndex: Map[String, Int] = columnNames.zipWithIndex.toMap
 
+  val columnNameToString:Seq[String] = columnNames.toSeq
   /**
     * Returns all type information as an array.
     */

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/FlinkTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/FlinkTable.scala
@@ -37,13 +37,21 @@ abstract class FlinkTable[T](
 
   if (fieldIndexes.length != fieldNames.length) {
     throw new TableException(
-      "Number of field indexes and field names must be equal.")
+      s"Number of field indexes and field names must be equal. " +
+        s"\nField names count is [${fieldNames.length}]" +
+        s"\nField indexs count is [${fieldIndexes.length}]" +
+        s"\nField names: ${fieldNames.mkString("[ ", ", ", " ]")}" +
+        s"\nField indexs: ${fieldIndexes.mkString("[ ", ", ", " ]")}")
   }
 
   // check uniqueness of field names
   if (fieldNames.length != fieldNames.toSet.size) {
+    val fieldNameBuffer = fieldNames.toBuffer
+    val duplicate = fieldNames.filter(name => fieldNameBuffer.-=(name).contains(name))
     throw new TableException(
-      "Table field names must be unique.")
+      s"Table field names must be unique." +
+        s"\nThe duplicate fields are: ${duplicate.mkString("[ ", ", ", " ]")}" +
+        s"\nAll field names: ${fieldNames.mkString("[ ", ", ", " ]")}")
   }
 
   val fieldTypes: Array[TypeInformation[_]] =

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/validation/FlinkTableValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/validation/FlinkTableValidationTest.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.api.validation
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.utils.TableTestBase
+import org.junit.Test
+
+class FlinkTableValidationTest extends TableTestBase {
+  @Test
+  def testFieldNamesDuplicate() {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Table field names must be unique." +
+      "\nThe duplicate fields are: [ a ]" +
+      "\nAll field names: [ a, a, b ]")
+    val util = batchTestUtil()
+    util.addTable[(Int, Int, String)]("MyTable", 'a, 'a, 'b)
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/validation/TableSchemaValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/validation/TableSchemaValidationTest.scala
@@ -24,10 +24,34 @@ import org.junit.Test
 
 class TableSchemaValidationTest extends TableTestBase {
 
-  @Test(expected = classOf[TableException])
-  def testInvalidSchema() {
+  @Test
+  def testColumnNameAndColumnTypeNotEqual() {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage(
+      "Number of column indexes and column names must be equal." +
+        "\nColumn names count is [3]" +
+        "\nColumn types count is [2]" +
+        "\nColumn names:[ a, b, c ]" +
+        "\nColumn types:[ Integer, String ]")
+
     val fieldNames = Array("a", "b", "c")
     val typeInfos: Array[TypeInformation[_]] = Array(
+      BasicTypeInfo.INT_TYPE_INFO,
+      BasicTypeInfo.STRING_TYPE_INFO)
+    new TableSchema(fieldNames, typeInfos)
+  }
+
+  @Test
+  def testColumnNamesDuplicate() {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage(
+      "Table column names must be unique." +
+        "\nThe duplicate columns are: [ a ]" +
+        "\nAll column names: [ a, a, c ]")
+
+    val fieldNames = Array("a", "a", "c")
+    val typeInfos: Array[TypeInformation[_]] = Array(
+      BasicTypeInfo.INT_TYPE_INFO,
       BasicTypeInfo.INT_TYPE_INFO,
       BasicTypeInfo.STRING_TYPE_INFO)
     new TableSchema(fieldNames, typeInfos)


### PR DESCRIPTION
## What is the purpose of the change
Currently, the exception message of `TableScheam` and `FlinkTable` a little confusing,In this PR. we want improve the exception message .


## Brief change log

  - *Improve TableSchema column name and column type validation exception message*
  - *Improve TableSchema column name duplicate validation exception message*
  - *Improve FlinkTable field name and field type validation exception message*
  - *Improve FlinkTable field name duplicate validation exception message*

## Verifying this change
- This change is verified by the new  `TableSchemaValidationTest#testColumnNameAndColumnTypeNotEqual` `TableSchemaValidationTest#testColumnNamesDuplicate` and `FlinkTableValidationTest#testFieldNamesDuplicate`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)

