### PR TITLE
[FLINK-6116] Watermarks don't work when unioning with same DataStream.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -60,17 +60,23 @@ public class StreamEdge implements Serializable {
 	 */
 	private StreamPartitioner<?> outputPartitioner;
 
+	/**
+	 * The unique id for differentiating edges between the same source and target.
+	 */
+	private final int edgeSubId;
+
 	public StreamEdge(StreamNode sourceVertex, StreamNode targetVertex, int typeNumber,
-			List<String> selectedNames, StreamPartitioner<?> outputPartitioner, OutputTag outputTag) {
+			List<String> selectedNames, StreamPartitioner<?> outputPartitioner, OutputTag outputTag, int edgeSubId) {
 		this.sourceVertex = sourceVertex;
 		this.targetVertex = targetVertex;
 		this.typeNumber = typeNumber;
 		this.selectedNames = selectedNames;
 		this.outputPartitioner = outputPartitioner;
 		this.outputTag = outputTag;
+		this.edgeSubId = edgeSubId;
 
 		this.edgeId = sourceVertex + "_" + targetVertex + "_" + typeNumber + "_" + selectedNames
-				+ "_" + outputPartitioner;
+				+ "_" + outputPartitioner + "_" + edgeSubId;
 	}
 
 	public StreamNode getSourceVertex() {
@@ -132,6 +138,6 @@ public class StreamEdge implements Serializable {
 	public String toString() {
 		return "(" + sourceVertex + " -> " + targetVertex + ", typeNumber=" + typeNumber
 				+ ", selectedNames=" + selectedNames + ", outputPartitioner=" + outputPartitioner
-				+ ", outputTag=" + outputTag + ')';
+				+ ", outputTag=" + outputTag + ", edgeSubId=" + edgeSubId + ")";
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -183,6 +183,14 @@ public class DataStreamTest {
 
 		// verify self union
 		assertTrue(streamGraph.getStreamNode(selfUnion.getId()).getInEdges().size() == 2);
+		assertTrue(streamGraph.getUniqueEdgeMap().size() == 12);
+		int selfUnionCount = 0;
+		for (Integer value : streamGraph.getUniqueEdgeMap().values()) {
+			if (value == 2) {
+				selfUnionCount++;
+			}
+		}
+		assertTrue(selfUnionCount == 2);
 		for (StreamEdge edge: streamGraph.getStreamNode(selfUnion.getId()).getInEdges()) {
 			assertTrue(edge.getPartitioner() instanceof ForwardPartitioner);
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -274,7 +274,8 @@ public class OneInputStreamTaskTest extends TestLogger {
 			0,
 			Collections.<String>emptyList(),
 			null,
-			null
+			null,
+			0
 		)));
 
 		watermarkOperatorConfig.setStreamOperator(watermarkOperator);
@@ -287,7 +288,8 @@ public class OneInputStreamTaskTest extends TestLogger {
 			0,
 			Collections.<String>emptyList(),
 			null,
-			null
+			null,
+			0
 		)));
 
 		List<StreamEdge> outEdgesInOrder = new LinkedList<StreamEdge>();
@@ -297,7 +299,8 @@ public class OneInputStreamTaskTest extends TestLogger {
 			0,
 			Collections.<String>emptyList(),
 			new BroadcastPartitioner<Object>(),
-			null));
+			null,
+			0));
 
 		tailOperatorConfig.setStreamOperator(tailOperator);
 		tailOperatorConfig.setOperatorID(new OperatorID(123L, 123L));
@@ -653,7 +656,8 @@ public class OneInputStreamTaskTest extends TestLogger {
 				0,
 				Collections.<String>emptyList(),
 				null,
-				null
+				null,
+				0
 			);
 
 			outputEdges.add(outputEdge);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -153,7 +153,7 @@ public class StreamTaskTestHarness<OUT> {
 		StreamNode sourceVertexDummy = new StreamNode(null, 0, "group", dummyOperator, "source dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
 		StreamNode targetVertexDummy = new StreamNode(null, 1, "group", dummyOperator, "target dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
 
-		outEdgesInOrder.add(new StreamEdge(sourceVertexDummy, targetVertexDummy, 0, new LinkedList<String>(), new BroadcastPartitioner<Object>(), null /* output tag */));
+		outEdgesInOrder.add(new StreamEdge(sourceVertexDummy, targetVertexDummy, 0, new LinkedList<String>(), new BroadcastPartitioner<Object>(), null /* output tag */, 0));
 
 		streamConfig.setOutEdgesInOrder(outEdgesInOrder);
 		streamConfig.setNonChainedOutputs(outEdgesInOrder);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
@@ -127,7 +127,8 @@ public class TwoInputStreamTaskTestHarness<IN1, IN2, OUT> extends StreamTaskTest
 							1,
 							new LinkedList<String>(),
 							new BroadcastPartitioner<Object>(),
-							null /* output tag */);
+							null /* output tag */,
+						1);
 
 					inPhysicalEdges.add(streamEdge);
 					break;
@@ -143,7 +144,8 @@ public class TwoInputStreamTaskTestHarness<IN1, IN2, OUT> extends StreamTaskTest
 							2,
 							new LinkedList<String>(),
 							new BroadcastPartitioner<Object>(),
-							null /* output tag */);
+							null /* output tag */,
+						1);
 
 					inPhysicalEdges.add(streamEdge);
 					break;


### PR DESCRIPTION
## What is the purpose of the change

In self-union case, the stream edges between the source and target will be regard as the single one. The `streamOutputMap` in `StreamGraph` will create only one `RecordWriterOutput` instance.


## Brief change log

  - Add edge subId for differentiating streamEdge between the same source and target node.


## Verifying this change

This change added tests and can be verified as follows:

`testUnion` case in `DataStreamTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)

