### PR TITLE
[FLINK-7582] [REST] Netty thread immediately parses responses

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -173,9 +173,8 @@ public class RestClient {
 				CompletableFuture<JsonResponse> future = handler.getJsonFuture();
 				channel.writeAndFlush(httpRequest);
 				return future;
-			}).thenComposeAsync(
-				(JsonResponse rawResponse) -> parseResponse(rawResponse, responseClass),
-				executor
+			}).thenCompose(
+				(JsonResponse rawResponse) -> parseResponse(rawResponse, responseClass)
 			);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestEndpointITCase.java
@@ -67,7 +67,7 @@ public class RestEndpointITCase extends TestLogger {
 		RestClientConfiguration clientConfig = RestClientConfiguration.fromConfiguration(config);
 
 		RestServerEndpoint serverEndpoint = new TestRestServerEndpoint(serverConfig);
-		RestClient clientEndpoint = new TestRestClient(clientConfig);
+		RestClient clientEndpoint = new RestClient(clientConfig);
 
 		try {
 			serverEndpoint.start();
@@ -144,13 +144,6 @@ public class RestEndpointITCase extends TestLogger {
 				}
 			}
 			return CompletableFuture.completedFuture(new TestResponse(request.getRequestBody().id));
-		}
-	}
-
-	private static class TestRestClient extends RestClient {
-
-		TestRestClient(RestClientConfiguration configuration) {
-			super(configuration, TestingUtils.defaultExecutor());
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the RestClient to make the netty receiver threads parse responses (and complete the associated future) immediately after receiving a response, instead of deferring the parsing to a separate executor.

This guarantees that we don't buffer responses that haven't been parsed yet. This was previously the case if the executor could not keep up with the response rate, for example because it was used exclusively for sending requests.

## Brief change log

* Make sending synchronous
* Netty threads immediately parse messages after receiving them
* remove (now unused) executor in RestClient

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
