### PR TITLE
[FLINK-7050][table] Add support of RFC compliant CSV parser for Table Source

### DIFF
--- a/flink-libraries/flink-table/pom.xml
+++ b/flink-libraries/flink-table/pom.xml
@@ -114,6 +114,12 @@ under the License.
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
 		</dependency>
+		<!-- FOR RFC 4180 Compliant CSV Parser -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-csv</artifactId>
+			<version>2.9.1</version>
+		</dependency>
 
 		<!-- test dependencies -->
 

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/batch/io/RFCCsvInputFormat.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/batch/io/RFCCsvInputFormat.java
@@ -18,14 +18,17 @@
 
 package org.apache.flink.table.runtime.batch.io;
 
-import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.io.FileInputFormat;
 import org.apache.flink.api.common.io.ParseException;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.types.parser.FieldParser;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
+
+import org.apache.flink.shaded.guava18.com.google.common.primitives.Bytes;
 
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
@@ -38,49 +41,58 @@ import java.io.IOException;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.util.ArrayList;
+import java.util.Arrays;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * InputFormat that reads csv files and compliant with RFC 4180 standards.
+ * InputFormat to read data from CSV files that are compliant with the RFC 4180 standard.
  *
- * @param <OUT>
+ * @param <OUT> type of output
  */
