### PR TITLE
[hotfix][docs] Fix a typo on log name for quick start guide.

### DIFF
--- a/docs/quickstart/setup_quickstart.md
+++ b/docs/quickstart/setup_quickstart.md
@@ -284,7 +284,7 @@ window of processing time, as long as words are floating in.
   as words are floating in, e.g.:
 
   ~~~bash
-  $ tail -f log/flink-*-jobmanager-*.out
+  $ tail -f log/flink-*-taskmanager-*.out
   lorem : 1
   bye : 1
   ipsum : 4

--- a/docs/quickstart/setup_quickstart.md
+++ b/docs/quickstart/setup_quickstart.md
@@ -269,7 +269,7 @@ window of processing time, as long as words are floating in.
   </div>
 
 * Words are counted in time windows of 5 seconds (processing time, tumbling
-  windows) and are printed to `stdout`. Monitor the JobManager's output file
+  windows) and are printed to `stdout`. Monitor the TaskManager's output file
   and write some text in `nc` (input is sent to Flink line by line after
   hitting <RETURN>):
 


### PR DESCRIPTION
## Brief change log

The console output of examples should appear in \*-taskmanager-\*.log instead of \*-jobmanager-\*.log

