### PR TITLE
[FLINK-7465][table]Add cardinality count for tableAPI and SQL.

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -2020,7 +2020,16 @@ COUNT(*)
         <p>Returns the number of input rows.</p>
       </td>
     </tr>
-
+<tr>
+      <td>
+        {% highlight text %}
+CARDINALITY_COUNT(rsd, value)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the approximate number of input rows for which <i>value</i> is not duplicate. <i>rsd<i> is the relative standard deviation for the counter. smaller values create counters that require more space. </p>
+      </td>
+    </tr>
     <tr>
       <td>
         {% highlight text %}

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -2704,6 +2704,17 @@ FIELD.count
       </td>
     </tr>
 
+        <tr>
+          <td>
+            {% highlight java %}
+    FIELD.cardinalityCount(rsd)
+    {% endhighlight %}
+          </td>
+          <td>
+          <p>Returns the approximate number of input rows for which <i>value</i> is not duplicate. <i>rsd<i> is the relative standard deviation for the counter. smaller values create counters that require more space. </p>
+          </td>
+        </tr>
+
     <tr>
       <td>
         {% highlight java %}

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/functions/aggfunctions/CardinalityCountAggFunction.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/functions/aggfunctions/CardinalityCountAggFunction.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.aggfunctions;
+
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.runtime.functions.aggfunctions.cardinality.CardinalityCountAccumulator;
+import org.apache.flink.table.runtime.functions.aggfunctions.cardinality.HyperLogLog;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Built-in cardinality count aggregate function.
+ */
+public class CardinalityCountAggFunction
+		extends AggregateFunction<Long, CardinalityCountAccumulator> {
+	@Override
+	public CardinalityCountAccumulator createAccumulator() {
+		return new CardinalityCountAccumulator();
+	}
+
+	public void accumulate(CardinalityCountAccumulator acc, Double rsd, Object value) {
+		if (acc.f0 == null) {
+			if (rsd <= 0.0 || rsd >= 1.0) {
+				throw new IllegalArgumentException(
+						"Relative standard deviation should be > 0.0 and < 1.0, but get [" + rsd + "].");
+			}
+			acc.f0 = rsd;
+			try {
+				HyperLogLog ce = new HyperLogLog(acc.f0);
+				acc.f1 = ce.getBytes();
+			} catch (IOException e) {
+				throw new RuntimeException(e.getCause());
+			}
+		}
+
+		if (value != null) {
+			try {
+				HyperLogLog ce = HyperLogLog.Builder.build(acc.f1);
+				ce.offer(value);
+				acc.f1 = ce.getBytes();
+			} catch (IOException e) {
+				throw new RuntimeException(e.getCause());
+			}
+		}
+	}
+
+	/**
+	 * Calcite resolve the 0.01 as BigDecimal.
+	 */
+	public void accumulate(CardinalityCountAccumulator acc, BigDecimal rsd, Object value) {
+		accumulate(acc, rsd.doubleValue(), value);
+	}
+
+	/**
+	 * Cardinality count is approximately statistical algorithm, we can ignore the
+	 * retract record.
+	 */
+	public void retract(Tuple1<byte[]> acc, Object value) {
+		// do nothing, ignore the retract record.
+	}
+
+	public void resetAccumulator(CardinalityCountAccumulator acc) {
+		acc.f0 = null;
+		acc.f1 = null;
+	}
+
+	public Long getValue(CardinalityCountAccumulator acc) {
+		try {
+			if (acc.f0 == null) {
+				return 0L;
+			}
+			return HyperLogLog.Builder.build(acc.f1).cardinality();
+		} catch (IOException e) {
+			throw new RuntimeException(e.getCause());
+		}
+	}
+
+}

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/functions/aggfunctions/cardinality/CardinalityCountAccumulator.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/functions/aggfunctions/cardinality/CardinalityCountAccumulator.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.aggfunctions.cardinality;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+
+/**
+ * Accumulator for cardinality count, we need a double value for relative standard deviation,
+ * And a byte array for cardinality calculation.
+ */
+public class CardinalityCountAccumulator extends Tuple2<Double, byte[]> {
+}

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/functions/aggfunctions/cardinality/HyperLogLog.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/functions/aggfunctions/cardinality/HyperLogLog.java
@@ -1,0 +1,333 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.aggfunctions.cardinality;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutput;
+import java.io.Serializable;
+
+/**
+ * Java implementation of HyperLogLog (HLL) algorithm from this paper:
+ * <p/>
+ * http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf
+ * <p/>
+ * HLL is an improved version of LogLog that is capable of estimating
+ * the cardinality of a set with accuracy = 1.04/sqrt(m) where
+ * m = 2^b.  So we can control accuracy vs space usage by increasing
+ * or decreasing b.
+ * <p/>
+ * The main benefit of using HLL over LL is that it only requires 64%
+ * of the space that LL does to get the same accuracy.
+ * <p/>
+ * <p>
+ * Note that this implementation does not include the long range correction function
+ * defined in the original paper.  Empirical evidence shows that the correction
+ * function causes more harm than good.
+ * </p>
+ */
+public class HyperLogLog implements ICardinality, Serializable {
+
+	private final RegisterSet registerSet;
+	private final int log2m;
+	private final double alphaMM;
+
+
+	/**
+	 * Create a new HyperLogLog instance using the specified standard deviation.
+	 *
+	 * @param rsd - the relative standard deviation for the counter.
+	 *            smaller values create counters that require more space.
+	 */
+	public HyperLogLog(double rsd) {
+		this(log2m(rsd));
+	}
+
+	private static int log2m(double rsd) {
+		return (int) (Math.log((1.106 / rsd) * (1.106 / rsd)) / Math.log(2));
+	}
+
+	private static double rsd(int log2m) {
+		return 1.106 / Math.sqrt(Math.exp(log2m * Math.log(2)));
+	}
+
+	private static void validateLog2m(int log2m) {
+		if (log2m < 0 || log2m > 30) {
+			throw new IllegalArgumentException("log2m argument is "
+					+ log2m + " and is outside the range [0, 30]");
+		}
+	}
+
+	private static double linearCounting(int m, double v) {
+		return m * Math.log(m / v);
+	}
+
+	/**
+	 * Create a new HyperLogLog instance.  The log2m parameter defines the accuracy of
+	 * the counter.  The larger the log2m the better the accuracy.
+	 * <p/>
+	 * accuracy = 1.04/sqrt(2^log2m)
+	 *
+	 * @param log2m - the number of bits to use as the basis for the HLL instance
+	 */
+	public HyperLogLog(int log2m) {
+		this(log2m, new RegisterSet(1 << log2m));
+	}
+
+	/**
+	 * Creates a new HyperLogLog instance using the given registers.  Used for unmarshalling a serialized
+	 * instance and for merging multiple counters together.
+	 *
+	 * @param registerSet - the initial values for the register set
+	 */
+	public HyperLogLog(int log2m, RegisterSet registerSet) {
+		validateLog2m(log2m);
+		this.registerSet = registerSet;
+		this.log2m = log2m;
+		int m = 1 << this.log2m;
+
+		alphaMM = getAlphaMM(log2m, m);
+	}
+
+	@Override
+	public boolean offerHashed(long hashedValue) {
+		// j becomes the binary address determined by the first b log2m of x
+		// j will be between 0 and 2^log2m
+		final int j = (int) (hashedValue >>> (Long.SIZE - log2m));
+		final int r = Long.numberOfLeadingZeros((hashedValue << this.log2m) | (1 << (this.log2m - 1)) + 1) + 1;
+		return registerSet.updateIfGreater(j, r);
+	}
+
+	@Override
+	public boolean offerHashed(int hashedValue) {
+		// j becomes the binary address determined by the first b log2m of x
+		// j will be between 0 and 2^log2m
+		final int j = hashedValue >>> (Integer.SIZE - log2m);
+		final int r = Integer.numberOfLeadingZeros((hashedValue << this.log2m) | (1 << (this.log2m - 1)) + 1) + 1;
+		return registerSet.updateIfGreater(j, r);
+	}
+
+	@Override
+	public boolean offer(Object o) {
+		final int x = MurmurHash.hash(o);
+		return offerHashed(x);
+	}
+
+	@Override
+	public long cardinality() {
+		double registerSum = 0;
+		int count = registerSet.count;
+		double zeros = 0.0;
+		for (int j = 0; j < registerSet.count; j++) {
+			int val = registerSet.get(j);
+			registerSum += 1.0 / (1 << val);
+			if (val == 0) {
+				zeros++;
+			}
+		}
+
+		double estimate = alphaMM * (1 / registerSum);
+
+		if (estimate <= (5.0 / 2.0) * count) {
+			// Small Range Estimate
+			return Math.round(linearCounting(count, zeros));
+		} else {
+			return Math.round(estimate);
+		}
+	}
+
+	@Override
+	public int sizeof() {
+		return registerSet.size * 4;
+	}
+
+	@Override
+	public byte[] getBytes() throws IOException {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		DataOutput dos = new DataOutputStream(baos);
+		writeBytes(dos);
+
+		return baos.toByteArray();
+	}
+
+	private void writeBytes(DataOutput serializedByteStream) throws IOException {
+		serializedByteStream.writeInt(log2m);
+		serializedByteStream.writeInt(registerSet.size * 4);
+		for (int x : registerSet.readOnlyBits()) {
+			serializedByteStream.writeInt(x);
+		}
+	}
+
+	/**
+	 * Add all the elements of the other set to this set.
+	 * <p/>
+	 * This operation does not imply a loss of precision.
+	 *
+	 * @param other A compatible Hyperloglog instance (same log2m)
+	 * @throws Exception if other is not compatible
+	 */
+	public void addAll(HyperLogLog other) throws Exception {
+		if (this.sizeof() != other.sizeof()) {
+			throw new Exception("Cannot merge estimators of different sizes");
+		}
+
+		registerSet.merge(other.registerSet);
+	}
+
+	@Override
+	public ICardinality merge(ICardinality... estimators) throws Exception {
+		HyperLogLog merged = new HyperLogLog(log2m, new RegisterSet(this.registerSet.count));
+		merged.addAll(this);
+
+		if (estimators == null) {
+			return merged;
+		}
+
+		for (ICardinality estimator : estimators) {
+			if (!(estimator instanceof HyperLogLog)) {
+				throw new Exception("Cannot merge estimators of different class");
+			}
+			HyperLogLog hll = (HyperLogLog) estimator;
+			merged.addAll(hll);
+		}
+
+		return merged;
+	}
+
+	private Object writeReplace() {
+		return new SerializationHolder(this);
+	}
+
+	/**
+	 * This class exists to support Externalizable semantics for
+	 * HyperLogLog objects without having to expose a public
+	 * constructor, public write/read methods, or pretend final
+	 * fields aren't final.
+	 *
+	 * <p>
+	 * In short, Externalizable allows you to skip some of the more
+	 * verbose meta-data default Serializable gets you, but still
+	 * includes the class name. In that sense, there is some cost
+	 * to this holder object because it has a longer class name. I
+	 * imagine people who care about optimizing for that have their
+	 * own work-around for long class names in general, or just use
+	 * a custom serialization framework. Therefore we make no attempt
+	 * to optimize that here (eg. by raising this from an inner class
+	 * and giving it an unhelpful name).
+	 * </p>
+	 */
+	private static class SerializationHolder implements Externalizable {
+
+		HyperLogLog hyperLogLogHolder;
+
+		public SerializationHolder(HyperLogLog hyperLogLogHolder) {
+			this.hyperLogLogHolder = hyperLogLogHolder;
+		}
+
+		@Override
+		public void writeExternal(ObjectOutput out) throws IOException {
+			hyperLogLogHolder.writeBytes(out);
+		}
+
+		@Override
+		public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+			hyperLogLogHolder = Builder.build(in);
+		}
+
+		private Object readResolve() {
+			return hyperLogLogHolder;
+		}
+	}
+
+	/**
+	 * Build a HyperLogLog instance.
+	 */
+	public static class Builder implements Serializable {
+		private static final long serialVersionUID = -2567898469253021883L;
+
+		private final double rsd;
+		private transient int log2m;
+
+		/**
+		 * Uses the given RSD percentage to determine how many bytes the constructed HyperLogLog will use.
+		 */
+		@Deprecated
+		public Builder(double rsd) {
+			this.log2m = log2m(rsd);
+			validateLog2m(log2m);
+			this.rsd = rsd;
+		}
+
+		private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+			in.defaultReadObject();
+			this.log2m = log2m(rsd);
+		}
+
+		public HyperLogLog build() {
+			return new HyperLogLog(log2m);
+		}
+
+		public static HyperLogLog build(byte[] bytes) throws IOException {
+			ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+			return build(new DataInputStream(bais));
+		}
+
+		public static HyperLogLog build(DataInput serializedByteStream) throws IOException {
+			int log2m = serializedByteStream.readInt();
+			int byteArraySize = serializedByteStream.readInt();
+			return new HyperLogLog(log2m,
+					new RegisterSet(1 << log2m, getBits(serializedByteStream, byteArraySize)));
+		}
+	}
+
+	/**
+	 * Byte array to int array.
+	 */
+	public static int[] getBits(DataInput dataIn, int byteLength) throws IOException {
+		int bitSize = byteLength / 4;
+		int[] bits = new int[bitSize];
+		for (int i = 0; i < bitSize; i++) {
+			bits[i] = dataIn.readInt();
+		}
+		return bits;
+	}
+
+	protected static double getAlphaMM(final int p, final int m) {
+		// See the paper.
+		switch (p) {
+			case 4:
+				return 0.673 * m * m;
+			case 5:
+				return 0.697 * m * m;
+			case 6:
+				return 0.709 * m * m;
+			default:
+				return (0.7213 / (1 + 1.079 / m)) * m * m;
+		}
+	}
+
+}

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/functions/aggfunctions/cardinality/ICardinality.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/functions/aggfunctions/cardinality/ICardinality.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.aggfunctions.cardinality;
+
+import java.io.IOException;
+
+/**
+ * An interface definition for implementation of cardinality.
+ */
+public interface ICardinality {
+
+	/**
+	 * Check whether the element is impact estimate.
+	 *
+	 * @param o stream element
+	 * @return false if the value returned by cardinality() is unaffected by the appearance of o in the stream.
+	 */
+	boolean offer(Object o);
+
+	/**
+	 * Offer the value as a hashed long value.
+	 *
+	 * @param hashedLong - the hash of the item to offer to the estimator
+	 * @return false if the value returned by cardinality() is unaffected by the appearance of hashedLong in the stream
+	 */
+	boolean offerHashed(long hashedLong);
+
+	/**
+	 * Offer the value as a hashed long value.
+	 *
+	 * @param hashedInt - the hash of the item to offer to the estimator
+	 * @return false if the value returned by cardinality() is unaffected by the appearance of hashedInt in the stream
+	 */
+	boolean offerHashed(int hashedInt);
+
+	/**
+	 * @return the number of unique elements in the stream or an estimate thereof.
+	 */
+	long cardinality();
+
+	/**
+	 * @return size in bytes needed for serialization.
+	 */
+	int sizeof();
+
+	/**
+	 * Get the byte array used for the calculation.
+	 *
+	 * @return The byte array used for the calculation
+	 * @throws IOException
+	 */
+	byte[] getBytes() throws IOException;
+
+	/**
+	 * Merges estimators to produce a new estimator for the combined streams
+	 * of this estimator and those passed as arguments.
+	 * <p/>
+	 * Nor this estimator nor the one passed as parameters are modified.
+	 *
+	 * @param estimators Zero or more compatible estimators
+	 * @throws Exception If at least one of the estimators is not compatible with this one
+	 */
+	ICardinality merge(ICardinality... estimators) throws Exception;
+}

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/functions/aggfunctions/cardinality/MurmurHash.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/functions/aggfunctions/cardinality/MurmurHash.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.aggfunctions.cardinality;
+
+/**
+ * This is a very fast, non-cryptographic hash suitable for general hash-based
+ * lookup. See http://murmurhash.googlepages.com/ for more details.
+ * <p/>
+ */
+public class MurmurHash {
+
+	public static int hash(Object o) {
+		if (o == null) {
+			return 0;
+		}
+		if (o instanceof Long) {
+			return hashLong((Long) o);
+		}
+		if (o instanceof Integer) {
+			return hashLong((Integer) o);
+		}
+		if (o instanceof Double) {
+			return hashLong(Double.doubleToRawLongBits((Double) o));
+		}
+		if (o instanceof Float) {
+			return hashLong(Float.floatToRawIntBits((Float) o));
+		}
+		if (o instanceof String) {
+			return hash(((String) o).getBytes());
+		}
+		if (o instanceof byte[]) {
+			return hash((byte[]) o);
+		}
+		return hash(o.toString());
+	}
+
+	public static int hash(byte[] data) {
+		return hash(data, data.length, -1);
+	}
+
+	public static int hash(byte[] data, int seed) {
+		return hash(data, data.length, seed);
+	}
+
+	public static int hash(byte[] data, int length, int seed) {
+		int m = 0x5bd1e995;
+		int r = 24;
+
+		int h = seed ^ length;
+
+		int len4 = length >> 2;
+
+		for (int i = 0; i < len4; i++) {
+			int i4 = i << 2;
+			int k = data[i4 + 3];
+			k = k << 8;
+			k = k | (data[i4 + 2] & 0xff);
+			k = k << 8;
+			k = k | (data[i4 + 1] & 0xff);
+			k = k << 8;
+			k = k | (data[i4 + 0] & 0xff);
+			k *= m;
+			k ^= k >>> r;
+			k *= m;
+			h *= m;
+			h ^= k;
+		}
+
+		// avoid calculating modulo
+		int lenM = len4 << 2;
+		int left = length - lenM;
+
+		if (left != 0) {
+			if (left >= 3) {
+				h ^= (int) data[length - 3] << 16;
+			}
+			if (left >= 2) {
+				h ^= (int) data[length - 2] << 8;
+			}
+			if (left >= 1) {
+				h ^= (int) data[length - 1];
+			}
+
+			h *= m;
+		}
+
+		h ^= h >>> 13;
+		h *= m;
+		h ^= h >>> 15;
+
+		return h;
+	}
+
+	public static int hashLong(long data) {
+		int m = 0x5bd1e995;
+		int r = 24;
+
+		int h = 0;
+
+		int k = (int) data * m;
+		k ^= k >>> r;
+		h ^= k * m;
+
+		k = (int) (data >> 32) * m;
+		k ^= k >>> r;
+		h *= m;
+		h ^= k * m;
+
+		h ^= h >>> 13;
+		h *= m;
+		h ^= h >>> 15;
+
+		return h;
+	}
+
+	public static long hash64(Object o) {
+		if (o == null) {
+			return 0L;
+		} else if (o instanceof String) {
+			final byte[] bytes = ((String) o).getBytes();
+			return hash64(bytes, bytes.length);
+		} else if (o instanceof byte[]) {
+			final byte[] bytes = (byte[]) o;
+			return hash64(bytes, bytes.length);
+		}
+		return hash64(o.toString());
+	}
+
+	// 64 bit implementation copied from here:  https://github.com/tnm/murmurhash-java
+
+	/**
+	 * Generates 64 bit hash from byte array with default seed value.
+	 *
+	 * @param data   byte array to hash
+	 * @param length length of the array to hash
+	 * @return 64 bit hash of the given string
+	 */
+	public static long hash64(final byte[] data, int length) {
+		return hash64(data, length, 0xe17a1465);
+	}
+
+
+	/**
+	 * Generates 64 bit hash from byte array of the given length and seed.
+	 *
+	 * @param data   byte array to hash
+	 * @param length length of the array to hash
+	 * @param seed   initial seed value
+	 * @return 64 bit hash of the given array
+	 */
+	public static long hash64(final byte[] data, int length, int seed) {
+		final long m = 0xc6a4a7935bd1e995L;
+		final int r = 47;
+
+		long h = (seed & 0xffffffffL) ^ (length * m);
+
+		int length8 = length / 8;
+
+		for (int i = 0; i < length8; i++) {
+			final int i8 = i * 8;
+			long k = ((long) data[i8 + 0] & 0xff) + (((long) data[i8 + 1] & 0xff) << 8)
+					+ (((long) data[i8 + 2] & 0xff) << 16) + (((long) data[i8 + 3] & 0xff) << 24)
+					+ (((long) data[i8 + 4] & 0xff) << 32) + (((long) data[i8 + 5] & 0xff) << 40)
+					+ (((long) data[i8 + 6] & 0xff) << 48) + (((long) data[i8 + 7] & 0xff) << 56);
+
+			k *= m;
+			k ^= k >>> r;
+			k *= m;
+
+			h ^= k;
+			h *= m;
+		}
+
+		switch (length % 8) {
+			case 7:
+				h ^= (long) (data[(length & ~7) + 6] & 0xff) << 48;
+				h ^= (long) (data[(length & ~7) + 5] & 0xff) << 40;
+				h ^= (long) (data[(length & ~7) + 4] & 0xff) << 32;
+				h ^= (long) (data[(length & ~7) + 3] & 0xff) << 24;
+				h ^= (long) (data[(length & ~7) + 2] & 0xff) << 16;
+				h ^= (long) (data[(length & ~7) + 1] & 0xff) << 8;
+				h ^= (long) (data[length & ~7] & 0xff);
+				h *= m;
+				break;
+			case 6:
+				h ^= (long) (data[(length & ~7) + 5] & 0xff) << 40;
+				h ^= (long) (data[(length & ~7) + 4] & 0xff) << 32;
+				h ^= (long) (data[(length & ~7) + 3] & 0xff) << 24;
+				h ^= (long) (data[(length & ~7) + 2] & 0xff) << 16;
+				h ^= (long) (data[(length & ~7) + 1] & 0xff) << 8;
+				h ^= (long) (data[length & ~7] & 0xff);
+				h *= m;
+				break;
+			case 5:
+				h ^= (long) (data[(length & ~7) + 4] & 0xff) << 32;
+				h ^= (long) (data[(length & ~7) + 3] & 0xff) << 24;
+				h ^= (long) (data[(length & ~7) + 2] & 0xff) << 16;
+				h ^= (long) (data[(length & ~7) + 1] & 0xff) << 8;
+				h ^= (long) (data[length & ~7] & 0xff);
+				h *= m;
+				break;
+			case 4:
+				h ^= (long) (data[(length & ~7) + 3] & 0xff) << 24;
+				h ^= (long) (data[(length & ~7) + 2] & 0xff) << 16;
+				h ^= (long) (data[(length & ~7) + 1] & 0xff) << 8;
+				h ^= (long) (data[length & ~7] & 0xff);
+				h *= m;
+				break;
+			case 3:
+				h ^= (long) (data[(length & ~7) + 2] & 0xff) << 16;
+				h ^= (long) (data[(length & ~7) + 1] & 0xff) << 8;
+				h ^= (long) (data[length & ~7] & 0xff);
+				h *= m;
+				break;
+			case 2:
+				h ^= (long) (data[(length & ~7) + 1] & 0xff) << 8;
+				h ^= (long) (data[length & ~7] & 0xff);
+				h *= m;
+				break;
+			case 1:
+				h ^= (long) (data[length & ~7] & 0xff);
+				h *= m;
+		}
+
+		h ^= h >>> r;
+		h *= m;
+		h ^= h >>> r;
+
+		return h;
+	}
+}

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/functions/aggfunctions/cardinality/RegisterSet.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/functions/aggfunctions/cardinality/RegisterSet.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.aggfunctions.cardinality;
+
+/**
+ * A basis structure for the HLL.
+ */
+public class RegisterSet {
+
+	public static final int LOG2_BITS_PER_WORD = 6;
+	public static final int REGISTER_SIZE = 5;
+
+	public final int count;
+	public final int size;
+
+	private final int[] m;
+
+	public static int getBits(int count) {
+		return count / LOG2_BITS_PER_WORD;
+	}
+
+	public static int getSizeForCount(int count) {
+		int bits = getBits(count);
+		if (bits == 0) {
+			return 1;
+		} else if (bits % Integer.SIZE == 0) {
+			return bits;
+		} else {
+			return bits + 1;
+		}
+	}
+
+	public RegisterSet(int count) {
+		this(count, null);
+	}
+
+	public RegisterSet(int count, int[] initialValues) {
+		this.count = count;
+
+		if (initialValues == null) {
+			this.m = new int[getSizeForCount(count)];
+		} else {
+			this.m = initialValues;
+		}
+		this.size = this.m.length;
+	}
+
+	public void set(int position, int value) {
+		int bucketPos = position / LOG2_BITS_PER_WORD;
+		int shift = REGISTER_SIZE * (position - (bucketPos * LOG2_BITS_PER_WORD));
+		this.m[bucketPos] = (this.m[bucketPos] & ~(0x1f << shift)) | (value << shift);
+	}
+
+	public int get(int position) {
+		int bucketPos = position / LOG2_BITS_PER_WORD;
+		int shift = REGISTER_SIZE * (position - (bucketPos * LOG2_BITS_PER_WORD));
+		return (this.m[bucketPos] & (0x1f << shift)) >>> shift;
+	}
+
+	public boolean updateIfGreater(int position, int value) {
+		int bucket = position / LOG2_BITS_PER_WORD;
+		int shift = REGISTER_SIZE * (position - (bucket * LOG2_BITS_PER_WORD));
+		int mask = 0x1f << shift;
+
+		// Use long to avoid sign issues with the left-most shift
+		long curVal = this.m[bucket] & mask;
+		long newVal = value << shift;
+		if (curVal < newVal) {
+			this.m[bucket] = (int) ((this.m[bucket] & ~mask) | newVal);
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	public void merge(RegisterSet that) {
+		for (int bucket = 0; bucket < m.length; bucket++) {
+			int word = 0;
+			for (int j = 0; j < LOG2_BITS_PER_WORD; j++) {
+				int mask = 0x1f << (REGISTER_SIZE * j);
+
+				int thisVal = (this.m[bucket] & mask);
+				int thatVal = (that.m[bucket] & mask);
+				word |= (thisVal < thatVal) ? thatVal : thisVal;
+			}
+			this.m[bucket] = word;
+		}
+	}
+
+	int[] readOnlyBits() {
+		return m;
+	}
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -189,6 +189,14 @@ trait ImplicitExpressionOperations {
   def count = Count(expr)
 
   /**
+    * Returns the approximate number of input rows for which the value is not duplicate.
+    *
+    * @param rsd the relative standard deviation for the counter.
+    *            smaller values create counters that require more space.
+    */
+  def cardinalityCount(rsd: Double) = CardinalityCount(rsd, expr)
+
+  /**
     * Returns the average (arithmetic mean) of the numeric field across all input values.
     */
   def avg = Avg(expr)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/AggSqlFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/AggSqlFunctions.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.functions.sql
+/**
+  * All built-in aggregate SQL functions.
+  */
+object AggSqlFunctions {
+ val CARDINALITY_COUNT = new SqlCardinalityCountAggFunction
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/SqlCardinalityCountAggFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/SqlCardinalityCountAggFunction.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.functions.sql
+
+import java.util
+
+import com.google.common.collect.ImmutableList
+import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory}
+import org.apache.calcite.sql.`type`._
+import org.apache.calcite.sql.validate.{SqlValidator, SqlValidatorScope}
+import org.apache.calcite.sql._
+
+class SqlCardinalityCountAggFunction
+  extends SqlAggFunction(
+    "CARDINALITY_COUNT",
+    null,
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.BIGINT,
+    null,
+    OperandTypes.family(SqlTypeFamily.EXACT_NUMERIC, SqlTypeFamily.ANY),
+    SqlFunctionCategory.NUMERIC,
+    false,
+    false) {
+
+  override def getSyntax = SqlSyntax.FUNCTION_STAR
+
+  override def getParameterTypes(typeFactory: RelDataTypeFactory): util.List[RelDataType] =
+    ImmutableList.of(
+      typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DECIMAL),true),
+      typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.ANY), true))
+
+  override def getReturnType(typeFactory: RelDataTypeFactory): RelDataType =
+    typeFactory.createSqlType(SqlTypeName.BIGINT)
+
+  override def deriveType(
+      validator: SqlValidator,
+      scope: SqlValidatorScope,
+      call: SqlCall): RelDataType =
+    if (call.isCountStar) {
+      validator.getTypeFactory
+      .createSqlType(SqlTypeName.BIGINT)
+    } else {
+      super.deriveType(validator, scope, call)
+    }
+
+  override def unwrap[T](clazz: Class[T]): T = if (clazz eq classOf[SqlSplittableAggFunction]) {
+    clazz.cast(SqlSplittableAggFunction.CountSplitter.INSTANCE)
+  } else {
+    super.unwrap(clazz)
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
@@ -40,10 +40,12 @@ import org.apache.flink.table.codegen.AggregationCodeGenerator
 import org.apache.flink.table.expressions.ExpressionUtils.isTimeIntervalLiteral
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.aggfunctions._
+import org.apache.flink.table.functions.sql.SqlCardinalityCountAggFunction
 import org.apache.flink.table.functions.utils.AggSqlFunction
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils._
 import org.apache.flink.table.functions.{AggregateFunction => TableAggregateFunction}
 import org.apache.flink.table.plan.logical._
+import org.apache.flink.table.runtime.functions.aggfunctions.CardinalityCountAggFunction
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
 import org.apache.flink.table.typeutils.TypeCheckUtils._
 import org.apache.flink.table.typeutils.{RowIntervalTypeInfo, TimeIntervalTypeInfo}
@@ -1409,6 +1411,9 @@ object AggregateUtil {
 
         case _: SqlCountAggFunction =>
           aggregates(index) = new CountAggFunction
+
+        case _: SqlCardinalityCountAggFunction =>
+          aggregates(index) = new CardinalityCountAggFunction
 
         case udagg: AggSqlFunction =>
           aggregates(index) = udagg.getFunction

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -23,7 +23,7 @@ import org.apache.calcite.sql.util.{ChainedSqlOperatorTable, ListSqlOperatorTabl
 import org.apache.calcite.sql.{SqlFunction, SqlOperator, SqlOperatorTable}
 import org.apache.flink.table.api._
 import org.apache.flink.table.expressions._
-import org.apache.flink.table.functions.sql.{DateTimeSqlFunction, ScalarSqlFunctions}
+import org.apache.flink.table.functions.sql.{AggSqlFunctions, DateTimeSqlFunction, ScalarSqlFunctions}
 import org.apache.flink.table.functions.utils.{AggSqlFunction, ScalarSqlFunction, TableSqlFunction}
 import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableFunction}
 
@@ -183,6 +183,7 @@ object FunctionCatalog {
     // aggregate functions
     "avg" -> classOf[Avg],
     "count" -> classOf[Count],
+    "cardinality_count" -> classOf[CardinalityCount],
     "max" -> classOf[Max],
     "min" -> classOf[Min],
     "sum" -> classOf[Sum],
@@ -335,6 +336,7 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     SqlStdOperatorTable.SUM,
     SqlStdOperatorTable.SUM0,
     SqlStdOperatorTable.COUNT,
+    AggSqlFunctions.CARDINALITY_COUNT,
     SqlStdOperatorTable.MIN,
     SqlStdOperatorTable.MAX,
     SqlStdOperatorTable.AVG,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/aggfunctions/CardinalityCountAggFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/aggfunctions/CardinalityCountAggFunctionTest.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.runtime.aggfunctions
+
+import java.lang.reflect.Method
+
+import org.apache.flink.table.functions.AggregateFunction
+import org.apache.flink.table.runtime.functions.aggfunctions.CardinalityCountAggFunction
+import org.apache.flink.table.runtime.functions.aggfunctions.cardinality.CardinalityCountAccumulator
+
+class CardinalityCountAggFunctionTest
+  extends AggFunctionTestBase[Long, CardinalityCountAccumulator] {
+
+  override def inputValueSets: Seq[Seq[_]] = Seq(
+    Seq(
+      List(0.01, 1),
+      List(0.01, 2),
+      List(0.01, 3),
+      List(0.01, 4),
+      List(0.01, 5),
+      List(0.01, 6),
+      List(0.01, 7),
+      List(0.01, 7),
+      List(0.01, 7)),
+    Seq(
+      List(0.01, "a"),
+      List(0.01, "b"),
+      List(0.01, "c"),
+      List(0.01, "2"),
+      List(0.01, "2"))
+  )
+
+  override def ignoreMethods = List[String]("retract")
+
+  override def accumulateFunc: Method =
+    aggregator.getClass.getMethod("accumulate", accType, classOf[java.lang.Double], classOf[Any])
+
+  override def accumulateVals(vals: Seq[_]): CardinalityCountAccumulator = {
+    val accumulator = aggregator.createAccumulator()
+    vals.foreach(
+      v =>
+        accumulateFunc.invoke(
+          aggregator,
+          accumulator.asInstanceOf[Object],
+          v.asInstanceOf[List[_]](0).asInstanceOf[java.lang.Double],
+          v.asInstanceOf[List[_]](1).asInstanceOf[Object])
+    )
+    accumulator
+  }
+  override def expectedResults: Seq[Long] = Seq(7, 4)
+
+  override def aggregator: AggregateFunction[Long, CardinalityCountAccumulator] = {
+    new CardinalityCountAggFunction()
+    .asInstanceOf[AggregateFunction[Long, CardinalityCountAccumulator]]
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/AggregateITCase.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.stream.sql
+
+import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.runtime.utils.{StreamITCase, StreamingWithStateTestBase}
+import org.apache.flink.types.Row
+import org.junit.Assert._
+import org.junit._
+
+import scala.collection.mutable
+
+class AggregateITCase extends StreamingWithStateTestBase {
+
+  /** test cardinality count **/
+  @Test
+  def testCardinalityCount(): Unit = {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
+    val sqlQuery = "SELECT " +
+      "c, cardinality_count(0.01, a), cardinality_count(0.05, a) " +
+      "FROM MyTable " +
+      "GROUP BY c"
+
+    val data = new mutable.MutableList[(Int, Long, String)]
+    for (i <- 0 until 100) {
+      data.+=((i, 1L, "Hi"))
+      data.+=((i % 50, 2L, "Hello"))
+      data.+=((i % 2, 2L, "Hello world"))
+    }
+
+    val t = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.registerTable("MyTable", t)
+
+    val result = tEnv.sql(sqlQuery).toRetractStream[Row]
+    result.addSink(new StreamITCase.RetractingSink)
+    env.execute()
+
+    val expected = List("Hello world,2,2", "Hello,49,52", "Hi,100,97")
+    assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
+  }
+}
+


### PR DESCRIPTION
## What is the purpose of the change

*In this PR. we want add add CARDINALITY_COUNT for tableAPI and SQL.(Using `HyperLogLog` algorithm). 
The implementation of HyperLogLog (HLL) algorithm from this paper: http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf 
As we know there are still some improved algorithms, such as: HyperLogLog++, HyperBitBit etc.
But `HyperLogLog` is a classic algorithm that has been massively verified, so I chose to use the `HyperLogLog` algorithm as the first version of cardinality to achieve. And we can improve the algorithm at any time If we need.
*

## Brief change log
  - *Add Java implementation of `HyperLogLog`(base on stream-lib)*
  - *Add MURMURHASH See more: http://murmurhash.googlepages.com/*
  - *Add build-in `CardinalityCountAggFunction`*
  - *Add some test case for the validation*
  - *Add documentation for TableAPI&SQL*

## Verifying this change
This change added tests and can be verified as follows:
  - *Added SQL/TableAPI integration tests for `cardinality_count`*
  - *Added `CardinalityCountAggFunctionTest` test case for verify the AGG logic.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs / JavaDocs)

