### PR TITLE
[FLINK-7521] Add config option to set the content length limit of REST server and client

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -35,9 +35,23 @@ public class RestOptions {
 			.defaultValue("localhost");
 
 	/**
+	 * The max content length that the server will handle.
+	 */
+	public static final ConfigOption<Integer> REST_SERVER_CONTENT_MAX_MB =
+		key("rest.server.content.max.mb")
+			.defaultValue(10);
+
+	/**
 	 * The port that the server listens on / the client connects to.
 	 */
 	public static final ConfigOption<Integer> REST_PORT =
 		key("rest.port")
 			.defaultValue(9067);
+
+	/**
+	 * The max content length that the client will handle.
+	 */
+	public static final ConfigOption<Integer> REST_CLIENT_CONTENT_MAX_MB =
+		key("rest.client.content.max.mb")
+			.defaultValue(1);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -97,7 +97,7 @@ public class RestClient {
 
 				socketChannel.pipeline()
 					.addLast(new HttpClientCodec())
-					.addLast(new HttpObjectAggregator(1024 * 1024))
+					.addLast(new HttpObjectAggregator(configuration.getMaxContentLength()))
 					.addLast(new ClientHandler())
 					.addLast(new PipelineErrorHandler(LOG));
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.ConfigurationException;
@@ -35,9 +36,11 @@ public final class RestClientConfiguration {
 
 	@Nullable
 	private final SSLEngine sslEngine;
+	private final int maxContentLength;
 
-	private RestClientConfiguration(@Nullable SSLEngine sslEngine) {
+	private RestClientConfiguration(@Nullable SSLEngine sslEngine, int maxContentLength) {
 		this.sslEngine = sslEngine;
+		this.maxContentLength = maxContentLength;
 	}
 
 	/**
@@ -48,6 +51,15 @@ public final class RestClientConfiguration {
 
 	public SSLEngine getSslEngine() {
 		return sslEngine;
+	}
+
+	/**
+	 * Returns the max content length that the REST client endpoint could handle.
+	 *
+	 * @return max content length that the REST client endpoint could handle
+	 */
+	public int getMaxContentLength() {
+		return maxContentLength;
 	}
 
 	/**
@@ -76,6 +88,11 @@ public final class RestClientConfiguration {
 			}
 		}
 
-		return new RestClientConfiguration(sslEngine);
+		int maxContentLength = config.getInteger(RestOptions.REST_CLIENT_CONTENT_MAX_MB) * 1024 * 1024;
+		if (maxContentLength <= 0) {
+			throw new ConfigurationException("Max content length for client must be a positive integer: " + maxContentLength);
+		}
+
+		return new RestClientConfiguration(sslEngine, maxContentLength);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -58,6 +58,7 @@ public abstract class RestServerEndpoint {
 	private final String configuredAddress;
 	private final int configuredPort;
 	private final SSLEngine sslEngine;
+	private final int maxContentLength;
 
 	private ServerBootstrap bootstrap;
 	private Channel serverChannel;
@@ -67,6 +68,7 @@ public abstract class RestServerEndpoint {
 		this.configuredAddress = configuration.getEndpointBindAddress();
 		this.configuredPort = configuration.getEndpointBindPort();
 		this.sslEngine = configuration.getSslEngine();
+		this.maxContentLength = configuration.getMaxContentLength();
 	}
 
 	/**
@@ -98,7 +100,7 @@ public abstract class RestServerEndpoint {
 
 				ch.pipeline()
 					.addLast(new HttpServerCodec())
-					.addLast(new HttpObjectAggregator(1024 * 1024 * 10))
+					.addLast(new HttpObjectAggregator(maxContentLength))
 					.addLast(handler.name(), handler)
 					.addLast(new PipelineErrorHandler(log));
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
@@ -39,13 +39,15 @@ public final class RestServerEndpointConfiguration {
 	private final int restBindPort;
 	@Nullable
 	private final SSLEngine sslEngine;
+	private final int maxContentLength;
 
-	private RestServerEndpointConfiguration(@Nullable String restBindAddress, int restBindPort, @Nullable SSLEngine sslEngine) {
+	private RestServerEndpointConfiguration(@Nullable String restBindAddress, int restBindPort, @Nullable SSLEngine sslEngine, int maxContentLength) {
 		this.restBindAddress = restBindAddress;
 
 		Preconditions.checkArgument(0 <= restBindPort && restBindPort < 65536, "The bing rest port " + restBindPort + " is out of range (0, 65536[");
 		this.restBindPort = restBindPort;
 		this.sslEngine = sslEngine;
+		this.maxContentLength = maxContentLength;
 	}
 
 	/**
@@ -76,6 +78,15 @@ public final class RestServerEndpointConfiguration {
 	}
 
 	/**
+	 * Returns the max content length that the REST server endpoint could handle.
+	 *
+	 * @return max content length that the REST server endpoint could handle
+	 */
+	public int getMaxContentLength() {
+		return maxContentLength;
+	}
+
+	/**
 	 * Creates and returns a new {@link RestServerEndpointConfiguration} from the given {@link Configuration}.
 	 *
 	 * @param config configuration from which the REST server endpoint configuration should be created from
@@ -103,6 +114,11 @@ public final class RestServerEndpointConfiguration {
 			}
 		}
 
-		return new RestServerEndpointConfiguration(address, port, sslEngine);
+		int maxContentLength = config.getInteger(RestOptions.REST_SERVER_CONTENT_MAX_MB) * 1024 * 1024;
+		if (maxContentLength <= 0) {
+			throw new ConfigurationException("Max content length for server must be a positive integer: " + maxContentLength);
+		}
+
+		return new RestServerEndpointConfiguration(address, port, sslEngine, maxContentLength);
 	}
 }


### PR DESCRIPTION
## Brief change log

 Add config option to set the content length limit of REST server and client

## Verifying this change

*(Please pick either of the following options)*

Add config option to set the content length, no test case

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

