### PR TITLE
[FLINK-7581] [REST] Name netty threads

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -52,6 +52,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponse;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVersion;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslHandler;
+import org.apache.flink.shaded.netty4.io.netty.util.concurrent.DefaultThreadFactory;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -102,7 +103,7 @@ public class RestClient {
 					.addLast(new PipelineErrorHandler(LOG));
 			}
 		};
-		NioEventLoopGroup group = new NioEventLoopGroup(1);
+		NioEventLoopGroup group = new NioEventLoopGroup(1, new DefaultThreadFactory("flink-rest-client-netty"));
 
 		bootstrap = new Bootstrap();
 		bootstrap

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -106,7 +106,7 @@ public abstract class RestServerEndpoint {
 		};
 
 		NioEventLoopGroup bossGroup = new NioEventLoopGroup(1, new DefaultThreadFactory("flink-rest-server-netty-boss"));
-		NioEventLoopGroup workerGroup = new NioEventLoopGroup(1, new DefaultThreadFactory("flink-rest-server-netty-worker"));
+		NioEventLoopGroup workerGroup = new NioEventLoopGroup(new DefaultThreadFactory("flink-rest-server-netty-worker"));
 
 		bootstrap = new ServerBootstrap();
 		bootstrap

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -38,6 +38,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpServerCode
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.router.Handler;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.router.Router;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslHandler;
+import org.apache.flink.shaded.netty4.io.netty.util.concurrent.DefaultThreadFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,8 +105,8 @@ public abstract class RestServerEndpoint {
 			}
 		};
 
-		NioEventLoopGroup bossGroup = new NioEventLoopGroup(1);
-		NioEventLoopGroup workerGroup = new NioEventLoopGroup();
+		NioEventLoopGroup bossGroup = new NioEventLoopGroup(1, new DefaultThreadFactory("flink-rest-server-netty-boss"));
+		NioEventLoopGroup workerGroup = new NioEventLoopGroup(1, new DefaultThreadFactory("flink-rest-server-netty-worker"));
 
 		bootstrap = new ServerBootstrap();
 		bootstrap


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the netty setup in the RestClient and RestServerEndpoint to explicitly provide a thread factory with an appropriate thread name, to make debugging a bit easier. We use the same factory implementation that would be used if we weren't passing a factory, just with a modified pool name.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
