### PR TITLE
[FLINK-7584] [doc] Fix checkstyle version in Setup IDE

### DIFF
--- a/docs/internals/ide_setup.md
+++ b/docs/internals/ide_setup.md
@@ -79,17 +79,18 @@ to enable support for Scala projects and files:
    i.e. "/home/*-your-user-*/.m2/repository/org/apache/flink/".
    Alternatively, `mvn clean package -DskipTests` also creates the necessary
    files for the IDE to work with but without installing libraries.
-8. Build the Project (Build -> Make Project)
+8. Build the Project (Build -> Build Project)
 
 ### Checkstyle
 IntelliJ supports checkstyle within the IDE using the Checkstyle-IDEA plugin.
 
 1. Install the "Checkstyle-IDEA" plugin from the IntelliJ plugin repository.
 2. Configure the plugin by going to Settings -> Other Settings -> Checkstyle.
-3. Set the "Scan Scope" to "Only Java sources (including tests)".
-4. Select _6.19_ in the "Checkstyle Version" dropdown and click apply. **This step is important,
+3. Set the "Checkstyle version" to "8.0" and click on "Apply".
+4. Set the "Scan Scope" to "Only Java sources (including tests)".
+5. Select _6.19_ in the "Checkstyle Version" dropdown and click apply. **This step is important,
    don't skip it!**
-5. In the "Configuration File" pane, add a new configuration using the plus icon:
+6. In the "Configuration File" pane, add a new configuration using the plus icon:
     1. Set the "Description" to "Flink".
     2. Select "Use a local Checkstyle file", and point it to
       `"tools/maven/checkstyle.xml"` within
@@ -98,9 +99,9 @@ IntelliJ supports checkstyle within the IDE using the Checkstyle-IDEA plugin.
       "Next".
     4. Configure the "checkstyle.suppressions.file" property value to
       `"suppressions.xml"`, and click "Next", then "Finish".
-6. Select "Flink" as the only active configuration file, and click "Apply" and
+7. Select "Flink" as the only active configuration file, and click "Apply" and
    "OK".
-7. Checkstyle will now give warnings in the editor for any Checkstyle
+8. Checkstyle will now give warnings in the editor for any Checkstyle
    violations.
 
 Once the plugin is installed you can directly import `"tools/maven/checkstyle.xml"` by going to Settings -> Editor -> Code Style -> Java -> Gear Icon next to Scheme dropbox. This will for example automatically adjust the imports layout.


### PR DESCRIPTION
## Problem
There is a breaking change in the Checkstyle-IDEA plugin since version **8.1**. The Flink `checkstyle.xml` is working up to version **8.0**.

## Fix
Changing the `checkstyle.xml` is a sensible topic so we decided to updated the documentation to stipulate that we have to use the **8.0** version instead of **8.1+**.
