### PR TITLE
[FLINK-7430] Set StreamTask.isRunning to false after closing StreamOperators

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -196,11 +196,14 @@ public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OU
 	public void close() throws Exception {
 		super.close();
 
+		// make sure that we hold the checkpointing lock
+		Thread.holdsLock(checkpointLock);
+
 		// close the reader to signal that no more splits will come. By doing this,
 		// the reader will exit as soon as it finishes processing the already pending splits.
 		// This method will wait until then. Further cleaning up is handled by the dispose().
 
-		if (reader != null && reader.isAlive() && reader.isRunning()) {
+		while (reader != null && reader.isAlive() && reader.isRunning()) {
 			reader.close();
 			checkpointLock.wait();
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -277,10 +277,12 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			// we also need to make sure that no triggers fire concurrently with the close logic
 			// at the same time, this makes sure that during any "regular" exit where still
 			synchronized (lock) {
-				isRunning = false;
-
 				// this is part of the main logic, so if this fails, the task is considered failed
 				closeAllOperators();
+
+				// only set the StreamTask to not running after all operators have been closed!
+				// See FLINK-7430
+				isRunning = false;
 			}
 
 			LOG.debug("Closed operators for task {}", getName());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -56,6 +56,8 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.operators.testutils.UnregisteredTaskMetricsGroup;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
@@ -73,6 +75,7 @@ import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskExecutionStateListener;
 import org.apache.flink.runtime.taskmanager.TaskManagerActions;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.DirectExecutorService;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -111,12 +114,14 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import scala.concurrent.Await;
 import scala.concurrent.Future;
@@ -717,9 +722,95 @@ public class StreamTaskTest extends TestLogger {
 		Assert.assertNull(checkpointResult.get(0));
 	}
 
+	/**
+	 * Tests that the StreamTask first closes alls its operators before setting its
+	 * state to not running (isRunning == false)
+	 *
+	 * See FLINK-7430.
+	 */
+	@Test
+	public void testOperatorClosingBeforeStopRunning() throws Throwable {
+		Configuration taskConfiguration = new Configuration();
+		StreamConfig streamConfig = new StreamConfig(taskConfiguration);
+		streamConfig.setStreamOperator(new BlockingCloseStreamOperator());
+		streamConfig.setOperatorID(new OperatorID());
+
+		MockEnvironment mockEnvironment = new MockEnvironment(
+			"Test Task",
+			32L * 1024L,
+			new MockInputSplitProvider(),
+			1,
+			taskConfiguration,
+			new ExecutionConfig());
+		StreamTask<Void, BlockingCloseStreamOperator> streamTask = new NoOpStreamTask<>(mockEnvironment);
+		final AtomicReference<Throwable> atomicThrowable = new AtomicReference<>(null);
+
+		CompletableFuture<Void> invokeFuture = CompletableFuture.runAsync(
+			() -> {
+				try {
+					streamTask.invoke();
+				} catch (Exception e) {
+					atomicThrowable.set(e);
+				}
+			},
+			TestingUtils.defaultExecutor());
+
+		BlockingCloseStreamOperator.inClose.await();
+
+		// check that the StreamTask is not yet in isRunning == false
+		assertTrue(streamTask.isRunning());
+
+		// let the operator finish its close operation
+		BlockingCloseStreamOperator.finishClose.trigger();
+
+		// wait until the invoke is complete
+		invokeFuture.get();
+
+		// now the StreamTask should no longer be running
+		assertFalse(streamTask.isRunning());
+
+		// check if an exception occurred
+		if (atomicThrowable.get() != null) {
+			throw atomicThrowable.get();
+		}
+	}
+
 	// ------------------------------------------------------------------------
 	//  Test Utilities
 	// ------------------------------------------------------------------------
+
+	private static class NoOpStreamTask<T, OP extends StreamOperator<T>> extends StreamTask<T, OP> {
+
+		public NoOpStreamTask(Environment environment) {
+			setEnvironment(environment);
+		}
+
+		@Override
+		protected void init() throws Exception {}
+
+		@Override
+		protected void run() throws Exception {}
+
+		@Override
+		protected void cleanup() throws Exception {}
+
+		@Override
+		protected void cancelTask() throws Exception {}
+	}
+
+	private static class BlockingCloseStreamOperator extends AbstractStreamOperator<Void> {
+		private static final long serialVersionUID = -9042150529568008847L;
+
+		public static final OneShotLatch inClose = new OneShotLatch();
+		public static final OneShotLatch finishClose = new OneShotLatch();
+
+		@Override
+		public void close() throws Exception {
+			inClose.trigger();
+			finishClose.await();
+			super.close();
+		}
+	}
 
 	private static class TestingExecutionStateListener implements TaskExecutionStateListener {
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -726,7 +726,7 @@ public class StreamTaskTest extends TestLogger {
 	 * Tests that the StreamTask first closes alls its operators before setting its
 	 * state to not running (isRunning == false)
 	 *
-	 * See FLINK-7430.
+	 * <p>See FLINK-7430.
 	 */
 	@Test
 	public void testOperatorClosingBeforeStopRunning() throws Throwable {
@@ -755,13 +755,13 @@ public class StreamTaskTest extends TestLogger {
 			},
 			TestingUtils.defaultExecutor());
 
-		BlockingCloseStreamOperator.inClose.await();
+		BlockingCloseStreamOperator.IN_CLOSE.await();
 
 		// check that the StreamTask is not yet in isRunning == false
 		assertTrue(streamTask.isRunning());
 
 		// let the operator finish its close operation
-		BlockingCloseStreamOperator.finishClose.trigger();
+		BlockingCloseStreamOperator.FINISH_CLOSE.trigger();
 
 		// wait until the invoke is complete
 		invokeFuture.get();
@@ -801,13 +801,13 @@ public class StreamTaskTest extends TestLogger {
 	private static class BlockingCloseStreamOperator extends AbstractStreamOperator<Void> {
 		private static final long serialVersionUID = -9042150529568008847L;
 
-		public static final OneShotLatch inClose = new OneShotLatch();
-		public static final OneShotLatch finishClose = new OneShotLatch();
+		public static final OneShotLatch IN_CLOSE = new OneShotLatch();
+		public static final OneShotLatch FINISH_CLOSE = new OneShotLatch();
 
 		@Override
 		public void close() throws Exception {
-			inClose.trigger();
-			finishClose.await();
+			IN_CLOSE.trigger();
+			FINISH_CLOSE.await();
 			super.close();
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

Closing StreamOperators is still part of the StreamTask's running lifecycle,
because operators which perform asynchronous operations usually finish their
work when the StreamOperator is closed. Since this also entails that errors
can occur and that a checkpointing operation is triggered, we should only set
the StreamTask's isRunning to false after all StreamOperators have been closed.

Furthermore, this commit introduces a while guard for the waiting condition in
ContinuousFileReaderOperator#close.

R @aljoscha.

## Brief change log

- Set `StreamTask#isRunning` to false after all operators have been closed
- Use `while` loop instead of `if` condition for guarding synchronization in `ContinuousFileReaderOperator#close`

## Verifying this change

This change added tests and can be verified as follows:

- `StreamTaskTest#testOperatorClosingBeforeStopRunning` verifies that `StreamTask#isRunning == true` when the close method of the `StreamOperators` is called.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - **Affects the `StreamTask` lifecycle**

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

