### PR TITLE
[FLINK-7567]: Removed keepPartitioning parameter from iterate method

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/FeedbackTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/FeedbackTransformation.java
@@ -87,7 +87,8 @@ public class FeedbackTransformation<T> extends StreamTransformation<T> {
 			throw new UnsupportedOperationException(
 					"Parallelism of the feedback stream must match the parallelism of the original" +
 							" stream. Parallelism of original stream: " + this.getParallelism() +
-							"; parallelism of feedback stream: " + transform.getParallelism());
+							"; parallelism of feedback stream: " + transform.getParallelism() +
+							". Parallelism can be modified using DataStream#setParallelism() method");
 		}
 
 		feedbackEdges.add(transform);

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -228,6 +228,10 @@ under the License.
 						<excludes combine.children="append">
 							<!-- Exclude generated classes from api compatibility checks -->
 							<exclude>*\$\$anon\$*</exclude>
+
+							<!-- Ignore method which was created automatically by Scala for default value calculation.
+							Can be removed once https://github.com/siom79/japicmp/issues/176 will be fixed -->
+							<exclude>org.apache.flink.streaming.api.scala.DataStream#iterate\$default\$3()</exclude>
 						</excludes>
 					</parameter>
 				</configuration>

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -499,23 +499,22 @@ class DataStream[T](stream: JavaStream[T]) {
    * stepfunction: initialStream => (feedback, output)
    *
    * A common pattern is to use output splitting to create feedback and output DataStream.
-   * Please refer to the .split(...) method of the DataStream
+   * Please refer to the [[split]] method of the DataStream
    *
    * By default a DataStream with iteration will never terminate, but the user
    * can use the maxWaitTime parameter to set a max waiting time for the iteration head.
    * If no data received in the set time the stream terminates.
    *
-   * By default the feedback partitioning is set to match the input, to override this set
-   * the keepPartitioning flag to true
-   *
+   * Parallelism of the feedback stream must match the parallelism of the original stream.
+   * Please refer to the [[setParallelism]] method for parallelism modification
    */
   @PublicEvolving
   def iterate[R](stepFunction: DataStream[T] => (DataStream[T], DataStream[R]),
-                    maxWaitTimeMillis:Long = 0,
-                    keepPartitioning: Boolean = false) : DataStream[R] = {
+                    maxWaitTimeMillis:Long = 0) : DataStream[R] = {
     val iterativeStream = stream.iterate(maxWaitTimeMillis)
 
     val (feedback, output) = stepFunction(new DataStream[T](iterativeStream))
+
     iterativeStream.closeWith(feedback.javaStream)
     output
   }


### PR DESCRIPTION
## What is the purpose of the change

Removed parameter keepPartitioning from DataStream#iterate method since it's ignored. Also slightly modified error message related to different parallelism levels of input and feedback streams

## Brief change log

  - Removed parameter keepPartitioning from DataStream#iterate 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) yes
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not applicable