-@Internal
 public abstract class RFCCsvInputFormat<OUT> extends FileInputFormat<OUT> {
 
 	private static final long serialVersionUID = 1L;
 
-	public static final String DEFAULT_LINE_DELIMITER = "\n";
+	/** Record delimiter, "\n" by default. */
+	public static final String DEFAULT_RECORD_DELIMITER = "\n";
+	private String recordDelimiterString = DEFAULT_RECORD_DELIMITER;
+	private byte[] recordDelimiter = recordDelimiterString.getBytes();
 
-	public static final String DEFAULT_FIELD_DELIMITER = ",";
+	/** Field delimiter, ',' by default. */
+	public static final char DEFAULT_FIELD_DELIMITER = ',';
+	private char fieldDelimiter = DEFAULT_FIELD_DELIMITER;
 
-	private String recordDelimiter = "\n";
-	private char fieldDelimiter = ',';
-
+	/** Skip the header line only for the first split. */
 	private boolean skipFirstLineAsHeader;
-	private boolean skipFirstLine = false; // only for first split
+	private boolean skipFirstLine = false;
 
+	/** To enable quoted string parsing, by default it's disabled. */
 	private boolean quotedStringParsing = false;
 	private char quoteCharacter;
 
-	private boolean lenient;
+	/** To skip records with parse error instead to fail. Throw an exception by default. */
+	private boolean lenient = false;
 
-	private String commentPrefix = null;
+	/** to skip the records with prefix '#'. */
 	private boolean allowComments = false;
 
-	private static final Class<?>[] EMPTY_TYPES = new Class<?>[0];
+	/** Type Information describing the result type. */
+	private TypeInformation[] fieldTypes = null;
 
-	private static final boolean[] EMPTY_INCLUDED = new boolean[0];
+	/** Projection mask to get only selected fields. */
+	private boolean[] fieldIncluded = new boolean[0];
 
-	private Class<?>[] fieldTypes = EMPTY_TYPES;
+	/** Record Iterator for a split returned by Csv parser. */
+	private MappingIterator<String[]> recordIterator = null;
 
-	private boolean[] fieldIncluded = EMPTY_INCLUDED;
-
-	MappingIterator<Object[]> recordIterator = null;
-
+	/** End of split, if record no record in split. */
 	private boolean endOfSplit = false;
+
+	/** The read buffer to find the first and last record delimiters for splits, default size is 4KB. */
+	private transient byte[] readBuffer;
+	private static final int DEFAULT_READ_BUFFER_SIZE = 4 * 1024;
+	private int bufferSize = -1;
 
 	protected RFCCsvInputFormat(Path filePath) {
 		super(filePath);
@@ -91,62 +103,50 @@ public abstract class RFCCsvInputFormat<OUT> extends FileInputFormat<OUT> {
 
 		super.open(split);
 
-		CsvMapper mapper = new CsvMapper();
-		mapper.disable(CsvParser.Feature.WRAP_AS_ARRAY);
-
+		initBuffers();
 		long firstDelimiterPosition = findFirstDelimiterPosition();
 		long lastDelimiterPosition = findLastDelimiterPosition();
-		long startPos = this.splitStart + firstDelimiterPosition;
-		long endPos = this.splitLength + lastDelimiterPosition - firstDelimiterPosition;
-		this.stream.seek(startPos);
-		BoundedInputStream boundedInputStream = new BoundedInputStream(this.stream, endPos);
+		long readStartingPoint = this.splitStart + firstDelimiterPosition;
+		long readLength = this.splitLength + lastDelimiterPosition - firstDelimiterPosition;
+		this.stream.seek(readStartingPoint);
+		BoundedInputStream boundedInputStream = new BoundedInputStream(this.stream, readLength);
 
-		if (skipFirstLineAsHeader && startPos == 0) {
+		if (skipFirstLineAsHeader && readStartingPoint == 0) {
 			skipFirstLine = true;
 		}
 
+		CsvMapper mapper = new CsvMapper();
+		mapper.disable(CsvParser.Feature.WRAP_AS_ARRAY);
 		CsvParser csvParser = mapper.getFactory().createParser(boundedInputStream);
 		CsvSchema csvSchema = configureParserSettings();
 		csvParser.setSchema(csvSchema);
 
-		recordIterator = mapper.readerFor(Object[].class).readValues(csvParser);
-	}
+		recordIterator = mapper.readerFor(String[].class).readValues(csvParser);
 
-	private CsvSchema configureParserSettings() {
-
-		CsvSchema csvSchema = CsvSchema.builder()
-			.setLineSeparator(this.recordDelimiter)
-			.setColumnSeparator(this.fieldDelimiter)
-			.setSkipFirstDataRow(skipFirstLine)
-			.setQuoteChar(this.quoteCharacter)
-			.setAllowComments(allowComments)
-			.build();
-		return  csvSchema;
 	}
 
 	public OUT nextRecord(OUT reuse) throws IOException {
 
 		if (recordIterator == null) {
-			return null;
+			throw new IllegalStateException("Parser is not initialized, first call open() function of RFCCsvInputFormat");
 		}
 
 		if (recordIterator.hasNext()) {
 
-			Object[] record = recordIterator.next();
-
-			if (record.length < fieldTypes.length) {
-				if (isLenient()) {
-					return nextRecord(reuse);
-				}
-				else {
-					throw new ParseException();
-				}
-			}
-
+			String[] record;
 			try {
-				return fillRecord(reuse, castRecord(projectedFields(record)));
+				record = recordIterator.next();
+				if (record.length < fieldTypes.length) {
+					if (isLenient()) {
+						return nextRecord(reuse);
+					}
+					else {
+						throw new ParseException();
+					}
+				}
+				return fillRecord(reuse, projectAndCastFields(record));
 			}
-			catch (IOException e) {
+			catch (Exception e) {
 				if (isLenient()) {
 					return nextRecord(reuse);
 				}
@@ -171,138 +171,227 @@ public abstract class RFCCsvInputFormat<OUT> extends FileInputFormat<OUT> {
 		return endOfSplit;
 	}
 
-	private Object[] projectedFields(Object[] record) throws IOException {
+	/**
+	 * Configure the CsvSchema used by the Csv Parser.
+	 * @return CsvSchema for parsing
+	 */
+	private CsvSchema configureParserSettings() {
 
-		Object[] resultantRecord = new Object[fieldTypes.length];
+		CsvSchema.Builder csvSchema = CsvSchema.builder()
+			.setLineSeparator(this.recordDelimiterString)
+			.setColumnSeparator(this.fieldDelimiter)
+			.setSkipFirstDataRow(this.skipFirstLine)
+			.setAllowComments(this.allowComments);
+		if (this.quotedStringParsing) {
+			if (getRuntimeContext().getNumberOfParallelSubtasks() > 1) {
+				throw new ParseException("Quoted string parsing is only supported with parallelism One");
+			}
+			csvSchema.setQuoteChar(this.quoteCharacter);
+		}
+		return  csvSchema.build();
+	}
+
+	/**
+	 * Initialize the read buffer, used to find first and last record delimiters for current split.
+	 */
+	private void initBuffers() {
+		this.bufferSize = this.bufferSize <= 0 ? DEFAULT_READ_BUFFER_SIZE : this.bufferSize;
+
+		if (this.bufferSize <= this.recordDelimiter.length) {
+			throw new IllegalArgumentException("Buffer size must be greater than length of delimiter.");
+		}
+
+		if (this.readBuffer == null || this.readBuffer.length != this.bufferSize) {
+			this.readBuffer = new byte[this.bufferSize];
+		}
+
+		this.endOfSplit = false;
+	}
+
+	/**
+	 * Fills the read buffer with bytes read from the stream.
+	 * @return	the total number of bytes read into the buffer, or
+	 * 			<code>-1</code> if there is no more data because the end of
+	 * 			the stream has been reached.
+	 * @throws	IOException if the input stream has been closed, or if
+	 * 			some other I/O error occurs.
+	 */
+	private int fillBuffer() throws IOException {
+		return this.stream.read(this.readBuffer, 0, this.bufferSize);
+	}
+
+	/**
+	 * Find the index of first record delimiter in a 'current split', used as a starting point of split
+	 * to create BoundedInputStream for csv parser.
+	 * @return	index of first record delimiter in a split + <code>1</code>,
+	 * 			<code>0</code> if current split is first split
+	 * @throws	IOException
+	 */
+	private long findFirstDelimiterPosition() throws IOException{
+
+		if (this.stream.getPos() == 0) {
+			return 0;
+		}
+		else {
+			this.stream.seek(this.getSplitStart());
+
+			int requests = 0;
+			int offset = 0;
+			while (requests < 10) {
+
+				int read = fillBuffer();
+				if (read < 0) {
+					throw new IOException();
+				}
+				offset = offset + this.bufferSize;
+
+				int indexOf = Bytes.indexOf(this.readBuffer, this.recordDelimiter);
+				if (indexOf > 0) {
+					return indexOf + 1;
+				}
+
+				requests++;
+			}
+			throw new IOException();
+
+		}
+	}
+
+	/**
+	 * Find the index of first record delimiter in the 'next split' of 'current split', used as an ending point of split
+	 * to create BoundedInputStream for csv parser.
+	 * @return	index of first record delimiter in the 'next split' of 'current split',
+	 * 			<code>0</code> if 'current split' is 'last split'
+	 *
+	 * @throws	IOException
+	 */
+	private long findLastDelimiterPosition() throws IOException{
+
+		this.stream.seek(this.splitStart + this.splitLength);
+
+		int offset = 0;
+		int read = fillBuffer();
+		if (read < 0) {
+			return 0;
+		}
+		offset = offset + this.bufferSize;
+
+		int indexOf = Bytes.indexOf(this.readBuffer, this.recordDelimiter);
+		if (indexOf > 0) {
+			return indexOf;
+		}
+
+		int requests = 0;
+		while (requests < 10) {
+
+			read = fillBuffer();
+			offset = offset + this.bufferSize;
+			if (read < 0) {
+				throw new IOException();
+			}
+
+			indexOf = Bytes.indexOf(this.readBuffer, this.recordDelimiter);
+			if (indexOf > 0) {
+				return indexOf;
+			}
+
+			requests++;
+		}
+		throw new IOException();
+
+	}
+
+	/**
+	 * Project and Cast the string array into object array using given projection mask and filed types.
+	 * @param record string array of
+	 * @return record as an object array
+	 * @throws IOException
+	 */
+	private Object[] projectAndCastFields(String[] record) throws IOException {
+
+		Object[] projectedFields = new Object[fieldTypes.length];
 		int index = 0;
 		for (int i = 0; i < this.fieldIncluded.length; i++) {
 
 			try {
 				if (fieldIncluded[i]) {
-					resultantRecord[index++] = record[i];
+
+					TypeInformation type = fieldTypes[index];
+					try {
+						if (record[i].length() == 0) {
+							if (type.equals(Types.STRING)) {
+								projectedFields[index] = record[i];
+							}
+							else {
+								projectedFields[index] = null;
+							}
+						}
+						else if (type.equals(Types.BOOLEAN)) {
+							projectedFields[index] = Boolean.valueOf(record[i]);
+						}
+						else if (type.equals(Types.BYTE)) {
+							projectedFields[index] = Byte.valueOf(record[i]);
+						}
+						else if (type.equals(Types.SHORT)) {
+							projectedFields[index] = Short.valueOf(record[i]);
+						}
+						else if (type.equals(Types.INT)) {
+							projectedFields[index] = Integer.valueOf(record[i]);
+						}
+						else if (type.equals(Types.LONG)) {
+							projectedFields[index] = Long.valueOf(record[i]);
+						}
+						else if (type.equals(Types.FLOAT)) {
+							projectedFields[index] = Float.valueOf(record[i]);
+						}
+						else if (type.equals(Types.DOUBLE)) {
+							projectedFields[index] = Double.valueOf(record[i]);
+						}
+						else if (type.equals(Types.DECIMAL)) {
+							projectedFields[index] = Double.valueOf(record[i]);
+						}
+						else if (type.equals(Types.SQL_DATE)) {
+							projectedFields[index] = Date.valueOf(record[i]);
+						}
+						else if (type.equals(Types.SQL_TIME)) {
+							projectedFields[index] = Time.valueOf(record[i]);
+						}
+						else if (type.equals(Types.SQL_TIMESTAMP)) {
+							projectedFields[index] = Timestamp.valueOf(record[i]);
+						}
+						else {
+							projectedFields[index] = record[i];
+						}
+					}
+					catch (Exception e) {
+						throw new ParseException();
+					}
+					index++;
 				}
 			}
 			catch (Exception e) {
 				throw new IOException();
 			}
 		}
-		return resultantRecord;
+		return projectedFields;
 	}
 
-	private long findFirstDelimiterPosition() throws IOException{
-
-		this.stream.seek(this.getSplitStart());
-		if (this.stream.getPos() == 0) {
-			return 0;
-		}
-		else {
-			int pos = 1;
-			while ((this.stream.read()) != this.recordDelimiter.charAt(0)) {
-				pos++;
-			}
-			return pos;
-		}
-	}
-
-	private long findLastDelimiterPosition() throws IOException{
-
-		this.stream.seek(this.splitStart + this.splitLength);
-		int pos = 0;
-		char c;
-		int read = this.stream.read();
-		while (read != -1) {
-			c = (char) read;
-			if (c == this.recordDelimiter.charAt(0)) {
-				break;
-			}
-			else {
-				read = this.stream.read();
-			}
-			pos++;
-		}
-		return pos;
-	}
-
-	private Object[] castRecord(Object[] record)  throws IOException {
-
-		if (isLenient()) {
-			for (int i = 0; i < this.fieldTypes.length; i++) {
-				try {
-					record[i] = dataTypeConversion(record[i], fieldTypes[i]);
-				} catch (Exception e) {
-					throw new IOException(e);
-				}
-			}
-		}
-		else {
-			for (int i = 0; i < this.fieldTypes.length; i++) {
-				try {
-					record[i] = dataTypeConversion(record[i], fieldTypes[i]);
-				} catch (Exception e) {
-					throw new IOException(e);
-				}
-			}
-		}
-		return record;
-	}
-
-	public <I, O> O dataTypeConversion(I input, Class<O> outputClass) throws Exception {
-
-		String type = outputClass.getSimpleName().toLowerCase();
-		try {
-			switch (type) {
-				case "string":
-					return (O) input.toString();
-				case "boolean":
-					if (input.toString().length() != 0) { // special case for boolean
-						return (O) Boolean.valueOf(input.toString());
-					}
-					return null;
-				case "byte":
-					return (O) Byte.valueOf(input.toString());
-				case "short":
-					return (O) Short.valueOf(input.toString());
-				case "integer":
-					return (O) Integer.valueOf(input.toString());
-				case "long":
-					return (O) Long.valueOf(input.toString());
-				case "float":
-					return (O) Float.valueOf(input.toString());
-				case "double":
-					return (O) Double.valueOf(input.toString());
-				case "decimal":
-					return (O) Double.valueOf(input.toString());
-				case "date":
-					return (O) Date.valueOf(input.toString());
-				case "time":
-					return (O) Time.valueOf(input.toString());
-				case "timestamp":
-					return (O) Timestamp.valueOf(input.toString());
-				default:
-					return (O) input;
-			}
-		}
-		catch (Exception e) {
-			if (isLenient()) {
-				return null;
-			}
-			else {
-				throw new ParseException();
-			}
-		}
-
-	}
-
-	// create projection mask
-
+	/**
+	 * Default projection mask to select all fields in a record.
+	 * @param size number of fields in a record
+	 * @return boolean array of given size with all true values
+	 */
 	protected static boolean[] createDefaultMask(int size) {
 		boolean[] includedMask = new boolean[size];
-		for (int x = 0; x < includedMask.length; x++) {
-			includedMask[x] = true;
-		}
+		Arrays.fill(includedMask, true);
 		return includedMask;
 	}
 
+	/**
+	 * Projection mask to select required fields in a record.
+	 * @param sourceFieldIndices Indices of projected fields
+	 * @return boolean array with true values only for projected fields
+	 */
 	protected static boolean[] toBooleanMask(int[] sourceFieldIndices) {
 		Preconditions.checkNotNull(sourceFieldIndices);
 
@@ -317,104 +406,22 @@ public abstract class RFCCsvInputFormat<OUT> extends FileInputFormat<OUT> {
 		boolean[] includedMask = new boolean[max + 1];
 
 		// check if we support parsers for these types
-		for (int i = 0; i < sourceFieldIndices.length; i++) {
-			includedMask[sourceFieldIndices[i]] = true;
+		for (int i : sourceFieldIndices) {
+			includedMask[i] = true;
 		}
 
 		return includedMask;
 	}
 
-	// configuration setting
-
-	public String getDelimiter() {
-		return recordDelimiter;
-	}
-
-	public void setDelimiter(char delimiter) {
-		setDelimiter(String.valueOf(delimiter));
-	}
-
-	public void setDelimiter(String delimiter) {
-		if (delimiter == null) {
-			throw new IllegalArgumentException("Delimiter must not be null");
-		}
-		if (delimiter.length() == 0) {
-			throw new IllegalArgumentException("Delimiter must not be empty");
-		}
-		this.recordDelimiter = delimiter;
-	}
-
-	public void setFieldDelimiter(char delimiter) {
-		if (String.valueOf(delimiter) == null) {
-			throw new IllegalArgumentException("Delimiter must not be null");
-		}
-		if (String.valueOf(delimiter).length() == 0) {
-			throw new IllegalArgumentException("Delimiter must not be empty");
-		}
-		this.fieldDelimiter = delimiter;
-	}
-
-	public void setFieldDelimiter(String delimiter) {
-		if (delimiter == null) {
-			throw new IllegalArgumentException("Delimiter must not be null");
-		}
-		if (delimiter.length() == 0) {
-			throw new IllegalArgumentException("Delimiter must not be empty");
-		}
-		this.fieldDelimiter = delimiter.charAt(0);
-	}
-
-	public char getFieldDelimiter() {
-		return this.fieldDelimiter;
-	}
-
-	public void setSkipFirstLineAsHeader(boolean skipFirstLine) {
-		this.skipFirstLineAsHeader = skipFirstLine;
-	}
-
-	public void enableQuotedStringParsing(char quoteCharacter) {
-		quotedStringParsing = true;
-		this.quoteCharacter = quoteCharacter;
-	}
-
-	public boolean isLenient() {
-		return lenient;
-	}
-
-	public void setLenient(boolean lenient) {
-		this.lenient = lenient;
-	}
-
-	public void setCommentPrefix(String commentPrefix) {
-		this.commentPrefix = commentPrefix;
-		this.allowComments = true;
-	}
-
-	protected Class<?>[] getGenericFieldTypes() {
-		// check if we are dense, i.e., we read all fields
-		if (this.fieldIncluded.length == this.fieldTypes.length) {
-			return this.fieldTypes;
-		}
-		else {
-			// sparse type array which we made dense for internal book keeping.
-			// create a sparse copy to return
-			Class<?>[] types = new Class<?>[this.fieldIncluded.length];
-
-			for (int i = 0, k = 0; i < this.fieldIncluded.length; i++) {
-				if (this.fieldIncluded[i]) {
-					types[i] = this.fieldTypes[k++];
-				}
-			}
-
-			return types;
-		}
-	}
-
-	protected void setFieldsGeneric(boolean[] includedMask, Class<?>[] fieldTypes) {
+	/**
+	 * Set the field types and projection mask.
+	 * Also, check that for given filed types parsing is supported or not.
+	 * @param includedMask projection mask
+	 * @param fieldTypes field types of projected fields
+	 */
+	protected void setOnlySupportedFieldsTypes(boolean[] includedMask, TypeInformation[] fieldTypes) {
 		checkNotNull(includedMask);
 		checkNotNull(fieldTypes);
-
-		ArrayList<Class<?>> types = new ArrayList<Class<?>>();
 
 		// check if types are valid for included fields
 		int typeIndex = 0;
@@ -424,7 +431,7 @@ public abstract class RFCCsvInputFormat<OUT> extends FileInputFormat<OUT> {
 				if (typeIndex > fieldTypes.length - 1) {
 					throw new IllegalArgumentException("Missing type for included field " + i + ".");
 				}
-				Class<?> type = fieldTypes[typeIndex++];
+				Class<?> type = fieldTypes[typeIndex++].getTypeClass();
 
 				if (type == null) {
 					throw new IllegalArgumentException("Type for included field " + i + " should not be null.");
@@ -433,17 +440,133 @@ public abstract class RFCCsvInputFormat<OUT> extends FileInputFormat<OUT> {
 					if (FieldParser.getParserForType(type) == null) {
 						throw new IllegalArgumentException("The type '" + type.getName() + "' is not supported for the CSV input format.");
 					}
-					types.add(type);
 				}
 			}
 		}
-
-		this.fieldTypes = types.toArray(new Class<?>[types.size()]);
+		this.fieldTypes = fieldTypes;
 		this.fieldIncluded = includedMask;
 	}
 
-	public Class<?>[] getFieldTypes() {
-		return getGenericFieldTypes();
+	/**
+	 * Get record delimiter used for parsing.
+	 * @return record delimiter as byte array
+	 */
+	public byte[] getRecordDelimiter() {
+		return this.recordDelimiter;
+	}
+
+	/**
+	 * Set record delimiter used for parsing.
+	 * @param recordDelimiter char record delimiter
+	 */
+	public void setRecordDelimiter(char recordDelimiter) {
+		setRecordDelimiter(String.valueOf(recordDelimiter));
+	}
+
+	/**
+	 * Set record delimiter used for parsing.
+	 * @param recordDelimiter string record delimiter
+	 */
+	public void setRecordDelimiter(String recordDelimiter) {
+		if (recordDelimiter == null) {
+			throw new IllegalArgumentException("Record delimiter must not be null");
+		}
+		if (recordDelimiter.length() == 0) {
+			throw new IllegalArgumentException("Record delimiter must not be empty");
+		}
+		if ((recordDelimiter.compareTo("\n") != 0) &&
+			(recordDelimiter.compareTo("\r\n") != 0) &&
+			(recordDelimiter.compareTo("\r") != 0)){
+			throw new IllegalArgumentException("Record delimiter " + recordDelimiter + " is not supported yet, " +
+				"Only \"\\r\", \"\\r\\n\", \"\\n\" are supported as record delimiter.");
+		}
+
+		this.recordDelimiterString = recordDelimiter;
+		this.recordDelimiter = recordDelimiter.getBytes();
+	}
+
+	/**
+	 * Get field delimiter used for parsing.
+	 * @return field delimiter as a char
+	 */
+	public char getFieldDelimiter() {
+		return this.fieldDelimiter;
+	}
+
+	/**
+	 * Set field delimiter used for parsing.
+	 * @param delimiter field delimiter
+	 */
+	public void setFieldDelimiter(char delimiter) {
+		if (String.valueOf(delimiter) == null) {
+			throw new IllegalArgumentException("Field delimiter must not be null");
+		}
+		if (String.valueOf(delimiter).length() == 0) {
+			throw new IllegalArgumentException("Field delimiter must not be empty");
+		}
+		if (String.valueOf(delimiter).length() != 1) {
+			throw new IllegalArgumentException("Filed delimiter must be a single character");
+		}
+		this.fieldDelimiter = delimiter;
+	}
+
+	/**
+	 * Set field delimiter used for parsing.
+	 * @param delimiter field delimiter
+	 */
+	public void setFieldDelimiter(String delimiter) {
+		if (delimiter == null) {
+			throw new IllegalArgumentException("Field delimiter must not be null");
+		}
+		if (delimiter.length() == 0) {
+			throw new IllegalArgumentException("Field delimiter must not be empty");
+		}
+		if (delimiter.length() != 1) {
+			throw new IllegalArgumentException("Filed delimiter must be a single character");
+		}
+		this.fieldDelimiter = delimiter.charAt(0);
+	}
+
+	/**
+	 * Skip the first line of csv file. Normally to skip header.
+	 * @param skipFirstLine true to skip the first line or header
+	 */
+	public void enableSkipFirstLine(boolean skipFirstLine) {
+		this.skipFirstLineAsHeader = skipFirstLine;
+	}
+
+	/**
+	 * Enable parsing for quoted strings in a csv file.
+	 * @param quoteCharacter Quote Character
+	 */
+	public void enableQuotedStringParsing(char quoteCharacter) {
+		quotedStringParsing = true;
+		this.quoteCharacter = quoteCharacter;
+	}
+
+	/**
+	 * Check that Lenient parsing is enabled or not.
+	 * @return return true if Lenient parsing is enabled, otherwise return false.
+	 */
+	private boolean isLenient() {
+		return lenient;
+	}
+
+	/**
+	 * Enable Lenient parsing. Ignore records with missing or wrond values.
+	 * @param lenient set true to enable lenient parsing
+	 */
+	public void enableLenientParsing(boolean lenient) {
+		this.lenient = lenient;
+	}
+
+	/**
+	 * Skip the comment lines.
+	 * Lines starting with a prefix '#'.
+	 * @param skipComment set true to skip lines starting with '#'
+	 */
+	public void enableSkipComment(boolean skipComment) {
+		this.allowComments = skipComment;
 	}
 
 }

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/batch/io/RFCCsvInputFormat.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/batch/io/RFCCsvInputFormat.java
@@ -1,0 +1,449 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.batch.io;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.io.FileInputFormat;
+import org.apache.flink.api.common.io.ParseException;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
+
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvParser;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+
+import org.apache.commons.io.input.BoundedInputStream;
+
+import java.io.IOException;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * InputFormat that reads csv files and compliant with RFC 4180 standards.
+ *
+ * @param <OUT>
+ */
+@Internal
+public abstract class RFCCsvInputFormat<OUT> extends FileInputFormat<OUT> {
+
+	private static final long serialVersionUID = 1L;
+
+	public static final String DEFAULT_LINE_DELIMITER = "\n";
+
+	public static final String DEFAULT_FIELD_DELIMITER = ",";
+
+	private String recordDelimiter = "\n";
+	private char fieldDelimiter = ',';
+
+	private boolean skipFirstLineAsHeader;
+	private boolean skipFirstLine = false; // only for first split
+
+	private boolean quotedStringParsing = false;
+	private char quoteCharacter;
+
+	private boolean lenient;
+
+	private String commentPrefix = null;
+	private boolean allowComments = false;
+
+	private static final Class<?>[] EMPTY_TYPES = new Class<?>[0];
+
+	private static final boolean[] EMPTY_INCLUDED = new boolean[0];
+
+	private Class<?>[] fieldTypes = EMPTY_TYPES;
+
+	private boolean[] fieldIncluded = EMPTY_INCLUDED;
+
+	MappingIterator<Object[]> recordIterator = null;
+
+	private boolean endOfSplit = false;
+
+	protected RFCCsvInputFormat(Path filePath) {
+		super(filePath);
+	}
+
+	@Override
+	public void open(FileInputSplit split) throws IOException {
+
+		super.open(split);
+
+		CsvMapper mapper = new CsvMapper();
+		mapper.disable(CsvParser.Feature.WRAP_AS_ARRAY);
+
+		long firstDelimiterPosition = findFirstDelimiterPosition();
+		long lastDelimiterPosition = findLastDelimiterPosition();
+		long startPos = this.splitStart + firstDelimiterPosition;
+		long endPos = this.splitLength + lastDelimiterPosition - firstDelimiterPosition;
+		this.stream.seek(startPos);
+		BoundedInputStream boundedInputStream = new BoundedInputStream(this.stream, endPos);
+
+		if (skipFirstLineAsHeader && startPos == 0) {
+			skipFirstLine = true;
+		}
+
+		CsvParser csvParser = mapper.getFactory().createParser(boundedInputStream);
+		CsvSchema csvSchema = configureParserSettings();
+		csvParser.setSchema(csvSchema);
+
+		recordIterator = mapper.readerFor(Object[].class).readValues(csvParser);
+	}
+
+	private CsvSchema configureParserSettings() {
+
+		CsvSchema csvSchema = CsvSchema.builder()
+			.setLineSeparator(this.recordDelimiter)
+			.setColumnSeparator(this.fieldDelimiter)
+			.setSkipFirstDataRow(skipFirstLine)
+			.setQuoteChar(this.quoteCharacter)
+			.setAllowComments(allowComments)
+			.build();
+		return  csvSchema;
+	}
+
+	public OUT nextRecord(OUT reuse) throws IOException {
+
+		if (recordIterator == null) {
+			return null;
+		}
+
+		if (recordIterator.hasNext()) {
+
+			Object[] record = recordIterator.next();
+
+			if (record.length < fieldTypes.length) {
+				if (isLenient()) {
+					return nextRecord(reuse);
+				}
+				else {
+					throw new ParseException();
+				}
+			}
+
+			try {
+				return fillRecord(reuse, castRecord(projectedFields(record)));
+			}
+			catch (IOException e) {
+				if (isLenient()) {
+					return nextRecord(reuse);
+				}
+				else {
+					throw new ParseException(e);
+				}
+			}
+		}
+		endOfSplit = true;
+		return null;
+	}
+
+	protected abstract OUT fillRecord(OUT reuse, Object[] parsedValues);
+
+	@Override
+	public String toString() {
+		return "CSV Input (" + StringUtils.showControlCharacters(String.valueOf(fieldDelimiter)) + ") " + getFilePath();
+	}
+
+	@Override
+	public boolean reachedEnd() throws IOException {
+		return endOfSplit;
+	}
+
+	private Object[] projectedFields(Object[] record) throws IOException {
+
+		Object[] resultantRecord = new Object[fieldTypes.length];
+		int index = 0;
+		for (int i = 0; i < this.fieldIncluded.length; i++) {
+
+			try {
+				if (fieldIncluded[i]) {
+					resultantRecord[index++] = record[i];
+				}
+			}
+			catch (Exception e) {
+				throw new IOException();
+			}
+		}
+		return resultantRecord;
+	}
+
+	private long findFirstDelimiterPosition() throws IOException{
+
+		this.stream.seek(this.getSplitStart());
+		if (this.stream.getPos() == 0) {
+			return 0;
+		}
+		else {
+			int pos = 1;
+			while ((this.stream.read()) != this.recordDelimiter.charAt(0)) {
+				pos++;
+			}
+			return pos;
+		}
+	}
+
+	private long findLastDelimiterPosition() throws IOException{
+
+		this.stream.seek(this.splitStart + this.splitLength);
+		int pos = 0;
+		char c;
+		int read = this.stream.read();
+		while (read != -1) {
+			c = (char) read;
+			if (c == this.recordDelimiter.charAt(0)) {
+				break;
+			}
+			else {
+				read = this.stream.read();
+			}
+			pos++;
+		}
+		return pos;
+	}
+
+	private Object[] castRecord(Object[] record)  throws IOException {
+
+		if (isLenient()) {
+			for (int i = 0; i < this.fieldTypes.length; i++) {
+				try {
+					record[i] = dataTypeConversion(record[i], fieldTypes[i]);
+				} catch (Exception e) {
+					throw new IOException(e);
+				}
+			}
+		}
+		else {
+			for (int i = 0; i < this.fieldTypes.length; i++) {
+				try {
+					record[i] = dataTypeConversion(record[i], fieldTypes[i]);
+				} catch (Exception e) {
+					throw new IOException(e);
+				}
+			}
+		}
+		return record;
+	}
+
+	public <I, O> O dataTypeConversion(I input, Class<O> outputClass) throws Exception {
+
+		String type = outputClass.getSimpleName().toLowerCase();
+		try {
+			switch (type) {
+				case "string":
+					return (O) input.toString();
+				case "boolean":
+					if (input.toString().length() != 0) { // special case for boolean
+						return (O) Boolean.valueOf(input.toString());
+					}
+					return null;
+				case "byte":
+					return (O) Byte.valueOf(input.toString());
+				case "short":
+					return (O) Short.valueOf(input.toString());
+				case "integer":
+					return (O) Integer.valueOf(input.toString());
+				case "long":
+					return (O) Long.valueOf(input.toString());
+				case "float":
+					return (O) Float.valueOf(input.toString());
+				case "double":
+					return (O) Double.valueOf(input.toString());
+				case "decimal":
+					return (O) Double.valueOf(input.toString());
+				case "date":
+					return (O) Date.valueOf(input.toString());
+				case "time":
+					return (O) Time.valueOf(input.toString());
+				case "timestamp":
+					return (O) Timestamp.valueOf(input.toString());
+				default:
+					return (O) input;
+			}
+		}
+		catch (Exception e) {
+			if (isLenient()) {
+				return null;
+			}
+			else {
+				throw new ParseException();
+			}
+		}
+
+	}
+
+	// create projection mask
+
+	protected static boolean[] createDefaultMask(int size) {
+		boolean[] includedMask = new boolean[size];
+		for (int x = 0; x < includedMask.length; x++) {
+			includedMask[x] = true;
+		}
+		return includedMask;
+	}
+
+	protected static boolean[] toBooleanMask(int[] sourceFieldIndices) {
+		Preconditions.checkNotNull(sourceFieldIndices);
+
+		int max = 0;
+		for (int i : sourceFieldIndices) {
+			if (i < 0) {
+				throw new IllegalArgumentException("Field indices must not be smaller than zero.");
+			}
+			max = Math.max(i, max);
+		}
+
+		boolean[] includedMask = new boolean[max + 1];
+
+		// check if we support parsers for these types
+		for (int i = 0; i < sourceFieldIndices.length; i++) {
+			includedMask[sourceFieldIndices[i]] = true;
+		}
+
+		return includedMask;
+	}
+
+	// configuration setting
+
+	public String getDelimiter() {
+		return recordDelimiter;
+	}
+
+	public void setDelimiter(char delimiter) {
+		setDelimiter(String.valueOf(delimiter));
+	}
+
+	public void setDelimiter(String delimiter) {
+		if (delimiter == null) {
+			throw new IllegalArgumentException("Delimiter must not be null");
+		}
+		if (delimiter.length() == 0) {
+			throw new IllegalArgumentException("Delimiter must not be empty");
+		}
+		this.recordDelimiter = delimiter;
+	}
+
+	public void setFieldDelimiter(char delimiter) {
+		if (String.valueOf(delimiter) == null) {
+			throw new IllegalArgumentException("Delimiter must not be null");
+		}
+		if (String.valueOf(delimiter).length() == 0) {
+			throw new IllegalArgumentException("Delimiter must not be empty");
+		}
+		this.fieldDelimiter = delimiter;
+	}
+
+	public void setFieldDelimiter(String delimiter) {
+		if (delimiter == null) {
+			throw new IllegalArgumentException("Delimiter must not be null");
+		}
+		if (delimiter.length() == 0) {
+			throw new IllegalArgumentException("Delimiter must not be empty");
+		}
+		this.fieldDelimiter = delimiter.charAt(0);
+	}
+
+	public char getFieldDelimiter() {
+		return this.fieldDelimiter;
+	}
+
+	public void setSkipFirstLineAsHeader(boolean skipFirstLine) {
+		this.skipFirstLineAsHeader = skipFirstLine;
+	}
+
+	public void enableQuotedStringParsing(char quoteCharacter) {
+		quotedStringParsing = true;
+		this.quoteCharacter = quoteCharacter;
+	}
+
+	public boolean isLenient() {
+		return lenient;
+	}
+
+	public void setLenient(boolean lenient) {
+		this.lenient = lenient;
+	}
+
+	public void setCommentPrefix(String commentPrefix) {
+		this.commentPrefix = commentPrefix;
+		this.allowComments = true;
+	}
+
+	protected Class<?>[] getGenericFieldTypes() {
+		// check if we are dense, i.e., we read all fields
+		if (this.fieldIncluded.length == this.fieldTypes.length) {
+			return this.fieldTypes;
+		}
+		else {
+			// sparse type array which we made dense for internal book keeping.
+			// create a sparse copy to return
+			Class<?>[] types = new Class<?>[this.fieldIncluded.length];
+
+			for (int i = 0, k = 0; i < this.fieldIncluded.length; i++) {
+				if (this.fieldIncluded[i]) {
+					types[i] = this.fieldTypes[k++];
+				}
+			}
+
+			return types;
+		}
+	}
+
+	protected void setFieldsGeneric(boolean[] includedMask, Class<?>[] fieldTypes) {
+		checkNotNull(includedMask);
+		checkNotNull(fieldTypes);
+
+		ArrayList<Class<?>> types = new ArrayList<Class<?>>();
+
+		// check if types are valid for included fields
+		int typeIndex = 0;
+		for (int i = 0; i < includedMask.length; i++) {
+
+			if (includedMask[i]) {
+				if (typeIndex > fieldTypes.length - 1) {
+					throw new IllegalArgumentException("Missing type for included field " + i + ".");
+				}
+				Class<?> type = fieldTypes[typeIndex++];
+
+				if (type == null) {
+					throw new IllegalArgumentException("Type for included field " + i + " should not be null.");
+				} else {
+					// check if we support parsers for this type
+					if (FieldParser.getParserForType(type) == null) {
+						throw new IllegalArgumentException("The type '" + type.getName() + "' is not supported for the CSV input format.");
+					}
+					types.add(type);
+				}
+			}
+		}
+
+		this.fieldTypes = types.toArray(new Class<?>[types.size()]);
+		this.fieldIncluded = includedMask;
+	}
+
+	public Class<?>[] getFieldTypes() {
+		return getGenericFieldTypes();
+	}
+
+}

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/batch/io/RFCRowCsvInputFormat.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/batch/io/RFCRowCsvInputFormat.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.batch.io;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.types.Row;
+
+import java.util.Arrays;
+
+/**
+ * Input format that reads csv into {@link Row}.
+ * Compliant with RFC 4180 standards.
+ */
+@PublicEvolving
+public class RFCRowCsvInputFormat extends RFCCsvInputFormat<Row> implements ResultTypeQueryable<Row> {
+
+	private static final long serialVersionUID = 1L;
+
+	private int arity;
+	private TypeInformation[] fieldTypeInfos;
+	private int[] fieldPosMap;
+	private boolean emptyColumnAsNull;
+
+	public RFCRowCsvInputFormat(Path filePath, TypeInformation[] fieldTypeInfos, String lineDelimiter, String fieldDelimiter, int[] selectedFields, boolean emptyColumnAsNull) {
+
+		super(filePath);
+		this.arity = fieldTypeInfos.length;
+		if (arity == 0) {
+			throw new IllegalArgumentException("At least one field must be specified");
+		}
+		if (arity != selectedFields.length) {
+			throw new IllegalArgumentException("Number of field types and selected fields must be the same");
+		}
+
+		this.fieldTypeInfos = fieldTypeInfos;
+		this.fieldPosMap = toFieldPosMap(selectedFields);
+		this.emptyColumnAsNull = emptyColumnAsNull;
+
+		boolean[] fieldsMask = toFieldMask(selectedFields);
+
+		setDelimiter(lineDelimiter);
+		setFieldDelimiter(fieldDelimiter);
+		setFieldsGeneric(fieldsMask, extractTypeClasses(fieldTypeInfos));
+	}
+
+	public RFCRowCsvInputFormat(Path filePath, TypeInformation[] fieldTypes, String lineDelimiter, String fieldDelimiter, int[] selectedFields) {
+		this(filePath, fieldTypes, lineDelimiter, fieldDelimiter, selectedFields, false);
+	}
+
+	public RFCRowCsvInputFormat(Path filePath, TypeInformation[] fieldTypes, String lineDelimiter, String fieldDelimiter) {
+		this(filePath, fieldTypes, lineDelimiter, fieldDelimiter, sequentialScanOrder(fieldTypes.length));
+	}
+
+	public RFCRowCsvInputFormat(Path filePath, TypeInformation[] fieldTypes, int[] selectedFields) {
+		this(filePath, fieldTypes, DEFAULT_LINE_DELIMITER, DEFAULT_FIELD_DELIMITER, selectedFields);
+	}
+
+	public RFCRowCsvInputFormat(Path filePath, TypeInformation[] fieldTypes, boolean emptyColumnAsNull) {
+		this(filePath, fieldTypes, DEFAULT_LINE_DELIMITER, DEFAULT_FIELD_DELIMITER, sequentialScanOrder(fieldTypes.length), emptyColumnAsNull);
+	}
+
+	public RFCRowCsvInputFormat(Path filePath, TypeInformation[] fieldTypes) {
+		this(filePath, fieldTypes, false);
+	}
+
+	private static Class<?>[] extractTypeClasses(TypeInformation[] fieldTypes) {
+		Class<?>[] classes = new Class<?>[fieldTypes.length];
+		for (int i = 0; i < fieldTypes.length; i++) {
+			classes[i] = fieldTypes[i].getTypeClass();
+		}
+		return classes;
+	}
+
+	private static int[] sequentialScanOrder(int arity) {
+		int[] sequentialOrder = new int[arity];
+		for (int i = 0; i < arity; i++) {
+			sequentialOrder[i] = i;
+		}
+		return sequentialOrder;
+	}
+
+	private static boolean[] toFieldMask(int[] selectedFields) {
+		int maxField = 0;
+		for (int selectedField : selectedFields) {
+			maxField = Math.max(maxField, selectedField);
+		}
+		boolean[] mask = new boolean[maxField + 1];
+		Arrays.fill(mask, false);
+
+		for (int selectedField : selectedFields) {
+			mask[selectedField] = true;
+		}
+		return mask;
+	}
+
+	private static int[] toFieldPosMap(int[] selectedFields) {
+		int[] fieldIdxs = Arrays.copyOf(selectedFields, selectedFields.length);
+		Arrays.sort(fieldIdxs);
+
+		int[] fieldPosMap = new int[selectedFields.length];
+		for (int i = 0; i < selectedFields.length; i++) {
+			int pos = Arrays.binarySearch(fieldIdxs, selectedFields[i]);
+			fieldPosMap[pos] = i;
+		}
+
+		return fieldPosMap;
+	}
+
+	@Override
+	protected Row fillRecord(Row reuse, Object[] parsedValues) {
+		Row reuseRow;
+		if (reuse == null) {
+			reuseRow = new Row(arity);
+		} else {
+			reuseRow = reuse;
+		}
+		for (int i = 0; i < parsedValues.length; i++) {
+			reuseRow.setField(i, parsedValues[fieldPosMap[i]]);
+		}
+		return reuseRow;
+	}
+
+	@Override
+	public TypeInformation<Row> getProducedType() {
+		return new RowTypeInfo(this.fieldTypeInfos);
+	}
+}

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/batch/io/RFCTupleCsvInputFormat.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/runtime/batch/io/RFCTupleCsvInputFormat.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.batch.io;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.java.typeutils.TupleTypeInfoBase;
+import org.apache.flink.api.java.typeutils.runtime.TupleSerializerBase;
+import org.apache.flink.core.fs.Path;
+
+/**
+ * Input format that reads csv into tuples.
+ * Compliant with RFC 4180 standards.
+ */
+@Internal
+public class RFCTupleCsvInputFormat<OUT> extends RFCCsvInputFormat<OUT> {
+
+	private static final long serialVersionUID = 1L;
+
+	private TupleSerializerBase<OUT> tupleSerializer;
+
+	public RFCTupleCsvInputFormat(Path filePath, TupleTypeInfoBase<OUT> tupleTypeInfo) {
+		this(filePath, DEFAULT_LINE_DELIMITER, DEFAULT_FIELD_DELIMITER, tupleTypeInfo);
+	}
+
+	public RFCTupleCsvInputFormat(Path filePath, String lineDelimiter, String fieldDelimiter, TupleTypeInfoBase<OUT> tupleTypeInfo) {
+		this(filePath, lineDelimiter, fieldDelimiter, tupleTypeInfo, createDefaultMask(tupleTypeInfo.getArity()));
+	}
+
+	public RFCTupleCsvInputFormat(Path filePath, TupleTypeInfoBase<OUT> tupleTypeInfo, int[] includedFieldsMask) {
+		this(filePath, DEFAULT_LINE_DELIMITER, DEFAULT_FIELD_DELIMITER, tupleTypeInfo, includedFieldsMask);
+	}
+
+	public RFCTupleCsvInputFormat(Path filePath, String lineDelimiter, String fieldDelimiter, TupleTypeInfoBase<OUT> tupleTypeInfo, int[] includedFieldsMask) {
+		super(filePath);
+		boolean[] mask = (includedFieldsMask == null)
+				? createDefaultMask(tupleTypeInfo.getArity())
+				: toBooleanMask(includedFieldsMask);
+		configure(lineDelimiter, fieldDelimiter, tupleTypeInfo, mask);
+	}
+
+	public RFCTupleCsvInputFormat(Path filePath, TupleTypeInfoBase<OUT> tupleTypeInfo, boolean[] includedFieldsMask) {
+		this(filePath, DEFAULT_LINE_DELIMITER, DEFAULT_FIELD_DELIMITER, tupleTypeInfo, includedFieldsMask);
+	}
+
+	public RFCTupleCsvInputFormat(Path filePath, String lineDelimiter, String fieldDelimiter, TupleTypeInfoBase<OUT> tupleTypeInfo, boolean[] includedFieldsMask) {
+		super(filePath);
+		configure(lineDelimiter, fieldDelimiter, tupleTypeInfo, includedFieldsMask);
+	}
+
+	private void configure(String lineDelimiter, String fieldDelimiter,
+			TupleTypeInfoBase<OUT> tupleTypeInfo, boolean[] includedFieldsMask) {
+
+		if (tupleTypeInfo.getArity() == 0) {
+			throw new IllegalArgumentException("Tuple size must be greater than 0.");
+		}
+
+		if (includedFieldsMask == null) {
+			includedFieldsMask = createDefaultMask(tupleTypeInfo.getArity());
+		}
+
+		tupleSerializer = (TupleSerializerBase<OUT>) tupleTypeInfo.createSerializer(new ExecutionConfig());
+
+		setDelimiter(lineDelimiter);
+		setFieldDelimiter(fieldDelimiter);
+
+		Class<?>[] classes = new Class<?>[tupleTypeInfo.getArity()];
+
+		for (int i = 0; i < tupleTypeInfo.getArity(); i++) {
+			classes[i] = tupleTypeInfo.getTypeAt(i).getTypeClass();
+		}
+
+		setFieldsGeneric(includedFieldsMask, classes);
+	}
+
+	@Override
+	public OUT fillRecord(OUT reuse, Object[] parsedValues) {
+		return tupleSerializer.createOrReuseInstance(parsedValues, reuse);
+	}
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/RFCCsvTableSource.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/RFCCsvTableSource.scala
@@ -48,8 +48,8 @@ class RFCCsvTableSource(
     private val path: String,
     private val fieldNames: Array[String],
     private val fieldTypes: Array[TypeInformation[_]],
-    private val fieldDelim: String = RFCCsvInputFormat.DEFAULT_FIELD_DELIMITER,
-    private val rowDelim: String = RFCCsvInputFormat.DEFAULT_LINE_DELIMITER,
+    private val fieldDelim: Char = RFCCsvInputFormat.DEFAULT_FIELD_DELIMITER,
+    private val rowDelim: String = RFCCsvInputFormat.DEFAULT_RECORD_DELIMITER,
     private val quoteCharacter: Character = null,
     private val ignoreFirstLine: Boolean = false,
     private val ignoreComments: String = null,
@@ -68,7 +68,7 @@ class RFCCsvTableSource(
     */
   def this(path: String, fieldNames: Array[String], fieldTypes: Array[TypeInformation[_]]) =
     this(path, fieldNames, fieldTypes, RFCCsvInputFormat.DEFAULT_FIELD_DELIMITER,
-      RFCCsvInputFormat.DEFAULT_LINE_DELIMITER, null, false, null, false)
+      RFCCsvInputFormat.DEFAULT_RECORD_DELIMITER, null, false, null, false)
 
   if (fieldNames.length != fieldTypes.length) {
     throw TableException("Number of field names and field types must be equal.")
@@ -128,13 +128,13 @@ class RFCCsvTableSource(
       fieldDelim,
       selectedFields)
 
-    inputFormat.setSkipFirstLineAsHeader(ignoreFirstLine)
-    inputFormat.setLenient(lenient)
+    inputFormat.enableSkipFirstLine(ignoreFirstLine)
+    inputFormat.enableLenientParsing(lenient)
     if (quoteCharacter != null) {
       inputFormat.enableQuotedStringParsing(quoteCharacter)
     }
     if (ignoreComments != null) {
-      inputFormat.setCommentPrefix(ignoreComments)
+      inputFormat.enableSkipComment(true)
     }
 
     inputFormat
@@ -179,8 +179,8 @@ object RFCCsvTableSource {
       mutable.LinkedHashMap[String, TypeInformation[_]]()
     private var quoteCharacter: Character = _
     private var path: String = _
-    private var fieldDelim: String = RFCCsvInputFormat.DEFAULT_FIELD_DELIMITER
-    private var lineDelim: String = RFCCsvInputFormat.DEFAULT_LINE_DELIMITER
+    private var fieldDelim: Char = RFCCsvInputFormat.DEFAULT_FIELD_DELIMITER
+    private var lineDelim: String = RFCCsvInputFormat.DEFAULT_RECORD_DELIMITER
     private var isIgnoreFirstLine: Boolean = false
     private var commentPrefix: String = _
     private var lenient: Boolean = false
@@ -200,7 +200,7 @@ object RFCCsvTableSource {
       *
       * @param delim the field delimiter
       */
-    def fieldDelimiter(delim: String): Builder = {
+    def fieldDelimiter(delim: Char): Builder = {
       this.fieldDelim = delim
       this
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/RFCCsvTableSource.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/RFCCsvTableSource.scala
@@ -1,0 +1,312 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
+import org.apache.flink.types.Row
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.core.fs.Path
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.runtime.batch.io.{RFCCsvInputFormat, RFCRowCsvInputFormat}
+
+import scala.collection.mutable
+
+/**
+  * A [[BatchTableSource]] and [[StreamTableSource]] for CSV files with a
+  * (logically) unlimited number of fields and compliant with RFC 4180 standards.
+  *
+  * @param path The path to the CSV file.
+  * @param fieldNames The names of the table fields.
+  * @param fieldTypes The types of the table fields.
+  * @param fieldDelim The field delimiter, "," by default.
+  * @param rowDelim The row delimiter, "\n" by default.
+  * @param quoteCharacter An optional quote character for String values, null by default.
+  * @param ignoreFirstLine Flag to ignore the first line, false by default.
+  * @param ignoreComments An optional prefix to indicate comments, null by default.
+  * @param lenient Flag to skip records with parse error instead to fail, false by default.
+  */
+class RFCCsvTableSource(
+    private val path: String,
+    private val fieldNames: Array[String],
+    private val fieldTypes: Array[TypeInformation[_]],
+    private val fieldDelim: String = RFCCsvInputFormat.DEFAULT_FIELD_DELIMITER,
+    private val rowDelim: String = RFCCsvInputFormat.DEFAULT_LINE_DELIMITER,
+    private val quoteCharacter: Character = null,
+    private val ignoreFirstLine: Boolean = false,
+    private val ignoreComments: String = null,
+    private val lenient: Boolean = false)
+  extends BatchTableSource[Row]
+  with StreamTableSource[Row]
+  with ProjectableTableSource[Row] {
+
+  /**
+    * A [[BatchTableSource]] and [[StreamTableSource]] for simple CSV files with a
+    * (logically) unlimited number of fields.
+    *
+    * @param path The path to the CSV file.
+    * @param fieldNames The names of the table fields.
+    * @param fieldTypes The types of the table fields.
+    */
+  def this(path: String, fieldNames: Array[String], fieldTypes: Array[TypeInformation[_]]) =
+    this(path, fieldNames, fieldTypes, RFCCsvInputFormat.DEFAULT_FIELD_DELIMITER,
+      RFCCsvInputFormat.DEFAULT_LINE_DELIMITER, null, false, null, false)
+
+  if (fieldNames.length != fieldTypes.length) {
+    throw TableException("Number of field names and field types must be equal.")
+  }
+
+  private val returnType = new RowTypeInfo(fieldTypes, fieldNames)
+
+  private var selectedFields: Array[Int] = fieldTypes.indices.toArray
+
+  /**
+    * Returns the data of the table as a [[DataSet]] of [[Row]].
+    *
+    * NOTE: This method is for internal use only for defining a [[TableSource]].
+    *       Do not use it in Table API programs.
+    */
+  override def getDataSet(execEnv: ExecutionEnvironment): DataSet[Row] = {
+    execEnv.createInput(createCsvInput(), returnType)
+  }
+
+  /** Returns the [[RowTypeInfo]] for the return type of the [[RFCCsvTableSource]]. */
+  override def getReturnType: RowTypeInfo = returnType
+
+  /**
+    * Returns the data of the table as a [[DataStream]] of [[Row]].
+    *
+    * NOTE: This method is for internal use only for defining a [[TableSource]].
+    *       Do not use it in Table API programs.
+    */
+  override def getDataStream(streamExecEnv: StreamExecutionEnvironment): DataStream[Row] = {
+    streamExecEnv.createInput(createCsvInput(), returnType)
+  }
+
+  /** Returns a copy of [[TableSource]] with ability to project fields */
+  override def projectFields(fields: Array[Int]): RFCCsvTableSource = {
+
+    val newFieldNames: Array[String] = fields.map(fieldNames(_))
+    val newFieldTypes: Array[TypeInformation[_]] = fields.map(fieldTypes(_))
+
+    val source = new RFCCsvTableSource(path,
+      newFieldNames,
+      newFieldTypes,
+      fieldDelim,
+      rowDelim,
+      quoteCharacter,
+      ignoreFirstLine,
+      ignoreComments,
+      lenient)
+    source.selectedFields = fields
+    source
+  }
+
+  private def createCsvInput(): RFCRowCsvInputFormat = {
+    val inputFormat = new RFCRowCsvInputFormat(
+      new Path(path),
+      fieldTypes,
+      rowDelim,
+      fieldDelim,
+      selectedFields)
+
+    inputFormat.setSkipFirstLineAsHeader(ignoreFirstLine)
+    inputFormat.setLenient(lenient)
+    if (quoteCharacter != null) {
+      inputFormat.enableQuotedStringParsing(quoteCharacter)
+    }
+    if (ignoreComments != null) {
+      inputFormat.setCommentPrefix(ignoreComments)
+    }
+
+    inputFormat
+  }
+
+  override def equals(other: Any): Boolean = other match {
+    case that: RFCCsvTableSource => returnType == that.returnType &&
+        path == that.path &&
+        fieldDelim == that.fieldDelim &&
+        rowDelim == that.rowDelim &&
+        quoteCharacter == that.quoteCharacter &&
+        ignoreFirstLine == that.ignoreFirstLine &&
+        ignoreComments == that.ignoreComments &&
+        lenient == that.lenient
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    returnType.hashCode()
+  }
+}
+
+object RFCCsvTableSource {
+
+  /**
+    * A builder for creating [[RFCCsvTableSource]] instances.
+    *
+    * For example:
+    *
+    * {{{
+    *   val source: RFCCsvTableSource = new RFCCsvTableSource.builder()
+    *     .path("/path/to/your/file.csv")
+    *     .field("myfield", Types.STRING)
+    *     .field("myfield2", Types.INT)
+    *     .build()
+    * }}}
+    *
+    */
+  class Builder {
+
+    private val schema: mutable.LinkedHashMap[String, TypeInformation[_]] =
+      mutable.LinkedHashMap[String, TypeInformation[_]]()
+    private var quoteCharacter: Character = _
+    private var path: String = _
+    private var fieldDelim: String = RFCCsvInputFormat.DEFAULT_FIELD_DELIMITER
+    private var lineDelim: String = RFCCsvInputFormat.DEFAULT_LINE_DELIMITER
+    private var isIgnoreFirstLine: Boolean = false
+    private var commentPrefix: String = _
+    private var lenient: Boolean = false
+
+    /**
+      * Sets the path to the CSV file. Required.
+      *
+      * @param path the path to the CSV file
+      */
+    def path(path: String): Builder = {
+      this.path = path
+      this
+    }
+
+    /**
+      * Sets the field delimiter, "," by default.
+      *
+      * @param delim the field delimiter
+      */
+    def fieldDelimiter(delim: String): Builder = {
+      this.fieldDelim = delim
+      this
+    }
+
+    /**
+      * Sets the line delimiter, "\n" by default.
+      *
+      * @param delim the line delimiter
+      */
+    def lineDelimiter(delim: String): Builder = {
+      this.lineDelim = delim
+      this
+    }
+
+    /**
+      * Adds a field with the field name and the type information. Required.
+      * This method can be called multiple times. The call order of this method defines
+      * also the order of thee fields in a row.
+      *
+      * @param fieldName the field name
+      * @param fieldType the type information of the field
+      */
+    def field(fieldName: String, fieldType: TypeInformation[_]): Builder = {
+      if (schema.contains(fieldName)) {
+        throw new IllegalArgumentException(s"Duplicate field name $fieldName.")
+      }
+      schema += (fieldName -> fieldType)
+      this
+    }
+
+    /**
+      * Sets a quote character for String values, null by default.
+      *
+      * @param quote the quote character
+      */
+    def quoteCharacter(quote: Character): Builder = {
+      this.quoteCharacter = quote
+      this
+    }
+
+    /**
+      * Sets a prefix to indicate comments, null by default.
+      *
+      * @param prefix the prefix to indicate comments
+      */
+    def commentPrefix(prefix: String): Builder = {
+      this.commentPrefix = prefix
+      this
+    }
+
+    /**
+      * Ignore the first line. Not skip the first line by default.
+      */
+    def ignoreFirstLine(): Builder = {
+      this.isIgnoreFirstLine = true
+      this
+    }
+
+    /**
+      * Skip records with parse error instead to fail. Throw an exception by default.
+      */
+    def ignoreParseErrors(): Builder = {
+      this.lenient = true
+      this
+    }
+
+    /**
+      * Apply the current values and constructs a newly-created [[RFCCsvTableSource]].
+      *
+      * @return a newly-created [[RFCCsvTableSource]].
+      */
+    def build(): RFCCsvTableSource = {
+      if (path == null) {
+        throw new IllegalArgumentException("Path must be defined.")
+      }
+      if (schema.isEmpty) {
+        throw new IllegalArgumentException("Fields can not be empty.")
+      }
+      new RFCCsvTableSource(
+        path,
+        schema.keys.toArray,
+        schema.values.toArray,
+        fieldDelim,
+        lineDelim,
+        quoteCharacter,
+        isIgnoreFirstLine,
+        commentPrefix,
+        lenient)
+    }
+
+  }
+
+  /**
+    * Return a new builder that builds a [[RFCCsvTableSource]].
+    *
+    * For example:
+    *
+    * {{{
+    *   val source: RFCCsvTableSource = RFCCsvTableSource
+    *     .builder()
+    *     .path("/path/to/your/file.csv")
+    *     .field("myfield", Types.STRING)
+    *     .field("myfield2", Types.INT)
+    *     .build()
+    * }}}
+    * @return a new builder to build a [[RFCCsvTableSource]]
+    */
+  def builder(): Builder = new Builder
+}

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/batch/io/RFCCsvInputFormatTest.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/batch/io/RFCCsvInputFormatTest.java
@@ -1,0 +1,831 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.batch.io;
+
+import org.apache.flink.api.common.io.ParseException;
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.java.tuple.Tuple6;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.StringParser;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.CoreMatchers.is;
+
+/**
+ * Tests for @{@link RFCCsvInputFormat}.
+ *
+ */
+public class RFCCsvInputFormatTest {
+
+	private static final Path PATH = new Path("an/ignored/file/");
+	//Static variables for testing the removal of \r\n to \n
+	private static final String FIRST_PART = "That is the first part";
+	private static final String SECOND_PART = "That is the second part";
+
+	@Test
+	public void ignoreSingleCharPrefixComments() {
+		try {
+			final String fileContent = "#description of the data\n" +
+				"#successive commented line\n" +
+				"this is|1|2.0|\n" +
+				"a test|3|4.0|\n" +
+				"#next|5|6.0|\n";
+
+			final FileInputSplit split = createTempFile(fileContent);
+
+			final TupleTypeInfo<Tuple3<String, Integer, Double>> typeInfo = TupleTypeInfo.getBasicTupleTypeInfo(String.class, Integer.class, Double.class);
+			final RFCCsvInputFormat<Tuple3<String, Integer, Double>> format = new RFCTupleCsvInputFormat<Tuple3<String, Integer, Double>>(PATH, "\n", "|", typeInfo);
+			format.setCommentPrefix("#");
+
+			final Configuration parameters = new Configuration();
+			format.configure(parameters);
+			format.open(split);
+
+			Tuple3<String, Integer, Double> result = new Tuple3<String, Integer, Double>();
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals("this is", result.f0);
+			Assert.assertEquals(Integer.valueOf(1), result.f1);
+			Assert.assertEquals(new Double(2.0), result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals("a test", result.f0);
+			Assert.assertEquals(Integer.valueOf(3), result.f1);
+			Assert.assertEquals(new Double(4.0), result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNull(result);
+		}
+		catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail("Test failed due to a " + ex.getClass().getName() + ": " + ex.getMessage());
+		}
+	}
+
+	// Test disabled because we do not support multi char prefix comments right now for RFC compliant CSV parser
+	@Test
+	@Ignore
+	public void ignoreMultiCharPrefixComments() {
+		try {
+
+			final String fileContent = "//description of the data\n" +
+				"//successive commented line\n" +
+				"this is|1|2.0|\n" +
+				"a test|3|4.0|\n" +
+				"//next|5|6.0|\n";
+
+			final FileInputSplit split = createTempFile(fileContent);
+
+			final TupleTypeInfo<Tuple3<String, Integer, Double>> typeInfo = TupleTypeInfo.getBasicTupleTypeInfo(String.class, Integer.class, Double.class);
+			final RFCCsvInputFormat<Tuple3<String, Integer, Double>> format = new RFCTupleCsvInputFormat<Tuple3<String, Integer, Double>>(PATH, "\n", "|", typeInfo);
+			format.setCommentPrefix("//");
+
+			final Configuration parameters = new Configuration();
+			format.configure(parameters);
+			format.open(split);
+
+			Tuple3<String, Integer, Double> result = new Tuple3<String, Integer, Double>();
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals("this is", result.f0);
+			Assert.assertEquals(Integer.valueOf(1), result.f1);
+			Assert.assertEquals(new Double(2.0), result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals("a test", result.f0);
+			Assert.assertEquals(Integer.valueOf(3), result.f1);
+			Assert.assertEquals(new Double(4.0), result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNull(result);
+		}
+		catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail("Test failed due to a " + ex.getClass().getName() + ": " + ex.getMessage());
+		}
+	}
+
+	@Test
+	public void readStringFields() {
+		try {
+			final String fileContent = "abc|def|ghijk\nabc||hhg\n|||";
+			final FileInputSplit split = createTempFile(fileContent);
+
+			final TupleTypeInfo<Tuple3<String, String, String>> typeInfo = TupleTypeInfo.getBasicTupleTypeInfo(String.class, String.class, String.class);
+			final RFCCsvInputFormat<Tuple3<String, String, String>> format = new RFCTupleCsvInputFormat<Tuple3<String, String, String>>(PATH, "\n", "|", typeInfo);
+
+			final Configuration parameters = new Configuration();
+			format.configure(parameters);
+			format.open(split);
+
+			Tuple3<String, String, String> result = new Tuple3<String, String, String>();
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals("abc", result.f0);
+			Assert.assertEquals("def", result.f1);
+			Assert.assertEquals("ghijk", result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals("abc", result.f0);
+			Assert.assertEquals("", result.f1);
+			Assert.assertEquals("hhg", result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals("", result.f0);
+			Assert.assertEquals("", result.f1);
+			Assert.assertEquals("", result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNull(result);
+			Assert.assertTrue(format.reachedEnd());
+		}
+		catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail("Test failed due to a " + ex.getClass().getName() + ": " + ex.getMessage());
+		}
+	}
+
+	@Test
+	public void readMixedQuotedStringFields() {
+		try {
+			final String fileContent = "@a|b|c@|def|@ghijk@\nabc||@|hhg@\n|||";
+			final FileInputSplit split = createTempFile(fileContent);
+
+			final TupleTypeInfo<Tuple3<String, String, String>> typeInfo = TupleTypeInfo.getBasicTupleTypeInfo(String.class, String.class, String.class);
+			final RFCCsvInputFormat<Tuple3<String, String, String>> format = new RFCTupleCsvInputFormat<Tuple3<String, String, String>>(PATH, "\n", "|", typeInfo);
+
+			final Configuration parameters = new Configuration();
+			format.configure(parameters);
+			format.enableQuotedStringParsing('@');
+			format.open(split);
+
+			Tuple3<String, String, String> result = new Tuple3<String, String, String>();
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals("a|b|c", result.f0);
+			Assert.assertEquals("def", result.f1);
+			Assert.assertEquals("ghijk", result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals("abc", result.f0);
+			Assert.assertEquals("", result.f1);
+			Assert.assertEquals("|hhg", result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals("", result.f0);
+			Assert.assertEquals("", result.f1);
+			Assert.assertEquals("", result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNull(result);
+			Assert.assertTrue(format.reachedEnd());
+		}
+		catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail("Test failed due to a " + ex.getClass().getName() + ": " + ex.getMessage());
+		}
+	}
+
+	@Test
+	public void readStringFieldsWithTrailingDelimiters() {
+		try {
+			final String fileContent = "abc-def-ghijk\nabc--hhg\n---\n";
+			final FileInputSplit split = createTempFile(fileContent);
+
+			final TupleTypeInfo<Tuple3<String, String, String>> typeInfo = TupleTypeInfo.getBasicTupleTypeInfo(String.class, String.class, String.class);
+			final RFCCsvInputFormat<Tuple3<String, String, String>> format = new RFCTupleCsvInputFormat<Tuple3<String, String, String>>(PATH, typeInfo);
+
+			format.setFieldDelimiter("-");
+
+			format.configure(new Configuration());
+			format.open(split);
+
+			Tuple3<String, String, String> result = new Tuple3<String, String, String>();
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals("abc", result.f0);
+			Assert.assertEquals("def", result.f1);
+			Assert.assertEquals("ghijk", result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals("abc", result.f0);
+			Assert.assertEquals("", result.f1);
+			Assert.assertEquals("hhg", result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals("", result.f0);
+			Assert.assertEquals("", result.f1);
+			Assert.assertEquals("", result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNull(result);
+			Assert.assertTrue(format.reachedEnd());
+		}
+		catch (Exception ex) {
+			Assert.fail("Test failed due to a " + ex.getClass().getName() + ": " + ex.getMessage());
+		}
+	}
+
+	@Test
+	public void testTailingEmptyFields() throws Exception {
+		final String fileContent = "aa,bb,cc\n" + // ok
+				"aa,bb,\n" +  // the last field is empty
+				"aa,,\n" +    // the last two fields are empty
+				",,\n" +      // all fields are empty
+				"aa,bb";      // row too short
+		final FileInputSplit split = createTempFile(fileContent);
+
+		final TupleTypeInfo<Tuple3<String, String, String>> typeInfo =
+				TupleTypeInfo.getBasicTupleTypeInfo(String.class, String.class, String.class);
+		final RFCCsvInputFormat<Tuple3<String, String, String>> format = new RFCTupleCsvInputFormat<Tuple3<String, String, String>>(PATH, typeInfo);
+
+		format.setFieldDelimiter(",");
+
+		format.configure(new Configuration());
+		format.open(split);
+
+		Tuple3<String, String, String> result = new Tuple3<String, String, String>();
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("aa", result.f0);
+		Assert.assertEquals("bb", result.f1);
+		Assert.assertEquals("cc", result.f2);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("aa", result.f0);
+		Assert.assertEquals("bb", result.f1);
+		Assert.assertEquals("", result.f2);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("aa", result.f0);
+		Assert.assertEquals("", result.f1);
+		Assert.assertEquals("", result.f2);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("", result.f0);
+		Assert.assertEquals("", result.f1);
+		Assert.assertEquals("", result.f2);
+
+		try {
+			format.nextRecord(result);
+			Assert.fail("Parse Exception was not thrown! (Row too short)");
+		} catch (ParseException e) {}
+	}
+
+	@Test
+	public void testIntegerFields() throws IOException {
+		try {
+			final String fileContent = "111|222|333|444|555\n666|777|888|999|000|\n";
+			final FileInputSplit split = createTempFile(fileContent);
+
+			final TupleTypeInfo<Tuple5<Integer, Integer, Integer, Integer, Integer>> typeInfo =
+				TupleTypeInfo.getBasicTupleTypeInfo(Integer.class, Integer.class, Integer.class, Integer.class, Integer.class);
+			final RFCCsvInputFormat<Tuple5<Integer, Integer, Integer, Integer, Integer>> format = new RFCTupleCsvInputFormat<Tuple5<Integer, Integer, Integer, Integer, Integer>>(PATH, typeInfo);
+
+			format.setFieldDelimiter("|");
+
+			format.configure(new Configuration());
+			format.open(split);
+
+			Tuple5<Integer, Integer, Integer, Integer, Integer> result = new Tuple5<Integer, Integer, Integer, Integer, Integer>();
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals(Integer.valueOf(111), result.f0);
+			Assert.assertEquals(Integer.valueOf(222), result.f1);
+			Assert.assertEquals(Integer.valueOf(333), result.f2);
+			Assert.assertEquals(Integer.valueOf(444), result.f3);
+			Assert.assertEquals(Integer.valueOf(555), result.f4);
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals(Integer.valueOf(666), result.f0);
+			Assert.assertEquals(Integer.valueOf(777), result.f1);
+			Assert.assertEquals(Integer.valueOf(888), result.f2);
+			Assert.assertEquals(Integer.valueOf(999), result.f3);
+			Assert.assertEquals(Integer.valueOf(000), result.f4);
+
+			result = format.nextRecord(result);
+			Assert.assertNull(result);
+			Assert.assertTrue(format.reachedEnd());
+		}
+		catch (Exception ex) {
+			Assert.fail("Test failed due to a " + ex.getClass().getName() + ": " + ex.getMessage());
+		}
+	}
+
+	@Test
+	public void testEmptyFields() throws IOException {
+		try {
+			final String fileContent = "|0|0|0|0|0\n" +
+				"1||1|1|1|1\n" +
+				"2|2||2|2|2\n" +
+				"3|3|3| |3|3\n" +
+				"4|4|4|4||4\n" +
+				"5|5|5|5|5\n";
+			final FileInputSplit split = createTempFile(fileContent);
+
+			final TupleTypeInfo<Tuple6<Short, Integer, Long, Float, Double, Byte>> typeInfo =
+				TupleTypeInfo.getBasicTupleTypeInfo(Short.class, Integer.class, Long.class, Float.class, Double.class, Byte.class);
+			final RFCCsvInputFormat<Tuple6<Short, Integer, Long, Float, Double, Byte>> format = new RFCTupleCsvInputFormat<Tuple6<Short, Integer, Long, Float, Double, Byte>>(PATH, typeInfo);
+
+			format.setFieldDelimiter("|");
+
+			format.configure(new Configuration());
+			format.open(split);
+
+			Tuple6<Short, Integer, Long, Float, Double, Byte> result = new Tuple6<Short, Integer, Long, Float, Double, Byte>();
+
+			try {
+				result = format.nextRecord(result);
+				Assert.fail("Empty String Parse Exception was not thrown! (ShortParser)");
+			} catch (ParseException e) {}
+			try {
+				result = format.nextRecord(result);
+				Assert.fail("Empty String Parse Exception was not thrown! (IntegerParser)");
+			} catch (ParseException e) {}
+			try {
+				result = format.nextRecord(result);
+				Assert.fail("Empty String Parse Exception was not thrown! (LongParser)");
+			} catch (ParseException e) {}
+			try {
+				result = format.nextRecord(result);
+				Assert.fail("Empty String Parse Exception was not thrown! (FloatParser)");
+			} catch (ParseException e) {}
+			try {
+				result = format.nextRecord(result);
+				Assert.fail("Empty String Parse Exception was not thrown! (DoubleParser)");
+			} catch (ParseException e) {}
+			try {
+				result = format.nextRecord(result);
+				Assert.fail("Empty String Parse Exception was not thrown! (ByteParser)");
+			} catch (ParseException e) {}
+
+			result = format.nextRecord(result);
+			Assert.assertNull(result);
+			Assert.assertTrue(format.reachedEnd());
+		}
+		catch (Exception ex) {
+			Assert.fail("Test failed due to a " + ex.getClass().getName() + ": " + ex.getMessage());
+		}
+	}
+
+	@Test
+	public void testDoubleFields() throws IOException {
+		try {
+			final String fileContent = "11.1|22.2|33.3|44.4|55.5\n66.6|77.7|88.8|99.9|00.0|\n";
+			final FileInputSplit split = createTempFile(fileContent);
+
+			final TupleTypeInfo<Tuple5<Double, Double, Double, Double, Double>> typeInfo =
+					TupleTypeInfo.getBasicTupleTypeInfo(Double.class, Double.class, Double.class, Double.class, Double.class);
+			final RFCCsvInputFormat<Tuple5<Double, Double, Double, Double, Double>> format = new RFCTupleCsvInputFormat<Tuple5<Double, Double, Double, Double, Double>>(PATH, typeInfo);
+
+			format.setFieldDelimiter("|");
+
+			format.configure(new Configuration());
+			format.open(split);
+
+			Tuple5<Double, Double, Double, Double, Double> result = new Tuple5<Double, Double, Double, Double, Double>();
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals(Double.valueOf(11.1), result.f0);
+			Assert.assertEquals(Double.valueOf(22.2), result.f1);
+			Assert.assertEquals(Double.valueOf(33.3), result.f2);
+			Assert.assertEquals(Double.valueOf(44.4), result.f3);
+			Assert.assertEquals(Double.valueOf(55.5), result.f4);
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals(Double.valueOf(66.6), result.f0);
+			Assert.assertEquals(Double.valueOf(77.7), result.f1);
+			Assert.assertEquals(Double.valueOf(88.8), result.f2);
+			Assert.assertEquals(Double.valueOf(99.9), result.f3);
+			Assert.assertEquals(Double.valueOf(00.0), result.f4);
+
+			result = format.nextRecord(result);
+			Assert.assertNull(result);
+			Assert.assertTrue(format.reachedEnd());
+		}
+		catch (Exception ex) {
+			Assert.fail("Test failed due to a " + ex.getClass().getName() + ": " + ex.getMessage());
+		}
+	}
+
+	@Test
+	public void testReadFirstN() throws IOException {
+		try {
+			final String fileContent = "111|222|333|444|555|\n666|777|888|999|000|\n";
+			final FileInputSplit split = createTempFile(fileContent);
+
+			final TupleTypeInfo<Tuple2<Integer, Integer>> typeInfo = TupleTypeInfo.getBasicTupleTypeInfo(Integer.class, Integer.class);
+			final RFCCsvInputFormat<Tuple2<Integer, Integer>> format = new RFCTupleCsvInputFormat<Tuple2<Integer, Integer>>(PATH, typeInfo);
+
+			format.setFieldDelimiter("|");
+
+			format.configure(new Configuration());
+			format.open(split);
+
+			Tuple2<Integer, Integer> result = new Tuple2<Integer, Integer>();
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals(Integer.valueOf(111), result.f0);
+			Assert.assertEquals(Integer.valueOf(222), result.f1);
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals(Integer.valueOf(666), result.f0);
+			Assert.assertEquals(Integer.valueOf(777), result.f1);
+
+			result = format.nextRecord(result);
+			Assert.assertNull(result);
+			Assert.assertTrue(format.reachedEnd());
+		}
+		catch (Exception ex) {
+			Assert.fail("Test failed due to a " + ex.getClass().getName() + ": " + ex.getMessage());
+		}
+
+	}
+
+	@Test
+	public void testReadSparseWithNullFieldsForTypes() throws IOException {
+		try {
+
+			final String fileContent = "111x222x333x444x555x666x777x888x999x000\n" +
+				"000x999x888x777x666x555x444x333x222x111";
+			final FileInputSplit split = createTempFile(fileContent);
+
+			final TupleTypeInfo<Tuple3<Integer, Integer, Integer>> typeInfo = TupleTypeInfo.getBasicTupleTypeInfo(Integer.class, Integer.class, Integer.class);
+			final RFCCsvInputFormat<Tuple3<Integer, Integer, Integer>> format = new RFCTupleCsvInputFormat<Tuple3<Integer, Integer, Integer>>(PATH, typeInfo, new boolean[]{true, false, false, true, false, false, false, true});
+
+			format.setFieldDelimiter("x");
+
+			format.configure(new Configuration());
+			format.open(split);
+
+			Tuple3<Integer, Integer, Integer> result = new Tuple3<Integer, Integer, Integer>();
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals(Integer.valueOf(111), result.f0);
+			Assert.assertEquals(Integer.valueOf(444), result.f1);
+			Assert.assertEquals(Integer.valueOf(888), result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals(Integer.valueOf(000), result.f0);
+			Assert.assertEquals(Integer.valueOf(777), result.f1);
+			Assert.assertEquals(Integer.valueOf(333), result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNull(result);
+			Assert.assertTrue(format.reachedEnd());
+		}
+		catch (Exception ex) {
+			Assert.fail("Test failed due to a " + ex.getClass().getName() + ": " + ex.getMessage());
+		}
+	}
+
+	@Test
+	public void testReadSparseWithPositionSetter() throws IOException {
+		try {
+			final String fileContent = "111|222|333|444|555|666|777|888|999|000|\n000|999|888|777|666|555|444|333|222|111|";
+			final FileInputSplit split = createTempFile(fileContent);
+
+			final TupleTypeInfo<Tuple3<Integer, Integer, Integer>> typeInfo = TupleTypeInfo.getBasicTupleTypeInfo(Integer.class, Integer.class, Integer.class);
+			final RFCCsvInputFormat<Tuple3<Integer, Integer, Integer>> format = new RFCTupleCsvInputFormat<Tuple3<Integer, Integer, Integer>>(PATH, typeInfo, new int[]{0, 3, 7});
+
+			format.setFieldDelimiter("|");
+
+			format.configure(new Configuration());
+			format.open(split);
+
+			Tuple3<Integer, Integer, Integer> result = new Tuple3<Integer, Integer, Integer>();
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals(Integer.valueOf(111), result.f0);
+			Assert.assertEquals(Integer.valueOf(444), result.f1);
+			Assert.assertEquals(Integer.valueOf(888), result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals(Integer.valueOf(000), result.f0);
+			Assert.assertEquals(Integer.valueOf(777), result.f1);
+			Assert.assertEquals(Integer.valueOf(333), result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNull(result);
+			Assert.assertTrue(format.reachedEnd());
+		}
+		catch (Exception ex) {
+			Assert.fail("Test failed due to a " + ex.getClass().getName() + ": " + ex.getMessage());
+		}
+	}
+
+	@Test
+	public void testReadSparseWithMask() throws IOException {
+		try {
+
+			final String fileContent = "111&222&333&444&555&666&777&888&999&000\n" +
+				"000&999&888&777&666&555&444&333&222&111";
+
+			final FileInputSplit split = createTempFile(fileContent);
+
+			final TupleTypeInfo<Tuple3<Integer, Integer, Integer>> typeInfo = TupleTypeInfo.getBasicTupleTypeInfo(Integer.class, Integer.class, Integer.class);
+			final RFCCsvInputFormat<Tuple3<Integer, Integer, Integer>> format = new RFCTupleCsvInputFormat<Tuple3<Integer, Integer, Integer>>(PATH, typeInfo, new boolean[]{true, false, false, true, false, false, false, true});
+
+			format.setFieldDelimiter("&");
+
+			format.configure(new Configuration());
+			format.open(split);
+
+			Tuple3<Integer, Integer, Integer> result = new Tuple3<Integer, Integer, Integer>();
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals(Integer.valueOf(111), result.f0);
+			Assert.assertEquals(Integer.valueOf(444), result.f1);
+			Assert.assertEquals(Integer.valueOf(888), result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNotNull(result);
+			Assert.assertEquals(Integer.valueOf(000), result.f0);
+			Assert.assertEquals(Integer.valueOf(777), result.f1);
+			Assert.assertEquals(Integer.valueOf(333), result.f2);
+
+			result = format.nextRecord(result);
+			Assert.assertNull(result);
+			Assert.assertTrue(format.reachedEnd());
+		}
+		catch (Exception ex) {
+			Assert.fail("Test failed due to a " + ex.getClass().getName() + ": " + ex.getMessage());
+		}
+	}
+
+	@Test
+	public void testParseStringErrors() throws Exception {
+		StringParser stringParser = new StringParser();
+		stringParser.enableQuotedStringParsing((byte) '"');
+
+		Object[][] failures = {
+				{"\"string\" trailing", FieldParser.ParseErrorState.UNQUOTED_CHARS_AFTER_QUOTED_STRING},
+				{"\"unterminated ", FieldParser.ParseErrorState.UNTERMINATED_QUOTED_STRING}
+		};
+
+		for (Object[] failure : failures) {
+			String input = (String) failure[0];
+
+			int result = stringParser.parseField(input.getBytes(ConfigConstants.DEFAULT_CHARSET), 0,
+				input.length(), new byte[]{'|'}, null);
+
+			Assert.assertThat(result, is(-1));
+			Assert.assertThat(stringParser.getErrorState(), is(failure[1]));
+		}
+
+	}
+
+	@Test
+	public void testParserCorrectness() throws Exception {
+		// RFC 4180 Compliance Test content
+		// Taken from http://en.wikipedia.org/wiki/Comma-separated_values#Example
+		final String fileContent =
+				"Year,Make,Model,Description,Price\n" +
+				"1997,Ford,E350,\"ac, abs, moon\",3000.00\n" +
+				"1999,Chevy,\"Venture \"\"Extended Edition\"\"\",\"\",4900.00\n" +
+				"1996,Jeep,Grand Cherokee,\"MUST SELL! air, moon roof, loaded\",4799.00\n" +
+				"1999,Chevy,\"Venture \"\"Extended Edition, Very Large\"\"\",,5000.00\n" +
+				",,\"Venture \"\"Extended Edition\"\"\",\"\",4900.00";
+
+		final FileInputSplit split = createTempFile(fileContent);
+
+		final TupleTypeInfo<Tuple5<Integer, String, String, String, Double>> typeInfo =
+				TupleTypeInfo.getBasicTupleTypeInfo(Integer.class, String.class, String.class, String.class, Double.class);
+		final RFCCsvInputFormat<Tuple5<Integer, String, String, String, Double>> format = new RFCTupleCsvInputFormat<Tuple5<Integer, String, String, String, Double>>(PATH, typeInfo);
+
+		format.setSkipFirstLineAsHeader(true);
+		format.setFieldDelimiter(",");
+		format.enableQuotedStringParsing('\"');
+		format.setLenient(true);
+
+		format.configure(new Configuration());
+		format.open(split);
+
+		Tuple5<Integer, String, String, String, Double> result = new Tuple5<Integer, String, String, String, Double>();
+
+		@SuppressWarnings("unchecked")
+		Tuple5<Integer, String, String, String, Double>[] expectedLines = new Tuple5[] {
+				new Tuple5<Integer, String, String, String, Double>(1997, "Ford", "E350", "ac, abs, moon", 3000.0),
+				new Tuple5<Integer, String, String, String, Double>(1999, "Chevy", "Venture \"Extended Edition\"", "", 4900.0),
+				new Tuple5<Integer, String, String, String, Double>(1996, "Jeep", "Grand Cherokee", "MUST SELL! air, moon roof, loaded", 4799.00),
+				new Tuple5<Integer, String, String, String, Double>(1999, "Chevy", "Venture \"Extended Edition, Very Large\"", "", 5000.00),
+				new Tuple5<Integer, String, String, String, Double>(null, "", "Venture \"Extended Edition\"", "", 4900.0)
+		};
+
+		try {
+			for (Tuple5<Integer, String, String, String, Double> expected : expectedLines) {
+				result = format.nextRecord(result);
+				Assert.assertEquals(expected, result);
+			}
+
+			Assert.assertNull(format.nextRecord(result));
+			Assert.assertTrue(format.reachedEnd());
+
+		} catch (Exception ex) {
+			Assert.fail("Test failed due to a " + ex.getClass().getName() + ": " + ex.getMessage());
+		}
+
+	}
+
+	@Test
+	public void testQuotedStringParsingWithIncludeFields() throws Exception {
+
+		final String fileContent = "\"20:41:52-1-3-2015\"|\"Re: Taskmanager memory error in Eclipse\"|" +
+			"\"Blahblah <blah@blahblah.org>\"|\"blaaa|\"\"blubb\"";
+
+		System.out.println(fileContent);
+
+		final File tempFile = File.createTempFile("CsvReaderQuotedString", "tmp");
+		tempFile.deleteOnExit();
+		tempFile.setWritable(true);
+
+		OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(tempFile));
+		writer.write(fileContent);
+		writer.close();
+
+		TupleTypeInfo<Tuple2<String, String>> typeInfo = TupleTypeInfo.getBasicTupleTypeInfo(String.class, String.class);
+		RFCCsvInputFormat<Tuple2<String, String>> inputFormat = new RFCTupleCsvInputFormat<Tuple2<String, String>>(new Path(tempFile.toURI().toString()), typeInfo, new boolean[]{true, false, true});
+
+		inputFormat.enableQuotedStringParsing('"');
+		inputFormat.setFieldDelimiter("|");
+		inputFormat.setDelimiter('\n');
+
+		inputFormat.configure(new Configuration());
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+
+		inputFormat.open(splits[0]);
+
+		Tuple2<String, String> record = inputFormat.nextRecord(new Tuple2<String, String>());
+
+		Assert.assertEquals("20:41:52-1-3-2015", record.f0);
+		Assert.assertEquals("Blahblah <blah@blahblah.org>", record.f1);
+	}
+
+	@Test
+	public void testQuotedStringParsingWithEscapedQuotes() throws Exception {
+
+		final String fileContent = "\"\\\"\"Hello\\\"\" World\"|\"We are\\\"\" young\"";
+
+		final File tempFile = File.createTempFile("CsvReaderQuotedString", "tmp");
+		tempFile.deleteOnExit();
+		tempFile.setWritable(true);
+
+		OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(tempFile));
+		writer.write(fileContent);
+		writer.close();
+
+		TupleTypeInfo<Tuple2<String, String>> typeInfo = TupleTypeInfo.getBasicTupleTypeInfo(String.class, String.class);
+		RFCCsvInputFormat<Tuple2<String, String>> inputFormat = new RFCTupleCsvInputFormat<>(new Path(tempFile.toURI().toString()), typeInfo);
+
+		inputFormat.enableQuotedStringParsing('"');
+		inputFormat.setFieldDelimiter("|");
+		inputFormat.setDelimiter('\n');
+
+		inputFormat.configure(new Configuration());
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+
+		inputFormat.open(splits[0]);
+
+		Tuple2<String, String> record = inputFormat.nextRecord(new Tuple2<String, String>());
+
+		Assert.assertEquals("\\\"Hello\\\" World", record.f0);
+		Assert.assertEquals("We are\\\" young", record.f1);
+	}
+
+	private FileInputSplit createTempFile(String content) throws IOException {
+		File tempFile = File.createTempFile("test_contents", "tmp");
+		tempFile.deleteOnExit();
+
+		OutputStreamWriter wrt = new OutputStreamWriter(
+				new FileOutputStream(tempFile), StandardCharsets.UTF_8
+		);
+		wrt.write(content);
+		wrt.close();
+
+		return new FileInputSplit(0, new Path(tempFile.toURI().toString()), 0, tempFile.length(), new String[] {"localhost"});
+	}
+
+	@Test
+	public void testWindowsLineEndRemoval() {
+
+		//Check typical use case -- linux file is correct and it is set up to linuc(\n)
+		this.testRemovingTrailingCR("\n", "\n");
+
+		//Check typical windows case -- windows file endings and file has windows file endings set up
+		this.testRemovingTrailingCR("\r\n", "\r\n");
+
+		//Check problematic case windows file -- windows file endings(\r\n) but linux line endings (\n) set up
+		this.testRemovingTrailingCR("\r\n", "\n");
+
+		//Check problematic case linux file -- linux file endings (\n) but windows file endings set up (\r\n)
+		//Specific setup for windows line endings will expect \r\n because it has to be set up and is not standard.
+	}
+
+	private void testRemovingTrailingCR(String lineBreakerInFile, String lineBreakerSetup) {
+		File tempFile = null;
+
+		String fileContent = RFCCsvInputFormatTest.FIRST_PART + lineBreakerInFile + RFCCsvInputFormatTest.SECOND_PART + lineBreakerInFile;
+
+		try {
+			// create input file
+			tempFile = File.createTempFile("RFCCsvInputFormatTest", "tmp");
+			tempFile.deleteOnExit();
+			tempFile.setWritable(true);
+
+			OutputStreamWriter wrt = new OutputStreamWriter(new FileOutputStream(tempFile));
+			wrt.write(fileContent);
+			wrt.close();
+
+			final TupleTypeInfo<Tuple1<String>> typeInfo = TupleTypeInfo.getBasicTupleTypeInfo(String.class);
+			final RFCCsvInputFormat<Tuple1<String>> inputFormat = new RFCTupleCsvInputFormat<Tuple1<String>>(new Path(tempFile.toURI().toString()), typeInfo);
+
+			Configuration parameters = new Configuration();
+			inputFormat.configure(parameters);
+
+			inputFormat.setDelimiter(lineBreakerSetup);
+
+			FileInputSplit[] splits = inputFormat.createInputSplits(1);
+
+			inputFormat.open(splits[0]);
+
+			Tuple1<String> result = inputFormat.nextRecord(new Tuple1<String>());
+
+			Assert.assertNotNull("Expecting to not return null", result);
+
+			Assert.assertEquals(FIRST_PART, result.f0);
+
+			result = inputFormat.nextRecord(result);
+
+			Assert.assertNotNull("Expecting to not return null", result);
+			Assert.assertEquals(SECOND_PART, result.f0);
+
+		}
+		catch (Throwable t) {
+			System.err.println("test failed with exception: " + t.getMessage());
+			t.printStackTrace(System.err);
+			Assert.fail("Test erroneous");
+		}
+	}
+
+}

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/batch/io/RFCRowCsvInputFormatTest.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/batch/io/RFCRowCsvInputFormatTest.java
@@ -1,0 +1,991 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.batch.io;
+
+import org.apache.flink.api.common.io.ParseException;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.StringParser;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests for {@link RFCRowCsvInputFormat}.
+ */
+public class RFCRowCsvInputFormatTest {
+
+	private static final Path PATH = new Path("an/ignored/file/");
+
+	// static variables for testing the removal of \r\n to \n
+	private static final String FIRST_PART = "That is the first part";
+	private static final String SECOND_PART = "That is the second part";
+
+	@Test
+	public void ignoreInvalidLines() throws Exception {
+		String fileContent =
+			"#description of the data\n" +
+				"header1|header2|header3|\n" +
+				"this is|1|2.0|\n" +
+				"//a comment\n" +
+				"a test|3|4.0|\n" +
+				"#next|5|6.0|\n";
+
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.DOUBLE_TYPE_INFO};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(PATH, fieldTypes, "\n", "|");
+		format.setLenient(false);
+		Configuration parameters = new Configuration();
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(3);
+		try {
+			result = format.nextRecord(result);
+			Assert.fail("Parse Exception was not thrown! (Row too short)");
+		} catch (ParseException ignored) {
+		} // => ok
+
+		try {
+			result = format.nextRecord(result);
+			Assert.fail("Parse Exception was not thrown! (Invalid int value)");
+		} catch (ParseException ignored) {
+		} // => ok
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("this is", result.getField(0));
+		Assert.assertEquals(1, result.getField(1));
+		Assert.assertEquals(2.0, result.getField(2));
+
+		try {
+			result = format.nextRecord(result);
+			Assert.fail("Parse Exception was not thrown! (Row too short)");
+		} catch (ParseException ignored) {
+		} // => ok
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("a test", result.getField(0));
+		Assert.assertEquals(3, result.getField(1));
+		Assert.assertEquals(4.0, result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("#next", result.getField(0));
+		Assert.assertEquals(5, result.getField(1));
+		Assert.assertEquals(6.0, result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNull(result);
+
+		// re-open with lenient = true
+		format.setLenient(true);
+		format.configure(parameters);
+		format.open(split);
+
+		result = new Row(3);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("header1", result.getField(0));
+		Assert.assertNull(result.getField(1));
+		Assert.assertNull(result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("this is", result.getField(0));
+		Assert.assertEquals(1, result.getField(1));
+		Assert.assertEquals(2.0, result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("a test", result.getField(0));
+		Assert.assertEquals(3, result.getField(1));
+		Assert.assertEquals(4.0, result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("#next", result.getField(0));
+		Assert.assertEquals(5, result.getField(1));
+		Assert.assertEquals(6.0, result.getField(2));
+		result = format.nextRecord(result);
+		Assert.assertNull(result);
+	}
+
+	@Test
+	public void ignoreSingleCharPrefixComments() throws Exception {
+		String fileContent =
+			"#description of the data\n" +
+				"#successive commented line\n" +
+				"this is|1|2.0|\n" +
+				"a test|3|4.0|\n" +
+				"#next|5|6.0|\n";
+
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.DOUBLE_TYPE_INFO};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(PATH, fieldTypes, "\n", "|");
+		format.setCommentPrefix("#");
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(3);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("this is", result.getField(0));
+		Assert.assertEquals(1, result.getField(1));
+		Assert.assertEquals(2.0, result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("a test", result.getField(0));
+		Assert.assertEquals(3, result.getField(1));
+		Assert.assertEquals(4.0, result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNull(result);
+	}
+
+	// Test disabled because we do not support multi char prefix comments right now for RFC compliant CSV parser
+	@Test
+	@Ignore
+	public void ignoreMultiCharPrefixComments() throws Exception {
+		String fileContent =
+			"//description of the data\n" +
+				"//successive commented line\n" +
+				"this is|1|2.0|\n" +
+				"a test|3|4.0|\n" +
+				"//next|5|6.0|\n";
+
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.DOUBLE_TYPE_INFO};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(PATH, fieldTypes, "\n", "|");
+		format.setCommentPrefix("//");
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(3);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("this is", result.getField(0));
+		Assert.assertEquals(1, result.getField(1));
+		Assert.assertEquals(2.0, result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("a test", result.getField(0));
+		Assert.assertEquals(3, result.getField(1));
+		Assert.assertEquals(4.0, result.getField(2));
+		result = format.nextRecord(result);
+		Assert.assertNull(result);
+	}
+
+	@Test
+	public void readStringFields() throws Exception {
+		String fileContent = "abc|def|ghijk\nabc||hhg\n|||\n||";
+
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(PATH, fieldTypes, "\n", "|");
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(3);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("abc", result.getField(0));
+		Assert.assertEquals("def", result.getField(1));
+		Assert.assertEquals("ghijk", result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("abc", result.getField(0));
+		Assert.assertEquals("", result.getField(1));
+		Assert.assertEquals("hhg", result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("", result.getField(0));
+		Assert.assertEquals("", result.getField(1));
+		Assert.assertEquals("", result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("", result.getField(0));
+		Assert.assertEquals("", result.getField(1));
+		Assert.assertEquals("", result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNull(result);
+		Assert.assertTrue(format.reachedEnd());
+	}
+
+	@Test
+	public void readMixedQuotedStringFields() throws Exception {
+		String fileContent = "@a|b|c@|def|@ghijk@\nabc||@|hhg@\n|||\n";
+
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(PATH, fieldTypes, "\n", "|");
+		format.configure(new Configuration());
+		format.enableQuotedStringParsing('@');
+		format.open(split);
+
+		Row result = new Row(3);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("a|b|c", result.getField(0));
+		Assert.assertEquals("def", result.getField(1));
+		Assert.assertEquals("ghijk", result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("abc", result.getField(0));
+		Assert.assertEquals("", result.getField(1));
+		Assert.assertEquals("|hhg", result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("", result.getField(0));
+		Assert.assertEquals("", result.getField(1));
+		Assert.assertEquals("", result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNull(result);
+		Assert.assertTrue(format.reachedEnd());
+	}
+
+	@Test
+	public void readStringFieldsWithTrailingDelimiters() throws Exception {
+		String fileContent = "abc|def|ghijk\nabc||hhg\n|||\n";
+
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(PATH, fieldTypes, "\n", "|");
+		format.setFieldDelimiter("|-");
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(3);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("abc", result.getField(0));
+		Assert.assertEquals("def", result.getField(1));
+		Assert.assertEquals("ghijk", result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("abc", result.getField(0));
+		Assert.assertEquals("", result.getField(1));
+		Assert.assertEquals("hhg", result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("", result.getField(0));
+		Assert.assertEquals("", result.getField(1));
+		Assert.assertEquals("", result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNull(result);
+		Assert.assertTrue(format.reachedEnd());
+	}
+
+	@Test
+	public void testTailingEmptyFields() throws Exception {
+		String fileContent = "abc|def|ghijk\n" +
+				"abc|def|\n" +
+				"abc||\n" +
+				"|||\n" +
+				"||\n" +
+				"abc|def\n";
+
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(PATH, fieldTypes, "\n", "|");
+		format.setFieldDelimiter("|");
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(3);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("abc", result.getField(0));
+		Assert.assertEquals("def", result.getField(1));
+		Assert.assertEquals("ghijk", result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("abc", result.getField(0));
+		Assert.assertEquals("def", result.getField(1));
+		Assert.assertEquals("", result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("abc", result.getField(0));
+		Assert.assertEquals("", result.getField(1));
+		Assert.assertEquals("", result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("", result.getField(0));
+		Assert.assertEquals("", result.getField(1));
+		Assert.assertEquals("", result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals("", result.getField(0));
+		Assert.assertEquals("", result.getField(1));
+		Assert.assertEquals("", result.getField(2));
+
+		try {
+			format.nextRecord(result);
+			Assert.fail("Parse Exception was not thrown! (Row too short)");
+		} catch (ParseException e) {}
+	}
+
+	@Test
+	public void testIntegerFields() throws Exception {
+		String fileContent = "111|222|333|444|555\n666|777|888|999|000|\n";
+
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(PATH, fieldTypes, "\n", "|");
+
+		format.setFieldDelimiter("|");
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(5);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(111, result.getField(0));
+		Assert.assertEquals(222, result.getField(1));
+		Assert.assertEquals(333, result.getField(2));
+		Assert.assertEquals(444, result.getField(3));
+		Assert.assertEquals(555, result.getField(4));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(666, result.getField(0));
+		Assert.assertEquals(777, result.getField(1));
+		Assert.assertEquals(888, result.getField(2));
+		Assert.assertEquals(999, result.getField(3));
+		Assert.assertEquals(0, result.getField(4));
+
+		result = format.nextRecord(result);
+		Assert.assertNull(result);
+		Assert.assertTrue(format.reachedEnd());
+	}
+
+	@Test
+	public void testEmptyFields() throws Exception {
+		String fileContent =
+			",,,,,,,,\n" +
+				",,,,,,,\n" +
+				",,,,,,,,\n" +
+				",,,,,,,\n" +
+				",,,,,,,,\n" +
+				",,,,,,,,\n" +
+				",,,,,,,\n" +
+				",,,,,,,,\n";
+
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.BOOLEAN_TYPE_INFO,
+			BasicTypeInfo.BYTE_TYPE_INFO,
+			BasicTypeInfo.DOUBLE_TYPE_INFO,
+			BasicTypeInfo.FLOAT_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.LONG_TYPE_INFO,
+			BasicTypeInfo.SHORT_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(PATH, fieldTypes, true);
+		format.setFieldDelimiter(",");
+		format.setLenient(true);
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(8);
+		int linesCnt = fileContent.split("\n").length;
+
+		for (int i = 0; i < linesCnt; i++) {
+			result = format.nextRecord(result);
+			if (i != 7) { // skip for string data type
+				Assert.assertNull(result.getField(i));
+			}
+		}
+
+		// ensure no more rows
+		Assert.assertNull(format.nextRecord(result));
+		Assert.assertTrue(format.reachedEnd());
+	}
+
+	@Test
+	public void testDoubleFields() throws Exception {
+		String fileContent = "11.1|22.2|33.3|44.4|55.5\n66.6|77.7|88.8|99.9|00.0|\n";
+
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.DOUBLE_TYPE_INFO,
+			BasicTypeInfo.DOUBLE_TYPE_INFO,
+			BasicTypeInfo.DOUBLE_TYPE_INFO,
+			BasicTypeInfo.DOUBLE_TYPE_INFO,
+			BasicTypeInfo.DOUBLE_TYPE_INFO};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(PATH, fieldTypes);
+		format.setFieldDelimiter("|");
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(5);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(11.1, result.getField(0));
+		Assert.assertEquals(22.2, result.getField(1));
+		Assert.assertEquals(33.3, result.getField(2));
+		Assert.assertEquals(44.4, result.getField(3));
+		Assert.assertEquals(55.5, result.getField(4));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(66.6, result.getField(0));
+		Assert.assertEquals(77.7, result.getField(1));
+		Assert.assertEquals(88.8, result.getField(2));
+		Assert.assertEquals(99.9, result.getField(3));
+		Assert.assertEquals(0.0, result.getField(4));
+
+		result = format.nextRecord(result);
+		Assert.assertNull(result);
+		Assert.assertTrue(format.reachedEnd());
+	}
+
+	@Test
+	public void testReadFirstN() throws Exception {
+		String fileContent = "111|222|333|444|555|\n666|777|888|999|000|\n";
+
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(PATH, fieldTypes);
+		format.setFieldDelimiter("|");
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(2);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(111, result.getField(0));
+		Assert.assertEquals(222, result.getField(1));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(666, result.getField(0));
+		Assert.assertEquals(777, result.getField(1));
+
+		result = format.nextRecord(result);
+		Assert.assertNull(result);
+		Assert.assertTrue(format.reachedEnd());
+	}
+
+	@Test
+	public void testReadSparseWithNullFieldsForTypes() throws Exception {
+		final String fileContent = "111x222x333x444x555x666x777x888x999x000\n" +
+			"000x999x888x777x666x555x444x333x222x111";
+
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(
+			PATH,
+			fieldTypes,
+			new int[]{0, 3, 7});
+		format.setFieldDelimiter("x");
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(3);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(111, result.getField(0));
+		Assert.assertEquals(444, result.getField(1));
+		Assert.assertEquals(888, result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(0, result.getField(0));
+		Assert.assertEquals(777, result.getField(1));
+		Assert.assertEquals(333, result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNull(result);
+		Assert.assertTrue(format.reachedEnd());
+	}
+
+	@Test
+	public void testReadSparseWithPositionSetter() throws Exception {
+		String fileContent = "111|222|333|444|555|666|777|888|999|000|\n" +
+			"000|999|888|777|666|555|444|333|222|111|";
+
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(
+			PATH,
+			fieldTypes,
+			new int[]{0, 3, 7});
+		format.setFieldDelimiter("|");
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(3);
+		result = format.nextRecord(result);
+
+		Assert.assertNotNull(result);
+		Assert.assertEquals(111, result.getField(0));
+		Assert.assertEquals(444, result.getField(1));
+		Assert.assertEquals(888, result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(0, result.getField(0));
+		Assert.assertEquals(777, result.getField(1));
+		Assert.assertEquals(333, result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNull(result);
+		Assert.assertTrue(format.reachedEnd());
+	}
+
+	@Test
+	public void testReadSparseWithMask() throws Exception {
+		String fileContent = "111&222&333&444&555&666&777&888&999&000&\n" +
+			"000&999&888&777&666&555&444&333&222&111&";
+
+		FileInputSplit split = RFCRowCsvInputFormatTest.createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(
+			PATH,
+			fieldTypes,
+			new int[]{0, 3, 7});
+		format.setFieldDelimiter("&");
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(3);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(111, result.getField(0));
+		Assert.assertEquals(444, result.getField(1));
+		Assert.assertEquals(888, result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(0, result.getField(0));
+		Assert.assertEquals(777, result.getField(1));
+		Assert.assertEquals(333, result.getField(2));
+
+		result = format.nextRecord(result);
+		Assert.assertNull(result);
+		Assert.assertTrue(format.reachedEnd());
+	}
+
+	@Test
+	public void testParseStringErrors() throws Exception {
+		StringParser stringParser = new StringParser();
+
+		stringParser.enableQuotedStringParsing((byte) '"');
+
+		Map<String, StringParser.ParseErrorState> failures = new HashMap<>();
+		failures.put("\"string\" trailing", FieldParser.ParseErrorState.UNQUOTED_CHARS_AFTER_QUOTED_STRING);
+		failures.put("\"unterminated ", FieldParser.ParseErrorState.UNTERMINATED_QUOTED_STRING);
+
+		for (Map.Entry<String, StringParser.ParseErrorState> failure : failures.entrySet()) {
+			int result = stringParser.parseField(
+				failure.getKey().getBytes(ConfigConstants.DEFAULT_CHARSET),
+				0,
+				failure.getKey().length(),
+				new byte[]{(byte) '|'},
+				null);
+			Assert.assertEquals(-1, result);
+			Assert.assertEquals(failure.getValue(), stringParser.getErrorState());
+		}
+	}
+
+	@Test
+	public void testParserCorrectness() throws Exception {
+		// RFC 4180 Compliance Test content
+		// Taken from http://en.wikipedia.org/wiki/Comma-separated_values#Example
+		String fileContent = "Year,Make,Model,Description,Price\n" +
+			"1997,Ford,E350,\"ac, abs, moon\",3000.00\n" +
+			"1999,Chevy,\"Venture \"\"Extended Edition\"\"\",\"\",4900.00\n" +
+			"1996,Jeep,Grand Cherokee,\"MUST SELL! air, moon roof, loaded\",4799.00\n" +
+			"1999,Chevy,\"Venture \"\"Extended Edition, Very Large\"\"\",,5000.00\n" +
+			",,\"Venture \"\"Extended Edition\"\"\",\"\",4900.00";
+
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.DOUBLE_TYPE_INFO};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(PATH, fieldTypes);
+		format.setSkipFirstLineAsHeader(true);
+		format.setFieldDelimiter(",");
+		format.enableQuotedStringParsing('\"');
+		format.setLenient(true);
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(5);
+		Row r1 = new Row(5);
+		r1.setField(0, 1997);
+		r1.setField(1, "Ford");
+		r1.setField(2, "E350");
+		r1.setField(3, "ac, abs, moon");
+		r1.setField(4, 3000.0);
+
+		Row r2 = new Row(5);
+		r2.setField(0, 1999);
+		r2.setField(1, "Chevy");
+		r2.setField(2, "Venture \"Extended Edition\"");
+		r2.setField(3, "");
+		r2.setField(4, 4900.0);
+
+		Row r3 = new Row(5);
+		r3.setField(0, 1996);
+		r3.setField(1, "Jeep");
+		r3.setField(2, "Grand Cherokee");
+		r3.setField(3, "MUST SELL! air, moon roof, loaded");
+		r3.setField(4, 4799.0);
+
+		Row r4 = new Row(5);
+		r4.setField(0, 1999);
+		r4.setField(1, "Chevy");
+		r4.setField(2, "Venture \"Extended Edition, Very Large\"");
+		r4.setField(3, "");
+		r4.setField(4, 5000.0);
+
+		Row r5 = new Row(5);
+		r5.setField(0, null);
+		r5.setField(1, "");
+		r5.setField(2, "Venture \"Extended Edition\"");
+		r5.setField(3, "");
+		r5.setField(4, 4900.0);
+
+		Row[] expectedLines = new Row[]{r1, r2, r3, r4, r5};
+		for (Row expected : expectedLines) {
+			result = format.nextRecord(result);
+			Assert.assertEquals(expected, result);
+		}
+		Assert.assertNull(format.nextRecord(result));
+		Assert.assertTrue(format.reachedEnd());
+	}
+
+	@Test
+	public void testWindowsLineEndRemoval() throws Exception {
+
+		// check typical use case -- linux file is correct and it is set up to linux(\n)
+		testRemovingTrailingCR("\n", "\n");
+
+		// check typical windows case -- windows file endings and file has windows file endings set up
+		testRemovingTrailingCR("\r\n", "\r\n");
+
+		// check problematic case windows file -- windows file endings(\r\n)
+		// but linux line endings (\n) set up
+		testRemovingTrailingCR("\r\n", "\n");
+
+		// check problematic case linux file -- linux file endings (\n)
+		// but windows file endings set up (\r\n)
+		// specific setup for windows line endings will expect \r\n because
+		// it has to be set up and is not standard.
+	}
+
+	@Test
+	public void testQuotedStringParsingWithIncludeFields() throws Exception {
+		final String fileContent = "\"20:41:52-1-3-2015\"|\"Re: Taskmanager memory error in Eclipse\"|" +
+			"\"Blahblah <blah@blahblah.org>\"|\"blaaa|\"\"blubb\"";
+		File tempFile = File.createTempFile("CsvReaderQuotedString", "tmp");
+		tempFile.deleteOnExit();
+		tempFile.setWritable(true);
+
+		OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(tempFile));
+		writer.write(fileContent);
+		writer.close();
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO};
+
+		RFCRowCsvInputFormat inputFormat = new RFCRowCsvInputFormat(
+			new Path(tempFile.toURI().toString()),
+			fieldTypes,
+			new int[]{0, 2});
+		inputFormat.enableQuotedStringParsing('"');
+		inputFormat.setFieldDelimiter("|");
+		inputFormat.setDelimiter('\n');
+		inputFormat.configure(new Configuration());
+
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+		inputFormat.open(splits[0]);
+
+		Row record = inputFormat.nextRecord(new Row(2));
+		Assert.assertEquals("20:41:52-1-3-2015", record.getField(0));
+		Assert.assertEquals("Blahblah <blah@blahblah.org>", record.getField(1));
+	}
+
+	@Test
+	public void testQuotedStringParsingWithEscapedQuotes() throws Exception {
+		String fileContent = "\"\\\"\"Hello\\\"\" World\"|\"We are\\\"\" young\"";
+		File tempFile = File.createTempFile("CsvReaderQuotedString", "tmp");
+		tempFile.deleteOnExit();
+		tempFile.setWritable(true);
+
+		OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(tempFile));
+		writer.write(fileContent);
+		writer.close();
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.STRING_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO};
+
+		RFCRowCsvInputFormat inputFormat = new RFCRowCsvInputFormat(new Path(tempFile.toURI().toString()), fieldTypes);
+		inputFormat.enableQuotedStringParsing('"');
+		inputFormat.setFieldDelimiter("|");
+		inputFormat.setDelimiter('\n');
+		inputFormat.configure(new Configuration());
+
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+		inputFormat.open(splits[0]);
+
+		Row record = inputFormat.nextRecord(new Row(2));
+		Assert.assertEquals("\\\"Hello\\\" World", record.getField(0));
+		Assert.assertEquals("We are\\\" young", record.getField(1));
+	}
+
+	@Test
+	public void testSqlTimeFields() throws Exception {
+		String fileContent = "1990-10-14|02:42:25|1990-10-14 02:42:25.123|1990-1-4 2:2:5\n" +
+			"1990-10-14|02:42:25|1990-10-14 02:42:25.123|1990-1-4 2:2:5.3\n";
+
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			SqlTimeTypeInfo.DATE,
+			SqlTimeTypeInfo.TIME,
+			SqlTimeTypeInfo.TIMESTAMP,
+			SqlTimeTypeInfo.TIMESTAMP};
+
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(PATH, fieldTypes);
+		format.setFieldDelimiter("|");
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(4);
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(Date.valueOf("1990-10-14"), result.getField(0));
+		Assert.assertEquals(Time.valueOf("02:42:25"), result.getField(1));
+		Assert.assertEquals(Timestamp.valueOf("1990-10-14 02:42:25.123"), result.getField(2));
+		Assert.assertEquals(Timestamp.valueOf("1990-01-04 02:02:05"), result.getField(3));
+
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(Date.valueOf("1990-10-14"), result.getField(0));
+		Assert.assertEquals(Time.valueOf("02:42:25"), result.getField(1));
+		Assert.assertEquals(Timestamp.valueOf("1990-10-14 02:42:25.123"), result.getField(2));
+		Assert.assertEquals(Timestamp.valueOf("1990-01-04 02:02:05.3"), result.getField(3));
+
+		result = format.nextRecord(result);
+		Assert.assertNull(result);
+		Assert.assertTrue(format.reachedEnd());
+	}
+
+	@Test
+	public void testScanOrder() throws Exception {
+		String fileContent =
+			// first row
+			"111|222|333|444|555|666|777|888|999|000|\n" +
+			// second row
+			"000|999|888|777|666|555|444|333|222|111|";
+		FileInputSplit split = createTempFile(fileContent);
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.INT_TYPE_INFO};
+
+		int[] order = new int[]{7, 3, 0};
+		RFCRowCsvInputFormat format = new RFCRowCsvInputFormat(
+			PATH,
+			fieldTypes,
+			order);
+
+		format.setFieldDelimiter("|");
+		format.configure(new Configuration());
+		format.open(split);
+
+		Row result = new Row(3);
+
+		// check first row
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(888, result.getField(0));
+		Assert.assertEquals(444, result.getField(1));
+		Assert.assertEquals(111, result.getField(2));
+
+		// check second row
+		result = format.nextRecord(result);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(333, result.getField(0));
+		Assert.assertEquals(777, result.getField(1));
+		Assert.assertEquals(0, result.getField(2));
+
+	}
+
+	private static FileInputSplit createTempFile(String content) throws IOException {
+		File tempFile = File.createTempFile("test_contents", "tmp");
+		tempFile.deleteOnExit();
+		OutputStreamWriter wrt = new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.UTF_8);
+		wrt.write(content);
+		wrt.close();
+		return new FileInputSplit(0, new Path(tempFile.toURI().toString()), 0, tempFile.length(), new String[]{"localhost"});
+	}
+
+	private static void testRemovingTrailingCR(String lineBreakerInFile, String lineBreakerSetup) throws IOException {
+		String fileContent = FIRST_PART + lineBreakerInFile + SECOND_PART + lineBreakerInFile;
+
+		// create input file
+		File tempFile = File.createTempFile("CsvInputFormatTest", "tmp");
+		tempFile.deleteOnExit();
+		tempFile.setWritable(true);
+
+		OutputStreamWriter wrt = new OutputStreamWriter(new FileOutputStream(tempFile));
+		wrt.write(fileContent);
+		wrt.close();
+
+		TypeInformation[] fieldTypes = new TypeInformation[]{BasicTypeInfo.STRING_TYPE_INFO};
+
+		RFCRowCsvInputFormat inputFormat = new RFCRowCsvInputFormat(new Path(tempFile.toURI().toString()), fieldTypes);
+		inputFormat.configure(new Configuration());
+		inputFormat.setDelimiter(lineBreakerSetup);
+
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+		inputFormat.open(splits[0]);
+
+		Row result = inputFormat.nextRecord(new Row(1));
+		Assert.assertNotNull("Expecting to not return null", result);
+		Assert.assertEquals(FIRST_PART, result.getField(0));
+
+		result = inputFormat.nextRecord(result);
+		Assert.assertNotNull("Expecting to not return null", result);
+		Assert.assertEquals(SECOND_PART, result.getField(0));
+	}
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/TableSourceTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/TableSourceTest.scala
@@ -364,7 +364,7 @@ class TableSourceTest extends TableTestBase {
       .field("myfield", Types.STRING)
       .field("myfield2", Types.INT)
       .quoteCharacter('"')
-      .fieldDelimiter(",")
+      .fieldDelimiter(',')
       .lineDelimiter("\n")
       .commentPrefix("#")
       .ignoreFirstLine()
@@ -375,7 +375,7 @@ class TableSourceTest extends TableTestBase {
       "/path/to/csv",
       Array("myfield", "myfield2"),
       Array(Types.STRING, Types.INT),
-      ",",
+      ',',
       "\n",
       '"',
       true,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/TableSourceTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/TableSourceTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.api
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils._
 import org.apache.flink.table.runtime.utils.CommonTestData
-import org.apache.flink.table.sources.{CsvTableSource, TableSource}
+import org.apache.flink.table.sources.{CsvTableSource, RFCCsvTableSource, TableSource}
 import org.apache.flink.table.utils.TableTestUtil._
 import org.apache.flink.table.utils.{TableTestBase, TestFilterableTableSource}
 import org.junit.{Assert, Test}
@@ -352,6 +352,34 @@ class TableSourceTest extends TableTestBase {
       ';',
       true,
       "%%",
+      true)
+
+    Assert.assertEquals(source1, source2)
+  }
+
+  @Test
+  def testRFCCsvTableSourceBuilder(): Unit = {
+    val source1 = RFCCsvTableSource.builder()
+      .path("/path/to/csv")
+      .field("myfield", Types.STRING)
+      .field("myfield2", Types.INT)
+      .quoteCharacter('"')
+      .fieldDelimiter(",")
+      .lineDelimiter("\n")
+      .commentPrefix("#")
+      .ignoreFirstLine()
+      .ignoreParseErrors()
+      .build()
+
+    val source2 = new RFCCsvTableSource(
+      "/path/to/csv",
+      Array("myfield", "myfield2"),
+      Array(Types.STRING, Types.INT),
+      ",",
+      "\n",
+      '"',
+      true,
+      "#",
       true)
 
     Assert.assertEquals(source1, source2)


### PR DESCRIPTION
## What is the purpose of the change

Currently CsvInputFormat is not compliant with RFC 4180 standards and we can't correctly parse fields containing double quotes, line delimiter or field delimiter.


## Brief change log

  - RFCCsvInputFormat is added to support RFC 4180 standards.
  - Also we added RFCRowCsvInputFormat, RFCTupleCsvInputFormat and RFCCsvTableSource for this purpose.
  - New dependency for Jackson parser is added in pom.xml of flink-table. 

## Verifying this change

This change added tests and can be verified as follows:

  - RFCCsvInputFormatTest and RFCRowCsvInputFormatTest are added to test the added CSV Input Format functionality.
  - TableSourceTest#testRFCCsvTableSourceBuilder is added for RFCCsvTableSource.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **yes**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **not documented yet**
