### PR TITLE
[FLINK-7598][travis] fix ineffective shaded artifacts checks

### DIFF
--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -270,33 +270,33 @@ watchdog () {
 check_shaded_artifacts() {
 	jar tf build-target/lib/flink-dist*.jar > allClasses
 	ASM=`cat allClasses | grep '^org/objectweb/asm/' | wc -l`
-	if [ $ASM != "0" ]; then
+	if [ "$ASM" != "0" ]; then
 		echo "=============================================================================="
-		echo "Detected $ASM unshaded asm dependencies in fat jar"
+		echo "Detected '$ASM' unshaded asm dependencies in fat jar"
 		echo "=============================================================================="
 		return 1
 	fi
 
 	GUAVA=`cat allClasses | grep '^com/google/common' | wc -l`
-	if [ $GUAVA != "0" ]; then
+	if [ "$GUAVA" != "0" ]; then
 		echo "=============================================================================="
-		echo "Detected $GUAVA guava dependencies in fat jar"
+		echo "Detected '$GUAVA' guava dependencies in fat jar"
 		echo "=============================================================================="
 		return 1
 	fi
 
 	SNAPPY=`cat allClasses | grep '^org/xerial/snappy' | wc -l`
-	if [ $SNAPPY == "0" ]; then
+	if [ "$SNAPPY" == "0" ]; then
 		echo "=============================================================================="
 		echo "Missing snappy dependencies in fat jar"
 		echo "=============================================================================="
 		return 1
 	fi
 
-    NETTY=`cat allClasses | grep '^io/netty' | wc -1`
-	if [ $NETTY != "0" ]; then
+	NETTY=`cat allClasses | grep '^io/netty' | wc -l`
+	if [ "$NETTY" != "0" ]; then
 		echo "=============================================================================="
-		echo "Detected $NETTY unshaded netty dependencies in fat jar"
+		echo "Detected '$NETTY' unshaded netty dependencies in fat jar"
 		echo "=============================================================================="
 		return 1
 	fi


### PR DESCRIPTION
## What is the purpose of the change

This fixes the Netty shaded dependencies check and makes all of the checks more robust against failures of the executed commands counting the number of dependencies.

## Brief change log

* fix `wc -1` call in the netty shaded dependencies check
* make all checks more robust against such failures by including unsafe variables in quotes

## Verifying this change

This change is covered by each travis run and it the following does not show up in the logs, the problem is fixed:

```
./tools/travis_mvn_watchdog.sh: line 382: 10052 Terminated              watchdog
wc: invalid option -- '1'
Try 'wc --help' for more information.
./tools/travis_mvn_watchdog.sh: line 297: [: !=: unary operator expected
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

